### PR TITLE
feat: add Hermes ACP driver support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "electron/main.mjs",
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/server/config.ts
+++ b/server/config.ts
@@ -91,6 +91,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
           computer: { driver: "boxAgent" },
+          hermes: { driver: "hermes" },
         };
   for (const entry of Object.values(map)) {
     entry.environment = {

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -1,0 +1,3 @@
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+const support: AcpSupport = { driverKind: "hermes", displayName: "Hermes", models: { default: "default", options: [{ id: "default", label: "Hermes default" }] }, defaultCli: "hermes-acp", nativeSource: "hermes.acp", loginNote: "Hermes ACP is not installed or authenticated — install it and complete its provider setup first", spawnArgs: () => [], pickAuthMethod: methods => methods[0]?.id ?? null, authFailure: "continue", isAuthenticated: () => true, buildPromptText: t => t.system ? `${t.system}\n\n${t.text}` : t.text };
+export const HermesDriver = createAcpDriver(support);

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -7,6 +7,7 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { HermesDriver } from "./acp/hermes.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -15,4 +16,5 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   ClaudeDriver,
   CodexDriver,
   BoxAgentDriver,
+  HermesDriver,
 ];

--- a/server/index.ts
+++ b/server/index.ts
@@ -814,8 +814,8 @@ const server = createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, "127.0.0.1", () => {
-  console.log(`openmausbot server on http://127.0.0.1:${PORT}`);
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`openmausbot server on http://0.0.0.0:${PORT} (accessible via Netbird at http://100.78.44.10:${PORT})`);
 });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -815,7 +815,7 @@ const server = createServer(async (req, res) => {
 });
 
 server.listen(PORT, "0.0.0.0", () => {
-  console.log(`openmausbot server on http://0.0.0.0:${PORT} (accessible via Netbird at http://100.78.44.10:${PORT})`);
+  console.log(`openmausbot server on http://0.0.0.0:${PORT} `);
 });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
     },
   },
   server: {
-    // Bind all interfaces so the app is reachable via the Netbird mesh IP
-    // (http://100.78.44.10:5199) as well as localhost.
     host: "0.0.0.0",
     port: 5199,
     // packager output lands inside the repo — its HTML files must never

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,9 +21,9 @@ export default defineConfig({
     },
   },
   server: {
-    // IPv4 explicitly — a bare ::1 bind makes localhost a coin-flip for
-    // clients that resolve IPv4 first
-    host: "127.0.0.1",
+    // Bind all interfaces so the app is reachable via the Netbird mesh IP
+    // (http://100.78.44.10:5199) as well as localhost.
+    host: "0.0.0.0",
     port: 5199,
     // packager output lands inside the repo — its HTML files must never
     // trigger dev full-page reloads


### PR DESCRIPTION
- Add Hermes ACP driver (server/drivers/acp/hermes.ts)
- Register HermesDriver in builtIn.ts
- Add hermes instance to default fleet in config.ts
- Bind harness to 0.0.0.0:8799 and Vite to 0.0.0.0:5199 
- Downgrade Node engine requirement >=24 to >=22 for server compat

Verified end-to-end: a Hermes bot spawned hermes-acp and replied through the harness

<!-- commands run, platforms tested on, what you clicked through -->

## Screenshots (UI changes)

<!-- before/after images; video for anything animated -->

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally
- [ ] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [ ] No `dist-server/` edits (it's build output)
- [ ] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [ ] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for the Hermes assistant, including its default model and authentication flow.
  - Included Hermes in the default available instance configurations.

- **Accessibility**
  - The application and development server can now be accessed through all network interfaces.
  - Startup logs display the accessible network address.

- **Compatibility**
  - Lowered the minimum supported Node.js version to 22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->