### PR TITLE
Paste images into the composer

### DIFF
--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -1,0 +1,48 @@
+// Pasted images: what the wire is allowed to carry, and what the Claude CLI
+// is handed for it.
+import { describe, expect, it } from "vitest";
+
+import { sanitizeImages, userContent } from "./attachments.ts";
+
+const png = { mime: "image/png", data: "aGVsbG8=" };
+
+describe("sanitizeImages", () => {
+  it("keeps well-formed images", () => {
+    expect(sanitizeImages([png])).toEqual([png]);
+  });
+
+  it("drops anything that is not a supported image", () => {
+    expect(sanitizeImages([{ mime: "application/pdf", data: "aGk=" }])).toEqual([]);
+    expect(sanitizeImages([{ mime: "image/png", data: "not base64!" }])).toEqual([]);
+    expect(sanitizeImages([{ mime: "image/png" }, null, "nope", 7])).toEqual([]);
+    expect(sanitizeImages(undefined)).toEqual([]);
+  });
+
+  it("refuses an image too big to be worth sending", () => {
+    expect(sanitizeImages([{ mime: "image/png", data: "a".repeat(5_000_001) }])).toEqual([]);
+  });
+
+  it("caps how many ride on one message", () => {
+    expect(sanitizeImages(Array.from({ length: 20 }, () => png))).toHaveLength(6);
+  });
+});
+
+describe("userContent", () => {
+  it("stays a plain string when nothing is attached", () => {
+    expect(userContent("hi")).toBe("hi");
+    expect(userContent("hi", [])).toBe("hi");
+  });
+
+  it("becomes image blocks plus the text", () => {
+    expect(userContent("what is this?", [png])).toEqual([
+      { type: "image", source: { type: "base64", media_type: "image/png", data: png.data } },
+      { type: "text", text: "what is this?" },
+    ]);
+  });
+
+  it("sends an image with no words as image blocks alone", () => {
+    expect(userContent("", [png])).toEqual([
+      { type: "image", source: { type: "base64", media_type: "image/png", data: png.data } },
+    ]);
+  });
+});

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -1,0 +1,48 @@
+/** Image attachments on a user turn: what the wire is allowed to carry, and
+ * the content a driver hands its agent for it. */
+
+export interface ImageAttachment {
+  /** image/png, image/jpeg, … */
+  mime: string;
+  /** base64, no data: prefix — the same shape as a screen frame's png */
+  data: string;
+  name?: string;
+}
+
+const SUPPORTED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const MAX_IMAGES = 6;
+/** base64 chars, so ~3.7MB of image — under the 5MB per-image ceiling the
+ * providers enforce, with room for the rest of the turn. */
+const MAX_BASE64 = 5_000_000;
+
+/** Whatever arrived on the wire → the images worth keeping. Anything
+ * malformed, oversized, or of an unsupported type is dropped, never thrown:
+ * a bad paste must not cost the user their message. */
+export function sanitizeImages(input: unknown): ImageAttachment[] {
+  if (!Array.isArray(input)) return [];
+  const out: ImageAttachment[] = [];
+  for (const raw of input) {
+    if (out.length >= MAX_IMAGES) break;
+    if (!raw || typeof raw !== "object") continue;
+    const { mime, data, name } = raw as Record<string, unknown>;
+    if (typeof mime !== "string" || !SUPPORTED.has(mime)) continue;
+    if (typeof data !== "string" || data.length === 0 || data.length > MAX_BASE64) continue;
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(data)) continue;
+    out.push({ mime, data, ...(typeof name === "string" && name ? { name: name.slice(0, 120) } : {}) });
+  }
+  return out;
+}
+
+/** The `content` of a stream-json user message for the Claude CLI: a plain
+ * string when nothing is attached, the Messages-API block array when
+ * something is. */
+export function userContent(text: string, images?: ImageAttachment[]): unknown {
+  if (!images?.length) return text;
+  return [
+    ...images.map((img) => ({
+      type: "image",
+      source: { type: "base64", media_type: img.mime, data: img.data },
+    })),
+    ...(text ? [{ type: "text", text }] : []),
+  ];
+}

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -89,6 +89,9 @@ export type RuntimeEventListener = (event: RuntimeEvent) => void;
 export interface SendTurnInput {
   threadId: ThreadId;
   text: string;
+  /** Images the user attached (base64). Drivers that cannot pass images to
+   * their agent ignore them and send the text alone. */
+  images?: Array<{ mime: string; data: string; name?: string }>;
   model?: string;
   resumeCursor?: unknown;
   /** Prior turns for transcript-replay providers (API-backed drivers). */

--- a/server/drivers/claude-images.test.ts
+++ b/server/drivers/claude-images.test.ts
@@ -1,0 +1,69 @@
+// Attached images reach the claude CLI as Messages-API image blocks, and a
+// turn without them keeps the plain-string prompt. Same scripted fake CLI
+// as claude.test.ts.
+import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ensureDirs } from "../config.ts";
+import type { ProviderInstance } from "../contracts.ts";
+import { recordEvents, type EventRecorder } from "../testing/events.ts";
+import { ClaudeDriver } from "./claude.ts";
+
+const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
+// spawning a shebang script — POSIX-only until Windows CLI spawning lands
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+posixOnly("ClaudeDriver image attachments (fake CLI)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+  let scratch: string;
+
+  beforeEach(async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    scratch = mkdtempSync(join(tmpdir(), "omb-claude-img-test-"));
+    instance = await ClaudeDriver.create({
+      instanceId: "claude-img-test",
+      displayName: "Claude Image Test",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, permissionMode: "acceptEdits" },
+    });
+    recorder = recordEvents(instance.adapter);
+  });
+
+  afterEach(async () => {
+    delete process.env.FAKE_CLAUDE_DUMP;
+    recorder?.stop();
+    await instance?.dispose();
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  const promptSentFor = async (turn: { threadId: string; text: string; images?: any[] }) => {
+    const dump = join(scratch, `${turn.threadId}.json`);
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    await instance.adapter.sendTurn(turn);
+    await recorder.until((e) => e.type === "turn.completed");
+    return JSON.parse(readFileSync(dump, "utf8")).prompt;
+  };
+
+  it("sends image blocks ahead of the text", async () => {
+    const prompt = await promptSentFor({
+      threadId: "t-images",
+      text: "what is this?",
+      images: [{ mime: "image/png", data: "aGVsbG8=" }],
+    });
+    expect(prompt.message.content).toEqual([
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" } },
+      { type: "text", text: "what is this?" },
+    ]);
+  });
+
+  it("leaves an image-free turn as a plain string prompt", async () => {
+    const prompt = await promptSentFor({ threadId: "t-no-images", text: "hi" });
+    expect(prompt.message.content).toBe("hi");
+  });
+});

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { userContent } from "../attachments.ts";
 import { DATA_DIR } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 
@@ -459,7 +460,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       emit({ ...base(threadId, turnId), type: "turn.started" });
 
       // prompt over stdin as a stream-json message — never argv (ARG_MAX)
-      const promptMsg = { type: "user", message: { role: "user", content: turn.text } };
+      // attached images ride along as Messages-API image blocks; with none,
+      // content stays a plain string
+      const promptMsg = { type: "user", message: { role: "user", content: userContent(turn.text, turn.images) } };
       child.stdin.write(JSON.stringify(promptMsg) + "\n");
       child.stdin.end();
       appendNative(threadId, { dir: "out", source: "claude.sdk.message", msg: promptMsg });

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 import { dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { sanitizeImages, type ImageAttachment } from "./attachments.ts";
 import * as box from "./box.ts";
 import * as composio from "./composio.ts";
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
@@ -282,7 +283,11 @@ function readCuaConnection(): { command: string; args: string[]; env: Record<str
 }
 
 // ── turn dispatch (upstream ProviderCommandReactor, miniature) ──────────
-async function startTurn(botId: string, text: string, opts?: { commsDepth?: number }) {
+async function startTurn(
+  botId: string,
+  text: string,
+  opts?: { commsDepth?: number; images?: ImageAttachment[] },
+) {
   const bot = store.bot(botId);
   if (!bot) throw Object.assign(new Error("no such bot"), { status: 404 });
   if (bot.busy) throw Object.assign(new Error("the bot is already working — interrupt it first"), { status: 409 });
@@ -296,7 +301,8 @@ async function startTurn(botId: string, text: string, opts?: { commsDepth?: numb
     );
   }
 
-  const userMessage = store.appendMessage(bot.threadId, { role: "user", kind: "text", text });
+  const images = opts?.images?.length ? opts.images : undefined;
+  const userMessage = store.appendMessage(bot.threadId, { role: "user", kind: "text", text, images });
   broadcast({ kind: "message", threadId: bot.threadId, message: userMessage });
 
   // transcript for API-backed drivers: settled text turns only
@@ -369,6 +375,7 @@ async function startTurn(botId: string, text: string, opts?: { commsDepth?: numb
       await instance.adapter.sendTurn({
         threadId: bot.threadId,
         text,
+        images,
         model: bot.modelSelection.model,
         resumeCursor: bot.resumeCursors[bot.modelSelection.instanceId],
         transcript,
@@ -582,8 +589,9 @@ const server = createServer(async (req, res) => {
     if (m && method === "POST") {
       const body = await readBody(req);
       const text = String(body.text ?? "").trim();
-      if (!text) return json(res, 400, { error: "text required" });
-      await startTurn(m[1], text);
+      const images = sanitizeImages(body.images);
+      if (!text && images.length === 0) return json(res, 400, { error: "text required" });
+      await startTurn(m[1], text, { images });
       return json(res, 202, { ok: true });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)\/respond$/);

--- a/server/store.ts
+++ b/server/store.ts
@@ -48,6 +48,8 @@ export interface Message {
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;
+  /** images the user attached to this message (base64) */
+  images?: Array<{ mime: string; data: string; name?: string }>;
   at: number;
 }
 

--- a/src/components/Attachments.tsx
+++ b/src/components/Attachments.tsx
@@ -1,0 +1,49 @@
+import { X } from "lucide-react";
+import { dataUrl, type Attachment } from "@/lib/images";
+
+/** The pending-image strip above the composer. */
+export function AttachmentStrip({
+  images,
+  onRemove,
+}: {
+  images: Attachment[];
+  onRemove: (index: number) => void;
+}) {
+  if (images.length === 0) return null;
+  return (
+    <div className="mb-2 flex flex-wrap gap-2 px-2">
+      {images.map((img, i) => (
+        <div key={i} className="group relative">
+          <img
+            src={dataUrl(img)}
+            alt={img.name ?? "Pasted image"}
+            className="size-16 rounded-lg border border-hairline/40 object-cover"
+          />
+          <button
+            onClick={() => onRemove(i)}
+            title="Remove"
+            className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/40 bg-raised text-ink-secondary opacity-0 transition-opacity hover:text-ink group-hover:opacity-100"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Images that came with a chat message, under its bubble. */
+export function MessageImages({ images }: { images: Attachment[] }) {
+  return (
+    <div className="mt-2 flex flex-wrap justify-end gap-2">
+      {images.map((img, i) => (
+        <img
+          key={i}
+          src={dataUrl(img)}
+          alt={img.name ?? "Attached image"}
+          className="max-h-56 max-w-full rounded-lg border border-hairline/40"
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import { ChatMarkdown } from "./ChatMarkdown";
 import { OptionCard } from "./OptionCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
+import { MessageImages } from "./Attachments";
 import { cn } from "@/lib/cn";
 
 /** Long user messages collapse behind a fade so pasted walls of text don't
@@ -40,6 +41,7 @@ function Bubble({ message }: { message: Message }) {
                 Show full message
               </button>
             )}
+            {message.images?.length ? <MessageImages images={message.images} /> : null}
           </>
         ) : (
           <ChatMarkdown text={text} />

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -5,6 +5,8 @@ import { useStore, type Bot } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { MausAvatar } from "./Avatar";
 import { normalizeState } from "@/lib/mascot";
+import { AttachmentStrip } from "./Attachments";
+import { hasImages, imagesFromClipboard, MAX_ATTACHMENTS, type Attachment } from "@/lib/images";
 
 /** The active @mention query at the caret: the text between an `@` that
  * starts a word and the caret. null = no mention being typed. */
@@ -21,6 +23,7 @@ function mentionQueryAt(text: string, caret: number): { start: number; query: st
 export function Composer({ bot }: { bot: Bot }) {
   const { state, dispatch } = useStore();
   const [text, setText] = useState("");
+  const [images, setImages] = useState<Attachment[]>([]);
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [caret, setCaret] = useState(0);
@@ -61,10 +64,21 @@ export function Composer({ bot }: { bot: Bot }) {
   };
 
   const send = () => {
-    if (!text.trim() || bot.busy) return;
-    dispatch({ type: "send", botId: bot.id, text: text.trim() });
+    if ((!text.trim() && images.length === 0) || bot.busy) return;
+    dispatch({ type: "send", botId: bot.id, text: text.trim(), images });
     track("message_sent", { driver: bot.modelSelection?.instanceId });
     setText("");
+    setImages([]);
+  };
+
+  // paste an image (or several) straight into the box — the text paste path
+  // is untouched, since a text clipboard carries no image items
+  const onPaste = (e: React.ClipboardEvent) => {
+    if (!hasImages(e.clipboardData)) return;
+    e.preventDefault();
+    void imagesFromClipboard(e.clipboardData).then((pasted) => {
+      if (pasted.length) setImages((cur) => [...cur, ...pasted].slice(0, MAX_ATTACHMENTS));
+    });
   };
 
   // native dictation: partials stream into the input while the Swift
@@ -135,6 +149,7 @@ export function Composer({ bot }: { bot: Bot }) {
             ))}
           </div>
         )}
+        <AttachmentStrip images={images} onRemove={(i) => setImages((cur) => cur.filter((_, j) => j !== i))} />
         <div className="flex items-center gap-2 rounded-full border border-hairline/40 bg-raised/60 py-2 pl-2 pr-2">
         <button
           className="flex size-8 shrink-0 items-center justify-center rounded-full text-ink-secondary hover:bg-raised hover:text-ink"
@@ -150,6 +165,7 @@ export function Composer({ bot }: { bot: Bot }) {
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
           }}
+          onPaste={onPaste}
           onKeyUp={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
           onKeyDown={(e) => {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,107 @@
+/** Pasted images, on their way to the model: clipboard → base64, small
+ * enough to be worth sending. */
+
+export interface Attachment {
+  /** image/png, image/jpeg, … */
+  mime: string;
+  /** base64, no data: prefix — same shape the harness uses for screen frames */
+  data: string;
+  name?: string;
+}
+
+/** Claude's vision pipeline downscales anything larger than this anyway, so
+ * shrinking here costs nothing and keeps the thread file from ballooning. */
+const MAX_EDGE = 1568;
+/** Past this, a resized PNG is re-encoded as JPEG. Screenshots of text stay
+ * PNG-crisp; photos, which is what gets big, lose nothing that matters. */
+const PNG_BUDGET = 1_500_000;
+
+const SUPPORTED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+/** Per message. The server enforces the same cap — this one is only so the
+ * composer stops collecting thumbnails nobody will send. */
+export const MAX_ATTACHMENTS = 6;
+
+/** Does this clipboard carry an image? Synchronous, so a paste handler can
+ * decide whether to preventDefault before the event goes stale — copying a
+ * file in Finder puts its *name* on the clipboard as text too, and that
+ * should not land in the box next to the thumbnail. */
+export function hasImages(data: DataTransfer | null): boolean {
+  return data ? [...data.items].some((item) => item.kind === "file" && SUPPORTED.has(item.type)) : false;
+}
+
+/** The image files on a clipboard event, encoded and ready to send. Returns
+ * [] for a plain-text paste, which is every other paste.
+ *
+ * Must be called synchronously from the paste handler: the DataTransfer is
+ * only readable while the event is being dispatched. */
+export async function imagesFromClipboard(data: DataTransfer | null): Promise<Attachment[]> {
+  if (!data) return [];
+  const files = [...data.items]
+    .filter((item) => item.kind === "file" && SUPPORTED.has(item.type))
+    .map((item) => item.getAsFile())
+    .filter((f): f is File => f !== null);
+  return encodeAll(files);
+}
+
+/** The image files of a drop or a file picker. */
+export async function imagesFromFiles(files: FileList | File[]): Promise<Attachment[]> {
+  return encodeAll(Array.from(files).filter((f) => SUPPORTED.has(f.type)));
+}
+
+async function encodeAll(files: File[]): Promise<Attachment[]> {
+  const out: Attachment[] = [];
+  for (const file of files) {
+    const encoded = await encode(file).catch(() => null);
+    if (encoded) out.push(encoded);
+  }
+  return out;
+}
+
+async function encode(file: File): Promise<Attachment> {
+  const original = { mime: file.type, data: await toBase64(file), name: file.name || undefined };
+  // GIFs are left alone: drawing one to a canvas would keep the first frame
+  // and silently throw the animation away.
+  if (file.type === "image/gif") return original;
+
+  const bitmap = await createImageBitmap(file).catch(() => null);
+  if (!bitmap) return original;
+  const scale = Math.min(1, MAX_EDGE / Math.max(bitmap.width, bitmap.height));
+  if (scale === 1 && original.data.length <= PNG_BUDGET) {
+    bitmap.close();
+    return original;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(bitmap.width * scale);
+  canvas.height = Math.round(bitmap.height * scale);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    bitmap.close();
+    return original;
+  }
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  const png = canvas.toDataURL("image/png");
+  const chosen =
+    png.length <= PNG_BUDGET ? { url: png, mime: "image/png" } : { url: canvas.toDataURL("image/jpeg", 0.85), mime: "image/jpeg" };
+  const data = chosen.url.slice(chosen.url.indexOf(",") + 1);
+  // a re-encode that came out bigger is not worth having
+  if (data.length >= original.data.length && scale === 1) return original;
+  return { mime: chosen.mime, data, name: original.name };
+}
+
+function toBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => {
+      const url = String(reader.result);
+      resolve(url.slice(url.indexOf(",") + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export const dataUrl = (a: { mime: string; data: string }) => `data:${a.mime};base64,${a.data}`;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -36,6 +36,8 @@ export interface Message {
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;
+  /** images the user attached to this message (base64) */
+  images?: Array<{ mime: string; data: string; name?: string }>;
   at: number;
 }
 
@@ -115,7 +117,7 @@ type Action =
   | { type: "instances"; instances: InstanceInfo[] }
   | { type: "configStatus"; config: ConfigStatus }
   | { type: "select"; id: string }
-  | { type: "send"; botId: string; text: string }
+  | { type: "send"; botId: string; text: string; images?: Message["images"] }
   | { type: "answerCard"; botId: string; messageId: string; answer: string }
   | { type: "dismissCard"; botId: string; messageId: string }
   | { type: "newBot" }
@@ -422,7 +424,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         case "send":
           api(`/api/bots/${action.botId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text }),
+            body: JSON.stringify({ text: action.text, images: action.images }),
           }).catch(showError);
           break;
         case "answerCard": {


### PR DESCRIPTION
The composer only takes text, so anything visual — a screenshot of a failing build, a chart, a photo of a whiteboard — has to be described in words, or saved to a file and referenced by path, which only works when the bot happens to have filesystem tools.

Pasting an image now stages it as a thumbnail above the input (hover for an ✕ to drop it), sends with or without accompanying text, and renders in the user's own bubble. The Claude driver turns the attachments into Messages-API image blocks on the stream-json prompt; a turn with no images sends the same plain string it does today, and a driver that cannot carry images ignores them and sends the text alone.

Sizing happens before anything leaves the browser: 1568px on the long edge (past that the providers downscale anyway), re-encoded as PNG, or JPEG when the PNG would be large — GIFs pass through untouched so animation survives. `server/attachments.ts` re-validates independently of the client (known image types, at most 6 per message, 5MB of base64 each) and drops what fails rather than throwing away the user's message.

**Composer, before and after a paste:**

![composer before](https://raw.githubusercontent.com/guilimasp/OpenMausBot/pr-assets/paste-before-composer.png)

![composer after](https://raw.githubusercontent.com/guilimasp/OpenMausBot/pr-assets/paste-after-composer.png)

**The turn itself — pasted chart, and the bot reading it:**

![conversation](https://raw.githubusercontent.com/guilimasp/OpenMausBot/pr-assets/paste-after-conversation.png)

New behavior is covered by `server/attachments.test.ts` (wire validation and the block shape) and `server/drivers/claude-images.test.ts` (the driver contract against the scripted fake CLI, `skipIf(win32)` like its neighbours). `pnpm typecheck && pnpm test` pass, and there are no new dependencies.

Two things deliberately left out, happy to add either if you'd rather they ship together: the `+` button is still inert — this is only about paste — and only the Claude driver forwards images today.
