### PR TITLE
feat: add an honest execution timeline

### DIFF
--- a/server/task-timeline.test.ts
+++ b/server/task-timeline.test.ts
@@ -18,4 +18,21 @@ describe("execution timeline", () => {
       { kind: "result", state: "complete" },
     ]);
   });
+
+  it("shows a pending activity as running until its completion patch arrives", () => {
+    const start = { id: "tool", role: "bot" as const, kind: "activity" as const, tool: { name: "browser.search" }, at: 2 };
+    expect(timelineEvents([start])).toMatchObject([{ label: "browser.search", state: "running" }]);
+    expect(timelineEvents([{ ...start, tool: { name: "browser.search", ok: true } }])).toMatchObject([
+      { label: "browser.search", state: "complete" },
+    ]);
+  });
+
+  it("does not call every later user reply a new task", () => {
+    const events = timelineEvents([
+      { id: "task", role: "user", kind: "text", text: "Research this", at: 1 },
+      { id: "reply", role: "bot", kind: "text", text: "What should I compare?", at: 2 },
+      { id: "answer", role: "user", kind: "text", text: "Price and privacy.", at: 3 },
+    ]);
+    expect(events.map((event) => event.label)).toEqual(["Task started", "Response recorded", "User input"]);
+  });
 });

--- a/server/task-timeline.test.ts
+++ b/server/task-timeline.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { timelineEvents } from "../src/lib/taskTimeline.ts";
+
+describe("execution timeline", () => {
+  it("derives only persisted, observable events and preserves failures", () => {
+    const events = timelineEvents([
+      { id: "start", role: "user", kind: "text", text: "Research this", at: 1 },
+      { id: "tool", role: "bot", kind: "activity", tool: { name: "browser.search", ok: true }, at: 2 },
+      { id: "screen", role: "bot", kind: "screen", png: "x", at: 3 },
+      { id: "failure", role: "bot", kind: "activity", tool: { name: "error: blocked", ok: false }, at: 4 },
+      { id: "response", role: "bot", kind: "text", text: "I could not complete it.", at: 5 },
+    ]);
+    expect(events).toMatchObject([
+      { kind: "task", state: "observed" },
+      { label: "browser.search", kind: "tool", state: "complete" },
+      { kind: "screen", state: "observed" },
+      { label: "blocked", kind: "tool", state: "failed" },
+      { kind: "result", state: "complete" },
+    ]);
+  });
+});

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -107,7 +107,7 @@ function TaskTimeline({ messages, busy }: { messages: Message[]; busy: boolean }
         <ol className="ml-2 border-l border-hairline/40 pb-2 pl-3">
           {recent.map((event) => (
             <li key={event.id} className="relative flex items-center gap-2 py-1 text-[12px] text-ink-secondary">
-              <span className={cn("absolute -left-[17px] size-2 rounded-full", event.state === "failed" ? "bg-danger" : event.state === "complete" ? "bg-success" : "bg-ink-secondary")} />
+              <span className={cn("absolute -left-[17px] size-2 rounded-full", event.state === "failed" ? "bg-danger" : event.state === "complete" ? "bg-success" : event.state === "running" ? "animate-pulse bg-accent" : "bg-ink-secondary")} />
               <span className="truncate">{event.label}</span>
               <time className="ml-auto shrink-0 text-[11px] text-ink-secondary/70">{formatTime(event.at)}</time>
             </li>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   Crown,
   Folder,
+  ListTree,
   Loader2,
   Monitor,
   Pencil,
@@ -61,6 +62,7 @@ import {
   resolveTranscriptWindow,
   tailWindowStart,
 } from "@/lib/transcript-window";
+import { timelineEvents } from "@/lib/taskTimeline";
 
 /** Long user messages collapse behind a fade so pasted walls of text don't
  * bury the conversation; bots get full markdown. */
@@ -82,6 +84,36 @@ function DaySeparator({ at }: { at: number }) {
   return (
     <div className="py-3 text-center text-[13px] text-ink-secondary">
       {dayLabel(at)} {formatTime(at)}
+    </div>
+  );
+}
+
+function TaskTimeline({ messages, busy }: { messages: Message[]; busy: boolean }) {
+  const [open, setOpen] = useState(false);
+  const events = useMemo(() => timelineEvents(messages), [messages]);
+  if (events.length === 0) return null;
+  const recent = events.slice(-8);
+  return (
+    <div className="mx-auto w-full max-w-[900px] px-5 pt-1">
+      <button
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-[12.5px] text-ink-secondary hover:bg-raised/50 hover:text-ink"
+      >
+        <span className="flex items-center gap-1.5"><ListTree size={14} /> Execution timeline{busy ? " · running" : ""}</span>
+        <ChevronDown size={14} className={cn("transition-transform", open && "rotate-180")} />
+      </button>
+      {open && (
+        <ol className="ml-2 border-l border-hairline/40 pb-2 pl-3">
+          {recent.map((event) => (
+            <li key={event.id} className="relative flex items-center gap-2 py-1 text-[12px] text-ink-secondary">
+              <span className={cn("absolute -left-[17px] size-2 rounded-full", event.state === "failed" ? "bg-danger" : event.state === "complete" ? "bg-success" : "bg-ink-secondary")} />
+              <span className="truncate">{event.label}</span>
+              <time className="ml-auto shrink-0 text-[11px] text-ink-secondary/70">{formatTime(event.at)}</time>
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   );
 }
@@ -1003,6 +1035,8 @@ export function ChatView({ bot }: { bot: Bot }) {
           dispatch({ type: "updateBot", botId: bot.id, patch: { pinnedMessageId: "" } })
         }
       />
+
+      <TaskTimeline messages={messages} busy={bot.busy ?? false} />
 
       {/* Messages */}
       <div

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -96,6 +96,7 @@ function TaskTimeline({ messages, busy }: { messages: Message[]; busy: boolean }
   return (
     <div className="mx-auto w-full max-w-[900px] px-5 pt-1">
       <button
+        type="button"
         onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
         className="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-[12.5px] text-ink-secondary hover:bg-raised/50 hover:text-ink"
@@ -107,7 +108,20 @@ function TaskTimeline({ messages, busy }: { messages: Message[]; busy: boolean }
         <ol className="ml-2 border-l border-hairline/40 pb-2 pl-3">
           {recent.map((event) => (
             <li key={event.id} className="relative flex items-center gap-2 py-1 text-[12px] text-ink-secondary">
-              <span className={cn("absolute -left-[17px] size-2 rounded-full", event.state === "failed" ? "bg-danger" : event.state === "complete" ? "bg-success" : event.state === "running" ? "animate-pulse bg-accent" : "bg-ink-secondary")} />
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute -left-[17px] size-2 rounded-full",
+                  event.state === "failed"
+                    ? "bg-danger"
+                    : event.state === "complete"
+                      ? "bg-success"
+                      : event.state === "running"
+                        ? "animate-pulse bg-accent"
+                        : "bg-ink-secondary",
+                )}
+              />
+              <span className="sr-only">{event.state}: </span>
               <span className="truncate">{event.label}</span>
               <time className="ml-auto shrink-0 text-[11px] text-ink-secondary/70">{formatTime(event.at)}</time>
             </li>
@@ -921,7 +935,9 @@ export function ChatView({ bot }: { bot: Bot }) {
   // on Windows the frameless window's min/max/close overlay sits at the
   // top-right: the header becomes the drag strip and clears room for it
   const isWin = window.ogb?.platform === "win32";
+  // SAFETY: Electron supports this nonstandard CSS property, which React's type declarations omit.
   const drag = isWin ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
+  // SAFETY: Electron supports this nonstandard CSS property, which React's type declarations omit.
   const noDrag = isWin ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
   return (

--- a/src/lib/taskTimeline.ts
+++ b/src/lib/taskTimeline.ts
@@ -1,0 +1,35 @@
+import type { Message } from "@/state/store";
+
+export interface TimelineEvent {
+  id: string;
+  at: number;
+  label: string;
+  state: "complete" | "failed" | "observed";
+  kind: "task" | "tool" | "screen" | "result";
+}
+
+/** Turn an already-persisted transcript into a compact, honest timeline. It
+ * deliberately derives only from events the harness has recorded — this UI
+ * never guesses that an action or result happened. */
+export function timelineEvents(messages: Message[]): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+  for (const message of messages) {
+    if (message.kind === "text" && message.role === "user" && message.text?.trim()) {
+      events.push({ id: message.id, at: message.at, label: "Task started", state: "observed", kind: "task" });
+    } else if (message.kind === "activity" && message.tool) {
+      const failed = message.tool.ok === false || message.tool.name.startsWith("error:");
+      events.push({
+        id: message.id,
+        at: message.at,
+        label: failed ? message.tool.name.replace(/^error:\s*/i, "") : message.tool.name,
+        state: failed ? "failed" : "complete",
+        kind: "tool",
+      });
+    } else if (message.kind === "screen") {
+      events.push({ id: message.id, at: message.at, label: "Screen observed", state: "observed", kind: "screen" });
+    } else if (message.kind === "text" && message.role === "bot" && message.text?.trim()) {
+      events.push({ id: message.id, at: message.at, label: "Response recorded", state: "complete", kind: "result" });
+    }
+  }
+  return events;
+}

--- a/src/lib/taskTimeline.ts
+++ b/src/lib/taskTimeline.ts
@@ -3,7 +3,7 @@
 export interface TimelineMessage {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen";
+  kind: "text" | "options" | "activity" | "screen" | "connector";
   text?: string;
   tool?: { name: string; ok?: boolean };
   png?: string;

--- a/src/lib/taskTimeline.ts
+++ b/src/lib/taskTimeline.ts
@@ -1,28 +1,48 @@
-import type { Message } from "@/state/store";
+/** The persisted message fields this pure projection needs. Keeping this
+ * structural avoids pulling the renderer's TSX store into server tests. */
+export interface TimelineMessage {
+  id: string;
+  role: "bot" | "user";
+  kind: "text" | "options" | "activity" | "screen";
+  text?: string;
+  tool?: { name: string; ok?: boolean };
+  png?: string;
+  at: number;
+}
 
 export interface TimelineEvent {
   id: string;
   at: number;
   label: string;
-  state: "complete" | "failed" | "observed";
+  state: "running" | "complete" | "failed" | "observed";
   kind: "task" | "tool" | "screen" | "result";
 }
 
 /** Turn an already-persisted transcript into a compact, honest timeline. It
  * deliberately derives only from events the harness has recorded — this UI
  * never guesses that an action or result happened. */
-export function timelineEvents(messages: Message[]): TimelineEvent[] {
+export function timelineEvents(messages: TimelineMessage[]): TimelineEvent[] {
   const events: TimelineEvent[] = [];
+  let sawUserInput = false;
   for (const message of messages) {
     if (message.kind === "text" && message.role === "user" && message.text?.trim()) {
-      events.push({ id: message.id, at: message.at, label: "Task started", state: "observed", kind: "task" });
+      events.push({
+        id: message.id,
+        at: message.at,
+        label: sawUserInput ? "User input" : "Task started",
+        state: "observed",
+        kind: "task",
+      });
+      sawUserInput = true;
     } else if (message.kind === "activity" && message.tool) {
       const failed = message.tool.ok === false || message.tool.name.startsWith("error:");
       events.push({
         id: message.id,
         at: message.at,
         label: failed ? message.tool.name.replace(/^error:\s*/i, "") : message.tool.name,
-        state: failed ? "failed" : "complete",
+        // An activity is appended at tool start and patched with its outcome.
+        // Until that patch arrives, do not imply that the action succeeded.
+        state: failed ? "failed" : message.tool.ok === true ? "complete" : "running",
         kind: "tool",
       });
     } else if (message.kind === "screen") {


### PR DESCRIPTION
## What changed\n- adds a compact, collapsible execution timeline above each bot transcript\n- derives task starts, tool outcomes, screen observations, and recorded responses from the persisted conversation events\n- distinguishes failed activity events visually and never infers an unrecorded success\n\n## Architecture\nThe timeline is a pure frontend projection of existing message records. It introduces no provider-specific instrumentation, no new persistence format, and no runtime event source, so it remains compatible with current CLI/ACP providers.\n\n## Overlap avoided\nThis does not duplicate PR #59's budget status, PR #60's checkpoint state, or PR #64's verification evidence. It gives the existing event stream a readable chronological view.\n\n## Tests\n- corepack pnpm exec vitest run server/task-timeline.test.ts — 1 passed\n- corepack pnpm typecheck — passed\n- corepack pnpm test — 62 passed, 39 skipped\n- corepack pnpm build — passed\n\n## Limitations\nThe timeline is intentionally retrospective/derived. It cannot show progress from providers that emit no activity records, and it does not claim task completion beyond the already-recorded response. No token or latency savings are claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible task timeline above chat messages.
  * Displays recent task activity, including tools, screens, results, and user follow-ups.
  * Shows event timestamps and running, completed, or failed statuses.

* **Tests**
  * Added coverage for timeline activity, persisted events, failures, pending states, and task transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->