### PR TITLE
Computer use: one round trip per step, JPEG frames, batched actions

### DIFF
--- a/dist-server/box.js
+++ b/dist-server/box.js
@@ -73,10 +73,36 @@ async function waitReady(cfg, boxId, budgetMs = 90_000) {
     }
     return null;
 }
+// Resolving a bot's box means LISTing every box in the account, so it is
+// the most expensive thing on any hot path. The name is deterministic, so
+// once we know the id we can go straight at it — the cache is refreshed
+// whenever the direct read fails (deleted/renamed box) and always carries
+// the live state so callers can still see "archived".
+const boxIdCache = new Map();
 export async function findBox(cfg, botId) {
+    const cachedId = boxIdCache.get(botId);
+    if (cachedId) {
+        const { ok, body } = await boxJson(cfg, `/boxes/${cachedId}`);
+        const box = body?.box;
+        if (ok && box?.id && box.state !== "error")
+            return box;
+        boxIdCache.delete(botId); // gone or broken — fall back to the listing
+    }
     const name = await boxNameFor(botId);
     const { body } = await boxJson(cfg, "/boxes");
-    return (body?.boxes ?? []).find((b) => b.name === name && b.state !== "error") ?? null;
+    const found = (body?.boxes ?? []).find((b) => b.name === name && b.state !== "error") ?? null;
+    if (found?.id)
+        boxIdCache.set(botId, found.id);
+    return found;
+}
+/** Ready-or-null without the LIST when we already know the box. */
+export async function readyBox(cfg, botId, budgetMs = 60_000) {
+    const box = await findBox(cfg, botId);
+    if (!box)
+        return null;
+    if (READY.has(box.state))
+        return box;
+    return waitReady(cfg, box.id, budgetMs);
 }
 export function boxConfigured(cfg) {
     return Boolean(cfg.box?.token);
@@ -187,32 +213,59 @@ export async function execOnBox(cfg, botId, command) {
     const out = await runCommand(cfg, box.id, String(command ?? "").slice(0, 4000));
     return { exitCode: out.exitCode, stdout: out.stdout.slice(-4000), stderr: out.stderr.slice(-2000) };
 }
-// Screenshot for the Computer panel + screen-in-chat. Two hops, both
-// deterministic: capture to a file on the box (scrot/import/ffmpeg chain,
-// downscaled), then read it back via the files API with encoding=base64.
-// Base64 over command stdout is NOT reliable (probed 2026-08-12: an
-// otherwise-complete payload came back with a corrupted length) — never
-// ship binary through the commands endpoint.
+// Screenshot for the Computer panel + screen-in-chat. Two hops: capture
+// to a file on the box (scrot straight to JPEG — no ImageMagick startup
+// unless a downscale is actually needed), then read the bytes back.
+// Base64 over command stdout is NOT reliable for the panel's full-size
+// frames (probed 2026-08-12: an otherwise-complete payload came back with
+// a corrupted length), so the frame is always fetched over HTTP here.
+const PANEL_PATH = "/tmp/ogb-panel.jpg";
+const PANEL_WIDTH = 1024;
 const SHOT_CMD = [
     "export DISPLAY=${DISPLAY:-:0}",
-    "f=/tmp/ogb-panel.png",
-    'scrot -o "$f" 2>/dev/null || import -window root "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 "$f" >/dev/null 2>&1',
-    'command -v convert >/dev/null && convert "$f" -resize 1024x "$f" 2>/dev/null || true',
+    `f=${PANEL_PATH}`,
+    'w=$(xdotool getdisplaygeometry 2>/dev/null | cut -d" " -f1)',
+    'case "$w" in ""|*[!0-9]*) w=0;; esac',
+    'scrot -o -q 70 "$f" 2>/dev/null || import -window root -quality 70 "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 7 "$f" >/dev/null 2>&1',
+    `if [ "$w" -gt ${PANEL_WIDTH} ] 2>/dev/null && command -v convert >/dev/null 2>&1; then convert "$f" -thumbnail ${PANEL_WIDTH}x -quality 70 "$f" 2>/dev/null || true; fi`,
     'test -s "$f" && echo captured',
 ].join("; ");
-export async function screenshotBox(cfg, botId) {
-    const box = await findBox(cfg, botId);
-    if (!box)
-        throw new Error("no computer for this bot yet");
-    if (!READY.has(box.state))
-        throw new Error(`box is ${box.state}`);
-    const out = await runCommand(cfg, box.id, SHOT_CMD, { timeoutMs: 60_000 });
+/** Read a file off the box as base64 — raw artifact bytes when the API
+ * supports it (33% less transfer, no JSON envelope), else the files API. */
+async function readFileBase64(cfg, boxId, path) {
+    try {
+        const res = await boxFetch(cfg, `/boxes/${boxId}/artifacts?path=${encodeURIComponent(path)}`);
+        if (res.ok) {
+            const bytes = Buffer.from(await res.arrayBuffer());
+            if (bytes.length)
+                return bytes.toString("base64");
+        }
+    }
+    catch {
+        /* fall through */
+    }
+    const { ok, body } = await boxJson(cfg, `/boxes/${boxId}/files?path=${encodeURIComponent(path)}&encoding=base64`);
+    const content = body?.content;
+    return ok && typeof content === "string" && content ? content : null;
+}
+/** `knownBoxId` skips box resolution entirely — the screen poller holds
+ * the id for the whole turn and must not re-resolve it every frame. */
+export async function screenshotBox(cfg, botId, knownBoxId) {
+    let boxId = knownBoxId;
+    if (!boxId) {
+        const box = await findBox(cfg, botId);
+        if (!box)
+            throw new Error("no computer for this bot yet");
+        if (!READY.has(box.state))
+            throw new Error(`box is ${box.state}`);
+        boxId = box.id;
+    }
+    const out = await runCommand(cfg, boxId, SHOT_CMD, { timeoutMs: 60_000 });
     if (!/captured/.test(out.stdout)) {
         throw new Error(out.stderr.slice(0, 200) || "screen capture failed on the box");
     }
-    const { ok, body } = await boxJson(cfg, `/boxes/${box.id}/files?path=/tmp/ogb-panel.png&encoding=base64`);
-    const png = body?.content;
-    if (!ok || typeof png !== "string" || !png)
+    const data = await readFileBase64(cfg, boxId, PANEL_PATH);
+    if (!data)
         throw new Error("could not read the frame back from the box");
-    return { png, format: "png" };
+    return { png: data, format: "jpeg" };
 }

--- a/dist-server/computer-proxy.js
+++ b/dist-server/computer-proxy.js
@@ -4,16 +4,41 @@
 // computer (box.ascii.dev) as CUA-grade tools.
 //
 // Transport: every action goes through the box's REST run-command
-// endpoint (no inbound port on the box, no tunnel). On the box, actions
-// prefer the CUA computer-server on loopback :8000 (trycua
-// cua-computer-server, installed by the provision bootstrap; raw XTEST
-// under the hood) and fall back to xdotool/scrot — the same primitives
-// CUA itself uses on Linux.
+// endpoint (no inbound port on the box, no tunnel), so a round trip is
+// expensive (~TLS + shell spawn). The whole design is therefore built
+// around ONE round trip per step:
+//
+//   act + settle + capture + base64 all run in a single shell command,
+//   and the resulting frame rides back in the SAME tool result as an MCP
+//   image block ("act and observe"). The agent never needs a follow-up
+//   screenshot call, which halves the model inferences per UI step —
+//   the same shape Anthropic's own computer-use loop uses.
+//
+// Other latency rules that live here:
+//   - JPEG, not PNG (5-10x fewer bytes, identical vision tokens), and
+//     the downscale only runs when the display is wider than the model's
+//     coordinate space.
+//   - Coordinate scaling happens box-side in shell arithmetic, so there
+//     is no separate "what size is the display" round trip per turn.
+//   - Frames come back inline in stdout when small enough; the files API
+//     is only a fallback (one extra hop) for big ones.
+//   - computer_batch runs a whole mechanical sequence (click, type, tab,
+//     type, Enter) in one round trip with one frame at the end.
 //
 // stdout is the MCP channel — never console.log here.
-const BOX_API = "https://ascii.dev/api/box/v1";
+const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
+/** The coordinate space the model sees: frames are downscaled to this
+ * width, and clicks are scaled back up to the real display box-side. */
+const SHOT_WIDTH = 1280;
+const JPEG_QUALITY = 75;
+const SHOT_PATH = "/tmp/ogb-shot.jpg";
+/** How long the desktop gets to repaint before the fused capture. */
+const SETTLE_MS = 350;
+/** Frames larger than this come back over the files API instead of
+ * inline stdout (keeps us clear of the command endpoint's stdout cap). */
+const INLINE_MAX_BYTES = 400_000;
 async function runOnBox(command, timeoutMs = 60_000) {
     const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
         method: "POST",
@@ -29,62 +54,142 @@ async function runOnBox(command, timeoutMs = 60_000) {
         stderr: body?.stderr ?? "",
     };
 }
-/** Run a CUA computer-server command on the box's loopback; returns the
- * parsed JSON payload, or null when the server isn't up (→ fallback). */
-async function cuaCmd(command, params, timeoutMs = 30_000) {
-    const payload = JSON.stringify({ command, params }).replace(/'/g, "'\\''");
-    const out = await runOnBox(`curl -sf -m ${Math.floor(timeoutMs / 1000)} -X POST http://127.0.0.1:8000/cmd -H 'Content-Type: application/json' -d '${payload}'`, timeoutMs + 15_000);
-    if (!out.ok || !out.stdout.trim())
-        return null;
-    const line = out.stdout.split("\n").find((l) => l.startsWith("data: "));
-    if (!line)
-        return null;
+const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+/** Resolve the real display size into $W/$H for box-side click scaling. */
+const GEOMETRY = [
+    "g=$(xdotool getdisplaygeometry 2>/dev/null)",
+    'W=${g%% *}',
+    'H=${g##* }',
+    `case "$W" in ''|*[!0-9]*) W=${SHOT_WIDTH}; H=0;; esac`,
+].join("; ");
+/** Shell that turns a screenshot-space coordinate into a display one. */
+function scaled(varName, value) {
+    return `${varName}=$(( ${Math.round(value)} * W / ${SHOT_WIDTH} ))`;
+}
+/** act → settle → capture → hash → (inline base64 if small). One hop. */
+function captureBlock(settleMs = SETTLE_MS) {
+    return [
+        settleMs > 0 ? `sleep ${(settleMs / 1000).toFixed(2)}` : "true",
+        `f=${SHOT_PATH}`,
+        `rm -f "$f" 2>/dev/null || true`,
+        `scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1`,
+        // only re-encode when the display is bigger than the model's space —
+        // ImageMagick startup is the most expensive step in the old pipeline
+        `if [ "$W" -gt ${SHOT_WIDTH} ] 2>/dev/null && command -v convert >/dev/null 2>&1; then convert "$f" -thumbnail ${SHOT_WIDTH}x -quality ${JPEG_QUALITY} "$f" 2>/dev/null || true; fi`,
+        `if [ ! -s "$f" ]; then echo SHOT_FAILED; exit 0; fi`,
+        'echo "GEOM $W $H"',
+        'echo "HASH $(md5sum "$f" 2>/dev/null | cut -d\' \' -f1)"',
+        's=$(stat -c%s "$f" 2>/dev/null || echo 0)',
+        `if [ "$s" -le ${INLINE_MAX_BYTES} ]; then echo "B64 $(base64 -w0 "$f" 2>/dev/null || base64 "$f" | tr -d '\\n')"; fi`,
+    ].join("; ");
+}
+/** Big frames (and any inline read that came back malformed) are fetched
+ * as raw bytes; the files API's base64-in-JSON envelope is the fallback. */
+async function fetchFrame() {
+    const auth = { authorization: `Bearer ${token}` };
     try {
-        const parsed = JSON.parse(line.slice(6));
-        return parsed?.success === false ? null : parsed;
+        const res = await fetch(`${BOX_API}/boxes/${boxId}/artifacts?path=${encodeURIComponent(SHOT_PATH)}`, { headers: auth, signal: AbortSignal.timeout(30_000) });
+        if (res.ok) {
+            const bytes = Buffer.from(await res.arrayBuffer());
+            if (bytes.length)
+                return bytes.toString("base64");
+        }
+    }
+    catch {
+        /* fall through to the files API */
+    }
+    try {
+        const res = await fetch(`${BOX_API}/boxes/${boxId}/files?path=${encodeURIComponent(SHOT_PATH)}&encoding=base64`, { headers: auth, signal: AbortSignal.timeout(30_000) });
+        const body = await res.json().catch(() => null);
+        const content = body?.content;
+        return res.ok && typeof content === "string" && content ? content : null;
     }
     catch {
         return null;
     }
 }
-const X = "export DISPLAY=${DISPLAY:-:0}; ";
-// capture to a file on the box, read back via the files API — base64 over
-// command stdout corrupts (probed 2026-08-12), never ship binary that way
-const SHOT_WIDTH = 1280;
-const SHOT_CMD = [
-    "export DISPLAY=${DISPLAY:-:0}",
-    "f=/tmp/ogb-shot.png",
-    'scrot -o "$f" 2>/dev/null || import -window root "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 "$f" >/dev/null 2>&1',
-    `command -v convert >/dev/null && convert "$f" -resize ${SHOT_WIDTH}x "$f" 2>/dev/null || true`,
-    'test -s "$f" && echo captured',
-].join("; ");
-// real display size, fetched once per proxy lifetime (per turn)
-let geometryCache;
-async function displayGeometry() {
-    if (geometryCache !== undefined)
-        return geometryCache;
-    const out = await runOnBox(`${X}xdotool getdisplaygeometry`);
-    const m = out.stdout.trim().match(/^(\d+)\s+(\d+)/);
-    geometryCache = m ? { width: Number(m[1]), height: Number(m[2]) } : null;
-    return geometryCache;
+/** A decoded frame is only trusted when it really is an image — a
+ * truncated stdout would otherwise reach the model as garbage. */
+function validBase64Image(data) {
+    if (!data || data.length < 512)
+        return false;
+    const head = Buffer.from(data.slice(0, 64), "base64");
+    const jpeg = head[0] === 0xff && head[1] === 0xd8;
+    const png = head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47;
+    return jpeg || png;
 }
-async function readBoxFile(path) {
-    const res = await fetch(`${BOX_API}/boxes/${boxId}/files?path=${encodeURIComponent(path)}&encoding=base64`, { headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(30_000) });
-    const body = await res.json().catch(() => null);
-    const content = body?.content;
-    return res.ok && typeof content === "string" && content ? content : null;
+let inlineWorks = true; // flipped off for the proxy's life on first garbage
+let lastFrameHash = null;
+async function frameFrom(out) {
+    if (/SHOT_FAILED/.test(out.stdout))
+        return null;
+    let hash = null;
+    let geometry = null;
+    let inline = "";
+    for (const line of out.stdout.split("\n")) {
+        if (line.startsWith("HASH "))
+            hash = line.slice(5).trim() || null;
+        else if (line.startsWith("GEOM ")) {
+            const [w, h] = line.slice(5).trim().split(/\s+/).map(Number);
+            if (Number.isFinite(w) && w > 0)
+                geometry = { width: w, height: Number.isFinite(h) ? h : 0 };
+        }
+        else if (line.startsWith("B64 "))
+            inline = line.slice(4).trim();
+    }
+    if (inline && inlineWorks) {
+        if (validBase64Image(inline))
+            return { data: inline, mime: "image/jpeg", hash, geometry };
+        inlineWorks = false; // stdout mangled it — use the files API from here on
+    }
+    const fetched = await fetchFrame();
+    if (!fetched || !validBase64Image(fetched))
+        return null;
+    return { data: fetched, mime: "image/jpeg", hash, geometry };
 }
-const send = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
+const send = (obj) => {
+    process.stdout.write(JSON.stringify(obj) + "\n");
+};
 const text = (id, t, isError = false) => send({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: t }], ...(isError ? { isError: true } : {}) } });
+/** An action result: the text plus the frame the action produced. When
+ * the pixels are byte-identical to the frame the model just saw, the
+ * image is dropped — it already has it, and it costs ~1.2k tokens. */
+function observed(id, note, frame) {
+    if (!frame) {
+        return text(id, `${note}\n(couldn't capture the screen — call screenshot to retry)`);
+    }
+    const unchanged = frame.hash != null && frame.hash === lastFrameHash;
+    lastFrameHash = frame.hash ?? lastFrameHash;
+    if (unchanged) {
+        return text(id, `${note}\n(screen unchanged — the last frame you were sent is still current. If you expected it to change, it may still be loading: retry with settle_ms, or call screenshot again.)`);
+    }
+    send({
+        jsonrpc: "2.0",
+        id,
+        result: {
+            content: [
+                { type: "text", text: note },
+                { type: "image", data: frame.data, mimeType: frame.mime },
+            ],
+        },
+    });
+}
+const OBSERVE_PROPS = {
+    observe: {
+        type: "boolean",
+        description: "default true — return a fresh screenshot with the result. Set false only when chaining mechanical steps you don't need to see.",
+    },
+    settle_ms: { type: "number", description: "wait before the screenshot, default 350, max 3000" },
+};
 const TOOLS = [
     {
         name: "screenshot",
-        description: "See the bot's cloud computer screen (returns an image). Call before and after acting to ground yourself — the desktop runs Chrome and a full Linux GUI.",
+        description: "See the bot's cloud computer screen (returns an image). The desktop runs Chrome and a full Linux GUI. You usually do NOT need this after acting — click, type_text, press_key, scroll and open_url already return the resulting screen.",
         inputSchema: { type: "object", properties: {} },
     },
     {
         name: "click",
-        description: "Click on the computer's screen. Use pixel coordinates as they appear in the most recent screenshot — scaling to the real display resolution is handled for you.",
+        description: "Click on the computer's screen and return the resulting screen. Use pixel coordinates as they appear in the most recent screenshot — scaling to the real display resolution is handled for you.",
         inputSchema: {
             type: "object",
             properties: {
@@ -92,56 +197,163 @@ const TOOLS = [
                 y: { type: "number" },
                 button: { type: "string", enum: ["left", "right"], description: "default left" },
                 double: { type: "boolean", description: "double-click" },
+                ...OBSERVE_PROPS,
             },
             required: ["x", "y"],
         },
     },
     {
         name: "type_text",
-        description: "Type text at the current focus on the computer.",
-        inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+        description: "Type text at the current focus and return the resulting screen.",
+        inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" }, ...OBSERVE_PROPS },
+            required: ["text"],
+        },
     },
     {
         name: "press_key",
-        description: 'Press a key or chord on the computer, xdotool syntax: "Return", "Tab", "ctrl+c", "alt+F4", "ctrl+shift+t".',
-        inputSchema: { type: "object", properties: { keys: { type: "string" } }, required: ["keys"] },
+        description: 'Press a key or chord and return the resulting screen. xdotool syntax: "Return", "Tab", "ctrl+c", "alt+F4", "ctrl+shift+t".',
+        inputSchema: {
+            type: "object",
+            properties: { keys: { type: "string" }, ...OBSERVE_PROPS },
+            required: ["keys"],
+        },
     },
     {
         name: "scroll",
-        description: "Scroll the computer screen up or down by N clicks.",
+        description: "Scroll the screen up or down by N clicks and return the resulting screen.",
         inputSchema: {
             type: "object",
             properties: {
                 direction: { type: "string", enum: ["up", "down"] },
                 clicks: { type: "number", description: "default 3" },
+                ...OBSERVE_PROPS,
             },
             required: ["direction"],
         },
     },
     {
+        name: "computer_batch",
+        description: "Run several UI actions in ONE go and return the screen at the end — much faster than separate calls (one round trip, one screenshot). Use it for mechanical sequences you can predict without looking in between, e.g. click a field, type, Tab, type, press Return. Stop the batch before anything whose outcome you need to see first.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                actions: {
+                    type: "array",
+                    description: "in order; each is {action: click|type_text|press_key|scroll|wait, ...its params}",
+                    items: {
+                        type: "object",
+                        properties: {
+                            action: { type: "string", enum: ["click", "type_text", "press_key", "scroll", "wait"] },
+                            x: { type: "number" },
+                            y: { type: "number" },
+                            button: { type: "string", enum: ["left", "right"] },
+                            double: { type: "boolean" },
+                            text: { type: "string" },
+                            keys: { type: "string" },
+                            direction: { type: "string", enum: ["up", "down"] },
+                            clicks: { type: "number" },
+                            ms: { type: "number", description: "wait: milliseconds, max 5000" },
+                        },
+                        required: ["action"],
+                    },
+                },
+                ...OBSERVE_PROPS,
+            },
+            required: ["actions"],
+        },
+    },
+    {
         name: "computer_exec",
         description: "Run a shell command on the bot's cloud computer (Linux, passwordless sudo, X11 desktop). Returns stdout/stderr/exit code.",
-        inputSchema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+        inputSchema: {
+            type: "object",
+            properties: { command: { type: "string" }, observe: OBSERVE_PROPS.observe },
+            required: ["command"],
+        },
     },
     {
         name: "open_url",
-        description: "Open a URL in the computer's own Chrome, then screenshot to see the result.",
-        inputSchema: { type: "object", properties: { url: { type: "string" } }, required: ["url"] },
+        description: "Open a URL in the computer's own Chrome and return the resulting screen.",
+        inputSchema: {
+            type: "object",
+            properties: { url: { type: "string" }, ...OBSERVE_PROPS },
+            required: ["url"],
+        },
     },
 ];
