### PR TITLE
@mention tagging UI + agent-comms test coverage

### DIFF
--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -13,7 +13,7 @@ import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.js";
 import { EventBus } from "./harness/bus.js";
 import { ProviderRegistry } from "./harness/registry.js";
-import { Store } from "./store.js";
+import { mentionedBots, Store } from "./store.js";
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
 const MIME = {
@@ -334,6 +334,12 @@ async function startTurn(botId, text, opts) {
             if (commsDepth < MAX_COMMS_DEPTH && store.bots.filter((b) => b.id !== bot.id && !b.hidden).length > 0) {
                 integrations.agents = agentsIntegration(bot.id, commsDepth);
             }
+            // @mentions in the user's message (the composer's tagging UI) become
+            // an explicit delegation nudge — the agent still does the ask_bot call
+            // itself, so the harness stays the single owner of turns/permissions
+            const tagged = integrations.agents
+                ? mentionedBots(text, store.bots.filter((b) => b.id !== bot.id))
+                : [];
             await instance.adapter.sendTurn({
                 threadId: bot.threadId,
                 text,
@@ -345,7 +351,15 @@ async function startTurn(botId, text, opts) {
                         ? " You have your own cloud computer — use the computer tools (screenshot, computer_exec, open_url) whenever browsing or acting on a desktop helps."
                         : integrations.localComputer
                             ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
-                            : ""),
+                            : "") +
+                    (integrations.agents
+                        ? " You can work with the user's other bots through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
+                        : "") +
+                    (tagged.length
+                        ? ` The user tagged ${tagged
+                            .map((t) => `@${t.name} (ask_bot bot_id ${t.id})`)
+                            .join(" and ")} in their message — bring them in with ask_bot and fold their reply into your answer.`
+                        : ""),
                 integrations,
             });
             if (integrations.computer)

--- a/dist-server/store.js
+++ b/dist-server/store.js
@@ -20,6 +20,27 @@ const COLORS = [
     "teal",
     "coral",
 ];
+/** Resolve @mentions in a message against a bot roster: `@` must start a
+ * word, names match case-insensitively, longest name wins (so "@New Bot 2"
+ * never half-matches "New Bot"), hidden bots skipped, results deduped.
+ * Callers pre-filter the sender out of `peers`. */
+export function mentionedBots(text, peers) {
+    const candidates = peers
+        .filter((p) => !p.hidden && p.name.trim())
+        .sort((a, b) => b.name.length - a.name.length);
+    const lower = text.toLowerCase();
+    const found = [];
+    let at = -1;
+    while ((at = lower.indexOf("@", at + 1)) !== -1) {
+        if (at > 0 && !/\s/.test(text[at - 1]))
+            continue; // user@host, not a tag
+        const rest = lower.slice(at + 1);
+        const hit = candidates.find((p) => rest.startsWith(p.name.toLowerCase()));
+        if (hit && !found.includes(hit))
+            found.push(hit);
+    }
+    return found;
+}
 const onboardingCard = () => ({
     title: "What do you mostly want help with?",
     subtitle: "Pick whatever's closest; we can always expand from there.",

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -1,0 +1,173 @@
+// Agent-to-agent comms, end to end: boots the real harness server with the
+// grokAgent driver pointed at the fake ACP CLI in ask-peer mode, then has
+// bot A's "agent" reach bot B through the injected agents proxy (list_bots →
+// ask_bot → B runs a real depth-1 turn → reply folds back into A's answer).
+// This exercises the whole chain the packaged app uses: startTurn →
+// session/new mcpServers → agents-proxy → /api/internal/ask-bot →
+// askBotAndWait → bus fold. The internal endpoints' auth is pinned too.
+//
+// The fake CLI is a shebang script, so the e2e half is POSIX-only (same
+// gating as acp.test.ts); the mention-resolution unit tests run everywhere.
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { mentionedBots } from "./store.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+describe("mentionedBots", () => {
+  const peers = [
+    { id: "1", name: "New Bot" },
+    { id: "2", name: "New Bot 2" },
+    { id: "3", name: "Milind" },
+    { id: "4", name: "Ghost", hidden: true },
+  ];
+  it("matches a tag at a word start, case-insensitively", () => {
+    expect(mentionedBots("hey @milind, look", peers).map((b) => b.id)).toEqual(["3"]);
+    expect(mentionedBots("@Milind first thing", peers).map((b) => b.id)).toEqual(["3"]);
+  });
+  it("prefers the longest name so prefixes never half-match", () => {
+    expect(mentionedBots("ask @New Bot 2 about it", peers).map((b) => b.id)).toEqual(["2"]);
+  });
+  it("dedupes repeats and collects multiple bots", () => {
+    expect(mentionedBots("@Milind and @New Bot and @Milind", peers).map((b) => b.id)).toEqual(["3", "1"]);
+  });
+  it("ignores emails, hidden bots, and mid-word @", () => {
+    expect(mentionedBots("mail milind@milind.dev please", peers)).toEqual([]);
+    expect(mentionedBots("@Ghost around?", peers)).toEqual([]);
+  });
+});
+
+posixOnly("comms e2e (fake ACP fleet)", () => {
+  let child: ChildProcess;
+  let home: string;
+  let stderr = "";
+
+  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json() };
+  };
+
+  beforeAll(async () => {
+    chmodSync(FAKE_CLI, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-comms-test-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          grok: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "ask-peer" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
+        },
+      }),
+    );
+
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: {
+        ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        HOME: home,
+        USERPROFILE: home,
+        OMB_PORT: String(PORT),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        const res = await fetch(`${BASE}/api/health`);
+        if (res.ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("seals the internal comms endpoints behind the boot token", async () => {
+    const agents = await api("GET", "/api/internal/agents?self=x");
+    expect(agents.status).toBe(401);
+    const ask = await api("POST", "/api/internal/ask-bot", { toBotId: "x", message: "hi" });
+    expect(ask.status).toBe(401);
+  });
+
+  it(
+    "carries a question from bot A through the agents proxy to bot B and back",
+    async () => {
+      // deterministic roster: hide the seeded bot, add Asker + Helper
+      const seeded = (await api("GET", "/api/bots")).body.bots[0];
+      await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
+      const selection = { instanceId: "grok", model: "fake-model" };
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, { name: "Helper", modelSelection: selection });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, { name: "Asker", modelSelection: selection });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, { text: "hey @Helper ping" });
+      expect(send.status).toBe(202);
+
+      // wait for A's turn to settle with the peer's reply folded in
+      const deadline = Date.now() + 25_000;
+      let askerBot: any;
+      for (;;) {
+        askerBot = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        const settled = askerBot.messages.some(
+          (m: any) => m.kind === "text" && m.role === "bot" && m.text?.includes("peer says:"),
+        );
+        if (settled && !askerBot.busy) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `A never got the peer reply. messages: ${JSON.stringify(askerBot.messages.slice(-6))}\nstderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      // A's answer contains B's actual reply, via the proxy's wrapper
+      const reply = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
+      expect(reply.text).toContain("Helper replied:");
+      expect(reply.text).toContain("hello from fake acp"); // B's happy-path turn text
+
+      // visibility: A's thread shows the outbound ask as an activity note
+      const note = askerBot.messages.find((m: any) => m.kind === "activity" && m.tool?.name?.startsWith("asked @Helper"));
+      expect(note).toBeTruthy();
+
+      // B's thread received the attributed message and ran a real turn
+      const helperBot = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === helper.id);
+      const inbound = helperBot.messages.find((m: any) => m.role === "user" && m.kind === "text");
+      expect(inbound.text).toContain("[Message from @Asker");
+      expect(inbound.text).toContain("ping from fake");
+      expect(helperBot.busy).toBeFalsy();
+    },
+    40_000,
+  );
+});

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -1,0 +1,146 @@
+// Contract test for the agent-to-agent comms MCP proxy (agents-proxy.ts):
+// spawn it exactly the way a driver's mcpServers entry does (process.execPath
+// + entry file + env) against a scripted stub of the harness's /api/internal
+// endpoints, and drive the MCP stdio surface end to end. No shebang, no
+// shell — plain node child, so this runs on every OS like index.test.ts.
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const PROXY = join(dirname(fileURLToPath(import.meta.url)), "agents-proxy.ts");
+const TOKEN = "test-comms-token";
+
+// scripted harness stub
+let stub: Server;
+let stubPort = 0;
+let lastAuth: string | undefined;
+let lastAskBody: any = null;
+let askResponse: unknown = { botName: "Helper", text: "hi from helper" };
+
+let child: ChildProcess;
+const pending = new Map<number, (msg: any) => void>();
+let nextId = 100;
+
+function rpc(method: string, params?: unknown): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, resolve);
+    child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    setTimeout(() => {
+      if (pending.delete(id)) reject(new Error(`${method} timed out`));
+    }, 10_000).unref?.();
+  });
+}
+const callTool = (name: string, args: unknown) => rpc("tools/call", { name, arguments: args });
+
+beforeAll(async () => {
+  stub = createServer((req, res) => {
+    lastAuth = req.headers.authorization;
+    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+      res.writeHead(401, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ error: "unauthorized" }));
+    }
+    if (req.method === "GET" && req.url?.startsWith("/api/internal/agents")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(
+        JSON.stringify({
+          bots: [{ id: "bot-helper", name: "Helper", model: "fake-model", busy: false }],
+        }),
+      );
+    }
+    if (req.method === "POST" && req.url === "/api/internal/ask-bot") {
+      let data = "";
+      req.on("data", (c) => (data += c));
+      req.on("end", () => {
+        lastAskBody = JSON.parse(data);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(askResponse));
+      });
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unknown" }));
+  });
+  await new Promise<void>((r) => stub.listen(0, "127.0.0.1", r));
+  stubPort = (stub.address() as { port: number }).port;
+
+  child = spawn(process.execPath, [PROXY], {
+    env: {
+      ...process.env,
+      OMB_HARNESS_URL: `http://127.0.0.1:${stubPort}`,
+      OMB_BOT_ID: "bot-asker",
+      OMB_COMMS_TOKEN: TOKEN,
+      OMB_TURN_DEPTH: "0",
+    },
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+  let buf = "";
+  child.stdout!.on("data", (c) => {
+    buf += c;
+    let nl;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      pending.get(msg.id)?.(msg);
+      pending.delete(msg.id);
+    }
+  });
+});
+
+afterAll(async () => {
+  child?.kill();
+  await new Promise<void>((r) => stub.close(() => r()));
+});
+
+describe("agents-proxy MCP surface", () => {
+  it("answers the MCP handshake and lists both tools", async () => {
+    const init = await rpc("initialize", { protocolVersion: "2024-11-05" });
+    expect(init.result.serverInfo.name).toContain("agents");
+    const list = await rpc("tools/list");
+    expect(list.result.tools.map((t: { name: string }) => t.name)).toEqual(["list_bots", "ask_bot"]);
+  });
+
+  it("list_bots renders the roster and authenticates with the shared token", async () => {
+    const res = await callTool("list_bots", {});
+    const text = res.result.content[0].text;
+    expect(text).toContain("Helper");
+    expect(text).toContain("bot-helper");
+    expect(lastAuth).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("ask_bot forwards sender + depth and returns the reply", async () => {
+    askResponse = { botName: "Helper", text: "hi from helper" };
+    const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
+    expect(res.result.content[0].text).toContain("Helper replied:");
+    expect(res.result.content[0].text).toContain("hi from helper");
+    expect(lastAskBody).toMatchObject({ fromBotId: "bot-asker", toBotId: "bot-helper", message: "ping", depth: 0 });
+  });
+
+  it("renders a busy peer as a clean answer, not an error", async () => {
+    askResponse = { busy: true };
+    const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
+    expect(res.result.content[0].text).toContain("busy");
+    expect(res.result.isError).toBeFalsy();
+  });
+
+  it("surfaces the harness's depth refusal as a tool error", async () => {
+    askResponse = { error: "message chains are limited to one hop" };
+    const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toContain("one hop");
+  });
+
+  it("rejects unknown tools with -32602", async () => {
+    const res = await rpc("tools/call", { name: "made_up", arguments: {} });
+    expect(res.error.code).toBe(-32602);
+  });
+
+  it("requires bot_id and message", async () => {
+    const res = await callTool("ask_bot", { bot_id: "", message: "" });
+    expect(res.result.isError).toBe(true);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,7 @@ import type { RuntimeEvent } from "./contracts.ts";
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
-import { Store, type Message } from "./store.ts";
+import { mentionedBots, Store, type Message } from "./store.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
@@ -348,6 +348,15 @@ async function startTurn(botId: string, text: string, opts?: { commsDepth?: numb
       if (commsDepth < MAX_COMMS_DEPTH && store.bots.filter((b) => b.id !== bot.id && !b.hidden).length > 0) {
         integrations.agents = agentsIntegration(bot.id, commsDepth);
       }
+      // @mentions in the user's message (the composer's tagging UI) become
+      // an explicit delegation nudge — the agent still does the ask_bot call
+      // itself, so the harness stays the single owner of turns/permissions
+      const tagged = integrations.agents
+        ? mentionedBots(
+            text,
+            store.bots.filter((b) => b.id !== bot.id),
+          )
+        : [];
 
       await instance.adapter.sendTurn({
         threadId: bot.threadId,
@@ -361,7 +370,15 @@ async function startTurn(botId: string, text: string, opts?: { commsDepth?: numb
             ? " You have your own cloud computer — use the computer tools (screenshot, computer_exec, open_url) whenever browsing or acting on a desktop helps."
             : integrations.localComputer
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
-              : ""),
+              : "") +
+          (integrations.agents
+            ? " You can work with the user's other bots through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
+            : "") +
+          (tagged.length
+            ? ` The user tagged ${tagged
+                .map((t) => `@${t.name} (ask_bot bot_id ${t.id})`)
+                .join(" and ")} in their message — bring them in with ask_bot and fold their reply into your answer.`
+            : ""),
         integrations,
       });
       if (integrations.computer) startScreenPoller(bot.id);

--- a/server/store.ts
+++ b/server/store.ts
@@ -94,6 +94,26 @@ const COLORS: MausColor[] = [
   "coral",
 ];
 
+/** Resolve @mentions in a message against a bot roster: `@` must start a
+ * word, names match case-insensitively, longest name wins (so "@New Bot 2"
+ * never half-matches "New Bot"), hidden bots skipped, results deduped.
+ * Callers pre-filter the sender out of `peers`. */
+export function mentionedBots<T extends { name: string; hidden?: boolean }>(text: string, peers: T[]): T[] {
+  const candidates = peers
+    .filter((p) => !p.hidden && p.name.trim())
+    .sort((a, b) => b.name.length - a.name.length);
+  const lower = text.toLowerCase();
+  const found: T[] = [];
+  let at = -1;
+  while ((at = lower.indexOf("@", at + 1)) !== -1) {
+    if (at > 0 && !/\s/.test(text[at - 1])) continue; // user@host, not a tag
+    const rest = lower.slice(at + 1);
+    const hit = candidates.find((p) => rest.startsWith(p.name.toLowerCase()));
+    if (hit && !found.includes(hit)) found.push(hit);
+  }
+  return found;
+}
+
 const onboardingCard = (): OptionCardData => ({
   title: "What do you mostly want help with?",
   subtitle: "Pick whatever's closest; we can always expand from there.",

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -6,14 +6,22 @@
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
 //   FAKE_ACP_MODE   happy (default) | exit-early | hang | no-auth | permission
+//                   | ask-peer (spawn the injected "agents" MCP server from
+//                     session/new's mcpServers, call list_bots + ask_bot on a
+//                     peer, and reply with what the peer said — the comms e2e)
 //   FAKE_ACP_DUMP   path to write {argv, env} as JSON, so a test can assert
 //                   argv shape (agent/stdio flags) and env hygiene
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
+import { spawn } from "node:child_process";
 import { writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "happy";
 const argv = process.argv.slice(2);
+if (argv.includes("--version")) {
+  console.log("fake-acp 1.0.0");
+  process.exit(0);
+}
 if (process.env.FAKE_ACP_DUMP) {
   writeFileSync(process.env.FAKE_ACP_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
 }
@@ -24,6 +32,60 @@ const result = (id: unknown, res: unknown) => out({ jsonrpc: "2.0", id, result: 
 // pending server→client permission request id → resolver
 let pendingPermissionId: number | null = null;
 let onPermissionAnswered: (() => void) | null = null;
+
+// ask-peer mode: the "agents" MCP server entry from session/new's mcpServers
+type McpEntry = { command: string; args?: string[]; env?: Array<{ name: string; value: string }> };
+let agentsMcp: McpEntry | null = null;
+
+/** Minimal one-shot MCP stdio client: initialize, call each tool in
+ * sequence, return the text of the last result. Dependency-free. */
+function driveMcp(entry: McpEntry, calls: Array<{ name: string; args: (prev: string) => unknown }>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+    for (const { name, value } of entry.env ?? []) env[name] = value;
+    const child = spawn(entry.command, entry.args ?? [], { env, stdio: ["pipe", "pipe", "inherit"] });
+    child.on("error", reject);
+    const timer = setTimeout(() => (child.kill(), reject(new Error("mcp timeout"))), 60_000);
+    let step = -1; // -1 = initialize in flight
+    let last = "";
+    const write = (obj: unknown) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const next = () => {
+      step += 1;
+      if (step >= calls.length) {
+        clearTimeout(timer);
+        child.kill();
+        return resolve(last);
+      }
+      const call = calls[step];
+      write({ jsonrpc: "2.0", id: step + 2, method: "tools/call", params: { name: call.name, arguments: call.args(last) } });
+    };
+    let buf = "";
+    child.stdout.on("data", (c) => {
+      buf += c;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: any;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg.id === undefined) continue;
+        if (step === -1) {
+          write({ jsonrpc: "2.0", method: "notifications/initialized" });
+          next();
+          continue;
+        }
+        last = String(msg.result?.content?.[0]?.text ?? "");
+        next();
+      }
+    });
+    write({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } });
+  });
+}
 
 function playTurn() {
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "hello from fake acp" } } } });
@@ -71,9 +133,12 @@ function handle(msg: any) {
     case "authenticate":
       result(msg.id, {});
       break;
-    case "session/new":
+    case "session/new": {
+      const servers: McpEntry[] = Array.isArray(msg.params?.mcpServers) ? msg.params.mcpServers : [];
+      agentsMcp = servers.find((s: any) => s?.name === "agents") ?? null;
       result(msg.id, { sessionId: "fake-acp-session" });
       break;
+    }
     case "session/load":
       result(msg.id, {});
       break;
@@ -85,6 +150,27 @@ function handle(msg: any) {
       }
       const complete = () =>
         result(msg.id, { stopReason: "end_turn", _meta: { inputTokens: 10, outputTokens: 5 } });
+      if (mode === "ask-peer" && agentsMcp) {
+        // the comms e2e: reach a peer bot through the injected agents proxy
+        // and reply with whatever it said (the peer's fake runs plain happy
+        // — its depth-1 turn gets no agents server, so no recursion)
+        void driveMcp(agentsMcp, [
+          { name: "list_bots", args: () => ({}) },
+          {
+            name: "ask_bot",
+            args: (list) => ({ bot_id: /id: ([\w-]+)/.exec(list)?.[1] ?? "", message: "ping from fake" }),
+          },
+        ])
+          .then((reply) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `peer says: ${reply}` } } } });
+            complete();
+          })
+          .catch((e) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `peer error: ${(e as Error).message}` } } } });
+            complete();
+          });
+        return;
+      }
       playTurn();
       if (mode === "permission") {
         // ask the client to approve a tool, then complete once answered

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,16 +1,61 @@
 import { track } from "@/lib/analytics";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Plus, Mic, Square } from "lucide-react";
 import { useStore, type Bot } from "@/state/store";
 import { cn } from "@/lib/cn";
