### PR TITLE
fix(desktop): stop the dictation helper on quit so it is never orphaned

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -202,6 +202,9 @@ app.on("before-quit", (e) => {
   try {
     serverProc?.kill();
   } catch {}
+  // a live dictation session runs its own helper child that holds the mic —
+  // stop it here so quitting never orphans a recording process
+  stopSpeech();
   stopCua().finally(() => {
     cuaCleanedUp = true;
     app.quit();


### PR DESCRIPTION
## What changed

Calls `stopSpeech()` in the `before-quit` cleanup so a dictation session in progress can never leave an orphaned recording process behind.

```js
// a live dictation session runs its own helper child that holds the mic —
// stop it here so quitting never orphans a recording process
stopSpeech();
```

## Why

**Problem:** `startSpeech()` spawns a dedicated `speech-helper` child process that owns the microphone session. The `before-quit` handler already kills the harness server and stops the CUA daemon, but never stops speech — so quitting while dictating orphans the helper process, which keeps the mic (and its TCC grant) held after the app is gone.

**Triage / root cause:** `stopSpeech` is only wired to the `speech:stop` IPC handler in `electron/main.mjs`; nothing in the quit path invokes it, even though the same handler already tears down the other two owned processes (server + CUA daemon).

**Fix:** call `stopSpeech()` in `before-quit` alongside the server kill, mirroring the CUA stop. `stopSpeech` is a no-op when no session is active (`if (!child) return`), so this is free in the common case.

## How it was verified

- `pnpm typecheck` — clean.
- `pnpm test` — 10 files / 82 tests pass.
- Electron shell code isn't covered by the vitest suite (CI never launches Electron), consistent with the existing repo layout — no `electron/` tests exist today.

## Screenshots (UI changes)

N/A — main-process lifecycle change, no UI.

## Notes

- Overlap: open PR #17 (Windows support) also touches `electron/speech.mjs`/`electron/main.mjs`; this change is in the quit handler only, happy to rebase if it lands first.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] No server behavior changed (electron-shell only) — no new tests needed per CONTRIBUTING
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
