### PR TITLE
Find the user's CLIs: resolve the login shell PATH at harness startup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import type { RuntimeEvent } from "./contracts.ts";
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
+import { ensureUserPath } from "./login-path.ts";
 import { Store, type Message } from "./store.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
@@ -29,6 +30,9 @@ const MIME: Record<string, string> = {
   ".woff2": "font/woff2",
 };
 
+// before anything probes or spawns a CLI: the packaged app is launched by
+// launchd, so without this the drivers only ever see /usr/bin:/bin:/usr/sbin:/sbin
+await ensureUserPath();
 ensureDirs();
 const cfg = loadConfig();
 const registry = new ProviderRegistry(BUILT_IN_DRIVERS);

--- a/server/login-path.test.ts
+++ b/server/login-path.test.ts
@@ -1,0 +1,115 @@
+// The bug this guards against is silent and total: with the launchd PATH
+// every driver reports its CLI missing on a machine where that CLI runs
+// fine in Terminal. So the contract is (a) the merge never loses an entry
+// the process already had, (b) a shell that hangs, dies or chatters can't
+// take the harness down or leave PATH worse than it was, and (c) the
+// probe really does read the login shell — proven against a real one.
+import { delimiter } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureUserPath, extractPath, loginShellPath, mergePath, type ProbeRunner } from "./login-path.ts";
+
+const LAUNCHD_PATH = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(delimiter);
+const posixOnly = process.platform === "win32" ? it.skip : it;
+
+const originalPath = process.env.PATH;
+afterEach(() => {
+  process.env.PATH = originalPath;
+});
+
+/** A shell that answers with `path`, wrapped in the noise rc files print. */
+const fakeShell =
+  (path: string): ProbeRunner =>
+  async () =>
+    `Welcome to your shell!\n__OMB_PATH_BEGIN__${path}\n__OMB_PATH_END__`;
+
+describe("mergePath", () => {
+  it("appends the extra entries and keeps the current ones first", () => {
+    expect(mergePath("/usr/bin:/bin", "/opt/homebrew/bin:/Users/x/.local/bin")).toBe(
+      "/usr/bin:/bin:/opt/homebrew/bin:/Users/x/.local/bin",
+    );
+  });
+
+  it("drops duplicates and empty segments", () => {
+    expect(mergePath("/usr/bin::/bin", "/bin:/usr/bin:/opt/homebrew/bin:")).toBe("/usr/bin:/bin:/opt/homebrew/bin");
+  });
+
+  it("survives an empty side", () => {
+    expect(mergePath("", "/opt/homebrew/bin")).toBe("/opt/homebrew/bin");
+    expect(mergePath("/usr/bin", "")).toBe("/usr/bin");
+  });
+});
+
+describe("extractPath", () => {
+  it("reads the PATH out of a chatty login shell", () => {
+    const out = `nvm loaded\n__OMB_PATH_BEGIN__/opt/homebrew/bin:/usr/bin\n__OMB_PATH_END__\nbye\n`;
+    expect(extractPath(out)).toBe("/opt/homebrew/bin:/usr/bin");
+  });
+
+  it("returns null when the sentinels never showed up", () => {
+    expect(extractPath("command not found: printenv\n")).toBeNull();
+    expect(extractPath("__OMB_PATH_BEGIN__/usr/bin")).toBeNull();
+  });
+
+  it("returns null for an empty answer rather than an empty PATH", () => {
+    expect(extractPath("__OMB_PATH_BEGIN__\n__OMB_PATH_END__")).toBeNull();
+  });
+});
+
+describe("ensureUserPath", () => {
+  posixOnly("adds the login shell's directories to the launchd PATH", async () => {
+    process.env.PATH = LAUNCHD_PATH;
+
+    const merged = await ensureUserPath(fakeShell(`${LAUNCHD_PATH}:/Users/x/.local/bin:/opt/homebrew/bin`));
+
+    expect(merged.split(delimiter)).toContain("/Users/x/.local/bin");
+    expect(merged.split(delimiter)).toContain("/opt/homebrew/bin");
+    expect(process.env.PATH).toBe(merged);
+  });
+
+  posixOnly("never drops an entry the process already had", async () => {
+    process.env.PATH = `${LAUNCHD_PATH}:/only/here`;
+
+    const merged = await ensureUserPath(fakeShell("/opt/homebrew/bin"));
+
+    for (const entry of [...LAUNCHD_PATH.split(delimiter), "/only/here"]) {
+      expect(merged.split(delimiter)).toContain(entry);
+    }
+  });
+
+  posixOnly("is idempotent — a second call adds no duplicates", async () => {
+    process.env.PATH = LAUNCHD_PATH;
+    const shell = fakeShell(`${LAUNCHD_PATH}:/opt/homebrew/bin`);
+
+    const once = await ensureUserPath(shell);
+    const twice = await ensureUserPath(shell);
+
+    expect(twice).toBe(once);
+  });
+
+  posixOnly("falls back instead of throwing when the shell fails", async () => {
+    process.env.PATH = LAUNCHD_PATH;
+    const brokenShell: ProbeRunner = async () => {
+      throw new Error("spawn /bin/zsh ETIMEDOUT");
+    };
+
+    const merged = await ensureUserPath(brokenShell);
+
+    expect(merged.split(delimiter)).toEqual(expect.arrayContaining(LAUNCHD_PATH.split(delimiter)));
+  });
+
+  it.skipIf(process.platform !== "win32")("leaves PATH alone on Windows", async () => {
+    process.env.PATH = "C:\\Windows\\system32";
+    expect(await ensureUserPath(fakeShell("/opt/homebrew/bin"))).toBe("C:\\Windows\\system32");
+  });
+});
+
+describe("loginShellPath", () => {
+  // the whole fix rests on this actually working against a real shell
+  posixOnly("reads a delimiter-joined PATH out of the host's login shell", async () => {
+    const path = await loginShellPath();
+
+    expect(path).toBeTruthy();
+    expect(path!.split(delimiter)).toContain("/usr/bin");
+  });
+});

