### PR TITLE
Add seamless vector Maus motion system

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,7 +1,9 @@
+import { memo, useId, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 import {
   MAUS_COLORS,
   type MausColor,
   type MausExpression,
+  type MausMotion,
 } from "@/lib/mascot";
 
 // Exact SupaMaus mascot silhouette from the website's
@@ -11,6 +13,15 @@ const BODY =
   "M93.4 40.6 L43 151.1 Q38 162 48.4 156 L91.4 131 Q100 126 108.7 131 L151.6 156 Q162 162 157 151.1 L106.6 40.6 Q100 26 93.4 40.6 Z";
 
 const INK = "#10201b";
+
+function shade(hex: string, amount: number) {
+  const value = Number.parseInt(hex.slice(1), 16);
+  const channel = (shift: number) =>
+    Math.max(0, Math.min(255, ((value >> shift) & 0xff) + amount));
+  return `#${[channel(16), channel(8), channel(0)]
+    .map((part) => part.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
 
 function PillEye({
   cx,
@@ -51,124 +62,276 @@ function Face({ expression }: { expression: MausExpression }) {
     case "friendly":
       return (
         <>
-          <PillEye cx={90} height={15} angle={-18} />
-          <PillEye cx={112} height={15} angle={-10} />
-          <path d="M88 105 Q101 118 114 105" {...line} />
+          <g className="maus-eyes">
+            <PillEye cx={90} height={15} angle={-18} />
+            <PillEye cx={112} height={15} angle={-10} />
+          </g>
+          <g className="maus-mouth"><path d="M88 105 Q101 118 114 105" {...line} /></g>
         </>
       );
     case "focused":
       return (
         <>
-          <path d="M83 80 L94 84 M108 84 L119 80" {...line} strokeWidth="5" />
-          <PillEye cx={90} cy={92} height={16} angle={-7} />
-          <PillEye cx={112} cy={92} height={16} angle={7} />
-          <path d="M90 111 Q101 107 112 111" {...line} />
+          <g className="maus-eyes">
+            <path d="M83 80 L94 84 M108 84 L119 80" {...line} strokeWidth="5" />
+            <PillEye cx={90} cy={92} height={16} angle={-7} />
+            <PillEye cx={112} cy={92} height={16} angle={7} />
+          </g>
+          <g className="maus-mouth"><path d="M90 111 Q101 107 112 111" {...line} /></g>
         </>
       );
     case "thinking":
       return (
         <>
-          <PillEye cx={90} cy={87} height={17} angle={-16} />
-          <PillEye cx={112} cy={82} height={14} angle={-7} />
-          <path d="M84 78 Q90 73 96 77 M108 73 Q115 70 120 75" {...line} strokeWidth="4.5" />
-          <path d="M93 111 Q101 105 110 109" {...line} />
+          <g className="maus-eyes">
+            <PillEye cx={90} cy={87} height={17} angle={-16} />
+            <PillEye cx={112} cy={82} height={14} angle={-7} />
+            <path d="M84 78 Q90 73 96 77 M108 73 Q115 70 120 75" {...line} strokeWidth="4.5" />
+          </g>
+          <g className="maus-mouth"><path d="M93 111 Q101 105 110 109" {...line} /></g>
         </>
       );
     case "excited":
       return (
         <>
-          <PillEye cx={90} cy={87} height={19} angle={-24} />
-          <PillEye cx={112} cy={87} height={19} angle={4} />
-          <path d="M88 102 Q101 124 114 102 Q101 109 88 102 Z" fill={INK} />
+          <g className="maus-eyes">
+            <PillEye cx={90} cy={87} height={19} angle={-24} />
+            <PillEye cx={112} cy={87} height={19} angle={4} />
+          </g>
+          <g className="maus-mouth"><path d="M88 102 Q101 124 114 102 Q101 109 88 102 Z" fill={INK} /></g>
         </>
       );
     case "sleepy":
       return (
         <>
-          <PillEye cx={90} cy={89} height={8} angle={-24} />
-          <PillEye cx={112} cy={89} height={8} angle={-6} />
-          <ellipse cx="101" cy="110" rx="6" ry="8" fill={INK} />
+          <g className="maus-eyes">
+            <PillEye cx={90} cy={89} height={8} angle={-24} />
+            <PillEye cx={112} cy={89} height={8} angle={-6} />
+          </g>
+          <g className="maus-mouth"><ellipse cx="101" cy="110" rx="6" ry="8" fill={INK} /></g>
         </>
       );
     case "surprised":
       return (
         <>
-          <PillEye cx={90} height={22} width={8} angle={-15} />
-          <PillEye cx={112} height={22} width={8} angle={-8} />
-          <circle cx="101" cy="111" r="8" fill={INK} />
+          <g className="maus-eyes">
+            <PillEye cx={90} height={22} width={8} angle={-15} />
+            <PillEye cx={112} height={22} width={8} angle={-8} />
+          </g>
+          <g className="maus-mouth"><circle cx="101" cy="111" r="8" fill={INK} /></g>
         </>
       );
     case "skeptical":
       return (
         <>
-          <path d="M83 82 L96 79 M107 77 L120 83" {...line} strokeWidth="5" />
-          <PillEye cx={90} cy={91} height={17} angle={-18} />
-          <PillEye cx={112} cy={92} height={8} angle={-2} />
-          <path d="M91 112 Q101 107 112 113" {...line} />
+          <g className="maus-eyes">
+            <path d="M83 82 L96 79 M107 77 L120 83" {...line} strokeWidth="5" />
+            <PillEye cx={90} cy={91} height={17} angle={-18} />
+            <PillEye cx={112} cy={92} height={8} angle={-2} />
+          </g>
+          <g className="maus-mouth"><path d="M91 112 Q101 107 112 113" {...line} /></g>
         </>
       );
     case "worried":
       return (
         <>
-          <path d="M83 82 Q90 76 97 82 M105 82 Q112 76 119 82" {...line} strokeWidth="4.5" />
-          <PillEye cx={90} cy={91} height={17} angle={-5} />
-          <PillEye cx={112} cy={91} height={17} angle={-20} />
-          <path d="M89 115 Q101 103 113 115" {...line} />
+          <g className="maus-eyes">
+            <path d="M83 82 Q90 76 97 82 M105 82 Q112 76 119 82" {...line} strokeWidth="4.5" />
+            <PillEye cx={90} cy={91} height={17} angle={-5} />
+            <PillEye cx={112} cy={91} height={17} angle={-20} />
+          </g>
+          <g className="maus-mouth"><path d="M89 115 Q101 103 113 115" {...line} /></g>
         </>
       );
     case "mischievous":
       return (
         <>
-          <path d="M83 82 L96 86 M106 86 L119 80" {...line} strokeWidth="5" />
-          <PillEye cx={90} cy={93} height={15} angle={-2} />
-          <PillEye cx={112} cy={93} height={15} angle={-22} />
-          <path d="M89 106 Q103 118 116 103 Q103 110 89 106 Z" fill={INK} />
+          <g className="maus-eyes">
+            <path d="M83 82 L96 86 M106 86 L119 80" {...line} strokeWidth="5" />
+            <PillEye cx={90} cy={93} height={15} angle={-2} />
+            <PillEye cx={112} cy={93} height={15} angle={-22} />
+          </g>
+          <g className="maus-mouth"><path d="M89 106 Q103 118 116 103 Q103 110 89 106 Z" fill={INK} /></g>
         </>
       );
     case "deadpan":
       return (
         <>
-          <PillEye cx={90} angle={-18} />
-          <PillEye cx={112} angle={-10} />
-          <path d="M88 110 L114 110" {...line} />
+          <g className="maus-eyes">
+            <PillEye cx={90} angle={-18} />
+            <PillEye cx={112} angle={-10} />
+          </g>
+          <g className="maus-mouth"><path d="M88 110 L114 110" {...line} /></g>
         </>
       );
   }
 }
 
-export function MausAvatar({
+function trackEyes(event: ReactPointerEvent<SVGSVGElement>) {
+  const rect = event.currentTarget.getBoundingClientRect();
+  const x = ((event.clientX - rect.left) / rect.width - 0.5) * 2;
+  const y = ((event.clientY - rect.top) / rect.height - 0.5) * 2;
+  event.currentTarget.style.setProperty("--maus-eye-x", `${Math.max(-1, Math.min(1, x)) * 3.4}px`);
+  event.currentTarget.style.setProperty("--maus-eye-y", `${Math.max(-1, Math.min(1, y)) * 2.6}px`);
+}
+
+function resetEyes(event: ReactPointerEvent<SVGSVGElement>) {
+  event.currentTarget.style.setProperty("--maus-eye-x", "0px");
+  event.currentTarget.style.setProperty("--maus-eye-y", "0px");
+}
+
+function MausAvatarComponent({
   color,
   expression = "deadpan",
   size = 44,
   label,
+  motion = "none",
+  motionKey = 0,
 }: {
   color: MausColor;
   expression?: MausExpression;
   size?: number;
   label?: string;
+  motion?: MausMotion;
+  motionKey?: number;
 }) {
   const fill = MAUS_COLORS[color] ?? MAUS_COLORS.green;
+  const uid = useId().replace(/:/g, "");
+  const surfaceId = `maus-surface-${uid}`;
+  const bevelId = `maus-bevel-${uid}`;
+  const glossId = `maus-gloss-${uid}`;
+  const clipId = `maus-clip-${uid}`;
+  const surfaceShade = shade(fill, -30);
+  const hasAlert = motion === "alert" || motion === "failure";
+  const hasEllipsis = motion === "thinking";
+  const hasRibbons = motion === "launch";
+  const hasBurst = motion === "celebrate";
+  const hasOrbit = motion === "arrive" || motion === "switch" || motion === "customize" || motion === "working";
 
   return (
     <svg
       width={size}
       height={size}
-      viewBox="25 20 150 150"
+      viewBox="-22 51 164 164"
       className="shrink-0 overflow-visible"
       role={label ? "img" : undefined}
       aria-label={label}
       aria-hidden={label ? undefined : true}
+      onPointerMove={trackEyes}
+      onPointerLeave={resetEyes}
+      style={{ "--maus-color": fill, "--maus-eye-x": "0px", "--maus-eye-y": "0px" } as CSSProperties}
     >
-      <g transform="rotate(-20 100 100)">
-        <path
-          d={BODY}
-          fill={fill}
-        />
-        <Face expression={expression} />
+      <defs>
+        <clipPath id={clipId}>
+          <path d={BODY} />
+        </clipPath>
+        <linearGradient id={surfaceId} x1="66" y1="45" x2="132" y2="156" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor={shade(fill, 54)} />
+          <stop offset="0.3" stopColor={shade(fill, 22)} />
+          <stop offset="0.72" stopColor={fill} />
+          <stop offset="1" stopColor={surfaceShade} />
+        </linearGradient>
+        <linearGradient id={bevelId} x1="57" y1="44" x2="146" y2="151" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#ffffff" stopOpacity="0.68" />
+          <stop offset="0.38" stopColor="#ffffff" stopOpacity="0.13" />
+          <stop offset="0.68" stopColor={surfaceShade} stopOpacity="0.1" />
+          <stop offset="1" stopColor={INK} stopOpacity="0.28" />
+        </linearGradient>
+        <radialGradient id={glossId} cx="0.5" cy="0.45" r="0.58">
+          <stop offset="0" stopColor="#ffffff" stopOpacity="0.62" />
+          <stop offset="0.55" stopColor="#ffffff" stopOpacity="0.16" />
+          <stop offset="1" stopColor="#ffffff" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      <g key={motionKey} className={`maus-motion maus-motion--${motion}`}>
+        {hasAlert && (
+          <g className="maus-fx maus-fx--alert" aria-hidden="true">
+            <path d="M97 45 Q100 40 103 45 L106 92 Q106 99 100 99 Q94 99 94 92 Z" fill={fill} />
+            <circle cx="100" cy="116" r="8" fill={fill} />
+          </g>
+        )}
+
+        {hasEllipsis && (
+          <g className="maus-fx maus-fx--ellipsis" aria-hidden="true">
+            <circle className="maus-ellipsis-dot maus-ellipsis-dot--one" cx="72" cy="101" r="8" fill={fill} />
+            <circle className="maus-ellipsis-dot maus-ellipsis-dot--two" cx="100" cy="101" r="10" fill={fill} />
+            <circle className="maus-ellipsis-dot maus-ellipsis-dot--three" cx="130" cy="101" r="8" fill={fill} />
+          </g>
+        )}
+
+        {hasRibbons && (
+          <g className="maus-fx maus-fx--ribbons" aria-hidden="true">
+            <path className="maus-ribbon maus-ribbon--one" pathLength="1" d="M55 119 C79 137 119 140 150 116" stroke={fill} />
+            <path className="maus-ribbon maus-ribbon--two" pathLength="1" d="M54 112 C85 126 119 125 145 103" stroke="#fcfcfc" />
+            <path className="maus-ribbon maus-ribbon--three" pathLength="1" d="M62 126 C87 145 126 145 156 121" stroke={shade(fill, 44)} />
+          </g>
+        )}
+
+        {hasBurst && (
+          <g className="maus-fx maus-fx--burst" aria-hidden="true">
+            <circle className="maus-burst-dot maus-burst-dot--one" cx="100" cy="100" r="5" fill={fill} />
+            <circle className="maus-burst-dot maus-burst-dot--two" cx="100" cy="100" r="4" fill="#fcfcfc" />
+            <circle className="maus-burst-dot maus-burst-dot--three" cx="100" cy="100" r="6" fill={shade(fill, 42)} />
+            <circle className="maus-burst-dot maus-burst-dot--four" cx="100" cy="100" r="3.5" fill={fill} />
+            <path className="maus-burst-ray maus-burst-ray--one" d="M100 100 L100 73" stroke={fill} />
+            <path className="maus-burst-ray maus-burst-ray--two" d="M100 100 L125 88" stroke="#fcfcfc" />
+            <path className="maus-burst-ray maus-burst-ray--three" d="M100 100 L82 121" stroke={shade(fill, 42)} />
+          </g>
+        )}
+
+        {hasOrbit && (
+          <g className="maus-orbit" aria-hidden="true">
+            <path className="maus-speed-line maus-speed-line--one" pathLength="1" d="M38 119 C23 81 45 42 78 29" />
+            <path className="maus-speed-line maus-speed-line--two" pathLength="1" d="M55 151 C32 126 29 94 39 70" />
+            <circle className="maus-orbit-dot maus-orbit-dot--one" cx="47" cy="54" r="4.6" fill={fill} />
+            <circle className="maus-orbit-dot maus-orbit-dot--two" cx="151" cy="65" r="3.4" fill="#fcfcfc" />
+            <circle className="maus-orbit-dot maus-orbit-dot--three" cx="155" cy="132" r="5.2" fill={fill} />
+          </g>
+        )}
+
+        <g className="maus-character">
+          <g className="maus-solid" transform="rotate(-20 100 100)">
+              <path className="maus-body" d={BODY} fill={`url(#${surfaceId})`} />
+              <path
+                className="maus-bevel"
+                d={BODY}
+                fill="none"
+                stroke={`url(#${bevelId})`}
+                strokeWidth="4.5"
+                clipPath={`url(#${clipId})`}
+              />
+              <ellipse
+                className="maus-specular"
+                cx="73"
+                cy="60"
+                rx="42"
+                ry="24"
+                fill={`url(#${glossId})`}
+                clipPath={`url(#${clipId})`}
+                transform="rotate(-26 73 60)"
+              />
+              <path
+                className="maus-rim-light"
+                d="M94 43 L48 144"
+                fill="none"
+                stroke="#ffffff"
+                strokeOpacity="0.35"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                clipPath={`url(#${clipId})`}
+              />
+              <g className="maus-face">
+                <Face expression={expression} />
+              </g>
+          </g>
+        </g>
       </g>
     </svg>
   );
 }
+
+export const MausAvatar = memo(MausAvatarComponent);
 
 export function InitialsAvatar({
   initials,

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -142,6 +142,7 @@ export function ChatView({ bot }: { bot: Bot }) {
 
   const streaming = state.streaming[bot.threadId];
   const provisioning = state.provisioning[bot.id];
+  const mascotMotion = state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
@@ -158,7 +159,13 @@ export function ChatView({ bot }: { bot: Bot }) {
           className="flex items-center gap-2.5 rounded-lg px-1.5 py-1 hover:bg-raised/50"
           title="Bot settings"
         >
-          <MausAvatar color={bot.color} expression={expressionForBot(bot)} size={28} />
+          <MausAvatar
+            color={bot.color}
+            expression={expressionForBot(bot)}
+            size={28}
+            motion={mascotMotion?.kind ?? "none"}
+            motionKey={mascotMotion?.nonce ?? 0}
+          />
           <span className="text-[15px] font-semibold text-ink">{bot.name}</span>
           {bot.busy && <Loader2 size={14} className="animate-spin text-ink-secondary" />}
         </button>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   MAUS_COLORS,
   MAUS_COLOR_NAMES,
   MAUS_EXPRESSIONS,
+  MAUS_MOTIONS,
 } from "@/lib/mascot";
 import { ModelPicker } from "./ModelPicker";
 import { cn } from "@/lib/cn";
@@ -29,13 +30,14 @@ const inputCls =
   "w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2.5 text-[15px] text-ink placeholder:text-ink-secondary focus:outline-none focus:border-hairline";
 
 export function SettingsPanel({ bot }: { bot: Bot }) {
-  const { dispatch } = useStore();
+  const { state, dispatch } = useStore();
   const patch = (
     p: Partial<
       Pick<Bot, "name" | "title" | "description" | "notifications" | "computer" | "color" | "mascotExpression">
     >,
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
   const activeExpression = expressionForBot(bot);
+  const mascotMotion = state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
 
   return (
     <aside className="animate-panel-in flex h-full w-[400px] shrink-0 flex-col border-l border-hairline/40 bg-panel">
@@ -58,7 +60,13 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
 
       <div className="flex-1 overflow-y-auto px-5 pb-5">
         <div className="flex justify-center py-5">
-          <MausAvatar color={bot.color} expression={activeExpression} size={112} />
+          <MausAvatar
+            color={bot.color}
+            expression={activeExpression}
+            size={112}
+            motion={mascotMotion?.kind ?? "none"}
+            motionKey={mascotMotion?.nonce ?? 0}
+          />
         </div>
 
         <div className="flex flex-col gap-4">
@@ -112,6 +120,22 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                     title={color}
                     aria-label={`Use ${color} mascot color`}
                   />
+                ))}
+              </div>
+
+              <div className="mb-2 mt-4 text-[12px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+                Motion preview
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {MAUS_MOTIONS.map((motion) => (
+                  <button
+                    key={motion}
+                    onClick={() => dispatch({ type: "previewMascotMotion", botId: bot.id, kind: motion })}
+                    className="rounded-lg bg-inset px-2 py-2 text-[12px] capitalize text-ink-secondary transition-colors hover:bg-raised hover:text-ink"
+                    aria-label={`Preview ${motion} animation`}
+                  >
+                    {motion}
+                  </button>
                 ))}
               </div>
             </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -134,6 +134,7 @@ function BotContextMenu({ menu, onClose }: { menu: MenuState; onClose: () => voi
 function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => void }) {
   const { state, dispatch } = useStore();
   const selected = state.selectedId === bot.id;
+  const mascotMotion = selected && state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
   const last = bot.messages[bot.messages.length - 1];
   return (
     <button
@@ -147,7 +148,13 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
         selected ? "bg-raised" : "hover:bg-raised/50",
       )}
     >
-      <MausAvatar color={bot.color} expression={expressionForBot(bot)} size={44} />
+      <MausAvatar
+        color={bot.color}
+        expression={expressionForBot(bot)}
+        size={44}
+        motion={mascotMotion?.kind ?? "none"}
+        motionKey={mascotMotion?.nonce ?? 0}
+      />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-2">
           <span className="flex min-w-0 items-center gap-1.5 truncate text-[15px] font-semibold text-ink">

--- a/src/lib/mascot.ts
+++ b/src/lib/mascot.ts
@@ -41,6 +41,23 @@ export const MAUS_EXPRESSIONS = [
 
 export type MausExpression = (typeof MAUS_EXPRESSIONS)[number];
 
+export const MAUS_MOTIONS = [
+  "arrive",
+  "switch",
+  "customize",
+  "alert",
+  "thinking",
+  "working",
+  "launch",
+  "success",
+  "celebrate",
+  "blink",
+  "surprise",
+  "failure",
+] as const;
+
+export type MausMotion = "none" | (typeof MAUS_MOTIONS)[number];
+
 type MascotMessage = {
   kind: string;
   tool?: { ok?: boolean };

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   type ReactNode,
 } from "react";
-import type { MausColor, MausExpression } from "@/lib/mascot";
+import type { MausColor, MausExpression, MausMotion } from "@/lib/mascot";
 
 export type { MausColor } from "@/lib/mascot";
 
@@ -101,6 +101,11 @@ interface AppState {
   provisioning: Record<string, boolean>;
   connected: boolean;
   error: string | null;
+  mascotMotion: {
+    botId: string;
+    nonce: number;
+    kind: Exclude<MausMotion, "none">;
+  } | null;
 }
 
 type Action =
@@ -131,6 +136,7 @@ type Action =
   | { type: "togglePlugins"; open?: boolean }
   | { type: "toggleComputer"; open?: boolean }
   | { type: "toggleAppSettings"; open?: boolean }
+  | { type: "previewMascotMotion"; botId: string; kind: Exclude<MausMotion, "none"> }
   | {
       type: "updateBot";
       botId: string;
@@ -144,6 +150,21 @@ type Action =
 
 function updateBot(state: AppState, botId: string, fn: (b: Bot) => Bot): AppState {
   return { ...state, bots: state.bots.map((b) => (b.id === botId ? fn(b) : b)) };
+}
+
+function withMascotMotion(
+  state: AppState,
+  botId: string,
+  kind: Exclude<MausMotion, "none">,
+): AppState {
+  return {
+    ...state,
+    mascotMotion: {
+      botId,
+      nonce: (state.mascotMotion?.nonce ?? 0) + 1,
+      kind,
+    },
+  };
 }
 
 function patchCard(state: AppState, botId: string, messageId: string, patch: Partial<OptionCardData>): AppState {
@@ -169,14 +190,26 @@ function reducer(state: AppState, action: Action): AppState {
     case "configStatus":
       return { ...state, config: action.config };
     case "select":
-      return updateBot({ ...state, selectedId: action.id }, action.id, (b) => ({ ...b, unread: false }));
+      return updateBot(
+        withMascotMotion({ ...state, selectedId: action.id }, action.id, "switch"),
+        action.id,
+        (b) => ({ ...b, unread: false }),
+      );
     // optimistic card settle; the server's message.patch confirms it later
     case "answerCard":
-      return patchCard(state, action.botId, action.messageId, { answered: action.answer });
+      return withMascotMotion(
+        patchCard(state, action.botId, action.messageId, { answered: action.answer }),
+        action.botId,
+        "working",
+      );
     case "dismissCard":
       return patchCard(state, action.botId, action.messageId, { dismissed: true });
     case "botAdded":
-      return { ...state, bots: [action.bot, ...state.bots], selectedId: action.bot.id };
+      return withMascotMotion({
+        ...state,
+        bots: [action.bot, ...state.bots],
+        selectedId: action.bot.id,
+      }, action.bot.id, "arrive");
     case "deleteBot": {
       const bots = state.bots.filter((b) => b.id !== action.botId);
       const selectedId =
@@ -184,9 +217,20 @@ function reducer(state: AppState, action: Action): AppState {
       return { ...state, bots, selectedId };
     }
     case "markUnread":
-      return updateBot(state, action.botId, (b) => ({ ...b, unread: true }));
-    case "botPatched":
-      return updateBot(state, action.bot.id, (b) => ({ ...b, ...action.bot, messages: b.messages }));
+      return updateBot(withMascotMotion(state, action.botId, "surprise"), action.botId, (b) => ({ ...b, unread: true }));
+    case "botPatched": {
+      const before = state.bots.find((b) => b.id === action.bot.id);
+      const kind =
+        action.bot.unread && !before?.unread
+          ? "surprise"
+          : action.bot.busy === true && !before?.busy
+            ? "working"
+            : action.bot.busy === false && before?.busy
+              ? "celebrate"
+              : null;
+      const next = kind ? withMascotMotion(state, action.bot.id, kind) : state;
+      return updateBot(next, action.bot.id, (b) => ({ ...b, ...action.bot, messages: b.messages }));
+    }
     case "messageAdded": {
       const bot = state.bots.find((b) => b.threadId === action.threadId);
       if (!bot) return state;
@@ -195,17 +239,39 @@ function reducer(state: AppState, action: Action): AppState {
           ? b
           : { ...b, messages: [...b.messages, action.message] },
       );
+      const motion =
+        action.message.kind === "options"
+          ? "thinking"
+          : action.message.kind === "activity"
+            ? action.message.tool?.ok === false
+              ? "failure"
+              : action.message.tool?.ok === true
+                ? "success"
+                : "working"
+            : action.message.role === "bot" && action.message.kind === "text"
+              ? "blink"
+              : null;
+      const animated = motion ? withMascotMotion(next, bot.id, motion) : next;
       // a settled assistant bubble replaces the in-flight stream
       if (action.message.role === "bot" && action.message.kind === "text") {
-        const { [action.threadId]: _, ...rest } = next.streaming;
-        return { ...next, streaming: rest };
+        const { [action.threadId]: _, ...rest } = animated.streaming;
+        return { ...animated, streaming: rest };
       }
-      return next;
+      return animated;
     }
     case "messagePatched": {
       const bot = state.bots.find((b) => b.threadId === action.threadId);
       if (!bot) return state;
-      return updateBot(state, bot.id, (b) => ({
+      const motion =
+        action.message.kind === "activity"
+          ? action.message.tool?.ok === false
+            ? "failure"
+            : action.message.tool?.ok === true
+              ? "success"
+              : "working"
+          : null;
+      const next = motion ? withMascotMotion(state, bot.id, motion) : state;
+      return updateBot(next, bot.id, (b) => ({
         ...b,
         messages: b.messages.map((m) => (m.id === action.message.id ? action.message : m)),
       }));
@@ -224,18 +290,26 @@ function reducer(state: AppState, action: Action): AppState {
     }
     case "screenFrame":
       return {
-        ...state,
+        ...withMascotMotion(state, action.botId, "success"),
         screens: { ...state.screens, [action.botId]: { png: action.png, mime: action.mime } },
         provisioning: { ...state.provisioning, [action.botId]: false },
       };
     case "provisioning":
-      return { ...state, provisioning: { ...state.provisioning, [action.botId]: action.on } };
+      return {
+        ...(action.on ? withMascotMotion(state, action.botId, "launch") : state),
+        provisioning: { ...state.provisioning, [action.botId]: action.on },
+      };
     case "setModel":
       return updateBot(state, action.botId, (b) => ({ ...b, modelSelection: action.selection }));
     case "connected":
       return { ...state, connected: action.value };
     case "error":
-      return { ...state, error: action.message };
+      return {
+        ...(action.message && state.selectedId
+          ? withMascotMotion(state, state.selectedId, "alert")
+          : state),
+        error: action.message,
+      };
     // bot settings, the computer panel, and app settings share the right slot
     case "toggleSettings": {
       const open = action.open ?? !state.settingsOpen;
@@ -267,10 +341,20 @@ function reducer(state: AppState, action: Action): AppState {
         pluginsOpen: open ? false : state.pluginsOpen,
       };
     }
-    case "updateBot":
-      return updateBot(state, action.botId, (b) => ({ ...b, ...action.patch }));
+    case "previewMascotMotion":
+      return withMascotMotion(state, action.botId, action.kind);
+    case "updateBot": {
+      const mascotChanged =
+        Object.prototype.hasOwnProperty.call(action.patch, "color") ||
+        Object.prototype.hasOwnProperty.call(action.patch, "mascotExpression");
+      const next = mascotChanged
+        ? withMascotMotion(state, action.botId, "customize")
+        : state;
+      return updateBot(next, action.botId, (b) => ({ ...b, ...action.patch }));
+    }
     // handled entirely by the async wrapper
     case "send":
+      return withMascotMotion(state, action.botId, "working");
     case "newBot":
     case "duplicateBot":
     case "interrupt":
@@ -292,6 +376,7 @@ const initialState: AppState = {
   provisioning: {},
   connected: false,
   error: null,
+  mascotMotion: null,
 };
 
 // ── API client ─────────────────────────────────────────────────────────

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,3 +61,468 @@ body {
   from { transform: scale(0.96) translateY(6px); opacity: 0; }
   to { transform: scale(1) translateY(0); opacity: 1; }
 }
+
+/* SupaMaus vector motion. The fast horizontal compression is the edge-on
+   moment of a turn; face parallax, surface lighting, and orbiting vector marks
+   sell the 3D rotation without duplicate silhouettes, raster frames, or WebGL. */
+.maus-character,
+.maus-orbit,
+.maus-face,
+.maus-solid,
+.maus-eyes,
+.maus-fx {
+  transform-box: view-box;
+  transform-origin: 100px 100px;
+}
+
+.maus-orbit,
+.maus-fx {
+  opacity: 0;
+}
+
+.maus-character {
+  transform-style: preserve-3d;
+}
+
+.maus-bevel,
+.maus-rim-light {
+  pointer-events: none;
+}
+
+.maus-specular {
+  opacity: 0.3;
+}
+
+.maus-eyes {
+  transform: translate(var(--maus-eye-x), var(--maus-eye-y));
+  transition: transform 150ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.maus-fx {
+  pointer-events: none;
+}
+
+.maus-ribbon,
+.maus-burst-ray {
+  fill: none;
+  stroke-linecap: round;
+}
+
+.maus-ribbon {
+  stroke-width: 4;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+}
+
+.maus-ribbon--two { stroke-width: 2.4; }
+.maus-ribbon--three { stroke-width: 3; }
+
+.maus-burst-dot,
+.maus-burst-ray,
+.maus-ellipsis-dot {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.maus-burst-ray {
+  stroke-width: 3;
+}
+
+.maus-speed-line {
+  fill: none;
+  stroke: var(--maus-color);
+  stroke-linecap: round;
+  stroke-width: 3.5px;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+}
+
+.maus-speed-line--two {
+  stroke: #fcfcfc;
+  stroke-width: 2.5px;
+}
+
+.maus-motion--arrive .maus-character {
+  animation: maus-arrive 940ms cubic-bezier(0.2, 0.82, 0.22, 1) both;
+}
+
+.maus-motion--switch .maus-character {
+  animation: maus-switch 760ms cubic-bezier(0.2, 0.74, 0.16, 1) both;
+}
+
+.maus-motion--customize .maus-character {
+  animation: maus-customize 720ms cubic-bezier(0.18, 0.78, 0.2, 1) both;
+}
+
+.maus-motion--switch .maus-face,
+.maus-motion--customize .maus-face {
+  animation: maus-face-parallax 760ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.maus-motion--arrive .maus-face {
+  animation-name: maus-face-arrive;
+  animation-duration: 940ms;
+}
+
+.maus-motion--arrive .maus-specular,
+.maus-motion--switch .maus-specular,
+.maus-motion--customize .maus-specular,
+.maus-motion--success .maus-specular,
+.maus-motion--celebrate .maus-specular {
+  animation: maus-specular-sweep 760ms ease-out both;
+}
+
+.maus-motion--arrive .maus-specular { animation-duration: 940ms; }
+
+.maus-motion--arrive .maus-orbit,
+.maus-motion--switch .maus-orbit,
+.maus-motion--customize .maus-orbit {
+  animation: maus-orbit-turn 760ms cubic-bezier(0.24, 0.76, 0.3, 1) both;
+}
+
+.maus-motion--arrive .maus-orbit {
+  animation-duration: 940ms;
+}
+
+.maus-motion--arrive .maus-speed-line,
+.maus-motion--switch .maus-speed-line,
+.maus-motion--customize .maus-speed-line {
+  animation: maus-line-draw 760ms ease-out both;
+}
+
+.maus-motion--arrive .maus-speed-line {
+  animation-duration: 940ms;
+}
+
+.maus-motion--arrive .maus-orbit-dot,
+.maus-motion--switch .maus-orbit-dot,
+.maus-motion--customize .maus-orbit-dot {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: maus-dot-pop 760ms ease-out both;
+}
+
+.maus-motion--arrive .maus-orbit-dot {
+  animation-duration: 940ms;
+}
+
+.maus-orbit-dot--two { animation-delay: 45ms !important; }
+.maus-orbit-dot--three { animation-delay: 85ms !important; }
+
+.maus-motion--alert .maus-character {
+  animation: maus-alert-body 1050ms cubic-bezier(0.18, 0.78, 0.18, 1) both;
+}
+
+.maus-motion--alert .maus-fx--alert {
+  animation: maus-alert-symbol 1050ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.maus-motion--thinking .maus-character {
+  animation: maus-thinking-body 1300ms cubic-bezier(0.2, 0.76, 0.18, 1) both;
+}
+
+.maus-motion--thinking .maus-fx--ellipsis {
+  animation: maus-ellipsis-stage 1300ms ease-in-out both;
+}
+
+.maus-motion--thinking .maus-ellipsis-dot {
+  animation: maus-ellipsis-dot 1300ms ease-in-out both;
+}
+
+.maus-motion--thinking .maus-ellipsis-dot--two { animation-delay: 70ms; }
+.maus-motion--thinking .maus-ellipsis-dot--three { animation-delay: 140ms; }
+
+.maus-motion--working .maus-character {
+  animation: maus-working-body 1150ms ease-in-out infinite;
+}
+
+.maus-motion--working .maus-orbit {
+  animation: maus-working-orbit 1150ms linear infinite;
+}
+
+.maus-motion--working .maus-orbit-dot {
+  animation: maus-working-dot 1150ms ease-in-out infinite;
+}
+
+.maus-motion--launch .maus-character {
+  animation: maus-launch-body 1180ms cubic-bezier(0.2, 0.8, 0.18, 1) both;
+}
+
+.maus-motion--launch .maus-fx--ribbons {
+  animation: maus-ribbon-stage 1180ms ease-out both;
+}
+
+.maus-motion--launch .maus-ribbon {
+  animation: maus-ribbon-draw 1180ms ease-out both;
+}
+
+.maus-motion--success .maus-character {
+  animation: maus-success-body 900ms cubic-bezier(0.18, 0.8, 0.2, 1) both;
+}
+
+.maus-motion--celebrate .maus-character {
+  animation: maus-celebrate-body 1250ms cubic-bezier(0.2, 0.82, 0.18, 1) both;
+}
+
+.maus-motion--celebrate .maus-fx--burst {
+  animation: maus-burst-stage 1250ms ease-out both;
+}
+
+.maus-motion--celebrate .maus-burst-dot,
+.maus-motion--celebrate .maus-burst-ray {
+  animation: maus-burst-piece 1250ms ease-out both;
+}
+
+.maus-motion--celebrate .maus-burst-dot--one { --maus-burst-x: -34px; --maus-burst-y: -27px; }
+.maus-motion--celebrate .maus-burst-dot--two { --maus-burst-x: 38px; --maus-burst-y: -19px; }
+.maus-motion--celebrate .maus-burst-dot--three { --maus-burst-x: 33px; --maus-burst-y: 31px; }
+.maus-motion--celebrate .maus-burst-dot--four { --maus-burst-x: -39px; --maus-burst-y: 22px; }
+
+.maus-motion--blink .maus-eyes {
+  animation: maus-blink-eyes 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.maus-motion--surprise .maus-character {
+  animation: maus-surprise-body 820ms cubic-bezier(0.2, 0.82, 0.2, 1) both;
+}
+
+.maus-motion--surprise .maus-eyes {
+  animation: maus-surprise-eyes 820ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.maus-motion--failure .maus-character {
+  animation: maus-failure-body 980ms cubic-bezier(0.22, 0.76, 0.2, 1) both;
+}
+
+.maus-motion--failure .maus-fx--alert {
+  animation: maus-failure-mark 980ms ease-out both;
+}
+
+@keyframes maus-arrive {
+  0% {
+    opacity: 0;
+    transform: perspective(180px) translate3d(34px, 5px, 0) rotateY(78deg) rotateZ(42deg) scale(0.28, 0.68);
+  }
+  18% {
+    opacity: 1;
+    transform: perspective(180px) translate3d(15px, -3px, 8px) rotateY(58deg) rotateZ(24deg) scale(0.58, 1.1);
+  }
+  46% {
+    transform: perspective(180px) translate3d(-4px, -3px, 13px) rotateY(-13deg) rotateZ(-8deg) scale(1.09, 0.91);
+  }
+  68% {
+    transform: perspective(180px) translate3d(2px, 1px, -3px) rotateY(7deg) rotateZ(3deg) scale(0.96, 1.04);
+  }
+  84% {
+    transform: perspective(180px) translate3d(-1px, 0, 1px) rotateY(-3deg) rotateZ(-1deg) scale(1.02, 0.985);
+  }
+  100% {
+    opacity: 1;
+    transform: perspective(180px) translate3d(0, 0, 0) rotateY(0) rotateZ(0) scale(1);
+  }
+}
+
+@keyframes maus-switch {
+  0% { transform: perspective(180px) translate3d(0, 0, 0) rotateY(0) rotateZ(0) scale(1); }
+  13% { transform: perspective(180px) translate3d(-3px, 1px, 4px) rotateY(-12deg) rotateZ(-5deg) scale(1.08, 0.91); }
+  35% { transform: perspective(180px) translate3d(8px, -2px, 10px) rotateY(76deg) rotateZ(13deg) scale(0.42, 1.06); }
+  53% { transform: perspective(180px) translate3d(-4px, -2px, 7px) rotateY(-24deg) rotateZ(-7deg) scale(0.82, 0.96); }
+  70% { transform: perspective(180px) translate3d(2px, 1px, -3px) rotateY(10deg) rotateZ(3deg) scale(1.07, 0.93); }
+  86% { transform: perspective(180px) translate3d(-1px, 0, 1px) rotateY(-4deg) rotateZ(-1deg) scale(0.975, 1.025); }
+  100% { transform: perspective(180px) translate3d(0, 0, 0) rotateY(0) rotateZ(0) scale(1); }
+}
+
+@keyframes maus-customize {
+  0% { transform: perspective(180px) translate3d(0, 0, 0) rotateY(0) rotateZ(0) scale(1); }
+  18% { transform: perspective(180px) translate3d(-4px, 1px, 5px) rotateY(-16deg) rotateZ(-7deg) scale(1.12, 0.88); }
+  38% { transform: perspective(180px) translate3d(7px, -3px, 11px) rotateY(74deg) rotateZ(12deg) scale(0.44, 1.08); }
+  57% { transform: perspective(180px) translate3d(-3px, -1px, 7px) rotateY(-23deg) rotateZ(-5deg) scale(1.08, 0.92); }
+  77% { transform: perspective(180px) translate3d(1px, 1px, -2px) rotateY(8deg) rotateZ(2deg) scale(0.97, 1.03); }
+  100% { transform: perspective(180px) translate3d(0, 0, 0) rotateY(0) rotateZ(0) scale(1); }
+}
+
+@keyframes maus-face-parallax {
+  0%, 12% { opacity: 1; transform: translateX(0); }
+  31% { opacity: 0.35; transform: translateX(-11px) scaleX(0.45); }
+  41% { opacity: 0; transform: translateX(-16px) scaleX(0.1); }
+  50% { opacity: 0; transform: translateX(14px) scaleX(0.12); }
+  62% { opacity: 1; transform: translateX(5px) scaleX(0.82); }
+  100% { opacity: 1; transform: translateX(0) scaleX(1); }
+}
+
+@keyframes maus-face-arrive {
+  0%, 19% { opacity: 0; transform: translateX(12px) scaleX(0.2); }
+  38% { opacity: 0.72; transform: translateX(5px) scaleX(0.7); }
+  58%, 100% { opacity: 1; transform: translateX(0) scaleX(1); }
+}
+
+@keyframes maus-specular-sweep {
+  0%, 100% { opacity: 0.3; translate: 0 0; }
+  18% { opacity: 0.54; translate: -5px -2px; }
+  38% { opacity: 0.92; translate: 34px 12px; }
+  57% { opacity: 0.2; translate: -18px 7px; }
+  78% { opacity: 0.38; translate: 4px 0; }
+}
+
+@keyframes maus-orbit-turn {
+  0%, 8% { opacity: 0; transform: rotate(-46deg) scale(0.62); }
+  25% { opacity: 0.9; }
+  66% { opacity: 0.72; transform: rotate(34deg) scale(1.04); }
+  100% { opacity: 0; transform: rotate(74deg) scale(1.18); }
+}
+
+@keyframes maus-line-draw {
+  0%, 12% { stroke-dashoffset: 1; opacity: 0; }
+  36% { stroke-dashoffset: 0.38; opacity: 0.9; }
+  68% { stroke-dashoffset: 0; opacity: 0.48; }
+  100% { stroke-dashoffset: -1; opacity: 0; }
+}
+
+@keyframes maus-dot-pop {
+  0%, 10% { opacity: 0; transform: scale(0.15); }
+  35% { opacity: 1; transform: scale(1.15); }
+  65% { opacity: 0.75; transform: scale(0.82); }
+  100% { opacity: 0; transform: scale(0.1); }
+}
+
+@keyframes maus-alert-body {
+  0%, 100% { opacity: 1; transform: perspective(180px) scale(1) rotateZ(0); }
+  16% { transform: perspective(180px) scale(1.12, 0.86) rotateZ(-6deg); }
+  34%, 57% { opacity: 0.08; transform: perspective(180px) scale(0.09, 0.82) rotateZ(2deg); }
+  72% { opacity: 1; transform: perspective(180px) scale(1.1, 0.9) rotateZ(5deg); }
+  86% { transform: perspective(180px) scale(0.96, 1.04) rotateZ(-2deg); }
+}
+
+@keyframes maus-alert-symbol {
+  0%, 22%, 66%, 100% { opacity: 0; transform: translateY(8px) scale(0.3); }
+  37% { opacity: 1; transform: translateY(-3px) scale(1.08); }
+  51% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes maus-thinking-body {
+  0%, 100% { opacity: 1; transform: scale(1) rotateZ(0); }
+  16% { transform: scale(1.08, 0.9) rotateZ(-5deg); }
+  31%, 65% { opacity: 0.2; transform: translateY(2px) scale(0.13); }
+  78% { opacity: 1; transform: scale(1.08, 0.92) rotateZ(4deg); }
+  90% { transform: scale(0.97, 1.03) rotateZ(-1deg); }
+}
+
+@keyframes maus-ellipsis-stage {
+  0%, 19%, 73%, 100% { opacity: 0; }
+  32%, 63% { opacity: 1; }
+}
+
+@keyframes maus-ellipsis-dot {
+  0%, 18%, 74%, 100% { opacity: 0; transform: translateY(8px) scale(0.25); }
+  35% { opacity: 1; transform: translateY(-3px) scale(1.12); }
+  48%, 62% { opacity: 0.78; transform: translateY(0) scale(0.88); }
+}
+
+@keyframes maus-working-body {
+  0%, 100% { transform: perspective(180px) translateY(0) rotateY(-8deg) rotateZ(-2deg) scale(0.98); }
+  50% { transform: perspective(180px) translateY(-3px) rotateY(12deg) rotateZ(3deg) scale(1.03); }
+}
+
+@keyframes maus-working-orbit {
+  0% { opacity: 0.18; transform: rotate(0deg) scale(0.78); }
+  45% { opacity: 0.9; }
+  100% { opacity: 0.18; transform: rotate(360deg) scale(1.08); }
+}
+
+@keyframes maus-working-dot {
+  0%, 100% { opacity: 0.32; transform: scale(0.65); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+@keyframes maus-launch-body {
+  0%, 100% { opacity: 1; transform: translate(0, 0) rotateZ(0) scale(1); }
+  16% { transform: translate(-5px, 2px) rotateZ(-9deg) scale(1.13, 0.86); }
+  31% { opacity: 0.72; transform: translate(-7px, 5px) rotateZ(-16deg) scale(0.16); }
+  48% { opacity: 0.95; transform: translate(24px, -12px) rotateZ(18deg) scale(0.45); }
+  66% { transform: translate(-3px, -2px) rotateZ(-6deg) scale(1.13, 0.9); }
+  84% { transform: translate(1px, 1px) rotateZ(2deg) scale(0.97, 1.03); }
+}
+
+@keyframes maus-ribbon-stage {
+  0%, 16%, 72%, 100% { opacity: 0; transform: rotate(-15deg) scale(0.65); }
+  32%, 58% { opacity: 0.92; transform: rotate(3deg) scale(1); }
+}
+
+@keyframes maus-ribbon-draw {
+  0%, 14% { opacity: 0; stroke-dashoffset: 1; }
+  45% { opacity: 1; stroke-dashoffset: 0; }
+  70%, 100% { opacity: 0; stroke-dashoffset: -1; }
+}
+
+@keyframes maus-success-body {
+  0%, 100% { transform: translateY(0) rotateZ(0) scale(1); }
+  20% { transform: translateY(4px) rotateZ(-5deg) scale(1.12, 0.82); }
+  46% { transform: translateY(-8px) rotateZ(5deg) scale(0.91, 1.13); }
+  68% { transform: translateY(1px) rotateZ(-2deg) scale(1.05, 0.95); }
+  84% { transform: translateY(-1px) scale(0.98, 1.02); }
+}
+
+@keyframes maus-celebrate-body {
+  0%, 100% { transform: perspective(180px) translateY(0) rotateY(0) rotateZ(0) scale(1); }
+  17% { transform: perspective(180px) translateY(5px) rotateY(-13deg) rotateZ(-8deg) scale(1.14, 0.84); }
+  42% { transform: perspective(180px) translateY(-10px) rotateY(22deg) rotateZ(13deg) scale(0.88, 1.15); }
+  66% { transform: perspective(180px) translateY(0) rotateY(-8deg) rotateZ(-4deg) scale(1.08, 0.94); }
+  84% { transform: perspective(180px) translateY(-2px) rotateY(3deg) rotateZ(2deg) scale(0.98, 1.02); }
+}
+
+@keyframes maus-burst-stage {
+  0%, 16%, 82%, 100% { opacity: 0; transform: scale(0.4) rotate(-16deg); }
+  34% { opacity: 1; transform: scale(1.12) rotate(4deg); }
+  64% { opacity: 0.68; transform: scale(1.28) rotate(12deg); }
+}
+
+@keyframes maus-burst-piece {
+  0%, 18% { opacity: 0; transform: translate(0, 0) scale(0.25); }
+  42% { opacity: 1; transform: translate(var(--maus-burst-x, 0), var(--maus-burst-y, 0)) scale(1.12); }
+  72%, 100% { opacity: 0; transform: translate(var(--maus-burst-x, 0), var(--maus-burst-y, 0)) scale(0.4); }
+}
+
+@keyframes maus-blink-eyes {
+  0%, 20%, 48%, 72%, 100% { transform: translate(var(--maus-eye-x), var(--maus-eye-y)) scaleY(1); }
+  34%, 60% { transform: translate(var(--maus-eye-x), var(--maus-eye-y)) scaleY(0.08); }
+}
+
+@keyframes maus-surprise-body {
+  0%, 100% { transform: translateY(0) scale(1); }
+  24% { transform: translateY(3px) scale(1.12, 0.86); }
+  48% { transform: translateY(-5px) scale(0.92, 1.16); }
+  72% { transform: translateY(1px) scale(1.05, 0.96); }
+}
+
+@keyframes maus-surprise-eyes {
+  0%, 100% { transform: translate(var(--maus-eye-x), var(--maus-eye-y)) scale(1); }
+  32%, 60% { transform: translate(var(--maus-eye-x), calc(var(--maus-eye-y) - 4px)) scale(1.24, 1.62); }
+  78% { transform: translate(var(--maus-eye-x), var(--maus-eye-y)) scale(0.94, 0.88); }
+}
+
+@keyframes maus-failure-body {
+  0%, 100% { opacity: 1; transform: translate(0, 0) rotateZ(0) scale(1); }
+  18% { transform: translate(-4px, 2px) rotateZ(-8deg) scale(1.08, 0.88); }
+  38% { opacity: 0.82; transform: translate(5px, 3px) rotateZ(19deg) scale(0.42, 1.08); }
+  55% { transform: translate(-7px, 1px) rotateZ(-13deg) scale(0.78, 0.94); }
+  72% { transform: translate(4px, 0) rotateZ(7deg) scale(1.08, 0.92); }
+  86% { transform: translate(-1px, 0) rotateZ(-2deg) scale(0.98, 1.02); }
+}
+
+@keyframes maus-failure-mark {
+  0%, 26%, 72%, 100% { opacity: 0; transform: translate(18px, -15px) scale(0.2); }
+  43%, 58% { opacity: 1; transform: translate(18px, -15px) scale(0.42); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maus-motion *,
+  .maus-motion {
+    animation: none !important;
+  }
+
+  .maus-orbit {
+    display: none;
+  }
+
+  .maus-eyes { transform: none; }
+}


### PR DESCRIPTION
## What changed

- Replaced the flat bot mascot rendering with a reusable pure-SVG Maus component based on the existing SupaMaus silhouette.
- Added 10 colors, 10 expressions, responsive pointer-following eyes, dimensional lighting, and a seamless single-surface body with no duplicate rear layer.
- Added 12 vector motion states: arrive, switch, customize, alert, thinking, working, launch, success, celebrate, blink, surprise, and failure.
- Wired motion states to bot creation, selection, customization, provisioning, task progress, replies, success, failure, and unread updates.
- Added motion preview controls in bot settings and applied the mascot consistently across the sidebar and chat header.
- Memoized avatars and conditionally mounted motion effects to keep idle DOM and animation overhead low; reduced-motion preferences are respected.

## Why

The bot mascots needed to match the SupaMaus cursor identity, communicate bot state through expressive vector motion, and remain visually seamless and lightweight at every avatar size.

## How it was verified

- `pnpm typecheck`
- `pnpm test` — 51 tests passed
- `pnpm build`
- Manually verified sidebar, chat header, settings, expression states, pointer-following eyes, and all motion previews in the local browser.

## Screenshots (UI changes)

The motion system was reviewed locally through the dedicated mascot preview page. The temporary preview page is intentionally not included in this production PR.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (no server behavior changed)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no platform-specific code added
- [x] No secrets in logs, responses, events, or argv
