### PR TITLE
fix(desktop): quit even when the CUA daemon stop hangs

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -195,6 +195,9 @@ app.on("window-all-closed", () => {
 
 // EMBEDDING.md lifecycle rule: defer the first quit until the embedded
 // daemon's async cleanup completes — it can't run after the host exits.
+// The defer is capped: a wedged daemon whose stop never settles must not
+// be able to hold the app hostage, so quit anyway after the timeout.
+const CUA_STOP_TIMEOUT_MS = 2500;
 let cuaCleanedUp = false;
 app.on("before-quit", (e) => {
   if (cuaCleanedUp) return;
@@ -202,7 +205,11 @@ app.on("before-quit", (e) => {
   try {
     serverProc?.kill();
   } catch {}
-  stopCua().finally(() => {
+  const cleanup = Promise.race([
+    stopCua(),
+    new Promise((resolve) => setTimeout(resolve, CUA_STOP_TIMEOUT_MS).unref()),
+  ]);
+  cleanup.finally(() => {
     cuaCleanedUp = true;
     app.quit();
   });


### PR DESCRIPTION
## What changed

Races the embedded CUA daemon's async stop against a short timeout in the `before-quit` handler so quitting can never hang on a wedged daemon.

```js
const cleanup = Promise.race([
  stopCua(),
  new Promise((resolve) => setTimeout(resolve, CUA_STOP_TIMEOUT_MS).unref()),
]);
cleanup.finally(() => {
  cuaCleanedUp = true;
  app.quit();
});
```

Closes #15.

## Why

**Problem:** `before-quit` defers quit on `stopCua()` (`electron/main.mjs`), which awaits `embeddedHost.stop()` (`electron/cua.mjs`). If the daemon is wedged, that promise never settles, `app.quit()` is never reached, and the app hangs indefinitely (the v0.1.5 packaged-app smoke test needed SIGKILL after 15s).

**Triage / root cause:** the `before-quit` handler calls `e.preventDefault()` and then only ever calls `app.quit()` from inside `stopCua().finally(...)`. A stop that never resolves leaves the handler waiting forever. The cleanup defer is correct per EMBEDDING.md — it just has no upper bound.

**Fix:** race `stopCua()` against a 2.5s timeout and quit regardless. The timeout timer is `unref()`'d so it can never keep the process alive on its own; the normal path (stop settles quickly) is unchanged.

## How it was verified

- `pnpm typecheck` — clean.
- `pnpm test` — 10 files / 82 tests pass.
- Repro reasoning: with `embeddedHost.stop()` never settling, `Promise.race` resolves at 2.5s, `finally` runs, `app.quit()` executes. Electron shell code isn't covered by the vitest suite (CI never launches Electron), consistent with the existing repo layout — no `electron/` tests exist today.

## Screenshots (UI changes)

N/A — main-process lifecycle change, no UI.

## Notes

- Overlap: open PRs #17 (Windows support) and #21 (hardening) also touch `electron/main.mjs` but not this handler — happy to rebase if they land first.
- The timeout lives in the quit path (as suggested in the issue) rather than inside `stopCua()`, keeping the change minimal and the diff surface small.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] No server behavior changed (electron-shell only) — no new tests needed per CONTRIBUTING
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
