### PR TITLE
Integrate #42: collision-safe Windows permission broker

### DIFF
--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -3,9 +3,9 @@
 // stream-json protocol into canonical events, keep argv hygiene (prompt
 // over stdin, secrets stripped), and broker permission asks.
 //
-// Spawn-based tests are POSIX-only until Windows CLI spawning lands: the
-// fake CLI is a shebang script, which Windows cannot exec directly (the
-// same reason claude.cmd needs special handling — see the Windows PRs).
+// These used to be POSIX-only: the fake CLI is a shebang script Windows
+// cannot exec, and the broker is a unix socket. Both now go through
+// resolveCliSpawn / permissionSocketPath, so they run everywhere.
 import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
@@ -13,13 +13,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { DATA_DIR, ensureDirs } from "../config.ts";
+import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { ClaudeDriver } from "./claude.ts";
+import { ClaudeDriver, permissionSocketPath } from "./claude.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
-const posixOnly = describe.skipIf(process.platform === "win32");
 
 describe("ClaudeDriver.decodeConfig", () => {
   it("defaults to the claude binary with acceptEdits", () => {
@@ -38,7 +37,7 @@ describe("ClaudeDriver.decodeConfig", () => {
   });
 });
 
-posixOnly("ClaudeDriver turns (fake CLI)", () => {
+describe("ClaudeDriver turns (fake CLI)", () => {
   let instance: ProviderInstance;
   let recorder: EventRecorder;
   let scratch: string;
@@ -233,11 +232,9 @@ posixOnly("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({ threadId: "t-perm-abc", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    // connect as the MCP proxy would and raise an ask (same tag rule as
-    // permissionSocketPath in claude.ts)
-    const tag = "t-perm-abc".replace(/[^\w-]/g, "").slice(0, 8);
-    const socketPath = join(DATA_DIR, `perm-${tag}.sock`);
-    const conn = connect(socketPath);
+    // connect as the MCP proxy would and raise an ask — unix socket on
+    // POSIX, named pipe on Windows, same one the driver handed the proxy
+    const conn = connect(permissionSocketPath("t-perm-abc"));
     const answered = new Promise<{ behavior: string }>((resolve) => {
       let buf = "";
       conn.on("data", (c) => {

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -3,9 +3,9 @@
 // stream-json protocol into canonical events, keep argv hygiene (prompt
 // over stdin, secrets stripped), and broker permission asks.
 //
-// Spawn-based tests are POSIX-only until Windows CLI spawning lands: the
-// fake CLI is a shebang script, which Windows cannot exec directly (the
-// same reason claude.cmd needs special handling — see the Windows PRs).
+// These used to be POSIX-only: the fake CLI is a shebang script Windows
+// cannot exec, and the broker is a unix socket. Both now go through
+// resolveCliSpawn / permissionSocketPath, so they run everywhere.
 import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
@@ -13,13 +13,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { DATA_DIR, ensureDirs } from "../config.ts";
+import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { ClaudeDriver } from "./claude.ts";
+import { ClaudeDriver, permissionSocketPath } from "./claude.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
-const posixOnly = describe.skipIf(process.platform === "win32");
 
 describe("ClaudeDriver.decodeConfig", () => {
   it("defaults to the claude binary with acceptEdits", () => {
@@ -36,9 +35,13 @@ describe("ClaudeDriver.decodeConfig", () => {
   it("throws on an invalid permissionMode (registry downgrades this to a shadow)", () => {
     expect(() => ClaudeDriver.decodeConfig({ permissionMode: "yolo" })).toThrow(/permissionMode/);
   });
+
+  it.skipIf(process.platform !== "win32")("names permission pipes per harness process", () => {
+    expect(permissionSocketPath("thread-abc")).toBe(`\\\\.\\pipe\\openmausbot-perm-${process.pid}-thread-a`);
+  });
 });
 
-posixOnly("ClaudeDriver turns (fake CLI)", () => {
+describe("ClaudeDriver turns (fake CLI)", () => {
   let instance: ProviderInstance;
   let recorder: EventRecorder;
   let scratch: string;
@@ -233,11 +236,9 @@ posixOnly("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({ threadId: "t-perm-abc", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    // connect as the MCP proxy would and raise an ask (same tag rule as
-    // permissionSocketPath in claude.ts)
-    const tag = "t-perm-abc".replace(/[^\w-]/g, "").slice(0, 8);
-    const socketPath = join(DATA_DIR, `perm-${tag}.sock`);
-    const conn = connect(socketPath);
+    // connect as the MCP proxy would and raise an ask — unix socket on
+    // POSIX, named pipe on Windows, same one the driver handed the proxy
+    const conn = connect(permissionSocketPath("t-perm-abc"));
     const answered = new Promise<{ behavior: string }>((resolve) => {
       let buf = "";
       conn.on("data", (c) => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -89,7 +89,7 @@ function askSummary(ask: Ask): string {
   return text === "{}" ? (ask.tool ?? "tool") : text.slice(0, 200);
 }
 
-function permissionSocketPath(threadId: string) {
+export function permissionSocketPath(threadId: string) {
   const tag = threadId.replace(/[^\w-]/g, "").slice(0, 8);
   return brokerSocketPath(DATA_DIR, tag);
 }
@@ -145,7 +145,12 @@ function createPermissionBroker(opts: {
       }
     });
   });
-  server.on("error", () => {});
+  // A broker that never came up used to be silent — every approval then
+  // timed out into a deny nobody could explain. Keep the turn fail-closed,
+  // but leave an actionable diagnostic.
+  server.on("error", (error) => {
+    console.error(`permission broker unavailable on ${opts.socketPath}: ${error.message}`);
+  });
   server.listen(opts.socketPath);
   return {
     answer(askId: string, behavior: string, message?: string): boolean {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -90,8 +90,13 @@ function askSummary(ask: Ask): string {
   return text === "{}" ? (ask.tool ?? "tool") : text.slice(0, 200);
 }
 
-function permissionSocketPath(threadId: string) {
+export function permissionSocketPath(threadId: string) {
   const tag = threadId.replace(/[^\w-]/g, "").slice(0, 8);
+  // Windows has no unix sockets — net.createServer binds a named pipe
+  // instead, same API on both ends. The pipe namespace is global and flat
+  // (DATA_DIR does not isolate it), so the pid keeps concurrent harnesses
+  // off each other's names.
+  if (process.platform === "win32") return `\\\\.\\pipe\\omb-perm-${process.pid}-${tag}`;
   return join(DATA_DIR, `perm-${tag}.sock`);
 }
 
@@ -146,7 +151,11 @@ function createPermissionBroker(opts: {
       }
     });
   });
-  server.on("error", () => {});
+  // a broker that never came up used to be silent — every approval then
+  // timed out into a deny nobody could explain. Say so.
+  server.on("error", (e) => {
+    console.error(`permission broker unavailable on ${opts.socketPath}: ${(e as Error).message}`);
+  });
   server.listen(opts.socketPath);
   return {
     answer(askId: string, behavior: string, message?: string): boolean {

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -76,6 +76,8 @@ export function killCliTree(child: ChildProcess): void {
  * (Node can't listen on a filesystem socket path there — EACCES). */
 export function brokerSocketPath(dataDir: string, tag: string): string {
   return process.platform === "win32"
-    ? `\\\\.\\pipe\\openmausbot-perm-${tag}`
+    // Named pipes share a global namespace; DATA_DIR cannot isolate two
+    // concurrent app instances the way a POSIX socket directory does.
+    ? `\\\\.\\pipe\\openmausbot-perm-${process.pid}-${tag}`
     : join(dataDir, `perm-${tag}.sock`);
 }


### PR DESCRIPTION
Ports the remaining #42 permission-broker work onto current `main` after #41/#81.

- preserves the centralized cross-platform broker path helper;
- includes the harness PID in Windows named pipes so concurrent app instances cannot collide;
- surfaces broker listen failures instead of silently turning every approval into a timeout denial;
- enables the full Claude fake-CLI/approval suite on Windows;
- adds an explicit Windows pipe-name regression test.

Local verification: typecheck, Electron syntax validation, production build, and 179 passing tests (seven Windows-only cases skipped locally).

Closes #42.