### PR TITLE
Tasks: give a bot more than one context

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -418,6 +418,8 @@ async function startTurn(
   if (!bot) throw Object.assign(new Error("no such bot"), { status: 404 });
   if (bot.busy) throw Object.assign(new Error("the bot is already working — interrupt it first"), { status: 409 });
   const commsDepth = opts?.commsDepth ?? 0;
+  // a task takes its name from the first thing you asked it to do
+  if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text);
 
   const instance = registry.get(bot.modelSelection.instanceId);
   if (!instance) {
@@ -544,7 +546,9 @@ async function startTurn(
         text: turnText,
         model: bot.modelSelection.model,
         // a rewound thread never resumes the abandoned branch's session
-        resumeCursor: rewound ? undefined : bot.resumeCursors[bot.modelSelection.instanceId],
+        // the active task's own session — another task's cursor would
+        // resume the wrong conversation and defeat the context bubble
+        resumeCursor: rewound ? undefined : store.activeTask(bot.id)?.resumeCursors[bot.modelSelection.instanceId],
         transcript,
         system:
           persona +
@@ -919,6 +923,7 @@ const server = createServer(async (req, res) => {
           ...b,
           messages: store.messagesFor(b.threadId),
           activeLeafId: store.activeLeaf(b.threadId),
+          tasks: (b.tasks ?? []).map(({ resumeCursors, ...t }) => t),
         })),
         groups: store.groups.map((g) => ({ ...g, messages: store.messagesFor(g.threadId) })),
       });
@@ -1164,6 +1169,57 @@ const server = createServer(async (req, res) => {
       const instance = registry.get(bot.modelSelection.instanceId);
       await instance?.adapter.interruptTurn(bot.threadId);
       return json(res, 200, { ok: true });
+    }
+
+    // ── tasks: a bot's separate contexts ────────────────────────────────
+    // The bot record answers with its messages because switching tasks
+    // changes which transcript is live, and a partial patch would leave
+    // the client showing the previous task's conversation.
+    const botWithThread = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
+      ...bot,
+      messages: store.messagesFor(bot.threadId),
+      activeLeafId: store.activeLeaf(bot.threadId),
+      tasks: store.tasks(bot.id).map(({ resumeCursors, ...t }) => t),
+    });
+
+    m = path.match(/^\/api\/bots\/([\w-]+)\/tasks$/);
+    if (m && method === "POST") {
+      const bot = store.bot(m[1]);
+      if (!bot) return json(res, 404, { error: "no such bot" });
+      if (bot.busy) return json(res, 409, { error: "this bot is working — let it finish before starting a task" });
+      const body = await readBody(req);
+      const task = store.createTask(bot.id, typeof body.title === "string" ? body.title : undefined);
+      if (!task) return json(res, 500, { error: "couldn't create that task" });
+      const fresh = botWithThread(store.bot(bot.id)!);
+      broadcast({ kind: "bot", bot: fresh });
+      return json(res, 201, { bot: fresh, task });
+    }
+    m = path.match(/^\/api\/bots\/([\w-]+)\/tasks\/([\w-]+)$/);
+    if (m && method === "POST") {
+      const switched = store.switchTask(m[1], m[2]);
+      if (!switched) return json(res, 404, { error: "no such task" });
+      const fresh = botWithThread(switched);
+      broadcast({ kind: "bot", bot: fresh });
+      return json(res, 200, { bot: fresh });
+    }
+    if (m && method === "PATCH") {
+      const body = await readBody(req);
+      const task = store.renameTask(m[1], m[2], String(body.title ?? ""));
+      if (!task) return json(res, 404, { error: "no such task" });
+      const fresh = botWithThread(store.bot(m[1])!);
+      broadcast({ kind: "bot", bot: fresh });
+      return json(res, 200, { task });
+    }
+    if (m && method === "DELETE") {
+      const bot = store.bot(m[1]);
+      if (bot?.busy && bot.threadId === m[2]) {
+        return json(res, 409, { error: "this task is running — stop it first" });
+      }
+      const updated = store.deleteTask(m[1], m[2]);
+      if (!updated) return json(res, 400, { error: "a bot keeps at least one task" });
+      const fresh = botWithThread(updated);
+      broadcast({ kind: "bot", bot: fresh });
+      return json(res, 200, { bot: fresh });
     }
 
     // identity handshake for the packaged app's port fallback: the forked

