### PR TITLE
Windows: resolve npm shims and shebang CLIs before spawning (no agent CLI is detected at all)

### DIFF
--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -6,8 +6,9 @@
 // session/new mcpServers → agents-proxy → /api/internal/ask-bot →
 // askBotAndWait → bus fold. The internal endpoints' auth is pinned too.
 //
-// The fake CLI is a shebang script, so the e2e half is POSIX-only (same
-// gating as acp.test.ts); the mention-resolution unit tests run everywhere.
+// The fake CLI is a shebang script — POSIX-only until resolveCliSpawn
+// turned it into `node <script>` on Windows too, so the e2e half now runs
+// everywhere alongside the mention-resolution units.
 import { spawn, type ChildProcess } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -21,7 +22,6 @@ const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
 const PORT = 18800 + Math.floor(Math.random() * 10_000);
 const BASE = `http://127.0.0.1:${PORT}`;
-const posixOnly = describe.skipIf(process.platform === "win32");
 
 describe("mentionedBots", () => {
   const peers = [
@@ -46,7 +46,7 @@ describe("mentionedBots", () => {
   });
 });
 
-posixOnly("comms e2e (fake ACP fleet)", () => {
+describe("comms e2e (fake ACP fleet)", () => {
   let child: ChildProcess;
   let home: string;
   let stderr = "";
@@ -81,6 +81,8 @@ posixOnly("comms e2e (fake ACP fleet)", () => {
       cwd: join(SERVER_DIR, ".."),
       env: {
         ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        // without SystemRoot, winsock fails to initialize in the child
+        ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
         HOME: home,
         USERPROFILE: home,
         OMB_PORT: String(PORT),

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -4,8 +4,8 @@
 // normalize the ACP handshake into canonical events, keep argv/env hygiene,
 // broker permission asks, and settle interrupts/crashes cleanly.
 //
-// Spawn-based tests are POSIX-only until Windows CLI spawning lands (the fake
-// CLI is a shebang script Windows cannot exec directly).
+// The fake CLI is a shebang script Windows cannot exec directly —
+// resolveCliSpawn turns it into `node <script>`, so these run everywhere.
 import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -19,7 +19,6 @@ import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
-const posixOnly = describe.skipIf(process.platform === "win32");
 
 describe("ACP decodeConfig", () => {
   it("grok defaults to the grok binary", () => {
@@ -34,7 +33,7 @@ describe("ACP decodeConfig", () => {
   });
 });
 
-posixOnly("ACP turns (fake CLI)", () => {
+describe("ACP turns (fake CLI)", () => {
   let instance: ProviderInstance;
   let recorder: EventRecorder;
   let scratch: string;
@@ -165,7 +164,7 @@ posixOnly("ACP turns (fake CLI)", () => {
   });
 });
 
-describe.skipIf(process.platform === "win32")("ACP snapshot", () => {
+describe("ACP snapshot", () => {
   it("a missing binary is unavailable", async () => {
     const instance = await GrokAgentDriver.create({
       instanceId: "grok-missing",

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -26,7 +26,7 @@ import type {
   SendTurnInput,
 } from "../../contracts.ts";
 import { newEventId, newId } from "../../contracts.ts";
-import { augmentedPath } from "../../env-path.ts";
+import { augmentedPath, resolveCliSpawn } from "../../env-path.ts";
 import { appendNative } from "../native.ts";
 
 export interface AcpConfig {
@@ -150,10 +150,12 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         const env = childEnv();
         const mcpServers = acpMcpServers(turn);
 
-        const child = spawn(config.cli, support.spawnArgs(config, turn), {
+        const cli = resolveCliSpawn(config.cli, support.spawnArgs(config, turn));
+        const child = spawn(cli.command, cli.args, {
           cwd,
           env,
           stdio: ["pipe", "pipe", "pipe"],
+          windowsVerbatimArguments: cli.windowsVerbatimArguments,
           detached: true,
         });
 
@@ -469,8 +471,12 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
       const snapshot = async (): Promise<ProviderSnapshot> => {
         const env = childEnv();
         const version = await new Promise<string | null>((resolve) => {
-          execFile(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
-            resolve(err ? null : stdout.trim()),
+          const cli = resolveCliSpawn(config.cli, ["--version"]);
+          execFile(
+            cli.command,
+            cli.args,
+            { timeout: 8000, env, windowsVerbatimArguments: cli.windowsVerbatimArguments },
+            (err, stdout) => resolve(err ? null : stdout.trim()),
           );
         });
         if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -17,7 +17,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { DATA_DIR } from "../config.ts";
-import { augmentedPath } from "../env-path.ts";
+import { augmentedPath, resolveCliSpawn } from "../env-path.ts";
 
 import type {
   DriverCreateInput,
@@ -322,10 +322,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       delete env.CLAUDECODE;
       delete env.CLAUDE_CODE_ENTRYPOINT;
 
-      const child = spawn(config.cli, args, {
+      // resolve npm shims / shebang scripts to a real spawn
+      const cli = resolveCliSpawn(config.cli, args);
+      const child = spawn(cli.command, cli.args, {
         cwd: turn.cwd ?? homedir(),
         env,
         stdio: ["pipe", "pipe", "pipe"],
+        windowsVerbatimArguments: cli.windowsVerbatimArguments,
         detached: true, // own process group: killing -pid reaps child MCP servers
       });
 
@@ -469,8 +472,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const version = await new Promise<string | null>((resolve) => {
-        execFile(config.cli, ["--version"], { timeout: 8000, env: { ...process.env, PATH: augmentedPath() } }, (err, stdout) =>
-          resolve(err ? null : stdout.trim()),
+        const cli = resolveCliSpawn(config.cli, ["--version"]);
+        execFile(
+          cli.command,
+          cli.args,
+          {
+            timeout: 8000,
+            env: { ...process.env, PATH: augmentedPath() },
+            windowsVerbatimArguments: cli.windowsVerbatimArguments,
+          },
+          (err, stdout) => resolve(err ? null : stdout.trim()),
         );
       });
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
@@ -509,10 +520,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       },
       generateText: (prompt: string) =>
         new Promise((resolve, reject) => {
+          const cli = resolveCliSpawn(config.cli, ["-p", prompt, "--model", "claude-haiku-4-5", "--output-format", "text"]);
           execFile(
-            config.cli,
-            ["-p", prompt, "--model", "claude-haiku-4-5", "--output-format", "text"],
-            { timeout: 60_000, env: { ...process.env, PATH: augmentedPath() } },
+            cli.command,
+            cli.args,
+            {
+              timeout: 60_000,
+              env: { ...process.env, PATH: augmentedPath() },
+              windowsVerbatimArguments: cli.windowsVerbatimArguments,
+            },
             (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
           );
         }),

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -3,8 +3,8 @@
 // JSON-RPC handshake, normalize notifications into canonical events, and
 // surface server->client approval requests as request.opened.
 //
-// Spawn-based tests are POSIX-only until Windows CLI spawning lands (the
-// fake is a shebang script — same constraint as codex.cmd itself).
+// The fake is a shebang script — the same constraint codex.cmd itself
+// hits on Windows. resolveCliSpawn covers both, so these run everywhere.
 import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -16,7 +16,6 @@ import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { CodexDriver } from "./codex.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
-const posixOnly = describe.skipIf(process.platform === "win32");
 
 describe("CodexDriver.decodeConfig", () => {
   it("defaults to the codex binary with fullAuto off", () => {
@@ -28,7 +27,7 @@ describe("CodexDriver.decodeConfig", () => {
   });
 });
 
-posixOnly("CodexDriver turns (fake app-server)", () => {
+describe("CodexDriver turns (fake app-server)", () => {
   let instance: ProviderInstance;
   let recorder: EventRecorder;
   let scratch: string;

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -22,7 +22,7 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { newEventId, newId } from "../contracts.ts";
-import { augmentedPath } from "../env-path.ts";
+import { augmentedPath, resolveCliSpawn } from "../env-path.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "codex";
@@ -92,10 +92,12 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       // billing to pay-as-you-go (agentcal)
       delete env.OPENAI_API_KEY;
 
-      const child = spawn(config.cli, ["app-server"], {
+      const cli = resolveCliSpawn(config.cli, ["app-server"]);
+      const child = spawn(cli.command, cli.args, {
         cwd: turn.cwd ?? homedir(),
         env,
         stdio: ["pipe", "pipe", "pipe"],
+        windowsVerbatimArguments: cli.windowsVerbatimArguments,
         detached: true,
       });
 
@@ -378,8 +380,16 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const version = await new Promise<string | null>((resolve) => {
-        execFile(config.cli, ["--version"], { timeout: 8000, env: { ...process.env, PATH: augmentedPath() } }, (err, stdout) =>
-          resolve(err ? null : stdout.trim()),
+        const cli = resolveCliSpawn(config.cli, ["--version"]);
+        execFile(
+          cli.command,
+          cli.args,
+          {
+            timeout: 8000,
+            env: { ...process.env, PATH: augmentedPath() },
+            windowsVerbatimArguments: cli.windowsVerbatimArguments,
+          },
+          (err, stdout) => resolve(err ? null : stdout.trim()),
         );
       });
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };

--- a/server/env-path.test.ts
+++ b/server/env-path.test.ts
@@ -2,12 +2,12 @@
 // well-known install dir — or an nvm bin dir — must be findable even
 // when the process itself started with a bare GUI PATH.
 import { execFile } from "node:child_process";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { augmentedPath, resetPathCacheForTests } from "./env-path.ts";
+import { augmentedPath, resetPathCacheForTests, resolveCliSpawn } from "./env-path.ts";
 
 const posixIt = it.skipIf(process.platform === "win32");
 
@@ -74,5 +74,150 @@ describe("augmentedPath", () => {
     const parts = augmentedPath().split(delimiter);
     // temp home: .volta was never created, so it must not appear
     expect(parts).not.toContain(join(homedir(), ".volta", "bin"));
+  });
+});
+
+// Windows CLI resolution — spawn(cli) alone finds nothing on Windows (no
+// PATHEXT in libuv, no #!, and a .cmd throws outright since Node's
+// CVE-2024-27980 fix). Fixtures are the two real npm shim shapes.
+const winOnly = describe.skipIf(process.platform !== "win32");
+
+// the exact bytes npm writes for a CLI whose bin is a native binary
+const EXE_SHIM = `@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+"%dp0%\\node_modules\\pkg\\bin\\ombfake.exe"   %*
+`;
+
+// ...and for one whose bin is a node script (the "_prog" dance)
+const JS_SHIM = `@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\\node.exe" (
+  SET "_prog=%dp0%\\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\pkg\\bin\\ombfake.js" %*
+`;
+
+describe("resolveCliSpawn", () => {
+  it.skipIf(process.platform === "win32")("is identity off Windows — the kernel already resolves PATH and #!", () => {
+    expect(resolveCliSpawn("claude", ["-p", "hi"])).toEqual({ command: "claude", args: ["-p", "hi"] });
+  });
+});
+
+winOnly("resolveCliSpawn (Windows)", () => {
+  let dir: string;
+  const onPath = () => {
+    process.env.OMB_EXTRA_PATH = dir;
+    resetPathCacheForTests();
+  };
+  const shimWith = (name: string, body: string, target: string, targetBody: string) => {
+    writeFileSync(join(dir, name), body);
+    mkdirSync(join(dir, "node_modules", "pkg", "bin"), { recursive: true });
+    writeFileSync(join(dir, "node_modules", "pkg", "bin", target), targetBody);
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-shim-"));
+  });
+  afterEach(() => {
+    delete process.env.OMB_EXTRA_PATH;
+    resetPathCacheForTests();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("parses an npm .cmd shim down to the .exe it wraps", () => {
+    shimWith("ombfake.cmd", EXE_SHIM, "ombfake.exe", "MZ-not-really");
+    onPath();
+    expect(resolveCliSpawn("ombfake", ["-p", "hi"])).toEqual({
+      command: join(dir, "node_modules", "pkg", "bin", "ombfake.exe"),
+      args: ["-p", "hi"],
+    });
+  });
+
+  it("parses an npm .cmd shim down to `node <cli.js>`, never the shim's own node.exe", async () => {
+    shimWith("ombfake.cmd", JS_SHIM, "ombfake.js", "console.log('js target ' + process.argv.slice(2).join(','));\n");
+    onPath();
+    const r = resolveCliSpawn("ombfake", ["-p", "hi"]);
+    expect(r.args).toEqual([join(dir, "node_modules", "pkg", "bin", "ombfake.js"), "-p", "hi"]);
+    expect(r.command.toLowerCase()).toMatch(/node\.exe$/);
+    expect(r.windowsVerbatimArguments).toBeUndefined();
+
+    const stdout = await new Promise<string>((resolve, reject) =>
+      execFile(r.command, r.args, (err, out) => (err ? reject(err) : resolve(out))),
+    );
+    expect(stdout.trim()).toBe("js target -p,hi");
+  });
+
+  it("prefers the PATHEXT hit over the extensionless sibling npm installs beside it", () => {
+    shimWith("ombfake.cmd", EXE_SHIM, "ombfake.exe", "MZ-not-really");
+    writeFileSync(join(dir, "ombfake"), "#!/bin/sh\n# the POSIX shim — unrunnable here\n");
+    onPath();
+    expect(resolveCliSpawn("ombfake", []).command).toBe(join(dir, "node_modules", "pkg", "bin", "ombfake.exe"));
+  });
+
+  it("runs a #!node script through node — Windows has no shebang support", async () => {
+    const script = join(dir, "ombfake-cli.ts");
+    writeFileSync(script, "#!/usr/bin/env node\nconsole.log('shebang ' + process.argv.slice(2).join(','));\n");
+    const r = resolveCliSpawn(script, ["a", "b"]);
+    expect(r.command.toLowerCase()).toMatch(/node(\.exe)?$/);
+    expect(r.args).toEqual([script, "a", "b"]);
+
+    const stdout = await new Promise<string>((resolve, reject) =>
+      execFile(r.command, r.args, (err, out) => (err ? reject(err) : resolve(out))),
+    );
+    expect(stdout.trim()).toBe("shebang a,b");
+  });
+
+  it("falls back to ComSpec for an unparseable shim, and a raw-JSON argument survives it byte for byte", async () => {
+    // no "%dp0%"-relative target to find: the fallback is the only route
+    writeFileSync(
+      join(dir, "ombfake.cmd"),
+      "@ECHO OFF\nnode -e \"require('fs').writeFileSync(process.argv[1],JSON.stringify(process.argv.slice(2)))\" %*\n",
+    );
+    onPath();
+    const out = join(dir, "seen.json");
+    // the real payload this has to survive: claude's --mcp-config
+    const payload = JSON.stringify({
+      mcpServers: {
+        ogb: {
+          command: "C:\\Program Files\\nodejs\\node.exe",
+          args: ["a b", "%PATH%", "x&y|z", "q^r", "<in>out"],
+          env: { TOK: 'he said "hi"' },
+        },
+      },
+    });
+
+    const r = resolveCliSpawn("ombfake", [out, "--mcp-config", payload]);
+    expect(r.windowsVerbatimArguments).toBe(true);
+    expect(r.command.toLowerCase()).toMatch(/cmd\.exe$/);
+
+    await new Promise<void>((resolve, reject) =>
+      execFile(r.command, r.args, { windowsVerbatimArguments: true }, (err) => (err ? reject(err) : resolve())),
+    );
+    expect(JSON.parse(readFileSync(out, "utf8"))).toEqual(["--mcp-config", payload]);
+  });
+
+  it("hands an unknown CLI back untouched so spawn reports its own ENOENT", () => {
+    onPath();
+    expect(resolveCliSpawn("definitely-not-installed", ["-p"])).toEqual({
+      command: "definitely-not-installed",
+      args: ["-p"],
+    });
   });
 });

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -10,9 +10,9 @@
 // on this machine, plus (async, best-effort) whatever PATH the user's
 // real login shell reports.
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter, join } from "node:path";
+import { basename, delimiter, dirname, extname, join } from "node:path";
 
 /** nvm keeps every node version's bin dir separately; newest first so a
  * CLI installed under the latest node wins. */
@@ -93,4 +93,134 @@ function probeLoginShellPath(): void {
 export function resetPathCacheForTests(): void {
   cached = null;
   probed = false;
+}
+
+// Windows CLI resolution ───────────────────────────────────────────────
+// PATH alone is not enough on Windows. libuv ignores PATHEXT, so
+// spawn("claude") never finds claude.cmd — and since Node's
+// CVE-2024-27980 fix, spawning a .cmd without shell:true throws
+// synchronously anyway. shell:true is not an option here: the drivers
+// pass raw JSON in argv (claude's --mcp-config), which cmd would mangle.
+// Windows also has no #! support, so a node-shebang script (every fake
+// CLI in server/testing) is unspawnable as itself.
+//
+// So resolve the real file ourselves, PATHEXT-aware, and turn what we
+// find into a spawn that needs no shell: npm's .cmd shims are parsed
+// down to the .exe or node script they wrap, shebang scripts become
+// `node <script>`, and only an unparseable shim falls back to ComSpec
+// (with the escaping that fallback then owns).
+
+export interface ResolvedSpawn {
+  command: string;
+  args: string[];
+  /** set only on the ComSpec fallback — the args carry their own quoting */
+  windowsVerbatimArguments?: boolean;
+}
+
+function isFile(p: string): boolean {
+  return statSync(p, { throwIfNoEntry: false })?.isFile() ?? false;
+}
+
+/** PATHEXT-aware `which`. A path-ish cli is probed where it points. */
+function whichWin(cli: string): string | null {
+  const exts = (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
+  // an extensionless name is not runnable on Windows, so PATHEXT wins over
+  // the bare file — npm installs both `claude` (a sh script) and `claude.cmd`
+  const probe = (base: string) => {
+    const order = extname(base) ? [base, ...exts.map((e) => base + e)] : [...exts.map((e) => base + e), base];
+    return order.find(isFile) ?? null;
+  };
+  if (/[\\/]/.test(cli) || /^[a-zA-Z]:/.test(cli)) return probe(cli);
+  for (const dir of augmentedPath().split(delimiter)) {
+    if (!dir) continue;
+    const hit = probe(join(dir, cli));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** node.exe to run a script with: the one npm's shim would pick, else
+ * PATH, else ourselves (win32 builds are not packaged, so process.execPath
+ * is real node — an Electron one would need ELECTRON_RUN_AS_NODE). */
+function nodeExe(near: string): string {
+  const local = join(near, "node.exe");
+  if (isFile(local)) return local;
+  const onPath = whichWin("node");
+  return onPath && extname(onPath).toLowerCase() === ".exe" ? onPath : process.execPath;
+}
+
+/** npm/pnpm .cmd shims all spell their target as "%dp0%\..." (or
+ * "%~dp0\..."). Whatever of those exists on disk is what the shim runs. */
+function parseCmdShim(shim: string): ResolvedSpawn | null {
+  let text: string;
+  try {
+    text = readFileSync(shim, "utf8");
+  } catch {
+    return null;
+  }
+  const dir = dirname(shim);
+  const targets = [...text.matchAll(/"%~?dp0%?\\?([^"]+)"/g)]
+    .map((m) => join(dir, m[1]))
+    .filter((p) => isFile(p) && basename(p).toLowerCase() !== "node.exe");
+  const script = targets.find((p) => /\.[cm]?js$/i.test(p));
+  if (script) return { command: nodeExe(dir), args: [script] };
+  const exe = targets.find((p) => extname(p).toLowerCase() === ".exe");
+  return exe ? { command: exe, args: [] } : null;
+}
+
+/** `#!/usr/bin/env node` → `node <script>`. Only node: nothing else has a
+ * meaningful Windows equivalent worth guessing at. */
+function parseNodeShebang(file: string): ResolvedSpawn | null {
+  let head = "";
+  try {
+    const fd = openSync(file, "r");
+    const buf = Buffer.alloc(128);
+    const n = readSync(fd, buf, 0, buf.length, 0);
+    closeSync(fd);
+    head = buf.subarray(0, n).toString("utf8").split("\n", 1)[0];
+  } catch {
+    return null;
+  }
+  return /^#!.*\bnode(\.exe)?\b/.test(head) ? { command: nodeExe(dirname(file)), args: [file] } : null;
+}
+
+// cmd.exe quoting, per cross-spawn / https://qntm.org/cmd: quote the
+// argument for the CRT parser first, then ^-escape what cmd itself eats.
+// Twice, because the target is always a .cmd here and its `%*` hands the
+// line to a second round of cmd parsing.
+const CMD_META = /([()[\]%!^"`<>&|;, *?])/g;
+
+function escapeCmdArg(arg: string): string {
+  const quoted = `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+  return quoted.replace(CMD_META, "^$1").replace(CMD_META, "^$1");
+}
+
+function comSpecFallback(file: string, args: string[]): ResolvedSpawn {
+  const line = [file.replace(CMD_META, "^$1"), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    command: process.env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    windowsVerbatimArguments: true,
+  };
+}
+
+/**
+ * How to actually spawn `cli` with `args` on this platform. Identity
+ * everywhere but win32 — POSIX already resolves PATH and #! itself.
+ */
+export function resolveCliSpawn(cli: string, args: string[]): ResolvedSpawn {
+  if (process.platform !== "win32") return { command: cli, args };
+  const file = whichWin(cli);
+  // not found: hand back the name so spawn reports its own ENOENT
+  if (!file) return { command: cli, args };
+  const ext = extname(file).toLowerCase();
+  if (ext === ".cmd" || ext === ".bat") {
+    const direct = parseCmdShim(file);
+    return direct
+      ? { command: direct.command, args: [...direct.args, ...args] }
+      : comSpecFallback(file, args);
+  }
+  if (ext === ".exe" || ext === ".com") return { command: file, args };
+  const viaNode = parseNodeShebang(file);
+  return viaNode ? { command: viaNode.command, args: [...viaNode.args, ...args] } : { command: file, args };
 }

--- a/server/testing/setup.ts
+++ b/server/testing/setup.ts
@@ -11,6 +11,16 @@ const home = mkdtempSync(join(tmpdir(), "omb-test-home-"));
 process.env.HOME = home;
 process.env.USERPROFILE = home;
 
-afterAll(() => {
-  rmSync(home, { recursive: true, force: true });
+afterAll(async () => {
+  // Windows holds a directory that is a live process's cwd, and a
+  // just-killed CLI lets go a beat after the kill call returns (rmSync's own
+  // maxRetries does not cover an EPERM on the directory itself). Retry
+  // briefly — and never fail a green suite over a temp dir.
+  for (let i = 0; i < 20; i++) {
+    try {
+      return rmSync(home, { recursive: true, force: true });
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
 });


### PR DESCRIPTION
## What's broken

On Windows, no agent CLI is ever detected. Every provider reports `unavailable` regardless of what is installed, so no bot can be selected and no turn can start — the app is unusable on the platform.

Measured on Windows 10 with Claude Code 2.1.229 and codex-cli 0.144.6 both installed and working in the terminal, against `main` (8511f02):

```
claude snapshot -> {"state":"unavailable","reason":"`claude` CLI not found"}
codex  snapshot -> {"state":"unavailable","reason":"`codex` CLI not found"}
```

## Root cause

Three separate problems, all in the spawn path, all Windows-specific:

1. **libuv does not apply `PATHEXT`.** `spawn("claude")` looks for a file named literally `claude` and walks straight past `claude.cmd`, which is what npm actually installs. (npm writes both: a `claude` sh script for Git Bash and a `claude.cmd` shim for Windows. Only the latter is runnable here.)
2. **A `.cmd` cannot be spawned directly any more.** Since Node's fix for CVE-2024-27980, spawning a `.cmd`/`.bat` without `shell: true` throws synchronously.
3. **Windows has no `#!` support.** A node-shebang script — every fake CLI under `server/testing/` — cannot be executed as itself.

`shell: true` is not an option here. The drivers pass raw JSON in argv (claude's `--mcp-config`), and handing that to `cmd` mangles it.

## The fix

`resolveCliSpawn(cli, args)` in `server/env-path.ts` works out how to actually spawn the thing, without a shell:

- PATHEXT-aware `which` over `augmentedPath()`, preferring the PATHEXT hit over an extensionless sibling.
- npm/pnpm `.cmd` shims are parsed down to what they actually run — the `.exe`, or `node <cli.js>` for the `_prog` shim shape (never the shim's own bundled `node.exe`).
- `#!...node` scripts become `node <script>`.
- Only an unparseable shim falls back to `ComSpec`, and that path owns its escaping: arguments are quoted for the CRT parser and then `^`-escaped twice, because a `.cmd`'s `%*` hands the line to a second round of cmd parsing. A raw-JSON `--mcp-config` payload survives byte for byte (there is a test pinning exactly that).
- If nothing is found, the name is handed back untouched so `spawn` reports its own `ENOENT` as before.

Off win32 it is the identity function — POSIX resolves PATH and `#!` in the kernel, so nothing changes there.

Every driver spawn/execFile goes through it: `claude` (spawn, snapshot, generateText), `codex` (spawn, snapshot), `acp/core` (spawn, snapshot).

## Tests

The spawn-based suites were skipped on win32 for exactly this reason, so they are unskipped here. Two supporting changes were needed to make them actually pass on Windows:

- `server/testing/setup.ts` retries the temp-home cleanup briefly. Windows holds a directory that was a live process's cwd for a beat after the kill returns, and `rmSync`'s own `maxRetries` does not cover an `EPERM` on the directory itself.
- `server/comms.test.ts` passes `SystemRoot` through to the spawned server, without which winsock fails to initialize in the child.

`server/drivers/claude.test.ts` stays skipped on win32 in this PR — it additionally needs the permission-broker fix, and is unskipped in #42 (stacked on this one). The other Windows fixes in this series, #43 and #44, are independent of this PR and of each other.

## How this was tested

- `pnpm typecheck` and `pnpm test` on Windows 10: **77 passed / 15 skipped**, up from 52 passed / 33 skipped on `main`. Nothing regressed; the delta is entirely previously-skipped tests now running.
- 6 new unit tests for `resolveCliSpawn` covering both real npm shim shapes, the PATHEXT-vs-extensionless preference, the shebang rewrite, the ComSpec fallback with a raw-JSON payload round-tripped through `cmd`, and the not-found passthrough. The two shim fixtures are the exact bytes npm writes.
- Smoke test on real Windows 10 against the installed CLIs, same machine and same snapshot call as the "before" above:

```
claude: resolveCliSpawn -> {"command":"...\\@anthropic-ai\\claude-code\\bin\\claude.exe","args":["--version"]}
        snapshot -> {"state":"available","version":"2.1.229 (Claude Code)"}
codex:  resolveCliSpawn -> {"command":"...\\node.EXE","args":["...\\@openai\\codex\\bin\\codex.js","--version"]}
        snapshot -> {"state":"available","version":"codex-cli 0.144.6"}
```

macOS behaviour is unchanged by construction — `resolveCliSpawn` returns its input unmodified off win32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgJeiantdRcZSBrc5sqqCp
