### PR TITLE
Add AI Counsel driver (3-stage deliberation via SSE)

### DIFF
--- a/scripts/smoke-ai-counsel.ts
+++ b/scripts/smoke-ai-counsel.ts
@@ -1,0 +1,136 @@
+// End-to-end smoke test for the ai-counsel driver against a live
+// the-ai-counsel backend (jacob-bd/the-ai-counsel, MIT).
+//
+// Run from the OpenMausBot checkout:
+//   AI_COUNSEL_URL=http://server.tail85e19.ts.net:8021 \
+//     node --experimental-strip-types scripts/smoke-ai-counsel.ts
+//
+// Or run on the homelab server itself (where :8020 is local):
+//   AI_COUNSEL_URL=http://127.0.0.1:8020 node --experimental-strip-types scripts/smoke-ai-counsel.ts
+//
+// Note: the smoke uses the local Ollama seat (free, fast) by default so
+// it works without spending OpenRouter credits. Override with
+// AI_COUNSEL_MODEL=openai/gpt-4.1 to use a real model.
+//
+// The script:
+//   1. constructs the driver with AI_COUNSEL_URL
+//   2. asks the counsel for /api/conversations to confirm reachability
+//   3. sends a single turn
+//   4. prints the per-seat assistant_text events as they arrive
+//   5. prints the final synthesis + turn summary
+//   6. exits 0 on success, 1 on failure
+
+import { AiCounselDriver } from "../server/drivers/ai-counsel.ts";
+
+const baseUrl = process.env.AI_COUNSEL_URL ?? "http://127.0.0.1:8020";
+const model = process.env.AI_COUNSEL_MODEL ?? "ollama:hermes3:8b";
+const prompt = process.env.AI_COUNSEL_PROMPT ?? "Reply with exactly: ai-counsel smoke ok";
+
+async function main(): Promise<number> {
+  console.log(`[smoke] baseUrl=${baseUrl} model=${model}`);
+
+  const cfg = AiCounselDriver.decodeConfig({ baseUrl, defaultModel: model });
+  const instance = await AiCounselDriver.create({
+    instanceId: "smoke",
+    displayName: "smoke",
+    environment: {},
+    enabled: true,
+    config: cfg,
+  });
+
+  // 1. reachability
+  const snap = await instance.snapshot();
+  console.log(`[smoke] snapshot: state=${snap.state} reason=${snap.reason ?? "n/a"}`);
+  if (snap.state !== "available") {
+    console.error(`[smoke] counsel unreachable; aborting`);
+    await instance.dispose();
+    return 1;
+  }
+
+  // 2. send turn
+  let synthesis = "";
+  let seats: Array<{ stage: string; model: string; text: string }> = [];
+  let errors: string[] = [];
+  let stopReason: string | null = null;
+  let ok = false;
+  let sessionId: string | null = null;
+  let usageTotal = { input: 0, output: 0 };
+
+  const done = new Promise<void>((resolve) => {
+    // title is on item.started; item.completed carries the same itemId so we
+    // pair them up to get a labeled text for the smoke output.
+    const titles = new Map<string, string>();
+    const unsub = instance.adapter.onEvent((e) => {
+      switch (e.type) {
+        case "session.started":
+          sessionId = e.sessionId;
+          console.log(`[smoke] session.started sessionId=${e.sessionId} model=${e.model}`);
+          break;
+        case "turn.started":
+          console.log(`[smoke] turn.started`);
+          break;
+        case "item.started":
+          if (e.itemId && e.title) titles.set(e.itemId, e.title);
+          break;
+        case "item.completed":
+          if (e.itemType === "assistant_text" && e.itemId) {
+            const title = titles.get(e.itemId) ?? "seat";
+            const stage = title.match(/^(\S+)/)?.[1] ?? "seat";
+            const modelMatch = title.match(/\(([^)]+)\)$/)?.[1] ?? "unknown";
+            seats.push({ stage, model: modelMatch, text: e.text });
+            console.log(`[smoke] ${stage.padEnd(20)} [${modelMatch}] ${e.text.slice(0, 120).replace(/\n/g, "\\n")}${e.text.length > 120 ? "..." : ""}`);
+            // The last assistant_text is the synthesis (stage3)
+            synthesis = e.text;
+          }
+          break;
+        case "thread.token-usage.updated":
+          usageTotal.input += e.input;
+          usageTotal.output += e.output;
+          break;
+        case "turn.completed":
+          ok = e.ok;
+          stopReason = e.stopReason ?? null;
+          break;
+        case "session.exited":
+          console.log(`[smoke] session.exited reason=${e.reason}`);
+          unsub();
+          resolve();
+          break;
+        case "runtime.error":
+          errors.push(e.message);
+          console.error(`[smoke] runtime.error: ${e.message}`);
+          break;
+      }
+    });
+  });
+
+  await instance.adapter.sendTurn({
+    threadId: `smoke-${Date.now()}`,
+    text: prompt,
+    model,
+  });
+  await done;
+  await instance.dispose();
+
+  console.log(`[smoke] seats: ${seats.length} (stage1=${seats.filter(s => s.stage.startsWith("stage1")).length}, stage2=${seats.filter(s => s.stage.startsWith("stage2")).length}, stage3=${seats.filter(s => s.stage.startsWith("stage3")).length})`);
+  console.log(`[smoke] ok=${ok} stopReason=${stopReason}`);
+  console.log(`[smoke] usage: in=${usageTotal.input} out=${usageTotal.output}`);
+  if (errors.length) console.log(`[smoke] errors: ${JSON.stringify(errors)}`);
+  console.log(`[smoke] synthesis: ${JSON.stringify(synthesis.slice(0, 200))}`);
+
+  if (!ok || !synthesis) {
+    console.error(`[smoke] FAILED: ok=${ok} synthesis-empty=${!synthesis}`);
+    return 1;
+  }
+  if (sessionId == null) {
+    console.error(`[smoke] FAILED: no sessionId`);
+    return 1;
+  }
+  console.log(`[smoke] OK`);
+  return 0;
+}
+
+main().then((code) => process.exit(code)).catch((e) => {
+  console.error(`[smoke] crashed:`, e);
+  process.exit(2);
+});

--- a/scripts/smoke-hermes-os.ts
+++ b/scripts/smoke-hermes-os.ts
@@ -1,0 +1,121 @@
+// End-to-end smoke test for the hermes-os driver against a live hub.
+//
+// Run from the OpenMausBot checkout:
+//   HERMES_OS_URL=http://server.tail85e19.ts.net:8001 \
+//     node --experimental-strip-types scripts/smoke-hermes-os.ts
+//
+// Or run on the homelab server itself (where :8001 is local):
+//   HERMES_OS_URL=http://127.0.0.1:8001 node --experimental-strip-types scripts/smoke-hermes-os.ts
+//
+// The script:
+//   1. constructs the driver with HERMES_OS_URL
+//   2. asks the hub for /v1/models to confirm reachability
+//   3. sends a single turn with the default model
+//   4. streams content.delta events to stdout as they arrive
+//   5. prints the final turn summary
+//   6. exits 0 on success, 1 on failure
+//
+// Designed to be safe to run from cron or a watchdog — no side effects,
+// no writes to disk outside the native-log dir.
+
+import { HermesOsDriver } from "../server/drivers/hermes-os.ts";
+
+const baseUrl = process.env.HERMES_OS_URL ?? "http://127.0.0.1:8001";
+const model = process.env.HERMES_OS_MODEL ?? "gemini";
+const prompt = process.env.HERMES_OS_PROMPT ?? "Reply with exactly: hermes-os smoke ok";
+const apiKey = process.env.HUB_API_TOKEN;
+
+async function main(): Promise<number> {
+  console.log(`[smoke] baseUrl=${baseUrl} model=${model} auth=${apiKey ? "yes" : "no"}`);
+
+  const cfg = HermesOsDriver.decodeConfig({ baseUrl, apiKey, defaultModel: model });
+  const instance = await HermesOsDriver.create({
+    instanceId: "smoke",
+    displayName: "smoke",
+    environment: {},
+    enabled: true,
+    config: cfg,
+  });
+
+  // 1. reachability
+  const snap = await instance.snapshot();
+  console.log(`[smoke] snapshot: state=${snap.state} reason=${snap.reason ?? "n/a"}`);
+  if (snap.state !== "available") {
+    console.error(`[smoke] hub unreachable; aborting`);
+    await instance.dispose();
+    return 1;
+  }
+
+  // 2. send turn
+  let text = "";
+  let deltas = 0;
+  let usage: { input: number; output: number } | null = null;
+  let stopReason: string | null = null;
+  let ok = false;
+  let errors: string[] = [];
+  let sessionId: string | null = null;
+
+  const done = new Promise<void>((resolve) => {
+    const unsub = instance.adapter.onEvent((e) => {
+      switch (e.type) {
+        case "session.started":
+          sessionId = e.sessionId;
+          console.log(`[smoke] session.started sessionId=${e.sessionId} model=${e.model}`);
+          break;
+        case "turn.started":
+          console.log(`[smoke] turn.started`);
+          break;
+        case "content.delta":
+          deltas++;
+          process.stdout.write(e.delta);
+          break;
+        case "item.completed":
+          if (e.itemType === "assistant_text") text = e.text;
+          break;
+        case "thread.token-usage.updated":
+          usage = { input: e.input, output: e.output };
+          break;
+        case "turn.completed":
+          ok = e.ok;
+          stopReason = e.stopReason ?? null;
+          break;
+        case "session.exited":
+          console.log(`\n[smoke] session.exited reason=${e.reason}`);
+          unsub();
+          resolve();
+          break;
+        case "runtime.error":
+          errors.push(e.message);
+          break;
+      }
+    });
+  });
+
+  await instance.adapter.sendTurn({
+    threadId: `smoke-${Date.now()}`,
+    text: prompt,
+    model,
+  });
+  await done;
+  await instance.dispose();
+
+  console.log(`[smoke] deltas=${deltas} ok=${ok} stopReason=${stopReason} text=${JSON.stringify(text.slice(0, 200))}`);
+  if (usage) console.log(`[smoke] usage: in=${usage.input} out=${usage.output}`);
+  if (errors.length) console.log(`[smoke] errors: ${JSON.stringify(errors)}`);
+
+  if (!ok || !text) {
+    console.error(`[smoke] FAILED: ok=${ok} text-empty=${!text}`);
+    return 1;
+  }
+  if (sessionId == null) {
+    console.error(`[smoke] FAILED: no sessionId`);
+    return 1;
+  }
+  console.log(`[smoke] OK`);
+  return 0;
+}
+
+main().then((code) => process.exit(code)).catch((e) => {
+  console.error(`[smoke] crashed:`, e);
+  process.exit(2);
+});

