### PR TITLE
Grok via subscription: grokAgent driver (Grok Build CLI over ACP) — no API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ One assistant in one box is the wrong shape for agents. OpenMausBot treats AI as
 of bots you chat with — each with its own personality, memory of its thread, model, computer, and apps — built
 on the agents you already have:
 
-- **Bring your own agents.** Bots run on the `claude` and `codex` CLIs installed on your Mac — your existing
-  logins and subscriptions, no new accounts, no proxy in the middle.
+- **Bring your own agents.** Bots run on the `claude`, `codex`, and `grok` CLIs installed on your Mac — your
+  existing logins and subscriptions, no new accounts, no proxy in the middle.
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch
@@ -148,7 +148,7 @@ flowchart LR
 
 | Layer | Where | What it does |
 |---|---|---|
-| Drivers | `server/drivers/` | One per provider: Claude and Codex over their local CLIs (stream-JSON / JSON-RPC), plus a cloud-computer agent. Unknown drivers degrade to "unavailable", never crash the fleet. |
+| Drivers | `server/drivers/` | One per provider: Claude, Codex, and Grok Build over their local CLIs (stream-JSON / JSON-RPC / ACP), plus a cloud-computer agent. Unknown drivers degrade to "unavailable", never crash the fleet. |
 | Harness | `server/harness/` | Registry (configs → live instances) and the fan-in event bus every client folds. |
 | API | `server/index.ts` | Bots, turns, approvals, model catalog, computer lifecycle, connectors, config — HTTP + SSE. |
 | App | `src/` | The chat shell. Server-backed store, one reducer, zero client-side transports. |
