### PR TITLE
feat: keep a long paste as an attachment chip

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,9 +1,16 @@
 import { track } from "@/lib/analytics";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, Clock, Mic, Square, X } from "lucide-react";
 import { useStore, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { MausAvatar } from "./Avatar";
+import { ComposerAttachments } from "./ComposerAttachments";
+import {
+  composeMessage,
+  isLongPaste,
+  pasteAttachment,
+  type Attachment,
+} from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
 
 /** The active @mention query at the caret: the text between an `@` that
@@ -37,6 +44,13 @@ export function Composer({
     ? (members?.find((b) => b.id === group.busyBotId)?.name ?? "A bot")
     : (bot?.name ?? "The bot");
   const [text, setText] = useState("");
+  // pastes too long for the input ride along as chips and fold back
+  // into the message on send
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const removeAttachment = useCallback(
+    (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
+    [],
+  );
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [caret, setCaret] = useState(0);
@@ -88,11 +102,12 @@ export function Composer({
   // the turn settles. Enter during a turn queues instead of silently dying.
   const [queued, setQueued] = useState<string | null>(null);
   const send = () => {
-    const t = text.trim();
+    const t = composeMessage(text, attachments);
     if (!t) return;
     if (busy) {
       setQueued(t);
       setText("");
+      setAttachments([]);
       return;
     }
     if (group) {
@@ -103,6 +118,7 @@ export function Composer({
       track("message_sent", { driver: bot.modelSelection?.instanceId });
     }
     setText("");
+    setAttachments([]);
   };
   useEffect(() => {
     if (!busy && queued) {
@@ -204,6 +220,7 @@ export function Composer({
             ))}
           </div>
         )}
+        <ComposerAttachments items={attachments} onRemove={removeAttachment} />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea
           ref={inputRef}
@@ -213,6 +230,13 @@ export function Composer({
             setText(e.target.value);
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
+          }}
+          onPaste={(e) => {
+            // a wall of text becomes a chip instead of burying the input
+            const pasted = e.clipboardData.getData("text/plain");
+            if (!isLongPaste(pasted)) return;
+            e.preventDefault();
+            setAttachments((prev) => [...prev, pasteAttachment(pasted)]);
           }}
           onKeyUp={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -101,6 +101,8 @@ export function Composer({
   // One message may be queued while the bot works; it auto-sends the moment
   // the turn settles. Enter during a turn queues instead of silently dying.
   const [queued, setQueued] = useState<string | null>(null);
+  // a chip on its own is a message: the send control has to appear for it
+  const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
     const t = composeMessage(text, attachments);
     if (!t) return;
@@ -297,7 +299,7 @@ export function Composer({
             <Square size={14} className="fill-current" />
           </button>
         )}
-        {!busy && !text.trim() && (
+        {!busy && !hasContent && (
           <button
             onClick={toggleMic}
             aria-label={recording ? "Stop dictation" : "Start dictation"}
@@ -312,7 +314,7 @@ export function Composer({
             <Mic size={18} />
           </button>
         )}
-        {text.trim() && (
+        {hasContent && (
           <button
             onClick={send}
             aria-label={busy ? "Queue message" : "Send message"}

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -16,13 +16,14 @@ export function ComposerAttachments({
   return (
     <div className="mb-2 flex flex-wrap gap-2">
       {items.map((a) => (
-        <PasteChip key={a.id} text={a.text} onRemove={() => onRemove(a.id)} />
+        <PasteChip key={a.id} item={a} onRemove={() => onRemove(a.id)} />
       ))}
     </div>
   );
 }
 
-function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
+function PasteChip({ item, onRemove }: { item: Attachment; onRemove: () => void }) {
+  const { text } = item;
   return (
     <div
       title={text.slice(0, 4000)}
@@ -37,17 +38,19 @@ function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
         </pre>
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
       </div>
-      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(text)}</div>
+      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(item)}</div>
       <div className="mt-1 flex items-center gap-1">
         <ClipboardPaste size={11} className="text-ink-secondary/70" />
         <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
           PASTED
         </span>
       </div>
+      {/* hover reveals it, but so must focus: `hidden` would take the only
+          way to drop a chip out of reach of the keyboard */}
       <button
         onClick={onRemove}
         aria-label="Remove pasted text"