+import { MausAvatar } from "./Avatar";
+
+/** The active @mention query at the caret: the text between an `@` that
+ * starts a word and the caret. null = no mention being typed. */
+function mentionQueryAt(text: string, caret: number): { start: number; query: string } | null {
+  const upto = text.slice(0, caret);
+  const at = upto.lastIndexOf("@");
+  if (at === -1) return null;
+  if (at > 0 && !/\s/.test(upto[at - 1])) return null; // user@host, not a tag
+  const query = upto.slice(at + 1);
+  if (query.length > 24 || query.includes("@") || query.includes("\n")) return null;
+  return { start: at, query };
+}
 
 export function Composer({ bot }: { bot: Bot }) {
-  const { dispatch } = useStore();
+  const { state, dispatch } = useStore();
   const [text, setText] = useState("");
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
+  const [caret, setCaret] = useState(0);
+  const [highlight, setHighlight] = useState(0);
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null); // Esc'd this @
+  const inputRef = useRef<HTMLInputElement>(null);
   // what was typed before the mic went on — partials append after it
   const baseText = useRef("");
+
+  // ── @mention picker (tag another bot; the agent reaches it via ask_bot) ──
+  const mention = mentionQueryAt(text, caret);
+  const candidates = useMemo(() => {
+    if (!mention || mention.start === dismissedAt) return [];
+    const q = mention.query.trim().toLowerCase();
+    return state.bots
+      .filter((b) => b.id !== bot.id && !b.hidden)
+      .filter((b) => !q || b.name.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [mention, dismissedAt, state.bots, bot.id]);
+  const pickerOpen = candidates.length > 0;
+
+  useEffect(() => setHighlight(0), [mention?.start, mention?.query]);
+
+  const pickMention = (peer: Bot) => {
+    if (!mention) return;
+    const after = text.slice(caret);
+    const next = `${text.slice(0, mention.start)}@${peer.name} ${after}`;
+    setText(next);
+    const newCaret = mention.start + peer.name.length + 2;
+    setCaret(newCaret);
+    setDismissedAt(null);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(newCaret, newCaret);
+    });
+  };
 
   const send = () => {
     if (!text.trim() || bot.busy) return;
@@ -67,7 +112,27 @@ export function Composer({ bot }: { bot: Bot }) {
           {speechError}
         </div>
       )}
