### PR TITLE
Windows: kill the process tree, not a POSIX process group (stopped turns orphan their MCP servers)

### DIFF
--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -27,6 +27,7 @@ import type {
 } from "../../contracts.ts";
 import { newEventId, newId } from "../../contracts.ts";
 import { augmentedPath } from "../../env-path.ts";
+import { killTree } from "../../kill-tree.ts";
 import { appendNative } from "../native.ts";
 
 export interface AcpConfig {
@@ -188,15 +189,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             send({ jsonrpc: "2.0", id, method, params });
           });
 
-        const stop = () => {
-          try {
-            process.kill(-child.pid!, "SIGTERM");
-          } catch {
-            try {
-              child.kill("SIGTERM");
-            } catch {}
-          }
-        };
+        const stop = () => killTree(child); // process groups are POSIX-only
 
         const settle = (ok: boolean, stopReason: string | null) => {
           if (state.settled) return;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 
 import { DATA_DIR } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
+import { killTree } from "../kill-tree.ts";
 
 import type {
   DriverCreateInput,
@@ -326,7 +327,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         cwd: turn.cwd ?? homedir(),
         env,
         stdio: ["pipe", "pipe", "pipe"],
-        detached: true, // own process group: killing -pid reaps child MCP servers
+        detached: true, // own process group, so killTree reaps child MCP servers (-pid on POSIX, taskkill /T on win32)
       });
 
       let settled = false;
@@ -446,15 +447,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         }
       });
 
-      const stop = () => {
-        try {
-          process.kill(-child.pid!, "SIGTERM");
-        } catch {
-          try {
-            child.kill("SIGTERM");
-          } catch {}
-        }
-      };
+      const stop = () => killTree(child); // process groups are POSIX-only
       active.set(threadId, { stop, turnId, broker });
       emit({ ...base(threadId, turnId), type: "turn.started" });
 

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -23,6 +23,7 @@ import type {
 } from "../contracts.ts";
 import { newEventId, newId } from "../contracts.ts";
 import { augmentedPath } from "../env-path.ts";
+import { killTree } from "../kill-tree.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "codex";
@@ -117,15 +118,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           send({ jsonrpc: "2.0", id, method, params });
         });
 
-      const stop = () => {
-        try {
-          process.kill(-child.pid!, "SIGTERM");
-        } catch {
-          try {
-            child.kill("SIGTERM");
-          } catch {}
-        }
-      };
+      const stop = () => killTree(child); // process groups are POSIX-only
 
       const settle = (ok: boolean, stopReason: string | null) => {
         if (state.settled) return;

--- a/server/kill-tree.test.ts
+++ b/server/kill-tree.test.ts
@@ -1,0 +1,50 @@
+// The drivers spawn their CLI detached so that stopping a turn also stops
+// whatever the CLI started (its MCP servers). That guarantee is the whole
+// contract of killTree, so it is what gets tested: a grandchild must not
+// survive the kill on either platform.
+import { spawn } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import { killTree } from "./kill-tree.ts";
+
+const IDLE = "setInterval(() => {}, 1000)";
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("killTree", () => {
+  it("reaps a grandchild, not just the process it was handed", async () => {
+    // a stand-in CLI: spawns one helper, reports its pid, then idles
+    const parent = spawn(
+      process.execPath,
+      [
+        "-e",
+        `const c = require("node:child_process").spawn(process.execPath, ["-e", ${JSON.stringify(IDLE)}], { stdio: "ignore" });` +
+          `console.log(c.pid); ${IDLE}`,
+      ],
+      { stdio: ["ignore", "pipe", "ignore"], detached: true },
+    );
+    const grandchild = await new Promise<number>((resolve) =>
+      parent.stdout!.once("data", (c) => resolve(Number(String(c).trim()))),
+    );
+    expect(grandchild).toBeGreaterThan(0);
+    expect(alive(grandchild)).toBe(true);
+
+    killTree(parent);
+
+    // wait for both, and read the parent's death off the child object: a
+    // POSIX parent stays a live pid as a zombie until node reaps it
+    const exited = () => parent.exitCode !== null || parent.signalCode !== null;
+    for (let i = 0; i < 100 && (alive(grandchild) || !exited()); i++) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(alive(grandchild)).toBe(false);
+    expect(exited()).toBe(true);
+  });
+});

--- a/server/kill-tree.ts
+++ b/server/kill-tree.ts
@@ -1,0 +1,33 @@
+// Killing a CLI *and* everything it started, on every platform.
+//
+// The drivers spawn their CLI detached so it leads its own process group,
+// then kill -pid to reap the whole group — the CLI's MCP servers and
+// helper processes included. Process groups are a POSIX concept:
+// process.kill(-pid) throws EINVAL on Windows, and the fallback that
+// catches it kills the CLI alone, orphaning every server it started.
+// Windows tracks the parent/child tree instead, which is what
+// `taskkill /T` walks.
+import { execFile, type ChildProcess } from "node:child_process";
+
+/** Terminate a spawned CLI together with its descendants. Best-effort and
+ * synchronous to call: nothing here throws. */
+export function killTree(child: ChildProcess): void {
+  const pid = child.pid;
+  if (!pid || child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform === "win32") {
+    execFile("taskkill", ["/T", "/F", "/PID", String(pid)], (err) => {
+      if (!err) return;
+      try {
+        child.kill(); // taskkill unavailable or already gone — at least the CLI
+      } catch {}
+    });
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      child.kill("SIGTERM");
+    } catch {}
+  }
+}


