### PR TITLE
Settings as a modal with sections, and a local computer you can set up

### DIFF
--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -1,0 +1,110 @@
+// A computer your bots can use, running on this machine in a container.
+//
+// The cloud box needs a paid plan, and the "This Mac" path points an agent
+// at the desktop the human is using. A container sits between them: free,
+// disposable, and isolated from the user's files — and it runs the same
+// X11 desktop our computer tools already speak (xdotool + scrot), so the
+// tool layer doesn't change, only where the commands run.
+//
+// This module is deliberately read-only. It reports what is installed and
+// never installs anything on someone's machine.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { augmentedPath } from "./env-path.ts";
+
+const run = promisify(execFile);
+
+/** The desktop image. Anthropic's computer-use demo image is the one whose
+ * toolchain matches our shell exactly — it ships xdotool, scrot and
+ * imagemagick — and it is MIT, with an arm64 build as well as x86. */
+export const IMAGE = "ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest";
+export const CONTAINER = "openmausbot-computer";
+
+/** Runtimes we can drive, best-known first. Docker is listed because most
+ * people already have it, NOT because we recommend installing it: its
+ * licence requires payment above 250 employees or $10M revenue, and for
+ * every government user. We adapt to whatever is already there. */
+const RUNTIMES = ["docker", "podman", "container"] as const;
+export type Runtime = (typeof RUNTIMES)[number];
+
+async function sh(cmd: string, args: string[], timeout = 8000) {
+  return run(cmd, args, { timeout, env: { ...process.env, PATH: augmentedPath() } });
+}
+
+async function installed(cmd: string): Promise<boolean> {
+  try {
+    await sh(process.platform === "win32" ? "where.exe" : "/usr/bin/which", [cmd], 4000);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ContainerComputerStatus {
+  /** the runtime we will use, or null when none is installed */
+  runtime: Runtime | null;
+  /** everything we found, so the UI can say which one it picked */
+  available: Runtime[];
+  /** installed is not the same as running */
+  daemonUp: boolean;
+  image: boolean;
+  container: "running" | "stopped" | "missing";
+  image_ref: string;
+  container_name: string;
+}
+
+export async function containerComputerStatus(): Promise<ContainerComputerStatus> {
+  const available: Runtime[] = [];
+  for (const r of RUNTIMES) if (await installed(r)) available.push(r);
+  const runtime = available[0] ?? null;
+  const status: ContainerComputerStatus = {
+    runtime,
+    available,
+    daemonUp: false,
+    image: false,
+    container: "missing",
+    image_ref: IMAGE,
+    container_name: CONTAINER,
+  };
+  if (!runtime) return status;
+
+  // Docker Desktop can be installed with its VM stopped, which fails every
+  // later command in a way that reads as "broken" rather than "not started"
+  try {
+    await sh(runtime, ["info", "--format", "{{.ServerVersion}}"], 10_000);
+    status.daemonUp = true;
+  } catch {
+    return status;
+  }
+
+  try {
+    await sh(runtime, ["image", "inspect", IMAGE]);
+    status.image = true;
+  } catch {
+    /* not pulled yet */
+  }
+
+  try {
+    const { stdout } = await sh(runtime, ["inspect", "-f", "{{.State.Running}}", CONTAINER]);
+    status.container = stdout.trim() === "true" ? "running" : "stopped";
+  } catch {
+    /* no such container */
+  }
+  return status;
+}
+
+/** The commands the user is shown, built from the same constants the check
+ * above uses — so the instructions can't drift from what we look for. */
+export function setupCommands(runtime: Runtime | null) {
+  const rt = runtime ?? "docker";
+  return {
+    pull: `${rt} pull ${IMAGE}`,
+    // 6080 is the desktop in a browser, 5900 for a native VNC viewer
+    run: `${rt} run -d --name ${CONTAINER} -p 6080:6080 -p 5900:5900 ${IMAGE}`,
+    start: `${rt} start ${CONTAINER}`,
+    stop: `${rt} stop ${CONTAINER}`,
+    remove: `${rt} rm -f ${CONTAINER}`,
+    view: "http://localhost:6080/vnc.html",
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { approvalKey, autoDecision } from "./auto-approve.ts";
 import * as box from "./box.ts";
 import * as composio from "./composio.ts";
+import { containerComputerStatus, setupCommands } from "./container-computer.ts";
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
@@ -1211,6 +1212,13 @@ const server = createServer(async (req, res) => {
       const fresh = botWithThread(updated);
       broadcast({ kind: "bot", bot: fresh });
       return json(res, 200, { bot: fresh });
+    }
+
+    // what the user's machine can host: which runtime is installed, whether
+    // its daemon is up, and whether the desktop image and container exist
+    if (method === "GET" && path === "/api/local-computer") {
+      const status = await containerComputerStatus();
+      return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
     }
 
     // identity handshake for the packaged app's port fallback: the forked

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { GroupView } from "@/components/GroupView";
 import { SettingsPanel } from "@/components/SettingsPanel";
 import { PluginsPanel } from "@/components/PluginsPanel";
 import { ComputerPanel } from "@/components/ComputerPanel";
-import { AppSettingsPanel } from "@/components/AppSettingsPanel";
+import { SettingsModal } from "@/components/SettingsModal";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { DesktopCapabilitiesProvider } from "@/components/DesktopCapabilities";
 
@@ -72,7 +72,7 @@ function Shell() {
       )}
       {state.settingsOpen && bot && <SettingsPanel bot={bot} />}
       {state.computerOpen && bot && <ComputerPanel bot={bot} />}
-      {state.appSettingsOpen && <AppSettingsPanel />}
+      {state.appSettingsOpen && <SettingsModal />}
       {state.pluginsOpen && <PluginsPanel />}
       </div>
     </div>

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -1,0 +1,175 @@
+// Setting up a computer your bots can use, on your own machine.
+//
+// Not a wall of instructions: it looks at what you actually have and only
+// tells you the next thing to do. Each step reports its own state, so a
+// half-finished setup is obvious instead of mysterious.
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Check, Circle, ExternalLink, Loader2, RefreshCw } from "lucide-react";
+import { Card, CommandLine } from "./SettingsModal";
+import { cn } from "@/lib/cn";
+
+interface Status {
+  runtime: string | null;
+  available: string[];
+  daemonUp: boolean;
+  image: boolean;
+  container: "running" | "stopped" | "missing";
+  image_ref: string;
+  container_name: string;
+  commands: Record<string, string>;
+}
+
+function Step({
+  n,
+  title,
+  done,
+  children,
+}: {
+  n: number;
+  title: string;
+  done: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-3">
+      <div
+        className={cn(
+          "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-[11px]",
+          done ? "bg-success/20 text-success" : "border border-hairline/50 text-ink-secondary",
+        )}
+      >
+        {done ? <Check size={12} /> : n}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className={cn("text-[14px]", done ? "text-ink-secondary line-through" : "text-ink")}>{title}</div>
+        {!done && children && <div className="mt-2 flex flex-col gap-2">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function LocalComputerSection() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    fetch("/api/local-computer")
+      .then((r) => r.json())
+      .then(setStatus)
+      .catch(() => setStatus(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(refresh, [refresh]);
+  // while the user is following the steps in a terminal, keep up with them
+  useEffect(() => {
+    const t = setInterval(refresh, 5000);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  const c = status?.commands ?? {};
+  const ready = status?.container === "running";
+
+  return (
+    <>
+      <Card
+        title="A computer of its own"
+        subtitle="Your bots can drive a Linux desktop running on this Mac — free, disposable, and separate from your own desktop and files. It runs in a container, so nothing it does touches your machine."
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12.5px]",
+              ready ? "bg-success/15 text-success" : "bg-raised text-ink-secondary",
+            )}
+          >
+            {loading ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : ready ? (
+              <Check size={12} />
+            ) : (
+              <Circle size={9} />
+            )}
+            {loading ? "Checking…" : ready ? "Ready" : "Not set up yet"}
+          </span>
+          <button
+            onClick={refresh}
+            className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink"
+          >
+            <RefreshCw size={12} /> Re-check
+          </button>
+          {ready && (
+            <a
+              href={c.view}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink hover:bg-raised"
+            >
+              <ExternalLink size={12} /> Watch the screen
+            </a>
+          )}
+        </div>
+      </Card>
+
+      <Card title="Setup" subtitle="Run these in Terminal. This panel notices when each step is done.">
+        <div className="flex flex-col gap-4">
+          <Step n={1} title="Install a container runtime" done={Boolean(status?.runtime)}>
+            <div className="text-[13px] leading-relaxed text-ink-secondary">
+              Any of these works — we use whichever you already have. <b className="text-ink">Colima</b> and{" "}
+              <b className="text-ink">Podman</b> are free for everyone; Docker Desktop needs a paid licence for
+              companies over 250 people or $10M revenue, and for government use.
+            </div>
+            <CommandLine command="brew install colima docker && colima start" />
+          </Step>
+
+          <Step
+            n={2}
+            title={
+              status?.runtime && !status.daemonUp
+                ? `Start ${status.runtime} — it's installed but not running`
+                : "Start the runtime"
+            }
+            done={Boolean(status?.daemonUp)}
+          >
+            <CommandLine command="colima start" />
+          </Step>
+
+          <Step n={3} title="Download the desktop image (about 1 GB, once)" done={Boolean(status?.image)}>
+            <CommandLine command={c.pull ?? ""} />
+          </Step>
+
+          <Step
+            n={4}
+            title={status?.container === "stopped" ? "Start the computer again" : "Start the computer"}
+            done={status?.container === "running"}
+          >
+            <CommandLine command={status?.container === "stopped" ? (c.start ?? "") : (c.run ?? "")} />
+          </Step>
+        </div>
+      </Card>
+
+      {status && !status.runtime && (
+        <Card title="">
+          <div className="flex gap-2 text-[13px] text-ink-secondary">
+            <AlertTriangle size={15} className="mt-0.5 shrink-0 text-warning" />
+            <span>
+              No container runtime found on this machine yet. Step 1 installs one; everything after it is
+              automatic.
+            </span>
+          </div>
+        </Card>
+      )}
+
+      <Card
+        title="What this is"
+        subtitle={`The desktop image is ${status?.image_ref ?? "Anthropic's computer-use demo image"} — an MIT-licensed Linux desktop with a browser, a file manager and an editor, plus the tools a bot needs to see the screen and click. It runs as "${status?.container_name ?? "openmausbot-computer"}", and you can stop or delete it any time.`}
+      >
+        <div className="flex flex-col gap-2">
+          <CommandLine command={c.stop ?? ""} />
+          <CommandLine command={c.remove ?? ""} />
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,205 @@
+// App settings, as a real modal with sections rather than one long panel.
+// Per-bot settings (persona, model, computer) stay in SettingsPanel — this
+// is the stuff shared by every bot: who you are, your keys, and the
+// machine your bots can borrow.
+import { useEffect, useState } from "react";
+import { Check, Copy, KeyRound, Monitor, RefreshCw, User, X } from "lucide-react";
+import { useStore } from "@/state/store";
+import { ApiKeyRow } from "./ApiKeys";
+import { useUpdaterState } from "@/lib/updater";
+import { LocalComputerSection } from "./LocalComputerSection";
+import { cn } from "@/lib/cn";
+
+type SectionId = "general" | "connections" | "computer";
+
+const SECTIONS: Array<{ id: SectionId; label: string; icon: typeof User }> = [
+  { id: "general", label: "General", icon: User },
+  { id: "connections", label: "Connections", icon: KeyRound },
+  { id: "computer", label: "Local computer", icon: Monitor },
+];
+
+/** Name + email, persisted to /api/config {profile} on blur. */
+function ProfileFields() {
+  const { state, dispatch } = useStore();
+  const [name, setName] = useState(state.config?.profile?.name ?? "");
+  const [email, setEmail] = useState(state.config?.profile?.email ?? "");
+  useEffect(() => {
+    setName(state.config?.profile?.name ?? "");
+    setEmail(state.config?.profile?.email ?? "");
+  }, [state.config?.profile?.name, state.config?.profile?.email]);
+
+  const save = () => {
+    void fetch("/api/config", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profile: { name: name.trim(), email: email.trim().toLowerCase() } }),
+    })
+      .then((r) => r.json())
+      .then((config) => dispatch({ type: "configStatus", config }))
+      .catch(() => {});
+  };
+
+  const inputClass =
+    "w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none";
+  return (
+    <div className="flex flex-col gap-3">
+      <input value={name} onChange={(e) => setName(e.target.value)} onBlur={save} placeholder="Your name" className={inputClass} />
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        onBlur={save}
+        placeholder="you@example.com"
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+function UpdatesRow() {
+  const s = useUpdaterState();
+  if (!window.ogb?.updater) return null;
+  const updater = window.ogb.updater;
+  const label =
+    s?.status === "checking"
+      ? "Checking…"
+      : s?.status === "available"
+        ? `${s.version} available`
+        : s?.status === "downloading"
+          ? `Downloading ${Math.round(s.percent ?? 0)}%`
+          : s?.status === "downloaded"
+            ? `${s.version} ready — restart to apply`
+            : "You're on the latest version we know of.";
+  return (
+    <Card title="Updates" subtitle={label}>
+      <button
+        onClick={() => (s?.status === "downloaded" ? updater.install() : updater.check())}
+        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised"
+      >
+        {s?.status === "downloaded" ? "Restart and install" : "Check for updates"}
+      </button>
+    </Card>
+  );
+}
+
+export function Card({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl bg-card p-4">
+      <div className="text-[15px] font-medium text-ink">{title}</div>
+      {subtitle && <div className="mt-0.5 text-[13px] leading-relaxed text-ink-secondary">{subtitle}</div>}
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  );
+}
+
+/** A command the user is meant to run, with one-click copy. */
+export function CommandLine({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-inset px-3 py-2">
+      <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-[12px] text-ink">
+        {command}
+      </code>
+      <button
+        onClick={() => {
+          void navigator.clipboard?.writeText(command);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        }}
+        aria-label="Copy command"
+        className="shrink-0 rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+      >
+        {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+      </button>
+    </div>
+  );
+}
+
+export function SettingsModal() {
+  const { dispatch } = useStore();
+  const [section, setSection] = useState<SectionId>("general");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && dispatch({ type: "toggleAppSettings", open: false });
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [dispatch]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
+      onMouseDown={(e) => e.target === e.currentTarget && dispatch({ type: "toggleAppSettings", open: false })}
+    >
+      <div className="flex h-[560px] w-full max-w-[860px] overflow-hidden rounded-2xl border border-hairline/50 bg-panel shadow-2xl">
+        {/* section nav */}
+        <nav className="flex w-[190px] shrink-0 flex-col gap-0.5 border-r border-hairline/40 p-3">
+          <div className="px-2 pb-2 pt-1 text-[15px] font-semibold text-ink">Settings</div>
+          {SECTIONS.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              onClick={() => setSection(id)}
+              className={cn(
+                "flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[14px]",
+                section === id ? "bg-raised text-ink" : "text-ink-secondary hover:bg-raised/50 hover:text-ink",
+              )}
+            >
+              <Icon size={15} />
+              {label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center justify-between px-5 py-3">
+            <span className="text-[15px] font-semibold text-ink">
+              {SECTIONS.find((s) => s.id === section)?.label}
+            </span>
+            <button
+              onClick={() => dispatch({ type: "toggleAppSettings", open: false })}
+              aria-label="Close settings"
+              className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-5">
+            {section === "general" && (
+              <>
+                <Card title="Profile" subtitle="Shown in the sidebar. Saved as you go.">
+                  <ProfileFields />
+                </Card>
+                <UpdatesRow />
+              </>
+            )}
+
+            {section === "connections" && (
+              <Card
+                title="Keys"
+                subtitle="Shared by all bots. Saving a key reloads providers instantly; keys are stored locally and never shown again."
+              >
+                <div className="flex flex-col gap-4">
+                  <ApiKeyRow section="composio" />
+                  <ApiKeyRow section="composioApi" />
+                  <ApiKeyRow section="box" />
+                </div>
+              </Card>
+            )}
+
+            {section === "computer" && <LocalComputerSection />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { RefreshCw };


### PR DESCRIPTION
### Settings, restructured

App settings were a single long right-hand panel. They're now a **modal with a section list** — General · Connections · Local computer — so new settings have somewhere to go that isn't "make the column longer."

### The new section: a computer your bots can borrow

A Linux desktop in a container on the user's own machine. Free, disposable, and isolated from their desktop and files — the middle ground between the cloud box (needs a paid plan) and "This Mac" (points the agent at the desktop the human is using).

It runs the **same X11 desktop our computer tools already speak** (`xdotool` + `scrot`), so the tool layer doesn't change — only where the commands run. The image is Anthropic's MIT-licensed computer-use demo image, which ships exactly the binaries our shell strings call.

**It's a checklist that watches itself, not a wall of instructions.** A read-only status endpoint (`GET /api/local-computer`) reports:

- which container runtime is installed (docker / podman / apple container)
- whether its **daemon is actually up** — installed ≠ running
- whether the image has been pulled
- whether the container is running, stopped, or missing

The panel polls while you work through the steps in a terminal and ticks each one off. Verified live against a real Docker install that was *installed but stopped* — precisely the case a naive `which docker` would call "ready" and then fail two steps later.

### Deliberate choices

- **We never tell anyone to install Docker.** Its licence requires payment above 250 employees or $10M revenue, and for all government use. The steps suggest Colima or Podman (both free) and we adapt to whatever is already installed.
- **Nothing here installs or runs anything.** The endpoint only inspects; the commands are shown for the user to run.
- Commands are generated from the same constants the status check uses, so instructions can't drift from what we look for.

### Notes

- Built in a worktree off current `main`, which surfaced two drifts from freshly merged community PRs: `ApiKeyRow` now carries its own labels, and a `server/local-computer.ts` already exists (the refactored "This Mac" descriptor reader) — mine is `container-computer.ts` to avoid clobbering it.
- Selecting this as a bot's computer is the **next** PR; this one gets the machine ready and tells you honestly whether it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings modal with sections for profile preferences, API connections, updates, and local computer setup.
  * Added local computer configuration for detecting and setting up a containerized Linux desktop.
  * Added runtime, daemon, image, and container status details with refresh and screen-view controls.
  * Added setup, stop, removal, and command-copy options for the local computer environment.
* **Improvements**
  * Profile name and email changes now save automatically.
  * Added update checking and installation progress indicators.
  * Settings can be dismissed with Escape or by clicking the backdrop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->