### PR TITLE
Dictate in the user's language, not always en-US

### DIFF
--- a/electron/resources/speech-helper.swift
+++ b/electron/resources/speech-helper.swift
@@ -24,8 +24,15 @@ func fail(_ message: String) -> Never {
 
 SFSpeechRecognizer.requestAuthorization { status in
   guard status == .authorized else { fail("speech-not-authorized") }
-  guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US")),
-    recognizer.isAvailable
+  // Recognize in the user's language: a hardcoded en-US recognizer
+  // transcribes everyone else into nonsense. First preference that has an
+  // available recognizer wins, with en-US as the last resort.
+  let candidates =
+    Locale.preferredLanguages.map { Locale(identifier: $0) }
+    + [Locale.current, Locale(identifier: "en-US")]
+  guard
+    let recognizer = candidates.lazy.compactMap({ SFSpeechRecognizer(locale: $0) })
+      .first(where: { $0.isAvailable })
   else { fail("recognizer-unavailable") }
 
   let request = SFSpeechAudioBufferRecognitionRequest()


### PR DESCRIPTION
`speech-helper.swift` pins the recognizer to `en-US`, so dictation only works for English speakers — everyone else gets their speech transcribed into English words that sound roughly similar.

It now walks `Locale.preferredLanguages` and uses the first locale with an available recognizer, falling back to `en-US`. A locale the system has no model for reports `isAvailable == false`, so this can only match today's behavior or improve on it.

One caveat: the system language is not always the language someone dictates in, so a per-user setting would cover that case properly. 

`pnpm typecheck && pnpm test` pass, and the helper compiles with `swiftc`.