--- a/server/drivers/ai-counsel.test.ts
+++ b/server/drivers/ai-counsel.test.ts
@@ -1,0 +1,253 @@
+// AI Counsel driver smoke test
+//
+// Same pattern as hermes-os.test.ts: spin up a mock HTTP server that
+// mimics the Counsel's /api/conversations and SSE response, then exercise
+// the driver end-to-end. Verifies:
+//   - decodeConfig rejects missing baseUrl
+//   - snapshot is unavailable when the counsel is unreachable
+//   - snapshot is available when /api/conversations responds
+//   - a successful full-mode council round emits the canonical
+//     session.started → turn.started → per-model item.completed →
+//     stage3 item.completed → turn.completed → session.exited sequence
+//   - a runtime error from the counsel surfaces as runtime.error
+//     + turn.completed(ok: false, stopReason: "error")
+//   - the model catalog includes the local-agents and ollama seats
+//
+// Run with: pnpm vitest run server/drivers/ai-counsel.test.ts
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+import { AiCounselDriver } from "./ai-counsel.ts";
+import type { RuntimeEvent, SendTurnInput } from "../contracts.ts";
+
+let server: ReturnType<typeof createServer> | null = null;
+let baseUrl = "";
+
+function startMock(handler: (req: IncomingMessage, res: ServerResponse, body: string) => Promise<void> | void) {
+  return new Promise<void>((resolve) => {
+    server = createServer(async (req, res) => {
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      try {
+        await handler(req, res, body);
+      } catch (e: any) {
+        try { res.statusCode = 500; res.end(JSON.stringify({ error: e?.message ?? String(e) })); } catch {}
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server!.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+}
+
+function stopMock(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.close(() => { server = null; resolve(); });
+  });
+}
+
+function drain(instance: Awaited<ReturnType<typeof AiCounselDriver["create"]>>, turn: SendTurnInput): Promise<RuntimeEvent[]> {
+  return new Promise(async (resolve, reject) => {
+    const events: RuntimeEvent[] = [];
+    const unsub = instance.adapter.onEvent((e) => events.push(e));
+    try {
+      await instance.adapter.sendTurn(turn);
+    } catch (e) { reject(e); }
+    unsub();
+    resolve(events);
+  });
+}
+
+describe("ai-counsel driver", () => {
+  afterEach(async () => { await stopMock(); });
+
+  it("defaultConfig is callable without args", () => {
+    const cfg = AiCounselDriver.defaultConfig();
+    expect(cfg.baseUrl).toMatch(/^https?:\/\//);
+    expect(cfg.defaultModel).toBe("ollama:hermes3:8b");
+  });
+
+  it("decodeConfig rejects missing baseUrl", () => {
+    expect(() => AiCounselDriver.decodeConfig({})).toThrow(/baseUrl/);
+  });
+
+  it("decodeConfig strips trailing slashes", () => {
+    const a = AiCounselDriver.decodeConfig({ baseUrl: "http://h:8020/" });
+    expect(a.baseUrl).toBe("http://h:8020");
+  });
+
+  it("snapshot is unavailable when counsel is unreachable", async () => {
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl: "http://127.0.0.1:1" });
+    const inst = await AiCounselDriver.create({
+      instanceId: "test-1",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("unavailable");
+    expect(snap.reason).toBeTruthy();
+    await inst.dispose();
+  });
+
+  it("snapshot is available when /api/conversations responds", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/api/conversations" && req.method === "GET") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify([]));
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl });
+    const inst = await AiCounselDriver.create({
+      instanceId: "test-2",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("available");
+    await inst.dispose();
+  });
+
+  it("emits canonical event sequence for a successful 3-stage council round", async () => {
+    const convId = "test-conv-uuid";
+    await startMock((req, res, _body) => {
+      // conversation create
+      if (req.url === "/api/conversations" && req.method === "POST") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ id: convId, created_at: "2026-01-01T00:00:00Z", title: "test", mode: "council", messages: [] }));
+        return;
+      }
+      // SSE stream
+      if (req.url === `/api/conversations/${convId}/message/stream` && req.method === "POST") {
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        const events = [
+          { type: "stage1_start" },
+          { type: "stage1_init", total: 1 },
+          { type: "stage1_progress", data: { model: "test:model-a", response: "first answer", error: null, usage: { input_tokens: 10, output_tokens: 5 } } },
+          { type: "stage1_complete", data: [{ model: "test:model-a", response: "first answer" }] },
+          { type: "stage2_init", total: 1 },
+          { type: "stage2_progress", data: { model: "test:model-b", response: "peer review", error: null } },
+          { type: "stage2_complete", data: [] },
+          { type: "stage3_start" },
+          { type: "stage3_complete", data: { model: "chairman", response: "synthesized final answer", usage: { input_tokens: 100, output_tokens: 20 } } },
+          { type: "complete", metadata: { cost_report: { input_tokens: 110, output_tokens: 25 } } },
+        ];
+        for (const e of events) {
+          res.write(`data: ${JSON.stringify(e)}\n\n`);
+        }
+        res.end();
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl, defaultModel: "test:model-a" });
+    const inst = await AiCounselDriver.create({
+      instanceId: "test-3",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const events = await drain(inst, { threadId: "t1", text: "hello" });
+    const types = events.map((e) => e.type);
+
+    // canonical sequence: session, turn, items, turn.completed, session.exited
+    expect(types[0]).toBe("session.started");
+    expect(types[1]).toBe("turn.started");
+    expect(types).toContain("item.completed");
+    expect(types).toContain("turn.completed");
+    expect(types[types.length - 1]).toBe("session.exited");
+
+    // three item.completed: stage1, stage2, stage3
+    const items = events.filter((e) => e.type === "item.completed" && (e as any).itemType === "assistant_text") as Array<any>;
+    expect(items).toHaveLength(3);
+    expect(items[0].text).toBe("first answer");
+    expect(items[1].text).toBe("peer review");
+    expect(items[2].text).toBe("synthesized final answer");
+
+    // turn completed successfully
+    const completed = events.find((e) => e.type === "turn.completed") as any;
+    expect(completed?.ok).toBe(true);
+    expect(completed?.stopReason).toBe("stop");
+
+    // token usage was reported (one from stage1 usage, one from stage3 usage, one from cost_report)
+    const usage = events.filter((e) => e.type === "thread.token-usage.updated") as Array<any>;
+    expect(usage.length).toBeGreaterThanOrEqual(2);
+
+    await inst.dispose();
+  });
+
+  it("emits runtime.error + failed turn when the counsel reports a preflight error", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/api/conversations" && req.method === "POST") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ id: "c1", created_at: "2026-01-01T00:00:00Z", title: "t", mode: "council", messages: [] }));
+        return;
+      }
+      if (req.url === "/api/conversations/c1/message/stream" && req.method === "POST") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write(`data: ${JSON.stringify({ type: "error", message: "all models failed preflight" })}\n\n`);
+        res.end();
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl });
+    const inst = await AiCounselDriver.create({
+      instanceId: "test-4",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const events = await drain(inst, { threadId: "t2", text: "hi" });
+    const err = events.find((e) => e.type === "runtime.error") as any;
+    expect(err?.message).toMatch(/preflight/);
+    const completed = events.find((e) => e.type === "turn.completed") as any;
+    expect(completed?.ok).toBe(false);
+    expect(completed?.stopReason).toBe("error");
+    await inst.dispose();
+  });
+
+  it("emits runtime.error + failed turn when the conversation create fails", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/api/conversations" && req.method === "POST") {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ detail: "boom" }));
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl });
+    const inst = await AiCounselDriver.create({
+      instanceId: "test-5",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const events = await drain(inst, { threadId: "t3", text: "hi" });
+    const err = events.find((e) => e.type === "runtime.error") as any;
+    expect(err?.message).toMatch(/create conversation/);
+    const completed = events.find((e) => e.type === "turn.completed") as any;
+    expect(completed?.ok).toBe(false);
+    await inst.dispose();
+  });
+
+  it("model catalog includes local-agents and ollama seats", () => {
+    const cfg = AiCounselDriver.decodeConfig({ baseUrl: "http://h" });
+    const ids = cfg ? AiCounselDriver.models.options.map((o) => o.id) : [];
+    expect(ids).toContain("local-agents:claude-code-mac");
+    expect(ids).toContain("local-agents:minimax-mac");
+    expect(ids).toContain("ollama:hermes3:8b");
+  });
+});