-        className="absolute -right-1.5 -top-1.5 hidden size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary hover:text-ink group-hover:flex"
+        className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary opacity-0 transition-opacity hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
       >
         <X size={11} />
       </button>

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -1,0 +1,56 @@
+// Chips for what is attached to the next message, shown above the input.
+// A long paste collapses into a card of its first lines instead of
+// flooding the composer with a wall of text.
+import { ClipboardPaste, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { pasteSummary, type Attachment } from "@/lib/composer-attachments";
+
+export function ComposerAttachments({
+  items,
+  onRemove,
+}: {
+  items: Attachment[];
+  onRemove: (id: string) => void;
+}) {
+  if (!items.length) return null;
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {items.map((a) => (
+        <PasteChip key={a.id} text={a.text} onRemove={() => onRemove(a.id)} />
+      ))}
+    </div>
+  );
+}
+
+function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
+  return (
+    <div
+      title={text.slice(0, 4000)}
+      className={cn(
+        "group relative w-[172px] rounded-xl border border-hairline/40 bg-raised px-2.5 py-2",
+        "transition-colors hover:border-hairline",
+      )}
+    >
+      <div className="relative h-[76px] overflow-hidden">
+        <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
+          {text.slice(0, 400)}
+        </pre>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
+      </div>
+      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(text)}</div>
+      <div className="mt-1 flex items-center gap-1">
+        <ClipboardPaste size={11} className="text-ink-secondary/70" />
+        <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
+          PASTED
+        </span>
+      </div>
+      <button
+        onClick={onRemove}
+        aria-label="Remove pasted text"
+        className="absolute -right-1.5 -top-1.5 hidden size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary hover:text-ink group-hover:flex"
+      >
+        <X size={11} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,7 +1,7 @@
 // Text pasted into the composer that is too long to live in the input.
 // It rides along as a chip and folds back into the message on send —
 // nothing here reaches the server, so every driver still sees a prompt.
-export type Attachment = { kind: "paste"; id: string; text: string };
+export type Attachment = { kind: "paste"; id: string; text: string; size: number };
 
 /** Past this, a paste stops reading as typing and becomes an attachment.
  * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
@@ -18,12 +18,20 @@ export function countLines(text: string): number {
 
 export function pasteAttachment(text: string): Attachment {
   const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
-  return { kind: "paste", id, text };
+  // measured once, here: a chip re-renders on every keystroke in the
+  // composer, and encoding half a megabyte each time would be felt
+  return { kind: "paste", id, text, size: byteLength(text) };
+}
+
+/** What the paste actually weighs — String#length counts UTF-16 units, so
+ * it reads a third under on accented text and half under on CJK. */
+export function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
 }
 
 /** "12 lines, 3.4 KB" — what the chip says under the preview. */
-export function pasteSummary(text: string): string {
-  return `${countLines(text)} lines, ${formatSize(text.length)}`;
+export function pasteSummary(a: { text: string; size: number }): string {
+  return `${countLines(a.text)} lines, ${formatSize(a.size)}`;
 }
 
 export function formatSize(bytes: number): string {

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,0 +1,44 @@
+// Text pasted into the composer that is too long to live in the input.
+// It rides along as a chip and folds back into the message on send —
+// nothing here reaches the server, so every driver still sees a prompt.
+export type Attachment = { kind: "paste"; id: string; text: string };
+
+/** Past this, a paste stops reading as typing and becomes an attachment.
+ * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
+export const PASTE_CHARS = 900;
+export const PASTE_LINES = 12;
+
+export function isLongPaste(text: string): boolean {
+  return text.length >= PASTE_CHARS || countLines(text) >= PASTE_LINES;
+}
+
+export function countLines(text: string): number {
+  return text.split("\n").length;
+}
+
+export function pasteAttachment(text: string): Attachment {
+  const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+  return { kind: "paste", id, text };
+}
+
+/** "12 lines, 3.4 KB" — what the chip says under the preview. */
+export function pasteSummary(text: string): string {
+  return `${countLines(text)} lines, ${formatSize(text.length)}`;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** The prompt the bot receives: what was typed, then one block per paste.
+ * Tagged blocks rather than fences — pasted code and markdown carry fences
+ * of their own, and nesting them loses the boundary. */
+export function composeMessage(text: string, attachments: Attachment[]): string {
+  const parts = [text.trim()];
+  attachments.forEach((a, i) => {
+    parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+  });
+  return parts.filter(Boolean).join("\n\n");
+}


### PR DESCRIPTION
Paste a stack trace, a log, or a page of code into the composer today and it buries the input: the textarea grows to its cap, the send button drifts down, and whatever you had written scrolls out of sight. The message is still fine — the composer is not.

Past ~900 characters or 12 lines, a paste becomes a chip above the input instead: the first lines fading out, the size beside them, an `x` to drop it. Shorter pastes are untouched and still land as text, so nothing about ordinary typing changes.

On send the chips fold back into the message as `<pasted-text index="…">` blocks. Tagged rather than fenced on purpose: pasted code and markdown carry fences of their own, and nesting them loses the boundary. Nothing crosses the server or a driver — the provider still receives one plain prompt.

Two new files (`src/lib/composer-attachments.ts`, `src/components/ComposerAttachments.tsx`) and ~25 lines in `Composer.tsx`.

#69 stacks on this branch and reuses the same chips for files dropped onto the window.

`pnpm typecheck && pnpm test` pass (101 tests). Exercised in the dev UI against a real thread: a 40-line paste collapses into the chip instead of the input, the chip removes cleanly, and short pastes still type through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197wYuWWpF21iBeNgHZ8n3X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long pasted text is now captured as removable attachment chips above the message composer.
  * Attachments show a text preview, size summary, and “Pasted” label.
  * Remove individual pasted attachments before sending or queuing.
  * Pasted content is included in sent or queued messages and cleared afterward.
  * The send control appears when attachments are present, while the microphone stays hidden whenever the composer contains content.
  * Short pastes continue to use the default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->