### PR TITLE
Windows shell: title bar overlay height, sidebar spacer, quiet background update checks

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -23,10 +23,11 @@ let serverProc = null;
 let serverReady = true;
 
 // The packaged app has no terminal: everything about the server child's life
-// goes to ~/Library/Logs/OpenMausBot/server.log (Console.app-visible), which
-// is also why stdio is piped, not inherited — under a Finder launch the
+// goes to server.log in the OS log dir (~/Library/Logs/OpenMausBot on macOS,
+// Console.app-visible; %APPDATA%\OpenMausBot\logs on Windows), which is also
+// why stdio is piped, not inherited — under a Finder/Explorer launch the
 // parent's stdio leads nowhere and a failed boot is otherwise undiagnosable.
-const LOG_DIR = path.join(app.getPath("home"), "Library", "Logs", "OpenMausBot");
+const LOG_DIR = app.getPath("logs");
 let logStream = null;
 function slog(line) {
   try {
@@ -103,7 +104,7 @@ async function startServerPackaged() {
 const ERROR_PAGE =
   "data:text/html;charset=utf-8," +
   encodeURIComponent(
-    `<body style="margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#070707;color:#fcfcfc;font:15px -apple-system,system-ui"><div style="text-align:center;max-width:360px"><div style="font-size:40px">🐭</div><h2 style="font-weight:600;margin:12px 0 6px">Couldn't start the bot server</h2><p style="color:#fcfcfc99;line-height:1.5">Something else is using its ports. Quit and reopen OpenMausBot — if it keeps happening, restart your Mac.</p></div></body>`,
+    `<body style="margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#070707;color:#fcfcfc;font:15px -apple-system,system-ui"><div style="text-align:center;max-width:360px"><div style="font-size:40px">🐭</div><h2 style="font-weight:600;margin:12px 0 6px">Couldn't start the bot server</h2><p style="color:#fcfcfc99;line-height:1.5">Something else is using its ports. Quit and reopen OpenMausBot — if it keeps happening, restart your computer.</p></div></body>`,
   );
 
 function createWindow() {
@@ -122,7 +123,11 @@ function createWindow() {
       ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 16 } }
       : {
           titleBarStyle: "hidden",
-          titleBarOverlay: { color: "#070707", symbolColor: "#b5b5b5", height: 40 },
+          // height MUST match the ChatView/GroupView header strip (px-5 py-3
+          // around a 36px control row = 60). Windows draws the caption buttons
+          // to fill the overlay, so anything shorter leaves a dead band under
+          // them and anything taller overhangs the header.
+          titleBarOverlay: { color: "#070707", symbolColor: "#b5b5b5", height: 60 },
         }),
     webPreferences: {
       contextIsolation: true,

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -16,6 +16,12 @@ let autoUpdater = null;
 let win = null;
 // status: idle | checking | available | downloading | downloaded | error
 let state = { status: "idle" };
+// Whether the in-flight check came from the user's button. Background checks
+// fail for reasons that are none of the user's business — no feed published
+// for this platform yet, offline, a GitHub blip — and a popup for those on
+// every launch is pure noise. Only a check the user asked for may surface an
+// error; automatic ones fall back to idle.
+let userInitiated = false;
 
 function setState(patch) {
   state = { ...state, ...patch };
@@ -26,18 +32,24 @@ function setState(patch) {
   }
 }
 
-function check() {
+function check(manual = false) {
   if (!autoUpdater) return;
+  userInitiated = manual;
   try {
     autoUpdater.checkForUpdates();
   } catch (e) {
-    setState({ status: "error", message: String(e?.message ?? e) });
+    reportError(e);
   }
+}
+
+function reportError(e) {
+  if (!userInitiated) return setState({ status: "idle" });
+  setState({ status: "error", message: String(e?.message ?? e) });
 }
 
 export function registerUpdaterIpc() {
   ipcMain.handle("update:get-state", () => state);
-  ipcMain.handle("update:check", () => check());
+  ipcMain.handle("update:check", () => check(true));
   ipcMain.handle("update:download", () => {
     try {
       autoUpdater?.downloadUpdate();
@@ -83,9 +95,11 @@ export function startUpdater(mainWindow) {
   autoUpdater.on("update-downloaded", (info) =>
     setState({ status: "downloaded", version: info?.version }),
   );
-  autoUpdater.on("error", (e) => setState({ status: "error", message: String(e?.message ?? e) }));
+  autoUpdater.on("error", reportError);
 
-  // first check ~15s after launch (let the app settle), then hourly
-  setTimeout(check, 15_000).unref?.();
-  setInterval(check, 60 * 60 * 1000).unref?.();
+  // first check ~15s after launch (let the app settle), then hourly — both
+  // silent on failure, hence the arrow: a bare `check` would receive the
+  // timer's argument as `manual` and start reporting errors again.
+  setTimeout(() => check(), 15_000).unref?.();
+  setInterval(() => check(), 60 * 60 * 1000).unref?.();
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -492,7 +492,10 @@ export function Sidebar() {
         style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
       >
         {isElectron ? (
-          <div className="w-14" />
+          // Reserves room for the macOS traffic lights. Windows has nothing on
+          // the left — its caption buttons overlay the chat header top-right —
+          // so reserving 56px there is just a blank gap.
+          <div className={window.ogb?.platform === "win32" ? "" : "w-14"} />
         ) : (
           <div className="flex items-center gap-2">
             <span className="size-3 rounded-full bg-[#ff5f57]" />

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -6,6 +6,19 @@ import { useState } from "react";
 import { ArrowDownToLine, RefreshCw, Sparkles, X } from "lucide-react";
 import { useUpdaterState } from "@/lib/updater";
 
+// electron-updater surfaces failures as a whole HTTP dump — status line,
+// every response header, stack trace. That is unreadable in a 300px popup,
+// so name the two cases that actually happen and clip anything else to its
+// first line.
+function friendlyError(message?: string): string {
+  if (!message) return "Something went wrong.";
+  if (/cannot find .*\.yml|404/i.test(message))
+    return "No update has been published for this platform yet.";
+  if (/ENOTFOUND|ECONNREFUSED|ETIMEDOUT|net::/i.test(message))
+    return "Couldn't reach the update server.";
+  return message.split("\n")[0].slice(0, 140);
+}
+
 export function UpdateBanner() {
   const s = useUpdaterState();
   // dismissal is per status+version, so the popup returns for the next
@@ -31,7 +44,7 @@ export function UpdateBanner() {
         ? `${Math.round(s.percent ?? 0)}%`
         : s.status === "downloaded"
           ? "Restart to finish updating."
-          : (s.message ?? "Something went wrong.");
+          : friendlyError(s.message);
 
   return (
     <div className="animate-panel-in fixed bottom-4 left-4 z-50 w-[300px] rounded-xl border border-hairline/40 bg-panel p-3.5 shadow-2xl shadow-black/50">


### PR DESCRIPTION
Three Windows-only papercuts found while testing the first packaged Windows build (`pnpm package:win`, installed and run on Windows 10).

## Title bar overlay left a dead band

`titleBarOverlay` declared `height: 40`, but the ChatView/GroupView header is **60px** (`px-5 py-3` = 24px padding around a 36px control row). Windows fills the overlay region with its caption buttons, so it painted a 40px strip and left a 20px band of nothing underneath — inside the space `pr-[148px]` had already cleared for it.

Measured on the running app at 125% scale: buttons occupied y `0–50` physical (= 40 logical) while the header content centred at y `37` physical (= 30 logical).

## Sidebar reserved space for traffic lights that aren't there

`Sidebar.tsx` rendered a 56px `w-14` spacer for the macOS traffic lights whenever running under Electron — Windows included, where there is nothing on the left at all, since the caption buttons overlay the chat header top-right. Now macOS-only.

## Background update checks popped an error card

The updater checks 15s after launch and hourly, unprompted. Those checks fail for reasons the user can't act on — no feed published for the platform yet, offline, a GitHub blip — and each failure raised a popup.

Dismissing it didn't help across relaunches: dismissal is component state, so every launch mounted a clean component, checked, failed, and popped the card again. Persisting the dismissal would have papered over the real problem, which is that an unprompted background check has no business raising a user-facing error at all.

Errors now surface only for checks the user explicitly asked for via the button; automatic ones fall back to `idle`.

> Both timers use `() => check()` deliberately. Passing `check` bare would hand the timer's argument in as `manual` and start reporting background errors again.

The message itself was the raw electron-updater HTTP dump — every response header, the stack, and a misleading "double check that your authentication token is correct" line when the actual cause is a missing file. `friendlyError` now names the two cases that occur in practice and clips anything else to its first line.

## Testing

- `pnpm typecheck` clean
- `pnpm package:win` builds; installer verified to contain `resources/server/index.js`, `resources/ui/index.html`, and an `app-update.yml` with no `publisherName` (required while the build is unsigned, or electron-updater rejects every update as untrusted)
- Installed and launched on Windows 10

Nothing here touches macOS behaviour: the overlay is inside the existing `isMac` ternary, the spacer is now explicitly `win32`-gated, and the updater changes are platform-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update error messages for missing releases, network issues, and other failures.
  - Manual update checks now report errors clearly, while automatic checks remain unobtrusive.
  - Updated server-start failure guidance to recommend restarting the computer.

- **Improvements**
  - Packaged-app logs are now stored in the appropriate operating-system log directory.
  - Improved Windows title-bar sizing and sidebar spacing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->