-      <div className="mx-auto flex max-w-[900px] items-center gap-2 rounded-full border border-hairline/40 bg-raised/60 py-2 pl-2 pr-2">
+      <div className="relative mx-auto max-w-[900px]">
+        {pickerOpen && (
+          <div className="absolute bottom-full left-10 z-20 mb-2 w-72 overflow-hidden rounded-xl border border-hairline/40 bg-raised shadow-lg">
+            {candidates.map((peer, i) => (
+              <button
+                key={peer.id}
+                onClick={() => pickMention(peer)}
+                onMouseEnter={() => setHighlight(i)}
+                className={cn(
+                  "flex w-full items-center gap-2.5 px-3 py-2 text-left",
+                  i === highlight ? "bg-raised-hover" : "",
+                )}
+              >
+                <MausAvatar color={peer.color} expression={peer.mascotExpression ?? "friendly"} size={24} />
+                <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{peer.name}</span>
+                <span className="shrink-0 text-xs text-ink-secondary">Agent</span>
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="flex items-center gap-2 rounded-full border border-hairline/40 bg-raised/60 py-2 pl-2 pr-2">
         <button
           className="flex size-8 shrink-0 items-center justify-center rounded-full text-ink-secondary hover:bg-raised hover:text-ink"
           title="Attach"
@@ -75,9 +140,34 @@ export function Composer({ bot }: { bot: Bot }) {
           <Plus size={20} />
         </button>
         <input
+          ref={inputRef}
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => {
+            setText(e.target.value);
+            setCaret(e.target.selectionStart ?? e.target.value.length);
+            setDismissedAt(null);
+          }}
+          onKeyUp={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
+          onClick={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
           onKeyDown={(e) => {
+            if (pickerOpen) {
+              if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                e.preventDefault();
+                const delta = e.key === "ArrowDown" ? 1 : -1;
+                setHighlight((h) => (h + delta + candidates.length) % candidates.length);
+                return;
+              }
+              if (e.key === "Enter" || e.key === "Tab") {
+                e.preventDefault();
+                pickMention(candidates[highlight]);
+                return;
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setDismissedAt(mention?.start ?? null);
+                return;
+              }
+            }
             if (e.key === "Enter") send();
             if (e.key === "Escape" && recording) setRecording(false);
           }}
@@ -108,6 +198,7 @@ export function Composer({ bot }: { bot: Bot }) {
             <Mic size={18} />
           </button>
         )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Front door + test coverage for the agent-to-agent comms layer (7f85af2).

## What
- **Composer @mention picker**: typing `@` pops an agent picker above the composer (mascot avatar + name + "Agent" chip), with arrow-key navigation, Enter/Tab to tag, Esc to dismiss, filtered as you type. Inserts `@Name` into the message.
- **Mention → delegation**: `startTurn` resolves `@mentions` against the bot roster (`mentionedBots` in `store.ts`: word-start only, longest-name-first so "New Bot 2" never half-matches "New Bot", hidden bots skipped, deduped) and adds a system-prompt nudge telling the agent to bring the tagged bot in with `ask_bot`. A general agents-tools hint is added whenever comms is injected.
- **Test coverage for the comms layer**:
  - `agents-proxy.test.ts` — MCP contract for the proxy against a scripted harness stub (handshake, roster rendering, token auth, busy/depth-refusal rendering, arg validation). Node-spawned, runs on all 3 OSes.
  - `comms.test.ts` — `mentionedBots` unit tests (all OSes) + a POSIX e2e that boots the real server on the fake ACP CLI's new `ask-peer` mode and drives the full loop: bot A's agent → injected agents proxy → `/api/internal/ask-bot` → bot B's depth-1 turn → reply folded back into A's answer. Also pins the 401 on unauthenticated internal endpoints.
- `fake-acp-cli.ts` grew `--version` (fast snapshot probes) and the `ask-peer` mode (spawns the session's injected MCP server and round-trips `list_bots` → `ask_bot`).

Suite: 81 tests green locally (macOS). `dist-server/` rebuilt via `pnpm build:server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)