### PR TITLE
Give ACP bots their computer (grok, gemini, antigravity)

### DIFF
--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -13,7 +13,10 @@
 // is never a security contract). session/load REPLAYS history as ordinary
 // session/update notifications, so updates are double-gated: nothing emits
 // before the prompt is sent, and `_meta.isReplay` updates are dropped.
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { execCli, killCliTree, spawnCli } from "../../procs.ts";
 
@@ -28,6 +31,13 @@ import type {
 } from "../../contracts.ts";
 import { newEventId, newId } from "../../contracts.ts";
 import { augmentedPath } from "../../env-path.ts";
+
+// the computer proxy entry: .ts in dev (node type stripping), .js in the
+// compiled dist-server the packaged app ships
+const COMPUTER_PROXY_PATH = (() => {
+  const ts = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "computer-proxy.ts");
+  return existsSync(ts) ? ts : ts.replace(/\.ts$/, ".js");
+})();
 import { appendNative } from "../native.ts";
 
 export interface AcpConfig {
@@ -131,13 +141,34 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
       // fine here. env is the ACP {name,value}[] shape.
       const acpMcpServers = (turn: SendTurnInput) => {
         const servers: Array<{ name: string; command: string; args: string[]; env: Array<{ name: string; value: string }> }> = [];
+        const acpEnv = (env: Record<string, string>) =>
+          Object.entries(env).map(([name, value]) => ({ name, value: String(value) }));
         const agents = turn.integrations?.agents;
         if (agents) {
+          servers.push({ name: "agents", command: agents.command, args: agents.args, env: acpEnv(agents.env) });
+        }
+        // the bot's computer, mounted exactly like the claude driver does:
+        // an ACP agent gets the same screenshot/click/batch tools instead of
+        // being told it has a machine it cannot touch
+        const computer = turn.integrations?.computer;
+        if (computer) {
           servers.push({
-            name: "agents",
-            command: agents.command,
-            args: agents.args,
-            env: Object.entries(agents.env).map(([name, value]) => ({ name, value: String(value) })),
+            name: "computer",
+            command: process.execPath,
+            args: [COMPUTER_PROXY_PATH],
+            env: acpEnv({
+              ELECTRON_RUN_AS_NODE: "1",
+              OGB_BOX_ID: computer.boxId,
+              OGB_BOX_TOKEN: computer.token,
+            }),
+          });
+        } else if (turn.integrations?.localComputer) {
+          const local = turn.integrations.localComputer;
+          servers.push({
+            name: "computer",
+            command: local.command,
+            args: local.args,
+            env: acpEnv(local.env ?? {}),
           });
         }
         return servers;
@@ -478,7 +509,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         snapshot,
         adapter: {
           provider: DRIVER_KIND,
-          capabilities: { sessionModelSwitch: "unsupported", agentsMcp: true },
+          capabilities: { sessionModelSwitch: "unsupported", agentsMcp: true, computerMcp: true },
           sendTurn,
           interruptTurn: async (threadId) => active.get(threadId)?.interrupt(),
           respondToRequest: async (threadId, requestId, decision) => {


### PR DESCRIPTION
### What was wrong

A bot running on an ACP engine — **grok, gemini, antigravity** — was told in its system prompt that it has a cloud computer, but the driver never mounted the computer tools. `screenshot`, `click`, `type_text`, `computer_batch` and friends simply didn't exist for it.

You can watch it happen: asked to open Chrome on its VM, the bot searches for a tool that isn't there, then calls `agents__list_bots` — it's hunting for a *teammate* who has a computer, because it can't find one on itself.

Only `server/drivers/claude.ts` mounted `computer-proxy`. The ACP core mounted exactly one MCP server, `agents`.

### The fix

`acpMcpServers()` now mounts the computer proxy the same way the claude driver does — same `computer` name, same entry file, box id and token passed through the env (ACP's `{name, value}[]` shape). The local "this Mac" path is mounted the same way for parity.

The driver declares `computerMcp: true`, so the harness attaches the box **and** the "you have your own cloud computer" prompt only to engines that can actually act on one — the capability gate added in 0.1.15.

### Notes

- The user's grok bot already has an idle box provisioned, so this is the only thing standing between it and its VM.
- Every computer-use improvement from 0.1.15 comes along for free on these engines: one round trip per action, JPEG frames, `computer_batch`, and waking an archived box.
- Typecheck clean, 107 tests pass. Not yet driven end-to-end on an ACP engine against a live box — worth one manual run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added computer integration support through the ACP MCP server.
  * Enabled compatibility with both remote and local computer connections.
  * Provider capabilities now indicate computer MCP support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->