@@ -170,9 +170,9 @@ pnpm dev           # app → http://127.0.0.1:5199
 pnpm dev:desktop   # or the Electron shell
 ```
 
-Requirements: **macOS**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code)
-or [`codex`](https://github.com/openai/codex) — installed and logged in. They appear in the model picker
-automatically.
+Requirements: **macOS**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code),
+[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
+in the model picker automatically.
 
 Optional, pasted once in **App Settings** (gear in the sidebar footer):
 

--- a/dist-server/config.js
+++ b/dist-server/config.js
@@ -59,12 +59,16 @@ export function saveConfig(patch) {
 // Config-file keys are injected as per-instance environment so drivers
 // see them without needing real process env vars.
 export function instanceConfigs(cfg) {
-    // No grok instance by default: the xAI API key is a credential Milind
-    // doesn't want to manage — the CLI agents + the box are the fleet. The
-    // driver stays registered; an `instances` entry brings it back anytime.
+    // The default `grok` instance rides the `grokAgent` driver, not the API-key
+    // one: like claude and codex it needs no credential from us, just the CLI
+    // installed and logged in (it shows up unavailable otherwise). The API-key
+    // `grok` driver stays registered but out of the default fleet — that key is
+    // a credential Milind doesn't want to manage; an `instances` entry brings
+    // it back anytime.
     const map = cfg.instances && Object.keys(cfg.instances).length
         ? cfg.instances
         : {
+            grok: { driver: "grokAgent" },
             claude: { driver: "claudeAgent" },
             codex: { driver: "codex" },
             computer: { driver: "boxAgent" },

--- a/dist-server/drivers/builtIn.js
+++ b/dist-server/drivers/builtIn.js
@@ -2,8 +2,10 @@ import { BoxAgentDriver } from "./boxagent.js";
 import { ClaudeDriver } from "./claude.js";
 import { CodexDriver } from "./codex.js";
 import { GrokDriver } from "./grok.js";
+import { GrokAgentDriver } from "./grokagent.js";
 export const BUILT_IN_DRIVERS = [
     GrokDriver,
+    GrokAgentDriver,
     ClaudeDriver,
     CodexDriver,
     BoxAgentDriver,

--- a/dist-server/drivers/grok.js
+++ b/dist-server/drivers/grok.js
@@ -19,7 +19,8 @@ function decodeConfig(raw) {
 }
 export const GrokDriver = {
     driverKind: DRIVER_KIND,
-    metadata: { displayName: "Grok", supportsMultipleInstances: true },
+    // "(API)" distinguishes this key-billed driver from grokAgent, the CLI one
+    metadata: { displayName: "Grok (API)", supportsMultipleInstances: true },
     models: MODELS,
     decodeConfig,
     defaultConfig: () => decodeConfig({}),

--- a/dist-server/drivers/grokagent.js
+++ b/dist-server/drivers/grokagent.js
@@ -1,0 +1,480 @@
+// Grok Build driver — the official `grok` CLI headless over its ACP (Agent
+// Client Protocol) stdio interface: JSON-RPC 2.0, newline-delimited, spawned
+// as `grok … agent stdio`. This is the subscription-login path
+// (~/.grok/auth.json), NOT the xAI API key — the API-backed driver lives in
+// drivers/grok.ts and stays separate.
+//
+// Unlike codex's app-server, ACP has no `turn/completed` notification: the
+// `session/prompt` RPC *result* is the completion signal (it carries the
+// stopReason and the usage counters), which is also why racing the `_x.ai/*`
+// side-channel notifications is pointless — they arrive first but the result
+// is authoritative. Permission requests arrive as server→client JSON-RPC
+// requests (`session/request_permission`) and surface as canonical
+// request.opened events, answered via respondToRequest — and answered
+// fail-closed: nothing is approved unless the agent explicitly offered an
+// `allow`-kind option, because option ORDER is not a security contract.
+//
+// The handshake is initialize → authenticate(cached_token) → session/*. The
+// authenticate step is not optional: without it the agent has no account
+// bound, and a missing cached_token means the user never ran `grok login`.
+//
+// resumeCursor is the ACP sessionId; a later turn tries session/load and
+// falls back to a fresh session/new. session/load REPLAYS the whole history
+// as ordinary session/update notifications, so updates are double-gated:
+// nothing is emitted before the prompt is sent, and anything flagged
+// `_meta.isReplay` is dropped. Verified against grok 1.0.0.
+import { spawn, execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { newEventId, newId } from "../contracts.js";
+import { appendNative } from "./native.js";
+const DRIVER_KIND = "grokAgent";
+// The CLI catalog is account-driven (`grok models` reports exactly one today);
+// this should eventually be read from the initialize result's
+// `_meta.modelState.availableModels` instead of being hardcoded.
+const MODELS = {
+    default: "grok-4.5",
+    options: [{ id: "grok-4.5", label: "Grok 4.5" }],
+};
+function decodeConfig(raw) {
+    const o = (raw ?? {});
+    return {
+        cli: typeof o.cli === "string" ? o.cli : "grok",
+        fullAuto: o.fullAuto === true,
+        workspace: typeof o.workspace === "string" ? o.workspace : undefined,
+    };
+}
+const DENY_TIMEOUT_NOTE = "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
+const LOGIN_NOTE = "Grok CLI is not signed in — run `grok login` in a terminal";
+// RPC deadlines. session/prompt gets none: a turn legitimately runs for
+// minutes, and interruptTurn plus the child `close` handler cover a real hang.
+const INIT_TIMEOUT = 20_000;
+const NEW_SESSION_TIMEOUT = 30_000;
+const LOAD_SESSION_TIMEOUT = 120_000; // history replay on a long thread is slow
+export const GrokAgentDriver = {
+    driverKind: DRIVER_KIND,
+    metadata: { displayName: "Grok", supportsMultipleInstances: true },
+    models: MODELS,
+    decodeConfig,
+    defaultConfig: () => decodeConfig({}),
+    async create(input) {
+        const { instanceId, config } = input;
+        const listeners = new Set();
+        const active = new Map();
+        const emit = (event) => {
+            for (const l of [...listeners])
+                l(event);
+        };
+        const base = (threadId, turnId) => ({
+            eventId: newEventId(),
+            provider: DRIVER_KIND,
+            threadId,
+            turnId,
+            createdAt: new Date().toISOString(),
+        });
+        const sendTurn = async (turn) => {
+            const { threadId } = turn;
+            if (active.has(threadId))
+                throw new Error("a turn is already running on this thread");
+            const turnId = newId();
+            // homedir is the fleet-wide convention (claude and codex do the same);
+            // config.workspace lets an instance be sandboxed to one directory
+            const cwd = turn.cwd ?? config.workspace ?? homedir();
+            const env = { ...process.env };
+            // the CLI owns its own grok.com login; a leaked API key silently flips
+            // billing from the subscription to pay-as-you-go
+            delete env.XAI_API_KEY;
+            // --permission-mode must always be explicit: ~/.grok/config.toml may set
+            // permission_mode = "always-approve", which would silently make every
+            // session yolo and never fire session/request_permission
+            const args = [
+                "--permission-mode",
+                config.fullAuto ? "bypassPermissions" : "default",
+                ...(turn.model ? ["-m", turn.model] : []),
+                "agent",
+                "stdio",
+            ];
+            const child = spawn(config.cli, args, {
+                cwd,
+                env,
+                stdio: ["pipe", "pipe", "pipe"],
+                detached: true,
+            });
+            // promptSent gates every session/update: session/load replays the whole
+            // history through the same channel before the real turn begins
+            const state = { settled: false, promptSent: false, text: "" };
+            const asks = new Map();
+            let nextId = 1;
+            let sessionId = null;
+            let interruptTimer = null;
+            const rpcPending = new Map();
+            const send = (obj) => {
+                try {
+                    child.stdin.write(JSON.stringify(obj) + "\n");
+                }
+                catch { }
+                appendNative(threadId, { dir: "out", source: "grok.acp", msg: obj });
+            };
+            const request = (method, params, timeoutMs) => new Promise((resolve, reject) => {
+                const id = nextId++;
+                let timer = null;
+                if (timeoutMs) {
+                    timer = setTimeout(() => {
+                        rpcPending.delete(id);
+                        reject(new Error(`${method} timed out`));
+                    }, timeoutMs);
+                    timer.unref?.();
+                }
+                rpcPending.set(id, { resolve, reject, timer });
+                send({ jsonrpc: "2.0", id, method, params });
+            });
+            const stop = () => {
+                try {
+                    process.kill(-child.pid, "SIGTERM");
+                }
+                catch {
+                    try {
+                        child.kill("SIGTERM");
+                    }
+                    catch { }
+                }
+            };
+            const settle = (ok, stopReason) => {
+                if (state.settled)
+                    return;
+                state.settled = true;
+                if (interruptTimer)
+                    clearTimeout(interruptTimer);
+                for (const finish of [...asks.values()])
+                    finish("cancel");
+                for (const p of rpcPending.values()) {
+                    if (p.timer)
+                        clearTimeout(p.timer);
+                    p.reject(new Error("turn settled"));
+                }
+                rpcPending.clear();
+                active.delete(threadId);
+                // chunks stream token by token — the transcript entry is the sum
+                if (state.text.trim()) {
+                    emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: state.text });
+                }
+                emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null });
+                stop(); // the agent process does not exit on its own
+            };
+            // server→client permission request → canonical request.opened
+            const handleServerRequest = (msg) => {
+                if (msg.method !== "session/request_permission") {
+                    // never leave an unknown server request hanging — the agent blocks
+                    return send({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "method not found" } });
+                }
+                const params = msg.params ?? {};
+                const options = Array.isArray(params.options) ? params.options : [];
+                // fail-closed: only an explicitly-kinded option counts. Falling back to
+                // options[0] would turn a malformed request into a silent approval.
+                const optionFor = (want) => options.find((o) => String(o.kind ?? "").startsWith(want) && typeof o.optionId === "string")?.optionId ?? null;
+                // "cancelled" is always a valid ACP outcome — it is the safe answer
+                const cancelled = { outcome: { outcome: "cancelled" } };
+                const missing = (want) => emit({
+                    ...base(threadId, turnId),
+                    type: "runtime.error",
+                    message: `grok offered no "${want}" permission option — cancelling the request instead of guessing`,
+                });
+                const toolCall = params.toolCall ?? {};
+                if (config.fullAuto) {
+                    const allow = optionFor("allow");
+                    if (!allow)
+                        missing("allow");
+                    return send({
+                        jsonrpc: "2.0",
+                        id: msg.id,
+                        result: allow ? { outcome: { outcome: "selected", optionId: allow } } : cancelled,
+                    });
+                }
+                const kind = String(toolCall.kind ?? "");
+                const tool = kind === "execute" ? "shell" : kind === "edit" ? "edit" : kind || "tool";
+                const summary = String(toolCall.rawInput?.command ?? toolCall.title ?? tool).slice(0, 200);
+                const requestId = newId();
+                const finish = (behavior) => {
+                    if (!asks.delete(requestId))
+                        return;
+                    clearTimeout(timer);
+                    const want = behavior === "allow" ? "allow" : "reject";
+                    const optionId = behavior === "cancel" ? null : optionFor(want);
+                    if (behavior !== "cancel" && !optionId)
+                        missing(want);
+                    send({
+                        jsonrpc: "2.0",
+                        id: msg.id,
+                        result: optionId ? { outcome: { outcome: "selected", optionId } } : cancelled,
+                    });
+                    // a settle-cancel (or a fail-closed cancel) still resolves the card:
+                    // source "system" marks it dismissed rather than answered by a human
+                    emit({
+                        ...base(threadId, turnId),
+                        type: "request.resolved",
+                        requestId,
+                        behavior: optionId && behavior === "allow" ? "allow" : "deny",
+                        source: optionId ? "user" : "system",
+                    });
+                };
+                const timer = setTimeout(() => {
+                    emit({ ...base(threadId, turnId), type: "runtime.error", message: DENY_TIMEOUT_NOTE });
+                    finish("deny");
+                }, 15 * 60_000);
+                timer.unref?.();
+                asks.set(requestId, finish);
+                emit({
+                    ...base(threadId, turnId),
+                    type: "request.opened",
+                    requestId,
+                    requestType: "permission",
+                    tool,
+                    summary,
+                });
+            };
+            const handleNotification = (msg) => {
+                // `_x.ai/*` notifications are teed to the native log but never
+                // normalized: the session/prompt result is the single settle signal
+                if (msg.method !== "session/update")
+                    return;
+                const p = msg.params ?? {};
+                if (!state.promptSent || p._meta?.isReplay === true)
+                    return;
+                const u = p.update ?? {};
+                switch (u.sessionUpdate) {
+                    case "agent_message_chunk": {
+                        const delta = u.content?.text;
+                        if (typeof delta === "string" && delta) {
+                            state.text += delta;
+                            emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
+                        }
+                        break;
+                    }
+                    case "agent_thought_chunk": {
+                        const delta = u.content?.text;
+                        if (typeof delta === "string" && delta) {
+                            emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "reasoning_text", delta });
+                        }
+                        break;
+                    }
+                    case "tool_call": {
+                        emit({
+                            ...base(threadId, turnId),
+                            type: "item.started",
+                            itemType: "tool",
+                            itemId: u.toolCallId,
+                            title: String(u.rawInput?.command ?? u.title ?? "tool").slice(0, 80),
+                        });
+                        break;
+                    }
+                    case "tool_call_update": {
+                        // status streams in_progress first — only the terminal one counts
+                        if (u.status === "completed" || u.status === "failed") {
+                            emit({
+                                ...base(threadId, turnId),
+                                type: "item.completed",
+                                itemType: "tool",
+                                itemId: u.toolCallId,
+                                ok: u.status !== "failed",
+                            });
+                        }
+                        break;
+                    }
+                }
+            };
+            let buf = "";
+            child.stdout.on("data", (chunk) => {
+                buf += chunk;
+                let nl;
+                while ((nl = buf.indexOf("\n")) !== -1) {
+                    const line = buf.slice(0, nl);
+                    buf = buf.slice(nl + 1);
+                    if (!line.trim())
+                        continue;
+                    let msg;
+                    try {
+                        msg = JSON.parse(line);
+                    }
+                    catch {
+                        continue;
+                    }
+                    appendNative(threadId, { dir: "in", source: "grok.acp", msg });
+                    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+                        const pend = rpcPending.get(msg.id);
+                        if (pend) {
+                            rpcPending.delete(msg.id);
+                            if (pend.timer)
+                                clearTimeout(pend.timer);
+                            msg.error ? pend.reject(new Error(msg.error.message ?? JSON.stringify(msg.error))) : pend.resolve(msg.result);
+                        }
+                    }
+                    else if (msg.id !== undefined && msg.method) {
+                        handleServerRequest(msg);
+                    }
+                    else if (msg.method) {
+                        handleNotification(msg);
+                    }
+                }
+            });
+            let stderr = "";
+            child.stderr.on("data", (c) => {
+                stderr += c;
+                if (stderr.length > 8192)
+                    stderr = stderr.slice(-8192);
+            });
+            child.on("error", (e) => {
+                emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+                settle(false, "spawn_error");
+            });
+            child.on("close", (code) => {
+                if (!state.settled) {
+                    emit({
+                        ...base(threadId, turnId),
+                        type: "runtime.error",
+                        message: `grok exited ${code} before the prompt result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
+                    });
+                    settle(false, "exit_before_result");
+                }
+            });
+            const interrupt = () => {
+                // a notification, no id: the pending session/prompt then resolves with
+                // stopReason "cancelled". Kill the group if it never does.
+                if (sessionId)
+                    send({ jsonrpc: "2.0", method: "session/cancel", params: { sessionId } });
+                else
+                    stop();
+                if (interruptTimer)
+                    clearTimeout(interruptTimer);
+                interruptTimer = setTimeout(() => settle(true, "cancelled"), 5_000);
+                interruptTimer.unref?.();
+            };
+            active.set(threadId, { stop, interrupt, turnId, asks });
+            emit({ ...base(threadId, turnId), type: "turn.started" });
+            // handshake + kickoff; any refusal surfaces as failure, not a hang
+            (async () => {
+                try {
+                    const init = await request("initialize", { protocolVersion: 1, clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } } }, INIT_TIMEOUT);
+                    // bind the grok.com subscription login. No API-key fallback exists
+                    // here by design — an unauthenticated CLI is a user action, not
+                    // something to paper over with a key.
+                    const methods = Array.isArray(init?.authMethods) ? init.authMethods : [];
+                    if (!methods.some((m) => m.id === "cached_token"))
+                        throw new Error(LOGIN_NOTE);
+                    try {
+                        await request("authenticate", { methodId: "cached_token" }, INIT_TIMEOUT);
+                    }
+                    catch {
+                        throw new Error(LOGIN_NOTE);
+                    }
+                    const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
+                    if (cursor) {
+                        try {
+                            // mcpServers is empty: turn.integrations (Composio / the cloud
+                            // computer / the local cua daemon) is not wired to this driver
+                            // yet. The agent advertises mcpCapabilities http+sse, so a
+                            // follow-up can map composio onto an ACP mcpServer entry; until
+                            // then bots here have Grok Build's native tools only.
+                            await request("session/load", { sessionId: cursor, cwd, mcpServers: [] }, LOAD_SESSION_TIMEOUT);
+                            sessionId = cursor;
+                        }
+                        catch {
+                            /* session gone, load unsupported, or too slow — start fresh */
+                        }
+                    }
+                    if (!sessionId) {
+                        const started = await request("session/new", { cwd, mcpServers: [] }, NEW_SESSION_TIMEOUT);
+                        sessionId = typeof started?.sessionId === "string" ? started.sessionId : null;
+                        if (!sessionId)
+                            throw new Error("session/new returned no sessionId");
+                    }
+                    emit({
+                        ...base(threadId, turnId),
+                        type: "session.started",
+                        sessionId,
+                        model: init?._meta?.modelState?.currentModelId ?? turn.model ?? null,
+                    });
+                    // `--append-system-prompt`/`--rules` are accepted by the CLI but do
+                    // NOT reach the agent-stdio system prompt (verified against 1.0.0),
+                    // so the persona is prepended codex-style
+                    state.promptSent = true;
+                    const result = await request("session/prompt", {
+                        sessionId,
+                        prompt: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
+                    });
+                    const usage = result?._meta ?? {};
+                    if (typeof usage.inputTokens === "number" || typeof usage.outputTokens === "number") {
+                        emit({
+                            ...base(threadId, turnId),
+                            type: "thread.token-usage.updated",
+                            input: usage.inputTokens ?? 0,
+                            output: usage.outputTokens ?? 0,
+                        });
+                    }
+                    const reason = result?.stopReason;
+                    // "cancelled" is a user deny or an interrupt, not a failure
+                    if (reason === "end_turn")
+                        settle(true, null);
+                    else if (reason === "cancelled")
+                        settle(true, "cancelled");
+                    else
+                        settle(false, reason ?? "failed");
+                }
+                catch (e) {
+                    if (!state.settled) {
+                        const message = e.message;
+                        emit({ ...base(threadId, turnId), type: "runtime.error", message });
+                        settle(false, message === LOGIN_NOTE ? "auth_required" : "rpc_error");
+                    }
+                }
+            })();
+            return { turnId };
+        };
+        const snapshot = async () => {
+            const version = await new Promise((resolve) => {
+                execFile(config.cli, ["--version"], { timeout: 8000 }, (err, stdout) => resolve(err ? null : stdout.trim()));
+            });
+            if (!version)
+                return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+            const authenticated = existsSync(join(homedir(), ".grok", "auth.json"));
+            return { state: "available", version, authenticated };
+        };
+        return {
+            instanceId,
+            driverKind: DRIVER_KIND,
+            displayName: input.displayName,
+            enabled: input.enabled,
+            models: MODELS,
+            snapshot,
+            adapter: {
+                provider: DRIVER_KIND,
+                capabilities: { sessionModelSwitch: "unsupported" },
+                sendTurn,
+                interruptTurn: async (threadId) => active.get(threadId)?.interrupt(),
+                respondToRequest: async (threadId, requestId, decision) => {
+                    const turn = active.get(threadId);
+                    const finish = turn?.asks.get(requestId);
+                    if (!finish)
+                        throw new Error("no such pending request");
+                    // fail-closed: only an explicit "allow" approves. ACP has no
+                    // free-text ask, so "answer" — and anything unrecognized — is a deny.
+                    finish(decision.behavior === "allow" ? "allow" : "deny");
+                },
+                hasSession: (threadId) => active.has(threadId),
+                stopAll: async () => {
+                    for (const { stop } of active.values())
+                        stop();
+                },
+                onEvent: (listener) => {
+                    listeners.add(listener);
+                    return () => listeners.delete(listener);
+                },
+            },
+            dispose: async () => {
+                for (const { stop } of active.values())
+                    stop();
+                listeners.clear();
+            },
+        };
+    },
+};

