### PR TITLE
Improve API key setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,17 @@ Requirements: **macOS**, **Node 24+**, **pnpm**, and at least one agent CLI — 
 [`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
 in the model picker automatically.
 
-Optional, pasted once in **App Settings** (gear in the sidebar footer):
+These credentials are optional — local chat works without them. Paste a key once in **App Settings** (gear
+in the sidebar footer) when you want to enable its integration:
 
-| Key | Unlocks |
-|---|---|
-| Composio Connect key (`ck_…`) | The connected-apps marketplace |
-| Composio API key (`ak_…`) | The full 500+ app catalog with official logos |
-| Box token ([box.ascii.dev](https://box.ascii.dev)) | Cloud computers for your bots |
+| Credential | What it enables | Where to get it |
+|---|---|---|
+| Composio Connect key (`ck_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [Composio Connect setup guide](https://docs.composio.dev/docs/composio-connect) |
+| Composio API key (`ak_…`) | Browse the full app catalog with official names and logos | [Composio project API key guide](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
+| Box API key | Give bots an isolated remote Linux computer with a desktop and terminal | [Box API key guide](https://docs.ascii.dev/box/api-keys) |
+
+Composio and Box are third-party services with their own accounts and terms. Box is a paid service after
+its trial, and using a cloud computer may incur charges.
 
 ```sh
 pnpm typecheck     # app + server

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -2,7 +2,7 @@
 // ~/.openmausbot/config.json and hot-reloads the provider fleet; secrets
 // are write-only — GET /api/config returns configured flags, never values.
 import { useState } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-react";
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
@@ -20,15 +20,83 @@ const SECTIONS: Record<
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
 };
 
+const CREDENTIALS: Record<
+  ConfigSection,
+  {
+    label: string;
+    placeholder: string;
+    description: string;
+    href: string;
+    linkLabel: string;
+    optional: boolean;
+    warning?: string;
+  }
+> = {
+  composio: {
+    label: "Composio Connect key",
+    placeholder: "ck_…",
+    description: "Connect Gmail, GitHub, Slack, Notion, and other apps to your bots.",
+    href: "https://docs.composio.dev/docs/composio-connect",
+    linkLabel: "Open Composio setup guide",
+    optional: true,
+  },
+  composioApi: {
+    label: "Composio API key",
+    placeholder: "ak_…",
+    description: "Unlock the full app catalog with official names and logos.",
+    href: "https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions",
+    linkLabel: "Open Composio API key guide",
+    optional: true,
+  },
+  box: {
+    label: "Box API key",
+    placeholder: "Paste your Box API key",
+    description: "Give bots an isolated remote Linux computer with a desktop and terminal.",
+    href: "https://docs.ascii.dev/box/api-keys",
+    linkLabel: "Open Box API key guide",
+    optional: true,
+    warning: "Box is a paid service after its trial. Usage may incur charges.",
+  },
+};
+
+function CredentialHelp({ section }: { section: ConfigSection }) {
+  const credential = CREDENTIALS[section];
+
+  return (
+    <details className="group relative ml-auto">
+      <summary
+        aria-label={`About ${credential.label}`}
+        className="flex size-6 cursor-pointer list-none items-center justify-center rounded-md text-ink-secondary outline-none transition-colors hover:bg-raised hover:text-ink focus-visible:ring-2 focus-visible:ring-accent/70 [&::-webkit-details-marker]:hidden"
+      >
+        <CircleHelp size={14} aria-hidden="true" />
+      </summary>
+      <div className="animate-pop-in absolute right-0 z-30 mt-1.5 w-[270px] rounded-xl border border-hairline bg-panel p-3 text-left shadow-2xl">
+        <div className="text-[12px] leading-[1.45] text-ink-secondary">{credential.description}</div>
+        {credential.warning && (
+          <div className="mt-2 flex gap-1.5 rounded-lg border border-warning/25 bg-warning/10 px-2 py-1.5 text-[11px] leading-[1.4] text-warning">
+            <TriangleAlert size={13} className="mt-px shrink-0" aria-hidden="true" />
+            <span>{credential.warning}</span>
+          </div>
+        )}
+        <a
+          href={credential.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2.5 flex items-center gap-1.5 text-[12px] font-medium text-accent hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+        >
+          {credential.linkLabel}
+          <ExternalLink size={12} aria-hidden="true" />
+        </a>
+      </div>
+    </details>
+  );
+}
+
 export function ApiKeyRow({
   section,
-  label,
-  placeholder,
   onSaved,
 }: {
   section: ConfigSection;
-  label: string;
-  placeholder: string;
   /** Called after a successful save with the section's new configured flag. */
   onSaved?: (configured: boolean) => void;
 }) {
@@ -39,6 +107,7 @@ export function ApiKeyRow({
 
   const configured = state.config ? SECTIONS[section].flag(state.config) : false;
   const clearing = !value.trim() && configured;
+  const credential = CREDENTIALS[section];
 
   const save = () => {
     if (saving || (!value.trim() && !configured)) return;
@@ -61,8 +130,14 @@ export function ApiKeyRow({
     <div>
       <div className="mb-1.5 flex items-center gap-2 text-[13px] text-ink-secondary">
         <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
-        {label}
+        <span>{credential.label}</span>
+        {credential.optional && (
+          <span className="rounded bg-raised px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-secondary">
+            Optional
+          </span>
+        )}
         {configured && <span className="text-[11px] text-success">Connected</span>}
+        <CredentialHelp section={section} />
       </div>
       <div className="flex gap-2">
         <input
@@ -70,7 +145,8 @@ export function ApiKeyRow({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && save()}
-          placeholder={configured ? "••••••••  (paste to replace)" : placeholder}
+          placeholder={configured ? "••••••••  (paste to replace)" : credential.placeholder}
+          aria-label={credential.label}
           autoComplete="off"
           className="w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 text-[13px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none"
         />

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -1,7 +1,7 @@
 // Paste-a-key rows for PUT /api/config. The server persists to
 // ~/.openmausbot/config.json and hot-reloads the provider fleet; secrets
 // are write-only — GET /api/config returns configured flags, never values.
-import { useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-react";
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
@@ -61,34 +61,71 @@ const CREDENTIALS: Record<
 
 function CredentialHelp({ section }: { section: ConfigSection }) {
   const credential = CREDENTIALS[section];
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsideClick);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
 
   return (
-    <details className="group relative ml-auto">
-      <summary
+    <div ref={rootRef} className="relative ml-auto">
+      <button
+        ref={buttonRef}
+        type="button"
         aria-label={`About ${credential.label}`}
-        className="flex size-6 cursor-pointer list-none items-center justify-center rounded-md text-ink-secondary outline-none transition-colors hover:bg-raised hover:text-ink focus-visible:ring-2 focus-visible:ring-accent/70 [&::-webkit-details-marker]:hidden"
+        aria-expanded={open}
+        aria-controls={popoverId}
+        onClick={() => setOpen((current) => !current)}
+        className="flex size-6 items-center justify-center rounded-md text-ink-secondary outline-none transition-colors hover:bg-raised hover:text-ink focus-visible:ring-2 focus-visible:ring-accent/70"
       >
         <CircleHelp size={14} aria-hidden="true" />
-      </summary>
-      <div className="animate-pop-in absolute right-0 z-30 mt-1.5 w-[270px] rounded-xl border border-hairline bg-panel p-3 text-left shadow-2xl">
-        <div className="text-[12px] leading-[1.45] text-ink-secondary">{credential.description}</div>
-        {credential.warning && (
-          <div className="mt-2 flex gap-1.5 rounded-lg border border-warning/25 bg-warning/10 px-2 py-1.5 text-[11px] leading-[1.4] text-warning">
-            <TriangleAlert size={13} className="mt-px shrink-0" aria-hidden="true" />
-            <span>{credential.warning}</span>
-          </div>
-        )}
-        <a
-          href={credential.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2.5 flex items-center gap-1.5 text-[12px] font-medium text-accent hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+      </button>
+      {open && (
+        <div
+          id={popoverId}
+          role="group"
+          aria-label={`${credential.label} help`}
+          className="animate-pop-in absolute right-0 z-30 mt-1.5 w-[270px] rounded-xl border border-hairline bg-panel p-3 text-left shadow-2xl"
         >
-          {credential.linkLabel}
-          <ExternalLink size={12} aria-hidden="true" />
-        </a>
-      </div>
-    </details>
+          <div className="text-[12px] leading-[1.45] text-ink-secondary">{credential.description}</div>
+          {credential.warning && (
+            <div className="mt-2 flex gap-1.5 rounded-lg border border-warning/25 bg-warning/10 px-2 py-1.5 text-[11px] leading-[1.4] text-warning">
+              <TriangleAlert size={13} className="mt-px shrink-0" aria-hidden="true" />
+              <span>{credential.warning}</span>
+            </div>
+          )}
+          <a
+            href={credential.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            className="mt-2.5 flex items-center gap-1.5 text-[12px] font-medium text-accent hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+          >
+            {credential.linkLabel}
+            <ExternalLink size={12} aria-hidden="true" />
+          </a>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/components/AppSettingsPanel.tsx
+++ b/src/components/AppSettingsPanel.tsx
@@ -79,13 +79,9 @@ export function AppSettingsPanel() {
             shown again.
           </div>
           <div className="mt-4 flex flex-col gap-4">
-            <ApiKeyRow section="composio" label="Composio Connect key" placeholder="ck_…" />
-            <ApiKeyRow
-              section="composioApi"
-              label="Composio API key (optional)"
-              placeholder="ak_…  unlocks the full app catalog"
-            />
-            <ApiKeyRow section="box" label="Box token" placeholder="Token from box.ascii.dev" />
+            <ApiKeyRow section="composio" />
+            <ApiKeyRow section="composioApi" />
+            <ApiKeyRow section="box" />
           </div>
         </div>
       </div>

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -44,7 +44,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<"join" | "sleep" | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // bumped when a Box token is saved inline, to re-run the spin-up flow
+  // bumped when a Box API key is saved inline, to re-run the spin-up flow
   const [retry, setRetry] = useState(0);
 
   // resolve the mode on open; box endpoints are only ever hit on the
@@ -248,12 +248,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         {phase === "unconfigured" && (
           <div className="mt-3 rounded-xl bg-card p-4">
             <div className="mb-3 text-[13px] text-ink-secondary">
-              Paste a Box token from box.ascii.dev to give this bot a cloud computer — it spins up right here.
+              Add a Box API key to give this bot a cloud computer — it spins up right here.
             </div>
             <ApiKeyRow
               section="box"
-              label="Box token"
-              placeholder="Token from box.ascii.dev"
               onSaved={(configured) => configured && setRetry((n) => n + 1)}
             />
           </div>


### PR DESCRIPTION
## Summary

- add compact, accessible help popovers for Composio Connect, Composio API, and Box credentials
- link each credential directly to its official setup documentation
- mark credentials as optional and call out potential Box charges
- rename "Box token" to "Box API key" throughout the UI
- document credential purpose, setup location, and Box billing considerations in the README

## Why

App Settings previously showed credential names and placeholders without explaining what each key enabled or exactly where users could obtain it. That made initial setup confusing for users unfamiliar with Composio or Box.

The new interaction keeps the settings panel visually clean by placing detailed guidance behind a keyboard-accessible help control.

## Validation

- pnpm typecheck
- pnpm test — 82 tests passed
- pnpm build
- browser-based visual review at 1440 × 900

Closes #19