### PR TITLE
Add customizable SupaMaus cursor mascots

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Two processes:
 
 Features wired end-to-end:
 
-- **Sidebar** — bot list with squishy blob avatars, previews, unread dots,
+- **Sidebar** — bot list with SupaMaus cursor mascots, role-aware expressions,
+  ten-color identities, previews, unread dots,
   new-bot button, Plugins + profile footer
 - **Chat** — streaming replies (token deltas), tool-run activity chips,
   approval/question cards answered inline, screenshots of the bot's cloud

--- a/server/index.ts
+++ b/server/index.ts
@@ -359,7 +359,7 @@ const server = createServer(async (req, res) => {
     if (m && method === "PATCH") {
       const body = await readBody(req);
       const patch: Record<string, unknown> = {};
-      for (const key of ["name", "title", "description", "notifications", "modelSelection", "unread", "computer"] as const) {
+      for (const key of ["name", "title", "description", "notifications", "modelSelection", "unread", "computer", "color", "mascotExpression"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
       }
       const bot = store.patchBot(m[1], patch);

--- a/server/store.ts
+++ b/server/store.ts
@@ -8,7 +8,29 @@ import { join } from "node:path";
 import { DATA_DIR } from "./config.ts";
 import { newId, type ModelSelection, type ThreadId } from "./contracts.ts";
 
-export type BlobColor = "red" | "orange" | "blue" | "green" | "purple";
+export type MausColor =
+  | "green"
+  | "blue"
+  | "red"
+  | "orange"
+  | "purple"
+  | "cyan"
+  | "pink"
+  | "yellow"
+  | "teal"
+  | "coral";
+
+export type MausExpression =
+  | "deadpan"
+  | "friendly"
+  | "focused"
+  | "thinking"
+  | "excited"
+  | "sleepy"
+  | "surprised"
+  | "skeptical"
+  | "worried"
+  | "mischievous";
 
 export interface OptionCardData {
   title: string;
@@ -41,7 +63,8 @@ export interface BotRecord {
   title: string;
   description: string;
   notifications: boolean;
-  color: BlobColor;
+  color: MausColor;
+  mascotExpression?: MausExpression | null;
   unread: boolean;
   modelSelection: ModelSelection;
   /** provider-native continuation per instance (e.g. claude session id) */
@@ -56,7 +79,18 @@ export interface BotRecord {
 const BOTS_FILE = join(DATA_DIR, "bots.json");
 const messagesFile = (threadId: string) => join(DATA_DIR, `messages-${threadId}.json`);
 
-const COLORS: BlobColor[] = ["blue", "red", "orange", "green", "purple"];
+const COLORS: MausColor[] = [
+  "green",
+  "blue",
+  "red",
+  "orange",
+  "purple",
+  "cyan",
+  "pink",
+  "yellow",
+  "teal",
+  "coral",
+];
 
 const onboardingCard = (): OptionCardData => ({
   title: "What do you mostly want help with?",

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,41 +1,171 @@
-import type { BlobColor } from "@/state/store";
+import {
+  MAUS_COLORS,
+  type MausColor,
+  type MausExpression,
+} from "@/lib/mascot";
 
-const FILLS: Record<BlobColor, string> = {
-  red: "#e5484d",
-  orange: "#f28a30",
-  blue: "#3f8cff",
-  green: "#46a758",
-  purple: "#8e4ec6",
-};
+// Exact SupaMaus mascot silhouette from the website's
+// components/v2/MascotSlot.js. The geometry and tilt remain faithful to that
+// source; app avatars use a larger borderless flat fill.
+const BODY =
+  "M93.4 40.6 L43 151.1 Q38 162 48.4 156 L91.4 131 Q100 126 108.7 131 L151.6 156 Q162 162 157 151.1 L106.6 40.6 Q100 26 93.4 40.6 Z";
 
-// Each color gets its own squishy silhouette, like Grok Bot's avatars:
-// red is a lumpy cloud, orange a rounded square, blue near-round.
-const SHAPES: Record<BlobColor, string> = {
-  red: "M13 14 C 14 8.5, 20 6.5, 24 9.5 C 27 6, 34 7, 36 12 C 40 13, 42 18, 40.5 22.5 C 42 28, 39 33.5, 33.5 35 C 28 38.5, 16 38.5, 10.5 34.5 C 5.5 31, 4.5 24, 7 19 C 8 16, 10 14.5, 13 14 Z",
-  orange: "M14 6.5 L 30 6.5 C 35.5 6.5, 38.5 9.5, 38.5 15 L 38.5 29 C 38.5 34.5, 35.5 37.5, 30 37.5 L 14 37.5 C 8.5 37.5, 5.5 34.5, 5.5 29 L 5.5 15 C 5.5 9.5, 8.5 6.5, 14 6.5 Z",
-  blue: "M22 5 C 32.5 5, 39.5 12, 39.5 22 C 39.5 32, 32.5 39, 22 39 C 11.5 39, 4.5 32, 4.5 22 C 4.5 12, 11.5 5, 22 5 Z",
-  green: "M22 5.5 C 31 4, 38 10, 38.5 19 C 39 28, 34 36.5, 24.5 38 C 15 39.5, 6.5 34, 5.5 24.5 C 4.5 15, 12 7, 22 5.5 Z",
-  purple: "M21 5.5 C 27 3.5, 34 6, 37.5 12 C 41 18, 40 26, 35.5 31.5 C 31 37, 22 39.5, 15 36.5 C 8 33.5, 4 26.5, 5.5 19 C 7 12, 14 7.5, 21 5.5 Z",
-};
+const INK = "#10201b";
 
-export function BlobAvatar({
-  color,
-  size = 44,
+function PillEye({
+  cx,
+  cy = 88,
+  width = 7,
+  height = 18,
+  angle = -12,
 }: {
-  color: BlobColor;
-  size?: number;
+  cx: number;
+  cy?: number;
+  width?: number;
+  height?: number;
+  angle?: number;
 }) {
+  return (
+    <rect
+      x={cx - width / 2}
+      y={cy - height / 2}
+      width={width}
+      height={height}
+      rx={width / 2}
+      fill={INK}
+      transform={`rotate(${angle} ${cx} ${cy})`}
+    />
+  );
+}
+
+function Face({ expression }: { expression: MausExpression }) {
+  const line = {
+    fill: "none",
+    stroke: INK,
+    strokeWidth: 6,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+
+  switch (expression) {
+    case "friendly":
+      return (
+        <>
+          <PillEye cx={90} height={15} angle={-18} />
+          <PillEye cx={112} height={15} angle={-10} />
+          <path d="M88 105 Q101 118 114 105" {...line} />
+        </>
+      );
+    case "focused":
+      return (
+        <>
+          <path d="M83 80 L94 84 M108 84 L119 80" {...line} strokeWidth="5" />
+          <PillEye cx={90} cy={92} height={16} angle={-7} />
+          <PillEye cx={112} cy={92} height={16} angle={7} />
+          <path d="M90 111 Q101 107 112 111" {...line} />
+        </>
+      );
+    case "thinking":
+      return (
+        <>
+          <PillEye cx={90} cy={87} height={17} angle={-16} />
+          <PillEye cx={112} cy={82} height={14} angle={-7} />
+          <path d="M84 78 Q90 73 96 77 M108 73 Q115 70 120 75" {...line} strokeWidth="4.5" />
+          <path d="M93 111 Q101 105 110 109" {...line} />
+        </>
+      );
+    case "excited":
+      return (
+        <>
+          <PillEye cx={90} cy={87} height={19} angle={-24} />
+          <PillEye cx={112} cy={87} height={19} angle={4} />
+          <path d="M88 102 Q101 124 114 102 Q101 109 88 102 Z" fill={INK} />
+        </>
+      );
+    case "sleepy":
+      return (
+        <>
+          <PillEye cx={90} cy={89} height={8} angle={-24} />
+          <PillEye cx={112} cy={89} height={8} angle={-6} />
+          <ellipse cx="101" cy="110" rx="6" ry="8" fill={INK} />
+        </>
+      );
+    case "surprised":
+      return (
+        <>
+          <PillEye cx={90} height={22} width={8} angle={-15} />
+          <PillEye cx={112} height={22} width={8} angle={-8} />
+          <circle cx="101" cy="111" r="8" fill={INK} />
+        </>
+      );
+    case "skeptical":
+      return (
+        <>
+          <path d="M83 82 L96 79 M107 77 L120 83" {...line} strokeWidth="5" />
+          <PillEye cx={90} cy={91} height={17} angle={-18} />
+          <PillEye cx={112} cy={92} height={8} angle={-2} />
+          <path d="M91 112 Q101 107 112 113" {...line} />
+        </>
+      );
+    case "worried":
+      return (
+        <>
+          <path d="M83 82 Q90 76 97 82 M105 82 Q112 76 119 82" {...line} strokeWidth="4.5" />
+          <PillEye cx={90} cy={91} height={17} angle={-5} />
+          <PillEye cx={112} cy={91} height={17} angle={-20} />
+          <path d="M89 115 Q101 103 113 115" {...line} />
+        </>
+      );
+    case "mischievous":
+      return (
+        <>
+          <path d="M83 82 L96 86 M106 86 L119 80" {...line} strokeWidth="5" />
+          <PillEye cx={90} cy={93} height={15} angle={-2} />
+          <PillEye cx={112} cy={93} height={15} angle={-22} />
+          <path d="M89 106 Q103 118 116 103 Q103 110 89 106 Z" fill={INK} />
+        </>
+      );
+    case "deadpan":
+      return (
+        <>
+          <PillEye cx={90} angle={-18} />
+          <PillEye cx={112} angle={-10} />
+          <path d="M88 110 L114 110" {...line} />
+        </>
+      );
+  }
+}
+
+export function MausAvatar({
+  color,
+  expression = "deadpan",
+  size = 44,
+  label,
+}: {
+  color: MausColor;
+  expression?: MausExpression;
+  size?: number;
+  label?: string;
+}) {
+  const fill = MAUS_COLORS[color] ?? MAUS_COLORS.green;
+
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 44 44"
-      className="shrink-0"
-      aria-hidden
+      viewBox="25 20 150 150"
+      className="shrink-0 overflow-visible"
+      role={label ? "img" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
     >
-      <path d={SHAPES[color]} fill={FILLS[color]} />
-      <circle cx="16.5" cy="20.5" r="2.6" fill="#141416" />
-      <circle cx="27.5" cy="20.5" r="2.6" fill="#141416" />
+      <g transform="rotate(-20 100 100)">
+        <path
+          d={BODY}
+          fill={fill}
+        />
+        <Face expression={expression} />
+      </g>
     </svg>
   );
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
 import { Check, Loader2, Monitor, Square, X } from "lucide-react";
 import { useStore, formatTime, type Bot, type Message } from "@/state/store";
-import { BlobAvatar } from "./Avatar";
+import { MausAvatar } from "./Avatar";
+import { expressionForBot } from "@/lib/mascot";
 import { OptionCard } from "./OptionCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
@@ -94,7 +95,7 @@ export function ChatView({ bot }: { bot: Bot }) {
           className="flex items-center gap-2.5 rounded-lg px-1.5 py-1 hover:bg-raised/50"
           title="Bot settings"
         >
-          <BlobAvatar color={bot.color} size={28} />
+          <MausAvatar color={bot.color} expression={expressionForBot(bot)} size={28} />
           <span className="text-[15px] font-semibold text-ink">{bot.name}</span>
           {bot.busy && <Loader2 size={14} className="animate-spin text-ink-secondary" />}
         </button>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,12 @@
 import { ChevronLeft, X } from "lucide-react";
 import { useStore, type Bot } from "@/state/store";
-import { BlobAvatar } from "./Avatar";
+import { MausAvatar } from "./Avatar";
+import {
+  expressionForBot,
+  MAUS_COLORS,
+  MAUS_COLOR_NAMES,
+  MAUS_EXPRESSIONS,
+} from "@/lib/mascot";
 import { ModelPicker } from "./ModelPicker";
 import { cn } from "@/lib/cn";
 
@@ -25,8 +31,11 @@ const inputCls =
 export function SettingsPanel({ bot }: { bot: Bot }) {
   const { dispatch } = useStore();
   const patch = (
-    p: Partial<Pick<Bot, "name" | "title" | "description" | "notifications" | "computer">>,
+    p: Partial<
+      Pick<Bot, "name" | "title" | "description" | "notifications" | "computer" | "color" | "mascotExpression">
+    >,
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
+  const activeExpression = expressionForBot(bot);
 
   return (
     <aside className="flex h-full w-[400px] shrink-0 flex-col border-l border-hairline/40 bg-panel">
@@ -48,11 +57,66 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
       </div>
 
       <div className="flex-1 overflow-y-auto px-5 pb-5">
-        <div className="flex justify-center py-6">
-          <BlobAvatar color={bot.color} size={72} />
+        <div className="flex justify-center py-5">
+          <MausAvatar color={bot.color} expression={activeExpression} size={112} />
         </div>
 
         <div className="flex flex-col gap-4">
+          <div className="overflow-hidden rounded-xl border border-hairline/40 bg-card">
+            <div className="flex items-center justify-between border-b border-hairline/40 px-3 py-2.5">
+              <span className="rounded-lg bg-raised px-3 py-1.5 text-[14px] font-medium text-ink">
+                Bot
+              </span>
+              <button
+                onClick={() => patch({ color: "green", mascotExpression: null })}
+                className="rounded-md px-2 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
+              >
+                Reset
+              </button>
+            </div>
+
+            <div className="p-3">
+              <div className="mb-2 text-[12px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+                Expression
+              </div>
+              <div className="grid grid-cols-5 gap-2">
+                {MAUS_EXPRESSIONS.map((expression) => (
+                  <button
+                    key={expression}
+                    onClick={() => patch({ mascotExpression: expression })}
+                    className={cn(
+                      "flex h-[58px] items-center justify-center rounded-xl bg-inset transition-colors hover:bg-raised",
+                      activeExpression === expression && "ring-2 ring-accent-border",
+                    )}
+                    title={expression}
+                    aria-label={`Use ${expression} expression`}
+                  >
+                    <MausAvatar color={bot.color} expression={expression} size={42} />
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-2 mt-4 text-[12px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+                Color
+              </div>
+              <div className="flex flex-wrap gap-2.5">
+                {MAUS_COLOR_NAMES.map((color) => (
+                  <button
+                    key={color}
+                    onClick={() => patch({ color })}
+                    className={cn(
+                      "size-8 rounded-full border-2 border-transparent transition-transform hover:scale-110",
+                      bot.color === color && "ring-2 ring-accent-border ring-offset-2 ring-offset-card",
+                    )}
+                    style={{ backgroundColor: MAUS_COLORS[color] }}
+                    title={color}
+                    aria-label={`Use ${color} mascot color`}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
           <Field label="Name">
             <input
               className={inputCls}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search, Puzzle, Settings } from "lucide-react";
 import { useStore, formatTime, type Bot } from "@/state/store";
-import { BlobAvatar, InitialsAvatar } from "./Avatar";
+import { MausAvatar, InitialsAvatar } from "./Avatar";
+import { expressionForBot } from "@/lib/mascot";
 import { cn } from "@/lib/cn";
 
 const isElectron = navigator.userAgent.includes("Electron");
@@ -27,7 +28,7 @@ function BotListItem({ bot }: { bot: Bot }) {
         selected ? "bg-raised" : "hover:bg-raised/50",
       )}
     >
-      <BlobAvatar color={bot.color} size={44} />
+      <MausAvatar color={bot.color} expression={expressionForBot(bot)} size={44} />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-2">
           <span className="truncate text-[15px] font-semibold text-ink">

--- a/src/lib/mascot.ts
+++ b/src/lib/mascot.ts
@@ -1,0 +1,106 @@
+export const MAUS_COLOR_NAMES = [
+  "green",
+  "blue",
+  "red",
+  "orange",
+  "purple",
+  "cyan",
+  "pink",
+  "yellow",
+  "teal",
+  "coral",
+] as const;
+
+export type MausColor = (typeof MAUS_COLOR_NAMES)[number];
+
+export const MAUS_COLORS: Record<MausColor, string> = {
+  green: "#009957",
+  blue: "#377FE6",
+  red: "#D94B52",
+  orange: "#E78531",
+  purple: "#8057C8",
+  cyan: "#0EA5C6",
+  pink: "#D84F8B",
+  yellow: "#D8A729",
+  teal: "#01A492",
+  coral: "#E5634E",
+};
+
+export const MAUS_EXPRESSIONS = [
+  "deadpan",
+  "friendly",
+  "focused",
+  "thinking",
+  "excited",
+  "sleepy",
+  "surprised",
+  "skeptical",
+  "worried",
+  "mischievous",
+] as const;
+
+export type MausExpression = (typeof MAUS_EXPRESSIONS)[number];
+
+type MascotMessage = {
+  kind: string;
+  tool?: { ok?: boolean };
+};
+
+export type MascotBotProfile = {
+  name: string;
+  title?: string;
+  description?: string;
+  mascotExpression?: MausExpression | null;
+  busy?: boolean;
+  unread?: boolean;
+  messages?: MascotMessage[];
+};
+
+/**
+ * Selects a face from live state first, then from what the bot is about.
+ * The keyword groups deliberately overlap as little as possible so a bot's
+ * visual identity stays stable while its title and description are edited.
+ */
+export function expressionForBot(bot: MascotBotProfile): MausExpression {
+  if (bot.mascotExpression) return bot.mascotExpression;
+
+  const last = bot.messages?.[bot.messages.length - 1];
+
+  if (last?.kind === "activity" && last.tool?.ok === false) return "worried";
+  if (bot.busy) return "focused";
+  if (bot.unread) return "surprised";
+  if (last?.kind === "options") return "thinking";
+
+  const profile = `${bot.name} ${bot.title ?? ""} ${bot.description ?? ""}`.toLowerCase();
+  const matches = (words: RegExp) => words.test(profile);
+
+  if (matches(/\b(code|coding|developer|development|engineer|engineering|build|debug|program|software)\b/)) {
+    return "focused";
+  }
+  if (matches(/\b(research|researcher|search|investigate|strategy|strategist|study|learn|knowledge)\b/)) {
+    return "thinking";
+  }
+  if (matches(/\b(marketing|growth|launch|campaign|social|sales|outreach|brand)\b/)) {
+    return "excited";
+  }
+  if (matches(/\b(overnight|night|background|async|queue|batch|long-running)\b/)) {
+    return "sleepy";
+  }
+  if (matches(/\b(monitor|monitoring|incident|alert|watch|status|uptime)\b/)) {
+    return "surprised";
+  }
+  if (matches(/\b(review|reviewer|audit|critic|critique|quality|qa|test|legal)\b/)) {
+    return "skeptical";
+  }
+  if (matches(/\b(security|secure|compliance|risk|privacy|finance|financial)\b/)) {
+    return "worried";
+  }
+  if (matches(/\b(design|designer|creative|brainstorm|art|illustration|music|story)\b/)) {
+    return "mischievous";
+  }
+  if (matches(/\b(support|help|success|onboarding|coach|teacher|guide|welcome)\b/)) {
+    return "friendly";
+  }
+
+  return "deadpan";
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -11,8 +11,9 @@ import {
   useRef,
   type ReactNode,
 } from "react";
+import type { MausColor, MausExpression } from "@/lib/mascot";
 
-export type BlobColor = "red" | "orange" | "blue" | "green" | "purple";
+export type { MausColor } from "@/lib/mascot";
 
 export interface OptionCardData {
   title: string;
@@ -50,7 +51,8 @@ export interface Bot {
   title: string;
   description: string;
   notifications: boolean;
-  color: BlobColor;
+  color: MausColor;
+  mascotExpression?: MausExpression | null;
   unread: boolean;
   busy?: boolean;
   modelSelection: ModelSelection;
@@ -127,7 +129,7 @@ type Action =
   | {
       type: "updateBot";
       botId: string;
-      patch: Partial<Pick<Bot, "name" | "title" | "description" | "notifications" | "computer">>;
+      patch: Partial<Pick<Bot, "name" | "title" | "description" | "notifications" | "computer" | "color" | "mascotExpression">>;
     };
 
 function updateBot(state: AppState, botId: string, fn: (b: Bot) => Bot): AppState {


### PR DESCRIPTION
## Summary
- replace blob avatars with the SupaMaus cursor silhouette
- add 10 solid colors and 10 role/state-aware expressions with pill-shaped eyes
- add a persistent expression/color picker and reset control in Bot Settings
- cycle new bots through all 10 colors while preserving existing bot data

## Validation
- `npm run build`
- verified sidebar, header, and settings rendering in the local app
- verified expression/color selections persist across reloads
- verified borderless mascot bodies and a clean browser load with no console warnings