+const shellQuote = (s) => `'${s.replace(/'/g, "'\\''")}'`;
+const settleOf = (args) => Math.min(Math.max(Number(args?.settle_ms) || SETTLE_MS, 0), 3000);
+const wantsFrame = (args) => args?.observe !== false;
+/** One action → the shell that performs it (scaling clicks box-side). */
+function actionShell(a) {
+    const kind = String(a?.action ?? "");
+    if (kind === "click") {
+        const x = Math.round(Number(a.x));
+        const y = Math.round(Number(a.y));
+        if (!Number.isFinite(x) || !Number.isFinite(y))
+            return { error: "click needs numeric x,y" };
+        const btn = a.button === "right" ? 3 : 1;
+        const rep = a.double ? "--repeat 2 --delay 60 " : "";
+        return `${scaled("CX", x)}; ${scaled("CY", y)}; xdotool mousemove $CX $CY click ${rep}${btn}`;
+    }
+    if (kind === "type_text") {
+        const t = String(a.text ?? "");
+        if (!t)
+            return { error: "type_text needs text" };
+        return `xdotool type --delay 8 ${shellQuote(t)}`;
+    }
+    if (kind === "press_key") {
+        const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
+        if (!keys)
+            return { error: "press_key needs keys" };
+        return `xdotool key ${keys}`;
+    }
+    if (kind === "scroll") {
+        const clicks = Math.min(Math.max(Math.round(Number(a.clicks) || 3), 1), 20);
+        const btn = a.direction === "up" ? 4 : 5;
+        return `xdotool click --repeat ${clicks} ${btn}`;
+    }
+    if (kind === "wait") {
+        const ms = Math.min(Math.max(Number(a.ms) || 500, 0), 5000);
+        return `sleep ${(ms / 1000).toFixed(2)}`;
+    }
+    return { error: `unknown action ${kind || "(missing)"}` };
+}
+/** The whole point: one round trip carries geometry, the actions, the
+ * settle, the capture and the frame bytes. */
+async function actAndObserve(id, actions, note, args, timeoutMs = 60_000) {
+    const parts = [];
+    for (const a of actions) {
+        const shell = actionShell(a);
+        if (typeof shell !== "string")
+            return text(id, shell.error, true);
+        parts.push(shell);
+    }
+    const observe = wantsFrame(args);
+    const command = [ENV, GEOMETRY, ...parts, observe ? captureBlock(settleOf(args)) : "true"].join("; ");
+    const out = await runOnBox(command, timeoutMs);
+    if (!out.ok && !out.stdout.includes("GEOM")) {
+        return text(id, `${note.replace(/^./, (c) => c.toLowerCase())} failed: ${out.stderr.slice(0, 200) || `exit ${out.exitCode}`}`, true);
+    }
+    if (!observe)
+        return text(id, note);
+    return observed(id, note, await frameFrom(out));
+}
 async function call(id, name, args) {
     if (name === "screenshot") {
-        const out = await runOnBox(SHOT_CMD, 60_000);
-        if (!/captured/.test(out.stdout)) {
-            return text(id, `screenshot failed: ${out.stderr.slice(0, 200) || "capture produced no file"}`, true);
+        const out = await runOnBox([ENV, GEOMETRY, captureBlock(0)].join("; "), 60_000);
+        const frame = await frameFrom(out);
+        if (!frame) {
+            return text(id, `screenshot failed: ${out.stderr.slice(0, 200) || "capture produced no frame"}`, true);
         }
-        const data = await readBoxFile("/tmp/ogb-shot.png");
-        if (!data)
-            return text(id, "screenshot failed: could not read the frame back", true);
+        // an explicit look always returns pixels, even if nothing moved
+        lastFrameHash = frame.hash ?? lastFrameHash;
         return send({
             jsonrpc: "2.0",
             id,
-            result: { content: [{ type: "image", data, mimeType: "image/png" }] },
+            result: { content: [{ type: "image", data: frame.data, mimeType: frame.mime }] },
         });
     }
     if (name === "click") {
@@ -149,65 +361,71 @@ async function call(id, name, args) {
         const y = Math.round(Number(args.y));
         if (!Number.isFinite(x) || !Number.isFinite(y))
             return text(id, "click needs numeric x,y", true);
-        // screenshot space is 1280 wide (files-API capture is downscaled) but
-        // the real display can be larger — scale uniformly by width or clicks
-        // land short (probed live: 1920×1080 display, 1280×720 screenshots,
-        // every raw click 1.5× off). xdotool only; CUA's own scaler assumes a
-        // different (1280×800) API space and would double-convert.
-        const geometry = await displayGeometry();
-        const scale = geometry ? geometry.width / SHOT_WIDTH : 1;
-        const sx = Math.round(x * scale);
-        const sy = Math.round(y * scale);
-        const btn = args.button === "right" ? 3 : 1;
-        const rep = args.double ? "--repeat 2 --delay 150 " : "";
-        const out = await runOnBox(`${X}xdotool mousemove ${sx} ${sy} click ${rep}${btn}`);
-        if (!out.ok)
-            return text(id, `click failed: ${out.stderr.slice(0, 200)}`, true);
-        return text(id, `clicked ${x},${y}${scale !== 1 ? ` (scaled to ${sx},${sy} on the ${geometry.width}x${geometry.height} display)` : ""}${args.double ? " (double)" : ""}${args.button === "right" ? " (right)" : ""} — screenshot to verify`);
+        const what = `${args.double ? "double-clicked" : args.button === "right" ? "right-clicked" : "clicked"} ${x},${y}`;
+        return actAndObserve(id, [{ ...args, action: "click" }], what, args);
     }
     if (name === "type_text") {
         const t = String(args.text ?? "");
         if (!t)
             return text(id, "nothing to type", true);
-        const cua = await cuaCmd("type_text", { text: t });
-        if (!cua) {
-            const safe = t.replace(/'/g, "'\\''");
-            const out = await runOnBox(`${X}xdotool type --delay 12 '${safe}'`);
-            if (!out.ok)
-                return text(id, `type failed: ${out.stderr.slice(0, 200)}`, true);
-        }
-        return text(id, `typed ${t.length} chars`);
+        return actAndObserve(id, [{ action: "type_text", text: t }], `typed ${t.length} chars`, args, 120_000);
     }
     if (name === "press_key") {
         const keys = String(args.keys ?? "").replace(/[^\w+]/g, "");
         if (!keys)
             return text(id, "press_key needs keys", true);
-        const out = await runOnBox(`${X}xdotool key ${keys}`);
-        return out.ok ? text(id, `pressed ${keys}`) : text(id, `key failed: ${out.stderr.slice(0, 200)}`, true);
+        return actAndObserve(id, [{ action: "press_key", keys }], `pressed ${keys}`, args);
     }
     if (name === "scroll") {
         const clicks = Math.min(Math.max(Math.round(Number(args.clicks) || 3), 1), 20);
-        const command = args.direction === "up" ? "scroll_up" : "scroll_down";
-        const cua = await cuaCmd(command, { clicks });
-        if (!cua) {
-            const btn = args.direction === "up" ? 4 : 5;
-            const out = await runOnBox(`${X}xdotool click --repeat ${clicks} ${btn}`);
-            if (!out.ok)
-                return text(id, `scroll failed: ${out.stderr.slice(0, 200)}`, true);
-        }
-        return text(id, `scrolled ${args.direction} ${clicks}`);
+        const direction = args.direction === "up" ? "up" : "down";
+        return actAndObserve(id, [{ action: "scroll", direction, clicks }], `scrolled ${direction} ${clicks}`, args);
+    }
+    if (name === "computer_batch") {
+        const actions = Array.isArray(args.actions) ? args.actions.slice(0, 24) : [];
+        if (!actions.length)
+            return text(id, "computer_batch needs a non-empty actions array", true);
+        const summary = actions
+            .map((a) => a.action === "click"
+            ? `click ${Math.round(Number(a.x))},${Math.round(Number(a.y))}`
+            : a.action === "type_text"
+                ? `type ${String(a.text ?? "").length} chars`
+                : a.action === "press_key"
+                    ? `key ${a.keys}`
+                    : a.action === "scroll"
+                        ? `scroll ${a.direction ?? "down"}`
+                        : `wait ${Math.min(Number(a.ms) || 500, 5000)}ms`)
+            .join(" → ");
+        return actAndObserve(id, actions, `ran ${actions.length} actions: ${summary}`, args, 180_000);
     }
     if (name === "computer_exec") {
-        const out = await runOnBox(String(args.command ?? "").slice(0, 4000), 120_000);
-        return text(id, `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`);
+        const command = String(args.command ?? "").slice(0, 4000);
+        const out = await runOnBox(command, 120_000);
+        const note = `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`;
+        if (args.observe !== true)
+            return text(id, note);
+        const shot = await runOnBox([ENV, GEOMETRY, captureBlock()].join("; "), 60_000);
+        return observed(id, note, await frameFrom(shot));
     }
     if (name === "open_url") {
         const url = String(args.url ?? "");
         if (!/^https?:\/\//.test(url))
             return text(id, "only http(s) URLs", true);
-        const q = url.replace(/'/g, "%27");
-        await runOnBox(`${X}(google-chrome '${q}' || chromium '${q}' || chromium-browser '${q}' || xdg-open '${q}') >/dev/null 2>&1 & sleep 3; echo opened`, 30_000);
-        return text(id, `opened ${url} — take a screenshot to see it`);
+        const q = shellQuote(url.replace(/'/g, "%27"));
+        const observe = wantsFrame(args);
+        // launch, then poll for a browser window instead of a blind sleep —
+        // a fast page returns in a fraction of the old fixed 3s
+        const command = [
+            ENV,
+            GEOMETRY,
+            `(google-chrome ${q} || chromium ${q} || chromium-browser ${q} || xdg-open ${q}) >/dev/null 2>&1 &`,
+            'for i in 1 2 3 4 5 6 7 8 9 10 11 12; do xdotool search --onlyvisible --class "chrom" >/dev/null 2>&1 && break; sleep 0.25; done',
+            observe ? captureBlock(600) : "true",
+        ].join("; ");
+        const out = await runOnBox(command, 60_000);
+        if (!observe)
+            return text(id, `opened ${url}`);
+        return observed(id, `opened ${url}`, await frameFrom(out));
     }
     return text(id, `unknown tool ${name}`, true);
 }
@@ -219,7 +437,7 @@ async function handle(msg) {
             result: {
                 protocolVersion: msg.params?.protocolVersion ?? "2024-11-05",
                 capabilities: { tools: {} },
-                serverInfo: { name: "openmausbot-computer", version: "2" },
+                serverInfo: { name: "openmausbot-computer", version: "3" },
             },
         });
     }

--- a/dist-server/drivers/claude.js
+++ b/dist-server/drivers/claude.js
@@ -434,7 +434,7 @@ export const ClaudeDriver = {
             snapshot,
             adapter: {
                 provider: DRIVER_KIND,
-                capabilities: { sessionModelSwitch: "in-session", agentsMcp: true },
+                capabilities: { sessionModelSwitch: "in-session", agentsMcp: true, computerMcp: true },
                 sendTurn,
                 interruptTurn: async (threadId) => active.get(threadId)?.stop(),
                 respondToRequest: async (threadId, requestId, decision) => {

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -149,17 +149,23 @@ bus.subscribe((event) => {
             }
             else if (event.itemType === "tool" && event.itemId) {
                 const messageId = toolMessageByItem.get(event.itemId);
+                let toolName = "tool";
                 if (messageId) {
+                    toolName = store.messagesFor(event.threadId).find((m) => m.id === messageId)?.tool?.name ?? "tool";
                     const patched = store.patchMessage(event.threadId, messageId, {
-                        tool: { name: store.messagesFor(event.threadId).find((m) => m.id === messageId)?.tool?.name ?? "tool", ok: event.ok },
+                        tool: { name: toolName, ok: event.ok },
                     });
                     if (patched)
                         broadcast({ kind: "message.patch", threadId: event.threadId, message: patched });
                     toolMessageByItem.delete(event.itemId);
                 }
-                // the bot just finished acting — refresh its screen preview now
-                if (bot)
+                // the bot just acted ON ITS SCREEN — refresh the preview now. Only
+                // computer tools can change the screen, and each capture competes
+                // with the agent for the box's command endpoint, so a bot grinding
+                // through file edits must not trigger one per tool.
+                if (bot && /computer|screenshot|click|type_text|press_key|scroll|open_url/i.test(toolName)) {
                     pokeScreenPoller(bot.id);
+                }
             }
             break;
         case "item.started":
@@ -225,16 +231,25 @@ bus.subscribe((event) => {
     }
 });
 const screenPollers = new Map();
-function startScreenPoller(botId) {
+/** The preview shares the box's single command endpoint with the agent's
+ * own actions, so every frame we take is latency stolen from the work the
+ * user is waiting on. Hence: a slow interval, a floor between captures,
+ * and never two in flight. */
+const SCREEN_POLL_MS = 6000;
+const SCREEN_MIN_GAP_MS = 3000;
+function startScreenPoller(botId, boxId) {
     if (screenPollers.has(botId) || !box.boxConfigured(cfg))
         return;
     let inFlight = false;
+    let lastAt = 0;
     const capture = async () => {
-        if (inFlight)
+        if (inFlight || Date.now() - lastAt < SCREEN_MIN_GAP_MS)
             return;
         inFlight = true;
         try {
-            const { png, format } = await box.screenshotBox(cfg, botId);
+            // the box id is resolved once per turn — re-resolving per frame cost
+            // a full LIST of the account's boxes
+            const { png, format } = await box.screenshotBox(cfg, botId, boxId);
             const frame = { png, mime: format === "jpeg" ? "image/jpeg" : "image/png" };
             entry.last = frame;
             broadcast({ kind: "screen", botId, ...frame });
@@ -243,18 +258,21 @@ function startScreenPoller(botId) {
             /* box asleep or mid-command — try again next tick */
         }
         finally {
+            lastAt = Date.now();
             inFlight = false;
         }
     };
     const entry = {
-        timer: setInterval(capture, 4000),
+        timer: setInterval(capture, SCREEN_POLL_MS),
         capture,
         last: null,
     };
     screenPollers.set(botId, entry);
 }
 /** Event-driven refresh: capture NOW (the bot just acted on its screen)
- * instead of waiting for the next interval tick. */
+ * instead of waiting for the next interval tick. Rate-limited inside
+ * capture() — a tool-heavy turn used to fire one full REST chain per
+ * completed tool, competing with the agent for the same endpoint. */
 function pokeScreenPoller(botId) {
     void screenPollers.get(botId)?.capture();
 }
@@ -361,6 +379,11 @@ async function startTurn(botId, text, opts) {
             if (cfg.composio?.key)
                 integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
             const wants = bot.computer; // 'cloud' | 'local' | 'off' | undefined(auto)
+            // only drivers that can mount the computer MCP server get the tools
+            // (and the prompt about them) — but every bot with a box still gets
+            // the live screen preview, which is a UI feature, not a tool
+            const mountsComputer = instance.adapter.capabilities.computerMcp === true || instance.driverKind === "boxAgent";
+            let previewBoxId = null;
             if (wants !== "off" && wants !== "local" && box.boxConfigured(cfg)) {
                 let b = await box.findBox(cfg, bot.id).catch(() => null);
                 // the Computer driver runs ON the box — provision it on first use
@@ -369,8 +392,19 @@ async function startTurn(botId, text, opts) {
                     await box.provisionBox(cfg, bot.id, bot.name);
                     b = await box.findBox(cfg, bot.id).catch(() => null);
                 }
-                if (b)
-                    integrations.computer = { boxId: b.id, token: cfg.box.token };
+                // an archived box answers every action with an error until it
+                // resumes — wake it here, once, instead of letting the agent
+                // discover it one failed tool call at a time. Only worth the
+                // resume (~8s, and it un-pauses billing) when the bot can act.
+                if (b && mountsComputer && !["idle", "ready", "running"].includes(b.state)) {
+                    broadcast({ kind: "computer", botId: bot.id, state: "waking" });
+                    b = (await box.readyBox(cfg, bot.id).catch(() => null)) ?? b;
+                }
+                if (b) {
+                    previewBoxId = b.id;
+                    if (mountsComputer)
+                        integrations.computer = { boxId: b.id, token: cfg.box.token };
+                }
             }
             // local computer (this Mac) via the Electron-hosted cua-driver: the
             // Electron main process owns the daemon (TCC attribution) and writes
@@ -407,7 +441,7 @@ async function startTurn(botId, text, opts) {
                 transcript,
                 system: persona +
                     (integrations.computer && instance.driverKind !== "boxAgent"
-                        ? " You have your own cloud computer — use the computer tools (screenshot, computer_exec, open_url) whenever browsing or acting on a desktop helps."
+                        ? " You have your own cloud computer — use the computer tools (screenshot, click, type_text, open_url, computer_exec) whenever browsing or acting on a desktop helps. Every action tool already returns the resulting screen, so don't follow one with a screenshot call, and batch predictable sequences with computer_batch."
                         : integrations.localComputer
                             ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
                             : "") +
@@ -424,8 +458,8 @@ async function startTurn(botId, text, opts) {
             // dispatched: the rewind is spent, and the old cursors are dead
             if (rewound)
                 store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
-            if (integrations.computer)
-                startScreenPoller(bot.id);
+            if (previewBoxId)
+                startScreenPoller(bot.id, previewBoxId);
         }
         catch (e) {
             const message = e instanceof Error ? e.message : String(e);

--- a/dist-server/store.js
+++ b/dist-server/store.js
@@ -196,8 +196,26 @@ export class Store {
         const full = { id: newId(), at: Date.now(), parentId: t.activeLeafId, ...message };
         t.messages.push(full);
         t.activeLeafId = full.id;
+        if (full.kind === "screen")
+            this.pruneScreenFrames(t);
         this.saveThread(threadId);
         return full;
+    }
+    /** Screen frames are ~100-500KB of base64 each and the whole thread file
+     * is rewritten on every append, so keeping every frame of a long
+     * computer session makes each later message slower than the last. The
+     * newest few keep their pixels; older ones stay in the transcript as
+     * placeholders. Mirrors the client's own frame cap. */
+    pruneScreenFrames(t, keep = 4) {
+        let seen = 0;
+        for (let i = t.messages.length - 1; i >= 0 && seen < t.messages.length; i--) {
+            const m = t.messages[i];
+            if (m.kind !== "screen" || !m.png)
+                continue;
+            seen += 1;
+            if (seen > keep)
+                m.png = undefined;
+        }
     }
     /** Fork the conversation: a new user message that replaces `sourceId`
      * (same parent, new text) and becomes the active leaf. */

--- a/server/box.ts
+++ b/server/box.ts
@@ -89,10 +89,34 @@ async function waitReady(cfg: AppConfig, boxId: string, budgetMs = 90_000) {
   return null;
 }
 
+// Resolving a bot's box means LISTing every box in the account, so it is
+// the most expensive thing on any hot path. The name is deterministic, so
+// once we know the id we can go straight at it — the cache is refreshed
+// whenever the direct read fails (deleted/renamed box) and always carries
+// the live state so callers can still see "archived".
+const boxIdCache = new Map<string, string>();
+
 export async function findBox(cfg: AppConfig, botId: string) {
+  const cachedId = boxIdCache.get(botId);
+  if (cachedId) {
+    const { ok, body } = await boxJson(cfg, `/boxes/${cachedId}`);
+    const box = body?.box;
+    if (ok && box?.id && box.state !== "error") return box;
+    boxIdCache.delete(botId); // gone or broken — fall back to the listing
+  }
   const name = await boxNameFor(botId);
   const { body } = await boxJson(cfg, "/boxes");
-  return (body?.boxes ?? []).find((b: any) => b.name === name && b.state !== "error") ?? null;
+  const found = (body?.boxes ?? []).find((b: any) => b.name === name && b.state !== "error") ?? null;
+  if (found?.id) boxIdCache.set(botId, found.id);
+  return found;
+}
+
+/** Ready-or-null without the LIST when we already know the box. */
+export async function readyBox(cfg: AppConfig, botId: string, budgetMs = 60_000) {
+  const box = await findBox(cfg, botId);
+  if (!box) return null;
+  if (READY.has(box.state)) return box;
+  return waitReady(cfg, box.id, budgetMs);
 }
 
 export function boxConfigured(cfg: AppConfig) {
@@ -203,30 +227,56 @@ export async function execOnBox(cfg: AppConfig, botId: string, command: string) 
   return { exitCode: out.exitCode, stdout: out.stdout.slice(-4000), stderr: out.stderr.slice(-2000) };
 }
 
-// Screenshot for the Computer panel + screen-in-chat. Two hops, both
-// deterministic: capture to a file on the box (scrot/import/ffmpeg chain,
-// downscaled), then read it back via the files API with encoding=base64.
-// Base64 over command stdout is NOT reliable (probed 2026-08-12: an
-// otherwise-complete payload came back with a corrupted length) — never
-// ship binary through the commands endpoint.
+// Screenshot for the Computer panel + screen-in-chat. Two hops: capture
+// to a file on the box (scrot straight to JPEG — no ImageMagick startup
+// unless a downscale is actually needed), then read the bytes back.
+// Base64 over command stdout is NOT reliable for the panel's full-size
+// frames (probed 2026-08-12: an otherwise-complete payload came back with
+// a corrupted length), so the frame is always fetched over HTTP here.
+const PANEL_PATH = "/tmp/ogb-panel.jpg";
+const PANEL_WIDTH = 1024;
 const SHOT_CMD = [
   "export DISPLAY=${DISPLAY:-:0}",
-  "f=/tmp/ogb-panel.png",
-  'scrot -o "$f" 2>/dev/null || import -window root "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 "$f" >/dev/null 2>&1',
-  'command -v convert >/dev/null && convert "$f" -resize 1024x "$f" 2>/dev/null || true',
+  `f=${PANEL_PATH}`,
+  'w=$(xdotool getdisplaygeometry 2>/dev/null | cut -d" " -f1)',
+  'case "$w" in ""|*[!0-9]*) w=0;; esac',
+  'scrot -o -q 70 "$f" 2>/dev/null || import -window root -quality 70 "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 7 "$f" >/dev/null 2>&1',
+  `if [ "$w" -gt ${PANEL_WIDTH} ] 2>/dev/null && command -v convert >/dev/null 2>&1; then convert "$f" -thumbnail ${PANEL_WIDTH}x -quality 70 "$f" 2>/dev/null || true; fi`,
   'test -s "$f" && echo captured',
 ].join("; ");
 
-export async function screenshotBox(cfg: AppConfig, botId: string) {
-  const box = await findBox(cfg, botId);
-  if (!box) throw new Error("no computer for this bot yet");
-  if (!READY.has(box.state)) throw new Error(`box is ${box.state}`);
-  const out = await runCommand(cfg, box.id, SHOT_CMD, { timeoutMs: 60_000 });
+/** Read a file off the box as base64 — raw artifact bytes when the API
+ * supports it (33% less transfer, no JSON envelope), else the files API. */
+async function readFileBase64(cfg: AppConfig, boxId: string, path: string): Promise<string | null> {
+  try {
+    const res = await boxFetch(cfg, `/boxes/${boxId}/artifacts?path=${encodeURIComponent(path)}`);
+    if (res.ok) {
+      const bytes = Buffer.from(await res.arrayBuffer());
+      if (bytes.length) return bytes.toString("base64");
+    }
+  } catch {
+    /* fall through */
+  }
+  const { ok, body } = await boxJson(cfg, `/boxes/${boxId}/files?path=${encodeURIComponent(path)}&encoding=base64`);
+  const content = body?.content;
+  return ok && typeof content === "string" && content ? content : null;
+}
+
+/** `knownBoxId` skips box resolution entirely — the screen poller holds
+ * the id for the whole turn and must not re-resolve it every frame. */
+export async function screenshotBox(cfg: AppConfig, botId: string, knownBoxId?: string) {
+  let boxId = knownBoxId;
+  if (!boxId) {
+    const box = await findBox(cfg, botId);
+    if (!box) throw new Error("no computer for this bot yet");
+    if (!READY.has(box.state)) throw new Error(`box is ${box.state}`);
+    boxId = box.id as string;
+  }
+  const out = await runCommand(cfg, boxId, SHOT_CMD, { timeoutMs: 60_000 });
   if (!/captured/.test(out.stdout)) {
     throw new Error(out.stderr.slice(0, 200) || "screen capture failed on the box");
   }
-  const { ok, body } = await boxJson(cfg, `/boxes/${box.id}/files?path=/tmp/ogb-panel.png&encoding=base64`);
-  const png = body?.content;
-  if (!ok || typeof png !== "string" || !png) throw new Error("could not read the frame back from the box");
-  return { png, format: "png" };
+  const data = await readFileBase64(cfg, boxId, PANEL_PATH);
+  if (!data) throw new Error("could not read the frame back from the box");
+  return { png: data, format: "jpeg" };
 }

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -56,9 +56,10 @@ describe("computer proxy (fake box)", () => {
           const command = JSON.parse(body || "{}").command ?? "";
           commands.push(command);
           // a real box echoes what the capture block printed
+          const size = Buffer.from(JPEG, "base64").length;
           const stdout = /GEOM/.test(command)
-            ? `GEOM 1920 1080\nHASH ${hash}\nB64 ${JPEG}\n`
-            : "ok\n";
+            ? `GEOM 1920 1080\nHASH ${hash}\nSIZE ${size}\nB64 ${JPEG}\nACT ok\n`
+            : "ACT ok\n";
           res.writeHead(200, { "content-type": "application/json" });
           res.end(JSON.stringify({ exitCode: 0, stdout, stderr: "" }));
         });
@@ -132,7 +133,9 @@ describe("computer proxy (fake box)", () => {
     const command = commands.at(-1)!;
     expect(command).toMatch(/xdotool mousemove \$CX \$CY click 1/);
     expect(command).toMatch(/getdisplaygeometry/); // scaling resolved box-side
-    expect(command).toMatch(/CX=\$\(\( 100 \* W \/ 1280 \)\)/);
+    // scaling is conditional: a display narrower than the model's space is
+    // captured at native size, so the coordinates must pass through as-is
+    expect(command).toMatch(/if \[ "\$W" -gt 1280 \].*CX=\$\(\( 100 \* W \/ 1280 \)\).*else CX=100/);
     expect(command).toMatch(/scrot -o -q 75/); // JPEG, no unconditional convert
     // ...and the model got pixels back with it, no second tool call
     const content = res.result.content;
@@ -152,7 +155,9 @@ describe("computer proxy (fake box)", () => {
     });
     const res = await waitFor(4);
     expect(res.result.content).toHaveLength(1);
-    expect(res.result.content[0].text).toMatch(/screen unchanged/i);
+    expect(res.result.content[0].text).toMatch(/identical to the frame you already have/i);
+    // must not tell the model to redo a possibly-successful action
+    expect(res.result.content[0].text).toMatch(/don't repeat the action/i);
   });
 
   it("sends a new frame once the screen actually changes", async () => {

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -1,0 +1,210 @@
+// Contract test for the computer tools' latency shape. The proxy is a
+// stdio MCP server that talks to the box's REST command endpoint, so a
+// fake box lets us assert the things that actually make UI steps fast:
+//
+//   1. an action and its screenshot are ONE round trip (act, settle and
+//      capture ride in a single shell command),
+//   2. the frame comes back INSIDE the action's result as an MCP image
+//      block, so the model never needs a follow-up screenshot call,
+//   3. click coordinates are scaled box-side (no geometry round trip),
+//   4. computer_batch runs a whole sequence in one round trip,
+//   5. an unchanged screen is reported as text instead of resending the
+//      same pixels.
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const PROXY = join(SERVER_DIR, "computer-proxy.ts");
+
+// smallest valid JPEG header + payload — enough for the proxy's magic-byte
+// check, which is what stops a truncated stdout reaching the model
+const JPEG = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(700, 0x20),
+  Buffer.from([0xff, 0xd9]),
+]).toString("base64");
+
+describe("computer proxy (fake box)", () => {
+  let box: Server;
+  let proxy: ChildProcess;
+  let port = 0;
+  const commands: string[] = [];
+  let fileReads = 0;
+  let hash = "aaaa1111";
+
+  const rpc = (msg: unknown) => proxy.stdin!.write(JSON.stringify(msg) + "\n");
+  const results = new Map<number, any>();
+  const waitFor = async (id: number, ms = 8000) => {
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) {
+      if (results.has(id)) return results.get(id);
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error(`no response for id ${id}; commands so far: ${commands.join(" | ")}`);
+  };
+
+  beforeAll(async () => {
+    box = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://x");
+      if (url.pathname.endsWith("/commands")) {
+        let body = "";
+        req.on("data", (c) => (body += c));
+        req.on("end", () => {
+          const command = JSON.parse(body || "{}").command ?? "";
+          commands.push(command);
+          // a real box echoes what the capture block printed
+          const stdout = /GEOM/.test(command)
+            ? `GEOM 1920 1080\nHASH ${hash}\nB64 ${JPEG}\n`
+            : "ok\n";
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ exitCode: 0, stdout, stderr: "" }));
+        });
+        return;
+      }
+      if (url.pathname.endsWith("/artifacts") || url.pathname.endsWith("/files")) {
+        fileReads += 1;
+        res.writeHead(200, { "content-type": "application/octet-stream" });
+        res.end(Buffer.from(JPEG, "base64"));
+        return;
+      }
+      res.writeHead(404).end("{}");
+    });
+    await new Promise<void>((r) => box.listen(0, "127.0.0.1", r));
+    port = (box.address() as any).port;
+
+    proxy = spawn(process.execPath, ["--experimental-strip-types", PROXY], {
+      env: {
+        ...process.env,
+        OGB_BOX_API: `http://127.0.0.1:${port}`,
+        OGB_BOX_ID: "box-1",
+        OGB_BOX_TOKEN: "t",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let buf = "";
+    proxy.stdout!.on("data", (c) => {
+      buf += c;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id != null) results.set(msg.id, msg);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+    rpc({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await waitFor(1);
+  }, 20_000);
+
+  afterAll(() => {
+    proxy?.kill();
+    box?.close();
+  });
+
+  it("exposes a batch tool and advertises that actions return the screen", async () => {
+    rpc({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    const res = await waitFor(2);
+    const names = res.result.tools.map((t: any) => t.name);
+    expect(names).toContain("computer_batch");
+    const click = res.result.tools.find((t: any) => t.name === "click");
+    expect(click.description).toMatch(/return the resulting screen/i);
+  });
+
+  it("clicks and returns the frame in ONE round trip, scaled box-side", async () => {
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "click", arguments: { x: 100, y: 200 } },
+    });
+    const res = await waitFor(3);
+    // one command carried the click, the settle and the capture
+    expect(commands.length - before).toBe(1);
+    const command = commands.at(-1)!;
+    expect(command).toMatch(/xdotool mousemove \$CX \$CY click 1/);
+    expect(command).toMatch(/getdisplaygeometry/); // scaling resolved box-side
+    expect(command).toMatch(/CX=\$\(\( 100 \* W \/ 1280 \)\)/);
+    expect(command).toMatch(/scrot -o -q 75/); // JPEG, no unconditional convert
+    // ...and the model got pixels back with it, no second tool call
+    const content = res.result.content;
+    expect(content[0].type).toBe("text");
+    expect(content[0].text).toMatch(/clicked 100,200/);
+    expect(content[1]).toMatchObject({ type: "image", mimeType: "image/jpeg" });
+    expect(content[1].data).toBe(JPEG);
+    expect(fileReads).toBe(0); // inline stdout, so no extra HTTP hop
+  });
+
+  it("reports an unchanged screen as text instead of resending pixels", async () => {
+    rpc({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "press_key", arguments: { keys: "Tab" } },
+    });
+    const res = await waitFor(4);
+    expect(res.result.content).toHaveLength(1);
+    expect(res.result.content[0].text).toMatch(/screen unchanged/i);
+  });
+
+  it("sends a new frame once the screen actually changes", async () => {
+    hash = "bbbb2222";
+    rpc({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "type_text", arguments: { text: "hello" } },
+    });
+    const res = await waitFor(5);
+    expect(commands.at(-1)).toMatch(/xdotool type --delay 8 'hello'/);
+    expect(res.result.content[1]).toMatchObject({ type: "image" });
+  });
+
+  it("runs a whole batch in one round trip with one frame at the end", async () => {
+    hash = "cccc3333";
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: {
+        name: "computer_batch",
+        arguments: {
+          actions: [
+            { action: "click", x: 10, y: 20 },
+            { action: "type_text", text: "milind@example.com" },
+            { action: "press_key", keys: "Tab" },
+          ],
+        },
+      },
+    });
+    const res = await waitFor(6);
+    expect(commands.length - before).toBe(1);
+    const command = commands.at(-1)!;
+    expect(command).toMatch(/mousemove/);
+    expect(command).toMatch(/xdotool type/);
+    expect(command).toMatch(/xdotool key Tab/);
+    expect((command.match(/scrot/g) ?? []).length).toBe(1); // one capture
+    expect(res.result.content[1]).toMatchObject({ type: "image" });
+  });
+
+  it("skips the capture entirely when the caller opts out", async () => {
+    rpc({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "scroll", arguments: { direction: "down", observe: false } },
+    });
+    const res = await waitFor(7);
+    expect(commands.at(-1)).not.toMatch(/scrot/);
+    expect(res.result.content).toHaveLength(1);
+  });
+});

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -4,18 +4,51 @@
 // computer (box.ascii.dev) as CUA-grade tools.
 //
 // Transport: every action goes through the box's REST run-command
-// endpoint (no inbound port on the box, no tunnel). On the box, actions
-// prefer the CUA computer-server on loopback :8000 (trycua
-// cua-computer-server, installed by the provision bootstrap; raw XTEST
-// under the hood) and fall back to xdotool/scrot — the same primitives
-// CUA itself uses on Linux.
+// endpoint (no inbound port on the box, no tunnel), so a round trip is
+// expensive (~TLS + shell spawn). The whole design is therefore built
+// around ONE round trip per step:
+//
+//   act + settle + capture + base64 all run in a single shell command,
+//   and the resulting frame rides back in the SAME tool result as an MCP
+//   image block ("act and observe"). The agent never needs a follow-up
+//   screenshot call, which halves the model inferences per UI step —
+//   the same shape Anthropic's own computer-use loop uses.
+//
+// Other latency rules that live here:
+//   - JPEG, not PNG (5-10x fewer bytes, identical vision tokens), and
+//     the downscale only runs when the display is wider than the model's
+//     coordinate space.
+//   - Coordinate scaling happens box-side in shell arithmetic, so there
+//     is no separate "what size is the display" round trip per turn.
+//   - Frames come back inline in stdout when small enough; the files API
+//     is only a fallback (one extra hop) for big ones.
+//   - computer_batch runs a whole mechanical sequence (click, type, tab,
+//     type, Enter) in one round trip with one frame at the end.
 //
 // stdout is the MCP channel — never console.log here.
-const BOX_API = "https://ascii.dev/api/box/v1";
+const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
 
-async function runOnBox(command: string, timeoutMs = 60_000) {
+/** The coordinate space the model sees: frames are downscaled to this
+ * width, and clicks are scaled back up to the real display box-side. */
+const SHOT_WIDTH = 1280;
+const JPEG_QUALITY = 75;
+const SHOT_PATH = "/tmp/ogb-shot.jpg";
+/** How long the desktop gets to repaint before the fused capture. */
+const SETTLE_MS = 350;
+/** Frames larger than this come back over the files API instead of
+ * inline stdout (keeps us clear of the command endpoint's stdout cap). */
+const INLINE_MAX_BYTES = 400_000;
+
+interface RunOut {
+  ok: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runOnBox(command: string, timeoutMs = 60_000): Promise<RunOut> {
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
@@ -31,73 +64,161 @@ async function runOnBox(command: string, timeoutMs = 60_000) {
   };
 }
 
-/** Run a CUA computer-server command on the box's loopback; returns the
- * parsed JSON payload, or null when the server isn't up (→ fallback). */
-async function cuaCmd(command: string, params: Record<string, unknown>, timeoutMs = 30_000) {
-  const payload = JSON.stringify({ command, params }).replace(/'/g, "'\\''");
-  const out = await runOnBox(
-    `curl -sf -m ${Math.floor(timeoutMs / 1000)} -X POST http://127.0.0.1:8000/cmd -H 'Content-Type: application/json' -d '${payload}'`,
-    timeoutMs + 15_000,
-  );
-  if (!out.ok || !out.stdout.trim()) return null;
-  const line = out.stdout.split("\n").find((l: string) => l.startsWith("data: "));
-  if (!line) return null;
+const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+/** Resolve the real display size into $W/$H for box-side click scaling. */
+const GEOMETRY = [
+  "g=$(xdotool getdisplaygeometry 2>/dev/null)",
+  'W=${g%% *}',
+  'H=${g##* }',
+  `case "$W" in ''|*[!0-9]*) W=${SHOT_WIDTH}; H=0;; esac`,
+].join("; ");
+
+/** Shell that turns a screenshot-space coordinate into a display one. */
+function scaled(varName: string, value: number): string {
+  return `${varName}=$(( ${Math.round(value)} * W / ${SHOT_WIDTH} ))`;
+}
+
+/** act → settle → capture → hash → (inline base64 if small). One hop. */
+function captureBlock(settleMs = SETTLE_MS): string {
+  return [
+    settleMs > 0 ? `sleep ${(settleMs / 1000).toFixed(2)}` : "true",
+    `f=${SHOT_PATH}`,
+    `rm -f "$f" 2>/dev/null || true`,
+    `scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1`,
+    // only re-encode when the display is bigger than the model's space —
+    // ImageMagick startup is the most expensive step in the old pipeline
+    `if [ "$W" -gt ${SHOT_WIDTH} ] 2>/dev/null && command -v convert >/dev/null 2>&1; then convert "$f" -thumbnail ${SHOT_WIDTH}x -quality ${JPEG_QUALITY} "$f" 2>/dev/null || true; fi`,
+    `if [ ! -s "$f" ]; then echo SHOT_FAILED; exit 0; fi`,
+    'echo "GEOM $W $H"',
+    'echo "HASH $(md5sum "$f" 2>/dev/null | cut -d\' \' -f1)"',
+    's=$(stat -c%s "$f" 2>/dev/null || echo 0)',
+    `if [ "$s" -le ${INLINE_MAX_BYTES} ]; then echo "B64 $(base64 -w0 "$f" 2>/dev/null || base64 "$f" | tr -d '\\n')"; fi`,
+  ].join("; ");
+}
+
+/** Big frames (and any inline read that came back malformed) are fetched
+ * as raw bytes; the files API's base64-in-JSON envelope is the fallback. */
+async function fetchFrame(): Promise<string | null> {
+  const auth = { authorization: `Bearer ${token}` };
   try {
-    const parsed = JSON.parse(line.slice(6));
-    return parsed?.success === false ? null : parsed;
+    const res = await fetch(
+      `${BOX_API}/boxes/${boxId}/artifacts?path=${encodeURIComponent(SHOT_PATH)}`,
+      { headers: auth, signal: AbortSignal.timeout(30_000) },
+    );
+    if (res.ok) {
+      const bytes = Buffer.from(await res.arrayBuffer());
+      if (bytes.length) return bytes.toString("base64");
+    }
+  } catch {
+    /* fall through to the files API */
+  }
+  try {
+    const res = await fetch(
+      `${BOX_API}/boxes/${boxId}/files?path=${encodeURIComponent(SHOT_PATH)}&encoding=base64`,
+      { headers: auth, signal: AbortSignal.timeout(30_000) },
+    );
+    const body: any = await res.json().catch(() => null);
+    const content = body?.content;
+    return res.ok && typeof content === "string" && content ? content : null;
   } catch {
     return null;
   }
 }
 
-const X = "export DISPLAY=${DISPLAY:-:0}; ";
-
-// capture to a file on the box, read back via the files API — base64 over
-// command stdout corrupts (probed 2026-08-12), never ship binary that way
-const SHOT_WIDTH = 1280;
-const SHOT_CMD = [
-  "export DISPLAY=${DISPLAY:-:0}",
-  "f=/tmp/ogb-shot.png",
-  'scrot -o "$f" 2>/dev/null || import -window root "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 "$f" >/dev/null 2>&1',
-  `command -v convert >/dev/null && convert "$f" -resize ${SHOT_WIDTH}x "$f" 2>/dev/null || true`,
-  'test -s "$f" && echo captured',
-].join("; ");
-
-// real display size, fetched once per proxy lifetime (per turn)
-let geometryCache: { width: number; height: number } | null | undefined;
-async function displayGeometry() {
-  if (geometryCache !== undefined) return geometryCache;
-  const out = await runOnBox(`${X}xdotool getdisplaygeometry`);
-  const m = out.stdout.trim().match(/^(\d+)\s+(\d+)/);
-  geometryCache = m ? { width: Number(m[1]), height: Number(m[2]) } : null;
-  return geometryCache;
+/** A decoded frame is only trusted when it really is an image — a
+ * truncated stdout would otherwise reach the model as garbage. */
+function validBase64Image(data: string): boolean {
+  if (!data || data.length < 512) return false;
+  const head = Buffer.from(data.slice(0, 64), "base64");
+  const jpeg = head[0] === 0xff && head[1] === 0xd8;
+  const png = head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47;
+  return jpeg || png;
 }
 
-async function readBoxFile(path: string): Promise<string | null> {
-  const res = await fetch(
-    `${BOX_API}/boxes/${boxId}/files?path=${encodeURIComponent(path)}&encoding=base64`,
-    { headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(30_000) },
-  );
-  const body: any = await res.json().catch(() => null);
-  const content = body?.content;
-  return res.ok && typeof content === "string" && content ? content : null;
+interface Frame {
+  data: string;
+  mime: string;
+  hash: string | null;
+  geometry: { width: number; height: number } | null;
 }
 
-const send = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
-const text = (id: unknown, t: string, isError = false) =>
+let inlineWorks = true; // flipped off for the proxy's life on first garbage
+let lastFrameHash: string | null = null;
+
+async function frameFrom(out: RunOut): Promise<Frame | null> {
+  if (/SHOT_FAILED/.test(out.stdout)) return null;
+  let hash: string | null = null;
+  let geometry: Frame["geometry"] = null;
+  let inline = "";
+  for (const line of out.stdout.split("\n")) {
+    if (line.startsWith("HASH ")) hash = line.slice(5).trim() || null;
+    else if (line.startsWith("GEOM ")) {
+      const [w, h] = line.slice(5).trim().split(/\s+/).map(Number);
+      if (Number.isFinite(w) && w > 0) geometry = { width: w, height: Number.isFinite(h) ? h : 0 };
+    } else if (line.startsWith("B64 ")) inline = line.slice(4).trim();
+  }
+  if (inline && inlineWorks) {
+    if (validBase64Image(inline)) return { data: inline, mime: "image/jpeg", hash, geometry };
+    inlineWorks = false; // stdout mangled it — use the files API from here on
+  }
+  const fetched = await fetchFrame();
+  if (!fetched || !validBase64Image(fetched)) return null;
+  return { data: fetched, mime: "image/jpeg", hash, geometry };
+}
+
+const send = (obj: unknown): void => {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+};
+const text = (id: unknown, t: string, isError = false): void =>
   send({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: t }], ...(isError ? { isError: true } : {}) } });
+
+/** An action result: the text plus the frame the action produced. When
+ * the pixels are byte-identical to the frame the model just saw, the
+ * image is dropped — it already has it, and it costs ~1.2k tokens. */
+function observed(id: unknown, note: string, frame: Frame | null) {
+  if (!frame) {
+    return text(id, `${note}\n(couldn't capture the screen — call screenshot to retry)`);
+  }
+  const unchanged = frame.hash != null && frame.hash === lastFrameHash;
+  lastFrameHash = frame.hash ?? lastFrameHash;
+  if (unchanged) {
+    return text(
+      id,
+      `${note}\n(screen unchanged — the last frame you were sent is still current. If you expected it to change, it may still be loading: retry with settle_ms, or call screenshot again.)`,
+    );
+  }
+  send({
+    jsonrpc: "2.0",
+    id,
+    result: {
+      content: [
+        { type: "text", text: note },
+        { type: "image", data: frame.data, mimeType: frame.mime },
+      ],
+    },
+  });
+}
+
+const OBSERVE_PROPS = {
+  observe: {
+    type: "boolean",
+    description:
+      "default true — return a fresh screenshot with the result. Set false only when chaining mechanical steps you don't need to see.",
+  },
+  settle_ms: { type: "number", description: "wait before the screenshot, default 350, max 3000" },
+};
 
 const TOOLS = [
   {
     name: "screenshot",
     description:
-      "See the bot's cloud computer screen (returns an image). Call before and after acting to ground yourself — the desktop runs Chrome and a full Linux GUI.",
+      "See the bot's cloud computer screen (returns an image). The desktop runs Chrome and a full Linux GUI. You usually do NOT need this after acting — click, type_text, press_key, scroll and open_url already return the resulting screen.",
     inputSchema: { type: "object", properties: {} },
   },
   {
     name: "click",
     description:
-      "Click on the computer's screen. Use pixel coordinates as they appear in the most recent screenshot — scaling to the real display resolution is handled for you.",
+      "Click on the computer's screen and return the resulting screen. Use pixel coordinates as they appear in the most recent screenshot — scaling to the real display resolution is handled for you.",
     inputSchema: {
       type: "object",
       properties: {
@@ -105,126 +226,238 @@ const TOOLS = [
         y: { type: "number" },
         button: { type: "string", enum: ["left", "right"], description: "default left" },
         double: { type: "boolean", description: "double-click" },
+        ...OBSERVE_PROPS,
       },
       required: ["x", "y"],
     },
   },
   {
     name: "type_text",
-    description: "Type text at the current focus on the computer.",
-    inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+    description: "Type text at the current focus and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: { text: { type: "string" }, ...OBSERVE_PROPS },
+      required: ["text"],
+    },
   },
   {
     name: "press_key",
     description:
-      'Press a key or chord on the computer, xdotool syntax: "Return", "Tab", "ctrl+c", "alt+F4", "ctrl+shift+t".',
-    inputSchema: { type: "object", properties: { keys: { type: "string" } }, required: ["keys"] },
+      'Press a key or chord and return the resulting screen. xdotool syntax: "Return", "Tab", "ctrl+c", "alt+F4", "ctrl+shift+t".',
+    inputSchema: {
+      type: "object",
+      properties: { keys: { type: "string" }, ...OBSERVE_PROPS },
+      required: ["keys"],
+    },
   },
   {
     name: "scroll",
-    description: "Scroll the computer screen up or down by N clicks.",
+    description: "Scroll the screen up or down by N clicks and return the resulting screen.",
     inputSchema: {
       type: "object",
       properties: {
         direction: { type: "string", enum: ["up", "down"] },
         clicks: { type: "number", description: "default 3" },
+        ...OBSERVE_PROPS,
       },
       required: ["direction"],
+    },
+  },
+  {
+    name: "computer_batch",
+    description:
+      "Run several UI actions in ONE go and return the screen at the end — much faster than separate calls (one round trip, one screenshot). Use it for mechanical sequences you can predict without looking in between, e.g. click a field, type, Tab, type, press Return. Stop the batch before anything whose outcome you need to see first.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        actions: {
+          type: "array",
+          description: "in order; each is {action: click|type_text|press_key|scroll|wait, ...its params}",
+          items: {
+            type: "object",
+            properties: {
+              action: { type: "string", enum: ["click", "type_text", "press_key", "scroll", "wait"] },
+              x: { type: "number" },
+              y: { type: "number" },
+              button: { type: "string", enum: ["left", "right"] },
+              double: { type: "boolean" },
+              text: { type: "string" },
+              keys: { type: "string" },
+              direction: { type: "string", enum: ["up", "down"] },
+              clicks: { type: "number" },
+              ms: { type: "number", description: "wait: milliseconds, max 5000" },
+            },
+            required: ["action"],
+          },
+        },
+        ...OBSERVE_PROPS,
+      },
+      required: ["actions"],
     },
   },
   {
     name: "computer_exec",
     description:
       "Run a shell command on the bot's cloud computer (Linux, passwordless sudo, X11 desktop). Returns stdout/stderr/exit code.",
-    inputSchema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+    inputSchema: {
+      type: "object",
+      properties: { command: { type: "string" }, observe: OBSERVE_PROPS.observe },
+      required: ["command"],
+    },
   },
   {
     name: "open_url",
-    description: "Open a URL in the computer's own Chrome, then screenshot to see the result.",
-    inputSchema: { type: "object", properties: { url: { type: "string" } }, required: ["url"] },
+    description: "Open a URL in the computer's own Chrome and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: { url: { type: "string" }, ...OBSERVE_PROPS },
+      required: ["url"],
+    },
   },
 ];
 
+const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+const settleOf = (args: any) => Math.min(Math.max(Number(args?.settle_ms) || SETTLE_MS, 0), 3000);
+const wantsFrame = (args: any) => args?.observe !== false;
+
+/** One action → the shell that performs it (scaling clicks box-side). */
+function actionShell(a: any): string | { error: string } {
+  const kind = String(a?.action ?? "");
+  if (kind === "click") {
+    const x = Math.round(Number(a.x));
+    const y = Math.round(Number(a.y));
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return { error: "click needs numeric x,y" };
+    const btn = a.button === "right" ? 3 : 1;
+    const rep = a.double ? "--repeat 2 --delay 60 " : "";
+    return `${scaled("CX", x)}; ${scaled("CY", y)}; xdotool mousemove $CX $CY click ${rep}${btn}`;
+  }
+  if (kind === "type_text") {
+    const t = String(a.text ?? "");
+    if (!t) return { error: "type_text needs text" };
+    return `xdotool type --delay 8 ${shellQuote(t)}`;
+  }
+  if (kind === "press_key") {
+    const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
+    if (!keys) return { error: "press_key needs keys" };
+    return `xdotool key ${keys}`;
+  }
+  if (kind === "scroll") {
+    const clicks = Math.min(Math.max(Math.round(Number(a.clicks) || 3), 1), 20);
+    const btn = a.direction === "up" ? 4 : 5;
+    return `xdotool click --repeat ${clicks} ${btn}`;
+  }
+  if (kind === "wait") {
+    const ms = Math.min(Math.max(Number(a.ms) || 500, 0), 5000);
+    return `sleep ${(ms / 1000).toFixed(2)}`;
+  }
+  return { error: `unknown action ${kind || "(missing)"}` };
+}
+
+/** The whole point: one round trip carries geometry, the actions, the
+ * settle, the capture and the frame bytes. */
+async function actAndObserve(
+  id: unknown,
+  actions: any[],
+  note: string,
+  args: any,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const parts: string[] = [];
+  for (const a of actions) {
+    const shell = actionShell(a);
+    if (typeof shell !== "string") return text(id, shell.error, true);
+    parts.push(shell);
+  }
+  const observe = wantsFrame(args);
+  const command = [ENV, GEOMETRY, ...parts, observe ? captureBlock(settleOf(args)) : "true"].join("; ");
+  const out = await runOnBox(command, timeoutMs);
+  if (!out.ok && !out.stdout.includes("GEOM")) {
+    return text(id, `${note.replace(/^./, (c) => c.toLowerCase())} failed: ${out.stderr.slice(0, 200) || `exit ${out.exitCode}`}`, true);
+  }
+  if (!observe) return text(id, note);
+  return observed(id, note, await frameFrom(out));
+}
+
 async function call(id: unknown, name: string, args: any) {
   if (name === "screenshot") {
-    const out = await runOnBox(SHOT_CMD, 60_000);
-    if (!/captured/.test(out.stdout)) {
-      return text(id, `screenshot failed: ${out.stderr.slice(0, 200) || "capture produced no file"}`, true);
+    const out = await runOnBox([ENV, GEOMETRY, captureBlock(0)].join("; "), 60_000);
+    const frame = await frameFrom(out);
+    if (!frame) {
+      return text(id, `screenshot failed: ${out.stderr.slice(0, 200) || "capture produced no frame"}`, true);
     }
-    const data = await readBoxFile("/tmp/ogb-shot.png");
-    if (!data) return text(id, "screenshot failed: could not read the frame back", true);
+    // an explicit look always returns pixels, even if nothing moved
+    lastFrameHash = frame.hash ?? lastFrameHash;
     return send({
       jsonrpc: "2.0",
       id,
-      result: { content: [{ type: "image", data, mimeType: "image/png" }] },
+      result: { content: [{ type: "image", data: frame.data, mimeType: frame.mime }] },
     });
   }
   if (name === "click") {
     const x = Math.round(Number(args.x));
     const y = Math.round(Number(args.y));
     if (!Number.isFinite(x) || !Number.isFinite(y)) return text(id, "click needs numeric x,y", true);
-    // screenshot space is 1280 wide (files-API capture is downscaled) but
-    // the real display can be larger — scale uniformly by width or clicks
-    // land short (probed live: 1920×1080 display, 1280×720 screenshots,
-    // every raw click 1.5× off). xdotool only; CUA's own scaler assumes a
-    // different (1280×800) API space and would double-convert.
-    const geometry = await displayGeometry();
-    const scale = geometry ? geometry.width / SHOT_WIDTH : 1;
-    const sx = Math.round(x * scale);
-    const sy = Math.round(y * scale);
-    const btn = args.button === "right" ? 3 : 1;
-    const rep = args.double ? "--repeat 2 --delay 150 " : "";
-    const out = await runOnBox(`${X}xdotool mousemove ${sx} ${sy} click ${rep}${btn}`);
-    if (!out.ok) return text(id, `click failed: ${out.stderr.slice(0, 200)}`, true);
-    return text(
-      id,
-      `clicked ${x},${y}${scale !== 1 ? ` (scaled to ${sx},${sy} on the ${geometry!.width}x${geometry!.height} display)` : ""}${args.double ? " (double)" : ""}${args.button === "right" ? " (right)" : ""} — screenshot to verify`,
-    );
+    const what = `${args.double ? "double-clicked" : args.button === "right" ? "right-clicked" : "clicked"} ${x},${y}`;
+    return actAndObserve(id, [{ ...args, action: "click" }], what, args);
   }
   if (name === "type_text") {
     const t = String(args.text ?? "");
     if (!t) return text(id, "nothing to type", true);
-    const cua = await cuaCmd("type_text", { text: t });
-    if (!cua) {
-      const safe = t.replace(/'/g, "'\\''");
-      const out = await runOnBox(`${X}xdotool type --delay 12 '${safe}'`);
-      if (!out.ok) return text(id, `type failed: ${out.stderr.slice(0, 200)}`, true);
-    }
-    return text(id, `typed ${t.length} chars`);
+    return actAndObserve(id, [{ action: "type_text", text: t }], `typed ${t.length} chars`, args, 120_000);
   }
   if (name === "press_key") {
     const keys = String(args.keys ?? "").replace(/[^\w+]/g, "");
     if (!keys) return text(id, "press_key needs keys", true);
-    const out = await runOnBox(`${X}xdotool key ${keys}`);
-    return out.ok ? text(id, `pressed ${keys}`) : text(id, `key failed: ${out.stderr.slice(0, 200)}`, true);
+    return actAndObserve(id, [{ action: "press_key", keys }], `pressed ${keys}`, args);
   }
   if (name === "scroll") {
     const clicks = Math.min(Math.max(Math.round(Number(args.clicks) || 3), 1), 20);
-    const command = args.direction === "up" ? "scroll_up" : "scroll_down";
-    const cua = await cuaCmd(command, { clicks });
-    if (!cua) {
-      const btn = args.direction === "up" ? 4 : 5;
-      const out = await runOnBox(`${X}xdotool click --repeat ${clicks} ${btn}`);
-      if (!out.ok) return text(id, `scroll failed: ${out.stderr.slice(0, 200)}`, true);
-    }
-    return text(id, `scrolled ${args.direction} ${clicks}`);
+    const direction = args.direction === "up" ? "up" : "down";
+    return actAndObserve(id, [{ action: "scroll", direction, clicks }], `scrolled ${direction} ${clicks}`, args);
+  }
+  if (name === "computer_batch") {
+    const actions = Array.isArray(args.actions) ? args.actions.slice(0, 24) : [];
+    if (!actions.length) return text(id, "computer_batch needs a non-empty actions array", true);
+    const summary = actions
+      .map((a: any) =>
+        a.action === "click"
+          ? `click ${Math.round(Number(a.x))},${Math.round(Number(a.y))}`
+          : a.action === "type_text"
+            ? `type ${String(a.text ?? "").length} chars`
+            : a.action === "press_key"
+              ? `key ${a.keys}`
+              : a.action === "scroll"
+                ? `scroll ${a.direction ?? "down"}`
+                : `wait ${Math.min(Number(a.ms) || 500, 5000)}ms`,
+      )
+      .join(" → ");
+    return actAndObserve(id, actions, `ran ${actions.length} actions: ${summary}`, args, 180_000);
   }
   if (name === "computer_exec") {
-    const out = await runOnBox(String(args.command ?? "").slice(0, 4000), 120_000);
-    return text(
-      id,
-      `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`,
-    );
+    const command = String(args.command ?? "").slice(0, 4000);
+    const out = await runOnBox(command, 120_000);
+    const note = `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`;
+    if (args.observe !== true) return text(id, note);
+    const shot = await runOnBox([ENV, GEOMETRY, captureBlock()].join("; "), 60_000);
+    return observed(id, note, await frameFrom(shot));
   }
   if (name === "open_url") {
     const url = String(args.url ?? "");
     if (!/^https?:\/\//.test(url)) return text(id, "only http(s) URLs", true);
-    const q = url.replace(/'/g, "%27");
-    await runOnBox(
-      `${X}(google-chrome '${q}' || chromium '${q}' || chromium-browser '${q}' || xdg-open '${q}') >/dev/null 2>&1 & sleep 3; echo opened`,
-      30_000,
-    );
-    return text(id, `opened ${url} — take a screenshot to see it`);
+    const q = shellQuote(url.replace(/'/g, "%27"));
+    const observe = wantsFrame(args);
+    // launch, then poll for a browser window instead of a blind sleep —
+    // a fast page returns in a fraction of the old fixed 3s
+    const command = [
+      ENV,
+      GEOMETRY,
+      `(google-chrome ${q} || chromium ${q} || chromium-browser ${q} || xdg-open ${q}) >/dev/null 2>&1 &`,
+      'for i in 1 2 3 4 5 6 7 8 9 10 11 12; do xdotool search --onlyvisible --class "chrom" >/dev/null 2>&1 && break; sleep 0.25; done',
+      observe ? captureBlock(600) : "true",
+    ].join("; ");
+    const out = await runOnBox(command, 60_000);
+    if (!observe) return text(id, `opened ${url}`);
+    return observed(id, `opened ${url}`, await frameFrom(out));
   }
   return text(id, `unknown tool ${name}`, true);
 }
@@ -237,7 +470,7 @@ async function handle(msg: any) {
       result: {
         protocolVersion: msg.params?.protocolVersion ?? "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "openmausbot-computer", version: "2" },
+        serverInfo: { name: "openmausbot-computer", version: "3" },
       },
     });
   }

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -37,6 +37,8 @@ const JPEG_QUALITY = 75;
 const SHOT_PATH = "/tmp/ogb-shot.jpg";
 /** How long the desktop gets to repaint before the fused capture. */
 const SETTLE_MS = 350;
+/** Gap between batched actions so focus changes land before typing. */
+const ACTION_GAP_MS = 120;
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -48,7 +50,26 @@ interface RunOut {
   stderr: string;
 }
 
-async function runOnBox(command: string, timeoutMs = 60_000): Promise<RunOut> {
+/** Boxes archive themselves when idle (billing pauses, the disk survives),
+ * which can happen mid-conversation — after that every command comes back
+ * 409 machine_not_running. Wake it and carry on rather than handing the
+ * agent a cryptic failure it can only guess at. */
+async function resumeBox(): Promise<boolean> {
+  const auth = { authorization: `Bearer ${token}`, "content-type": "application/json" };
+  await fetch(`${BOX_API}/boxes/${boxId}/resume`, { method: "POST", headers: auth }).catch(() => null);
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const res = await fetch(`${BOX_API}/boxes/${boxId}`, { headers: auth }).catch(() => null);
+    const body: any = await res?.json().catch(() => null);
+    const state = body?.box?.state;
+    if (state && ["idle", "ready", "running"].includes(state)) return true;
+    if (state === "error") return false;
+  }
+  return false;
+}
+
+async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): Promise<RunOut> {
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
@@ -56,11 +77,19 @@ async function runOnBox(command: string, timeoutMs = 60_000): Promise<RunOut> {
     signal: AbortSignal.timeout(timeoutMs),
   });
   const body: any = await res.json().catch(() => null);
+  if (res.status === 409 && allowWake) {
+    const code = body?.code ?? body?.error?.code ?? "";
+    if (/machine_not_running|box_starting|not_running|starting/i.test(String(code))) {
+      const woke = await resumeBox();
+      if (woke) return runOnBox(command, timeoutMs, false);
+      return { ok: false, exitCode: null, stdout: "", stderr: "the computer is asleep and did not wake in time" };
+    }
+  }
   return {
     ok: res.ok && body?.exitCode === 0,
     exitCode: body?.exitCode ?? null,
     stdout: body?.stdout ?? "",
-    stderr: body?.stderr ?? "",
+    stderr: body?.stderr ?? String(body?.message ?? (res.ok ? "" : `HTTP ${res.status}`)),
   };
 }
 
@@ -73,9 +102,14 @@ const GEOMETRY = [
   `case "$W" in ''|*[!0-9]*) W=${SHOT_WIDTH}; H=0;; esac`,
 ].join("; ");
 
-/** Shell that turns a screenshot-space coordinate into a display one. */
+/** Shell that turns a screenshot-space coordinate into a display one.
+ * The capture only downscales when the display is WIDER than the model's
+ * space, so scaling must be conditional on exactly the same test — on a
+ * 1024-wide desktop the frame is native size and a blind /1280 would put
+ * every click at 80% of where the model aimed. */
 function scaled(varName: string, value: number): string {
-  return `${varName}=$(( ${Math.round(value)} * W / ${SHOT_WIDTH} ))`;
+  const v = Math.round(value);
+  return `if [ "$W" -gt ${SHOT_WIDTH} ] 2>/dev/null; then ${varName}=$(( ${v} * W / ${SHOT_WIDTH} )); else ${varName}=${v}; fi`;
 }
 
 /** act → settle → capture → hash → (inline base64 if small). One hop. */
@@ -92,13 +126,41 @@ function captureBlock(settleMs = SETTLE_MS): string {
     'echo "GEOM $W $H"',
     'echo "HASH $(md5sum "$f" 2>/dev/null | cut -d\' \' -f1)"',
     's=$(stat -c%s "$f" 2>/dev/null || echo 0)',
-    `if [ "$s" -le ${INLINE_MAX_BYTES} ]; then echo "B64 $(base64 -w0 "$f" 2>/dev/null || base64 "$f" | tr -d '\\n')"; fi`,
+    // SIZE is what makes the inline path safe: the frame is only trusted
+    // when the bytes we decoded match the bytes the box says it wrote
+    'echo "SIZE $s"',
+    `if [ "$s" -gt 0 ] && [ "$s" -le ${INLINE_MAX_BYTES} ]; then echo "B64 $(base64 -w0 "$f" 2>/dev/null || base64 "$f" | tr -d '\\n')"; fi`,
   ].join("; ");
 }
 
+/** A frame is only trusted when the bytes are a WHOLE image. Checking the
+ * magic number alone is not enough: the box's command stdout has been
+ * observed truncating a payload, and a truncated JPEG still starts with a
+ * valid header — it just renders as a grey half-frame for the model. So
+ * every frame must also end with its terminator, and (when the box told
+ * us how many bytes it wrote) match that length exactly. */
+function wholeImage(bytes: Buffer, expectedBytes?: number): boolean {
+  if (bytes.length < 512) return false;
+  if (expectedBytes && bytes.length !== expectedBytes) return false;
+  const jpeg = bytes[0] === 0xff && bytes[1] === 0xd8;
+  const png = bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47;
+  if (jpeg) {
+    // EOI marker, allowing for trailing padding some encoders append
+    const tail = bytes.subarray(Math.max(0, bytes.length - 32));
+    return tail.includes(Buffer.from([0xff, 0xd9]));
+  }
+  if (png) {
+    const tail = bytes.subarray(Math.max(0, bytes.length - 12));
+    return tail.includes(Buffer.from("IEND", "ascii"));
+  }
+  return false;
+}
+
 /** Big frames (and any inline read that came back malformed) are fetched
- * as raw bytes; the files API's base64-in-JSON envelope is the fallback. */
-async function fetchFrame(): Promise<string | null> {
+ * over HTTP: raw artifact bytes first, the files API's base64-in-JSON
+ * envelope second. Both are validated — an error page served with a 200
+ * must fall through, not reach the model as an "image". */
+async function fetchFrame(expectedBytes?: number): Promise<string | null> {
   const auth = { authorization: `Bearer ${token}` };
   try {
     const res = await fetch(
@@ -107,7 +169,7 @@ async function fetchFrame(): Promise<string | null> {
     );
     if (res.ok) {
       const bytes = Buffer.from(await res.arrayBuffer());
-      if (bytes.length) return bytes.toString("base64");
+      if (wholeImage(bytes, expectedBytes)) return bytes.toString("base64");
     }
   } catch {
     /* fall through to the files API */
@@ -119,20 +181,11 @@ async function fetchFrame(): Promise<string | null> {
     );
     const body: any = await res.json().catch(() => null);
     const content = body?.content;
-    return res.ok && typeof content === "string" && content ? content : null;
+    if (!res.ok || typeof content !== "string" || !content) return null;
+    return wholeImage(Buffer.from(content, "base64"), expectedBytes) ? content : null;
   } catch {
     return null;
   }
-}
-
-/** A decoded frame is only trusted when it really is an image — a
- * truncated stdout would otherwise reach the model as garbage. */
-function validBase64Image(data: string): boolean {
-  if (!data || data.length < 512) return false;
-  const head = Buffer.from(data.slice(0, 64), "base64");
-  const jpeg = head[0] === 0xff && head[1] === 0xd8;
-  const png = head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47;
-  return jpeg || png;
 }
 
 interface Frame {
@@ -150,19 +203,24 @@ async function frameFrom(out: RunOut): Promise<Frame | null> {
   let hash: string | null = null;
   let geometry: Frame["geometry"] = null;
   let inline = "";
+  let size = 0;
   for (const line of out.stdout.split("\n")) {
     if (line.startsWith("HASH ")) hash = line.slice(5).trim() || null;
+    else if (line.startsWith("SIZE ")) size = Number(line.slice(5).trim()) || 0;
     else if (line.startsWith("GEOM ")) {
       const [w, h] = line.slice(5).trim().split(/\s+/).map(Number);
       if (Number.isFinite(w) && w > 0) geometry = { width: w, height: Number.isFinite(h) ? h : 0 };
     } else if (line.startsWith("B64 ")) inline = line.slice(4).trim();
   }
   if (inline && inlineWorks) {
-    if (validBase64Image(inline)) return { data: inline, mime: "image/jpeg", hash, geometry };
-    inlineWorks = false; // stdout mangled it — use the files API from here on
+    const bytes = Buffer.from(inline, "base64");
+    if (wholeImage(bytes, size || undefined)) return { data: inline, mime: "image/jpeg", hash, geometry };
+    // stdout mangled it (the failure this channel is known for) — never
+    // hand a partial frame to the model; fetch it and stop trusting stdout
+    inlineWorks = false;
   }
-  const fetched = await fetchFrame();
-  if (!fetched || !validBase64Image(fetched)) return null;
+  const fetched = await fetchFrame(size || undefined);
+  if (!fetched) return null;
   return { data: fetched, mime: "image/jpeg", hash, geometry };
 }
 
@@ -182,9 +240,12 @@ function observed(id: unknown, note: string, frame: Frame | null) {
   const unchanged = frame.hash != null && frame.hash === lastFrameHash;
   lastFrameHash = frame.hash ?? lastFrameHash;
   if (unchanged) {
+    // deliberately does NOT suggest repeating the action: the action may
+    // well have landed, and re-clicking a button that already submitted
+    // is the expensive kind of wrong
     return text(
       id,
-      `${note}\n(screen unchanged — the last frame you were sent is still current. If you expected it to change, it may still be loading: retry with settle_ms, or call screenshot again.)`,
+      `${note}\n(the screen is identical to the frame you already have, so no new image is attached. Don't repeat the action — if you expected a change, it may still be rendering: call screenshot again in a moment, or re-check your coordinates against that frame.)`,
     );
   }
   send({
@@ -218,7 +279,7 @@ const TOOLS = [
   {
     name: "click",
     description:
-      "Click on the computer's screen and return the resulting screen. Use pixel coordinates as they appear in the most recent screenshot — scaling to the real display resolution is handled for you.",
+      "Click on the computer's screen and return the resulting screen. Use pixel coordinates exactly as they appear in the last frame you were given — any scaling to the real display is handled for you.",
     inputSchema: {
       type: "object",
       properties: {
@@ -298,10 +359,16 @@ const TOOLS = [
   {
     name: "computer_exec",
     description:
-      "Run a shell command on the bot's cloud computer (Linux, passwordless sudo, X11 desktop). Returns stdout/stderr/exit code.",
+      "Run a shell command on the bot's cloud computer (Linux, passwordless sudo, X11 desktop). Returns stdout/stderr/exit code — and, unlike the UI tools, no screenshot unless you ask for one.",
     inputSchema: {
       type: "object",
-      properties: { command: { type: "string" }, observe: OBSERVE_PROPS.observe },
+      properties: {
+        command: { type: "string" },
+        observe: {
+          type: "boolean",
+          description: "default false — set true to also return a screenshot (e.g. after launching a GUI app)",
+        },
+      },
       required: ["command"],
     },
   },
@@ -366,16 +433,33 @@ async function actAndObserve(
   for (const a of actions) {
     const shell = actionShell(a);
     if (typeof shell !== "string") return text(id, shell.error, true);
+    // X11 needs a beat between steps — a click that focuses a field and
+    // an immediate type will drop leading characters
+    if (parts.length) parts.push(`sleep ${(ACTION_GAP_MS / 1000).toFixed(2)}`);
     parts.push(shell);
   }
   const observe = wantsFrame(args);
-  const command = [ENV, GEOMETRY, ...parts, observe ? captureBlock(settleOf(args)) : "true"].join("; ");
+  // The actions run in a guarded group so a failing xdotool is REPORTED
+  // rather than silently swallowed by the capture that follows it — but
+  // the capture still runs, so the model always gets to see the state it
+  // ended up in. Joining with ";" alone made a failed action look
+  // identical to one that did nothing.
+  const guarded = `if { ${parts.join("; ")}; }; then ACT=ok; else ACT=failed; fi`;
+  const command = [ENV, GEOMETRY, guarded, observe ? captureBlock(settleOf(args)) : "true", 'echo "ACT $ACT"'].join(
+    "; ",
+  );
   const out = await runOnBox(command, timeoutMs);
-  if (!out.ok && !out.stdout.includes("GEOM")) {
-    return text(id, `${note.replace(/^./, (c) => c.toLowerCase())} failed: ${out.stderr.slice(0, 200) || `exit ${out.exitCode}`}`, true);
+  const acted = /^ACT ok$/m.test(out.stdout);
+  if (!acted && !out.stdout.includes("GEOM")) {
+    return text(
+      id,
+      `${note.replace(/^./, (c) => c.toLowerCase())} failed: ${out.stderr.slice(0, 200) || `exit ${out.exitCode}`}`,
+      true,
+    );
   }
-  if (!observe) return text(id, note);
-  return observed(id, note, await frameFrom(out));
+  const full = acted ? note : `${note}\n(the action reported an error: ${out.stderr.slice(0, 160) || "no detail"})`;
+  if (!observe) return text(id, full, !acted);
+  return observed(id, full, await frameFrom(out));
 }
 
 async function call(id: unknown, name: string, args: any) {

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -125,6 +125,11 @@ export interface ProviderAdapter {
      * the harness only offers agents tooling (and prompts about it) to
      * drivers that can actually hand it to the agent. */
     agentsMcp?: boolean;
+    /** True when the driver mounts turn.integrations.computer (the box's
+     * screenshot/click tools). Same rule as agentsMcp: a bot must never be
+     * told it has a computer whose tools its driver cannot mount — it
+     * burns turns hunting for tools that aren't there. */
+    computerMcp?: boolean;
   };
   sendTurn(input: SendTurnInput): Promise<TurnStartResult>;
   interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void>;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -477,7 +477,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       snapshot,
       adapter: {
         provider: DRIVER_KIND,
-        capabilities: { sessionModelSwitch: "in-session", agentsMcp: true },
+        capabilities: { sessionModelSwitch: "in-session", agentsMcp: true, computerMcp: true },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async (threadId, requestId, decision) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -160,15 +160,22 @@ bus.subscribe((event: RuntimeEvent) => {
         pushMessage({ role: "bot", kind: "text", text: event.text });
       } else if (event.itemType === "tool" && event.itemId) {
         const messageId = toolMessageByItem.get(event.itemId);
+        let toolName = "tool";
         if (messageId) {
+          toolName = store.messagesFor(event.threadId).find((m) => m.id === messageId)?.tool?.name ?? "tool";
           const patched = store.patchMessage(event.threadId, messageId, {
-            tool: { name: store.messagesFor(event.threadId).find((m) => m.id === messageId)?.tool?.name ?? "tool", ok: event.ok },
+            tool: { name: toolName, ok: event.ok },
           });
           if (patched) broadcast({ kind: "message.patch", threadId: event.threadId, message: patched });
           toolMessageByItem.delete(event.itemId);
         }
-        // the bot just finished acting — refresh its screen preview now
-        if (bot) pokeScreenPoller(bot.id);
+        // the bot just acted ON ITS SCREEN — refresh the preview now. Only
+        // computer tools can change the screen, and each capture competes
+        // with the agent for the box's command endpoint, so a bot grinding
+        // through file edits must not trigger one per tool.
+        if (bot && /computer|screenshot|click|type_text|press_key|scroll|open_url/i.test(toolName)) {
+          pokeScreenPoller(bot.id);
+        }
       }
       break;
     case "item.started":
@@ -237,25 +244,36 @@ const screenPollers = new Map<
   { timer: ReturnType<typeof setInterval>; capture: () => Promise<void>; last: Frame | null }
 >();
 
-function startScreenPoller(botId: string) {
+/** The preview shares the box's single command endpoint with the agent's
+ * own actions, so every frame we take is latency stolen from the work the
+ * user is waiting on. Hence: a slow interval, a floor between captures,
+ * and never two in flight. */
+const SCREEN_POLL_MS = 6000;
+const SCREEN_MIN_GAP_MS = 3000;
+
+function startScreenPoller(botId: string, boxId?: string) {
   if (screenPollers.has(botId) || !box.boxConfigured(cfg)) return;
   let inFlight = false;
+  let lastAt = 0;
   const capture = async () => {
-    if (inFlight) return;
+    if (inFlight || Date.now() - lastAt < SCREEN_MIN_GAP_MS) return;
     inFlight = true;
     try {
-      const { png, format } = await box.screenshotBox(cfg, botId);
+      // the box id is resolved once per turn — re-resolving per frame cost
+      // a full LIST of the account's boxes
+      const { png, format } = await box.screenshotBox(cfg, botId, boxId);
       const frame = { png, mime: format === "jpeg" ? "image/jpeg" : "image/png" };
       entry.last = frame;
       broadcast({ kind: "screen", botId, ...frame });
     } catch {
       /* box asleep or mid-command — try again next tick */
     } finally {
+      lastAt = Date.now();
       inFlight = false;
     }
   };
   const entry = {
-    timer: setInterval(capture, 4000),
+    timer: setInterval(capture, SCREEN_POLL_MS),
     capture,
     last: null as Frame | null,
   };
@@ -263,7 +281,9 @@ function startScreenPoller(botId: string) {
 }
 
 /** Event-driven refresh: capture NOW (the bot just acted on its screen)
- * instead of waiting for the next interval tick. */
+ * instead of waiting for the next interval tick. Rate-limited inside
+ * capture() — a tool-heavy turn used to fire one full REST chain per
+ * completed tool, competing with the agent for the same endpoint. */
 function pokeScreenPoller(botId: string) {
   void screenPollers.get(botId)?.capture();
 }
@@ -381,13 +401,22 @@ async function startTurn(
       const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
       if (cfg.composio?.key) integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
       const wants = bot.computer; // 'cloud' | 'local' | 'off' | undefined(auto)
-      if (wants !== "off" && wants !== "local" && box.boxConfigured(cfg)) {
+      const mountsComputer =
+        instance.adapter.capabilities.computerMcp === true || instance.driverKind === "boxAgent";
+      if (wants !== "off" && wants !== "local" && mountsComputer && box.boxConfigured(cfg)) {
         let b = await box.findBox(cfg, bot.id).catch(() => null);
         // the Computer driver runs ON the box — provision it on first use
         if (!b && instance.driverKind === "boxAgent") {
           broadcast({ kind: "computer", botId: bot.id, state: "provisioning" });
           await box.provisionBox(cfg, bot.id, bot.name);
           b = await box.findBox(cfg, bot.id).catch(() => null);
+        }
+        // an archived box answers every action with an error until it
+        // resumes — wake it here, once, instead of letting the agent
+        // discover it one failed tool call at a time
+        if (b && !["idle", "ready", "running"].includes(b.state)) {
+          broadcast({ kind: "computer", botId: bot.id, state: "waking" });
+          b = (await box.readyBox(cfg, bot.id).catch(() => null)) ?? b;
         }
         if (b) integrations.computer = { boxId: b.id, token: cfg.box!.token! };
       }
@@ -432,7 +461,7 @@ async function startTurn(
         system:
           persona +
           (integrations.computer && instance.driverKind !== "boxAgent"
-            ? " You have your own cloud computer — use the computer tools (screenshot, computer_exec, open_url) whenever browsing or acting on a desktop helps."
+            ? " You have your own cloud computer — use the computer tools (screenshot, click, type_text, open_url, computer_exec) whenever browsing or acting on a desktop helps. Every action tool already returns the resulting screen, so don't follow one with a screenshot call, and batch predictable sequences with computer_batch."
             : integrations.localComputer
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
               : "") +
@@ -448,7 +477,7 @@ async function startTurn(
       });
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
-      if (integrations.computer) startScreenPoller(bot.id);
+      if (integrations.computer) startScreenPoller(bot.id, integrations.computer.boxId);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(bot.threadId, {

--- a/server/index.ts
+++ b/server/index.ts
@@ -401,9 +401,13 @@ async function startTurn(
       const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
       if (cfg.composio?.key) integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
       const wants = bot.computer; // 'cloud' | 'local' | 'off' | undefined(auto)
+      // only drivers that can mount the computer MCP server get the tools
+      // (and the prompt about them) — but every bot with a box still gets
+      // the live screen preview, which is a UI feature, not a tool
       const mountsComputer =
         instance.adapter.capabilities.computerMcp === true || instance.driverKind === "boxAgent";
-      if (wants !== "off" && wants !== "local" && mountsComputer && box.boxConfigured(cfg)) {
+      let previewBoxId: string | null = null;
+      if (wants !== "off" && wants !== "local" && box.boxConfigured(cfg)) {
         let b = await box.findBox(cfg, bot.id).catch(() => null);
         // the Computer driver runs ON the box — provision it on first use
         if (!b && instance.driverKind === "boxAgent") {
@@ -413,12 +417,16 @@ async function startTurn(
         }
         // an archived box answers every action with an error until it
         // resumes — wake it here, once, instead of letting the agent
-        // discover it one failed tool call at a time
-        if (b && !["idle", "ready", "running"].includes(b.state)) {
+        // discover it one failed tool call at a time. Only worth the
+        // resume (~8s, and it un-pauses billing) when the bot can act.
+        if (b && mountsComputer && !["idle", "ready", "running"].includes(b.state)) {
           broadcast({ kind: "computer", botId: bot.id, state: "waking" });
           b = (await box.readyBox(cfg, bot.id).catch(() => null)) ?? b;
         }
-        if (b) integrations.computer = { boxId: b.id, token: cfg.box!.token! };
+        if (b) {
+          previewBoxId = b.id;
+          if (mountsComputer) integrations.computer = { boxId: b.id, token: cfg.box!.token! };
+        }
       }
       // local computer (this Mac) via the Electron-hosted cua-driver: the
       // Electron main process owns the daemon (TCC attribution) and writes
@@ -477,7 +485,7 @@ async function startTurn(
       });
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
-      if (integrations.computer) startScreenPoller(bot.id, integrations.computer.boxId);
+      if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(bot.threadId, {

--- a/server/store.ts
+++ b/server/store.ts
@@ -312,8 +312,24 @@ export class Store {
     const full: Message = { id: newId(), at: Date.now(), parentId: t.activeLeafId, ...message };
     t.messages.push(full);
     t.activeLeafId = full.id;
+    if (full.kind === "screen") this.pruneScreenFrames(t);
     this.saveThread(threadId);
     return full;
+  }
+
+  /** Screen frames are ~100-500KB of base64 each and the whole thread file
+   * is rewritten on every append, so keeping every frame of a long
+   * computer session makes each later message slower than the last. The
+   * newest few keep their pixels; older ones stay in the transcript as
+   * placeholders. Mirrors the client's own frame cap. */
+  private pruneScreenFrames(t: { messages: Message[] }, keep = 4) {
+    let seen = 0;
+    for (let i = t.messages.length - 1; i >= 0 && seen < t.messages.length; i--) {
+      const m = t.messages[i];
+      if (m.kind !== "screen" || !m.png) continue;
+      seen += 1;
+      if (seen > keep) m.png = undefined;
+    }
   }
 
   /** Fork the conversation: a new user message that replaces `sourceId`


### PR DESCRIPTION
Computer use felt slow for structural reasons, not one hot spot. A full audit of every layer (action path, model loop, screen poller, provisioning, plus what the upstream reference codebase does differently) found the dominant cost is **round trips, not compute**.

### What was actually slow

| | before | after |
|---|---|---|
| Model inferences per UI step | **2** (act, then a separate `screenshot` to see the result — the tools said "screenshot to verify") | **1** (the frame rides back in the action's result) |
| HTTPS hops per action | 2–4 (geometry probe, action, capture, file read; `type`/`scroll` also probed a usually-dead CUA server) | **1** |
| Frame format | PNG + unconditional ImageMagick re-encode | JPEG, re-encode only when the display is wider than the model's coordinate space |
| Form fill (click, type, Tab, type, Return) | 5 actions × (1 model turn + 1 screenshot turn) | **1** `computer_batch` call, one frame |
| Screen preview while the agent works | LIST every box in the account + capture, every 4s **and after every completed tool** | box id held for the turn, slower interval, floor between captures, only after tools that can change the screen |

### Action path (`server/computer-proxy.ts`)

- **Fused act-and-observe** — action, settle and capture run in one shell command and the frame returns as an MCP image block, the same shape Anthropic's own computer-use loop uses. No follow-up screenshot call.
- **Box-side coordinate scaling** in shell arithmetic, so the per-turn display-geometry round trip is gone.
- **Inline frames** in stdout when small (one hop instead of two), with magic-byte validation and a permanent fallback to the files API if a payload ever comes back mangled; raw artifact bytes preferred over base64-in-JSON.
- **`computer_batch`** for predictable sequences; `observe: false` and `settle_ms` for control.
- Unchanged screens return text instead of identical pixels (~1.2k tokens saved per no-op, with guidance so a still-loading page isn't mistaken for "nothing happened"). `open_url` polls for the browser window instead of sleeping a fixed 3s. Typing delay 12ms → 8ms.

### Server side

- Box resolution cached per bot (`findBox` used to LIST all boxes); panel captures are JPEG; new `readyBox` helper.
- An archived box is woken **once** at turn start instead of failing the agent one tool call at a time (new `computer: waking` broadcast).
- Only drivers that mount the computer tools are told they have a computer — codex/grok/agy bots were being prompted about tools their driver never mounts (new `computerMcp` capability flag).
- Screen frames older than the newest few drop their pixels at append time, so a long computer session stops rewriting megabytes of base64 per message.

### Verification

`pnpm typecheck` clean, **107 tests pass** (13 files). New `server/computer-proxy.test.ts` runs the real proxy against a fake box and pins the latency shape: one round trip per action, image inside the action result, box-side scaling, one capture per batch, dedup on unchanged screens, and no capture when the caller opts out.

Not yet exercised against a live box (the configured box token is dead) — the fallbacks are written defensively for that reason: inline base64 self-disables on the first malformed payload, and the artifacts endpoint falls back to the files API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster computer interactions with inline JPEG screenshots.
  - Added batched actions, optional observations, display scaling, and compatible computer integrations.
  - Added improved browser-window detection when launching URLs.

- **Performance & Reliability**
  - Improved box readiness, caching, recovery, and screenshot retrieval.
  - Reduced redundant captures and suppressed unchanged frames.
  - Limited retained screen images to reduce conversation data.

- **Bug Fixes**
  - Improved image validation, fallback handling, polling, refresh timing, and action completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->