--- a/server/login-path.ts
+++ b/server/login-path.ts
@@ -1,0 +1,107 @@
+// The user's real PATH, recovered once at harness startup.
+//
+// A packaged macOS app is launched by launchd, not by a shell, so it
+// inherits PATH=/usr/bin:/bin:/usr/sbin:/sbin and nothing else. Every
+// driver spawns its CLI by bare name — `spawn(config.cli, …)` with
+// { ...process.env } — so a working install in ~/.local/bin, Homebrew,
+// nvm, pnpm or bun is invisible to the harness and the probe reports
+// "`claude` CLI not found" on a machine where `claude` runs fine in
+// Terminal (#12, #8).
+//
+// The login shell is the only thing that knows where the user put their
+// tools, so ask it: `-l` for the profile files, `-i` because nvm, pyenv
+// and friends usually export from an rc file only interactive shells
+// read. Its stdout is whatever those rc files felt like printing, so the
+// answer comes back between sentinels rather than as "the output", and
+// via `printenv` rather than `$PATH` so shells with list-valued PATH
+// (fish) still hand back a delimiter-joined string.
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const BEGIN = "__OMB_PATH_BEGIN__";
+const END = "__OMB_PATH_END__";
+const PROBE_SCRIPT = `printf %s "${BEGIN}"; printenv PATH; printf %s "${END}"`;
+const PROBE_TIMEOUT_MS = 5_000;
+
+/** Where user-managed CLIs land, for when the shell won't answer. */
+function fallbackDirs(): string[] {
+  const home = homedir();
+  return [
+    join(home, ".local", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    join(home, ".npm-global", "bin"),
+    join(home, ".bun", "bin"),
+    join(home, "Library", "pnpm"),
+    join(home, ".volta", "bin"),
+  ].filter((dir) => existsSync(dir));
+}
+
+/** `current` then `extra`, first occurrence wins, empty segments dropped. */
+export function mergePath(current: string, extra: string): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of [...current.split(delimiter), ...extra.split(delimiter)]) {
+    if (!entry || seen.has(entry)) continue;
+    seen.add(entry);
+    out.push(entry);
+  }
+  return out.join(delimiter);
+}
+
+/** The PATH between the sentinels, or null if the shell talked past them. */
+export function extractPath(output: string): string | null {
+  const start = output.indexOf(BEGIN);
+  if (start === -1) return null;
+  const from = start + BEGIN.length;
+  const end = output.indexOf(END, from);
+  if (end === -1) return null;
+  return output.slice(from, end).trim() || null;
+}
+
+/** Runs the probe. Injectable so tests never depend on the host's rc files. */
+export type ProbeRunner = (shell: string, args: string[]) => Promise<string>;
+
+const runLoginShell: ProbeRunner = async (shell, args) => {
+  const { stdout } = await execFileAsync(shell, args, {
+    encoding: "utf8",
+    timeout: PROBE_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout;
+};
+
+/** The PATH a terminal would have, or null if the shell wouldn't say. */
+export async function loginShellPath(run: ProbeRunner = runLoginShell): Promise<string | null> {
+  const shell = process.env.SHELL || "/bin/sh";
+  try {
+    return extractPath(await run(shell, ["-l", "-i", "-c", PROBE_SCRIPT]));
+  } catch {
+    // missing shell, an rc file that hangs past the timeout, a non-zero
+    // exit — all the same answer here, and the fallback covers it
+    return null;
+  }
+}
+
+/**
+ * Merge the user's real PATH into process.env.PATH, before any driver
+ * probes or spawns. Never throws and never shrinks PATH: a harness that
+ * boots with a worse PATH than it started with would be strictly worse
+ * than one that boots a little slower.
+ */
+export async function ensureUserPath(run?: ProbeRunner): Promise<string> {
+  const current = process.env.PATH ?? "";
+  // POSIX login shells only — Windows inherits a usable PATH from the shell
+  // that started it, and has no `$SHELL -lic` to ask
+  if (process.platform === "win32") return current;
+  const extra = (await loginShellPath(run)) ?? fallbackDirs().join(delimiter);
+  const merged = mergePath(current, extra);
+  process.env.PATH = merged;
+  return merged;
+}


### PR DESCRIPTION
## What changed

`server/login-path.ts` (new) asks the login shell for the PATH it would give a terminal, and `server/index.ts` merges that into `process.env.PATH` once at startup — before `registry.load()` probes any driver.

- `-l -i -c` because the profile files hold Homebrew and the rc files hold nvm/pyenv, and only interactive shells read the latter.
- The answer comes back between sentinels, not as "the output" — rc files print whatever they like.
- It reads `printenv PATH` rather than `$PATH`, so shells with a list-valued PATH (fish) still return a delimiter-joined string.
- 5s timeout; if the shell can't answer, a short list of common install dirs (`~/.local/bin`, `/opt/homebrew/bin`, `~/.bun/bin`, `~/Library/pnpm`, …) stands in.
- The merge only appends and dedupes, so PATH can never come back smaller than it started. `ensureUserPath()` never throws.
- Windows returns early — it inherits a usable PATH from the shell that started it, and has no `$SHELL -lic` to ask.

No `electron/` changes: in the packaged app the harness is the utilityProcess that owns every CLI spawn, so fixing PATH there covers `claude`, `codex` and `grokAgent` at once, and keeps this off the files the in-flight Windows ports are editing.

## Why

A packaged app is launched by launchd, not by a shell, so it inherits `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. Every driver spawns its CLI by bare name — `spawn(config.cli, …)` with `{ ...process.env }` — so a working install in `~/.local/bin`, Homebrew, nvm, pnpm or bun is invisible to the harness. The probe then reports ``​`claude` CLI not found`` on a machine where `claude` runs fine in Terminal.

Fixes #12
Refs #8 — the NVM report is the same root cause (that one also needs `node` on PATH for the `#!/usr/bin/env node` shim, which the login PATH supplies).

## How it was verified

macOS 15 (arm64), Node 24, `claude` 2.1.224 installed at `~/.local/bin/claude`.

`pnpm typecheck` and `pnpm test` pass (62 passed, 1 skipped — the Windows-only case).

Reproduced the exact launchd environment and compared before/after:

```
env -i HOME="$HOME" SHELL=/bin/zsh PATH=/usr/bin:/bin:/usr/sbin:/sbin OMB_PORT=8801 node server/index.ts
curl -s http://127.0.0.1:8801/api/instances
```

before (`main`):

```
claude   unavailable  `claude` CLI not found
```

after:

```
claude   available    2.1.224 (Claude Code)
```

`grok` and `codex` correctly stay `unavailable` — they really aren't installed on this machine.

Probe cost measured at **177 ms**, once per harness boot.

Also ran the probe script directly against every shell on the box:

| shell | result |
| --- | --- |
| zsh, bash, dash, ksh, sh | returns a delimiter-joined PATH |
| tcsh, csh | no sentinels → falls back |

`-i` earns its place: zsh returns 8 directories `-l` alone does not, including `/opt/homebrew/bin` and `~/.npm-global/bin` — where most people's `claude` and `codex` actually live.

### Known limit

When the shell can't answer (csh/tcsh, or an rc file slower than the 5s timeout) the static fallback covers `~/.local/bin`, Homebrew, bun, pnpm and volta, but not the versioned directories of nvm/asdf/mise. A csh user whose CLI came from nvm is still stuck. Resolving those would mean directory scanning plus a "which version" policy per version manager, which felt well above the altitude of this fix — happy to add it if you'd rather cover that case.

New tests in `server/login-path.test.ts` cover the merge (appends, dedupes, never loses an existing entry, idempotent), sentinel extraction out of chatty rc output, the fallback path when the shell throws or times out, the Windows early return, and one case that runs the probe against the host's real login shell — the whole fix rests on that actually working.

## Screenshots (UI changes)

None — server-side only.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
