### PR TITLE
Resolve the computer-use contract under the real userData dir per platform (never found off macOS)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -263,14 +263,23 @@ function stopScreenPoller(botId: string): Frame | null {
   return entry.last;
 }
 
+// Where Electron's app.getPath("userData") lands, per platform — the
+// hardcoded macOS path found nothing anywhere else, and threw the
+// non-ENOENT errors into the same silent catch.
+function userDataRoot(): string {
+  if (process.platform === "win32") return process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  if (process.platform === "darwin") return join(homedir(), "Library", "Application Support");
+  return process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+}
+
 // Local computer-use contract written by Electron main on startup
-// (~/Library/Application Support/OpenMausBot/cua-connection.json). Read
-// fresh each turn — Electron may restart or permissions may change.
+// (<userData>/cua-connection.json). Read fresh each turn — Electron may
+// restart or permissions may change.
 function readCuaConnection(): { command: string; args: string[]; env: Record<string, string> } | null {
   // new name first; pre-rename desktop builds used the old directory
   for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
     try {
-      const p = join(homedir(), "Library", "Application Support", dir, "cua-connection.json");
+      const p = join(userDataRoot(), dir, "cua-connection.json");
       const conn = JSON.parse(readFileSync(p, "utf8"));
       if (!conn || conn.mode === "unavailable" || !conn.mcpCommand) continue;
       return { command: conn.mcpCommand, args: conn.mcpArgs ?? ["mcp"], env: conn.mcpEnv ?? {} };

--- a/server/index.ts
+++ b/server/index.ts
@@ -266,10 +266,14 @@ function stopScreenPoller(botId: string): Frame | null {
 // Where Electron's app.getPath("userData") lands, per platform — the
 // hardcoded macOS path found nothing anywhere else, and threw the
 // non-ENOENT errors into the same silent catch.
+// `||`, not `??`: a set-but-empty APPDATA/XDG_CONFIG_HOME would otherwise
+// join into a RELATIVE path resolved against the server's cwd — the same
+// silent ENOENT this function exists to stop. Electron ignores empty values
+// the same way.
 function userDataRoot(): string {
-  if (process.platform === "win32") return process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  if (process.platform === "win32") return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
   if (process.platform === "darwin") return join(homedir(), "Library", "Application Support");
-  return process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
 }
 
 // Local computer-use contract written by Electron main on startup


### PR DESCRIPTION
## What's broken

The local computer-use (CUA) bridge is never found on Windows or Linux. The desktop app writes its connection contract on startup, the server never sees it, and the computer-use tools stay unavailable — with no error to point at, because the failure is swallowed.

## Root cause

`readCuaConnection()` in `server/index.ts` looks for `cua-connection.json` under a hardcoded path:

```js
const p = join(homedir(), "Library", "Application Support", dir, "cua-connection.json");
```

That is Electron's `app.getPath("userData")` **on macOS only**. Electron puts userData at `%APPDATA%` on Windows and `$XDG_CONFIG_HOME` (falling back to `~/.config`) on Linux. So off macOS the path simply does not exist, `readFileSync` throws `ENOENT` into the `catch`, the loop tries the next legacy directory name, and every one of them fails the same way — ending at `return null`.

The same `catch` also swallows genuine errors (a malformed contract, a permissions problem) in exactly the same silent way, so there is nothing to distinguish "not running" from "wrong path" from "broken file".

## The fix

`userDataRoot()` returns the same directory Electron would, per platform:

| platform | userData |
|---|---|
| win32 | `%APPDATA%` (fallback `~/AppData/Roaming`) |
| darwin | `~/Library/Application Support` |
| other | `$XDG_CONFIG_HOME` (fallback `~/.config`) |

The existing loop over the four directory names (current plus pre-rename builds) is untouched, and the stale comment naming the macOS path is updated to `<userData>/cua-connection.json`.

**macOS behaviour is unchanged** — the `darwin` branch returns exactly the path that was hardcoded.

## How this was tested

- `pnpm typecheck` and `pnpm test` on Windows 10: **52 passed / 33 skipped**, identical to `main`. This path has no test coverage in the suite either before or after; the change is a pure path correction with the macOS case pinned to the previous literal.
- Verified by inspection against Electron's documented `app.getPath("userData")` platform table, and against where the desktop build actually writes the file on Windows (`%APPDATA%\OpenMausBot\cua-connection.json`).

Independent of the other Windows fixes in this series — it touches only `server/index.ts` and branches from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgJeiantdRcZSBrc5sqqCp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-file discovery across Windows, macOS, and Linux.
  * The application now uses each platform’s standard user-data location instead of assuming a macOS-specific path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->