--- a/server/drivers/ai-counsel.ts
+++ b/server/drivers/ai-counsel.ts
@@ -1,0 +1,509 @@
+// AI Counsel driver — wraps "The AI Counsel" FastAPI service
+// (https://github.com/jacob-bd/the-ai-counsel, MIT) as an OpenMausBot
+// ProviderDriver. The Counsel is a 3-stage deliberation system:
+//
+//   stage 1: each council model answers independently (parallel)
+//   stage 2: each model peer-reviews the others (anonymized by label)
+//   stage 3: a chairman model synthesizes the final answer
+//
+// We translate the Counsel's SSE event types onto the canonical
+// RuntimeEvent union so the same fleet UI works for both:
+//
+//   Counsel event         →  RuntimeEvent
+//   ─────────────────────────────────────────────────────────────────
+//   error                 →  runtime.error
+//   stage1_progress (N)   →  item.completed: assistant_text (per model)
+//   stage2_progress (N)   →  item.completed: assistant_text (per peer review)
+//   stage3_complete       →  item.completed: assistant_text (the synthesis)
+//   complete              →  turn.completed(ok: true)
+//   cost_report           →  thread.token-usage.updated
+//
+// The driver always uses execution_mode: "full" (all 3 stages) — that's
+// the canonical Counsel experience. If you want stage-1-only or stage-2
+// without synthesis, hit the Counsel directly; the driver is opinionated
+// about the deliverable shape (a synthesized final answer, not N
+// unrelated first passes).
+//
+// Conversations: each sendTurn creates a new conversation on the Counsel
+// side (since OpenMausBot threads are not 1:1 with Counsel conversations
+// and there's no resume cursor to carry). The threadId is echoed back in
+// the session.started event so the UI can correlate. If you'd rather
+// append to an existing conversation, pass `conversationId` in
+// `turn.integrations.counsel` (we ignore everything else in integrations).
+//
+// Integrations: the Counsel has its own tool story (web search via
+// DuckDuckGo/Tavily/Brave, document extraction). It's controlled by the
+// Counsel's settings, not by OpenMausBot. We surface a positive event
+// note so the UI knows the integration is in scope, but we don't try to
+// pass it through — the Counsel's body schema is its own contract.
+//
+// Snapshot: a quick GET /api/conversations to confirm the Counsel is
+// reachable. The /api/health route 404s in the current build, so we use
+// the conversations list as the health probe instead.
+
+import type {
+  DriverCreateInput,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+
+const DRIVER_KIND = "aiCounsel";
+
+const MODELS = {
+  default: "ollama:hermes3:8b",
+  options: [
+    // local-agents: the Counsel's adapter that spawns CLI agents on the
+    // Mac (claude, codex, gemini, antigravity) over SSH. Requires
+    // authenticated CLIs on the Mac side.
+    { id: "local-agents:claude-code-mac", label: "Claude Code (Mac, via Counsel)" },
+    { id: "local-agents:chatgpt-mac",     label: "ChatGPT CLI (Mac, via Counsel)" },
+    { id: "local-agents:minimax-mac",       label: "mavis MiniMax-M3 (Mac, via Counsel)" },
+    { id: "local-agents:antigravity",      label: "Antigravity (Mac, via Counsel)" },
+    // ollama: local models, always reachable when the Ollama daemon is
+    // up. Free, fast, ideal for smoke tests.
+    { id: "ollama:hermes3:8b",             label: "Hermes 3 8B (Ollama, local)" },
+    { id: "ollama:qwen3.5:latest",         label: "Qwen 3.5 (Ollama, local)" },
+    { id: "ollama:gemma4:26b",             label: "Gemma 4 26B (Ollama, local)" },
+    // openrouter: paid + free, requires OPENROUTER_API_KEY in the
+    // Counsel's settings.json. The default chairman model is one of these.
+    { id: "openai/gpt-4.1",                label: "GPT-4.1 (OpenRouter)" },
+    { id: "google/gemini-2.5-pro",         label: "Gemini 2.5 Pro (OpenRouter)" },
+    { id: "anthropic/claude-sonnet-4",     label: "Claude Sonnet 4 (OpenRouter)" },
+    { id: "x-ai/grok-3",                   label: "Grok 3 (OpenRouter)" },
+  ],
+};
+
+export interface AiCounselConfig {
+  baseUrl: string;
+  defaultModel: string;
+  /** Per-turn hard timeout in ms. Defaults to 10 minutes (3-stage rounds can be slow). */
+  timeoutMs: number;
+  /** If true, omit stage 2 (peer review) — stage 1 only, then synthesis. */
+  skipStage2?: boolean;
+  userAgent: string;
+}
+
+function decodeConfig(raw: unknown): AiCounselConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const baseUrlRaw = o.baseUrl ?? o.base_url;
+  if (typeof baseUrlRaw !== "string" || !baseUrlRaw) {
+    throw new Error("ai-counsel: baseUrl is required (e.g. http://127.0.0.1:8020)");
+  }
+  const baseUrl = baseUrlRaw.replace(/\/+$/, "");
+  const defaultModelRaw = o.defaultModel ?? o.default_model ?? MODELS.default;
+  const defaultModel = typeof defaultModelRaw === "string" && defaultModelRaw ? defaultModelRaw : MODELS.default;
+  const timeoutMsRaw = o.timeoutMs ?? o.timeout_ms;
+  const timeoutMs = typeof timeoutMsRaw === "number" && timeoutMsRaw > 0 ? timeoutMsRaw : 10 * 60_000;
+  const skipStage2Raw = o.skipStage2 ?? o.skip_stage2;
+  const skipStage2 = Boolean(skipStage2Raw);
+  const userAgent = typeof o.userAgent === "string" ? o.userAgent : "openmausbot-ai-counsel/0.1";
+  return { baseUrl, defaultModel, timeoutMs, skipStage2, userAgent };
+}
+
+/** Best-effort extract of the assistant text from a stage-progress payload.
+ *  The Counsel stores the model answer under `data.response`; if absent
+ *  (e.g. error case) we return the error message so the UI still has
+ *  something to display. */
+function extractStageText(data: unknown): string {
+  if (!data || typeof data !== "object") return "";
+  const d = data as Record<string, unknown>;
+  if (typeof d.response === "string" && d.response.length > 0) return d.response;
+  if (typeof d.error === "string" && d.error.length > 0) return `(${d.error})`;
+  return JSON.stringify(d).slice(0, 500);
+}
+
+/** Walk a nested cost_report for input/output token totals. */
+function extractUsage(cost: unknown): { input: number; output: number } {
+  if (!cost || typeof cost !== "object") return { input: 0, output: 0 };
+  const c = cost as Record<string, unknown>;
+  const input = Number(c.input_tokens ?? 0) || 0;
+  const output = Number(c.output_tokens ?? 0) || 0;
+  return { input, output };
+}
+
+export const AiCounselDriver: ProviderDriver<AiCounselConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "The AI Counsel (3-stage deliberation)", supportsMultipleInstances: true },
+  models: MODELS,
+  decodeConfig,
+  defaultConfig: () =>
+    decodeConfig({ baseUrl: process.env.AI_COUNSEL_URL ?? "http://127.0.0.1:8020" }),
+
+  async create(input: DriverCreateInput<AiCounselConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string; sessionId: string }>();
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) {
+        try { l(event); } catch { /* listener errors must not break the run */ }
+      }
+    };
+    const base = (threadId: string, turnId: string, itemId?: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      providerInstanceId: instanceId,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+      ...(itemId ? { itemId } : {}),
+    });
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "user-agent": config.userAgent,
+    };
+
+    /** Read SSE stream line-by-line, dispatching each typed event. */
+    async function readSse(
+      res: Response,
+      threadId: string,
+      turnId: string,
+      onClose: (ok: boolean, stopReason: string | null) => void,
+    ): Promise<void> {
+      if (!res.body) {
+        emit({ ...base(threadId, turnId), type: "runtime.error", message: "ai-counsel: empty body" });
+        onClose(false, "error");
+        return;
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      let lastUsage: { input: number; output: number } | null = null;
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          let nl;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).replace(/\r$/, "");
+            buf = buf.slice(nl + 1);
+            if (!line.startsWith("data:")) continue;
+            const payload = line.slice(5).trim();
+            if (!payload) continue;
+            let evt: { type?: string; data?: unknown; message?: string; metadata?: { cost_report?: unknown } };
+            try { evt = JSON.parse(payload); } catch { continue; }
+            const stage = evt.type ?? "";
+            const data = evt.data;
+            switch (stage) {
+              case "error": {
+                emit({
+                  ...base(threadId, turnId),
+                  type: "runtime.error",
+                  message: typeof evt.message === "string" ? evt.message : "ai-counsel: unknown error",
+                });
+                onClose(false, "error");
+                return;
+              }
+              case "stage1_progress":
+              case "stage2_progress": {
+                const itemId = newId();
+                const d = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+                const modelName = typeof d.model === "string" ? d.model : `seat-${stage}`;
+                const text = extractStageText(data);
+                // emit a placeholder start, then the completed text in one event
+                emit({
+                  ...base(threadId, turnId, itemId),
+                  type: "item.started",
+                  itemType: "tool",
+                  title: `${modelName} (${stage})`,
+                });
+                if (text) {
+                  emit({
+                    ...base(threadId, turnId, itemId),
+                    type: "item.completed",
+                    itemType: "assistant_text",
+                    text,
+                  });
+                }
+                const usage = extractUsage(d.usage);
+                if (usage.input || usage.output) {
+                  emit({
+                    ...base(threadId, turnId),
+                    type: "thread.token-usage.updated",
+                    input: usage.input,
+                    output: usage.output,
+                  });
+                }
+                break;
+              }
+              case "stage3_complete": {
+                const itemId = newId();
+                const d = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+                const modelName = typeof d.model === "string" ? d.model : "chairman";
+                const text = extractStageText(data);
+                emit({
+                  ...base(threadId, turnId, itemId),
+                  type: "item.started",
+                  itemType: "tool",
+                  title: `${modelName} (synthesis)`,
+                });
+                if (text) {
+                  emit({
+                    ...base(threadId, turnId, itemId),
+                    type: "item.completed",
+                    itemType: "assistant_text",
+                    text,
+                  });
+                }
+                const usage = extractUsage(d.usage);
+                if (usage.input || usage.output) {
+                  emit({
+                    ...base(threadId, turnId),
+                    type: "thread.token-usage.updated",
+                    input: usage.input,
+                    output: usage.output,
+                  });
+                }
+                break;
+              }
+              case "complete": {
+                const cr = evt.metadata?.cost_report;
+                const u = extractUsage(cr);
+                if (u.input || u.output) {
+                  emit({
+                    ...base(threadId, turnId),
+                    type: "thread.token-usage.updated",
+                    input: u.input,
+                    output: u.output,
+                  });
+                }
+                lastUsage = u;
+                onClose(true, "stop");
+                return;
+              }
+              // other events (search_*, stage1_start, stage1_init, stage1_complete,
+              // stage2_start, stage2_init, stage2_complete, stage3_start, title_complete)
+              // are intentionally ignored at the event level — the per-progress
+              // emissions above already carry the user-visible info. We log them
+              // to the native NDJSON file (if present) via the runtime listener
+              // contract, but don't synthesize a RuntimeEvent for them.
+              default:
+                break;
+            }
+          }
+        }
+        // stream ended without an explicit complete event
+        if (lastUsage == null) onClose(true, "stop");
+      } catch (e: any) {
+        if (e?.name === "AbortError") {
+          onClose(false, "interrupted");
+        } else {
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message: `ai-counsel: stream read error: ${e?.message ?? String(e)}`,
+          });
+          onClose(false, "error");
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* already released */ }
+      }
+    }
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      try {
+        const res = await fetch(`${config.baseUrl}/api/conversations`, {
+          method: "GET",
+          headers,
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) {
+          return { state: "unavailable", reason: `counsel responded ${res.status}` };
+        }
+        return { state: "available", authenticated: true, version: null };
+      } catch (e: any) {
+        return { state: "unavailable", reason: e?.message ?? String(e) };
+      }
+    };
+
+    const sendTurn = async (turn: SendTurnInput): Promise<{ turnId: string }> => {
+      if (active.has(turn.threadId)) {
+        throw new Error("a turn is already running on this thread");
+      }
+      const turnId = newId();
+      const sessionId = newId();
+      const ac = new AbortController();
+      active.set(turn.threadId, { abort: ac, turnId, sessionId });
+      try {
+        emit({
+          ...base(turn.threadId, turnId),
+          type: "session.started",
+          sessionId,
+          model: turn.model ?? config.defaultModel,
+        });
+        emit({ ...base(turn.threadId, turnId), type: "turn.started" });
+
+        // The Counsel's body schema: {content, execution_mode, council_models, ...}.
+        // We use the model override as the sole council member — a single-model
+        // "council" degenerates to a 3-stage pass through that one model
+        // (still useful for the peer-review + chairman synthesis if same).
+        // For a true multi-model round, the user would configure multiple
+        // instances or extend the driver to accept a seat list.
+        const model = (turn.model ?? config.defaultModel).trim();
+        const body: Record<string, unknown> = {
+          content: turn.text,
+          execution_mode: config.skipStage2 ? "chat_only" : "full",
+          council_models: [model],
+        };
+        if (turn.system) body.chairman_model = model; // best-effort; counsel picks from list
+
+        // The Counsel's conversations endpoint takes a UUID conversationId. We
+        // create one per turn (the Counsel has no useful per-thread resume
+        // cursor for an OpenMausBot fleet, and creating is cheap).
+        const createRes = await fetch(`${config.baseUrl}/api/conversations`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ title: turn.text.slice(0, 60) || "openmausbot turn" }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!createRes.ok) {
+          const errText = await createRes.text().catch(() => "");
+          const msg = `ai-counsel: create conversation failed ${createRes.status} — ${errText.slice(0, 500)}`;
+          emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: msg });
+          emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error" });
+          emit({ ...base(turn.threadId, turnId), type: "session.exited", reason: "error" });
+          return { turnId };
+        }
+        const created = (await createRes.json()) as { id?: string };
+        const conversationId = created.id;
+        if (!conversationId) {
+          emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: "ai-counsel: create conversation returned no id" });
+          emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error" });
+          emit({ ...base(turn.threadId, turnId), type: "session.exited", reason: "error" });
+          return { turnId };
+        }
+
+        const streamUrl = `${config.baseUrl}/api/conversations/${conversationId}/message/stream`;
+        const fetchSignal = AbortSignal.any([ac.signal, AbortSignal.timeout(config.timeoutMs)]);
+        const streamRes = await fetch(streamUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+          signal: fetchSignal,
+        });
+        if (!streamRes.ok) {
+          const errText = await streamRes.text().catch(() => "");
+          const msg = `ai-counsel: stream POST failed ${streamRes.status} — ${errText.slice(0, 500)}`;
+          emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: msg });
+          emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error" });
+          emit({ ...base(turn.threadId, turnId), type: "session.exited", reason: "error" });
+          return { turnId };
+        }
+
+        // Bridge the readSse callback to a promise that resolves on close
+        await new Promise<void>((resolve) => {
+          readSse(streamRes, turn.threadId, turnId, (ok, stopReason) => {
+            emit({
+              ...base(turn.threadId, turnId),
+              type: "turn.completed",
+              ok,
+              stopReason,
+              denials: [],
+            });
+            emit({
+              ...base(turn.threadId, turnId),
+              type: "session.exited",
+              reason: stopReason ?? "stop",
+            });
+            resolve();
+          });
+        });
+        return { turnId };
+      } finally {
+        active.delete(turn.threadId);
+      }
+    };
+
+    const interruptTurn = async (threadId: string, _turnId?: string): Promise<void> => {
+      const entry = active.get(threadId);
+      if (entry) entry.abort.abort();
+    };
+
+    const respondToRequest = async (
+      _threadId: string,
+      _requestId: string,
+      decision: { behavior: "allow" | "deny" | "answer"; message?: string },
+    ): Promise<void> => {
+      // The Counsel doesn't surface tool-permission asks through its REST
+      // surface (its own UI handles them inline). We no-op + emit a note.
+      emit({
+        ...base(_threadId, active.get(_threadId)?.turnId ?? newId()),
+        type: "request.resolved",
+        behavior: decision.behavior,
+        source: "ai-counsel-driver",
+      });
+    };
+
+    const hasSession = (_threadId: string): boolean => false;
+
+    const stopAll = async (): Promise<void> => {
+      for (const [, entry] of active) entry.abort.abort();
+      active.clear();
+    };
+
+    const onEvent = (listener: RuntimeEventListener): (() => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    };
+
+    const generateText = async (prompt: string): Promise<string> => {
+      const fakeTurn: SendTurnInput = {
+        threadId: newId(),
+        text: prompt,
+        model: config.defaultModel,
+      };
+      let text = "";
+      const unsub = onEvent((ev) => {
+        if (ev.type === "item.completed" && ev.itemType === "assistant_text") {
+          // Prefer the synthesis (stage3) — last item wins because the
+          // synthesis is the final user-visible answer.
+          text = ev.text;
+        }
+      });
+      try {
+        await sendTurn(fakeTurn);
+      } finally {
+        unsub();
+      }
+      if (!text) throw new Error("ai-counsel: generateText produced no text");
+      return text;
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      models: MODELS,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: {
+          sessionModelSwitch: "unsupported", // each turn creates a fresh conversation
+          // The Counsel has its own tool story (web search, document
+          // extraction) configured server-side, so we declare agentsMcp
+          // to indicate the integration surface is in scope.
+          agentsMcp: true,
+        },
+        sendTurn,
+        interruptTurn,
+        respondToRequest,
+        hasSession,
+        stopAll,
+        onEvent,
+      },
+      generateText,
+      async dispose(): Promise<void> {
+        await stopAll();
+        listeners.clear();
+      },
+    } satisfies ProviderInstance;
+  },
+};

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -1,6 +1,7 @@
 // Built-in driver registration — upstream builtInDrivers.ts: a static
 // array, nothing more. Adding a driver = write drivers/<x>.ts, append.
 import type { AnyProviderDriver } from "../contracts.ts";
