### PR TITLE
Reliability, privacy & CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# least privilege: CI only reads the checkout, it never writes back
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -25,9 +29,9 @@ jobs:
       # tests never launch Electron; skip the binary download
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -151,9 +151,10 @@ ipcMain.handle("perm:open-settings", (_event, pane) => {
     screen: "Privacy_ScreenCapture",
     speech: "Privacy_SpeechRecognition",
   };
-  return shell.openExternal(
-    `x-apple.systempreferences:com.apple.preference.security?${panes[pane] ?? "Privacy"}`,
-  );
+  // own-property lookup only — a renderer-supplied "__proto__"/"constructor"
+  // would otherwise resolve up the prototype chain to a truthy object
+  const anchor = Object.hasOwn(panes, pane) ? panes[pane] : "Privacy";
+  return shell.openExternal(`x-apple.systempreferences:com.apple.preference.security?${anchor}`);
 });
 
 ipcMain.handle("speech:start", (event) => {

--- a/server/atomic.test.ts
+++ b/server/atomic.test.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeFileAtomic } from "./atomic.ts";
+
+describe("writeFileAtomic", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-atomic-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the file", () => {
+    const p = join(dir, "x.json");
+    writeFileAtomic(p, '{"a":1}');
+    expect(readFileSync(p, "utf8")).toBe('{"a":1}');
+  });
+
+  it("replaces existing contents in full", () => {
+    const p = join(dir, "x.json");
+    writeFileAtomic(p, "old-and-longer");
+    writeFileAtomic(p, "new");
+    expect(readFileSync(p, "utf8")).toBe("new");
+  });
+
+  it("leaves no temp files behind", () => {
+    const p = join(dir, "x.json");
+    writeFileAtomic(p, "a");
+    writeFileAtomic(p, "b");
+    expect(readdirSync(dir)).toEqual(["x.json"]);
+  });
+
+  it("preserves unicode across the write", () => {
+    const p = join(dir, "u.json");
+    const s = JSON.stringify({ msg: "café — 日本語 — 🚀" });
+    writeFileAtomic(p, s);
+    expect(readFileSync(p, "utf8")).toBe(s);
+    expect(existsSync(p)).toBe(true);
+  });
+});

--- a/server/atomic.ts
+++ b/server/atomic.ts
@@ -1,0 +1,28 @@
+// Durable, atomic file replace: write to a sibling temp file, fsync it, then
+// rename over the target. rename(2) is atomic on the same filesystem, so a
+// crash or power loss mid-write can never leave a truncated file behind — a
+// reader always sees either the complete old contents or the complete new
+// ones. Without this, an interrupted writeFileSync produces half-written JSON
+// that fails to parse on next boot and is silently treated as empty state.
+import { closeSync, fsyncSync, openSync, renameSync, unlinkSync, writeSync } from "node:fs";
+
+export function writeFileAtomic(path: string, data: string): void {
+  const tmp = `${path}.${process.pid}.tmp`;
+  const fd = openSync(tmp, "w");
+  try {
+    writeSync(fd, data);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  try {
+    renameSync(tmp, path);
+  } catch (e) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw e;
+  }
+}

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -44,6 +44,10 @@ describe("mentionedBots", () => {
     expect(mentionedBots("mail milind@milind.dev please", peers)).toEqual([]);
     expect(mentionedBots("@Ghost around?", peers)).toEqual([]);
   });
+  it("requires a word boundary at the end of the name", () => {
+    expect(mentionedBots("ask @New Bottle about it", peers)).toEqual([]);
+    expect(mentionedBots("@Milindo is someone else", peers)).toEqual([]);
+  });
 });
 
 posixOnly("comms e2e (fake ACP fleet)", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,10 +1,11 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
 //   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
 //     "instances": { "<instanceId>": {"driver":"grok", …} } }
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
+import { readFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { writeFileAtomic } from "./atomic.ts";
 import type { InstanceConfigMap } from "./contracts.ts";
 
 export interface AppConfig {
@@ -67,7 +68,7 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     }
   }
   mkdirSync(DATA_DIR, { recursive: true });
-  writeFileSync(p, JSON.stringify(disk, null, 2));
+  writeFileAtomic(p, JSON.stringify(disk, null, 2));
 }
 
 // Default fleet: one instance per built-in driver (upstream

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -332,6 +332,9 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         };
 
         let buf = "";
+        // decode as UTF-8 across chunk boundaries — a raw `buf += chunk` splits
+        // multibyte characters that straddle two reads and corrupts the text
+        child.stdout.setEncoding("utf8");
         child.stdout.on("data", (chunk) => {
           buf += chunk;
           let nl;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -379,6 +379,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       };
 
       let buf = "";
+      // decode as UTF-8 across chunk boundaries — a raw `buf += chunk` splits
+      // multibyte characters that straddle two reads and corrupts the text
+      child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk) => {
         buf += chunk;
         let nl;

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -110,10 +110,25 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         } catch {}
         appendNative(threadId, { dir: "out", source: "codex.app-server", msg: obj });
       };
-      const request = (method: string, params: unknown) =>
+      const request = (method: string, params: unknown, timeoutMs = 60_000) =>
         new Promise<any>((resolve, reject) => {
           const id = nextId++;
-          rpcPending.set(id, { resolve, reject });
+          // a wedged app-server can accept stdin and never reply; without this
+          // the handshake await hangs forever and the bot stays busy for good
+          const timer = setTimeout(() => {
+            if (rpcPending.delete(id)) reject(new Error(`codex ${method} timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+          if (typeof timer.unref === "function") timer.unref();
+          rpcPending.set(id, {
+            resolve: (v) => {
+              clearTimeout(timer);
+              resolve(v);
+            },
+            reject: (e) => {
+              clearTimeout(timer);
+              reject(e);
+            },
+          });
           send({ jsonrpc: "2.0", id, method, params });
         });
 
@@ -263,6 +278,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       };
 
       let buf = "";
+      // decode as UTF-8 across chunk boundaries — a raw `buf += chunk` splits
+      // multibyte characters that straddle two reads and corrupts the text
+      child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk) => {
         buf += chunk;
         let nl;

--- a/server/index.ts
+++ b/server/index.ts
@@ -129,8 +129,11 @@ function broadcast(payload: unknown) {
 // ── server-side event folding (upstream's ingestion worker, miniature) ──
 // The canonical stream is the source of truth; the persisted transcript
 // and every client view are projections of it.
-const toolMessageByItem = new Map<string, string>(); // itemId -> messageId
-const askMessageByRequest = new Map<string, string>(); // requestId -> messageId
+// keyed by `${threadId}:${itemId}` / `${threadId}:${requestId}` — provider
+// item/request ids are only unique within a thread, so two bots acting at
+// once can collide on a bare id and patch each other's messages.
+const toolMessageByItem = new Map<string, string>(); // threadId:itemId -> messageId
+const askMessageByRequest = new Map<string, string>(); // threadId:requestId -> messageId
 
 bus.subscribe((event: RuntimeEvent) => {
   broadcast({ kind: "runtime", event });
@@ -153,13 +156,14 @@ bus.subscribe((event: RuntimeEvent) => {
       if (event.itemType === "assistant_text") {
         pushMessage({ role: "bot", kind: "text", text: event.text });
       } else if (event.itemType === "tool" && event.itemId) {
-        const messageId = toolMessageByItem.get(event.itemId);
+        const itemKey = `${event.threadId}:${event.itemId}`;
+        const messageId = toolMessageByItem.get(itemKey);
         if (messageId) {
           const patched = store.patchMessage(event.threadId, messageId, {
             tool: { name: store.messagesFor(event.threadId).find((m) => m.id === messageId)?.tool?.name ?? "tool", ok: event.ok },
           });
           if (patched) broadcast({ kind: "message.patch", threadId: event.threadId, message: patched });
-          toolMessageByItem.delete(event.itemId);
+          toolMessageByItem.delete(itemKey);
         }
         // the bot just finished acting — refresh its screen preview now
         pokeScreenPoller(bot.id);
@@ -168,7 +172,7 @@ bus.subscribe((event: RuntimeEvent) => {
     case "item.started":
       if (event.itemType === "tool") {
         const message = pushMessage({ role: "bot", kind: "activity", tool: { name: event.title ?? "tool" } });
-        if (event.itemId) toolMessageByItem.set(event.itemId, message.id);
+        if (event.itemId) toolMessageByItem.set(`${event.threadId}:${event.itemId}`, message.id);
       }
       break;
     case "request.opened": {
@@ -183,11 +187,11 @@ bus.subscribe((event: RuntimeEvent) => {
           requestId: event.requestId,
         },
       });
-      if (event.requestId) askMessageByRequest.set(event.requestId, message.id);
+      if (event.requestId) askMessageByRequest.set(`${event.threadId}:${event.requestId}`, message.id);
       break;
     }
     case "request.resolved": {
-      const messageId = event.requestId ? askMessageByRequest.get(event.requestId) : null;
+      const messageId = event.requestId ? askMessageByRequest.get(`${event.threadId}:${event.requestId}`) : null;
       if (messageId) {
         const existing = store.messagesFor(event.threadId).find((m) => m.id === messageId);
         if (existing?.card && !existing.card.answered) {
@@ -196,7 +200,7 @@ bus.subscribe((event: RuntimeEvent) => {
           });
           if (patched) broadcast({ kind: "message.patch", threadId: event.threadId, message: patched });
         }
-        if (event.requestId) askMessageByRequest.delete(event.requestId);
+        if (event.requestId) askMessageByRequest.delete(`${event.threadId}:${event.requestId}`);
       }
       break;
     }
@@ -420,6 +424,15 @@ function configStatus() {
 async function reloadProviders() {
   bus.detachAll();
   await registry.disposeAll();
+  // disposing kills any in-flight turn, but its completion handler is already
+  // detached — so a bot caught mid-turn would stay `busy: true` forever and
+  // refuse new messages. Clear it here, the same way a restart does.
+  for (const b of store.bots) {
+    if (b.busy) {
+      store.patchBot(b.id, { busy: false });
+      broadcast({ kind: "bot", bot: store.bot(b.id) });
+    }
+  }
   await registry.load(instanceConfigs(cfg));
   bus.attach(registry.instances());
 }
@@ -434,18 +447,33 @@ function json(res: ServerResponse, status: number, body: unknown) {
 function readBody(req: IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = "";
+    let done = false;
+    const fail = (status: number, msg: string) => {
+      if (done) return;
+      done = true;
+      const err = Object.assign(new Error(msg), { status });
+      reject(err);
+    };
     req.on("data", (c) => {
+      if (done) return;
       data += c;
-      if (data.length > 1_000_000) reject(new Error("body too large"));
-    });
-    req.on("end", () => {
-      try {
-        resolve(data ? JSON.parse(data) : {});
-      } catch {
-        reject(new Error("invalid JSON body"));
+      // stop buffering the moment we cross the limit — otherwise a hostile
+      // (or runaway) client keeps growing `data` in memory after the reject
+      if (data.length > 1_000_000) {
+        fail(413, "body too large");
+        req.destroy();
       }
     });
-    req.on("error", reject);
+    req.on("end", () => {
+      if (done) return;
+      try {
+        done = true;
+        resolve(data ? JSON.parse(data) : {});
+      } catch {
+        fail(400, "invalid JSON body");
+      }
+    });
+    req.on("error", (e) => fail(400, e instanceof Error ? e.message : String(e)));
   });
 }
 

--- a/server/store.ts
+++ b/server/store.ts
@@ -2,9 +2,10 @@
 // thread→instance binding and per-instance resume cursors — upstream's
 // ProviderSessionDirectory, recipe step 6: persist the binding from day
 // one). messages-<threadId>.json holds the folded transcript.
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { readFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
+import { writeFileAtomic } from "./atomic.ts";
 import { DATA_DIR } from "./config.ts";
 import { newId, type ModelSelection, type ThreadId } from "./contracts.ts";
 
@@ -95,9 +96,10 @@ const COLORS: MausColor[] = [
 ];
 
 /** Resolve @mentions in a message against a bot roster: `@` must start a
- * word, names match case-insensitively, longest name wins (so "@New Bot 2"
- * never half-matches "New Bot"), hidden bots skipped, results deduped.
- * Callers pre-filter the sender out of `peers`. */
+ * word, the name must end on a word boundary (so "@New Bottle" never matches
+ * "New Bot"), names match case-insensitively, longest name wins (so
+ * "@New Bot 2" never half-matches "New Bot"), hidden bots skipped, results
+ * deduped. Callers pre-filter the sender out of `peers`. */
 export function mentionedBots<T extends { name: string; hidden?: boolean }>(text: string, peers: T[]): T[] {
   const candidates = peers
     .filter((p) => !p.hidden && p.name.trim())
@@ -108,7 +110,12 @@ export function mentionedBots<T extends { name: string; hidden?: boolean }>(text
   while ((at = lower.indexOf("@", at + 1)) !== -1) {
     if (at > 0 && !/\s/.test(text[at - 1])) continue; // user@host, not a tag
     const rest = lower.slice(at + 1);
-    const hit = candidates.find((p) => rest.startsWith(p.name.toLowerCase()));
+    const hit = candidates.find((p) => {
+      const name = p.name.toLowerCase();
+      if (!rest.startsWith(name)) return false;
+      const after = rest[name.length]; // must not run into a longer word
+      return after === undefined || !/[a-z0-9]/i.test(after);
+    });
     if (hit && !found.includes(hit)) found.push(hit);
   }
   return found;
@@ -138,7 +145,7 @@ export class Store {
   }
 
   private saveBots() {
-    writeFileSync(BOTS_FILE, JSON.stringify(this.bots, null, 2));
+    writeFileAtomic(BOTS_FILE, JSON.stringify(this.bots, null, 2));
   }
 
   messagesFor(threadId: string): Message[] {
@@ -158,7 +165,7 @@ export class Store {
     const full: Message = { id: newId(), at: Date.now(), ...message };
     const list = this.messagesFor(threadId);
     list.push(full);
-    writeFileSync(messagesFile(threadId), JSON.stringify(list, null, 2));
+    writeFileAtomic(messagesFile(threadId), JSON.stringify(list, null, 2));
     return full;
   }
 
@@ -167,7 +174,7 @@ export class Store {
     const idx = list.findIndex((m) => m.id === messageId);
     if (idx === -1) return null;
     list[idx] = { ...list[idx], ...patch, card: patch.card ?? list[idx].card };
-    writeFileSync(messagesFile(threadId), JSON.stringify(list, null, 2));
+    writeFileAtomic(messagesFile(threadId), JSON.stringify(list, null, 2));
     return list[idx];
   }
 

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -49,12 +49,16 @@ export function PluginsPanel() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
-  const refreshStatus = useCallback((slugs: string[]) => {
-    if (!slugs.length) return Promise.resolve();
+  const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, { connected: boolean }>> => {
+    if (!slugs.length) return Promise.resolve({});
     setRefreshing(true);
     return api(`/api/connectors?services=${slugs.join(",")}`)
-      .then((r) => setStatus(r.services ?? {}))
-      .catch(() => {})
+      .then((r) => {
+        const services: Record<string, { connected: boolean }> = r.services ?? {};
+        setStatus(services);
+        return services;
+      })
+      .catch(() => ({}))
       .finally(() => setRefreshing(false));
   }, []);
 
@@ -80,11 +84,14 @@ export function PluginsPanel() {
     api(`/api/connectors/${slug}/authorize`, { method: "POST" })
       .then(({ url }) => {
         window.open(url);
-        // the user finishes OAuth in the browser; poll a few times to catch it
+        // the user finishes OAuth in the browser; poll a few times to catch it.
+        // check the freshly-fetched result, not the `status` captured in this
+        // closure — that snapshot never updates, so it would always poll 6×
         let tries = 0;
         const timer = setInterval(() => {
-          void refreshStatus([slug]);
-          if (++tries >= 6 || status[slug]?.connected) clearInterval(timer);
+          void refreshStatus([slug]).then((s) => {
+            if (++tries >= 6 || s[slug]?.connected) clearInterval(timer);
+          });
         }, 5000);
       })
       .catch((e) => setError(e.message))

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,8 +1,10 @@
 // PostHog usage analytics + the email → person identity link.
 // The phc_ token is a write-only public key (safe to ship in the client).
-// Autocapture gives clicks/inputs for free; the named events below are the
-// product funnel. Email submissions call identify(), so PostHog's Persons
-// tab doubles as the collected-email list.
+// Only the named events below are sent — autocapture is OFF on purpose:
+// it would ship the $el_text of clicked elements, and the sidebar/option
+// cards render model output and message previews, so it would leak fragments
+// of private conversations to a third party. Email submissions call
+// identify(), so PostHog's Persons tab doubles as the collected-email list.
 import posthog from "posthog-js";
 
 const TOKEN = "phc_m2hP39w8y2gLPvHgDvSXAu6xcZ3agjf4ruL56rGcMZEe";
@@ -13,7 +15,7 @@ export function initAnalytics() {
   if (ready) return;
   posthog.init(TOKEN, {
     api_host: "https://us.i.posthog.com",
-    autocapture: true,
+    autocapture: false, // never capture clicked-element text (conversation leak)
     capture_pageview: false, // single-window desktop app — no page routes
     person_profiles: "identified_only",
     persistence: "localStorage",


### PR DESCRIPTION
Closes #20.

A batch of reliability, privacy and CI hardening fixes found while reading through the code. All independent of feature work; typecheck is clean and the full suite passes (87 tests, +5 new).

Reviewable as three commits:

### `reliability:` atomic persistence, bounded requests, and lifecycle fixes
- **Atomic writes** — `bots.json` / `messages-*.json` / `config.json` now go through a temp-file + `fsync` + `rename` helper (`server/atomic.ts`), so an interrupted write can never truncate the JSON into silent empty state on next boot.
- **`readBody`** stops buffering and returns `413` past 1 MB (it previously kept concatenating after rejecting), and returns `400` instead of `500` on invalid JSON.
- **`reloadProviders`** clears `busy` on bots caught mid-turn, which `disposeAll` would otherwise strand busy forever.
- **UTF-8** — agent stdout is decoded across chunk boundaries with `setEncoding("utf8")` (claude/codex/acp), fixing corruption of multibyte characters that straddle two reads.
- **Message-map keys** scoped by `threadId` so two bots acting at once can't patch each other's messages.
- **codex JSON-RPC timeout** (60s) so a wedged `app-server` can't hang the turn.
- **`@mention`** requires a word boundary at the end of a name (`@New Bottle` no longer matches `New Bot`).
- **`PluginsPanel`** polls OAuth status off the fresh fetch result instead of a stale closure.
- **`perm:open-settings`** uses an own-property lookup for the pane key.

### `privacy:` disable PostHog autocapture
Autocapture ships the `$el_text` of clicked elements; the sidebar and option cards render model output and message previews, so it would send fragments of private conversations to a third party. Named product events are unchanged.

### `ci:` pin actions to SHAs + least-privilege permissions
Pin `checkout` / `action-setup` / `setup-node` to their v4.4.0 commit and add `permissions: contents: read`.

Tests: `server/atomic.test.ts` (new) and an added `@mention` boundary case. Happy to split into separate PRs if you prefer, and to rebase around the in-flight Windows PRs since a few of these touch the same files.