--- a/server/config.ts
+++ b/server/config.ts
@@ -72,13 +72,17 @@ export function saveConfig(patch: Partial<AppConfig>): void {
 // Config-file keys are injected as per-instance environment so drivers
 // see them without needing real process env vars.
 export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
-  // No grok instance by default: the xAI API key is a credential Milind
-  // doesn't want to manage — the CLI agents + the box are the fleet. The
-  // driver stays registered; an `instances` entry brings it back anytime.
+  // The default `grok` instance rides the `grokAgent` driver, not the API-key
+  // one: like claude and codex it needs no credential from us, just the CLI
+  // installed and logged in (it shows up unavailable otherwise). The API-key
+  // `grok` driver stays registered but out of the default fleet — that key is
+  // a credential Milind doesn't want to manage; an `instances` entry brings
+  // it back anytime.
   const map: InstanceConfigMap =
     cfg.instances && Object.keys(cfg.instances).length
       ? cfg.instances
       : {
+          grok: { driver: "grokAgent" },
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
           computer: { driver: "boxAgent" },

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -5,9 +5,11 @@ import { BoxAgentDriver } from "./boxagent.ts";
 import { ClaudeDriver } from "./claude.ts";
 import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
+import { GrokAgentDriver } from "./grokagent.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
+  GrokAgentDriver,
   ClaudeDriver,
   CodexDriver,
   BoxAgentDriver,

--- a/server/drivers/grok.ts
+++ b/server/drivers/grok.ts
@@ -43,7 +43,8 @@ function decodeConfig(raw: unknown): GrokConfig {
 
 export const GrokDriver: ProviderDriver<GrokConfig> = {
   driverKind: DRIVER_KIND,
-  metadata: { displayName: "Grok", supportsMultipleInstances: true },
+  // "(API)" distinguishes this key-billed driver from grokAgent, the CLI one
+  metadata: { displayName: "Grok (API)", supportsMultipleInstances: true },
   models: MODELS,
   decodeConfig,
   defaultConfig: () => decodeConfig({}),

--- a/server/drivers/grokagent.ts
+++ b/server/drivers/grokagent.ts
@@ -1,0 +1,507 @@
+// Grok Build driver — the official `grok` CLI headless over its ACP (Agent
+// Client Protocol) stdio interface: JSON-RPC 2.0, newline-delimited, spawned
+// as `grok … agent stdio`. This is the subscription-login path
+// (~/.grok/auth.json), NOT the xAI API key — the API-backed driver lives in
+// drivers/grok.ts and stays separate.
+//
+// Unlike codex's app-server, ACP has no `turn/completed` notification: the
+// `session/prompt` RPC *result* is the completion signal (it carries the
+// stopReason and the usage counters), which is also why racing the `_x.ai/*`
+// side-channel notifications is pointless — they arrive first but the result
+// is authoritative. Permission requests arrive as server→client JSON-RPC
+// requests (`session/request_permission`) and surface as canonical
+// request.opened events, answered via respondToRequest — and answered
+// fail-closed: nothing is approved unless the agent explicitly offered an
+// `allow`-kind option, because option ORDER is not a security contract.
+//
+// The handshake is initialize → authenticate(cached_token) → session/*. The
+// authenticate step is not optional: without it the agent has no account
+// bound, and a missing cached_token means the user never ran `grok login`.
+//
+// resumeCursor is the ACP sessionId; a later turn tries session/load and
+// falls back to a fresh session/new. session/load REPLAYS the whole history
+// as ordinary session/update notifications, so updates are double-gated:
+// nothing is emitted before the prompt is sent, and anything flagged
+// `_meta.isReplay` is dropped. Verified against grok 1.0.0.
+import { spawn, execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type {
+  DriverCreateInput,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "grokAgent";
+
+// The CLI catalog is account-driven (`grok models` reports exactly one today);
+// this should eventually be read from the initialize result's
+// `_meta.modelState.availableModels` instead of being hardcoded.
+const MODELS = {
+  default: "grok-4.5",
+  options: [{ id: "grok-4.5", label: "Grok 4.5" }],
+};
+
+export interface GrokAgentConfig {
+  cli: string;
+  fullAuto: boolean;
+  /** Optional home for this instance's sessions — see the cwd note below. */
+  workspace?: string;
+}
+
+function decodeConfig(raw: unknown): GrokAgentConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    cli: typeof o.cli === "string" ? o.cli : "grok",
+    fullAuto: o.fullAuto === true,
+    workspace: typeof o.workspace === "string" ? o.workspace : undefined,
+  };
+}
+
+const DENY_TIMEOUT_NOTE =
+  "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
+const LOGIN_NOTE = "Grok CLI is not signed in — run `grok login` in a terminal";
+
+// RPC deadlines. session/prompt gets none: a turn legitimately runs for
+// minutes, and interruptTurn plus the child `close` handler cover a real hang.
+const INIT_TIMEOUT = 20_000;
+const NEW_SESSION_TIMEOUT = 30_000;
+const LOAD_SESSION_TIMEOUT = 120_000; // history replay on a long thread is slow
+
+export const GrokAgentDriver: ProviderDriver<GrokAgentConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Grok", supportsMultipleInstances: true },
+  models: MODELS,
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<GrokAgentConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const listeners = new Set<RuntimeEventListener>();
+    interface Turn {
+      stop: () => void;
+      interrupt: () => void;
+      turnId: string;
+      /** ACP permission has no free-text channel — a decision is just a verb. */
+      asks: Map<string, (behavior: string) => void>;
+    }
+    const active = new Map<string, Turn>();
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const turnId = newId();
+      // homedir is the fleet-wide convention (claude and codex do the same);
+      // config.workspace lets an instance be sandboxed to one directory
+      const cwd = turn.cwd ?? config.workspace ?? homedir();
+
+      const env: Record<string, string | undefined> = { ...process.env };
+      // the CLI owns its own grok.com login; a leaked API key silently flips
+      // billing from the subscription to pay-as-you-go
+      delete env.XAI_API_KEY;
+
+      // --permission-mode must always be explicit: ~/.grok/config.toml may set
+      // permission_mode = "always-approve", which would silently make every
+      // session yolo and never fire session/request_permission
+      const args = [
+        "--permission-mode",
+        config.fullAuto ? "bypassPermissions" : "default",
+        ...(turn.model ? ["-m", turn.model] : []),
+        "agent",
+        "stdio",
+      ];
+      const child = spawn(config.cli, args, {
+        cwd,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+        detached: true,
+      });
+
+      // promptSent gates every session/update: session/load replays the whole
+      // history through the same channel before the real turn begins
+      const state = { settled: false, promptSent: false, text: "" };
+      const asks = new Map<string, (behavior: string) => void>();
+      let nextId = 1;
+      let sessionId: string | null = null;
+      let interruptTimer: ReturnType<typeof setTimeout> | null = null;
+      const rpcPending = new Map<
+        number,
+        { resolve: (v: any) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> | null }
+      >();
+
+      const send = (obj: unknown) => {
+        try {
+          child.stdin.write(JSON.stringify(obj) + "\n");
+        } catch {}
+        appendNative(threadId, { dir: "out", source: "grok.acp", msg: obj });
+      };
+      const request = (method: string, params: unknown, timeoutMs?: number) =>
+        new Promise<any>((resolve, reject) => {
+          const id = nextId++;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          if (timeoutMs) {
+            timer = setTimeout(() => {
+              rpcPending.delete(id);
+              reject(new Error(`${method} timed out`));
+            }, timeoutMs);
+            timer.unref?.();
+          }
+          rpcPending.set(id, { resolve, reject, timer });
+          send({ jsonrpc: "2.0", id, method, params });
+        });
+
+      const stop = () => {
+        try {
+          process.kill(-child.pid!, "SIGTERM");
+        } catch {
+          try {
+            child.kill("SIGTERM");
+          } catch {}
+        }
+      };
+
+      const settle = (ok: boolean, stopReason: string | null) => {
+        if (state.settled) return;
+        state.settled = true;
+        if (interruptTimer) clearTimeout(interruptTimer);
+        for (const finish of [...asks.values()]) finish("cancel");
+        for (const p of rpcPending.values()) {
+          if (p.timer) clearTimeout(p.timer);
+          p.reject(new Error("turn settled"));
+        }
+        rpcPending.clear();
+        active.delete(threadId);
+        // chunks stream token by token — the transcript entry is the sum
+        if (state.text.trim()) {
+          emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: state.text });
+        }
+        emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null });
+        stop(); // the agent process does not exit on its own
+      };
+
+      // server→client permission request → canonical request.opened
+      const handleServerRequest = (msg: any) => {
+        if (msg.method !== "session/request_permission") {
+          // never leave an unknown server request hanging — the agent blocks
+          return send({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "method not found" } });
+        }
+        const params = msg.params ?? {};
+        const options: Array<{ optionId?: string; kind?: string }> = Array.isArray(params.options) ? params.options : [];
+        // fail-closed: only an explicitly-kinded option counts. Falling back to
+        // options[0] would turn a malformed request into a silent approval.
+        const optionFor = (want: "allow" | "reject") =>
+          options.find((o) => String(o.kind ?? "").startsWith(want) && typeof o.optionId === "string")?.optionId ?? null;
+        // "cancelled" is always a valid ACP outcome — it is the safe answer
+        const cancelled = { outcome: { outcome: "cancelled" } };
+        const missing = (want: string) =>
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message: `grok offered no "${want}" permission option — cancelling the request instead of guessing`,
+          });
+
+        const toolCall = params.toolCall ?? {};
+        if (config.fullAuto) {
+          const allow = optionFor("allow");
+          if (!allow) missing("allow");
+          return send({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: allow ? { outcome: { outcome: "selected", optionId: allow } } : cancelled,
+          });
+        }
+        const kind = String(toolCall.kind ?? "");
+        const tool = kind === "execute" ? "shell" : kind === "edit" ? "edit" : kind || "tool";
+        const summary = String(toolCall.rawInput?.command ?? toolCall.title ?? tool).slice(0, 200);
+        const requestId = newId();
+        const finish = (behavior: string) => {
+          if (!asks.delete(requestId)) return;
+          clearTimeout(timer);
+          const want = behavior === "allow" ? "allow" : "reject";
+          const optionId = behavior === "cancel" ? null : optionFor(want);
+          if (behavior !== "cancel" && !optionId) missing(want);
+          send({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: optionId ? { outcome: { outcome: "selected", optionId } } : cancelled,
+          });
+          // a settle-cancel (or a fail-closed cancel) still resolves the card:
+          // source "system" marks it dismissed rather than answered by a human
+          emit({
+            ...base(threadId, turnId),
+            type: "request.resolved",
+            requestId,
+            behavior: optionId && behavior === "allow" ? "allow" : "deny",
+            source: optionId ? "user" : "system",
+          });
+        };
+        const timer = setTimeout(() => {
+          emit({ ...base(threadId, turnId), type: "runtime.error", message: DENY_TIMEOUT_NOTE });
+          finish("deny");
+        }, 15 * 60_000);
+        timer.unref?.();
+        asks.set(requestId, finish);
+        emit({
+          ...base(threadId, turnId),
+          type: "request.opened",
+          requestId,
+          requestType: "permission",
+          tool,
+          summary,
+        });
+      };
+
+      const handleNotification = (msg: any) => {
+        // `_x.ai/*` notifications are teed to the native log but never
+        // normalized: the session/prompt result is the single settle signal
+        if (msg.method !== "session/update") return;
+        const p = msg.params ?? {};
+        if (!state.promptSent || p._meta?.isReplay === true) return;
+        const u = p.update ?? {};
+        switch (u.sessionUpdate) {
+          case "agent_message_chunk": {
+            const delta = u.content?.text;
+            if (typeof delta === "string" && delta) {
+              state.text += delta;
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
+            }
+            break;
+          }
+          case "agent_thought_chunk": {
+            const delta = u.content?.text;
+            if (typeof delta === "string" && delta) {
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "reasoning_text", delta });
+            }
+            break;
+          }
+          case "tool_call": {
+            emit({
+              ...base(threadId, turnId),
+              type: "item.started",
+              itemType: "tool",
+              itemId: u.toolCallId,
+              title: String(u.rawInput?.command ?? u.title ?? "tool").slice(0, 80),
+            });
+            break;
+          }
+          case "tool_call_update": {
+            // status streams in_progress first — only the terminal one counts
+            if (u.status === "completed" || u.status === "failed") {
+              emit({
+                ...base(threadId, turnId),
+                type: "item.completed",
+                itemType: "tool",
+                itemId: u.toolCallId,
+                ok: u.status !== "failed",
+              });
+            }
+            break;
+          }
+        }
+      };
+
+      let buf = "";
+      child.stdout.on("data", (chunk) => {
+        buf += chunk;
+        let nl;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          if (!line.trim()) continue;
+          let msg: any;
+          try {
+            msg = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          appendNative(threadId, { dir: "in", source: "grok.acp", msg });
+          if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+            const pend = rpcPending.get(msg.id);
+            if (pend) {
+              rpcPending.delete(msg.id);
+              if (pend.timer) clearTimeout(pend.timer);
+              msg.error ? pend.reject(new Error(msg.error.message ?? JSON.stringify(msg.error))) : pend.resolve(msg.result);
+            }
+          } else if (msg.id !== undefined && msg.method) {
+            handleServerRequest(msg);
+          } else if (msg.method) {
+            handleNotification(msg);
+          }
+        }
+      });
+
+      let stderr = "";
+      child.stderr.on("data", (c) => {
+        stderr += c;
+        if (stderr.length > 8192) stderr = stderr.slice(-8192);
+      });
+      child.on("error", (e) => {
+        emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+        settle(false, "spawn_error");
+      });
+      child.on("close", (code) => {
+        if (!state.settled) {
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message: `grok exited ${code} before the prompt result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
+          });
+          settle(false, "exit_before_result");
+        }
+      });
+
+      const interrupt = () => {
+        // a notification, no id: the pending session/prompt then resolves with
+        // stopReason "cancelled". Kill the group if it never does.
+        if (sessionId) send({ jsonrpc: "2.0", method: "session/cancel", params: { sessionId } });
+        else stop();
+        if (interruptTimer) clearTimeout(interruptTimer);
+        interruptTimer = setTimeout(() => settle(true, "cancelled"), 5_000);
+        interruptTimer.unref?.();
+      };
+      active.set(threadId, { stop, interrupt, turnId, asks });
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+
+      // handshake + kickoff; any refusal surfaces as failure, not a hang
+      (async () => {
+        try {
+          const init = await request(
+            "initialize",
+            { protocolVersion: 1, clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } } },
+            INIT_TIMEOUT,
+          );
+          // bind the grok.com subscription login. No API-key fallback exists
+          // here by design — an unauthenticated CLI is a user action, not
+          // something to paper over with a key.
+          const methods: Array<{ id?: string }> = Array.isArray(init?.authMethods) ? init.authMethods : [];
+          if (!methods.some((m) => m.id === "cached_token")) throw new Error(LOGIN_NOTE);
+          try {
+            await request("authenticate", { methodId: "cached_token" }, INIT_TIMEOUT);
+          } catch {
+            throw new Error(LOGIN_NOTE);
+          }
+          const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
+          if (cursor) {
+            try {
+              // mcpServers is empty: turn.integrations (Composio / the cloud
+              // computer / the local cua daemon) is not wired to this driver
+              // yet. The agent advertises mcpCapabilities http+sse, so a
+              // follow-up can map composio onto an ACP mcpServer entry; until
+              // then bots here have Grok Build's native tools only.
+              await request("session/load", { sessionId: cursor, cwd, mcpServers: [] }, LOAD_SESSION_TIMEOUT);
+              sessionId = cursor;
+            } catch {
+              /* session gone, load unsupported, or too slow — start fresh */
+            }
+          }
+          if (!sessionId) {
+            const started = await request("session/new", { cwd, mcpServers: [] }, NEW_SESSION_TIMEOUT);
+            sessionId = typeof started?.sessionId === "string" ? started.sessionId : null;
+            if (!sessionId) throw new Error("session/new returned no sessionId");
+          }
+          emit({
+            ...base(threadId, turnId),
+            type: "session.started",
+            sessionId,
+            model: init?._meta?.modelState?.currentModelId ?? turn.model ?? null,
+          });
+          // `--append-system-prompt`/`--rules` are accepted by the CLI but do
+          // NOT reach the agent-stdio system prompt (verified against 1.0.0),
+          // so the persona is prepended codex-style
+          state.promptSent = true;
+          const result = await request("session/prompt", {
+            sessionId,
+            prompt: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
+          });
+          const usage = result?._meta ?? {};
+          if (typeof usage.inputTokens === "number" || typeof usage.outputTokens === "number") {
+            emit({
+              ...base(threadId, turnId),
+              type: "thread.token-usage.updated",
+              input: usage.inputTokens ?? 0,
+              output: usage.outputTokens ?? 0,
+            });
+          }
+          const reason = result?.stopReason;
+          // "cancelled" is a user deny or an interrupt, not a failure
+          if (reason === "end_turn") settle(true, null);
+          else if (reason === "cancelled") settle(true, "cancelled");
+          else settle(false, reason ?? "failed");
+        } catch (e) {
+          if (!state.settled) {
+            const message = (e as Error).message;
+            emit({ ...base(threadId, turnId), type: "runtime.error", message });
+            settle(false, message === LOGIN_NOTE ? "auth_required" : "rpc_error");
+          }
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      const version = await new Promise<string | null>((resolve) => {
+        execFile(config.cli, ["--version"], { timeout: 8000 }, (err, stdout) =>
+          resolve(err ? null : stdout.trim()),
+        );
+      });
+      if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+      const authenticated = existsSync(join(homedir(), ".grok", "auth.json"));
+      return { state: "available", version, authenticated };
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      models: MODELS,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "unsupported" },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.interrupt(),
+        respondToRequest: async (threadId, requestId, decision) => {
+          const turn = active.get(threadId);
+          const finish = turn?.asks.get(requestId);
+          if (!finish) throw new Error("no such pending request");
+          // fail-closed: only an explicit "allow" approves. ACP has no
+          // free-text ask, so "answer" — and anything unrecognized — is a deny.
+          finish(decision.behavior === "allow" ? "allow" : "deny");
+        },
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { stop } of active.values()) stop();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      dispose: async () => {
+        for (const { stop } of active.values()) stop();
+        listeners.clear();
+      },
+    };
+  },
+};

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -81,6 +81,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   const byKind = (kind: string) => instances?.find((i) => i.driverKind === kind);
   const claude = byKind("claudeAgent");
   const codex = byKind("codex");
+  const grok = byKind("grokAgent");
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-app">
@@ -157,6 +158,18 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                       codex?.snapshot.state === "available"
                         ? "Installed — bots can run on Codex too."
                         : "Optional. Install: npm i -g @openai/codex"
+                    }
+                  />
+                  <StatusRow
+                    ok={grok?.snapshot.state === "available"}
+                    warn
+                    title={`Grok Build ${grok?.snapshot.version ? `· ${grok.snapshot.version.split(" ")[1]}` : ""}`}
+                    detail={
+                      grok?.snapshot.state === "available"
+                        ? grok.snapshot.authenticated
+                          ? "Installed and signed in — bots can run on Grok too."
+                          : "Installed. Run `grok login` in a terminal to sign in."
+                        : "Optional. Install: curl -fsSL https://x.ai/cli/install.sh | bash"
                     }
                   />
                 </>

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -39,6 +39,7 @@ export function ComputerMark({ size = 16, className }: IconProps) {
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {
   switch (driverKind) {
     case "grok":
+    case "grokAgent":
       return <GrokMark size={size} className={className} />;
     case "claudeAgent":
       return <ClaudeMark size={size} className={className} />;


### PR DESCRIPTION
Closes #3

## What

A new `grokAgent` driver that runs the official **Grok Build CLI** (`grok`) headless over its **ACP stdio** interface (`grok agent stdio`, JSON-RPC 2.0/NDJSON), so bots ride the user's **grok.com subscription login** — no xAI API key anywhere.

This directly resolves the reason Grok sat outside the default fleet (the old comment in `config.ts`: the API key is a credential nobody wants to manage). The new driver plays by the same rule as claude/codex: **no credential in the app, just the CLI installed and signed in** — otherwise it degrades to the usual unavailable shadow in the model picker. The API-key driver stays registered (now labeled "Grok (API)") for anyone who brings a key via an `instances` entry.

One driver file + registration, per the contributing note in the README:

- `server/drivers/grokagent.ts` — the driver (mirrors `codex.ts` structurally: per-turn child process, RPC pending map, permission asks map, native NDJSON tee, process-group teardown)
- `builtIn.ts` / `config.ts` — registration + default fleet entry
- `ProviderIcons.tsx`, `Onboarding.tsx`, `README.md` — Grok mark for the new kind, a "Grok Build" engine row, docs
- `dist-server/` regenerated via `pnpm build:server`

## Protocol notes (all verified against grok CLI 1.0.0)

- Handshake: `initialize` → `authenticate {methodId: "cached_token"}` → `session/load|new` → `session/prompt`. The prompt RPC **result** is the turn-completion signal (stopReason + usage); ACP has no `turn/completed` notification.
- **`session/load` replays the whole history** through the normal `session/update` channel, so resume is double-gated (nothing emitted before the prompt is sent + anything flagged `_meta.isReplay` is dropped) — old messages never duplicate into the chat. resumeCursor is the ACP sessionId.
- **`--append-system-prompt` / `--rules` are accepted-but-inert for `agent stdio`** (proved with a passphrase probe), so personas are prepended codex-style. Recorded in a comment so nobody re-discovers this the hard way.
- Permission requests arrive as server→client `session/request_permission` and surface as the canonical approval cards.

## Security decisions

- **`--permission-mode` is always explicit.** A user-level `permission_mode = "always-approve"` in `~/.grok/config.toml` silently makes sessions yolo (verified: tools ran with zero permission requests until the flag forced it back). Bots always broker approvals through the chat regardless of the user's TUI config. `fullAuto` maps to `bypassPermissions`, default off.
- **Fail-closed approvals.** Nothing is approved unless the agent explicitly offered an `allow`-kinded ACP option — option order is never treated as a security contract; malformed/unknown option sets answer `cancelled`. Only `behavior === "allow"` approves; unknown behaviors deny. 12/12 adversarial cases pass against a fake ACP agent (empty options, unknown kinds, reject-only sets, fullAuto without an allow option).
- **`XAI_API_KEY` is scrubbed from the child env** (same spirit as the codex driver's `OPENAI_API_KEY` note) so billing can never silently flip from the subscription to pay-as-you-go.
- Handshake/auth/session RPCs carry timeouts; `session/prompt` deliberately has none (turns legitimately run long; interrupt + process-exit guards cover hangs).

## Verified

- Driver SPI level: basic turn, resume (memory across turns, same sessionId), deny (no execution leaked), allow (command ran, tool card resolves), interrupt via `session/cancel`, snapshot with a missing CLI → unavailable shadow.
- Harness E2E: bot on the `grok` instance → streamed reply → **resume across a server restart** (persisted resumeCursor) → approval card in chat → Allow via `POST /respond` → command output in the transcript. Both typecheck configs clean.

## Known MVP gaps (documented in-code)

- `turn.integrations` (Composio / cloud computer / local cua) is not wired yet — `mcpServers: []`. The agent advertises MCP http+sse capabilities, so mapping Composio onto an ACP mcpServer entry is a natural follow-up PR; until then bots on this driver have Grok Build's native tools only.
- Model catalog is static (`grok-4.5`, what the CLI reports today); the initialize result carries `modelState.availableModels` for a future dynamic catalog.
- `cost: null` — ACP reports `costUsdTicks` with no documented unit; passing a possibly-wrong number seemed worse than null.