### PR DESCRIPTION
## What's broken

Stopping a turn on Windows leaves the CLI's MCP servers running. They accumulate for as long as the app runs — every interrupted or completed turn orphans another set of node processes, holding ports, file handles and memory.

## Root cause

Every driver spawns its CLI with `detached: true` specifically so the CLI leads its own process group, and then reaps the whole group:

```js
const stop = () => {
  try {
    process.kill(-child.pid!, "SIGTERM");   // the group: CLI + its MCP servers
  } catch {
    try { child.kill("SIGTERM"); } catch {}  // fallback
  }
};
```

Process groups are a POSIX concept. On Windows `process.kill(-pid, ...)` throws `EINVAL` immediately, the `catch` swallows it, and the fallback `child.kill()` terminates **the CLI alone**. Every server and helper the CLI started survives as an orphan.

So the fallback is not a degraded path on Windows — it is the only path, and it is the wrong one.

## The fix

Windows tracks a parent/child tree rather than process groups, and `taskkill /T` walks it. `server/kill-tree.ts` picks the right mechanism per platform behind one call:

```js
const stop = () => killTree(child);
```

The POSIX branch is the existing code, unchanged, including its `child.kill()` fallback. The win32 branch is `taskkill /T /F /PID <pid>`, with `child.kill()` as its own fallback if taskkill is unavailable or the process is already gone.

`killTree` keeps the contract `stop()` had: best-effort, synchronous to call, never throws, and a no-op if the child has already exited.

Used by all three drivers (`claude`, `codex`, `acp/core`) in place of the identical inline `stop()` each carried.

## Tests

`server/kill-tree.test.ts` is new: it spawns a stand-in CLI that itself spawns one helper, calls `killTree` on the parent, and asserts the **grandchild** is gone — which is the entire point of spawning detached, and exactly what the old code failed to do on Windows. It runs on both platforms and would fail on Windows against `main`.

## How this was tested

- `pnpm typecheck` and `pnpm test` on Windows 10: **53 passed / 33 skipped** (52/33 on `main`, plus the new test). No regressions.
- The new test verified both ways on Windows: passing with `killTree`, and confirmed the grandchild survives with the old inline `stop()`.
- POSIX behaviour is unchanged by construction — that branch is the original code verbatim. The test reads the parent's death off the `ChildProcess` object rather than its pid, so a POSIX zombie window cannot make it flaky.

## Note on merge order

This touches the same `import { augmentedPath } from "../env-path.ts"` lines in the three drivers as #41, and lines adjacent to the claude spawn block. Whichever lands second needs a trivial rebase — happy to do it on request, in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgJeiantdRcZSBrc5sqqCp
