### PR TITLE
Clear the composer when switching bots

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -271,7 +271,10 @@ export function ChatView({ bot }: { bot: Bot }) {
         </button>
       )}
 
-      <Composer bot={bot} />
+      {/* keyed by bot: a draft belongs to the conversation it was typed in,
+          so switching bots starts from an empty composer instead of carrying
+          the previous bot's half-written message over */}
+      <Composer key={bot.id} bot={bot} />
     </main>
   );
 }


### PR DESCRIPTION
`Composer` owns its `text` state and stays mounted across bot switches, so a half-written message follows you into the next conversation — and pressing Enter there sends it to the wrong bot.

Keying it by bot id remounts it on every switch, which drops the draft and resets the mention picker with it. The dictation effect already stops the helper in its cleanup, so a recording in flight ends cleanly rather than leaking into another thread.

No visual change to capture — the difference is an empty input where the previous bot's text used to be. Happy to add a recording if you'd like one.

If you would rather keep drafts than drop them, per-bot drafts in `App` would work too; this is the smaller change and matches what the UI implies today.

`pnpm typecheck && pnpm test` pass.