### PR TITLE
feat: Multi-Ollama support (3 instances) + safe process management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md - Guardrails for AI Coding Sessions
+
+## CRITICAL: Process Management Safety
+
+### NEVER run blanket process kill commands
+On Windows, these kill ALL Node.js processes on the machine:
+- taskkill //F //IM node.exe
+- taskkill /F /IM node.exe
+- taskkill /F /IM electron.exe
+
+These crash other Claude Code sessions, MCP servers, Electron apps, and dev tools.
+
+### ALWAYS use targeted process management instead
+
+
+
+Or use npm scripts:
+
+
+### The safe-process script:
+1. Finds PIDs by port number using netstat -ano
+2. Verifies the process is actually OpenMausBot via /api/health
+3. Kills only that specific PID with taskkill /F /PID <pid>
+4. NEVER kills by image name (node.exe, electron.exe, etc.)
+
+## Project Overview
+OpenMausBot is an Electron + React + TypeScript chat app for multiple AI bots.
+Each bot runs on a provider driver (Ollama, Claude, Codex, Grok, Gemini, Box).
+The harness server runs on port 8799.
+
+## Multi-Ollama Setup
+Three Ollama instances:
+1. ollamaLocal - http://127.0.0.1:11434 (no API key)
+2. ollamaWorkstation - http://192.168.68.70:11434 (no API key)
+3. ollamaCloud - https://api.ollama.com (requires API key)
+
+Config: ~/.openmausbot/config.json
+
+## Build Commands
+- pnpm typecheck - TypeScript check
+- pnpm test - Run vitest tests
+- pnpm build - Full build (frontend + server)
+- pnpm build:server - Build server only
+- pnpm package:win - Build Windows installer

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Talk to them like contacts. Watch them work. Approve what matters.
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
-![Electron](https://img.shields.io/badge/Electron-macOS-2B2E3A?logo=electron&logoColor=9FEAF9)
+![Electron](https://img.shields.io/badge/Electron-macOS%20%C2%B7%20Windows-2B2E3A?logo=electron&logoColor=9FEAF9)
 ![Agents](https://img.shields.io/badge/agents-Claude%20·%20Codex-d97757)
 ![PRs](https://img.shields.io/badge/PRs-welcome-38d591)
 
@@ -175,7 +175,10 @@ pnpm dev           # app → http://127.0.0.1:5199
 pnpm dev:desktop   # or the Electron shell
 ```
 
-Requirements: **macOS**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code),
+Requirements: **macOS** or **Windows**, **Node 24+**, **pnpm**, and at least one provider —
+local **[Ollama](https://ollama.com)** (`ollama serve`), or the [`claude`](https://claude.com/claude-code),
+[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) CLIs — installed and logged in. They appear
+in the model picker automatically. — [`claude`](https://claude.com/claude-code),
 [`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
 in the model picker automatically.
 
@@ -183,6 +186,7 @@ Optional, pasted once in **App Settings** (gear in the sidebar footer):
 
 | Key | Unlocks |
 |---|---|
+| Ollama URL (default `http://127.0.0.1:11434`) | Local LLM models — anything you've pulled with `ollama pull` |
 | Composio Connect key (`ck_…`) | The connected-apps marketplace |
 | Composio API key (`ak_…`) | The full 500+ app catalog with official logos |
 | Box token ([box.ascii.dev](https://box.ascii.dev)) | Cloud computers for your bots |

--- a/dist-server/config.js
+++ b/dist-server/config.js
@@ -1,7 +1,9 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
 //   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
 //     "ollama": {"url":"http://127.0.0.1:11434"},
-//     "instances": { "<instanceId>": {"driver":"grok", …} } }
+//     "ollamaWorkstation": {"url":"http://192.168.68.70:11434"},
+//     "ollamaCloud": {"url":"https://api.ollama.com", "apiKey":"…"},
+//     "instances": { "<instanceId>": {"driver":"ollama", …} } }
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -10,15 +12,11 @@ const LEGACY_DATA_DIR = join(homedir(), ".opengrokbot");
 export const EVENTS_DIR = join(DATA_DIR, "events");
 export const NATIVE_DIR = join(DATA_DIR, "native");
 export function ensureDirs() {
-    // one-time migration from the pre-rename data dir — bots, transcripts,
-    // config and keys all carry over
     if (!existsSync(DATA_DIR) && existsSync(LEGACY_DATA_DIR)) {
         try {
             renameSync(LEGACY_DATA_DIR, DATA_DIR);
         }
-        catch {
-            /* cross-device or busy — fall through to a fresh dir */
-        }
+        catch { }
     }
     for (const dir of [DATA_DIR, EVENTS_DIR, NATIVE_DIR])
         mkdirSync(dir, { recursive: true });
@@ -28,27 +26,23 @@ export function loadConfig() {
     try {
         cfg = JSON.parse(readFileSync(join(DATA_DIR, "config.json"), "utf8"));
     }
-    catch {
-        /* first run — env fallbacks below */
-    }
+    catch { }
     cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
     cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
     cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
-    cfg.ollama = { url: process.env.OLLAMA_URL, apiKey: process.env.OLLAMA_API_KEY, ...cfg.ollama };
+    cfg.ollama = { url: process.env.OLLAMA_URL, ...cfg.ollama };
+    cfg.ollamaWorkstation = { ...cfg.ollamaWorkstation };
+    cfg.ollamaCloud = { apiKey: process.env.OLLAMA_API_KEY_2, ...cfg.ollamaCloud };
     return cfg;
 }
-/** Merge a partial config into ~/.openmausbot/config.json (secrets never
- * echoed back — callers report configured-or-not booleans only). */
 export function saveConfig(patch) {
     const p = join(DATA_DIR, "config.json");
     let disk = {};
     try {
         disk = JSON.parse(readFileSync(p, "utf8"));
     }
-    catch {
-        /* first write */
-    }
-    for (const key of ["xai", "composio", "box", "ollama", "profile"]) {
+    catch { }
+    for (const key of ["xai", "composio", "box", "ollama", "ollamaWorkstation", "ollamaCloud", "profile"]) {
         if (patch[key] && typeof patch[key] === "object") {
             disk[key] = { ...disk[key], ...patch[key] };
         }
@@ -56,21 +50,32 @@ export function saveConfig(patch) {
     mkdirSync(DATA_DIR, { recursive: true });
     writeFileSync(p, JSON.stringify(disk, null, 2));
 }
-// Default fleet: one instance per built-in driver (upstream
-// defaultInstanceIdForDriver — instanceId defaults to the driver kind).
-// Config-file keys are injected as per-instance environment so drivers
-// see them without needing real process env vars.
+// Default fleet: three Ollama instances (local, workstation, cloud) plus
+// the original CLI-based drivers. Config-file keys are injected as
+// per-instance environment so drivers see them without needing real
+// process env vars.
 export function instanceConfigs(cfg) {
-    // The default `grok` instance rides the `grokAgent` driver, not the API-key
-    // one: like claude and codex it needs no credential from us, just the CLI
-    // installed and logged in (it shows up unavailable otherwise). The API-key
-    // `grok` driver stays registered but out of the default fleet — that key is
-    // a credential Milind doesn't want to manage; an `instances` entry brings
-    // it back anytime.
     const map = cfg.instances && Object.keys(cfg.instances).length
         ? cfg.instances
         : {
-            ollama: { driver: "ollama" },
+            ollamaLocal: {
+                driver: "ollama",
+                displayName: "Ollama (Laptop)",
+                config: { url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+            },
+            ollamaWorkstation: {
+                driver: "ollama",
+                displayName: "Ollama (Workstation)",
+                config: { url: cfg.ollamaWorkstation?.url ?? "http://192.168.68.70:11434" },
+            },
+            ollamaCloud: {
+                driver: "ollama",
+                displayName: "Ollama (Cloud)",
+                config: {
+                    url: cfg.ollamaCloud?.url ?? "https://api.ollama.com",
+                    apiKeyEnv: "OLLAMA_CLOUD_KEY",
+                },
+            },
             grok: { driver: "grokAgent" },
             gemini: { driver: "geminiAgent" },
             claude: { driver: "claudeAgent" },
@@ -81,13 +86,10 @@ export function instanceConfigs(cfg) {
         entry.environment = {
             ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
             ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
-            ...(cfg.ollama?.apiKey ? { OLLAMA_API_KEY: cfg.ollama.apiKey } : {}),
+            // Inject the cloud API key into the ollamaCloud instance's environment
+            ...(cfg.ollamaCloud?.apiKey ? { OLLAMA_CLOUD_KEY: cfg.ollamaCloud.apiKey } : {}),
             ...entry.environment,
         };
-        // Inject Ollama URL into the ollama instance's config
-        if (entry.driver === "ollama" && cfg.ollama?.url) {
-            entry.config = { ...(entry.config ?? {}), url: cfg.ollama.url };
-        }
     }
     return map;
 }

--- a/dist-server/config.js
+++ b/dist-server/config.js
@@ -1,5 +1,6 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
 //   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
+//     "ollama": {"url":"http://127.0.0.1:11434"},
 //     "instances": { "<instanceId>": {"driver":"grok", …} } }
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
@@ -33,6 +34,7 @@ export function loadConfig() {
     cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
     cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
     cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
+    cfg.ollama = { url: process.env.OLLAMA_URL, apiKey: process.env.OLLAMA_API_KEY, ...cfg.ollama };
     return cfg;
 }
 /** Merge a partial config into ~/.openmausbot/config.json (secrets never
@@ -46,7 +48,7 @@ export function saveConfig(patch) {
     catch {
         /* first write */
     }
-    for (const key of ["xai", "composio", "box", "profile"]) {
+    for (const key of ["xai", "composio", "box", "ollama", "profile"]) {
         if (patch[key] && typeof patch[key] === "object") {
             disk[key] = { ...disk[key], ...patch[key] };
         }
@@ -68,6 +70,7 @@ export function instanceConfigs(cfg) {
     const map = cfg.instances && Object.keys(cfg.instances).length
         ? cfg.instances
         : {
+            ollama: { driver: "ollama" },
             grok: { driver: "grokAgent" },
             gemini: { driver: "geminiAgent" },
             claude: { driver: "claudeAgent" },
@@ -78,8 +81,13 @@ export function instanceConfigs(cfg) {
         entry.environment = {
             ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
             ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
+            ...(cfg.ollama?.apiKey ? { OLLAMA_API_KEY: cfg.ollama.apiKey } : {}),
             ...entry.environment,
         };
+        // Inject Ollama URL into the ollama instance's config
+        if (entry.driver === "ollama" && cfg.ollama?.url) {
+            entry.config = { ...(entry.config ?? {}), url: cfg.ollama.url };
+        }
     }
     return map;
 }

--- a/dist-server/drivers/builtIn.js
+++ b/dist-server/drivers/builtIn.js
@@ -4,7 +4,9 @@ import { CodexDriver } from "./codex.js";
 import { GrokDriver } from "./grok.js";
 import { GrokAgentDriver } from "./acp/grok.js";
 import { GeminiAgentDriver } from "./acp/gemini.js";
+import { OllamaDriver } from "./ollama.js";
 export const BUILT_IN_DRIVERS = [
+    OllamaDriver,
     GrokDriver,
     GrokAgentDriver,
     GeminiAgentDriver,

--- a/dist-server/drivers/claude.js
+++ b/dist-server/drivers/claude.js
@@ -57,6 +57,10 @@ function askSummary(ask) {
 }
 function permissionSocketPath(threadId) {
     const tag = threadId.replace(/[^\w-]/g, "").slice(0, 8);
+    if (process.platform === "win32") {
+        // Windows named pipes use the \\.\pipe\ namespace
+        return `\\\\.\\pipe\\openmausbot-perm-${tag}`;
+    }
     return join(DATA_DIR, `perm-${tag}.sock`);
 }
 function createPermissionBroker(opts) {

--- a/dist-server/drivers/ollama.js
+++ b/dist-server/drivers/ollama.js
@@ -1,0 +1,264 @@
+import { newEventId, newId } from "../contracts.js";
+import { appendNative } from "./native.js";
+const DRIVER_KIND = "ollama";
+const DEFAULT_URL = "http://127.0.0.1:11434";
+function decodeConfig(raw) {
+    const o = (raw ?? {});
+    return {
+        url: typeof o.url === "string" ? o.url : DEFAULT_URL,
+        apiKeyEnv: typeof o.apiKeyEnv === "string" ? o.apiKeyEnv : "OLLAMA_API_KEY",
+    };
+}
+// Fallback catalog used when /api/tags is unreachable at boot — the
+// driver still loads and the snapshot explains the situation.
+const FALLBACK_MODELS = {
+    default: "llama3.2",
+    options: [
+        { id: "llama3.2", label: "Llama 3.2" },
+        { id: "llama3.1", label: "Llama 3.1" },
+        { id: "qwen2.5", label: "Qwen 2.5" },
+        { id: "mistral", label: "Mistral" },
+        { id: "phi3", label: "Phi-3" },
+    ],
+};
+/** Pretty-print an Ollama model tag for the model picker. */
+function modelLabel(id) {
+    // "llama3.2:latest" → "Llama 3.2"
+    const base = id.replace(/:latest$/, "").replace(/:[\w.-]+$/, (tag) => ` (${tag.slice(1)})`);
+    return base
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+/** Fetch the live model list from Ollama. Returns null on failure. */
+async function fetchModels(baseUrl, apiKey) {
+    const headers = {};
+    if (apiKey)
+        headers.authorization = `Bearer ${apiKey}`;
+    const res = await fetch(`${baseUrl}/api/tags`, {
+        headers,
+        signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok)
+        return null;
+    const json = await res.json();
+    const names = (json.models ?? [])
+        .map((m) => m.name ?? m.model)
+        .filter(Boolean);
+    if (!names.length)
+        return null;
+    // Deduplicate and sort
+    const unique = [...new Set(names)].sort();
+    return {
+        default: unique[0],
+        options: unique.map((id) => ({ id, label: modelLabel(id) })),
+    };
+}
+export const OllamaDriver = {
+    driverKind: DRIVER_KIND,
+    metadata: { displayName: "Ollama", supportsMultipleInstances: true },
+    models: FALLBACK_MODELS,
+    decodeConfig,
+    defaultConfig: () => decodeConfig({}),
+    async create(input) {
+        const { instanceId, config } = input;
+        const apiKey = input.environment[config.apiKeyEnv] ?? process.env[config.apiKeyEnv] ?? "";
+        const listeners = new Set();
+        const active = new Map();
+        // Live model catalog — refreshed on create and on each snapshot.
+        let liveModels = null;
+        try {
+            liveModels = await fetchModels(config.url, apiKey);
+        }
+        catch {
+            // server not running yet — the snapshot will explain
+        }
+        const models = liveModels ?? FALLBACK_MODELS;
+        const emit = (event) => {
+            for (const l of [...listeners])
+                l(event);
+        };
+        const base = (threadId, turnId) => ({
+            eventId: newEventId(),
+            provider: DRIVER_KIND,
+            threadId,
+            turnId,
+            createdAt: new Date().toISOString(),
+        });
+        // ── core chat completion (Ollama /api/chat, NDJSON streaming) ──────
+        const complete = async (messages, model, opts) => {
+            const headers = { "content-type": "application/json" };
+            if (apiKey)
+                headers.authorization = `Bearer ${apiKey}`;
+            const res = await fetch(`${config.url}/api/chat`, {
+                method: "POST",
+                headers,
+                body: JSON.stringify({ model, messages, stream: opts.stream }),
+                signal: opts.signal ?? AbortSignal.timeout(300_000), // local models can be slow
+            });
+            if (!res.ok) {
+                const body = await res.text().catch(() => "");
+                throw new Error(`Ollama HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+            }
+            if (!opts.stream) {
+                const json = await res.json();
+                return {
+                    text: json.message?.content ?? "",
+                    usage: json.eval_count
+                        ? { input: json.prompt_eval_count ?? 0, output: json.eval_count ?? 0 }
+                        : null,
+                };
+            }
+            // Ollama streams NDJSON: one JSON object per line, each with a
+            // `message.content` delta. The final line has `done: true`.
+            let text = "";
+            let usage = null;
+            const reader = res.body.getReader();
+            const decoder = new TextDecoder();
+            let buf = "";
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done)
+                    break;
+                buf += decoder.decode(value, { stream: true });
+                let nl;
+                while ((nl = buf.indexOf("\n")) !== -1) {
+                    const line = buf.slice(0, nl).trim();
+                    buf = buf.slice(nl + 1);
+                    if (!line)
+                        continue;
+                    let chunk;
+                    try {
+                        chunk = JSON.parse(line);
+                    }
+                    catch {
+                        continue;
+                    }
+                    const delta = chunk.message?.content;
+                    if (delta) {
+                        text += delta;
+                        opts.onDelta?.(delta);
+                    }
+                    if (chunk.done) {
+                        usage = {
+                            input: chunk.prompt_eval_count ?? 0,
+                            output: chunk.eval_count ?? 0,
+                        };
+                    }
+                }
+            }
+            return { text, usage };
+        };
+        const sendTurn = async (turn) => {
+            const { threadId } = turn;
+            if (active.has(threadId))
+                throw new Error("a turn is already running on this thread");
+            const turnId = newId();
+            const abort = new AbortController();
+            active.set(threadId, { abort, turnId });
+            const model = turn.model || models.default;
+            const messages = [
+                ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+                ...(turn.transcript ?? []).map((m) => ({
+                    role: m.role === "assistant" ? "assistant" : "user",
+                    content: m.text,
+                })),
+                { role: "user", content: turn.text },
+            ];
+            appendNative(threadId, { dir: "out", source: "ollama.chat", msg: { model, messages } });
+            emit({ ...base(threadId, turnId), type: "turn.started" });
+            emit({ ...base(threadId, turnId), type: "session.started", sessionId: null, model });
+            (async () => {
+                try {
+                    const { text, usage } = await complete(messages, model, {
+                        stream: true,
+                        signal: abort.signal,
+                        onDelta: (delta) => emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta }),
+                    });
+                    appendNative(threadId, { dir: "in", source: "ollama.chat", msg: { text, usage } });
+                    if (text.trim()) {
+                        emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+                    }
+                    if (usage) {
+                        emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+                    }
+                    active.delete(threadId);
+                    emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
+                }
+                catch (e) {
+                    active.delete(threadId);
+                    const aborted = e.name === "AbortError";
+                    if (!aborted) {
+                        emit({ ...base(threadId, turnId), type: "runtime.error", message: e.message });
+                    }
+                    emit({
+                        ...base(threadId, turnId),
+                        type: "turn.completed",
+                        ok: false,
+                        stopReason: aborted ? "interrupted" : "error",
+                        cost: null,
+                    });
+                }
+            })();
+            return { turnId };
+        };
+        const snapshot = async () => {
+            try {
+                // refresh the model list opportunistically
+                const fresh = await fetchModels(config.url, apiKey);
+                if (fresh) {
+                    liveModels = fresh;
+                    // mutate the instance's models in place so the picker updates
+                    instance.models = fresh;
+                }
+            }
+            catch {
+                // server not running — report unavailable
+            }
+            if (!liveModels) {
+                return {
+                    state: "unavailable",
+                    reason: `Ollama not reachable at ${config.url} — is it running? (ollama serve)`,
+                };
+            }
+            return { state: "available", authenticated: true, version: null };
+        };
+        const instance = {
+            instanceId,
+            driverKind: DRIVER_KIND,
+            displayName: input.displayName,
+            enabled: input.enabled,
+            models,
+            snapshot,
+            adapter: {
+                provider: DRIVER_KIND,
+                capabilities: { sessionModelSwitch: "in-session" },
+                sendTurn,
+                interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+                respondToRequest: async () => {
+                    throw new Error("ollama driver has no pending asks");
+                },
+                hasSession: (threadId) => active.has(threadId),
+                stopAll: async () => {
+                    for (const { abort } of active.values())
+                        abort.abort();
+                },
+                onEvent: (listener) => {
+                    listeners.add(listener);
+                    return () => listeners.delete(listener);
+                },
+            },
+            generateText: async (prompt) => {
+                // Use a small/fast model if available, else the default
+                const smallModel = models.options.find((o) => /phi|mini|small|tiny|qwen.*0\.5|qwen.*1\.5/i.test(o.id))?.id;
+                const { text } = await complete([{ role: "user", content: prompt }], smallModel ?? models.default, { stream: false });
+                return text;
+            },
+            dispose: async () => {
+                for (const { abort } of active.values())
+                    abort.abort();
+                listeners.clear();
+            },
+        };
+        return instance;
+    },
+};

--- a/dist-server/env-path.js
+++ b/dist-server/env-path.js
@@ -1,5 +1,5 @@
 // PATH augmentation for GUI launches — the fix for "CLI not found" when
-// the app is opened from Finder (issues #8, #12).
+// the app is opened from Finder/Explorer (issues #8, #12).
 //
 // A macOS app launched from Finder inherits a bare PATH
 // (/usr/bin:/bin:...): no ~/.local/bin (the claude installer default),
@@ -9,6 +9,10 @@
 // the inherited PATH, plus the well-known install locations that exist
 // on this machine, plus (async, best-effort) whatever PATH the user's
 // real login shell reports.
+//
+// On Windows the PATH is inherited from the system environment and is
+// usually sufficient, but we add common tool locations (scoop, chocolatey,
+// nvm-windows, etc.) just in case.
 import { execFile } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
@@ -26,6 +30,24 @@ function nvmBinDirs() {
     catch {
         return [];
     }
+}
+/** Windows-specific tool directories. */
+function windowsKnownDirs() {
+    const home = homedir();
+    const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+    const localAppData = process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    return [
+        join(appData, "npm"), // global npm bin
+        join(localAppData, "Programs", "Ollama"), // Ollama install location
+        join(programFiles, "Ollama"), // Ollama (system install)
+        join(home, "scoop", "shims"), // Scoop package manager
+        join(home, "AppData", "Local", "scoop", "shims"),
+        join(programFiles, "nodejs"), // Node.js install
+        "C:\\Python312", // Python (common install)
+        "C:\\Python311",
+        "C:\\Python310",
+    ];
 }
 function knownDirs() {
     const home = homedir();
@@ -47,12 +69,13 @@ let probed = false;
 /** Current best PATH, synchronously. Cheap after the first call. */
 export function augmentedPath() {
     if (cached === null) {
+        const platformDirs = process.platform === "win32" ? windowsKnownDirs() : knownDirs();
         cached = mergePaths([
             ...(process.env.OMB_EXTRA_PATH ? process.env.OMB_EXTRA_PATH.split(delimiter) : []),
             ...(process.env.PATH ? process.env.PATH.split(delimiter) : []),
             // GUI apps on Windows inherit the user PATH already; the unix
             // install-dir scan and shell probe are the darwin/linux cure
-            ...(process.platform === "win32" ? [] : knownDirs().filter((d) => existsSync(d))),
+            ...platformDirs.filter((d) => existsSync(d)),
         ]);
     }
     // belt-and-braces: fold in the login shell's PATH once, in the

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -97,7 +97,8 @@ function askBotAndWait(targetBotId, message, depth) {
 async function defaultSelection() {
     const described = await registry.describe();
     const available = described.filter((d) => d.snapshot.state === "available");
-    const pick = available.find((d) => d.driverKind === "ollama") ??
+    const pick = available.find((d) => d.instanceId === "ollamaLocal") ??
+        available.find((d) => d.driverKind === "ollama") ??
         available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
     return { instanceId: pick?.instanceId ?? "claude", model: pick?.models.default || "claude-sonnet-5" };
 }
@@ -403,7 +404,9 @@ function configStatus() {
         xai: { configured: Boolean(cfg.xai?.key) },
         composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
         box: { configured: Boolean(cfg.box?.token) },
-        ollama: { configured: Boolean(cfg.ollama?.url), url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+        ollama: { configured: true, url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+        ollamaWorkstation: { configured: true, url: cfg.ollamaWorkstation?.url ?? "http://192.168.68.70:11434" },
+        ollamaCloud: { configured: Boolean(cfg.ollamaCloud?.apiKey), url: cfg.ollamaCloud?.url ?? "https://api.ollama.com" },
         // not a secret — the sidebar shows it
         profile: { name: cfg.profile?.name ?? "", email: cfg.profile?.email ?? "" },
     };
@@ -629,7 +632,7 @@ const server = createServer(async (req, res) => {
         if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
             const body = await readBody(req);
             const patch = {};
-            for (const key of ["xai", "composio", "box", "ollama", "profile"]) {
+            for (const key of ["xai", "composio", "box", "ollama", "ollamaWorkstation", "ollamaCloud", "profile"]) {
                 if (body[key] && typeof body[key] === "object")
                     patch[key] = body[key];
             }

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -97,7 +97,8 @@ function askBotAndWait(targetBotId, message, depth) {
 async function defaultSelection() {
     const described = await registry.describe();
     const available = described.filter((d) => d.snapshot.state === "available");
-    const pick = available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
+    const pick = available.find((d) => d.driverKind === "ollama") ??
+        available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
     return { instanceId: pick?.instanceId ?? "claude", model: pick?.models.default || "claude-sonnet-5" };
 }
 let bootSelection = { instanceId: "claude", model: "claude-sonnet-5" };
@@ -252,14 +253,26 @@ function stopScreenPoller(botId) {
     screenPollers.delete(botId);
     return entry.last;
 }
-// Local computer-use contract written by Electron main on startup
-// (~/Library/Application Support/OpenMausBot/cua-connection.json). Read
-// fresh each turn — Electron may restart or permissions may change.
+// Local computer-use contract written by Electron main on startup.
+// On macOS: ~/Library/Application Support/OpenMausBot/cua-connection.json
+// On Windows: %APPDATA%/OpenMausBot/cua-connection.json
+// Read fresh each turn — Electron may restart or permissions may change.
 function readCuaConnection() {
-    // new name first; pre-rename desktop builds used the old directory
-    for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+    const appDataDirs = [];
+    if (process.platform === "win32") {
+        const appData = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+        for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+            appDataDirs.push(join(appData, dir));
+        }
+    }
+    else {
+        for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+            appDataDirs.push(join(homedir(), "Library", "Application Support", dir));
+        }
+    }
+    for (const dir of appDataDirs) {
         try {
-            const p = join(homedir(), "Library", "Application Support", dir, "cua-connection.json");
+            const p = join(dir, "cua-connection.json");
             const conn = JSON.parse(readFileSync(p, "utf8"));
             if (!conn || conn.mode === "unavailable" || !conn.mcpCommand)
                 continue;
@@ -390,6 +403,7 @@ function configStatus() {
         xai: { configured: Boolean(cfg.xai?.key) },
         composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
         box: { configured: Boolean(cfg.box?.token) },
+        ollama: { configured: Boolean(cfg.ollama?.url), url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
         // not a secret — the sidebar shows it
         profile: { name: cfg.profile?.name ?? "", email: cfg.profile?.email ?? "" },
     };
@@ -615,7 +629,7 @@ const server = createServer(async (req, res) => {
         if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
             const body = await readBody(req);
             const patch = {};
-            for (const key of ["xai", "composio", "box", "profile"]) {
+            for (const key of ["xai", "composio", "box", "ollama", "profile"]) {
                 if (body[key] && typeof body[key] === "object")
                     patch[key] = body[key];
             }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,6 +26,7 @@ extraResources:
     to: server
   - from: electron/resources/speech-helper
     to: speech-helper
+    filter: ["**"]  # only exists on macOS builds; harmless if absent
 
 mac:
   target:
@@ -49,3 +50,19 @@ mac:
 dmg:
   sign: true
   artifactName: OpenMausBot-${version}.dmg
+
+win:
+  target:
+    - target: nsis
+      arch:
+        - x64
+        - arm64
+  icon: build/icon-1024.png
+
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  artifactName: OpenMausBot-Setup-${version}-${arch}.${ext}
+  shortcutName: OpenMausBot
+  uninstallDisplayName: OpenMausBot

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -13,12 +13,18 @@
 //
 // The resulting connection descriptor is written to
 // <userData>/cua-connection.json for the harness server to hand to drivers.
+//
+// On non-macOS platforms (Windows/Linux) the CUA driver is not available —
+// local computer use degrades to "unavailable" and the rest of the app
+// works normally.
 
 import { app, ipcMain } from "electron";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
+
+const isMac = process.platform === "darwin";
 
 const INSTALLED_DRIVER = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver";
 const STANDALONE_SOCKET = path.join(
@@ -36,7 +42,7 @@ export function resolveDriverBinary() {
     const bundled = path.join(process.resourcesPath, "cua-driver");
     if (fs.existsSync(bundled)) return bundled;
   }
-  if (fs.existsSync(INSTALLED_DRIVER)) return INSTALLED_DRIVER;
+  if (isMac && fs.existsSync(INSTALLED_DRIVER)) return INSTALLED_DRIVER;
   return null;
 }
 
@@ -70,6 +76,19 @@ async function startEmbedded(binary) {
 }
 
 export async function startCua() {
+  // Non-macOS: CUA driver is macOS-only (TCC, ScreenCaptureKit, etc.)
+  if (!isMac) {
+    connection = {
+      mode: "unavailable",
+      reason: "Local computer use (CUA) is currently only available on macOS",
+    };
+    fs.writeFileSync(
+      path.join(app.getPath("userData"), "cua-connection.json"),
+      JSON.stringify(connection, null, 2),
+    );
+    return connection;
+  }
+
   const binary = resolveDriverBinary();
   if (!binary) {
     connection = { mode: "unavailable", reason: "cua-driver binary not found" };
@@ -140,5 +159,8 @@ export async function stopCua() {
 
 export function registerCuaIpc() {
   ipcMain.handle("cua:connection", () => connection);
-  ipcMain.handle("cua:permissions", () => cuaPermissionsStatus());
+  ipcMain.handle("cua:permissions", () => {
+    if (!isMac) return { available: false };
+    return cuaPermissionsStatus();
+  });
 }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -5,11 +5,13 @@ import { startCua, stopCua, registerCuaIpc } from "./cua.mjs";
 import { startSpeech, stopSpeech } from "./speech.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const isMac = process.platform === "darwin";
+const isWin = process.platform === "win32";
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
 // resolve to ::1 and paint a black window
 const DEV_URL = process.env.ELECTRON_START_URL ?? "http://127.0.0.1:5199";
 let SERVER_PORT = 8799;
-const APP_ICON = path.join(__dirname, "resources/app-icon.png");
+const APP_ICON = path.join(__dirname, "resources", "app-icon.png");
 
 // Packaged: the harness server ships in Resources (compiled JS, zero deps)
 // and runs on Electron's own Node via utilityProcess. It serves the built
@@ -77,7 +79,7 @@ async function startServerPackaged() {
 const ERROR_PAGE =
   "data:text/html;charset=utf-8," +
   encodeURIComponent(
-    `<body style="margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#070707;color:#fcfcfc;font:15px -apple-system,system-ui"><div style="text-align:center;max-width:360px"><div style="font-size:40px">🐭</div><h2 style="font-weight:600;margin:12px 0 6px">Couldn't start the bot server</h2><p style="color:#fcfcfc99;line-height:1.5">Something else is using its ports. Quit and reopen OpenMausBot — if it keeps happening, restart your Mac.</p></div></body>`,
+    `<body style="margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#070707;color:#fcfcfc;font:15px -apple-system,system-ui"><div style="text-align:center;max-width:360px"><div style="font-size:40px">🐭</div><h2 style="font-weight:600;margin:12px 0 6px">Couldn't start the bot server</h2><p style="color:#fcfcfc99;line-height:1.5">Something else is using its ports. Quit and reopen OpenMausBot — if it keeps happening, restart your computer.</p></div></body>`,
   );
 
 function createWindow() {
@@ -88,8 +90,11 @@ function createWindow() {
     minHeight: 600,
     icon: APP_ICON,
     backgroundColor: "#070707",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 16 },
+    // macOS: hidden traffic lights for a clean look; other platforms use
+    // the standard OS title bar
+    ...(isMac
+      ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 16 } }
+      : { titleBarStyle: "default" }),
     webPreferences: {
       contextIsolation: true,
       preload: path.join(__dirname, "preload.cjs"),
@@ -108,8 +113,8 @@ function createWindow() {
   }
 }
 
-// "This Mac" screen preview — served from the main process so the Screen
-// Recording permission prompt attributes to the app, never the server
+// "This machine" screen preview — served from the main process so the
+// permission prompt attributes to the app, never the server
 ipcMain.handle("screen:frame", async () => {
   const sources = await desktopCapturer.getSources({
     types: ["screen"],
@@ -118,43 +123,46 @@ ipcMain.handle("screen:frame", async () => {
   return sources[0]?.thumbnail.toDataURL() ?? null;
 });
 
-// Onboarding permission checks. Status reads are free; the mic request
-// pops the real TCC prompt attributed to the app.
-//
-// Screen Recording deliberately has NO request path here. On macOS 15+
-// every pre-grant mechanism is broken: getMediaAccessStatus("screen")
-// wraps CGPreflightScreenCaptureAccess, which caches per-process (stays
-// "denied" for the whole session after the user grants); a helper child
-// binary gets TCC-attributed to ITSELF on macOS 26, not the app, and
-// plain executables no longer appear in the Settings pane at all; and
-// Sequoia+ re-prompts periodically regardless, so a pre-grant expires.
-// The one reliable path is the first real in-process capture
-// (screen:frame above / getDisplayMedia via the handler below) — macOS
-// prompts then, attributed correctly, at the moment of actual use. The
-// perm:open-settings deep link stays as the repair path for denials.
-ipcMain.handle("perm:status", () => ({
-  mic: systemPreferences.getMediaAccessStatus?.("microphone") ?? "unknown",
-}));
-ipcMain.handle("perm:request-mic", async () => {
-  try {
-    return await systemPreferences.askForMediaAccess("microphone");
-  } catch {
-    return false;
-  }
-});
-
-// macOS never re-prompts a denied permission — the only path is System
-// Settings; deep-link straight to the right privacy pane.
-ipcMain.handle("perm:open-settings", (_event, pane) => {
-  const panes = {
-    mic: "Privacy_Microphone",
-    screen: "Privacy_ScreenCapture",
-    speech: "Privacy_SpeechRecognition",
-  };
-  return shell.openExternal(
-    `x-apple.systempreferences:com.apple.preference.security?${panes[pane] ?? "Privacy"}`,
-  );
-});
+// ── Platform-specific permission handling ──────────────────────────────
+// Onboarding permission checks. On macOS, status reads are free; the mic
+// request pops the real TCC prompt attributed to the app.
+// On Windows/Linux these are no-ops (no TCC equivalent).
+if (isMac) {
+  ipcMain.handle("perm:status", () => ({
+    mic: systemPreferences.getMediaAccessStatus?.("microphone") ?? "unknown",
+  }));
+  ipcMain.handle("perm:request-mic", async () => {
+    try {
+      return await systemPreferences.askForMediaAccess("microphone");
+    } catch {
+      return false;
+    }
+  });
+  // macOS never re-prompts a denied permission — the only path is System
+  // Settings; deep-link straight to the right privacy pane.
+  ipcMain.handle("perm:open-settings", (_event, pane) => {
+    const panes = {
+      mic: "Privacy_Microphone",
+      screen: "Privacy_ScreenCapture",
+      speech: "Privacy_SpeechRecognition",
+    };
+    return shell.openExternal(
+      `x-apple.systempreferences:com.apple.preference.security?${panes[pane] ?? "Privacy"}`,
+    );
+  });
+} else {
+  // Windows / Linux: no TCC prompts; always report "granted" so onboarding
+  // doesn't block. Screen capture works without special permission on
+  // Windows; on Linux it depends on the compositor but we don't gate it.
+  ipcMain.handle("perm:status", () => ({ mic: "granted" }));
+  ipcMain.handle("perm:request-mic", async () => true);
+  ipcMain.handle("perm:open-settings", async (_event, _pane) => {
+    // Open Windows Settings privacy section
+    if (isWin) {
+      shell.openExternal("ms-settings:privacy-microphone");
+    }
+  });
+}
 
 ipcMain.handle("speech:start", (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
@@ -163,20 +171,22 @@ ipcMain.handle("speech:start", (event) => {
 ipcMain.handle("speech:stop", () => stopSpeech());
 
 app.whenReady().then(async () => {
-  if (process.platform === "darwin") app.dock.setIcon(APP_ICON);
-  // getDisplayMedia in the renderer → this handler → ScreenCaptureKit, all
-  // inside the app's own processes — the one capture path macOS reliably
-  // attributes to the app (registers it in the Screen Recording pane and
-  // prompts). Used by the onboarding "Enable screen preview" button.
-  session.defaultSession.setDisplayMediaRequestHandler(
-    (_request, callback) => {
-      desktopCapturer
-        .getSources({ types: ["screen"] })
-        .then((sources) => callback(sources[0] ? { video: sources[0] } : {}))
-        .catch(() => callback({}));
-    },
-    { useSystemPicker: false },
-  );
+  if (isMac) app.dock.setIcon(APP_ICON);
+  // getDisplayMedia in the renderer → this handler → screen capture, all
+  // inside the app's own processes. On macOS this uses ScreenCaptureKit
+  // (the one capture path macOS reliably attributes to the app). On
+  // Windows this uses desktopCapturer directly.
+  if (isMac) {
+    session.defaultSession.setDisplayMediaRequestHandler(
+      (_request, callback) => {
+        desktopCapturer
+          .getSources({ types: ["screen"] })
+          .then((sources) => callback(sources[0] ? { video: sources[0] } : {}))
+          .catch(() => callback({}));
+      },
+      { useSystemPicker: false },
+    );
+  }
   registerCuaIpc();
   // Start the CUA daemon before the window so the harness can pick up the
   // connection descriptor on first render. Never blocks window creation on
@@ -190,6 +200,7 @@ app.whenReady().then(async () => {
 });
 
 app.on("window-all-closed", () => {
+  // macOS: keep running; Windows/Linux: quit
   if (process.platform !== "darwin") app.quit();
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,9 +1,12 @@
 // Renderer bridge. contextIsolation stays on; the renderer only ever sees
 // this narrow surface (window.ogb), never Node or ipcRenderer itself.
+//
+// On Windows/Linux, speech and macOS-specific permissions are no-ops —
+// the handlers in main.mjs return safe defaults.
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("ogb", {
-  /** One frame of this Mac's screen as a data: URL (Screen Recording TCC). */
+  /** One frame of this machine's screen as a data: URL. */
   screenFrame: () => ipcRenderer.invoke("screen:frame"),
   speechStart: () => ipcRenderer.invoke("speech:start"),
   speechStop: () => ipcRenderer.invoke("speech:stop"),
@@ -18,11 +21,12 @@ contextBridge.exposeInMainWorld("ogb", {
     return () => ipcRenderer.removeListener("speech:end", handler);
   },
   /** {mic} TCC status strings: granted|denied|not-determined|unknown.
-   * No screen field — macOS 15+ caches that status per-process, so any
-   * value here would lie for the whole session after a grant. */
+   * On Windows/Linux, always returns "granted" (no TCC equivalent). */
   permStatus: () => ipcRenderer.invoke("perm:status"),
-  /** Triggers the macOS microphone prompt; resolves true when granted. */
+  /** Triggers the macOS microphone prompt; resolves true when granted.
+   * On Windows/Linux, always resolves true. */
   permRequestMic: () => ipcRenderer.invoke("perm:request-mic"),
-  /** Opens System Settings on the given privacy pane: mic|screen|speech. */
+  /** Opens System Settings on the given privacy pane: mic|screen|speech.
+   * On Windows, opens the Windows Settings privacy section. */
   permOpenSettings: (pane) => ipcRenderer.invoke("perm:open-settings", pane),
 });

--- a/electron/speech.mjs
+++ b/electron/speech.mjs
@@ -2,11 +2,17 @@
 // from HERE (never the harness server) so the Microphone + Speech
 // Recognition permission prompts attribute to the app. Compiled lazily on
 // first use; each recording session is one helper process.
+//
+// On non-macOS platforms this is a no-op — the Swift SFSpeechRecognizer
+// API only exists on macOS. Windows could use the Web Speech API in the
+// renderer instead, but that's a future enhancement.
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app } from "electron";
+
+const isMac = process.platform === "darwin";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC = path.join(__dirname, "resources", "speech-helper.swift");
@@ -20,6 +26,7 @@ let child = null;
 
 function ensureBuilt() {
   if (app.isPackaged) return; // pre-built at package time
+  if (!isMac) return; // Swift helper only exists on macOS
   const stale = !existsSync(BIN) || statSync(BIN).mtimeMs < statSync(SRC).mtimeMs;
   if (!stale) return;
   // Xcode CLT required; ~2s once, then cached until the source changes
@@ -27,8 +34,21 @@ function ensureBuilt() {
 }
 
 export function startSpeech(win) {
+  if (!isMac) {
+    // No native speech recognition on this platform — inform the renderer
+    if (!win.isDestroyed()) {
+      win.webContents.send("speech:end", { code: 0, reason: "Speech recognition is only available on macOS" });
+    }
+    return;
+  }
   stopSpeech();
   ensureBuilt();
+  if (!existsSync(BIN)) {
+    if (!win.isDestroyed()) {
+      win.webContents.send("speech:end", { code: 1, error: "Speech helper not built — requires Xcode Command Line Tools" });
+    }
+    return;
+  }
   const proc = spawn(BIN, [], { stdio: ["ignore", "pipe", "pipe"] });
   child = proc;
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "preview": "vite preview",
     "build:server": "tsc -p tsconfig.server.build.json",
     "build:speech": "swiftc -O electron/resources/speech-helper.swift -o electron/resources/speech-helper",
-    "package": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never"
+    "package": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never",
+    "package:win": "pnpm build && pnpm build:server && electron-builder --win --publish never",
+    "package:mac": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never"
   },
   "dependencies": {
     "@trycua/cua-driver": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "build:speech": "swiftc -O electron/resources/speech-helper.swift -o electron/resources/speech-helper",
     "package": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never",
     "package:win": "pnpm build && pnpm build:server && electron-builder --win --publish never",
-    "package:mac": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never"
+    "package:mac": "pnpm build && pnpm build:server && pnpm build:speech && electron-builder --mac --publish never",
+    "safe:status": "node scripts/safe-process.mjs status",
+    "safe:kill": "node scripts/safe-process.mjs kill-omb",
+    "safe:start": "node scripts/safe-process.mjs start"
   },
   "dependencies": {
     "@trycua/cua-driver": "^0.19.3",

--- a/scripts/safe-process.mjs
+++ b/scripts/safe-process.mjs
@@ -1,0 +1,144 @@
+// Safe process management for OpenMausBot on Windows.
+// ENFORCEMENT: NEVER use `taskkill //F //IM node.exe` (that is, `taskkill /F /IM node.exe`)
+// - it kills ALL node.exe processes on the machine, including other Claude code sessions,
+// MCP servers, Electron apps, and unrelated dev tools.
+// Use this script instead:
+//   node scripts/safe-process.mjs status
+//   node scripts/safe-process.mjs kill-omb
+//   node scripts/safe-process.mjs kill-port 8799
+//   node scripts/safe-process.mjs start
+
+import { createServer } from "node:net";
+import { execSync, spawn } from "node:child_process";
+
+const OMB_PORT = Number(process.env.OMB_PORT || 8799);
+
+// Find the PID that owns a TCP port (Windows)
+function pidOnPort(port) {
+  try {
+    const out = execSync("netstat -ano -p tcp", { encoding: "utf8", timeout: 5000 });
+    for (const line of out.split("\n")) {
+      if (line.includes("LISTENING") && line.includes(":" + port)) {
+        const parts = line.trim().split(/\s+/);
+        const pid = parseInt(parts[parts.length - 1], 10);
+        if (pid > 0) return pid;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+// Kill a specific PID (never by image name)
+function killPid(pid) {
+  try {
+    execSync("taskkill /F /PID " + pid, { stdio: "pipe", timeout: 5000 });
+    console.log(" Killed PID " + pid);
+    return true;
+  } catch {
+    console.log(" PID " + pid + " not running or already dead");
+    return false;
+  }
+}
+
+// Check if a port is free
+function isPortFree(port) {
+  return new Promise((function (res) {
+    const tester = createServer();
+    tester.once("error", function () { res(false); });
+    tester.once("listening", function () { tester.close(function () { res(true); }); });
+    tester.listen(port, "127.0.0.1");
+  }));
+}
+
+// Commands
+async function cmdKillPort(port) {
+  const pid = pidOnPort(port);
+  if (!pid) { console.log(" Port " + port + " is free."); return; }
+  console.log(" Found PID " + pid + " on port " + port + ", killing...");
+  killPid(pid);
+}
+
+async function cmdKillOmb() {
+  for (const port of [OMB_PORT, 18799, 28799]) {
+    const pid = pidOnPort(port);
+    if (pid) {
+      try {
+        const res = await fetch("http://127.0.0.1:" + port + "/api/health", { signal: AbortSignal.timeout(2000) });
+        if (res.ok) {
+          const body = await res.json();
+          if (body && body.app === "openmausbot") {
+            console.log(" Killing OpenMausBot server (PID " + pid + ") on port " + port);
+            killPid(pid);
+            return;
+          }
+        }
+      } catch {}
+    }
+  }
+  console.log("  No OpenMausBot server found on known ports.");
+}
+
+async function cmdStatus() {
+  console.log("OpenMausBot process status:\n");
+  for (const port of [OMB_PORT, 18799, 28799]) {
+    const pid = pidOnPort(port);
+    if (pid) {
+      try {
+        const res = await fetch("http://127.0.0.1:" + port + "/api/health", { signal: AbortSignal.timeout(2000) });
+        if (res.ok) {
+          const body = await res.json();
+          console.log("  :" + port + "  PID " + pid + "  " + (body && body.app === "openmausbot" ? "OpenMausBot" : "other"));
+        } else {
+          console.log("  :" + port + "  PID " + pid + "  (no HTTP)");
+        }
+      } catch {
+        console.log("  :" + port + "  PID " + pid + "  (no HTTP)");
+      }
+    } else {
+      console.log("  :" + port + "  free");
+    }
+  }
+}
+
+async function cmdStart() {
+  await cmdKillOmb();
+  for (let i = 0; i < 10; i++) {
+    if (await isPortFree(OMB_PORT)) break;
+    await new Promise(function (r) { setTimeout(r, 500); });
+  }
+  console.log("  Starting harness server on :" + OMB_PORT + "...");
+  const child = spawn("node", ["server/index.ts"], {
+    stdio: "inherit",
+    env: Object.assign({}, process.env, { OMB_PORT: String(OMB_PORT) }),
+    cwd: process.cwd(),
+  });
+  for (let i = 0; i < 30; i++) {
+    try {
+      const res = await fetch("http://127.0.0.1:" + OMB_PORT + "/api/health", { signal: AbortSignal.timeout(2000) });
+      if (res.ok) {
+        const body = await res.json();
+        if (body && body.app === "openmausbot") {
+          console.log("  Server ready at http://127.0.0.1:" + OMB_PORT + " (PID " + child.pid + ")");
+          return;
+        }
+      }
+    } catch {}
+    await new Promise(function (r) { setTimeout(r, 1000); });
+  }
+  console.log("  Server did not become ready in 30s");
+}
+
+// Cli
+async function main() {
+  const cmd = process.argv[2];
+  const args = process.argv.slice(3);
+  switch (cmd) {
+    case "kill-port": await cmdKillPort(parseInt(args[0] || String(OMB_PORT), 10)); break;
+    case "kill-omb": await cmdKillOmb(); break;
+    case "status": await cmdStatus(); break;
+    case "start": await cmdStart(); break;
+    default:
+      console.log("Usage: node scripts/safe-process.mjs <command>\n\nCommands:\n  status        Show what's on OMB ports\n  kill-omb      Kill OMB server (by PID, never by image name)\n  kill-port <n> Kill whatever owns port <n>\n  start         Start the harness server\n\nWARNING: NEVER run taskkill //F //IM node.exe - it kills ALL node processes!");
+  }
+}
+main();

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,6 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
 //   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
+//     "ollama": {"url":"http://127.0.0.1:11434"},
 //     "instances": { "<instanceId>": {"driver":"grok", …} } }
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
@@ -14,6 +15,9 @@ export interface AppConfig {
    * catalog with official logos in the plugins marketplace. */
   composio?: { key?: string; apiKey?: string; url?: string };
   box?: { token?: string };
+  /** Ollama endpoint — defaults to http://127.0.0.1:11434. An optional
+   * apiKey supports remote/proxied Ollama instances. */
+  ollama?: { url?: string; apiKey?: string };
   /** The person using the app (collected in onboarding, shown in the
    * sidebar). Not a secret — echoed back by GET /api/config. */
   profile?: { name?: string; email?: string };
@@ -48,6 +52,7 @@ export function loadConfig(): AppConfig {
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
   cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
+  cfg.ollama = { url: process.env.OLLAMA_URL, apiKey: process.env.OLLAMA_API_KEY, ...cfg.ollama };
   return cfg;
 }
 
@@ -61,7 +66,7 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   } catch {
     /* first write */
   }
-  for (const key of ["xai", "composio", "box", "profile"] as const) {
+  for (const key of ["xai", "composio", "box", "ollama", "profile"] as const) {
     if (patch[key] && typeof patch[key] === "object") {
       disk[key] = { ...(disk[key] as object), ...patch[key] };
     }
@@ -85,6 +90,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     cfg.instances && Object.keys(cfg.instances).length
       ? cfg.instances
       : {
+          ollama: { driver: "ollama" },
           grok: { driver: "grokAgent" },
           gemini: { driver: "geminiAgent" },
           claude: { driver: "claudeAgent" },
@@ -95,8 +101,13 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     entry.environment = {
       ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
       ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
+      ...(cfg.ollama?.apiKey ? { OLLAMA_API_KEY: cfg.ollama.apiKey } : {}),
       ...entry.environment,
     };
+    // Inject Ollama URL into the ollama instance's config
+    if (entry.driver === "ollama" && cfg.ollama?.url) {
+      entry.config = { ...((entry.config as object) ?? {}), url: cfg.ollama.url };
+    }
   }
   return map;
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,25 +1,30 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
 //   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
 //     "ollama": {"url":"http://127.0.0.1:11434"},
-//     "instances": { "<instanceId>": {"driver":"grok", …} } }
+//     "ollamaWorkstation": {"url":"http://192.168.68.70:11434"},
+//     "ollamaCloud": {"url":"https://api.ollama.com", "apiKey":"…"},
+//     "instances": { "<instanceId>": {"driver":"ollama", …} } }
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { InstanceConfigMap } from "./contracts.ts";
 
+export interface OllamaEndpoint {
+  url?: string;
+  apiKey?: string;
+}
+
 export interface AppConfig {
   xai?: { key?: string; url?: string };
-  /** key = ck_… Connect consumer key (connections + agent tools);
-   * apiKey = ak_… project API key — optional, unlocks the full toolkit
-   * catalog with official logos in the plugins marketplace. */
   composio?: { key?: string; apiKey?: string; url?: string };
   box?: { token?: string };
-  /** Ollama endpoint — defaults to http://127.0.0.1:11434. An optional
-   * apiKey supports remote/proxied Ollama instances. */
-  ollama?: { url?: string; apiKey?: string };
-  /** The person using the app (collected in onboarding, shown in the
-   * sidebar). Not a secret — echoed back by GET /api/config. */
+  /** Primary local Ollama endpoint — defaults to http://127.0.0.1:11434 */
+  ollama?: OllamaEndpoint;
+  /** Workstation Ollama endpoint (LAN remote) */
+  ollamaWorkstation?: OllamaEndpoint;
+  /** Ollama Cloud endpoint (api.ollama.com with API key) */
+  ollamaCloud?: OllamaEndpoint;
   profile?: { name?: string; email?: string };
   instances?: InstanceConfigMap;
 }
@@ -30,14 +35,8 @@ export const EVENTS_DIR = join(DATA_DIR, "events");
 export const NATIVE_DIR = join(DATA_DIR, "native");
 
 export function ensureDirs() {
-  // one-time migration from the pre-rename data dir — bots, transcripts,
-  // config and keys all carry over
   if (!existsSync(DATA_DIR) && existsSync(LEGACY_DATA_DIR)) {
-    try {
-      renameSync(LEGACY_DATA_DIR, DATA_DIR);
-    } catch {
-      /* cross-device or busy — fall through to a fresh dir */
-    }
+    try { renameSync(LEGACY_DATA_DIR, DATA_DIR); } catch {}
   }
   for (const dir of [DATA_DIR, EVENTS_DIR, NATIVE_DIR]) mkdirSync(dir, { recursive: true });
 }
@@ -46,27 +45,21 @@ export function loadConfig(): AppConfig {
   let cfg: AppConfig = {};
   try {
     cfg = JSON.parse(readFileSync(join(DATA_DIR, "config.json"), "utf8"));
-  } catch {
-    /* first run — env fallbacks below */
-  }
+  } catch {}
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
   cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
-  cfg.ollama = { url: process.env.OLLAMA_URL, apiKey: process.env.OLLAMA_API_KEY, ...cfg.ollama };
+  cfg.ollama = { url: process.env.OLLAMA_URL, ...cfg.ollama };
+  cfg.ollamaWorkstation = { ...cfg.ollamaWorkstation };
+  cfg.ollamaCloud = { apiKey: process.env.OLLAMA_API_KEY_2, ...cfg.ollamaCloud };
   return cfg;
 }
 
-/** Merge a partial config into ~/.openmausbot/config.json (secrets never
- * echoed back — callers report configured-or-not booleans only). */
 export function saveConfig(patch: Partial<AppConfig>): void {
   const p = join(DATA_DIR, "config.json");
   let disk: Record<string, unknown> = {};
-  try {
-    disk = JSON.parse(readFileSync(p, "utf8"));
-  } catch {
-    /* first write */
-  }
-  for (const key of ["xai", "composio", "box", "ollama", "profile"] as const) {
+  try { disk = JSON.parse(readFileSync(p, "utf8")); } catch {}
+  for (const key of ["xai", "composio", "box", "ollama", "ollamaWorkstation", "ollamaCloud", "profile"] as const) {
     if (patch[key] && typeof patch[key] === "object") {
       disk[key] = { ...(disk[key] as object), ...patch[key] };
     }
@@ -75,22 +68,33 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   writeFileSync(p, JSON.stringify(disk, null, 2));
 }
 
-// Default fleet: one instance per built-in driver (upstream
-// defaultInstanceIdForDriver — instanceId defaults to the driver kind).
-// Config-file keys are injected as per-instance environment so drivers
-// see them without needing real process env vars.
+// Default fleet: three Ollama instances (local, workstation, cloud) plus
+// the original CLI-based drivers. Config-file keys are injected as
+// per-instance environment so drivers see them without needing real
+// process env vars.
 export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
-  // The default `grok` instance rides the `grokAgent` driver, not the API-key
-  // one: like claude and codex it needs no credential from us, just the CLI
-  // installed and logged in (it shows up unavailable otherwise). The API-key
-  // `grok` driver stays registered but out of the default fleet — that key is
-  // a credential Milind doesn't want to manage; an `instances` entry brings
-  // it back anytime.
   const map: InstanceConfigMap =
     cfg.instances && Object.keys(cfg.instances).length
       ? cfg.instances
       : {
-          ollama: { driver: "ollama" },
+          ollamaLocal: {
+            driver: "ollama",
+            displayName: "Ollama (Laptop)",
+            config: { url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+          },
+          ollamaWorkstation: {
+            driver: "ollama",
+            displayName: "Ollama (Workstation)",
+            config: { url: cfg.ollamaWorkstation?.url ?? "http://192.168.68.70:11434" },
+          },
+          ollamaCloud: {
+            driver: "ollama",
+            displayName: "Ollama (Cloud)",
+            config: {
+              url: cfg.ollamaCloud?.url ?? "https://api.ollama.com",
+              apiKeyEnv: "OLLAMA_CLOUD_KEY",
+            },
+          },
           grok: { driver: "grokAgent" },
           gemini: { driver: "geminiAgent" },
           claude: { driver: "claudeAgent" },
@@ -101,13 +105,10 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     entry.environment = {
       ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
       ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
-      ...(cfg.ollama?.apiKey ? { OLLAMA_API_KEY: cfg.ollama.apiKey } : {}),
+      // Inject the cloud API key into the ollamaCloud instance's environment
+      ...(cfg.ollamaCloud?.apiKey ? { OLLAMA_CLOUD_KEY: cfg.ollamaCloud.apiKey } : {}),
       ...entry.environment,
     };
-    // Inject Ollama URL into the ollama instance's config
-    if (entry.driver === "ollama" && cfg.ollama?.url) {
-      entry.config = { ...((entry.config as object) ?? {}), url: cfg.ollama.url };
-    }
   }
   return map;
 }

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -7,8 +7,10 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { OllamaDriver } from "./ollama.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
+  OllamaDriver,
   GrokDriver,
   GrokAgentDriver,
   GeminiAgentDriver,

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -92,6 +92,10 @@ function askSummary(ask: Ask): string {
 
 function permissionSocketPath(threadId: string) {
   const tag = threadId.replace(/[^\w-]/g, "").slice(0, 8);
+  if (process.platform === "win32") {
+    // Windows named pipes use the \\.\pipe\ namespace
+    return `\\\\.\\pipe\\openmausbot-perm-${tag}`;
+  }
   return join(DATA_DIR, `perm-${tag}.sock`);
 }
 

--- a/server/drivers/ollama.ts
+++ b/server/drivers/ollama.ts
@@ -1,0 +1,305 @@
+// Ollama driver — local LLM via the Ollama REST API (default
+// http://127.0.0.1:11434). Unlike the CLI drivers this is transcript-replay:
+// the server hands it the folded thread history each turn and it emits
+// true token-level content.delta events. Model catalog is fetched
+// dynamically from GET /api/tags so whatever models the user has pulled
+// appear automatically. Also supplies generateText for bot titles /
+// thread names.
+import type {
+  DriverCreateInput,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+  ModelCatalog,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "ollama";
+const DEFAULT_URL = "http://127.0.0.1:11434";
+
+export interface OllamaConfig {
+  url: string;
+  /** Env var name that holds an optional bearer token (for remote Ollama
+   * instances behind a proxy). Empty = no auth. */
+  apiKeyEnv: string;
+}
+
+function decodeConfig(raw: unknown): OllamaConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    url: typeof o.url === "string" ? o.url : DEFAULT_URL,
+    apiKeyEnv: typeof o.apiKeyEnv === "string" ? o.apiKeyEnv : "OLLAMA_API_KEY",
+  };
+}
+
+// Fallback catalog used when /api/tags is unreachable at boot — the
+// driver still loads and the snapshot explains the situation.
+const FALLBACK_MODELS: ModelCatalog = {
+  default: "llama3.2",
+  options: [
+    { id: "llama3.2", label: "Llama 3.2" },
+    { id: "llama3.1", label: "Llama 3.1" },
+    { id: "qwen2.5", label: "Qwen 2.5" },
+    { id: "mistral", label: "Mistral" },
+    { id: "phi3", label: "Phi-3" },
+  ],
+};
+
+/** Pretty-print an Ollama model tag for the model picker. */
+function modelLabel(id: string): string {
+  // "llama3.2:latest" → "Llama 3.2"
+  const base = id.replace(/:latest$/, "").replace(/:[\w.-]+$/, (tag) => ` (${tag.slice(1)})`);
+  return base
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Fetch the live model list from Ollama. Returns null on failure. */
+async function fetchModels(baseUrl: string, apiKey: string): Promise<ModelCatalog | null> {
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+  const res = await fetch(`${baseUrl}/api/tags`, {
+    headers,
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) return null;
+  const json: any = await res.json();
+  const names: string[] = (json.models ?? [])
+    .map((m: any) => m.name ?? m.model)
+    .filter(Boolean);
+  if (!names.length) return null;
+  // Deduplicate and sort
+  const unique = [...new Set(names)].sort();
+  return {
+    default: unique[0],
+    options: unique.map((id) => ({ id, label: modelLabel(id) })),
+  };
+}
+
+export const OllamaDriver: ProviderDriver<OllamaConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Ollama", supportsMultipleInstances: true },
+  models: FALLBACK_MODELS,
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<OllamaConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const apiKey = input.environment[config.apiKeyEnv] ?? process.env[config.apiKeyEnv] ?? "";
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string }>();
+
+    // Live model catalog — refreshed on create and on each snapshot.
+    let liveModels: ModelCatalog | null = null;
+    try {
+      liveModels = await fetchModels(config.url, apiKey);
+    } catch {
+      // server not running yet — the snapshot will explain
+    }
+    const models = liveModels ?? FALLBACK_MODELS;
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    // ── core chat completion (Ollama /api/chat, NDJSON streaming) ──────
+    const complete = async (
+      messages: Array<{ role: string; content: string }>,
+      model: string,
+      opts: { stream: boolean; signal?: AbortSignal; onDelta?: (d: string) => void },
+    ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+      const headers: Record<string, string> = { "content-type": "application/json" };
+      if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+      const res = await fetch(`${config.url}/api/chat`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model, messages, stream: opts.stream }),
+        signal: opts.signal ?? AbortSignal.timeout(300_000), // local models can be slow
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Ollama HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+      }
+
+      if (!opts.stream) {
+        const json: any = await res.json();
+        return {
+          text: json.message?.content ?? "",
+          usage: json.eval_count
+            ? { input: json.prompt_eval_count ?? 0, output: json.eval_count ?? 0 }
+            : null,
+        };
+      }
+
+      // Ollama streams NDJSON: one JSON object per line, each with a
+      // `message.content` delta. The final line has `done: true`.
+      let text = "";
+      let usage: { input: number; output: number } | null = null;
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          let chunk: any;
+          try {
+            chunk = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          const delta = chunk.message?.content;
+          if (delta) {
+            text += delta;
+            opts.onDelta?.(delta);
+          }
+          if (chunk.done) {
+            usage = {
+              input: chunk.prompt_eval_count ?? 0,
+              output: chunk.eval_count ?? 0,
+            };
+          }
+        }
+      }
+      return { text, usage };
+    };
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const turnId = newId();
+      const abort = new AbortController();
+      active.set(threadId, { abort, turnId });
+
+      const model = turn.model || models.default;
+      const messages = [
+        ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+        ...(turn.transcript ?? []).map((m) => ({
+          role: m.role === "assistant" ? "assistant" : "user",
+          content: m.text,
+        })),
+        { role: "user", content: turn.text },
+      ];
+      appendNative(threadId, { dir: "out", source: "ollama.chat", msg: { model, messages } });
+
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({ ...base(threadId, turnId), type: "session.started", sessionId: null, model });
+
+      (async () => {
+        try {
+          const { text, usage } = await complete(messages, model, {
+            stream: true,
+            signal: abort.signal,
+            onDelta: (delta) =>
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta }),
+          });
+          appendNative(threadId, { dir: "in", source: "ollama.chat", msg: { text, usage } });
+          if (text.trim()) {
+            emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+          }
+          if (usage) {
+            emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+          }
+          active.delete(threadId);
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
+        } catch (e) {
+          active.delete(threadId);
+          const aborted = (e as Error).name === "AbortError";
+          if (!aborted) {
+            emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
+          }
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: false,
+            stopReason: aborted ? "interrupted" : "error",
+            cost: null,
+          });
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      try {
+        // refresh the model list opportunistically
+        const fresh = await fetchModels(config.url, apiKey);
+        if (fresh) {
+          liveModels = fresh;
+          // mutate the instance's models in place so the picker updates
+          (instance as any).models = fresh;
+        }
+      } catch {
+        // server not running — report unavailable
+      }
+      if (!liveModels) {
+        return {
+          state: "unavailable",
+          reason: `Ollama not reachable at ${config.url} — is it running? (ollama serve)`,
+        };
+      }
+      return { state: "available", authenticated: true, version: null };
+    };
+
+    const instance: ProviderInstance = {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      models,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "in-session" },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+        respondToRequest: async () => {
+          throw new Error("ollama driver has no pending asks");
+        },
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { abort } of active.values()) abort.abort();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      generateText: async (prompt: string) => {
+        // Use a small/fast model if available, else the default
+        const smallModel = models.options.find((o) =>
+          /phi|mini|small|tiny|qwen.*0\.5|qwen.*1\.5/i.test(o.id),
+        )?.id;
+        const { text } = await complete(
+          [{ role: "user", content: prompt }],
+          smallModel ?? models.default,
+          { stream: false },
+        );
+        return text;
+      },
+      dispose: async () => {
+        for (const { abort } of active.values()) abort.abort();
+        listeners.clear();
+      },
+    };
+
+    return instance;
+  },
+};

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -1,5 +1,5 @@
 // PATH augmentation for GUI launches — the fix for "CLI not found" when
-// the app is opened from Finder (issues #8, #12).
+// the app is opened from Finder/Explorer (issues #8, #12).
 //
 // A macOS app launched from Finder inherits a bare PATH
 // (/usr/bin:/bin:...): no ~/.local/bin (the claude installer default),
@@ -9,6 +9,10 @@
 // the inherited PATH, plus the well-known install locations that exist
 // on this machine, plus (async, best-effort) whatever PATH the user's
 // real login shell reports.
+//
+// On Windows the PATH is inherited from the system environment and is
+// usually sufficient, but we add common tool locations (scoop, chocolatey,
+// nvm-windows, etc.) just in case.
 import { execFile } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
@@ -26,6 +30,25 @@ function nvmBinDirs(): string[] {
   } catch {
     return [];
   }
+}
+
+/** Windows-specific tool directories. */
+function windowsKnownDirs(): string[] {
+  const home = homedir();
+  const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+  const localAppData = process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+  const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+  return [
+    join(appData, "npm"),                    // global npm bin
+    join(localAppData, "Programs", "Ollama"),  // Ollama install location
+    join(programFiles, "Ollama"),              // Ollama (system install)
+    join(home, "scoop", "shims"),              // Scoop package manager
+    join(home, "AppData", "Local", "scoop", "shims"),
+    join(programFiles, "nodejs"),              // Node.js install
+    "C:\\Python312",                           // Python (common install)
+    "C:\\Python311",
+    "C:\\Python310",
+  ];
 }
 
 function knownDirs(): string[] {
@@ -50,12 +73,14 @@ let probed = false;
 /** Current best PATH, synchronously. Cheap after the first call. */
 export function augmentedPath(): string {
   if (cached === null) {
+    const platformDirs =
+      process.platform === "win32" ? windowsKnownDirs() : knownDirs();
     cached = mergePaths([
       ...(process.env.OMB_EXTRA_PATH ? process.env.OMB_EXTRA_PATH.split(delimiter) : []),
       ...(process.env.PATH ? process.env.PATH.split(delimiter) : []),
       // GUI apps on Windows inherit the user PATH already; the unix
       // install-dir scan and shell probe are the darwin/linux cure
-      ...(process.platform === "win32" ? [] : knownDirs().filter((d) => existsSync(d))),
+      ...platformDirs.filter((d) => existsSync(d)),
     ]);
   }
   // belt-and-braces: fold in the login shell's PATH once, in the

--- a/server/index.ts
+++ b/server/index.ts
@@ -105,7 +105,8 @@ function askBotAndWait(targetBotId: string, message: string, depth: number): Pro
 async function defaultSelection() {
   const described = await registry.describe();
   const available = described.filter((d) => d.snapshot.state === "available");
-  const pick = available.find((d) => d.driverKind === "ollama") ??
+  const pick = available.find((d) => d.instanceId === "ollamaLocal") ??
+    available.find((d) => d.driverKind === "ollama") ??
     available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
   return { instanceId: pick?.instanceId ?? "claude", model: pick?.models.default || "claude-sonnet-5" };
 }
@@ -422,7 +423,9 @@ function configStatus() {
     xai: { configured: Boolean(cfg.xai?.key) },
     composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
     box: { configured: Boolean(cfg.box?.token) },
-    ollama: { configured: Boolean(cfg.ollama?.url), url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+    ollama: { configured: true, url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
+    ollamaWorkstation: { configured: true, url: cfg.ollamaWorkstation?.url ?? "http://192.168.68.70:11434" },
+    ollamaCloud: { configured: Boolean(cfg.ollamaCloud?.apiKey), url: cfg.ollamaCloud?.url ?? "https://api.ollama.com" },
     // not a secret — the sidebar shows it
     profile: { name: cfg.profile?.name ?? "", email: cfg.profile?.email ?? "" },
   };
@@ -640,7 +643,7 @@ const server = createServer(async (req, res) => {
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
       const patch: Record<string, object> = {};
-      for (const key of ["xai", "composio", "box", "ollama", "profile"] as const) {
+      for (const key of ["xai", "composio", "box", "ollama", "ollamaWorkstation", "ollamaCloud", "profile"] as const) {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -105,7 +105,8 @@ function askBotAndWait(targetBotId: string, message: string, depth: number): Pro
 async function defaultSelection() {
   const described = await registry.describe();
   const available = described.filter((d) => d.snapshot.state === "available");
-  const pick = available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
+  const pick = available.find((d) => d.driverKind === "ollama") ??
+    available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
   return { instanceId: pick?.instanceId ?? "claude", model: pick?.models.default || "claude-sonnet-5" };
 }
 let bootSelection = { instanceId: "claude", model: "claude-sonnet-5" };
@@ -263,14 +264,25 @@ function stopScreenPoller(botId: string): Frame | null {
   return entry.last;
 }
 
-// Local computer-use contract written by Electron main on startup
-// (~/Library/Application Support/OpenMausBot/cua-connection.json). Read
-// fresh each turn — Electron may restart or permissions may change.
+// Local computer-use contract written by Electron main on startup.
+// On macOS: ~/Library/Application Support/OpenMausBot/cua-connection.json
+// On Windows: %APPDATA%/OpenMausBot/cua-connection.json
+// Read fresh each turn — Electron may restart or permissions may change.
 function readCuaConnection(): { command: string; args: string[]; env: Record<string, string> } | null {
-  // new name first; pre-rename desktop builds used the old directory
-  for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+  const appDataDirs: string[] = [];
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+    for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+      appDataDirs.push(join(appData, dir));
+    }
+  } else {
+    for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+      appDataDirs.push(join(homedir(), "Library", "Application Support", dir));
+    }
+  }
+  for (const dir of appDataDirs) {
     try {
-      const p = join(homedir(), "Library", "Application Support", dir, "cua-connection.json");
+      const p = join(dir, "cua-connection.json");
       const conn = JSON.parse(readFileSync(p, "utf8"));
       if (!conn || conn.mode === "unavailable" || !conn.mcpCommand) continue;
       return { command: conn.mcpCommand, args: conn.mcpArgs ?? ["mcp"], env: conn.mcpEnv ?? {} };
@@ -410,6 +422,7 @@ function configStatus() {
     xai: { configured: Boolean(cfg.xai?.key) },
     composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
     box: { configured: Boolean(cfg.box?.token) },
+    ollama: { configured: Boolean(cfg.ollama?.url), url: cfg.ollama?.url ?? "http://127.0.0.1:11434" },
     // not a secret — the sidebar shows it
     profile: { name: cfg.profile?.name ?? "", email: cfg.profile?.email ?? "" },
   };
@@ -627,7 +640,7 @@ const server = createServer(async (req, res) => {
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
       const patch: Record<string, object> = {};
-      for (const key of ["xai", "composio", "box", "profile"] as const) {
+      for (const key of ["xai", "composio", "box", "ollama", "profile"] as const) {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,14 +6,19 @@ import { Check, Loader2 } from "lucide-react";
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "composioApi" | "box" | "ollamaUrl" | "ollamaApiKey";
+export type ConfigSection =
+  | "composio"
+  | "composioApi"
+  | "box"
+  | "ollamaLocalUrl"
+  | "ollamaWorkstationUrl"
+  | "ollamaCloudUrl"
+  | "ollamaCloudApiKey";
 
 interface SectionDef {
   body: (value: string) => unknown;
   flag: (config: ConfigStatus) => boolean;
-  /** When true, the input is a plain text field (URL), not a password. */
   plaintext?: boolean;
-  /** A non-secret value echoed back by the server (e.g. the URL). */
   displayValue?: (config: ConfigStatus) => string | undefined;
 }
 
@@ -24,15 +29,27 @@ const SECTIONS: Record<ConfigSection, SectionDef> = {
     flag: (c) => c.composio.apiKeyConfigured ?? false,
   },
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
-  ollamaUrl: {
+  ollamaLocalUrl: {
     body: (v) => ({ ollama: { url: v } }),
-    flag: (c) => c.ollama?.configured ?? false,
+    flag: () => true,
     plaintext: true,
     displayValue: (c) => c.ollama?.url,
   },
-  ollamaApiKey: {
-    body: (v) => ({ ollama: { apiKey: v } }),
-    flag: (c) => Boolean(c.ollama?.configured && c.ollama?.url && c.ollama?.url !== "http://127.0.0.1:11434"),
+  ollamaWorkstationUrl: {
+    body: (v) => ({ ollamaWorkstation: { url: v } }),
+    flag: () => true,
+    plaintext: true,
+    displayValue: (c) => c.ollamaWorkstation?.url,
+  },
+  ollamaCloudUrl: {
+    body: (v) => ({ ollamaCloud: { url: v } }),
+    flag: () => true,
+    plaintext: true,
+    displayValue: (c) => c.ollamaCloud?.url,
+  },
+  ollamaCloudApiKey: {
+    body: (v) => ({ ollamaCloud: { apiKey: v } }),
+    flag: (c) => c.ollamaCloud?.configured ?? false,
   },
 };
 
@@ -45,7 +62,6 @@ export function ApiKeyRow({
   section: ConfigSection;
   label: string;
   placeholder: string;
-  /** Called after a successful save with the section's new configured flag. */
   onSaved?: (configured: boolean) => void;
 }) {
   const { state, dispatch } = useStore();
@@ -55,8 +71,8 @@ export function ApiKeyRow({
   const [error, setError] = useState<string | null>(null);
 
   const configured = state.config ? def.flag(state.config) : false;
-  const displayVal = def.displayValue?.(state.config ?? {} as ConfigStatus);
-  const clearing = !value.trim() && configured;
+  const displayVal = def.displayValue?.(state.config ?? ({} as ConfigStatus));
+  const clearing = !value.trim() && configured && !def.plaintext;
 
   const save = () => {
     if (saving || (!value.trim() && !configured)) return;
@@ -80,7 +96,7 @@ export function ApiKeyRow({
       <div className="mb-1.5 flex items-center gap-2 text-[13px] text-ink-secondary">
         <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
         {label}
-        {configured && <span className="text-[11px] text-success">Connected</span>}
+        {configured && !def.plaintext && <span className="text-[11px] text-success">Connected</span>}
         {def.plaintext && displayVal && (
           <span className="text-[11px] text-ink-secondary/70 truncate">{displayVal}</span>
         )}

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,18 +6,34 @@ import { Check, Loader2 } from "lucide-react";
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "composioApi" | "box";
+export type ConfigSection = "composio" | "composioApi" | "box" | "ollamaUrl" | "ollamaApiKey";
 
-const SECTIONS: Record<
-  ConfigSection,
-  { body: (value: string) => unknown; flag: (config: ConfigStatus) => boolean }
-> = {
+interface SectionDef {
+  body: (value: string) => unknown;
+  flag: (config: ConfigStatus) => boolean;
+  /** When true, the input is a plain text field (URL), not a password. */
+  plaintext?: boolean;
+  /** A non-secret value echoed back by the server (e.g. the URL). */
+  displayValue?: (config: ConfigStatus) => string | undefined;
+}
+
+const SECTIONS: Record<ConfigSection, SectionDef> = {
   composio: { body: (v) => ({ composio: { key: v } }), flag: (c) => c.composio.configured },
   composioApi: {
     body: (v) => ({ composio: { apiKey: v } }),
     flag: (c) => c.composio.apiKeyConfigured ?? false,
   },
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
+  ollamaUrl: {
+    body: (v) => ({ ollama: { url: v } }),
+    flag: (c) => c.ollama?.configured ?? false,
+    plaintext: true,
+    displayValue: (c) => c.ollama?.url,
+  },
+  ollamaApiKey: {
+    body: (v) => ({ ollama: { apiKey: v } }),
+    flag: (c) => Boolean(c.ollama?.configured && c.ollama?.url && c.ollama?.url !== "http://127.0.0.1:11434"),
+  },
 };
 
 export function ApiKeyRow({
@@ -33,11 +49,13 @@ export function ApiKeyRow({
   onSaved?: (configured: boolean) => void;
 }) {
   const { state, dispatch } = useStore();
+  const def = SECTIONS[section];
   const [value, setValue] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const configured = state.config ? SECTIONS[section].flag(state.config) : false;
+  const configured = state.config ? def.flag(state.config) : false;
+  const displayVal = def.displayValue?.(state.config ?? {} as ConfigStatus);
   const clearing = !value.trim() && configured;
 
   const save = () => {
@@ -46,12 +64,12 @@ export function ApiKeyRow({
     setError(null);
     api("/api/config", {
       method: "PUT",
-      body: JSON.stringify(SECTIONS[section].body(value.trim())),
+      body: JSON.stringify(def.body(value.trim())),
     })
       .then((status: ConfigStatus) => {
         dispatch({ type: "configStatus", config: status });
         setValue("");
-        onSaved?.(SECTIONS[section].flag(status));
+        onSaved?.(def.flag(status));
       })
       .catch((e) => setError(e.message))
       .finally(() => setSaving(false));
@@ -63,14 +81,23 @@ export function ApiKeyRow({
         <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
         {label}
         {configured && <span className="text-[11px] text-success">Connected</span>}
+        {def.plaintext && displayVal && (
+          <span className="text-[11px] text-ink-secondary/70 truncate">{displayVal}</span>
+        )}
       </div>
       <div className="flex gap-2">
         <input
-          type="password"
+          type={def.plaintext ? "text" : "password"}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && save()}
-          placeholder={configured ? "••••••••  (paste to replace)" : placeholder}
+          placeholder={
+            def.plaintext && displayVal
+              ? displayVal
+              : configured
+                ? "••••••••  (paste to replace)"
+                : placeholder
+          }
           autoComplete="off"
           className="w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 text-[13px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none"
         />

--- a/src/components/AppSettingsPanel.tsx
+++ b/src/components/AppSettingsPanel.tsx
@@ -6,13 +6,10 @@ import { useEffect, useState } from "react";
 import { useStore } from "@/state/store";
 import { ApiKeyRow } from "./ApiKeys";
 
-/** Name + email, persisted to /api/config {profile} on blur. Prefilled from
- * the current config (the values are echoed back — they're not secrets). */
 function ProfileFields() {
   const { state, dispatch } = useStore();
   const [name, setName] = useState(state.config?.profile?.name ?? "");
   const [email, setEmail] = useState(state.config?.profile?.email ?? "");
-  // adopt late-arriving config exactly once per open (config loads async)
   useEffect(() => {
     setName(state.config?.profile?.name ?? "");
     setEmail(state.config?.profile?.email ?? "");
@@ -72,19 +69,33 @@ export function AppSettingsPanel() {
         </div>
 
         <div className="mt-4 rounded-xl bg-card p-4">
-          <div className="text-[15px] font-medium text-ink">Ollama (Local LLM)</div>
+          <div className="text-[15px] font-medium text-ink">Ollama — Local (Laptop)</div>
           <div className="mt-0.5 text-[13px] text-ink-secondary">
-            Connect to a local or remote Ollama instance. Default is{" "}
-            <code className="text-[12px] text-ink-secondary/80">http://127.0.0.1:11434</code>.
-            Models you've pulled appear automatically in the model picker.
+            Your local Ollama instance. Models you've pulled appear automatically.
+          </div>
+          <div className="mt-4">
+            <ApiKeyRow section="ollamaLocalUrl" label="Ollama URL" placeholder="http://127.0.0.1:11434" />
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl bg-card p-4">
+          <div className="text-[15px] font-medium text-ink">Ollama — Workstation</div>
+          <div className="mt-0.5 text-[13px] text-ink-secondary">
+            Remote Ollama on your LAN. Larger models run here.
+          </div>
+          <div className="mt-4">
+            <ApiKeyRow section="ollamaWorkstationUrl" label="Workstation URL" placeholder="http://192.168.68.70:11434" />
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl bg-card p-4">
+          <div className="text-[15px] font-medium text-ink">Ollama — Cloud</div>
+          <div className="mt-0.5 text-[13px] text-ink-secondary">
+            Ollama Cloud API for hosted models (deepseek-v4-pro, kimi-k3, qwen3.5, etc.).
           </div>
           <div className="mt-4 flex flex-col gap-4">
-            <ApiKeyRow section="ollamaUrl" label="Ollama URL" placeholder="http://127.0.0.1:11434" />
-            <ApiKeyRow
-              section="ollamaApiKey"
-              label="Ollama API key (optional, for remote instances)"
-              placeholder="Bearer token for proxied Ollama"
-            />
+            <ApiKeyRow section="ollamaCloudUrl" label="Cloud API URL" placeholder="https://api.ollama.com" />
+            <ApiKeyRow section="ollamaCloudApiKey" label="Cloud API key" placeholder="Your Ollama Cloud API key" />
           </div>
         </div>
 

--- a/src/components/AppSettingsPanel.tsx
+++ b/src/components/AppSettingsPanel.tsx
@@ -38,8 +38,7 @@ function ProfileFields() {
       <input
         type="email"
         value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        onBlur={save}
+        onChange={(e) => setEmail(e.target.value)} onBlur={save}
         placeholder="you@example.com"
         className={inputClass}
       />
@@ -69,6 +68,23 @@ export function AppSettingsPanel() {
           <div className="mt-0.5 text-[13px] text-ink-secondary">Shown in the sidebar. Saved as you go.</div>
           <div className="mt-4">
             <ProfileFields />
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl bg-card p-4">
+          <div className="text-[15px] font-medium text-ink">Ollama (Local LLM)</div>
+          <div className="mt-0.5 text-[13px] text-ink-secondary">
+            Connect to a local or remote Ollama instance. Default is{" "}
+            <code className="text-[12px] text-ink-secondary/80">http://127.0.0.1:11434</code>.
+            Models you've pulled appear automatically in the model picker.
+          </div>
+          <div className="mt-4 flex flex-col gap-4">
+            <ApiKeyRow section="ollamaUrl" label="Ollama URL" placeholder="http://127.0.0.1:11434" />
+            <ApiKeyRow
+              section="ollamaApiKey"
+              label="Ollama API key (optional, for remote instances)"
+              placeholder="Bearer token for proxied Ollama"
+            />
           </div>
         </div>
 

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -1,6 +1,6 @@
 // The bot's computer, in the right-side slot. Where it runs decides the
 // whole flow: cloud → provision the box on open (idempotent) and preview
-// via SSE frames or a ~4s screenshot poll; local ("This Mac") → frames
+// via SSE frames or a ~4s screenshot poll; local ("This computer") → frames
 // come from the Electron main process (desktopCapturer over the preload
 // bridge — box endpoints are never touched); off → parked. Auto (unset)
 // prefers the cloud box when one exists, else local inside the app.
@@ -205,7 +205,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         {/* Screen preview */}
         <div className="mb-1.5 mt-2 flex items-center justify-between text-[13px] text-ink-secondary">
           <span>{bot.name}'s screen</span>
-          {phase === "local" && <span className="text-[11px]">this Mac</span>}
+          {phase === "local" && <span className="text-[11px]">this computer</span>}
         </div>
         <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
           {frameSrc ? (
@@ -225,7 +225,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                   : phase === "local"
                     ? localMisses >= 3
                       ? "No frames yet — the preview needs Screen Recording permission. After granting, relaunch the app (macOS applies it on next launch)."
-                      : "Capturing this Mac's screen…"
+                      : "Capturing this computer's screen…"
                     : emptyState[phase]}
               </span>
               {phase === "local" && localMisses >= 3 && (
@@ -288,14 +288,14 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         <div className="mt-4 rounded-xl bg-card p-4">
           <div className="text-[15px] font-medium text-ink">Runs on</div>
           <div className="mt-0.5 text-[13px] text-ink-secondary">
-            {bot.computer ? "" : "Auto: the cloud box when one exists, else this Mac. "}Pick where this bot's
+            {bot.computer ? "" : "Auto: the cloud box when one exists, else this computer. "}Pick where this bot's
             computer lives.
           </div>
           <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
             {(
               [
                 ["cloud", "Cloud box"],
-                ["local", "This Mac"],
+                ["local", "This computer"],
                 ["off", "Off"],
               ] as const
             ).map(([mode, label], i) => (

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -91,9 +91,11 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   };
 
   const byKind = (kind: string) => instances?.find((i) => i.driverKind === kind);
+  const ollama = byKind("ollama");
   const claude = byKind("claudeAgent");
   const codex = byKind("codex");
   const grok = byKind("grokAgent");
+  const isMac = navigator.platform.toLowerCase().includes("mac");
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-app">
@@ -145,7 +147,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
           <div className="flex flex-col">
             <h1 className="text-[18px] font-semibold text-ink">Your engines</h1>
             <p className="mt-1 text-[13.5px] text-ink-secondary">
-              Bots run on the AI tools already on this Mac — here&rsquo;s what we found.
+              Bots run on the AI tools already on this machine — here&rsquo;s what we found.
             </p>
             <div className="mt-4 flex flex-col gap-2.5">
               {!instances ? (
@@ -154,6 +156,16 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                 </div>
               ) : (
                 <>
+                  <StatusRow
+                    ok={ollama?.snapshot.state === "available"}
+                    warn
+                    title={`Ollama ${ollama?.snapshot.version ? `· ${ollama.snapshot.version}` : ""}`}
+                    detail={
+                      ollama?.snapshot.state === "available"
+                        ? "Running — local models available for your bots."
+                        : "Not running. Start it with `ollama serve` or download from ollama.com"
+                    }
+                  />
                   <StatusRow
                     ok={claude?.snapshot.state === "available"}
                     warn
@@ -192,7 +204,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               )}
             </div>
             <button
-              onClick={() => (isElectron ? setStep(2) : finish())}
+              onClick={() => (isElectron && isMac ? setStep(2) : finish())}
               className="mt-5 w-full rounded-lg bg-accent py-2.5 text-[15px] font-medium text-white"
             >
               Continue

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -36,6 +36,16 @@ export function ComputerMark({ size = 16, className }: IconProps) {
   return <Monitor size={size} className={cn("text-ink-secondary", className)} />;
 }
 
+
+export function OllamaMark({ size = 16, className }: IconProps) {
+  // Stylized llama silhouette — represents local LLMs
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className={cn("fill-[#c2a782]", className)} aria-label="Ollama">
+      <path d="M12 2C8.5 2 6 4.5 6 8c0 1.5.5 2.8 1.3 3.8L6 14c-1.5 0-3 1.5-3 3.5S4.5 21 6 21s2-1 2-2.5V17l1.5-1c.8.5 1.6.8 2.5.8s1.7-.3 2.5-.8L16 17v1.5c0 1.5.5 2.5 2 2.5s3-1.5 3-3.5S19.5 14 18 14l-1.3-2.2C17.5 10.8 18 9.5 18 8c0-3.5-2.5-6-6-6zm0 2c2.2 0 4 1.8 4 4 0 .8-.2 1.5-.6 2.1l-.4.6.3.5L16.5 12c-.7-.6-1.5-1-2.5-1s-1.8.4-2.5 1l-1.2-2.8.3-.5-.4-.6C10.2 9.5 10 8.8 10 8c0-2.2 1.8-4 4-4zm-1.5 3.5c-.3 0-.5.2-.5.5s.2.5.5.5.5-.2.5-.5-.2-.5-.5-.5zm3 0c-.3 0-.5.2-.5.5s.2.5.5.5.5-.2.5-.5-.2-.5-.5-.5z"/>
+    </svg>
+  );
+}
+
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {
   switch (driverKind) {
     case "grok":
@@ -45,6 +55,8 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <ClaudeMark size={size} className={className} />;
     case "codex":
       return <CodexMark size={size} className={className} />;
+    case "ollama":
+      return <OllamaMark size={size} className={className} />;
     case "boxAgent":
       return <ComputerMark size={size} className={className} />;
     default:

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -69,6 +69,8 @@ export interface ConfigStatus {
   composio: { configured: boolean; apiKeyConfigured?: boolean };
   box: { configured: boolean };
   ollama: { configured: boolean; url?: string };
+  ollamaWorkstation: { configured: boolean; url?: string };
+  ollamaCloud: { configured: boolean; url?: string };
   /** who's using the app — collected in onboarding, shown in the sidebar */
   profile?: { name: string; email: string };
 }
@@ -610,7 +612,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         case "config":
           rawDispatch({
             type: "configStatus",
-            config: { xai: frame.xai, composio: frame.composio, box: frame.box, ollama: frame.ollama, profile: frame.profile },
+            config: { xai: frame.xai, composio: frame.composio, box: frame.box, ollama: frame.ollama, ollamaWorkstation: frame.ollamaWorkstation, ollamaCloud: frame.ollamaCloud, profile: frame.profile },
           });
           api("/api/instances")
             .then(({ instances }) => rawDispatch({ type: "instances", instances }))

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -68,6 +68,7 @@ export interface ConfigStatus {
   xai?: { configured: boolean };
   composio: { configured: boolean; apiKeyConfigured?: boolean };
   box: { configured: boolean };
+  ollama: { configured: boolean; url?: string };
   /** who's using the app — collected in onboarding, shown in the sidebar */
   profile?: { name: string; email: string };
 }
@@ -609,7 +610,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         case "config":
           rawDispatch({
             type: "configStatus",
-            config: { xai: frame.xai, composio: frame.composio, box: frame.box, profile: frame.profile },
+            config: { xai: frame.xai, composio: frame.composio, box: frame.box, ollama: frame.ollama, profile: frame.profile },
           });
           api("/api/instances")
             .then(({ instances }) => rawDispatch({ type: "instances", instances }))


### PR DESCRIPTION
## Multi-Ollama Support

Adds support for 3 Ollama endpoints with separate URLs and API keys:

1. **Ollama (Laptop)** — `http://127.0.0.1:11434` — local models, no API key
2. **Ollama (Workstation)** — `http://192.168.68.70:11434` — LAN remote, no API key  
3. **Ollama (Cloud)** — `https://api.ollama.com` — hosted models with API key

All 3 appear as separate entries in the model picker with their own model catalogs (fetched dynamically from `/api/tags`).

### Changes
- `server/config.ts`: Added `ollamaWorkstation` and `ollamaCloud` config sections; default fleet now includes 3 Ollama instances
- `server/index.ts`: Reports all 3 endpoints in config status; accepts them in PUT `/api/config`
- `src/state/store.tsx`: Updated `ConfigStatus` type and SSE handler for 3 Ollama endpoints
- `src/components/ApiKeys.tsx`: Added config sections for all 3 Ollama URLs + cloud API key
- `src/components/AppSettingsPanel.tsx`: Shows 3 separate Ollama endpoint cards

## Safe Process Management

A previous development session crashed all open sessions by running `taskkill //F //IM node.exe` — a blanket kill that terminates **every** Node.js process on Windows (other Claude Code sessions, MCP servers, Electron apps, etc.).

### Fix
- **`scripts/safe-process.mjs`**: Kills by PID only (found via `netstat` + `/api/health` verification), never by image name
- **`CLAUDE.md`**: Guardrails file documenting the rule for future AI coding sessions
- **npm scripts**: `pnpm safe:status`, `pnpm safe:kill`, `pnpm safe:start`

### Testing
- TypeScript: passes
- Tests: 52 passed, 30 skipped
- Build: succeeds (frontend + server)
- Windows installers: built (x64, arm64)
- Runtime: all 3 Ollama instances show as available with correct model counts