### PR TITLE
fix: keep each thread's composer draft when switching bots

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, Clock, Mic, Square, X } from "lucide-react";
 import { useStore, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
+import { useDraft } from "@/lib/drafts";
 import { MausAvatar } from "./Avatar";
 import { normalizeState } from "@/lib/mascot";
 
@@ -36,7 +37,9 @@ export function Composer({
   const busyName = group
     ? (members?.find((b) => b.id === group.busyBotId)?.name ?? "A bot")
     : (bot?.name ?? "The bot");
-  const [text, setText] = useState("");
+  // per-thread draft: switching bots unmounts this component, so the text
+  // has to outlive it (see lib/drafts)
+  const [text, setText] = useDraft(group ? `group:${group.id}` : `bot:${bot?.id ?? ""}`);
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [caret, setCaret] = useState(0);

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -38,9 +38,19 @@ export function setDraft(store: Store, id: string, text: string): void {
   }
 }
 
+// Reaching for localStorage is itself a failure point: on an origin with
+// storage blocked the getter throws, and `typeof` doesn't shield it.
+function getStore(): Store {
+  try {
+    return typeof localStorage === "undefined" ? undefined : localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
 /** useState for the composer text, persisted under `id` (a bot or room). */
 export function useDraft(id: string): [string, (next: string) => void] {
-  const store = typeof localStorage === "undefined" ? undefined : localStorage;
+  const store = getStore();
   const [text, setText] = useState(() => getDraft(store, id));
   const set = useCallback(
     (next: string) => {

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -1,0 +1,53 @@
+// Unsent composer text, kept per thread. The Composer is keyed by bot/room
+// id, so switching threads unmounts it and its local text state dies with
+// it. Drafts live in localStorage, so coming back to a bot — in this
+// session or after a restart — finds what you were typing still there.
+import { useCallback, useState } from "react";
+
+const KEY = "omb-drafts";
+
+type Drafts = Record<string, string>;
+type Store = Pick<Storage, "getItem" | "setItem"> | undefined;
+
+// Storage is best-effort: a full quota, a locked-down origin, or a garbled
+// value must never cost a keystroke — every failure reads as "no drafts".
+function read(store: Store): Drafts {
+  try {
+    const raw = store?.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Drafts) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getDraft(store: Store, id: string): string {
+  const text = read(store)[id];
+  return typeof text === "string" ? text : "";
+}
+
+export function setDraft(store: Store, id: string, text: string): void {
+  const drafts = read(store);
+  // an emptied composer drops its entry rather than storing "" forever
+  if (text) drafts[id] = text;
+  else delete drafts[id];
+  try {
+    store?.setItem(KEY, JSON.stringify(drafts));
+  } catch {
+    /* quota / private mode — the draft just doesn't outlive the mount */
+  }
+}
+
+/** useState for the composer text, persisted under `id` (a bot or room). */
+export function useDraft(id: string): [string, (next: string) => void] {
+  const store = typeof localStorage === "undefined" ? undefined : localStorage;
+  const [text, setText] = useState(() => getDraft(store, id));
+  const set = useCallback(
+    (next: string) => {
+      setText(next);
+      setDraft(store, id, next);
+    },
+    [store, id],
+  );
+  return [text, set];
+}


### PR DESCRIPTION
Follow-up to my #39, and the half of it I should have seen at the time.

#39 keyed the composer by bot id so a half-written message stops following you into the next conversation — the wrong-bot send is real. But remounting also throws the draft away: leave a thread mid-sentence, come back, and the box is empty. I even wrote in that PR that per-bot drafts would work too and picked the smaller change; having lived with it, dropping the text is the part users notice.

So: keep the draft instead of discarding it.

- New `src/lib/drafts.ts` — the unsent text per bot (and per room) in `localStorage`, plus a `useDraft(id)` hook that is a drop-in for `useState("")`.
- `Composer.tsx` — one line and an import. Remounting still isolates threads from each other and still resets the mention picker and dictation exactly as #39 arranged; only the text now survives the trip, including across a restart. Sending or emptying the box clears the entry.

Storage is best-effort: a full quota, a locked-down origin, or a garbled value reads as "no drafts" rather than costing a keystroke.

`pnpm typecheck && pnpm test` pass (101 tests). Also ran it in a packaged build: type to one bot, switch away, come back — the text is waiting; send empties it; quitting and reopening keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197wYuWWpF21iBeNgHZ8n3X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft messages are saved automatically while composing.
  * Drafts are preserved separately for each bot or group conversation.
  * Empty drafts are removed automatically when no text remains.

* **Bug Fixes**
  * Improved resilience when saved draft data is unavailable, malformed, or inaccessible.
  * Draft content now remains available when switching between conversations and returning to a previous thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->