### PR TITLE
feat: add Reasonix ACP driver

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -108,6 +108,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
           codex: { driver: "codex" },
           antigravity: { driver: "antigravityAgent" },
           opencodeGo: { driver: "opencodeGo" },
+          reasonix: { driver: "reasonix" },
           computer: { driver: "boxAgent" },
         };
   for (const entry of Object.values(map)) {

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -20,6 +20,7 @@ import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 import { KimiAgentDriver } from "./kimi.ts";
 import { DroidAgentDriver } from "./droid.ts";
+import { ReasonixDriver } from "./reasonix.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
 
@@ -650,6 +651,51 @@ describe("ACP snapshot", () => {
       expect((await instance.snapshot()).authenticated).toBe(true);
     } finally {
       await instance.dispose();
+    }
+  });
+
+  it("reasonix checks REASONIX_HOME before the child HOME", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-reasonix-auth-"));
+    const reasonixHome = join(scratch, "custom-reasonix-home");
+    const childHome = join(scratch, "child-home");
+    mkdirSync(childHome, { recursive: true });
+    writeFileSync(join(childHome, ".env"), "export DEEPSEEK_API_KEY=sk-abc123\n");
+
+    const instance = await ReasonixDriver.create({
+      instanceId: "reasonix-custom-home",
+      displayName: undefined,
+      environment: { REASONIX_HOME: reasonixHome, HOME: childHome },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(false);
+      mkdirSync(reasonixHome, { recursive: true });
+      writeFileSync(join(reasonixHome, ".env"), "export DEEPSEEK_API_KEY=sk-abc123\n");
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("reasonix resolves default credentials from the child HOME", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-reasonix-home-"));
+    mkdirSync(join(scratch, ".reasonix"), { recursive: true });
+    writeFileSync(join(scratch, ".reasonix", ".env"), "export DEEPSEEK_API_KEY=sk-abc123\n");
+
+    const instance = await ReasonixDriver.create({
+      instanceId: "reasonix-child-home",
+      displayName: undefined,
+      environment: { HOME: scratch },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
     }
   });
 });

--- a/server/drivers/acp/reasonix.test.ts
+++ b/server/drivers/acp/reasonix.test.ts
@@ -1,0 +1,90 @@
+// Reasonix credential resolution — pure unit tests, no spawn. Covers the
+// <Reasonix home>/.env detection the reviewer asked for: REASONIX_HOME and
+// Windows %APPDATA% fallback, plus the .env value grammar (valid, empty,
+// comment-only, quoted-empty, export-prefixed).
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { hasReasonixCredentials, isReasonixAuthenticated, reasonixHome } from "./reasonix.ts";
+
+describe("reasonixHome", () => {
+  it("REASONIX_HOME wins over every fallback", () => {
+    expect(reasonixHome({ REASONIX_HOME: "/custom/reasonix" }, "linux")).toBe("/custom/reasonix");
+    expect(reasonixHome({ REASONIX_HOME: "/custom/reasonix", APPDATA: "C:\\AppData" }, "win32")).toBe(
+      "/custom/reasonix",
+    );
+  });
+
+  it("Windows uses %APPDATA%\\reasonix", () => {
+    expect(reasonixHome({ APPDATA: "C:\\Users\\me\\AppData\\Roaming" }, "win32")).toBe(
+      join("C:\\Users\\me\\AppData\\Roaming", "reasonix"),
+    );
+  });
+
+  it("Windows without APPDATA falls back to ~/AppData/Roaming/reasonix", () => {
+    expect(reasonixHome({}, "win32")).toBe(
+      join(process.env.HOME || process.env.USERPROFILE || "", "AppData", "Roaming", "reasonix"),
+    );
+  });
+
+  it("non-Windows defaults to ~/.reasonix", () => {
+    expect(reasonixHome({}, "linux")).toBe(join(process.env.HOME || "", ".reasonix"));
+  });
+});
+
+describe("hasReasonixCredentials", () => {
+  it("accepts a plain KEY=value", () => {
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY=sk-abc123")).toBe(true);
+  });
+
+  it("accepts an export-prefixed assignment", () => {
+    expect(hasReasonixCredentials("export DEEPSEEK_API_KEY=sk-abc123")).toBe(true);
+  });
+
+  it("accepts quoted values", () => {
+    expect(hasReasonixCredentials('DEEPSEEK_API_KEY="sk-abc123"')).toBe(true);
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY='sk-abc123'")).toBe(true);
+  });
+
+  it("rejects an empty assignment", () => {
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY=")).toBe(false);
+  });
+
+  it("rejects a quoted-empty assignment", () => {
+    expect(hasReasonixCredentials('DEEPSEEK_API_KEY=""')).toBe(false);
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY=''")).toBe(false);
+  });
+
+  it("rejects a comment-only file", () => {
+    expect(hasReasonixCredentials("# DEEPSEEK_API_KEY=sk-abc123\n# another comment")).toBe(false);
+  });
+
+  it("finds a valid key among comments and blanks", () => {
+    expect(hasReasonixCredentials("# header\n\nDEEPSEEK_API_KEY=sk-abc123\n")).toBe(true);
+  });
+});
+
+describe("isReasonixAuthenticated", () => {
+  let scratch: string;
+
+  afterEach(() => rmSync(scratch, { recursive: true, force: true }));
+
+  it("true when <home>/.env has a credential", () => {
+    scratch = mkdtempSync(join(tmpdir(), "omb-reasonix-"));
+    writeFileSync(join(scratch, ".env"), "export DEEPSEEK_API_KEY=sk-abc123\n");
+    expect(isReasonixAuthenticated({ REASONIX_HOME: scratch })).toBe(true);
+  });
+
+  it("false when <home>/.env is empty or quoted-empty", () => {
+    scratch = mkdtempSync(join(tmpdir(), "omb-reasonix-"));
+    writeFileSync(join(scratch, ".env"), 'DEEPSEEK_API_KEY=""\n');
+    expect(isReasonixAuthenticated({ REASONIX_HOME: scratch })).toBe(false);
+  });
+
+  it("false when <home>/.env is missing", () => {
+    scratch = mkdtempSync(join(tmpdir(), "omb-reasonix-"));
+    expect(isReasonixAuthenticated({ REASONIX_HOME: scratch })).toBe(false);
+  });
+});

--- a/server/drivers/acp/reasonix.test.ts
+++ b/server/drivers/acp/reasonix.test.ts
@@ -52,6 +52,14 @@ describe("hasReasonixCredentials", () => {
     expect(hasReasonixCredentials("DEEPSEEK_API_KEY=")).toBe(false);
   });
 
+  it("rejects an empty assignment followed by a comment", () => {
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY=\n# comment")).toBe(false);
+  });
+
+  it("rejects an empty assignment followed by a blank line and comment", () => {
+    expect(hasReasonixCredentials("DEEPSEEK_API_KEY=\n\n# comment")).toBe(false);
+  });
+
   it("rejects a quoted-empty assignment", () => {
     expect(hasReasonixCredentials('DEEPSEEK_API_KEY=""')).toBe(false);
     expect(hasReasonixCredentials("DEEPSEEK_API_KEY=''")).toBe(false);

--- a/server/drivers/acp/reasonix.test.ts
+++ b/server/drivers/acp/reasonix.test.ts
@@ -3,7 +3,7 @@
 // Windows %APPDATA% fallback, plus the .env value grammar (valid, empty,
 // comment-only, quoted-empty, export-prefixed).
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -23,14 +23,30 @@ describe("reasonixHome", () => {
     );
   });
 
-  it("Windows without APPDATA falls back to ~/AppData/Roaming/reasonix", () => {
-    expect(reasonixHome({}, "win32")).toBe(
-      join(process.env.HOME || process.env.USERPROFILE || "", "AppData", "Roaming", "reasonix"),
+  it("Windows without APPDATA uses USERPROFILE/AppData/Roaming/reasonix", () => {
+    expect(reasonixHome({ USERPROFILE: "C:\\Users\\me" }, "win32")).toBe(
+      join("C:\\Users\\me", "AppData", "Roaming", "reasonix"),
     );
   });
 
-  it("non-Windows defaults to ~/.reasonix", () => {
-    expect(reasonixHome({}, "linux")).toBe(join(process.env.HOME || "", ".reasonix"));
+  it("Windows without APPDATA falls back HOME for AppData/Roaming/reasonix", () => {
+    expect(reasonixHome({ HOME: "C:\\Users\\home" }, "win32")).toBe(
+      join("C:\\Users\\home", "AppData", "Roaming", "reasonix"),
+    );
+  });
+
+  it("Windows without APPDATA, USERPROFILE or HOME falls back to homedir", () => {
+    expect(reasonixHome({}, "win32")).toBe(
+      join(homedir(), "AppData", "Roaming", "reasonix"),
+    );
+  });
+
+  it("non-Windows defaults to <HOME>/.reasonix", () => {
+    expect(reasonixHome({ HOME: "/home/child" }, "linux")).toBe(join("/home/child", ".reasonix"));
+  });
+
+  it("non-Windows falls back to homedir when HOME unset", () => {
+    expect(reasonixHome({}, "linux")).toBe(join(homedir(), ".reasonix"));
   });
 });
 

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -2,11 +2,11 @@
 // over stdio). Rides the generic ACP runtime in acp/core.ts; this file is only
 // the per-harness quirks.
 //
-// Auth is lenient (authFailure "continue"): the advertised method is the
-// terminal `reasonix-setup` flow, which OpenMausBot cannot drive, so the turn
-// proceeds on Reasonix's ambient login — the AI_GATEWAY_API_KEY seeded into
-// ~/.reasonix/.env by the finix `reasonix` wrapper.
-import { existsSync } from "node:fs";
+// Auth is lenient (authFailure "continue"): the only advertised method is the
+// terminal `reasonix-setup` flow, which a GUI host cannot drive, so it is
+// skipped entirely and the turn proceeds on Reasonix's ambient login —
+// <Reasonix home>/.env (see CONFIG_PATHS.md upstream).
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -30,14 +30,28 @@ const support: AcpSupport = {
   // OpenMausBot passes the picker model verbatim (provider name or provider/model).
   spawnArgs: (_config, turn) => ["acp", ...(turn.model ? ["--model", turn.model] : [])],
 
-  // The one advertised auth method is terminal (launches `reasonix setup`); skip
-  // authenticate and rely on the ambient ~/.reasonix/.env login.
-  pickAuthMethod: (methods) =>
-    methods.some((m) => m.id === "reasonix-setup") ? "reasonix-setup" : null,
+  // The one advertised auth method is terminal (launches `reasonix setup` in a
+  // real terminal); OpenMausBot cannot drive it, so skip authenticate and rely
+  // on the ambient <Reasonix home>/.env login. Returning the id would make
+  // core.ts issue a useless terminal authenticate RPC.
+  pickAuthMethod: () => null,
   authFailure: "continue",
   isAuthenticated: (env) => {
-    const stateHome = env.REASONIX_STATE_HOME || join(homedir(), ".reasonix");
-    return existsSync(join(stateHome, ".env"));
+    // Credentials live in <Reasonix home>/.env. REASONIX_HOME overrides;
+    // REASONIX_STATE_HOME only relocates runtime state (sessions/archives/
+    // memory), never provider credentials. Windows: %APPDATA%\reasonix.
+    const home =
+      env.REASONIX_HOME ||
+      (process.platform === "win32"
+        ? join(env.APPDATA || join(homedir(), "AppData", "Roaming"), "reasonix")
+        : join(homedir(), ".reasonix"));
+    try {
+      const content = readFileSync(join(home, ".env"), "utf8");
+      // at least one non-comment KEY=value line with a non-empty value
+      return /^\s*[A-Za-z_][A-Za-z0-9_]*=.+\S/m.test(content);
+    } catch {
+      return false;
+    }
   },
 };
 

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -12,6 +12,37 @@ import { join } from "node:path";
 
 import { createAcpDriver, type AcpSupport } from "./core.ts";
 
+// Credentials live in <Reasonix home>/.env. REASONIX_HOME overrides;
+// REASONIX_STATE_HOME only relocates runtime state (sessions/archives/
+// memory), never provider credentials. Windows: %APPDATA%\reasonix.
+export function reasonixHome(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return (
+    env.REASONIX_HOME ||
+    (platform === "win32"
+      ? join(env.APPDATA || join(homedir(), "AppData", "Roaming"), "reasonix")
+      : join(homedir(), ".reasonix"))
+  );
+}
+
+// One KEY=value assignment with a non-empty value; `export` prefix and quoted
+// values are accepted by Reasonix's own reader. Rejects empty, comment-only,
+// and quoted-empty (`KEY=""`/`KEY=''`) assignments.
+export function hasReasonixCredentials(content: string): boolean {
+  return /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=\s*["']?[^\s"'=]/m.test(content);
+}
+
+// True when <Reasonix home>/.env holds a non-empty credential.
+export function isReasonixAuthenticated(env: Record<string, string | undefined>): boolean {
+  try {
+    return hasReasonixCredentials(readFileSync(join(reasonixHome(env), ".env"), "utf8"));
+  } catch {
+    return false;
+  }
+}
+
 const support: AcpSupport = {
   driverKind: "reasonix",
   displayName: "Reasonix",
@@ -36,24 +67,7 @@ const support: AcpSupport = {
   // core.ts issue a useless terminal authenticate RPC.
   pickAuthMethod: () => null,
   authFailure: "continue",
-  isAuthenticated: (env) => {
-    // Credentials live in <Reasonix home>/.env. REASONIX_HOME overrides;
-    // REASONIX_STATE_HOME only relocates runtime state (sessions/archives/
-    // memory), never provider credentials. Windows: %APPDATA%\reasonix.
-    const home =
-      env.REASONIX_HOME ||
-      (process.platform === "win32"
-        ? join(env.APPDATA || join(homedir(), "AppData", "Roaming"), "reasonix")
-        : join(homedir(), ".reasonix"));
-    try {
-      const content = readFileSync(join(home, ".env"), "utf8");
-      // one KEY=value assignment with a non-empty value; `export` prefix and
-      // quoted values are accepted by Reasonix's own reader
-      return /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=\s*\S/m.test(content);
-    } catch {
-      return false;
-    }
-  },
+  isAuthenticated: isReasonixAuthenticated,
 };
 
 export const ReasonixDriver = createAcpDriver(support);

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -1,0 +1,44 @@
+// Reasonix driver — `reasonix acp`, a full ACP v1 agent (NDJSON JSON-RPC 2.0
+// over stdio). Rides the generic ACP runtime in acp/core.ts; this file is only
+// the per-harness quirks.
+//
+// Auth is lenient (authFailure "continue"): the advertised method is the
+// terminal `reasonix-setup` flow, which OpenMausBot cannot drive, so the turn
+// proceeds on Reasonix's ambient login — the AI_GATEWAY_API_KEY seeded into
+// ~/.reasonix/.env by the finix `reasonix` wrapper.
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+
+const support: AcpSupport = {
+  driverKind: "reasonix",
+  displayName: "Reasonix",
+  models: {
+    default: "deepseek-flash-0731",
+    options: [
+      { id: "deepseek-flash-0731", label: "DeepSeek Flash 0731" },
+      { id: "deepseek-pro", label: "DeepSeek Pro (v4 0813)" },
+    ],
+  },
+  defaultCli: "reasonix",
+  nativeSource: "reasonix.acp",
+  loginNote: "Reasonix not configured — run `reasonix setup` and add a provider key",
+
+  // `--model` selects the startup model when the client does not override it;
+  // OpenMausBot passes the picker model verbatim (provider name or provider/model).
+  spawnArgs: (_config, turn) => ["acp", ...(turn.model ? ["--model", turn.model] : [])],
+
+  // The one advertised auth method is terminal (launches `reasonix setup`); skip
+  // authenticate and rely on the ambient ~/.reasonix/.env login.
+  pickAuthMethod: (methods) =>
+    methods.some((m) => m.id === "reasonix-setup") ? "reasonix-setup" : null,
+  authFailure: "continue",
+  isAuthenticated: (env) => {
+    const stateHome = env.REASONIX_STATE_HOME || join(homedir(), ".reasonix");
+    return existsSync(join(stateHome, ".env"));
+  },
+};
+
+export const ReasonixDriver = createAcpDriver(support);

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -31,7 +31,7 @@ export function reasonixHome(
 // values are accepted by Reasonix's own reader. Rejects empty, comment-only,
 // and quoted-empty (`KEY=""`/`KEY=''`) assignments.
 export function hasReasonixCredentials(content: string): boolean {
-  return /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=\s*["']?[^\s"'=]/m.test(content);
+  return /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=[ \t]*["']?[^\s"'=]/m.test(content);
 }
 
 // True when <Reasonix home>/.env holds a non-empty credential.

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -47,8 +47,9 @@ const support: AcpSupport = {
         : join(homedir(), ".reasonix"));
     try {
       const content = readFileSync(join(home, ".env"), "utf8");
-      // at least one non-comment KEY=value line with a non-empty value
-      return /^\s*[A-Za-z_][A-Za-z0-9_]*=.+\S/m.test(content);
+      // one KEY=value assignment with a non-empty value; `export` prefix and
+      // quoted values are accepted by Reasonix's own reader
+      return /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=\s*\S/m.test(content);
     } catch {
       return false;
     }

--- a/server/drivers/acp/reasonix.ts
+++ b/server/drivers/acp/reasonix.ts
@@ -22,8 +22,8 @@ export function reasonixHome(
   return (
     env.REASONIX_HOME ||
     (platform === "win32"
-      ? join(env.APPDATA || join(homedir(), "AppData", "Roaming"), "reasonix")
-      : join(homedir(), ".reasonix"))
+      ? join(env.APPDATA || join(env.USERPROFILE || env.HOME || homedir(), "AppData", "Roaming"), "reasonix")
+      : join(env.HOME || homedir(), ".reasonix"))
   );
 }
 

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -11,6 +11,7 @@ import { GeminiAgentDriver } from "./acp/gemini.ts";
 import { KimiAgentDriver } from "./acp/kimi.ts";
 import { DroidAgentDriver } from "./acp/droid.ts";
 import { OpenCodeGoDriver } from "./acp/opencode-go.ts";
+import { ReasonixDriver } from "./acp/reasonix.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -19,6 +20,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   KimiAgentDriver,
   DroidAgentDriver,
   OpenCodeGoDriver,
+  ReasonixDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,


### PR DESCRIPTION
Adds [Reasonix](https://github.com/y0usaf/reasonix-flake) — a cache-first DeepSeek coding agent with a documented [ACP v1](https://agentclientprotocol.com/) implementation (`reasonix acp`, NDJSON JSON-RPC 2.0 over stdio).

## Change

One support object on the generic ACP runtime (`server/drivers/acp/core.ts`), plus a registration line and a default-fleet entry:

- `server/drivers/acp/reasonix.ts` (new) — 44 lines
- `server/drivers/builtIn.ts` — +1 import, +1 registration
- `server/config.ts` — +1 default-fleet entry

## Details

- **Models**: `deepseek-flash-0731` (default), `deepseek-pro`
- **Auth**: lenient (`authFailure: "continue"`). The only advertised method is the terminal `reasonix-setup` flow, which a GUI host cannot drive, so turns proceed on Reasonix ambient login (`~/.reasonix/.env`).
- **Verified live** against reasonix 1.24.1: `initialize` advertises `protocolVersion: 1` and the `reasonix-setup` terminal auth method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Reasonix AI provider through the ACP v1 protocol.
  * Reasonix is now available as a default instance option.
  * Added support for selecting Reasonix models when starting a session.
  * Automatically detects existing Reasonix credentials, including platform-specific credential locations.
  * Supports custom Reasonix home-directory configuration.
  * Sessions can continue when terminal authentication is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->