### PR TITLE
docs: add grok to the architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ flowchart LR
     subgraph agents ["Agents on your Mac"]
         CL[claude CLI]
         CX[codex CLI]
+        GR[grok CLI]
     end
     UI -- "HTTP commands" --> server
     BUS -- "one SSE stream" --> UI
-    REG --> CL & CX
-    CL & CX -- "MCP" --> BROKER
+    REG --> CL & CX & GR
+    CL & CX & GR -- "permission requests" --> BROKER
     server -- "Box API" --> BOX[("Cloud computer<br/>box.ascii.dev")]
     server -- "Composio Connect" --> APPS[("Gmail · Slack · GitHub · …")]
 ```


### PR DESCRIPTION
The architecture diagram only showed the `claude` and `codex` CLIs, but the rest of the README already treats `grok` as a first-class agent CLI — the "bring your own agents" bullet, the requirements list, and the drivers table all mention it (and it ships as a default instance via the `grokAgent` driver).

This adds the `grok CLI` node to the "Agents on your Mac" subgraph and wires it through the driver registry and the permission broker like the others.

While here, the broker edge label went from `MCP` to `permission requests`: `MCP` only described the claude path — codex talks JSON-RPC and grok/gemini talk ACP, but all of them surface consent through the same broker.

Note: `gemini` also ships as a default driver (`geminiAgent`) but isn't mentioned anywhere in the README prose, so I left it out of the diagram to avoid it being the only place it appears — happy to add it (diagram + prose) in a follow-up if it should be first-class too.
