### PR TITLE
Bump version to 0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "electron/main.mjs",
   "engines": {


### PR DESCRIPTION
Cuts 0.1.15, the first version published for Windows.

Contents beyond 0.1.14 are the two merged Windows PRs:

- #71 — title bar overlay height, sidebar traffic-light spacer, quiet background update checks
- #72 — Windows download links, the release runbook, packaging notes

## Platform state at this version

**Windows ships at 0.1.15.** The macOS dmg is not being rebuilt right now, so macOS users stay on 0.1.14 and will not be offered an update.

That is correct behaviour rather than a gap: the two platforms read different metadata files from the release (`latest-mac.yml` and `latest.yml`), so a release carrying only `latest.yml` is invisible to macOS. Nothing strands mac users — they keep resolving against the 0.1.14 feed until a dmg is attached.

The runbook added in #72 asks that both platforms ship together, and this deliberately doesn't. Worth attaching the mac artifacts to the same `v0.1.15` tag when convenient, so the version means one codebase everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->