--- a/server/store.ts
+++ b/server/store.ts
@@ -87,9 +87,37 @@ export interface GroupRecord {
   busyBotId?: string | null;
 }
 
+/** One task = one conversation with its own context.
+ *
+ * A bot used to be a single endless thread, which meant every job
+ * contaminated the next and the only way to get a clean slate was to
+ * clone the bot. A task is that clean slate: its own thread, its own
+ * transcript, and — the part that actually matters — its own provider
+ * session. Sharing resume cursors between tasks would resume the other
+ * task's session and quietly undo the whole thing. */
+export interface TaskRecord {
+  threadId: ThreadId;
+  title: string;
+  createdAt: number;
+  /** provider-native continuation per instance, for THIS task only */
+  resumeCursors: Record<string, unknown>;
+}
+
+/** What a task is called before its first message names it. */
+export const UNTITLED_TASK = "New task";
+
+/** A task's name, taken from the first thing you asked it to do. */
+export function titleFromMessage(text: string): string {
+  const line = text.trim().split("\n")[0]!.trim();
+  return line.length > 48 ? `${line.slice(0, 47)}…` : line || UNTITLED_TASK;
+}
+
 export interface BotRecord {
   id: string;
+  /** the ACTIVE task's thread — everything that runs a turn reads this */
   threadId: ThreadId;
+  /** every task this bot has, newest first */
+  tasks?: TaskRecord[];
   name: string;
   title: string;
   description: string;
@@ -192,6 +220,19 @@ export class Store {
     // busy never survives a restart — no turn does either
     for (const b of this.bots) b.busy = false;
     for (const g of this.groups) g.busyBotId = null;
+    // bots saved before tasks existed have one endless thread; adopt it as
+    // their first task so nothing is lost and nothing special-cases it
+    for (const b of this.bots) {
+      if (b.tasks?.length) continue;
+      b.tasks = [
+        {
+          threadId: b.threadId,
+          title: this.firstUserLine(b.threadId) ?? UNTITLED_TASK,
+          createdAt: b.createdAt,
+          resumeCursors: b.resumeCursors ?? {},
+        },
+      ];
+    }
   }
 
   private saveBots() {
@@ -414,6 +455,7 @@ export class Store {
       resumeCursors: {},
       createdAt: Date.now(),
     };
+    bot.tasks = [{ threadId: bot.threadId, title: UNTITLED_TASK, createdAt: bot.createdAt, resumeCursors: {} }];
     this.bots.unshift(bot);
     this.saveBots();
     this.appendMessage(bot.threadId, {
@@ -429,11 +471,14 @@ export class Store {
     const bot = this.bot(id);
     if (!bot) return false;
     this.bots = this.bots.filter((b) => b.id !== id);
-    this.threads.delete(bot.threadId);
+    // every task's transcript goes with the bot, not just the open one
+    for (const threadId of new Set([bot.threadId, ...(bot.tasks ?? []).map((t) => t.threadId)])) {
+      this.threads.delete(threadId);
+      try {
+        unlinkSync(messagesFile(threadId));
+      } catch {}
+    }
     this.saveBots();
-    try {
-      unlinkSync(messagesFile(bot.threadId));
-    } catch {}
     return true;
   }
 
@@ -448,8 +493,89 @@ export class Store {
   setResumeCursor(botId: string, instanceId: string, cursor: unknown) {
     const bot = this.bot(botId);
     if (!bot) return;
-    bot.resumeCursors[instanceId] = cursor;
+    // the cursor belongs to the task that produced it, not to the bot
+    const task = this.activeTask(botId);
+    if (task) task.resumeCursors[instanceId] = cursor;
+    bot.resumeCursors[instanceId] = cursor; // legacy mirror
     this.saveBots();
+  }
+
+  // ── tasks ─────────────────────────────────────────────────────────────
+  /** The first thing the human asked in a thread — a task's natural name. */
+  private firstUserLine(threadId: string): string | null {
+    const first = this.messagesFor(threadId).find((m) => m.role === "user" && m.kind === "text" && m.text?.trim());
+    return first?.text ? titleFromMessage(first.text) : null;
+  }
+
+  tasks(botId: string): TaskRecord[] {
+    return this.bot(botId)?.tasks ?? [];
+  }
+
+  activeTask(botId: string): TaskRecord | undefined {
+    const bot = this.bot(botId);
+    return bot?.tasks?.find((t) => t.threadId === bot.threadId);
+  }
+
+  /** A fresh context on the same bot: new thread, new session, same
+   * persona/tools/computer. Becomes the active task. */
+  createTask(botId: string, title?: string): TaskRecord | null {
+    const bot = this.bot(botId);
+    if (!bot) return null;
+    const task: TaskRecord = {
+      threadId: newId(),
+      title: title?.trim() || UNTITLED_TASK,
+      createdAt: Date.now(),
+      resumeCursors: {},
+    };
+    bot.tasks = [task, ...(bot.tasks ?? [])];
+    bot.threadId = task.threadId;
+    bot.resumeCursors = {}; // legacy mirror follows the active task
+    this.saveBots();
+    return task;
+  }
+
+  switchTask(botId: string, threadId: string): BotRecord | null {
+    const bot = this.bot(botId);
+    const task = bot?.tasks?.find((t) => t.threadId === threadId);
+    if (!bot || !task) return null;
+    bot.threadId = task.threadId;
+    bot.resumeCursors = { ...task.resumeCursors };
+    this.saveBots();
+    return bot;
+  }
+
+  renameTask(botId: string, threadId: string, title: string): TaskRecord | null {
+    const task = this.bot(botId)?.tasks?.find((t) => t.threadId === threadId);
+    if (!task) return null;
+    task.title = title.trim().slice(0, 80) || UNTITLED_TASK;
+    this.saveBots();
+    return task;
+  }
+
+  /** Name a task after its first message, once. */
+  titleTaskFromFirstMessage(botId: string, text: string) {
+    const task = this.activeTask(botId);
+    if (!task || task.title !== UNTITLED_TASK) return;
+    task.title = titleFromMessage(text);
+    this.saveBots();
+  }
+
+  /** Delete a task and its transcript. A bot always keeps one. */
+  deleteTask(botId: string, threadId: string): BotRecord | null {
+    const bot = this.bot(botId);
+    if (!bot || !bot.tasks || bot.tasks.length < 2) return null;
+    if (!bot.tasks.some((t) => t.threadId === threadId)) return null;
+    bot.tasks = bot.tasks.filter((t) => t.threadId !== threadId);
+    this.threads.delete(threadId);
+    try {
+      unlinkSync(messagesFile(threadId));
+    } catch {}
+    if (bot.threadId === threadId) {
+      bot.threadId = bot.tasks[0]!.threadId;
+      bot.resumeCursors = { ...bot.tasks[0]!.resumeCursors };
+    }
+    this.saveBots();
+    return bot;
   }
 
   /** First-run seed: one bot so the app never opens empty — it gets a

--- a/server/tasks.test.ts
+++ b/server/tasks.test.ts
@@ -1,0 +1,117 @@
+// Tasks: a bot's separate contexts.
+//
+// The load-bearing property is isolation — each task keeps its own
+// transcript AND its own provider session. If resume cursors leaked
+// between tasks, a "fresh" task would silently resume the previous
+// conversation, which is the exact thing tasks exist to prevent.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+let home: string;
+
+async function freshStore() {
+  home = mkdtempSync(join(tmpdir(), "omb-tasks-"));
+  vi.resetModules();
+  vi.stubEnv("HOME", home);
+  vi.stubEnv("USERPROFILE", home);
+  const { Store, UNTITLED_TASK, titleFromMessage } = await import("./store.ts");
+  return { store: new Store(() => ({ instanceId: "claude", model: "m" })), UNTITLED_TASK, titleFromMessage };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("tasks", () => {
+  it("gives every new bot one task pointing at its thread", async () => {
+    const { store, UNTITLED_TASK } = await freshStore();
+    const bot = store.createBot();
+    expect(store.tasks(bot.id)).toHaveLength(1);
+    expect(store.activeTask(bot.id)).toMatchObject({ threadId: bot.threadId, title: UNTITLED_TASK });
+  });
+
+  it("starts a new task on a fresh thread and makes it active", async () => {
+    const { store } = await freshStore();
+    const bot = store.createBot();
+    const firstThread = bot.threadId;
+    const task = store.createTask(bot.id)!;
+
+    expect(task.threadId).not.toBe(firstThread);
+    expect(store.bot(bot.id)!.threadId).toBe(task.threadId);
+    expect(store.tasks(bot.id).map((t) => t.threadId)).toEqual([task.threadId, firstThread]);
+    // a brand new context: nothing carried over from the greeting thread
+    expect(store.messagesFor(task.threadId)).toHaveLength(0);
+    expect(store.messagesFor(firstThread).length).toBeGreaterThan(0);
+  });
+
+  it("keeps provider sessions apart — the whole point of a task", async () => {
+    const { store } = await freshStore();
+    const bot = store.createBot();
+    const first = bot.threadId;
+    store.setResumeCursor(bot.id, "claude", "session-one");
+
+    const second = store.createTask(bot.id)!;
+    // the new task must NOT inherit the old session
+    expect(store.activeTask(bot.id)!.resumeCursors.claude).toBeUndefined();
+    store.setResumeCursor(bot.id, "claude", "session-two");
+
+    store.switchTask(bot.id, first);
+    expect(store.activeTask(bot.id)!.resumeCursors.claude).toBe("session-one");
+    store.switchTask(bot.id, second.threadId);
+    expect(store.activeTask(bot.id)!.resumeCursors.claude).toBe("session-two");
+  });
+
+  it("names a task after the first thing you asked it", async () => {
+    const { store, UNTITLED_TASK, titleFromMessage } = await freshStore();
+    const bot = store.createBot();
+    store.createTask(bot.id);
+    expect(store.activeTask(bot.id)!.title).toBe(UNTITLED_TASK);
+
+    store.titleTaskFromFirstMessage(bot.id, "Audit the payroll spreadsheet\nand flag anything odd");
+    expect(store.activeTask(bot.id)!.title).toBe("Audit the payroll spreadsheet");
+
+    // only the first message names it
+    store.titleTaskFromFirstMessage(bot.id, "something else entirely");
+    expect(store.activeTask(bot.id)!.title).toBe("Audit the payroll spreadsheet");
+    expect(titleFromMessage("x".repeat(80))).toHaveLength(48);
+  });
+
+  it("deletes a task with its transcript, but never the last one", async () => {
+    const { store } = await freshStore();
+    const bot = store.createBot();
+    const first = bot.threadId;
+    const second = store.createTask(bot.id)!;
+    store.appendMessage(second.threadId, { role: "user", kind: "text", text: "secret" });
+
+    expect(store.deleteTask(bot.id, second.threadId)).toBeTruthy();
+    expect(store.tasks(bot.id)).toHaveLength(1);
+    // deleting the ACTIVE task falls back to one that still exists
+    expect(store.bot(bot.id)!.threadId).toBe(first);
+    expect(store.messagesFor(second.threadId)).toHaveLength(0);
+
+    expect(store.deleteTask(bot.id, first)).toBeNull();
+    expect(store.tasks(bot.id)).toHaveLength(1);
+  });
+
+  it("adopts a pre-tasks bot's endless thread as its first task", async () => {
+    const { store, UNTITLED_TASK } = await freshStore();
+    const bot = store.createBot();
+    store.appendMessage(bot.threadId, { role: "user", kind: "text", text: "Plan the offsite" });
+    // simulate a record saved before tasks existed
+    const legacy = store.bot(bot.id)!;
+    delete (legacy as { tasks?: unknown }).tasks;
+    // patchBot persists, so what lands on disk is the pre-tasks shape
+    store.patchBot(bot.id, { resumeCursors: { claude: "old-session" } });
+
+    const { Store } = await import("./store.ts");
+    const reloaded = new Store(() => ({ instanceId: "claude", model: "m" }));
+    const migrated = reloaded.tasks(bot.id);
+    expect(migrated).toHaveLength(1);
+    expect(migrated[0]).toMatchObject({ threadId: bot.threadId, resumeCursors: { claude: "old-session" } });
+    // and it is named from the conversation rather than left blank
+    expect(migrated[0]!.title).not.toBe(UNTITLED_TASK);
+  });
+});

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -23,6 +23,7 @@ import { OptionCard } from "./OptionCard";
 import { ApprovalCard } from "./ApprovalCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
+import { TaskPicker } from "./TaskPicker";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { cn } from "@/lib/cn";
 
@@ -645,6 +646,7 @@ export function ChatView({ bot }: { bot: Bot }) {
               Stop
             </button>
           )}
+          <TaskPicker bot={bot} />
           <ModelPicker bot={bot} />
           <button
             onClick={() => dispatch({ type: "toggleComputer" })}

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -1,0 +1,136 @@
+// A bot's tasks: separate contexts on the same bot.
+//
+// One endless thread per bot means every job contaminates the next, and
+// the only clean slate is a second bot. A task is a real boundary — its
+// own transcript and its own provider session — so sensitive work, a
+// long job and a quick question can sit side by side under one agent.
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Plus, Trash2 } from "lucide-react";
+import { useStore, formatTime, type Bot } from "@/state/store";
+import { cn } from "@/lib/cn";
+
+export function TaskPicker({ bot }: { bot: Bot }) {
+  const { dispatch } = useStore();
+  const [open, setOpen] = useState(false);
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+
+  const tasks = bot.tasks ?? [];
+  const current = tasks.find((t) => t.threadId === bot.threadId);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // a bot that has only ever done one thing doesn't need a switcher yet —
+  // just the button that gives it a second context
+  if (tasks.length <= 1) {
+    return (
+      <button
+        onClick={() => dispatch({ type: "newTask", botId: bot.id })}
+        disabled={bot.busy}
+        title={bot.busy ? "Let this turn finish first" : "New task — a fresh context on this bot"}
+        className="flex items-center gap-1 rounded-full border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40"
+      >
+        <Plus size={12} /> Task
+      </button>
+    );
+  }
+
+  const commitRename = (threadId: string) => {
+    const title = draft.trim();
+    setRenaming(null);
+    if (title) dispatch({ type: "renameTask", botId: bot.id, threadId, title });
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="Switch task"
+        className="flex max-w-[220px] items-center gap-1.5 rounded-full border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink"
+      >
+        <span className="truncate">{current?.title ?? "Task"}</span>
+        <span className="shrink-0 tabular-nums opacity-60">{tasks.length}</span>
+        <ChevronDown size={12} className="shrink-0" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-40 mt-1 w-[300px] overflow-hidden rounded-xl border border-hairline/50 bg-card py-1 shadow-2xl shadow-black/50">
+          <div className="max-h-[320px] overflow-y-auto">
+            {tasks.map((task) => {
+              const active = task.threadId === bot.threadId;
+              return (
+                <div
+                  key={task.threadId}
+                  className={cn("group flex items-center gap-2 px-2.5 py-2", active ? "bg-raised/60" : "hover:bg-raised/40")}
+                >
+                  <Check size={13} className={cn("shrink-0", active ? "text-accent" : "opacity-0")} />
+                  {renaming === task.threadId ? (
+                    <input
+                      autoFocus
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      onBlur={() => commitRename(task.threadId)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename(task.threadId);
+                        if (e.key === "Escape") setRenaming(null);
+                      }}
+                      className="min-w-0 flex-1 rounded bg-inset px-1.5 py-0.5 text-[13px] text-ink focus:outline-none"
+                    />
+                  ) : (
+                    <button
+                      onClick={() => {
+                        if (!active) dispatch({ type: "switchTask", botId: bot.id, threadId: task.threadId });
+                        setOpen(false);
+                      }}
+                      onDoubleClick={() => {
+                        setDraft(task.title);
+                        setRenaming(task.threadId);
+                      }}
+                      className="min-w-0 flex-1 text-left"
+                      title="Click to switch · double-click to rename"
+                    >
+                      <div className="truncate text-[13px] text-ink">{task.title}</div>
+                      <div className="text-[11px] text-ink-secondary">{formatTime(task.createdAt)}</div>
+                    </button>
+                  )}
+                  <button
+                    onClick={() => dispatch({ type: "deleteTask", botId: bot.id, threadId: task.threadId })}
+                    disabled={bot.busy && active}
+                    aria-label="Delete task"
+                    title="Delete this task and its conversation"
+                    className="rounded p-1 text-ink-secondary opacity-0 hover:bg-raised hover:text-danger group-hover:opacity-100 disabled:opacity-20"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          <button
+            onClick={() => {
+              dispatch({ type: "newTask", botId: bot.id });
+              setOpen(false);
+            }}
+            disabled={bot.busy}
+            className="mt-1 flex w-full items-center gap-2 border-t border-hairline/40 px-3 py-2 text-left text-[13px] text-ink hover:bg-raised/50 disabled:opacity-40"
+          >
+            <Plus size={13} className="text-ink-secondary" /> New task
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -75,9 +75,19 @@ export interface ModelSelection {
   model: string;
 }
 
+/** One of a bot's separate contexts: its own thread, transcript and
+ * provider session. The bot's threadId points at the active one. */
+export interface Task {
+  threadId: string;
+  title: string;
+  createdAt: number;
+}
+
 export interface Bot {
   id: string;
   threadId: string;
+  /** every context this bot has, newest first */
+  tasks?: Task[];
   name: string;
   title: string;
   description: string;
@@ -204,6 +214,10 @@ type Action =
       /** remember this exact grant (the server's allowKey) for the bot */
       alwaysAllow?: { botId: string; key: string };
     }
+  | { type: "newTask"; botId: string }
+  | { type: "switchTask"; botId: string; threadId: string }
+  | { type: "renameTask"; botId: string; threadId: string; title: string }
+  | { type: "deleteTask"; botId: string; threadId: string }
   | { type: "newBot" }
   | { type: "botAdded"; bot: Bot }
   | { type: "deleteBot"; botId: string }
@@ -523,6 +537,11 @@ function reducer(state: AppState, action: Action): AppState {
     case "send":
     case "editMessage":
       return withMascotMotion(state, action.botId, "working");
+    case "newTask":
+    case "switchTask":
+    case "renameTask":
+    case "deleteTask":
+      return state;
     case "newBot":
     case "duplicateBot":
     case "interrupt":
@@ -821,6 +840,29 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
         case "interrupt":
           api(`/api/bots/${action.botId}/interrupt`, { method: "POST" }).catch(showError);
+          break;
+        // tasks: the server answers with the bot AND the live transcript,
+        // because switching changes which conversation is on screen
+        case "newTask":
+          api(`/api/bots/${action.botId}/tasks`, { method: "POST", body: "{}" })
+            .then((r: any) => r?.bot && dispatch({ type: "botPatched", bot: r.bot }))
+            .catch(showError);
+          break;
+        case "switchTask":
+          api(`/api/bots/${action.botId}/tasks/${action.threadId}`, { method: "POST" })
+            .then((r: any) => r?.bot && dispatch({ type: "botPatched", bot: r.bot }))
+            .catch(showError);
+          break;
+        case "renameTask":
+          api(`/api/bots/${action.botId}/tasks/${action.threadId}`, {
+            method: "PATCH",
+            body: JSON.stringify({ title: action.title }),
+          }).catch(showError);
+          break;
+        case "deleteTask":
+          api(`/api/bots/${action.botId}/tasks/${action.threadId}`, { method: "DELETE" })
+            .then((r: any) => r?.bot && dispatch({ type: "botPatched", bot: r.bot }))
+            .catch(showError);
           break;
         case "interruptGroup":
           api(`/api/groups/${action.groupId}/interrupt`, { method: "POST" }).catch(showError);


### PR DESCRIPTION
A bot was one endless thread. Every job contaminated the next, there was no point where a task began or ended, and the only way to get a clean slate — or keep sensitive work out of the rest of the conversation — was to clone the bot.

This is the gap a reviewer put their finger on when comparing this shape of app to thread-first tools: *"every agent uses a single long-running thread… if I'm working with sensitive data, this forces me to create copies of the same agent so I can force context bubbles."*

### What a task is

Its own thread, its own transcript, and — the part that makes it real — **its own provider session**. Sharing resume cursors between tasks would silently resume the previous conversation and undo the isolation the feature exists to provide. There's a test for exactly that.

### Shape

- Each bot keeps a list of tasks, newest first. `bot.threadId` points at the active one, so every code path that runs a turn is unchanged.
- **New task · switch · rename** (double-click) **· delete**, from a picker beside the model picker. A bot with a single task shows only a small `+ Task` button, so nothing new appears until you want it.
- A task takes its **name from the first thing you ask it**.
- Bots saved before this adopt their endless thread as task one, named from its first message, keeping its session — nothing is lost and nothing special-cases them.
- Deleting a bot now removes *every* task's transcript, not just the open one. A bot always keeps at least one task.

### Deliberately not in scope

Turns stay one-at-a-time per bot. The composer already queues a message while a bot is working, which covers "I don't want to interrupt a long job"; running two tasks of the same bot **in parallel** is a bigger change (per-task busy state, concurrent CLI processes, interrupt semantics) and deserves its own PR.

### Verification

`pnpm typecheck` clean, production build clean, **159 tests pass** (6 new). The new `server/tasks.test.ts` pins isolation both ways, auto-titling, delete-with-transcript, never-delete-the-last, and the migration of a pre-tasks bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple tasks within each bot.
  * Create, switch, rename, and delete tasks from the chat header.
  * Task conversations maintain separate context and transcripts.
  * Tasks are automatically titled from the first message when available.
  * Added task metadata and compact controls for bots with a single task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->