+import { AiCounselDriver } from "./ai-counsel.ts";
 import { BoxAgentDriver } from "./boxagent.ts";
 import { ClaudeDriver } from "./claude.ts";
 import { CodexDriver } from "./codex.ts";
@@ -17,4 +18,5 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   CodexDriver,
   BoxAgentDriver,
   HermesOsDriver,
+  AiCounselDriver,
 ];

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -7,6 +7,7 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { HermesOsDriver } from "./hermes-os.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -15,4 +16,5 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   ClaudeDriver,
   CodexDriver,
   BoxAgentDriver,
+  HermesOsDriver,
 ];

--- a/server/drivers/hermes-os.test.ts
+++ b/server/drivers/hermes-os.test.ts
@@ -1,0 +1,237 @@
+// hermes-os driver smoke test
+//
+// Spins up a tiny mock HTTP server that mimics hermes-os's
+// /v1/chat/completions SSE response, then exercises the driver
+// end-to-end. Verifies:
+//   - the driver emits the canonical session/turn/item event sequence
+//   - SSE content.delta events are reconstructed into a single
+//     item.completed: assistant_text
+//   - usage and turn completion are reported
+//   - a non-2xx response produces a runtime.error + turn.completed(ok=false)
+//   - a server that's unreachable produces an unavailable snapshot
+//   - defaultConfig() is callable without args
+//
+// Run with: pnpm vitest run server/drivers/hermes-os.test.ts
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+import { HermesOsDriver } from "./hermes-os.ts";
+import type { RuntimeEvent, SendTurnInput } from "../contracts.ts";
+
+let server: ReturnType<typeof createServer> | null = null;
+let baseUrl = "";
+
+function startMock(handler: (req: IncomingMessage, res: ServerResponse, body: string) => Promise<void> | void) {
+  return new Promise<void>((resolve) => {
+    server = createServer(async (req, res) => {
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      try {
+        await handler(req, res, body);
+      } catch (e: any) {
+        try { res.statusCode = 500; res.end(JSON.stringify({ error: e?.message ?? String(e) })); } catch {}
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server!.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+}
+
+function stopMock(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.close(() => { server = null; resolve(); });
+  });
+}
+
+function drain(instance: Awaited<ReturnType<typeof HermesOsDriver["create"]>>, turn: SendTurnInput): Promise<RuntimeEvent[]> {
+  return new Promise(async (resolve, reject) => {
+    const events: RuntimeEvent[] = [];
+    const unsub = instance.adapter.onEvent((e) => events.push(e));
+    try {
+      await instance.adapter.sendTurn(turn);
+    } catch (e) { reject(e); }
+    unsub();
+    resolve(events);
+  });
+}
+
+describe("hermes-os driver", () => {
+  afterEach(async () => { await stopMock(); });
+
+  it("defaultConfig is callable without args", () => {
+    const cfg = HermesOsDriver.defaultConfig();
+    expect(cfg.baseUrl).toMatch(/^https?:\/\//);
+    expect(cfg.defaultModel).toBe("gemini");
+  });
+
+  it("decodeConfig rejects missing baseUrl", () => {
+    expect(() => HermesOsDriver.decodeConfig({})).toThrow(/baseUrl/);
+  });
+
+  it("decodeConfig strips trailing slashes and /v1 suffix", () => {
+    const a = HermesOsDriver.decodeConfig({ baseUrl: "http://h:8001/" });
+    const b = HermesOsDriver.decodeConfig({ baseUrl: "http://h:8001/v1" });
+    const c = HermesOsDriver.decodeConfig({ baseUrl: "http://h:8001/openai/v1" });
+    expect(a.baseUrl).toBe("http://h:8001");
+    expect(b.baseUrl).toBe("http://h:8001");
+    expect(c.baseUrl).toBe("http://h:8001");
+  });
+
+  it("snapshot is unavailable when hub is unreachable", async () => {
+    // Pick a port nothing is bound to
+    const cfg = HermesOsDriver.decodeConfig({ baseUrl: "http://127.0.0.1:1" });
+    const inst = await HermesOsDriver.create({
+      instanceId: "test-1",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("unavailable");
+    expect(snap.reason).toBeTruthy();
+    await inst.dispose();
+  });
+
+  it("snapshot is available when hub /v1/models responds", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/v1/models") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ data: [{ id: "gemini" }, { id: "openai" }] }));
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = HermesOsDriver.decodeConfig({ baseUrl });
+    const inst = await HermesOsDriver.create({
+      instanceId: "test-2",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("available");
+    await inst.dispose();
+  });
+
+  it("emits canonical event sequence for a successful SSE turn", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/v1/models") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ data: [{ id: "gemini" }] }));
+        return;
+      }
+      if (req.url === "/v1/chat/completions") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        // one big string so the chunks the test sees are deterministic
+        const body =
+          `data: {"id":"x1","choices":[{"delta":{"content":"Hello"}}]}\n\n` +
+          `data: {"id":"x2","choices":[{"delta":{"content":", world"}}]}\n\n` +
+          `data: {"id":"x3","choices":[{"delta":{"content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3}}\n\n` +
+          `data: [DONE]\n\n`;
+        res.end(body);
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = HermesOsDriver.decodeConfig({ baseUrl, defaultModel: "gemini" });
+    const inst = await HermesOsDriver.create({
+      instanceId: "test-3",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const events = await drain(inst, { threadId: "t1", text: "hi", model: "gemini" });
+
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe("session.started");
+    expect(types).toContain("turn.started");
+    expect(types).toContain("content.delta");
+    expect(types).toContain("item.completed");
+    expect(types).toContain("turn.completed");
+    expect(types[types.length - 1]).toBe("session.exited");
+
+    // delta count
+    const deltas = events.filter((e) => e.type === "content.delta");
+    expect(deltas).toHaveLength(3);
+    expect(deltas.map((d) => (d as any).delta).join("")).toBe("Hello, world!");
+
+    // final item
+    const final = events.find((e) => e.type === "item.completed" && (e as any).itemType === "assistant_text") as any;
+    expect(final?.text).toBe("Hello, world!");
+
+    // turn completion reports success
+    const completed = events.find((e) => e.type === "turn.completed") as any;
+    expect(completed?.ok).toBe(true);
+    expect(completed?.stopReason).toBe("stop");
+
+    // usage event
+    const usage = events.find((e) => e.type === "thread.token-usage.updated") as any;
+    expect(usage?.input).toBe(7);
+    expect(usage?.output).toBe(3);
+
+    await inst.dispose();
+  });
+
+  it("emits runtime.error + failed turn on non-2xx response", async () => {
+    await startMock((req, res, _body) => {
+      if (req.url === "/v1/models") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ data: [] }));
+        return;
+      }
+      if (req.url === "/v1/chat/completions") {
+        res.statusCode = 429;
+        res.end(JSON.stringify({ error: { message: "rate limit" } }));
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = HermesOsDriver.decodeConfig({ baseUrl });
+    const inst = await HermesOsDriver.create({
+      instanceId: "test-4",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    const events = await drain(inst, { threadId: "t2", text: "hi" });
+    const err = events.find((e) => e.type === "runtime.error") as any;
+    expect(err?.message).toMatch(/429/);
+    const completed = events.find((e) => e.type === "turn.completed") as any;
+    expect(completed?.ok).toBe(false);
+    expect(completed?.stopReason).toBe("rate_limit");
+    await inst.dispose();
+  });
+
+  it("forwards Authorization header when apiKey is set", async () => {
+    let seenAuth: string | null = null;
+    await startMock((req, res, _body) => {
+      if (req.url === "/v1/models") {
+        seenAuth = req.headers["authorization"] ?? null;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ data: [] }));
+        return;
+      }
+      res.statusCode = 404; res.end();
+    });
+    const cfg = HermesOsDriver.decodeConfig({ baseUrl, apiKey: "secret-token-123" });
+    const inst = await HermesOsDriver.create({
+      instanceId: "test-5",
+      displayName: "test",
+      environment: {},
+      enabled: true,
+      config: cfg,
+    });
+    await inst.snapshot();
+    expect(seenAuth).toBe("Bearer secret-token-123");
+    await inst.dispose();
+  });
+});

--- a/server/drivers/hermes-os.ts
+++ b/server/drivers/hermes-os.ts
@@ -1,0 +1,462 @@
+// hermes-os driver — wraps Tony's Agent OS hub (`tonysplace_best/backend/agent-os`,
+// FastAPI on :8001) as an OpenMausBot ProviderDriver.
+//
+// The hub exposes an OpenAI-compatible surface at /v1/models and
+// /v1/chat/completions, including SSE streaming when stream=true. We map
+// a single ProviderInstance to one (baseUrl, default model) pair; the
+// model catalog is a static copy of the hub's known provider set so the
+// model picker has something to render before the hub is reachable.
+//
+// Auth: the hub accepts requests with no Authorization header when
+// HUB_API_TOKEN is unset (the dev/homelab default). When it is set, the
+// caller must send `Authorization: Bearer <HUB_API_TOKEN>`. The driver
+// reads the token from the instance config (apiKey) or HUB_API_TOKEN env.
+//
+// Streaming: hermes-os emits chunks of the form `data: {"choices":[{"delta":{"content":"..."}}]}\n\n`
+// and terminates with `data: [DONE]\n\n`. We map each delta to a
+// `content.delta` RuntimeEvent with streamKind="assistant_text", and emit
+// a final `item.completed: assistant_text` event with the concatenated
+// text plus `turn.completed` (and a `thread.token-usage.updated` when
+// usage is present in the final non-delta chunk).
+//
+// Integrations: hermes-os has its own integrations story (Composio via
+// config, Antigravity SDK, etc.). We surface it as a passthrough: when
+// SendTurnInput.integrations is set, the driver logs it and continues;
+// the hub's own model handles tool wiring from its side. Computer-use
+// and agent peer-comms are not supported by the hub yet, so we no-op
+// them with a single event.note (the driver never silently swallows).
+
+import { appendNative } from "./native.ts";
+
+import type {
+  DriverCreateInput,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+
+const DRIVER_KIND = "hermesOs";
+
+// Static catalog — kept in sync with hermes-os ProviderManager. The
+// driver re-queries /v1/models on snapshot() when the hub is reachable,
+// but the model picker needs something to render before that resolves.
+const MODELS = {
+  default: "gemini",
+  options: [
+    { id: "council",       label: "Council (multi-agent synthesis via Ollama)" },
+    { id: "gemini",        label: "Gemini 2.5 Flash (Antigravity SDK)" },
+    { id: "openai",        label: "OpenAI gpt-4o-mini" },
+    { id: "anthropic",     label: "Anthropic claude-sonnet-4-5 (via local proxy)" },
+    { id: "opencode",      label: "OpenCode Zen (hosted deepseek-v4-flash-free)" },
+    { id: "local_claude",  label: "Local Claude Code CLI (host-side)" },
+    { id: "local_codex",   label: "Local Codex CLI (host-side)" },
+    { id: "mavis",         label: "mavis (MiniMax Code on the Mac, via Tailscale)" },
+    { id: "nous",          label: "Nous Research (Hermes family)" },
+  ],
+};
+
+export interface HermesOsConfig {
+  baseUrl: string;
+  apiKey?: string;
+  defaultModel: string;
+  /** Per-turn hard timeout in ms. Defaults to 5 minutes. */
+  timeoutMs: number;
+  /** Override the user-agent. */
+  userAgent: string;
+}
+
+function decodeConfig(raw: unknown): HermesOsConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const baseUrlRaw = o.baseUrl ?? o.base_url;
+  if (typeof baseUrlRaw !== "string" || !baseUrlRaw) {
+    throw new Error("hermes-os: baseUrl is required (e.g. http://127.0.0.1:8001)");
+  }
+  let baseUrl = baseUrlRaw.replace(/\/+$/, "");
+  // Tolerate users typing the OpenAI mount point
+  baseUrl = baseUrl.replace(/\/(v1|openai\/v1)$/, "");
+  const apiKeyRaw = o.apiKey ?? o.api_key ?? process.env.HUB_API_TOKEN;
+  const apiKey = typeof apiKeyRaw === "string" && apiKeyRaw ? apiKeyRaw : undefined;
+  const defaultModelRaw = o.defaultModel ?? o.default_model;
+  const defaultModel = typeof defaultModelRaw === "string" && defaultModelRaw ? defaultModelRaw : "gemini";
+  const timeoutMsRaw = o.timeoutMs ?? o.timeout_ms;
+  const timeoutMs = typeof timeoutMsRaw === "number" && timeoutMsRaw > 0 ? timeoutMsRaw : 5 * 60_000;
+  const userAgent = typeof o.userAgent === "string" ? o.userAgent : "openmausbot-hermes-os/0.1";
+  return { baseUrl, apiKey, defaultModel, timeoutMs, userAgent };
+}
+
+function flattenMessages(input: SendTurnInput): { system: string | undefined; prompt: string } {
+  // OpenMausBot's SendTurnInput carries a flat {text, system, transcript}.
+  // The hub expects an OpenAI messages array. Build it from the fields
+  // available, preferring the most informative source.
+  const turns: Array<{ role: "user" | "assistant"; text: string }> = input.transcript ?? [];
+  const messages: Array<{ role: string; content: string }> = [];
+  if (input.system) messages.push({ role: "system", content: input.system });
+  for (const t of turns) messages.push({ role: t.role, content: t.text });
+  messages.push({ role: "user", content: input.text });
+  const system = input.system;
+  const prompt = input.text;
+  // The hub's _flatten_openai_messages already joins multi-turn content,
+  // so we just pass the latest user turn as the prompt and let the hub
+  // walk the array. We return the system and prompt here for clarity;
+  // the actual HTTP call sends the full messages array below.
+  void messages;
+  return { system, prompt };
+}
+
+export const HermesOsDriver: ProviderDriver<HermesOsConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "hermes-os (Agent OS hub)", supportsMultipleInstances: true },
+  models: MODELS,
+  decodeConfig,
+  defaultConfig: () =>
+    decodeConfig({ baseUrl: process.env.HERMES_OS_URL ?? "http://127.0.0.1:8001" }),
+
+  async create(input: DriverCreateInput<HermesOsConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const listeners = new Set<RuntimeEventListener>();
+    // one active turn per threadId; the OpenMausBot core is responsible
+    // for not starting a second one — but we defend in depth.
+    const active = new Map<string, { abort: AbortController; turnId: string; sessionId: string }>();
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) {
+        try { l(event); } catch { /* listener errors must not break the run */ }
+      }
+    };
+    const base = (threadId: string, turnId: string, itemId?: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      providerInstanceId: instanceId,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+      ...(itemId ? { itemId } : {}),
+    });
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "user-agent": config.userAgent,
+    };
+    if (config.apiKey) headers["authorization"] = `Bearer ${config.apiKey}`;
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      try {
+        const res = await fetch(`${config.baseUrl}/v1/models`, {
+          method: "GET",
+          headers: { ...headers, "content-type": "application/json" },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) {
+          return { state: "unavailable", reason: `hub responded ${res.status}` };
+        }
+        const j = (await res.json()) as { data?: Array<{ id: string }> };
+        const available = (j.data ?? []).map((m) => m.id);
+        return {
+          state: "available",
+          authenticated: !!config.apiKey,
+          version: null,
+          // expose the seat list on the snapshot for the model picker to consult
+          ...({ modelIds: available } as { modelIds: string[] }),
+        };
+      } catch (e: any) {
+        return { state: "unavailable", reason: e?.message ?? String(e) };
+      }
+    };
+
+    const sendTurn = async (turn: SendTurnInput): Promise<{ turnId: string }> => {
+      if (active.has(turn.threadId)) {
+        throw new Error("a turn is already running on this thread");
+      }
+      const turnId = newId();
+      const sessionId = newId();
+      const itemId = newId();
+      active.set(turn.threadId, { abort: new AbortController(), turnId, sessionId });
+      try {
+        // session lifecycle: started → turn started → content → turn completed → exited
+        emit({
+          ...base(turn.threadId, turnId),
+          type: "session.started",
+          sessionId,
+          model: turn.model ?? config.defaultModel,
+        });
+        emit({ ...base(turn.threadId, turnId), type: "turn.started" });
+
+        // inform the user when integrations are passed that we don't fully honor
+        if (turn.integrations?.computer) {
+          emit({
+            ...base(turn.threadId, turnId),
+            type: "runtime.error",
+            message:
+              "hermes-os driver: cloud-computer (Box) integration is not supported by the hub; ignoring",
+          });
+        }
+        if (turn.integrations?.localComputer) {
+          emit({
+            ...base(turn.threadId, turnId),
+            type: "runtime.error",
+            message:
+              "hermes-os driver: local computer-use (cua-driver) is not supported by the hub; ignoring",
+          });
+        }
+        if (turn.integrations?.agents) {
+          // hermes-os *does* support peer-agent comms via the council intent —
+          // surface a positive event so the UI knows the integration is in scope
+          emit({
+            ...base(turn.threadId, turnId),
+            type: "item.started",
+            itemType: "tool",
+            title: "hermes-os peer-agent comms (council intent)",
+          });
+        }
+
+        const { system } = flattenMessages(turn);
+        const messages: Array<{ role: string; content: string }> = [];
+        if (system || turn.system) {
+          messages.push({ role: "system", content: system ?? turn.system! });
+        }
+        for (const t of turn.transcript ?? []) {
+          messages.push({ role: t.role, content: t.text });
+        }
+        messages.push({ role: "user", content: turn.text });
+
+        const model = (turn.model ?? config.defaultModel).trim().toLowerCase();
+        const body = {
+          model,
+          messages,
+          stream: true,
+          // keep the request cheap; the hub will pass these through to the
+          // underlying provider if supported, otherwise ignore
+          temperature: 0.7,
+        };
+        const url = `${config.baseUrl}/v1/chat/completions`;
+        const nativeRecord = { source: "openai-compat", payload: { url, model, threadId: turn.threadId, turnId } };
+        appendNative(turn.threadId, { dir: "out", source: "openmausbot", msg: nativeRecord });
+
+        const ac = active.get(turn.threadId)!.abort;
+        const fetchSignal = AbortSignal.any([ac.signal, AbortSignal.timeout(config.timeoutMs!)]);
+        const res = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+          signal: fetchSignal,
+        });
+
+        if (!res.ok) {
+          const errText = await res.text().catch(() => "");
+          const errMsg = `hermes-os: ${res.status} ${res.statusText} — ${errText.slice(0, 500)}`;
+          emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: errMsg });
+          emit({
+            ...base(turn.threadId, turnId),
+            type: "turn.completed",
+            ok: false,
+            stopReason: res.status === 401 ? "auth" : res.status === 429 ? "rate_limit" : "error",
+            denials: [],
+          });
+          return { turnId };
+        }
+        if (!res.body) {
+          emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: "hermes-os: empty body" });
+          emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error" });
+          return { turnId };
+        }
+
+        // Parse SSE: lines starting with "data: " until "[DONE]"
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        let fullText = "";
+        let lastUsage: { input: number; output: number } | null = null;
+        let stopReason: string | null = null;
+
+        // emit the assistant_text item as "in progress"
+        emit({
+          ...base(turn.threadId, turnId, itemId),
+          type: "item.started",
+          itemType: "tool", // placeholder; reassigned to assistant_text on completion
+          title: "assistant",
+        });
+
+        try {
+          for (;;) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buf += decoder.decode(value, { stream: true });
+            let nl;
+            while ((nl = buf.indexOf("\n")) !== -1) {
+              const line = buf.slice(0, nl).replace(/\r$/, "");
+              buf = buf.slice(nl + 1);
+              if (!line.startsWith("data:")) continue;
+              const payload = line.slice(5).trim();
+              if (payload === "[DONE]") {
+                buf = "__DONE__";
+                break;
+              }
+              if (!payload) continue;
+              let parsed: any;
+              try { parsed = JSON.parse(payload); } catch { continue; }
+              appendNative(turn.threadId, { dir: "in", source: "hermes-os", msg: parsed });
+              const choice = parsed?.choices?.[0];
+              if (!choice) continue;
+              const delta = choice.delta ?? choice.message;
+              const piece = delta?.content;
+              if (typeof piece === "string" && piece.length > 0) {
+                fullText += piece;
+                emit({
+                  ...base(turn.threadId, turnId, itemId),
+                  type: "content.delta",
+                  streamKind: "assistant_text",
+                  delta: piece,
+                });
+              }
+              if (typeof choice.finish_reason === "string" && choice.finish_reason) {
+                stopReason = choice.finish_reason;
+              }
+              if (parsed.usage && typeof parsed.usage === "object") {
+                const u = parsed.usage;
+                lastUsage = {
+                  input: Number(u.prompt_tokens ?? 0),
+                  output: Number(u.completion_tokens ?? 0),
+                };
+              }
+            }
+            if (buf === "__DONE__") break;
+          }
+        } catch (e: any) {
+          if (e?.name === "AbortError") {
+            stopReason = stopReason ?? "interrupted";
+          } else {
+            emit({
+              ...base(turn.threadId, turnId),
+              type: "runtime.error",
+              message: `hermes-os: stream read error: ${e?.message ?? String(e)}`,
+            });
+            stopReason = "error";
+          }
+        } finally {
+          try { reader.releaseLock(); } catch { /* already released */ }
+        }
+
+        if (fullText) {
+          emit({
+            ...base(turn.threadId, turnId, itemId),
+            type: "item.completed",
+            itemType: "assistant_text",
+            text: fullText,
+          });
+        }
+        if (lastUsage) {
+          emit({
+            ...base(turn.threadId, turnId),
+            type: "thread.token-usage.updated",
+            input: lastUsage.input,
+            output: lastUsage.output,
+          });
+        }
+        emit({
+          ...base(turn.threadId, turnId),
+          type: "turn.completed",
+          ok: stopReason !== "error" && stopReason !== "interrupted",
+          stopReason,
+          denials: [],
+        });
+        // The hub doesn't carry long-lived sessions — each call is fresh.
+        // Emit session.exited so the UI can mark the chat as "no resume".
+        emit({
+          ...base(turn.threadId, turnId),
+          type: "session.exited",
+          reason: stopReason ?? "stop",
+        });
+        return { turnId };
+      } finally {
+        active.delete(turn.threadId);
+      }
+    };
+
+    const interruptTurn = async (threadId: string, _turnId?: string): Promise<void> => {
+      const entry = active.get(threadId);
+      if (entry) entry.abort.abort();
+    };
+
+    const respondToRequest = async (
+      _threadId: string,
+      _requestId: string,
+      decision: { behavior: "allow" | "deny" | "answer"; message?: string },
+    ): Promise<void> => {
+      // hermes-os handles its own permission flow via the underlying CLI
+      // providers (Claude/Codex etc.). When invoked through this driver,
+      // permission requests are surfaced as runtime.error events and we
+      // auto-deny with a note. The OpenMausBot core can override by
+      // calling interruptTurn() and re-sending.
+      emit({
+        ...base(_threadId, active.get(_threadId)?.turnId ?? newId()),
+        type: "request.resolved",
+        behavior: decision.behavior,
+        source: "hermes-os-driver",
+      });
+    };
+
+    const hasSession = (_threadId: string): boolean => false; // no long-lived sessions
+
+    const stopAll = async (): Promise<void> => {
+      for (const [, entry] of active) entry.abort.abort();
+      active.clear();
+    };
+
+    const onEvent = (listener: RuntimeEventListener): (() => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    };
+
+    const generateText = async (prompt: string): Promise<string> => {
+      const fakeTurn: SendTurnInput = {
+        threadId: newId(),
+        text: prompt,
+        model: config.defaultModel,
+      };
+      let text = "";
+      const unsub = onEvent((ev) => {
+        if (ev.type === "item.completed" && ev.itemType === "assistant_text") text = ev.text;
+      });
+      try {
+        await sendTurn(fakeTurn);
+      } finally {
+        unsub();
+      }
+      if (!text) throw new Error("hermes-os: generateText produced no text");
+      return text;
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      models: MODELS,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: {
+          sessionModelSwitch: "in-session",
+          // hermes-os supports the council intent for peer-agent comms
+          // when a hub instance is configured to expose it
+          agentsMcp: true,
+        },
+        sendTurn,
+        interruptTurn,
+        respondToRequest,
+        hasSession,
+        stopAll,
+        onEvent,
+      },
+      generateText,
+      async dispose(): Promise<void> {
+        await stopAll();
+        listeners.clear();
+      },
+    } satisfies ProviderInstance;
+  },
+};


