### PR TITLE
Add MAUS-powered routines calendar

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { mentionedBots, Store, type Message } from "./store.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { RoutineManager } from "./routines.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
@@ -114,6 +115,13 @@ const store = new Store(() => bootSelection);
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
 
+const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
+  ...bot,
+  messages: store.messagesFor(bot.threadId),
+  activeLeafId: store.activeLeaf(bot.threadId),
+  tasks: store.tasks(bot.id).map(({ resumeCursors, ...task }) => task),
+});
+
 // ── SSE fan-out to clients ─────────────────────────────────────────────
 const sseClients = new Set<ServerResponse>();
 function broadcast(payload: unknown) {
@@ -139,10 +147,11 @@ const askMessageByRequest = new Map<string, string>(); // threadId:requestId -> 
 // Group threads: the fold needs to know WHO is talking — the turn engine
 // records the active member here before dispatching its turn.
 const groupSpeakers = new Map<string, { botId: string; name: string; color: string }>();
-
+let routines: RoutineManager | null = null;
 
 bus.subscribe((event: RuntimeEvent) => {
   broadcast({ kind: "runtime", event });
+  routines?.handleRuntimeEvent(event);
   const bot = store.botByThread(event.threadId);
   const group = bot ? undefined : store.groupByThread(event.threadId);
   if (!bot && !group) return;
@@ -157,7 +166,7 @@ bus.subscribe((event: RuntimeEvent) => {
   switch (event.type) {
     case "session.started":
       if (bot && event.sessionId && event.providerInstanceId) {
-        store.setResumeCursor(bot.id, event.providerInstanceId, event.sessionId);
+        store.setResumeCursor(bot.id, event.providerInstanceId, event.sessionId, event.threadId);
       }
       break;
     case "item.completed":
@@ -384,14 +393,23 @@ async function finalScreenFrame(botId: string): Promise<Frame | null> {
 async function startTurn(
   botId: string,
   text: string,
-  opts?: { commsDepth?: number; userMessage?: Message },
+  opts?: {
+    commsDepth?: number;
+    userMessage?: Message;
+    /** Routines run in detached tasks; pin the destination for the whole turn. */
+    threadId?: string;
+    onDispatchError?: (message: string) => void;
+  },
 ) {
   const bot = store.bot(botId);
   if (!bot) throw Object.assign(new Error("no such bot"), { status: 404 });
   if (bot.busy) throw Object.assign(new Error("the bot is already working — interrupt it first"), { status: 409 });
+  const threadId = opts?.threadId ?? bot.threadId;
+  const task = store.taskByThread(bot.id, threadId);
+  if (!task) throw Object.assign(new Error("no such task"), { status: 404 });
   const commsDepth = opts?.commsDepth ?? 0;
   // a task takes its name from the first thing you asked it to do
-  if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text);
+  if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text, threadId);
 
   const instance = registry.get(bot.modelSelection.instanceId);
   if (!instance) {
@@ -404,14 +422,14 @@ async function startTurn(
   // an edit hands us its already-branched user message; a plain send appends
   let userMessage = opts?.userMessage;
   if (!userMessage) {
-    userMessage = store.appendMessage(bot.threadId, { role: "user", kind: "text", text });
-    broadcast({ kind: "message", threadId: bot.threadId, message: userMessage });
+    userMessage = store.appendMessage(threadId, { role: "user", kind: "text", text });
+    broadcast({ kind: "message", threadId, message: userMessage });
   }
 
   // transcript for API-backed drivers: settled text turns on the ACTIVE
   // branch only — abandoned forks never reach the model
   const transcript = store
-    .activePath(bot.threadId)
+    .activePath(threadId)
     .filter((m) => m.kind === "text" && m.text && m.id !== userMessage.id)
     .slice(-40)
     .map((m) => ({ role: m.role === "user" ? ("user" as const) : ("assistant" as const), text: m.text! }));
@@ -422,7 +440,7 @@ async function startTurn(
   // inline (transcript-replay drivers get it via transcript). The flag is
   // cleared only once the turn is actually dispatched — clearing it here
   // would cost the next attempt its history if this dispatch fails.
-  const rewound = Boolean(bot.rewound);
+  const rewound = threadId === bot.threadId && Boolean(bot.rewound);
   const turnText =
     rewound && instance.driverKind !== "grok" && transcript.length
       ? [
@@ -514,13 +532,13 @@ async function startTurn(
         : [];
 
       await instance.adapter.sendTurn({
-        threadId: bot.threadId,
+        threadId,
         text: turnText,
         model: bot.modelSelection.model,
         // a rewound thread never resumes the abandoned branch's session
         // the active task's own session — another task's cursor would
         // resume the wrong conversation and defeat the context bubble
-        resumeCursor: rewound ? undefined : store.activeTask(bot.id)?.resumeCursors[bot.modelSelection.instanceId],
+        resumeCursor: rewound ? undefined : task.resumeCursors[bot.modelSelection.instanceId],
         transcript,
         system:
           persona +
@@ -544,17 +562,43 @@ async function startTurn(
       if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      const failure = store.appendMessage(bot.threadId, {
+      const failure = store.appendMessage(threadId, {
         role: "bot",
         kind: "activity",
         tool: { name: `error: ${message.slice(0, 160)}`, ok: false },
       });
-      broadcast({ kind: "message", threadId: bot.threadId, message: failure });
+      broadcast({ kind: "message", threadId, message: failure });
       store.patchBot(bot.id, { busy: false });
       broadcast({ kind: "bot", bot: store.bot(bot.id) });
+      opts?.onDispatchError?.(message);
     }
   })();
 }
+
+// ── routines: persisted definitions → detached bot tasks ───────────────
+// The scheduler owns timing and receipts; the existing harness remains the
+// only owner of provider sessions, approvals, tools, computers and messages.
+routines = new RoutineManager({
+  emit: broadcast,
+  botState: (botId) => {
+    const bot = store.bot(botId);
+    return !bot ? "missing" : bot.busy ? "busy" : "ready";
+  },
+  createTask: (botId, title) => {
+    const task = store.createTask(botId, title, false);
+    const bot = store.bot(botId);
+    if (task && bot) broadcast({ kind: "bot", bot: publicBot(bot) });
+    return task;
+  },
+  startTurn: (botId, threadId, prompt, onDispatchError) =>
+    startTurn(botId, prompt, { threadId, onDispatchError }),
+  interruptTurn: async (botId, threadId) => {
+    const bot = store.bot(botId);
+    const instance = bot ? registry.get(bot.modelSelection.instanceId) : null;
+    await instance?.adapter.interruptTurn(threadId);
+  },
+});
+routines.start();
 
 // ── config hot-reload ─────────────────────────────────────────────────
 // ── group turn engine ──────────────────────────────────────────────────
@@ -886,6 +930,43 @@ const server = createServer(async (req, res) => {
       return json(res, 404, { error: "unknown internal endpoint" });
     }
 
+    // ── routines calendar ────────────────────────────────────────────────
+    if (path === "/api/routines" && method === "GET") {
+      const fromParam = url.searchParams.get("from");
+      const toParam = url.searchParams.get("to");
+      const from = fromParam == null ? undefined : Number(fromParam);
+      const to = toParam == null ? undefined : Number(toParam);
+      return json(res, 200, {
+        routines: routines!.listRoutines(),
+        runs: routines!.listRuns(from != null && Number.isFinite(from) ? from : undefined, to != null && Number.isFinite(to) ? to : undefined),
+      });
+    }
+    if (path === "/api/routines" && method === "POST") {
+      return json(res, 201, { routine: routines!.create(await readBody(req)) });
+    }
+    let routineMatch = path.match(/^\/api\/routines\/([\w-]+)\/run$/);
+    if (routineMatch && method === "POST") {
+      const run = routines!.runNow(routineMatch[1]);
+      return run ? json(res, 201, { run }) : json(res, 404, { error: "no such routine" });
+    }
+    routineMatch = path.match(/^\/api\/routines\/([\w-]+)$/);
+    if (routineMatch && method === "PATCH") {
+      const routine = routines!.update(routineMatch[1], await readBody(req));
+      return routine ? json(res, 200, { routine }) : json(res, 404, { error: "no such routine" });
+    }
+    if (routineMatch && method === "DELETE") {
+      return routines!.remove(routineMatch[1])
+        ? json(res, 200, { ok: true })
+        : json(res, 404, { error: "no such routine" });
+    }
+    const runMatch = path.match(/^\/api\/routine-runs\/([\w-]+)\/(cancel|seen)$/);
+    if (runMatch && method === "POST") {
+      const run = runMatch[2] === "cancel"
+        ? await routines!.cancelRun(runMatch[1])
+        : routines!.markSeen(runMatch[1]);
+      return run ? json(res, 200, { run }) : json(res, 404, { error: "no such active run" });
+    }
+
     // ── events stream ──
     if (method === "GET" && path === "/api/events") {
       res.writeHead(200, {
@@ -910,12 +991,7 @@ const server = createServer(async (req, res) => {
     // ── bots ──
     if (method === "GET" && path === "/api/bots") {
       return json(res, 200, {
-        bots: store.bots.map((b) => ({
-          ...b,
-          messages: store.messagesFor(b.threadId),
-          activeLeafId: store.activeLeaf(b.threadId),
-          tasks: (b.tasks ?? []).map(({ resumeCursors, ...t }) => t),
-        })),
+        bots: store.bots.map(publicBot),
         groups: store.groups.map((g) => ({ ...g, messages: store.messagesFor(g.threadId) })),
       });
     }
@@ -1037,6 +1113,7 @@ const server = createServer(async (req, res) => {
       // a running turn dies with its bot
       await registry.get(bot.modelSelection.instanceId)?.adapter.interruptTurn(bot.threadId).catch(() => {});
       stopScreenPoller(bot.id);
+      routines!.disableForBot(bot.id);
       store.deleteBot(bot.id);
       for (const dir of [EVENTS_DIR, NATIVE_DIR]) {
         try {
@@ -1157,6 +1234,11 @@ const server = createServer(async (req, res) => {
     if (m && method === "POST") {
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
+      const routineRun = routines!.activeRunForBot(bot.id);
+      if (routineRun) {
+        await routines!.cancelRun(routineRun.id);
+        return json(res, 200, { ok: true });
+      }
       const instance = registry.get(bot.modelSelection.instanceId);
       await instance?.adapter.interruptTurn(bot.threadId);
       return json(res, 200, { ok: true });
@@ -1203,7 +1285,7 @@ const server = createServer(async (req, res) => {
     }
     if (m && method === "DELETE") {
       const bot = store.bot(m[1]);
-      if (bot?.busy && bot.threadId === m[2]) {
+      if (bot?.busy && (bot.threadId === m[2] || routines!.isActiveThread(m[2]))) {
         return json(res, 409, { error: "this task is running — stop it first" });
       }
       const updated = store.deleteTask(m[1], m[2]);
@@ -1328,6 +1410,7 @@ server.listen(PORT, "127.0.0.1", () => {
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
+    routines?.stop();
     void registry.disposeAll().finally(() => process.exit(0));
   });
 }

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { nextOccurrence, RoutineManager, type RoutineManagerOptions } from "./routines.ts";
+
+const dirs: string[] = [];
+
+function tempFile() {
+  const dir = mkdtempSync(join(tmpdir(), "omb-routines-"));
+  dirs.push(dir);
+  return join(dir, "routines.json");
+}
+
+function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
+  let now = start;
+  let bot: "ready" | "busy" | "missing" = "ready";
+  let task = 0;
+  const started: Array<{ botId: string; threadId: string; prompt: string }> = [];
+  const emitted: any[] = [];
+  const options: RoutineManagerOptions = {
+    file: tempFile(),
+    now: () => now,
+    emit: (payload) => emitted.push(payload),
+    botState: () => bot,
+    createTask: () => ({ threadId: `thread-${++task}` }),
+    startTurn: async (botId, threadId, prompt) => {
+      started.push({ botId, threadId, prompt });
+    },
+  };
+  const manager = new RoutineManager(options);
+  return {
+    manager,
+    options,
+    emitted,
+    started,
+    setNow: (value: number) => (now = value),
+    setBot: (value: typeof bot) => (bot = value),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("nextOccurrence", () => {
+  it("finds the next selected weekday in local wall-clock time", () => {
+    const monday = new Date(2026, 7, 17, 10, 0, 0).getTime();
+    const next = nextOccurrence({ type: "daily", time: "09:30", weekdays: [1, 3] }, monday)!;
+    const d = new Date(next);
+    expect(d.getDay()).toBe(3);
+    expect([d.getHours(), d.getMinutes()]).toEqual([9, 30]);
+  });
+
+  it("returns a one-off only while it is still in the future", () => {
+    expect(nextOccurrence({ type: "once", at: 200 }, 100)).toBe(200);
+    expect(nextOccurrence({ type: "once", at: 100 }, 100)).toBeNull();
+  });
+});
+
+describe("RoutineManager", () => {
+  it("persists definitions separately from permanent run receipts", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Morning brief",
+      prompt: "Summarize what changed",
+      botId: "maus-1",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 5).getTime() },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+
+    const reloaded = new RoutineManager(h.options);
+    expect(reloaded.listRoutines()).toHaveLength(1);
+    expect(reloaded.listRuns()).toMatchObject([
+      { routineId: routine.id, routineName: "Morning brief", status: "failed", threadId: "thread-1" },
+    ]);
+    // Reload recovery truthfully marks an in-process run as interrupted.
+    expect(reloaded.listRuns()[0]!.error).toContain("restarted");
+  });
+
+  it("queues behind a busy bot, then dispatches into a detached task", async () => {
+    const h = harness();
+    h.setBot("busy");
+    const routine = h.manager.create({
+      name: "Review queue",
+      prompt: "Review the queue",
+      botId: "maus-2",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+      durationMinutes: 45,
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+    expect(h.manager.listRuns()[0]!.status).toBe("queued");
+    expect(h.started).toHaveLength(0);
+
+    h.setBot("ready");
+    await h.manager.tick();
+    expect(h.started).toEqual([{ botId: "maus-2", threadId: "thread-1", prompt: "Review the queue" }]);
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "running", threadId: "thread-1" });
+    expect(h.manager.activeRunForBot("maus-2")?.threadId).toBe("thread-1");
+    expect(h.manager.isActiveThread("thread-1")).toBe(true);
+  });
+
+  it("cancels queued work when a routine is paused", async () => {
+    const h = harness();
+    h.setBot("busy");
+    const routine = h.manager.create({
+      name: "Pauseable check",
+      prompt: "Check later",
+      botId: "maus-2",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+
+    h.manager.update(routine.id, { enabled: false });
+    h.setBot("ready");
+    await h.manager.tick();
+
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "cancelled" });
+    expect(h.started).toHaveLength(0);
+  });
+
+  it("snapshots queued instructions so later edits do not rewrite a receipt", async () => {
+    const h = harness();
+    h.setBot("busy");
+    const routine = h.manager.create({
+      name: "Original brief",
+      prompt: "Use the original instructions",
+      botId: "maus-2",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+    h.manager.update(routine.id, { name: "Edited brief", prompt: "Use the new instructions" });
+
+    h.setBot("ready");
+    await h.manager.tick();
+
+    expect(h.started[0]?.prompt).toBe("Use the original instructions");
+    expect(h.manager.listRuns()[0]).toMatchObject({
+      routineName: "Original brief",
+      prompt: "Use the original instructions",
+    });
+  });
+
+  it("folds provider lifecycle events into the calendar receipt", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Ship report",
+      prompt: "Write the report",
+      botId: "maus-3",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+    const base = {
+      eventId: "event-1",
+      provider: "fake",
+      threadId: "thread-1",
+      createdAt: new Date(h.manager.listRuns()[0]!.startedAt!).toISOString(),
+    };
+    h.manager.handleRuntimeEvent({ ...base, type: "request.opened", requestType: "question", tool: "ask", summary: "Need a date" });
+    expect(h.manager.listRuns()[0]!.status).toBe("waiting");
+    h.manager.handleRuntimeEvent({ ...base, type: "request.resolved", behavior: "answer", source: "user" });
+    h.manager.handleRuntimeEvent({ ...base, type: "item.completed", itemType: "assistant_text", text: "Report shipped." });
+    h.manager.handleRuntimeEvent({ ...base, type: "turn.completed", ok: true, cost: 0.02 });
+
+    expect(h.manager.listRuns()[0]).toMatchObject({
+      status: "completed",
+      output: "Report shipped.",
+      cost: 0.02,
+    });
+  });
+
+  it("keeps recurring history while advancing the definition", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Daily check",
+      prompt: "Check it",
+      botId: "maus-4",
+      schedule: { type: "daily", time: "08:05", weekdays: [1, 2, 3, 4, 5] },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+    h.manager.handleRuntimeEvent({
+      eventId: "done",
+      provider: "fake",
+      threadId: "thread-1",
+      createdAt: new Date().toISOString(),
+      type: "turn.completed",
+      ok: true,
+    });
+
+    expect(h.manager.listRuns()).toHaveLength(1);
+    expect(h.manager.listRoutines()[0]!.nextRunAt).toBeGreaterThan(routine.nextRunAt!);
+  });
+
+  it("records a missed receipt instead of launching very stale work", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Old check",
+      prompt: "Do the old thing",
+      botId: "maus-5",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+    });
+    h.setNow(routine.nextRunAt! + 13 * 60 * 60_000);
+    await h.manager.tick();
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "missed" });
+    expect(h.started).toHaveLength(0);
+  });
+});

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -1,0 +1,475 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { DATA_DIR } from "./config.ts";
+import type { RuntimeEvent } from "./contracts.ts";
+
+export type RoutineSchedule =
+  | { type: "once"; at: number }
+  | { type: "daily"; time: string; weekdays: number[] };
+
+export type RoutineRunStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "missed";
+
+export interface Routine {
+  id: string;
+  name: string;
+  prompt: string;
+  botId: string;
+  enabled: boolean;
+  schedule: RoutineSchedule;
+  durationMinutes: number;
+  nextRunAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RoutineRun {
+  id: string;
+  routineId: string;
+  routineName: string;
+  /** Snapshot the work so an edited/deleted definition cannot rewrite history. */
+  prompt?: string;
+  durationMinutes?: number;
+  botId: string;
+  scheduledFor: number;
+  status: RoutineRunStatus;
+  manual: boolean;
+  threadId?: string;
+  startedAt?: number;
+  finishedAt?: number;
+  output?: string;
+  error?: string;
+  cost?: number | null;
+  denials?: string[];
+  createdAt: number;
+  seenAt?: number;
+}
+
+export interface RoutineInput {
+  name: string;
+  prompt: string;
+  botId: string;
+  enabled?: boolean;
+  schedule: RoutineSchedule;
+  durationMinutes?: number;
+}
+
+interface RoutineFile {
+  version: 1;
+  routines: Routine[];
+  runs: RoutineRun[];
+}
+
+export interface RoutineManagerOptions {
+  file?: string;
+  now?: () => number;
+  emit?: (payload: unknown) => void;
+  botState: (botId: string) => "ready" | "busy" | "missing";
+  createTask: (botId: string, title: string) => { threadId: string } | null;
+  startTurn: (
+    botId: string,
+    threadId: string,
+    prompt: string,
+    onDispatchError: (message: string) => void,
+  ) => Promise<void>;
+  interruptTurn?: (botId: string, threadId: string) => Promise<void>;
+}
+
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+const CATCH_UP_MS = 12 * 60 * 60_000;
+const MAX_RUNS = 2_000;
+
+function cleanDays(days: unknown): number[] {
+  if (!Array.isArray(days)) return ALL_DAYS;
+  const out = [...new Set(days.filter((d): d is number => Number.isInteger(d) && d >= 0 && d <= 6))].sort();
+  return out.length ? out : ALL_DAYS;
+}
+
+function cleanSchedule(schedule: RoutineSchedule): RoutineSchedule {
+  if (schedule?.type === "once") {
+    const at = Number(schedule.at);
+    if (!Number.isFinite(at)) throw new Error("Choose a valid date and time");
+    return { type: "once", at };
+  }
+  if (schedule?.type === "daily") {
+    const time = String(schedule.time ?? "");
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(time)) throw new Error("Time must use HH:MM");
+    return { type: "daily", time, weekdays: cleanDays(schedule.weekdays) };
+  }
+  throw new Error("Choose a supported schedule");
+}
+
+/** Next wall-clock occurrence in this computer's timezone, strictly after `after`. */
+export function nextOccurrence(schedule: RoutineSchedule, after: number): number | null {
+  if (schedule.type === "once") return schedule.at > after ? schedule.at : null;
+  const [hour, minute] = schedule.time.split(":").map(Number);
+  const weekdays = new Set(cleanDays(schedule.weekdays));
+  for (let offset = 0; offset <= 8; offset++) {
+    const d = new Date(after);
+    d.setDate(d.getDate() + offset);
+    d.setHours(hour, minute, 0, 0);
+    if (d.getTime() > after && weekdays.has(d.getDay())) return d.getTime();
+  }
+  return null;
+}
+
+function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | "updatedAt" | "nextRunAt"> {
+  const name = String(input.name ?? "").trim().slice(0, 80);
+  const prompt = String(input.prompt ?? "").trim().slice(0, 20_000);
+  const botId = String(input.botId ?? "").trim();
+  if (!name) throw new Error("Give the routine a name");
+  if (!prompt) throw new Error("Tell the bot what to do");
+  if (!botId) throw new Error("Choose a bot");
+  return {
+    name,
+    prompt,
+    botId,
+    enabled: input.enabled !== false,
+    schedule: cleanSchedule(input.schedule),
+    durationMinutes: Math.min(240, Math.max(15, Math.round(Number(input.durationMinutes) || 30))),
+  };
+}
+
+export class RoutineManager {
+  private readonly file: string;
+  private readonly now: () => number;
+  private readonly options: RoutineManagerOptions;
+  private routines: Routine[] = [];
+  private runs: RoutineRun[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private ticking = false;
+
+  constructor(options: RoutineManagerOptions) {
+    this.options = options;
+    this.file = options.file ?? join(DATA_DIR, "routines.json");
+    this.now = options.now ?? Date.now;
+    try {
+      const disk = JSON.parse(readFileSync(this.file, "utf8")) as Partial<RoutineFile>;
+      this.routines = Array.isArray(disk.routines) ? disk.routines : [];
+      this.runs = Array.isArray(disk.runs) ? disk.runs : [];
+    } catch {
+      this.routines = [];
+      this.runs = [];
+    }
+    // A local process cannot still own these turns after a full restart.
+    let recovered = false;
+    for (const run of this.runs) {
+      if (run.status === "running" || run.status === "waiting") {
+        run.status = "failed";
+        run.error = "OpenMausBot restarted while this routine was running";
+        run.finishedAt = this.now();
+        recovered = true;
+      }
+    }
+    if (recovered) this.save();
+  }
+
+  listRoutines(): Routine[] {
+    return this.routines.map((r) => ({ ...r, schedule: { ...r.schedule } }));
+  }
+
+  listRuns(from?: number, to?: number): RoutineRun[] {
+    return this.runs
+      .filter((r) => (from == null || r.scheduledFor >= from) && (to == null || r.scheduledFor <= to))
+      .sort((a, b) => b.scheduledFor - a.scheduledFor)
+      .map((r) => ({ ...r }));
+  }
+
+  activeRunForBot(botId: string): RoutineRun | null {
+    const run = this.runs.find(
+      (candidate) => candidate.botId === botId && ["running", "waiting"].includes(candidate.status),
+    );
+    return run ? { ...run } : null;
+  }
+
+  isActiveThread(threadId: string): boolean {
+    return this.runs.some(
+      (run) => run.threadId === threadId && ["running", "waiting"].includes(run.status),
+    );
+  }
+
+  create(input: RoutineInput): Routine {
+    const clean = sanitizeInput(input);
+    if (this.options.botState(clean.botId) === "missing") throw new Error("That bot no longer exists");
+    const at = this.now();
+    const routine: Routine = {
+      id: randomUUID(),
+      ...clean,
+      nextRunAt: clean.enabled ? this.initialOccurrence(clean.schedule, at) : null,
+      createdAt: at,
+      updatedAt: at,
+    };
+    this.routines.unshift(routine);
+    this.save();
+    this.emitRoutine(routine);
+    return { ...routine, schedule: { ...routine.schedule } };
+  }
+
+  update(id: string, patch: Partial<RoutineInput>): Routine | null {
+    const routine = this.routines.find((r) => r.id === id);
+    if (!routine) return null;
+    const clean = sanitizeInput({
+      name: patch.name ?? routine.name,
+      prompt: patch.prompt ?? routine.prompt,
+      botId: patch.botId ?? routine.botId,
+      enabled: patch.enabled ?? routine.enabled,
+      schedule: patch.schedule ?? routine.schedule,
+      durationMinutes: patch.durationMinutes ?? routine.durationMinutes,
+    });
+    if (this.options.botState(clean.botId) === "missing") throw new Error("That bot no longer exists");
+    Object.assign(routine, clean, {
+      nextRunAt: clean.enabled ? this.initialOccurrence(clean.schedule, this.now()) : null,
+      updatedAt: this.now(),
+    });
+    if (patch.enabled === false) {
+      for (const run of this.runs) {
+        if (run.routineId !== routine.id || run.status !== "queued") continue;
+        run.status = "cancelled";
+        run.finishedAt = this.now();
+        run.error = "The routine was paused before this run started";
+        this.emitRun(run);
+      }
+    }
+    this.save();
+    this.emitRoutine(routine);
+    return { ...routine, schedule: { ...routine.schedule } };
+  }
+
+  remove(id: string): boolean {
+    const at = this.routines.findIndex((r) => r.id === id);
+    if (at === -1) return false;
+    this.routines.splice(at, 1);
+    for (const run of this.runs) {
+      if (run.routineId === id && run.status === "queued") {
+        run.status = "cancelled";
+        run.finishedAt = this.now();
+        this.emitRun(run);
+      }
+    }
+    this.save();
+    this.options.emit?.({ kind: "routine.deleted", routineId: id });
+    return true;
+  }
+
+  disableForBot(botId: string) {
+    let changed = false;
+    for (const routine of this.routines) {
+      if (routine.botId !== botId || !routine.enabled) continue;
+      routine.enabled = false;
+      routine.nextRunAt = null;
+      routine.updatedAt = this.now();
+      this.emitRoutine(routine);
+      changed = true;
+    }
+    for (const run of this.runs) {
+      if (run.botId !== botId || !["queued", "running", "waiting"].includes(run.status)) continue;
+      run.status = "cancelled";
+      run.finishedAt = this.now();
+      run.error = "The assigned bot was deleted";
+      this.emitRun(run);
+      if (run.threadId) void this.options.interruptTurn?.(run.botId, run.threadId).catch(() => {});
+      changed = true;
+    }
+    if (changed) this.save();
+  }
+
+  runNow(id: string): RoutineRun | null {
+    const routine = this.routines.find((r) => r.id === id);
+    if (!routine) return null;
+    const run = this.newRun(routine, this.now(), true);
+    this.save();
+    this.emitRun(run);
+    queueMicrotask(() => void this.tick());
+    return { ...run };
+  }
+
+  async cancelRun(id: string): Promise<RoutineRun | null> {
+    const run = this.runs.find((r) => r.id === id);
+    if (!run || !["queued", "running", "waiting"].includes(run.status)) return null;
+    run.status = "cancelled";
+    run.finishedAt = this.now();
+    this.save();
+    this.emitRun(run);
+    if (run.threadId) await this.options.interruptTurn?.(run.botId, run.threadId).catch(() => {});
+    queueMicrotask(() => void this.tick());
+    return { ...run };
+  }
+
+  markSeen(id: string): RoutineRun | null {
+    const run = this.runs.find((r) => r.id === id);
+    if (!run) return null;
+    if (!run.seenAt) {
+      run.seenAt = this.now();
+      this.save();
+      this.emitRun(run);
+    }
+    return { ...run };
+  }
+
+  start() {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), 10_000);
+    this.timer.unref?.();
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<void> {
+    if (this.ticking) return;
+    this.ticking = true;
+    try {
+      const now = this.now();
+      let changed = false;
+      for (const routine of this.routines) {
+        if (!routine.enabled || routine.nextRunAt == null || routine.nextRunAt > now) continue;
+        const scheduledFor = routine.nextRunAt;
+        const late = now - scheduledFor;
+        if (late > CATCH_UP_MS) {
+          const missed = this.newRun(routine, scheduledFor, false);
+          missed.status = "missed";
+          missed.finishedAt = now;
+          missed.error = "This computer was offline for more than 12 hours after the scheduled time";
+          this.emitRun(missed);
+        } else {
+          const run = this.newRun(routine, scheduledFor, false);
+          this.emitRun(run);
+        }
+        routine.nextRunAt =
+          routine.schedule.type === "once" ? null : nextOccurrence(routine.schedule, Math.max(now, scheduledFor));
+        if (routine.schedule.type === "once") routine.enabled = false;
+        routine.updatedAt = now;
+        this.emitRoutine(routine);
+        changed = true;
+      }
+      if (changed) this.save();
+
+      for (const run of [...this.runs].reverse()) {
+        if (run.status !== "queued") continue;
+        const state = this.options.botState(run.botId);
+        if (state === "busy") continue;
+        if (state === "missing") {
+          run.status = "failed";
+          run.error = "The assigned bot no longer exists";
+          run.finishedAt = this.now();
+          this.save();
+          this.emitRun(run);
+          continue;
+        }
+        const task = this.options.createTask(run.botId, run.routineName);
+        if (!task) {
+          run.status = "failed";
+          run.error = "Could not create a task for this run";
+          run.finishedAt = this.now();
+          this.save();
+          this.emitRun(run);
+          continue;
+        }
+        run.threadId = task.threadId;
+        run.startedAt = this.now();
+        run.status = "running";
+        this.save();
+        this.emitRun(run);
+        try {
+          const prompt = run.prompt ?? this.routines.find((r) => r.id === run.routineId)?.prompt;
+          if (!prompt) {
+            this.failThread(task.threadId, "The routine was deleted before it could start");
+            continue;
+          }
+          await this.options.startTurn(run.botId, task.threadId, prompt, (message) =>
+            this.failThread(task.threadId, message),
+          );
+        } catch (error) {
+          this.failThread(task.threadId, error instanceof Error ? error.message : String(error));
+        }
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+
+  handleRuntimeEvent(event: RuntimeEvent) {
+    const run = this.runs.find((r) => r.threadId === event.threadId && ["running", "waiting"].includes(r.status));
+    if (!run) return;
+    if (event.type === "request.opened") {
+      run.status = "waiting";
+    } else if (event.type === "request.resolved") {
+      run.status = "running";
+    } else if (event.type === "item.completed" && event.itemType === "assistant_text") {
+      run.output = event.text.trim().slice(0, 2_000);
+    } else if (event.type === "runtime.error") {
+      run.error = event.message.slice(0, 500);
+    } else if (event.type === "turn.completed") {
+      run.status = event.ok ? "completed" : "failed";
+      run.finishedAt = this.now();
+      run.error = event.ok ? undefined : (event.stopReason ?? run.error ?? "The bot did not complete this run");
+      run.cost = event.cost;
+      run.denials = event.denials;
+    } else {
+      return;
+    }
+    this.save();
+    this.emitRun(run);
+    if (event.type === "turn.completed") queueMicrotask(() => void this.tick());
+  }
+
+  failThread(threadId: string, message: string) {
+    const run = this.runs.find((r) => r.threadId === threadId && ["running", "waiting"].includes(r.status));
+    if (!run) return;
+    run.status = "failed";
+    run.error = message.slice(0, 500);
+    run.finishedAt = this.now();
+    this.save();
+    this.emitRun(run);
+    queueMicrotask(() => void this.tick());
+  }
+
+  private initialOccurrence(schedule: RoutineSchedule, now: number): number | null {
+    if (schedule.type === "once") return Math.max(schedule.at, now);
+    return nextOccurrence(schedule, now);
+  }
+
+  private newRun(routine: Routine, scheduledFor: number, manual: boolean): RoutineRun {
+    const run: RoutineRun = {
+      id: randomUUID(),
+      routineId: routine.id,
+      routineName: routine.name,
+      prompt: routine.prompt,
+      durationMinutes: routine.durationMinutes,
+      botId: routine.botId,
+      scheduledFor,
+      status: "queued",
+      manual,
+      createdAt: this.now(),
+    };
+    this.runs.push(run);
+    if (this.runs.length > MAX_RUNS) this.runs.splice(0, this.runs.length - MAX_RUNS);
+    return run;
+  }
+
+  private emitRoutine(routine: Routine) {
+    this.options.emit?.({ kind: "routine", routine: { ...routine, schedule: { ...routine.schedule } } });
+  }
+
+  private emitRun(run: RoutineRun) {
+    this.options.emit?.({ kind: "routine.run", run: { ...run } });
+  }
+
+  private save() {
+    mkdirSync(dirname(this.file), { recursive: true });
+    const temp = `${this.file}.tmp`;
+    writeFileSync(temp, JSON.stringify({ version: 1, routines: this.routines, runs: this.runs } satisfies RoutineFile, null, 2));
+    renameSync(temp, this.file);
+  }
+}

--- a/server/store.ts
+++ b/server/store.ts
@@ -444,7 +444,7 @@ export class Store {
   }
 
   botByThread(threadId: string) {
-    return this.bots.find((b) => b.threadId === threadId) ?? null;
+    return this.bots.find((b) => b.threadId === threadId || b.tasks?.some((t) => t.threadId === threadId)) ?? null;
   }
 
   createBot(): BotRecord {
@@ -497,13 +497,15 @@ export class Store {
     return bot;
   }
 
-  setResumeCursor(botId: string, instanceId: string, cursor: unknown) {
+  setResumeCursor(botId: string, instanceId: string, cursor: unknown, threadId?: string) {
     const bot = this.bot(botId);
     if (!bot) return;
     // the cursor belongs to the task that produced it, not to the bot
-    const task = this.activeTask(botId);
+    const task = threadId ? this.taskByThread(botId, threadId) : this.activeTask(botId);
     if (task) task.resumeCursors[instanceId] = cursor;
-    bot.resumeCursors[instanceId] = cursor; // legacy mirror
+    // The legacy mirror follows the task visible in chat, never a detached
+    // routine task working in the background.
+    if (!threadId || bot.threadId === threadId) bot.resumeCursors[instanceId] = cursor;
     this.saveBots();
   }
 
@@ -523,9 +525,13 @@ export class Store {
     return bot?.tasks?.find((t) => t.threadId === bot.threadId);
   }
 
+  taskByThread(botId: string, threadId: string): TaskRecord | undefined {
+    return this.bot(botId)?.tasks?.find((t) => t.threadId === threadId);
+  }
+
   /** A fresh context on the same bot: new thread, new session, same
    * persona/tools/computer. Becomes the active task. */
-  createTask(botId: string, title?: string): TaskRecord | null {
+  createTask(botId: string, title?: string, activate = true): TaskRecord | null {
     const bot = this.bot(botId);
     if (!bot) return null;
     const task: TaskRecord = {
@@ -535,8 +541,10 @@ export class Store {
       resumeCursors: {},
     };
     bot.tasks = [task, ...(bot.tasks ?? [])];
-    bot.threadId = task.threadId;
-    bot.resumeCursors = {}; // legacy mirror follows the active task
+    if (activate) {
+      bot.threadId = task.threadId;
+      bot.resumeCursors = {}; // legacy mirror follows the active task
+    }
     this.saveBots();
     return task;
   }
@@ -560,8 +568,8 @@ export class Store {
   }
 
   /** Name a task after its first message, once. */
-  titleTaskFromFirstMessage(botId: string, text: string) {
-    const task = this.activeTask(botId);
+  titleTaskFromFirstMessage(botId: string, text: string, threadId?: string) {
+    const task = threadId ? this.taskByThread(botId, threadId) : this.activeTask(botId);
     if (!task || task.title !== UNTITLED_TASK) return;
     task.title = titleFromMessage(text);
     this.saveBots();

--- a/server/tasks.test.ts
+++ b/server/tasks.test.ts
@@ -47,6 +47,21 @@ describe("tasks", () => {
     expect(store.messagesFor(firstThread).length).toBeGreaterThan(0);
   });
 
+  it("can create a detached routine task without changing the visible conversation", async () => {
+    const { store } = await freshStore();
+    const bot = store.createBot();
+    const visibleThread = bot.threadId;
+    const routineTask = store.createTask(bot.id, "Morning brief", false)!;
+
+    expect(routineTask.threadId).not.toBe(visibleThread);
+    expect(store.bot(bot.id)!.threadId).toBe(visibleThread);
+    expect(store.botByThread(routineTask.threadId)?.id).toBe(bot.id);
+
+    store.setResumeCursor(bot.id, "claude", "routine-session", routineTask.threadId);
+    expect(store.taskByThread(bot.id, routineTask.threadId)?.resumeCursors.claude).toBe("routine-session");
+    expect(store.activeTask(bot.id)?.resumeCursors.claude).toBeUndefined();
+  });
+
   it("keeps provider sessions apart — the whole point of a task", async () => {
     const { store } = await freshStore();
     const bot = store.createBot();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ComputerPanel } from "@/components/ComputerPanel";
 import { AppSettingsPanel } from "@/components/AppSettingsPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { DesktopCapabilitiesProvider } from "@/components/DesktopCapabilities";
+import { RoutinesPage } from "@/components/RoutinesPage";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -53,7 +54,9 @@ function Shell() {
       <UpdateBanner />
       <div className="relative flex min-h-0 flex-1">
       <Sidebar />
-      {group ? (
+      {state.activeView === "routines" ? (
+        <RoutinesPage />
+      ) : group ? (
         <GroupView key={group.id} group={group} />
       ) : bot ? (
         <ChatView bot={bot} />

--- a/src/components/RoutinesPage.tsx
+++ b/src/components/RoutinesPage.tsx
@@ -1,0 +1,593 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  CalendarClock,
+  CalendarDays,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  CircleAlert,
+  ExternalLink,
+  Loader2,
+  Pause,
+  Play,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { MausAvatar } from "@/components/Avatar";
+import { cn } from "@/lib/cn";
+import { MAUS_COLORS, type MausState } from "@/lib/mascot";
+import type { Routine, RoutineInput, RoutineRun, RoutineRunStatus } from "@/lib/routines";
+import { api, useStore, type Bot } from "@/state/store";
+
+const HOUR_HEIGHT = 68;
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+type CalendarItem = {
+  id: string;
+  at: number;
+  routine: Routine | null;
+  run: RoutineRun | null;
+};
+
+function startOfDay(at: number) {
+  const date = new Date(at);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function addDays(at: number, days: number) {
+  const date = new Date(at);
+  date.setDate(date.getDate() + days);
+  return date.getTime();
+}
+
+function startOfWeek(at: number) {
+  const date = new Date(startOfDay(at));
+  const offset = (date.getDay() + 6) % 7;
+  date.setDate(date.getDate() - offset);
+  return date.getTime();
+}
+
+function atLocalTime(day: number, time: string) {
+  const [hour, minute] = time.split(":").map(Number);
+  const date = new Date(day);
+  date.setHours(hour, minute, 0, 0);
+  return date.getTime();
+}
+
+function toInputDateTime(at: number) {
+  const date = new Date(at - new Date(at).getTimezoneOffset() * 60_000);
+  return date.toISOString().slice(0, 16);
+}
+
+function niceDate(at: number, includeWeekday = true) {
+  return new Date(at).toLocaleDateString([], {
+    weekday: includeWeekday ? "long" : undefined,
+    month: "short",
+    day: "numeric",
+    year: new Date(at).getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
+  });
+}
+
+function niceTime(at: number) {
+  return new Date(at).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function scheduleLabel(routine: Routine) {
+  if (routine.schedule.type === "once") {
+    return `${niceDate(routine.schedule.at)}, ${niceTime(routine.schedule.at)}`;
+  }
+  const days = routine.schedule.weekdays;
+  const dayLabel =
+    days.length === 7
+      ? "Every day"
+      : days.join(",") === "1,2,3,4,5"
+        ? "Weekdays"
+        : days.map((day) => DAY_NAMES[day]).join(", ");
+  return `${dayLabel} at ${niceTime(atLocalTime(Date.now(), routine.schedule.time))}`;
+}
+
+function canToggleRoutine(routine: Routine) {
+  return routine.schedule.type === "daily" || routine.schedule.at > Date.now();
+}
+
+function statusState(status: RoutineRunStatus): MausState {
+  switch (status) {
+    case "queued":
+      return "drowsy";
+    case "running":
+      return "working";
+    case "waiting":
+      return "curious";
+    case "completed":
+      return "proud";
+    case "failed":
+    case "missed":
+      return "sad";
+    case "cancelled":
+      return "sleeping";
+  }
+}
+
+function statusTone(status: RoutineRunStatus) {
+  switch (status) {
+    case "running":
+      return "text-accent";
+    case "waiting":
+      return "text-warning";
+    case "completed":
+      return "text-success";
+    case "failed":
+    case "missed":
+      return "text-danger";
+    default:
+      return "text-ink-secondary";
+  }
+}
+
+function nextHour() {
+  const date = new Date(Date.now() + 60 * 60_000);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+}
+
+function projectedItems(routines: Routine[], runs: RoutineRun[], from: number, to: number): CalendarItem[] {
+  const items: CalendarItem[] = runs
+    .filter((run) => run.scheduledFor >= from && run.scheduledFor < to)
+    .map((run) => ({
+      id: `run-${run.id}`,
+      at: run.scheduledFor,
+      routine: routines.find((routine) => routine.id === run.routineId) ?? null,
+      run,
+    }));
+
+  const hasReceipt = (routineId: string, at: number) =>
+    runs.some((run) => run.routineId === routineId && Math.abs(run.scheduledFor - at) < 60_000);
+
+  for (const routine of routines) {
+    if (!routine.enabled) continue;
+    if (routine.schedule.type === "once") {
+      const at = routine.schedule.at;
+      if (at >= from && at < to && !hasReceipt(routine.id, at)) {
+        items.push({ id: `next-${routine.id}-${at}`, at, routine, run: null });
+      }
+      continue;
+    }
+    for (let day = startOfDay(from); day < to; day = addDays(day, 1)) {
+      const date = new Date(day);
+      if (!routine.schedule.weekdays.includes(date.getDay())) continue;
+      const at = atLocalTime(day, routine.schedule.time);
+      if (at >= from && at < to && at >= routine.createdAt && !hasReceipt(routine.id, at)) {
+        items.push({ id: `next-${routine.id}-${at}`, at, routine, run: null });
+      }
+    }
+  }
+  return items.sort((a, b) => a.at - b.at);
+}
+
+function RoutineCard({ item, bot, compact, onOpen }: { item: CalendarItem; bot: Bot; compact: boolean; onOpen: () => void }) {
+  const status = item.run?.status;
+  const color = MAUS_COLORS[bot.color];
+  const title = item.routine?.name ?? item.run?.routineName ?? "Routine";
+  const animated = status === "running" || status === "waiting";
+  return (
+    <button
+      onClick={onOpen}
+      className={cn(
+        "group absolute left-1.5 right-1.5 z-10 overflow-hidden rounded-xl border py-1.5 text-left shadow-lg shadow-black/15 transition hover:z-20 hover:-translate-y-0.5 hover:brightness-110",
+        compact ? "px-1.5" : "px-2",
+        status === "failed" || status === "missed" ? "border-danger/50" : "border-white/10",
+        status === "cancelled" && "opacity-55",
+      )}
+      style={{
+        top: `${((new Date(item.at).getHours() * 60 + new Date(item.at).getMinutes()) / 60) * HOUR_HEIGHT}px`,
+        minHeight: `${Math.max(48, ((item.routine?.durationMinutes ?? item.run?.durationMinutes ?? 30) / 60) * HOUR_HEIGHT)}px`,
+        background: `linear-gradient(115deg, color-mix(in srgb, ${color} 48%, #181818), color-mix(in srgb, ${color} 20%, #111))`,
+      }}
+    >
+      <div className={cn("flex min-w-0 items-center", compact ? "gap-1.5" : "gap-2")}>
+        <MausAvatar
+          color={bot.color}
+          state={status ? statusState(status) : "idle"}
+          size={compact ? 32 : 38}
+          animated={animated}
+          trackPointer={animated}
+          label={`${bot.name} — ${title}`}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[12px] font-semibold text-white">{title}</div>
+          <div className="mt-0.5 flex items-center gap-1.5 truncate text-[10.5px] text-white/70">
+            {animated && <Loader2 size={10} className="animate-spin" />}
+            <span>{niceTime(item.at)}</span>
+            <span>·</span>
+            <span className="truncate">{status ? status.replace("waiting", "needs you") : bot.name}</span>
+          </div>
+        </div>
+        {status === "failed" && !item.run?.seenAt && <span className="size-2 shrink-0 rounded-full bg-danger" />}
+      </div>
+    </button>
+  );
+}
+
+function CalendarGrid({
+  anchor,
+  days,
+  items,
+  bots,
+  onOpen,
+}: {
+  anchor: number;
+  days: number;
+  items: CalendarItem[];
+  bots: Bot[];
+  onOpen: (item: CalendarItem) => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const today = startOfDay(Date.now());
+  const starts = Array.from({ length: days }, (_, index) => addDays(anchor, index));
+  const minDayWidth = days === 7 ? 110 : days === 3 ? 180 : 300;
+  const gridTemplateColumns = `58px repeat(${days}, minmax(${minDayWidth}px, 1fr))`;
+  const minWidth = 58 + days * minDayWidth;
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: HOUR_HEIGHT * 7 - 24 });
+  }, [days]);
+
+  return (
+    <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto border-t border-hairline/40">
+      <div className="sticky top-0 z-30 grid bg-app/95 backdrop-blur" style={{ gridTemplateColumns, minWidth }}>
+        <div className="border-b border-r border-hairline/40" />
+        {starts.map((start) => {
+          const isToday = start === today;
+          const date = new Date(start);
+          return (
+            <div key={start} className="border-b border-r border-hairline/40 px-3 py-2.5 text-center last:border-r-0">
+              <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-ink-secondary">{DAY_NAMES[date.getDay()]}</div>
+              <div className={cn("mx-auto mt-1 flex size-7 items-center justify-center rounded-full text-[14px] font-semibold", isToday ? "bg-accent text-white" : "text-ink")}>{date.getDate()}</div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="relative grid" style={{ height: HOUR_HEIGHT * 24, gridTemplateColumns, minWidth }}>
+        <div className="relative border-r border-hairline/40">
+          {Array.from({ length: 24 }, (_, hour) => (
+            <div key={hour} className="absolute right-2 -translate-y-1/2 text-[10px] tabular-nums text-ink-secondary/65" style={{ top: hour * HOUR_HEIGHT }}>
+              {hour === 0 ? "" : new Date(2000, 0, 1, hour).toLocaleTimeString([], { hour: "numeric" })}
+            </div>
+          ))}
+        </div>
+        {starts.map((start) => {
+          const dayItems = items.filter((item) => startOfDay(item.at) === start);
+          const now = new Date();
+          const nowTop = ((now.getHours() * 60 + now.getMinutes()) / 60) * HOUR_HEIGHT;
+          return (
+            <div key={start} className="relative border-r border-hairline/40 last:border-r-0">
+              {Array.from({ length: 24 }, (_, hour) => (
+                <div key={hour} className="absolute inset-x-0 border-t border-hairline/25" style={{ top: hour * HOUR_HEIGHT }} />
+              ))}
+              {start === today && (
+                <div className="absolute inset-x-0 z-20 flex items-center" style={{ top: nowTop }}>
+                  <span className="-ml-1 size-2 rounded-full bg-danger" />
+                  <span className="h-px flex-1 bg-danger/80" />
+                </div>
+              )}
+              {dayItems.map((item) => {
+                const bot = bots.find((candidate) => candidate.id === (item.routine?.botId ?? item.run?.botId));
+                return bot ? <RoutineCard key={item.id} item={item} bot={bot} compact={days === 7} onOpen={() => onOpen(item)} /> : null;
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RoutineEditor({ routine, bots, onClose }: { routine?: Routine; bots: Bot[]; onClose: () => void }) {
+  const { dispatch } = useStore();
+  const [name, setName] = useState(routine?.name ?? "");
+  const [prompt, setPrompt] = useState(routine?.prompt ?? "");
+  const [botId, setBotId] = useState(routine?.botId ?? bots[0]?.id ?? "");
+  const [kind, setKind] = useState<"once" | "daily">(routine?.schedule.type ?? "daily");
+  const [at, setAt] = useState(
+    toInputDateTime(routine?.schedule.type === "once" ? routine.schedule.at : nextHour()),
+  );
+  const [time, setTime] = useState(routine?.schedule.type === "daily" ? routine.schedule.time : "09:00");
+  const [weekdays, setWeekdays] = useState(
+    routine?.schedule.type === "daily" ? routine.schedule.weekdays : [1, 2, 3, 4, 5],
+  );
+  const [durationMinutes, setDurationMinutes] = useState(routine?.durationMinutes ?? 30);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const save = async () => {
+    const input: RoutineInput = {
+      name,
+      prompt,
+      botId,
+      enabled: routine ? undefined : true,
+      durationMinutes,
+      schedule:
+        kind === "once"
+          ? { type: "once", at: new Date(at).getTime() }
+          : { type: "daily", time, weekdays },
+    };
+    setSaving(true);
+    setError("");
+    try {
+      const response = await api(routine ? `/api/routines/${routine.id}` : "/api/routines", {
+        method: routine ? "PATCH" : "POST",
+        body: JSON.stringify(input),
+      });
+      dispatch({ type: "routinePatched", routine: response.routine });
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-5 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
+      <div className="max-h-[90vh] w-full max-w-[620px] overflow-y-auto rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-hairline/40 bg-panel/95 px-5 py-4 backdrop-blur">
+          <div>
+            <div className="text-[17px] font-semibold text-ink">{routine ? "Edit routine" : "New routine"}</div>
+            <div className="mt-0.5 text-[12px] text-ink-secondary">Give a MAUS recurring work with a calendar you can trust.</div>
+          </div>
+          <button onClick={onClose} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button>
+        </div>
+        <div className="space-y-5 p-5">
+          <label className="block">
+            <span className="mb-1.5 block text-[12px] font-medium text-ink-secondary">Routine name</span>
+            <input autoFocus value={name} onChange={(event) => setName(event.target.value)} placeholder="Morning research brief" className="w-full rounded-xl border border-hairline/60 bg-inset px-3.5 py-2.5 text-[14px] text-ink outline-none placeholder:text-ink-secondary/60 focus:border-accent/70" />
+          </label>
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-ink-secondary">Who does it?</div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {bots.map((bot) => (
+                <button key={bot.id} type="button" onClick={() => setBotId(bot.id)} className={cn("flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left", botId === bot.id ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60")}>
+                  <MausAvatar color={bot.color} state={botId === bot.id ? "happy" : "idle"} size={38} animated={false} />
+                  <span className="truncate text-[13px] font-medium text-ink">{bot.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="block">
+            <span className="mb-1.5 block text-[12px] font-medium text-ink-secondary">What should this MAUS do?</span>
+            <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} rows={6} placeholder="Check the latest project activity, summarize what changed, and call out anything that needs my attention…" className="w-full resize-y rounded-xl border border-hairline/60 bg-inset px-3.5 py-3 text-[14px] leading-relaxed text-ink outline-none placeholder:text-ink-secondary/60 focus:border-accent/70" />
+          </label>
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-ink-secondary">When?</div>
+            <div className="mb-3 inline-flex rounded-xl bg-inset p-1">
+              {(["once", "daily"] as const).map((value) => (
+                <button key={value} onClick={() => setKind(value)} className={cn("rounded-lg px-4 py-1.5 text-[13px] capitalize", kind === value ? "bg-raised text-ink shadow" : "text-ink-secondary hover:text-ink")}>{value === "daily" ? "Repeating" : "Once"}</button>
+              ))}
+            </div>
+            {kind === "once" ? (
+              <input type="datetime-local" value={at} onChange={(event) => setAt(event.target.value)} className="block rounded-xl border border-hairline/60 bg-inset px-3.5 py-2.5 text-[14px] text-ink outline-none focus:border-accent/70 [color-scheme:dark]" />
+            ) : (
+              <div className="space-y-3">
+                <input type="time" value={time} onChange={(event) => setTime(event.target.value)} className="rounded-xl border border-hairline/60 bg-inset px-3.5 py-2.5 text-[14px] text-ink outline-none focus:border-accent/70 [color-scheme:dark]" />
+                <div className="flex flex-wrap gap-1.5">
+                  {DAY_NAMES.map((label, day) => (
+                    <button key={label} type="button" onClick={() => setWeekdays((current) => current.includes(day) ? (current.length === 1 ? current : current.filter((value) => value !== day)) : [...current, day].sort())} className={cn("size-10 rounded-xl border text-[11px] font-medium", weekdays.includes(day) ? "border-accent bg-accent text-white" : "border-hairline/50 bg-inset text-ink-secondary hover:text-ink")}>{label.slice(0, 2)}</button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+          <label className="block">
+            <span className="mb-1.5 block text-[12px] font-medium text-ink-secondary">Calendar block</span>
+            <select value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-xl border border-hairline/60 bg-inset px-3.5 py-2.5 text-[14px] text-ink outline-none focus:border-accent/70">
+              {[15, 30, 45, 60, 90, 120].map((minutes) => <option key={minutes} value={minutes}>{minutes < 60 ? `${minutes} minutes` : `${minutes / 60} ${minutes === 60 ? "hour" : "hours"}`}</option>)}
+            </select>
+          </label>
+          {error && <div className="flex items-start gap-2 rounded-xl border border-danger/30 bg-danger/10 px-3 py-2.5 text-[13px] text-danger"><CircleAlert size={16} className="mt-0.5 shrink-0" />{error}</div>}
+        </div>
+        <div className="sticky bottom-0 flex justify-end gap-2 border-t border-hairline/40 bg-panel/95 px-5 py-4 backdrop-blur">
+          <button onClick={onClose} className="rounded-xl px-4 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink">Cancel</button>
+          <button onClick={save} disabled={saving || !name.trim() || !prompt.trim() || !botId} className="flex items-center gap-2 rounded-xl bg-accent px-4 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40">
+            {saving && <Loader2 size={14} className="animate-spin" />}{routine ? "Save changes" : "Create routine"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoutineDetails({ item, bot, onClose, onEdit }: { item: CalendarItem; bot: Bot; onClose: () => void; onEdit: (routine: Routine) => void }) {
+  const { dispatch } = useStore();
+  const routine = item.routine;
+  const run = item.run;
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+  const title = routine?.name ?? run?.routineName ?? "Routine";
+
+  const invoke = async (path: string, method = "POST") => {
+    setWorking(true);
+    setError("");
+    try {
+      const response = await api(path, { method });
+      if (response.routine) dispatch({ type: "routinePatched", routine: response.routine });
+      if (response.run) dispatch({ type: "routineRunPatched", run: response.run });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-5 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
+      <div className="w-full max-w-[520px] overflow-hidden rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
+        <div className="relative overflow-hidden border-b border-hairline/40 px-5 py-5" style={{ background: `linear-gradient(135deg, color-mix(in srgb, ${MAUS_COLORS[bot.color]} 28%, #111), #111)` }}>
+          <button onClick={onClose} className="absolute right-3 top-3 rounded-lg p-2 text-white/60 hover:bg-white/10 hover:text-white"><X size={18} /></button>
+          <div className="flex items-center gap-4 pr-10">
+            <MausAvatar color={bot.color} state={run ? statusState(run.status) : "idle"} size={72} animated={run?.status === "running" || run?.status === "waiting"} label={bot.name} />
+            <div className="min-w-0">
+              <div className="truncate text-[20px] font-semibold text-white">{title}</div>
+              <div className="mt-1 flex items-center gap-2 text-[13px] text-white/65"><span>{bot.name}</span><span>·</span><span>{niceDate(item.at)}, {niceTime(item.at)}</span></div>
+              <div className={cn("mt-2 inline-flex items-center gap-1.5 rounded-full bg-black/25 px-2.5 py-1 text-[11px] font-medium capitalize", run ? statusTone(run.status) : "text-white/70")}>
+                {run?.status === "running" && <Loader2 size={11} className="animate-spin" />}
+                {run?.status === "completed" && <CheckCircle2 size={11} />}
+                {run ? run.status.replace("waiting", "needs you") : "scheduled"}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="max-h-[55vh] space-y-4 overflow-y-auto p-5">
+          {routine && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-xl bg-inset p-3"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Schedule</div><div className="mt-1 text-[13px] text-ink">{scheduleLabel(routine)}</div></div>
+              <div className="rounded-xl bg-inset p-3"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Duration</div><div className="mt-1 text-[13px] text-ink">{routine.durationMinutes} minutes</div></div>
+            </div>
+          )}
+          {(routine?.prompt ?? run?.prompt) && <div><div className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-ink-secondary">Instructions</div><div className="whitespace-pre-wrap rounded-xl border border-hairline/40 bg-inset px-3.5 py-3 text-[13px] leading-relaxed text-ink">{routine?.prompt ?? run?.prompt}</div></div>}
+          {run?.output && <div><div className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-ink-secondary">Last output</div><div className="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-xl border border-success/20 bg-success/5 px-3.5 py-3 text-[13px] leading-relaxed text-ink">{run.output}</div></div>}
+          {run?.error && <div className="flex items-start gap-2 rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[13px] text-danger"><CircleAlert size={16} className="mt-0.5 shrink-0" /><span>{run.error}</span></div>}
+          {error && <div className="flex items-start gap-2 rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[13px] text-danger"><CircleAlert size={16} className="mt-0.5 shrink-0" /><span>{error}</span></div>}
+          {run?.status === "waiting" && <div className="rounded-xl border border-warning/30 bg-warning/10 px-3.5 py-3 text-[13px] text-warning">This MAUS needs your answer. Open its task to continue the run.</div>}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 border-t border-hairline/40 px-5 py-4">
+          {routine && <button disabled={working} onClick={() => void invoke(`/api/routines/${routine.id}/run`)} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Play size={14} />Run now</button>}
+          {run?.threadId && <button onClick={() => { dispatch({ type: "select", id: bot.id }); dispatch({ type: "switchTask", botId: bot.id, threadId: run.threadId! }); onClose(); }} className="flex items-center gap-2 rounded-xl bg-raised px-3.5 py-2 text-[13px] text-ink hover:bg-raised-hover"><ExternalLink size={14} />Open task</button>}
+          {run && ["queued", "running", "waiting"].includes(run.status) && <button disabled={working} onClick={() => void invoke(`/api/routine-runs/${run.id}/cancel`)} className="flex items-center gap-2 rounded-xl bg-raised px-3.5 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-40"><X size={14} />Cancel run</button>}
+          <div className="flex-1" />
+          {routine && canToggleRoutine(routine) && <button disabled={working} onClick={async () => { setWorking(true); setError(""); try { const response = await api(`/api/routines/${routine.id}`, { method: "PATCH", body: JSON.stringify({ enabled: !routine.enabled }) }); dispatch({ type: "routinePatched", routine: response.routine }); } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); } finally { setWorking(false); } }} className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40">{routine.enabled ? <Pause size={14} /> : <Play size={14} />}{routine.enabled ? "Pause" : "Resume"}</button>}
+          {routine && <button onClick={() => onEdit(routine)} className="rounded-xl px-3 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink">Edit</button>}
+          {routine && <button onClick={() => { if (!window.confirm(`Delete “${routine.name}”? Its past run receipts will stay in the calendar.`)) return; dispatch({ type: "deleteRoutine", routineId: routine.id }); onClose(); }} className="rounded-xl p-2 text-ink-secondary hover:bg-danger/10 hover:text-danger" title="Delete routine"><Trash2 size={16} /></button>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PausedRoutines({ routines, bots, onClose, onEdit }: { routines: Routine[]; bots: Bot[]; onClose: () => void; onEdit: (routine: Routine) => void }) {
+  const { dispatch } = useStore();
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-5 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
+      <div className="w-full max-w-[560px] overflow-hidden rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
+        <div className="flex items-center justify-between border-b border-hairline/40 px-5 py-4">
+          <div><div className="text-[17px] font-semibold text-ink">Paused routines</div><div className="mt-0.5 text-[12px] text-ink-secondary">They keep their history and will not create new runs.</div></div>
+          <button onClick={onClose} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button>
+        </div>
+        <div className="max-h-[60vh] space-y-2 overflow-y-auto p-4">
+          {routines.map((routine) => {
+            const bot = bots.find((candidate) => candidate.id === routine.botId);
+            return (
+              <div key={routine.id} className="flex items-center gap-3 rounded-xl border border-hairline/40 bg-inset p-3">
+                {bot ? <MausAvatar color={bot.color} state="sleeping" size={44} animated={false} label={bot.name} /> : <div className="flex size-11 items-center justify-center rounded-xl bg-raised text-ink-secondary"><CalendarClock size={20} /></div>}
+                <div className="min-w-0 flex-1"><div className="truncate text-[14px] font-semibold text-ink">{routine.name}</div><div className="mt-0.5 truncate text-[11.5px] text-ink-secondary">{bot?.name ?? "Deleted MAUS"} · {scheduleLabel(routine)}</div></div>
+                {bot && <button onClick={() => dispatch({ type: "updateRoutine", routineId: routine.id, patch: { enabled: true } })} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[12px] font-medium text-white hover:brightness-110"><Play size={12} />Resume</button>}
+                <button onClick={() => onEdit(routine)} className="rounded-lg px-2 py-1.5 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink">Edit</button>
+                <button onClick={() => { if (!window.confirm(`Delete “${routine.name}”?`)) return; dispatch({ type: "deleteRoutine", routineId: routine.id }); }} className="rounded-lg p-2 text-ink-secondary hover:bg-danger/10 hover:text-danger" title="Delete routine"><Trash2 size={15} /></button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RoutinesPage() {
+  const { state, dispatch } = useStore();
+  const [viewDays, setViewDays] = useState<1 | 3 | 7>(7);
+  const [anchor, setAnchor] = useState(() => startOfWeek(Date.now()));
+  const [botFilter, setBotFilter] = useState("all");
+  const [editor, setEditor] = useState<Routine | "new" | null>(null);
+  const [selected, setSelected] = useState<CalendarItem | null>(null);
+  const [pausedOpen, setPausedOpen] = useState(false);
+  const visibleBots = state.bots.filter((bot) => !bot.hidden);
+  const rangeStart = viewDays === 7 ? startOfWeek(anchor) : startOfDay(anchor);
+  const rangeEnd = addDays(rangeStart, viewDays);
+  const items = useMemo(
+    () => projectedItems(state.routines, state.routineRuns, rangeStart, rangeEnd).filter((item) => botFilter === "all" || (item.routine?.botId ?? item.run?.botId) === botFilter),
+    [state.routines, state.routineRuns, rangeStart, rangeEnd, botFilter],
+  );
+  const liveSelected = selected
+    ? {
+        ...selected,
+        routine: selected.routine ? state.routines.find((routine) => routine.id === selected.routine?.id) ?? null : null,
+        run: selected.run ? state.routineRuns.find((run) => run.id === selected.run?.id) ?? selected.run : null,
+      }
+    : null;
+  const selectedBot = liveSelected
+    ? state.bots.find((bot) => bot.id === (liveSelected.routine?.botId ?? liveSelected.run?.botId))
+    : undefined;
+  const unseenFailures = state.routineRuns.filter((run) => ["failed", "missed"].includes(run.status) && !run.seenAt).length;
+  const running = state.routineRuns.filter((run) => ["queued", "running", "waiting"].includes(run.status)).length;
+  const paused = state.routines.filter((routine) => !routine.enabled && canToggleRoutine(routine));
+  useEffect(() => {
+    if (pausedOpen && paused.length === 0) setPausedOpen(false);
+  }, [pausedOpen, paused.length]);
+
+  const move = (direction: number) => setAnchor((current) => addDays(current, direction * viewDays));
+  const goToday = () => setAnchor(viewDays === 7 ? startOfWeek(Date.now()) : startOfDay(Date.now()));
+  const openItem = (item: CalendarItem) => {
+    setSelected(item);
+    if (item.run && ["failed", "missed"].includes(item.run.status) && !item.run.seenAt) {
+      dispatch({ type: "markRoutineRunSeen", runId: item.run.id });
+    }
+  };
+
+  return (
+    <main className="flex h-full min-w-0 flex-1 flex-col bg-app">
+      <header className="shrink-0 px-5 pb-4 pt-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2.5"><CalendarDays size={21} className="text-accent" /><h1 className="text-[20px] font-semibold tracking-tight text-ink">Routines</h1></div>
+            <p className="mt-1 text-[12.5px] text-ink-secondary">Scheduled work runs through your real MAUS team while OpenMausBot is open.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {running > 0 && <span className="flex items-center gap-1.5 rounded-full border border-accent/25 bg-accent/10 px-2.5 py-1.5 text-[11px] text-accent"><Loader2 size={12} className="animate-spin" />{running} active</span>}
+            {unseenFailures > 0 && <span className="flex items-center gap-1.5 rounded-full border border-danger/25 bg-danger/10 px-2.5 py-1.5 text-[11px] text-danger"><CircleAlert size={12} />{unseenFailures} need attention</span>}
+            {paused.length > 0 && <button onClick={() => setPausedOpen(true)} className="flex items-center gap-1.5 rounded-full border border-hairline/50 bg-panel px-2.5 py-1.5 text-[11px] text-ink-secondary hover:bg-raised hover:text-ink"><Pause size={12} />{paused.length} paused</button>}
+            <button onClick={() => setEditor("new")} disabled={visibleBots.length === 0} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2 text-[13px] font-medium text-white shadow-lg shadow-accent/10 hover:brightness-110 disabled:opacity-40"><Plus size={15} />New routine</button>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="flex items-center rounded-xl border border-hairline/50 bg-panel p-0.5">
+            <button onClick={() => move(-1)} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Previous dates"><ChevronLeft size={16} /></button>
+            <button onClick={goToday} className="px-2.5 py-1.5 text-[12px] font-medium text-ink hover:text-accent">Today</button>
+            <button onClick={() => move(1)} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Next dates"><ChevronRight size={16} /></button>
+          </div>
+          <div className="min-w-[190px] px-2 text-[14px] font-semibold text-ink">
+            {new Date(rangeStart).toLocaleDateString([], { month: "long", year: "numeric" })}
+          </div>
+          <select value={botFilter} onChange={(event) => setBotFilter(event.target.value)} className="rounded-xl border border-hairline/50 bg-panel px-3 py-2 text-[12px] text-ink outline-none focus:border-accent/60">
+            <option value="all">All MAUSes</option>
+            {visibleBots.map((bot) => <option key={bot.id} value={bot.id}>{bot.name}</option>)}
+          </select>
+          <div className="ml-auto flex rounded-xl bg-panel p-1">
+            {([1, 3, 7] as const).map((days) => <button key={days} onClick={() => { setViewDays(days); setAnchor(days === 7 ? startOfWeek(anchor) : startOfDay(anchor)); }} className={cn("rounded-lg px-3 py-1.5 text-[11px] font-medium", viewDays === days ? "bg-raised text-ink shadow" : "text-ink-secondary hover:text-ink")}>{days === 1 ? "Day" : days === 3 ? "3 days" : "Week"}</button>)}
+          </div>
+        </div>
+      </header>
+
+      {state.routines.length === 0 && state.routineRuns.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center p-8">
+          <div className="max-w-[430px] text-center">
+            <div className="relative mx-auto mb-5 flex h-28 w-44 items-end justify-center">
+              {visibleBots.slice(0, 3).map((bot, index) => <div key={bot.id} className="-ml-3 first:ml-0" style={{ transform: `translateY(${Math.abs(index - 1) * 9}px) rotate(${(index - 1) * 5}deg)` }}><MausAvatar color={bot.color} state={index === 1 ? "excited" : "idle"} size={84} /></div>)}
+              {visibleBots.length === 0 && <CalendarClock size={58} className="text-ink-secondary/40" />}
+            </div>
+            <h2 className="text-[18px] font-semibold text-ink">Put your MAUS team on a rhythm</h2>
+            <p className="mt-2 text-[13px] leading-relaxed text-ink-secondary">Plan research briefs, daily check-ins, recurring reviews, or one-time work. Every run becomes a separate task with its own result.</p>
+            <button onClick={() => setEditor("new")} disabled={visibleBots.length === 0} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />Create your first routine</button>
+            {visibleBots.length === 0 && <p className="mt-3 text-[12px] text-warning">Create a bot first, then come back to schedule it.</p>}
+          </div>
+        </div>
+      ) : (
+        <CalendarGrid anchor={rangeStart} days={viewDays} items={items} bots={state.bots} onOpen={openItem} />
+      )}
+
+      {editor && <RoutineEditor routine={editor === "new" ? undefined : editor} bots={visibleBots} onClose={() => setEditor(null)} />}
+      {liveSelected && selectedBot && <RoutineDetails item={liveSelected} bot={selectedBot} onClose={() => setSelected(null)} onEdit={(routine) => { setSelected(null); setEditor(routine); }} />}
+      {pausedOpen && <PausedRoutines routines={paused} bots={state.bots} onClose={() => setPausedOpen(false)} onEdit={(routine) => { setPausedOpen(false); setEditor(routine); }} />}
+    </main>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownToLine,
   BellDot,
   Bot as BotIcon,
+  CalendarDays,
   Check,
   ClipboardCopy,
   Copy,
@@ -162,7 +163,7 @@ function StackedMauses({ members }: { members: Bot[] }) {
 
 function GroupListItem({ group, onMenu }: { group: Group; onMenu: (menu: { groupId: string; x: number; y: number }) => void }) {
   const { state, dispatch } = useStore();
-  const selected = state.selectedId === group.id;
+  const selected = state.activeView === "chat" && state.selectedId === group.id;
   const members = group.memberIds
     .map((id) => state.bots.find((b) => b.id === id))
     .filter((b): b is Bot => Boolean(b));
@@ -413,7 +414,7 @@ function BotContextMenu({ menu, onClose }: { menu: MenuState; onClose: () => voi
 
 function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => void }) {
   const { state, dispatch } = useStore();
-  const selected = state.selectedId === bot.id;
+  const selected = state.activeView === "chat" && state.selectedId === bot.id;
   const mascotMotion = selected && state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
   // the visible branch, so a version switch changes the row with the chat
   const visible = visibleMessages(bot);
@@ -576,6 +577,19 @@ export function Sidebar() {
 
       {/* Footer */}
       <div className="px-3 pb-3 pt-2">
+        <button
+          onClick={() => dispatch({ type: "showRoutines" })}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition-colors",
+            state.activeView === "routines" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+          )}
+        >
+          <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
+          <span className="flex-1 text-[14px]">Routines</span>
+          {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
+            <span className="size-2 rounded-full bg-danger" />
+          )}
+        </button>
         <button
           onClick={() => dispatch({ type: "togglePlugins", open: true })}
           className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-raised/50"

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -1,0 +1,55 @@
+export type RoutineSchedule =
+  | { type: "once"; at: number }
+  | { type: "daily"; time: string; weekdays: number[] };
+
+export type RoutineRunStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "missed";
+
+export interface Routine {
+  id: string;
+  name: string;
+  prompt: string;
+  botId: string;
+  enabled: boolean;
+  schedule: RoutineSchedule;
+  durationMinutes: number;
+  nextRunAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RoutineRun {
+  id: string;
+  routineId: string;
+  routineName: string;
+  prompt?: string;
+  durationMinutes?: number;
+  botId: string;
+  scheduledFor: number;
+  status: RoutineRunStatus;
+  manual: boolean;
+  threadId?: string;
+  startedAt?: number;
+  finishedAt?: number;
+  output?: string;
+  error?: string;
+  cost?: number | null;
+  denials?: string[];
+  createdAt: number;
+  seenAt?: number;
+}
+
+export interface RoutineInput {
+  name: string;
+  prompt: string;
+  botId: string;
+  enabled?: boolean;
+  schedule: RoutineSchedule;
+  durationMinutes?: number;
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -13,6 +13,7 @@ import {
   type ReactNode,
 } from "react";
 import type { MausColor, MausMotion } from "@/lib/mascot";
+import type { Routine, RoutineInput, RoutineRun } from "@/lib/routines";
 
 export type { MausColor } from "@/lib/mascot";
 
@@ -167,6 +168,9 @@ interface AppState {
   config: ConfigStatus | null;
   /** selected chat — a bot id OR a group id */
   selectedId: string;
+  activeView: "chat" | "routines";
+  routines: Routine[];
+  routineRuns: RoutineRun[];
   settingsOpen: boolean;
   pluginsOpen: boolean;
   computerOpen: boolean;
@@ -186,6 +190,17 @@ interface AppState {
 
 type Action =
   | { type: "hydrate"; bots: Bot[]; groups: Group[] }
+  | { type: "showRoutines" }
+  | { type: "routinesHydrated"; routines: Routine[]; runs: RoutineRun[] }
+  | { type: "routinePatched"; routine: Routine }
+  | { type: "routineDeleted"; routineId: string }
+  | { type: "routineRunPatched"; run: RoutineRun }
+  | { type: "createRoutine"; input: RoutineInput }
+  | { type: "updateRoutine"; routineId: string; patch: Partial<RoutineInput> }
+  | { type: "deleteRoutine"; routineId: string }
+  | { type: "runRoutine"; routineId: string }
+  | { type: "cancelRoutineRun"; runId: string }
+  | { type: "markRoutineRunSeen"; runId: string }
   | { type: "groupPatched"; group: Partial<Group> & { id: string } }
   | { type: "groupDeleted"; groupId: string }
   | { type: "createGroup"; memberIds: string[]; name?: string }
@@ -283,6 +298,35 @@ function reducer(state: AppState, action: Action): AppState {
         state.selectedId && known(state.selectedId) ? state.selectedId : (action.bots[0]?.id ?? "");
       return { ...state, bots: action.bots, groups: action.groups, selectedId };
     }
+    case "showRoutines":
+      return {
+        ...state,
+        activeView: "routines",
+        settingsOpen: false,
+        computerOpen: false,
+        appSettingsOpen: false,
+        pluginsOpen: false,
+      };
+    case "routinesHydrated":
+      return { ...state, routines: action.routines, routineRuns: action.runs };
+    case "routinePatched": {
+      const exists = state.routines.some((routine) => routine.id === action.routine.id);
+      return {
+        ...state,
+        routines: exists
+          ? state.routines.map((routine) => (routine.id === action.routine.id ? action.routine : routine))
+          : [action.routine, ...state.routines],
+      };
+    }
+    case "routineDeleted":
+      return { ...state, routines: state.routines.filter((routine) => routine.id !== action.routineId) };
+    case "routineRunPatched": {
+      const exists = state.routineRuns.some((run) => run.id === action.run.id);
+      const runs = exists
+        ? state.routineRuns.map((run) => (run.id === action.run.id ? action.run : run))
+        : [action.run, ...state.routineRuns];
+      return { ...state, routineRuns: runs.sort((a, b) => b.scheduledFor - a.scheduledFor) };
+    }
     case "groupPatched": {
       const exists = state.groups.some((g) => g.id === action.group.id);
       const groups = exists
@@ -303,12 +347,13 @@ function reducer(state: AppState, action: Action): AppState {
       if (state.groups.some((g) => g.id === action.id)) {
         return {
           ...state,
+          activeView: "chat",
           selectedId: action.id,
           groups: state.groups.map((g) => (g.id === action.id ? { ...g, unread: false } : g)),
         };
       }
       return updateBot(
-        withMascotMotion({ ...state, selectedId: action.id }, action.id, "switch"),
+        withMascotMotion({ ...state, activeView: "chat", selectedId: action.id }, action.id, "switch"),
         action.id,
         (b) => ({ ...b, unread: false }),
       );
@@ -328,6 +373,7 @@ function reducer(state: AppState, action: Action): AppState {
       return withMascotMotion({
         ...state,
         bots: [action.bot, ...state.bots],
+        activeView: "chat",
         selectedId: action.bot.id,
       }, action.bot.id, "arrive");
     case "deleteBot": {
@@ -549,6 +595,12 @@ function reducer(state: AppState, action: Action): AppState {
     case "sendGroup":
     case "deleteGroup":
     case "interruptGroup":
+    case "createRoutine":
+    case "updateRoutine":
+    case "deleteRoutine":
+    case "runRoutine":
+    case "cancelRoutineRun":
+    case "markRoutineRunSeen":
       return state;
   }
 }
@@ -562,6 +614,9 @@ const initialState: AppState = {
   instances: [],
   config: null,
   selectedId: "",
+  activeView: "chat",
+  routines: [],
+  routineRuns: [],
   settingsOpen: false,
   pluginsOpen: false,
   computerOpen: false,
@@ -672,6 +727,27 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const wrapped: React.Dispatch<Action> = (action) => {
       rawDispatch(action);
       switch (action.type) {
+        case "createRoutine":
+          api("/api/routines", { method: "POST", body: JSON.stringify(action.input) }).catch(showError);
+          break;
+        case "updateRoutine":
+          api(`/api/routines/${action.routineId}`, {
+            method: "PATCH",
+            body: JSON.stringify(action.patch),
+          }).catch(showError);
+          break;
+        case "deleteRoutine":
+          api(`/api/routines/${action.routineId}`, { method: "DELETE" }).catch(showError);
+          break;
+        case "runRoutine":
+          api(`/api/routines/${action.routineId}/run`, { method: "POST" }).catch(showError);
+          break;
+        case "cancelRoutineRun":
+          api(`/api/routine-runs/${action.runId}/cancel`, { method: "POST" }).catch(showError);
+          break;
+        case "markRoutineRunSeen":
+          api(`/api/routine-runs/${action.runId}/seen`, { method: "POST" }).catch(showError);
+          break;
         case "send":
           api(`/api/bots/${action.botId}/messages`, {
             method: "POST",
@@ -901,6 +977,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       api("/api/config")
         .then((config) => alive && rawDispatch({ type: "configStatus", config }))
         .catch(() => {});
+      api("/api/routines")
+        .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs }))
+        .catch(() => {});
     };
     loadAll();
 
@@ -961,6 +1040,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         }
         case "group.deleted":
           rawDispatch({ type: "groupDeleted", groupId: frame.groupId });
+          break;
+        case "routine":
+          rawDispatch({ type: "routinePatched", routine: frame.routine });
+          break;
+        case "routine.deleted":
+          rawDispatch({ type: "routineDeleted", routineId: frame.routineId });
+          break;
+        case "routine.run":
+          rawDispatch({ type: "routineRunPatched", run: frame.run });
           break;
         case "runtime": {
           const event = frame.event;


### PR DESCRIPTION
## What this adds

- a first-class **Routines** destination with day, 3-day, and week calendar views
- recurring and one-time routine creation, MAUS assignment, local-time scheduling, filters, editing, pause/resume, run-now, cancellation, and deletion
- assigned MAUS mascots rendered directly on projected and historical calendar cards
- detail receipts for queued, running, waiting, completed, failed, cancelled, and missed runs
- durable local persistence for routine definitions and immutable run receipts
- a scheduler that catches up recent work, records stale work as missed, and queues behind busy bots
- one detached task per routine run, with provider session/cursor isolation so switching chats cannot redirect background output
- lifecycle folding for output, cost, denials, approval/question waits, completion, failure, cancellation, and restart recovery
- normal bot Stop behavior and task-deletion guards for live routine runs

## Why the execution model matters

Routine definitions are kept separate from occurrence receipts. Each occurrence snapshots its name, prompt, duration, bot, and scheduled time, then runs in its own pinned task. Editing the routine later cannot rewrite history, and changing the visible task while a run is active cannot move its output into another conversation.

## Verification

- `npm test` — 189 passed, 6 skipped
- `npm run build`
- `npm run check:electron`
- browser QA: empty state, routine creation, full-week rendering, MAUS card, detail view, pause/resume, and console errors

## Runtime note

This first local-first version runs schedules while OpenMausBot is running. A 12-hour catch-up window handles normal sleep/restart gaps; older occurrences are recorded as missed rather than launched unexpectedly.