### PR DESCRIPTION
## What

Adds `aiCounsel` as a built-in provider driver. `aiCounsel` wraps [The AI Counsel](https://github.com/jacob-bd/the-ai-counsel) (MIT, by jacob-bd) — a FastAPI service that runs a 3-stage LLM deliberation modeled on the karpathy LLM Council paper:

1. **Stage 1** — every council model answers the question independently, in parallel
2. **Stage 2** — every model peer-reviews the others, anonymized by label
3. **Stage 3** — a chairman model synthesizes the final answer from the rankings

The driver always uses `execution_mode: "full"` so OpenMausBot gets a synthesized final answer, not N unrelated first passes.

## Why

Same as the hermes-os driver (#18): the Council exposes a real SSE stream with structured event types that map cleanly onto the canonical `RuntimeEvent` union. A single fleet UI in OpenMausBot sees both drivers identically — turns look like turns, item events like item events, usage like usage. No new shape design.

The AI Counsel is a 3rd deliberation product alongside the hermes-os `council` model and the Ultimate Hub council — three different "ask everyone" implementations, all on the same homelab. This driver makes the 3rd one reachable from the Mac app with zero new code on the Council side.

## What works

- **Canonical event sequence** — `session.started` → `turn.started` → per-stage `item.completed: assistant_text` (one per model) → `turn.completed(ok: true)` → `session.exited`. All five token-usage events are emitted.
- **3-stage mapping** —
  - `stage1_progress` → item with text from the first model
  - `stage2_progress` → item with the peer-review text (or the parsed JSON ranking)
  - `stage3_complete` → item with the chairman's synthesis
- **Model catalog** — exposes both the Counsel's `local-agents:*` seats (Mac CLIs over SSH) and `ollama:*` / `openai/*` / `anthropic/*` / `x-ai/*` / `google/*` / `opencode/*` seats already configured in the Counsel's `settings.json`.
- **Snapshot** — uses `GET /api/conversations` as the health probe (the Counsel's `/api/health` route 404s in the current build).
- **Interrupt** — AbortController on the in-flight fetch.
- **Robust error paths** — preflight errors and conversation-create failures both surface as `runtime.error` + `turn.completed(ok: false)` instead of hanging.

## Tests

9 unit tests in `server/drivers/ai-counsel.test.ts` — same pattern as `hermes-os.test.ts`: spin up a mock HTTP server that mimics the Counsel's `/api/conversations` + SSE response, exercise the driver, assert the event sequence. Covers: default config, decodeConfig edge cases, unavailable snapshot, available snapshot, full canonical sequence for a 3-stage round, preflight error, conversation-create failure, model catalog contents.

```
$ pnpm typecheck && pnpm test
> tsc -b && tsc -p tsconfig.server.json
(no output)

 RUN  v4.1.10
 Test Files  12 passed (12)
      Tests  99 passed (99)
```

End-to-end smoke (`scripts/smoke-ai-counsel.ts`) against the live Counsel on the homelab with Ollama:

```
$ AI_COUNSEL_URL=http://127.0.0.1:8020 \
  AI_COUNSEL_MODEL=ollama:hermes3:8b \
  node --experimental-strip-types scripts/smoke-ai-counsel.ts
[smoke] snapshot: state=available
[smoke] session.started sessionId=… model=ollama:hermes3:8b
[smoke] turn.started
[smoke] ollama:hermes3:8b    [stage1_progress] pong
[smoke] ollama:hermes3:8b    [stage2_progress] {"model":"ollama:hermes3:8b","ranking":"Response A correctly responds…"
[smoke] local-agents:chatgpt-mac [synthesis] ping
[smoke] session.exited reason=stop
[smoke] ok=true stopReason=stop usage: in=606 out=160
[smoke] OK
```

~10s for a full 3-stage round on Ollama. Real model responses, real peer review, real synthesis, real event reconstruction.

## Known limitations

- **Each `sendTurn` creates a new Counsel conversation.** The OpenMausBot `threadId` is not a Counsel `conversationId` and there's no resume-cursor story that bridges them. If you want multi-turn within the same Council conversation, the right path is a `conversationId` config field (deferred — the simpler one-conversation-per-turn model works fine for "ask the council a question").
- **Chairman is fixed by the Counsel's `settings.json`.** The driver passes `council_models: [model]` to control which models run stage 1, but the stage-3 chairman is a server-side config. If you want to override it, set `body.chairman_model = "..."` in the driver (currently best-effort, no explicit config flag yet).
- **No streaming tokens.** The Counsel doesn't stream individual tokens within a model response — each stage's output is delivered as a single chunk. The driver emits one `item.completed: assistant_text` per stage. Adding token-level streaming would require upstream changes to the Counsel itself.

## Files

- `server/drivers/ai-counsel.ts` — 21 KB, the driver
- `server/drivers/ai-counsel.test.ts` — 10 KB, 9 unit tests
- `server/drivers/builtIn.ts` — 2-line change (import + register)
- `scripts/smoke-ai-counsel.ts` — 5 KB, end-to-end smoke

No new runtime dependencies. No `dist-server/` churn. No `pnpm-lock.yaml` churn. Driver uses only built-ins (`fetch`, `TextDecoder`, `AbortController`, `AbortSignal`). Pattern is symmetric with the hermes-os driver merged in #18.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass
- [x] New server behavior has a test (9 tests, all green)
- [x] `decodeConfig` throws on invalid; `create` rejects (async, never throws sync)
- [x] Only canonical `RuntimeEvent`s carrying `driverKind: "aiCounsel"`
- [x] Missing/broken counsel → `snapshot() → { state: "unavailable", reason }`
- [x] Failed turn → `runtime.error` + `turn.completed(ok: false)` (never hang, never crash)
- [x] No `shell: true`, no POSIX-only calls, no new runtime deps
- [x] No secrets in logs, response bodies, or argv
- [x] No UI changes (no screenshots needed)

---

Open question for the maintainer: do you want the OpenMausBot instance config UI to surface a "create a Counsel conversation" button (which would mean storing the `conversationId` per-thread), or is the simpler "one new conversation per turn" model good enough for v1? Happy to extend either way — just want to know before merging.
