### PR TITLE
Local VM: a bot can drive a Linux desktop on this machine

### DIFF
--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -26,9 +26,18 @@
 //     type, Enter) in one round trip with one frame at the end.
 //
 // stdout is the MCP channel — never console.log here.
+import { spawn } from "node:child_process";
 const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
+// The same desktop can live in a cloud box or in a container on this
+// machine. Only the two functions below know the difference — every tool
+// above them just runs shell and reads a file back.
+const container = process.env.OGB_CONTAINER ?? "";
+const runtime = process.env.OGB_RUNTIME || "docker";
+const local = Boolean(container);
+// the desktop images run X on :1; a cloud box uses :0
+const CONTAINER_DISPLAY = process.env.OGB_DISPLAY || ":1";
 
 /** The coordinate space the model sees: frames are downscaled to this
  * width, and clicks are scaled back up to the real display box-side. */
@@ -69,7 +78,38 @@ async function resumeBox(): Promise<boolean> {
   return false;
 }
 
+/** Run a command inside the local container. No network and no waking: a
+ * stopped container is reported plainly instead of hanging. */
+function runInContainer(command: string, timeoutMs: number): Promise<RunOut> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      runtime,
+      ["exec", "-e", `DISPLAY=${CONTAINER_DISPLAY}`, container, "bash", "-lc", command],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    child.stdout.on("data", (c) => (stdout += c));
+    child.stderr.on("data", (c) => (stderr += c));
+    child.on("error", (e) =>
+      resolve({ ok: false, exitCode: null, stdout: "", stderr: `${runtime} not available: ${e.message}` }),
+    );
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        ok: code === 0,
+        exitCode: code,
+        stdout,
+        stderr:
+          code === 0 ? stderr : stderr || `the local computer isn't running — start it: ${runtime} start ${container}`,
+      });
+    });
+  });
+}
+
 async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): Promise<RunOut> {
+  if (local) return runInContainer(command, timeoutMs);
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
@@ -93,7 +133,7 @@ async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): 
   };
 }
 
-const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+const ENV = local ? `export DISPLAY=${CONTAINER_DISPLAY}` : 'export DISPLAY=${DISPLAY:-:0}';
 /** Resolve the real display size into $W/$H for box-side click scaling. */
 const GEOMETRY = [
   "g=$(xdotool getdisplaygeometry 2>/dev/null)",
@@ -161,6 +201,13 @@ function wholeImage(bytes: Buffer, expectedBytes?: number): boolean {
  * envelope second. Both are validated — an error page served with a 200
  * must fall through, not reach the model as an "image". */
 async function fetchFrame(expectedBytes?: number): Promise<string | null> {
+  if (local) {
+    // no HTTP hop at all — read the bytes straight out of the container
+    const out = await runInContainer(`base64 -w0 ${SHOT_PATH}`, 30_000);
+    const data = out.stdout.trim();
+    if (!data) return null;
+    return wholeImage(Buffer.from(data, "base64"), expectedBytes) ? data : null;
+  }
   const auth = { authorization: `Bearer ${token}` };
   try {
     const res = await fetch(

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -1,0 +1,53 @@
+// Which transport a bot's computer uses. This is the one decision that
+// separates "drive a cloud box over REST" from "drive a container on this
+// machine over exec", and both drivers depend on getting it right.
+import { describe, expect, it } from "vitest";
+
+import { CONTAINER, IMAGE, computerProxyEnv, setupCommands } from "./container-computer.ts";
+
+describe("computerProxyEnv", () => {
+  it("hands the proxy a container when the bot runs on a local VM", () => {
+    expect(computerProxyEnv({ kind: "container", container: "openmausbot-computer", runtime: "podman" })).toEqual({
+      OGB_CONTAINER: "openmausbot-computer",
+      OGB_RUNTIME: "podman",
+    });
+  });
+
+  it("defaults the runtime rather than shipping an empty command", () => {
+    expect(computerProxyEnv({ kind: "container", container: "c" }).OGB_RUNTIME).toBe("docker");
+  });
+
+  it("hands the proxy a box otherwise — the cloud path is unchanged", () => {
+    expect(computerProxyEnv({ boxId: "bx_1", token: "t" })).toEqual({
+      OGB_BOX_ID: "bx_1",
+      OGB_BOX_TOKEN: "t",
+    });
+  });
+
+  it("never leaks box credentials into a container turn", () => {
+    const env = computerProxyEnv({ kind: "container", container: "c", runtime: "docker" });
+    expect(env.OGB_BOX_TOKEN).toBeUndefined();
+    expect(env.OGB_BOX_ID).toBeUndefined();
+  });
+});
+
+describe("setupCommands", () => {
+  it("uses the runtime the user actually has", () => {
+    expect(setupCommands("podman").pull).toBe(`podman pull ${IMAGE}`);
+    expect(setupCommands("podman").run).toContain("podman run -d --name");
+  });
+
+  it("falls back to docker when nothing is installed, so the steps still read", () => {
+    expect(setupCommands(null).pull.startsWith("docker pull ")).toBe(true);
+  });
+
+  it("names one container, so start/stop/remove all refer to the same thing", () => {
+    const c = setupCommands("docker");
+    for (const cmd of [c.run, c.start, c.stop, c.remove]) expect(cmd).toContain(CONTAINER);
+  });
+
+  it("publishes the desktop so a human can watch what the bot does", () => {
+    expect(setupCommands("docker").run).toContain("-p 6080:6080");
+    expect(setupCommands("docker").view).toContain("6080");
+  });
+});

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -108,3 +108,14 @@ export function setupCommands(runtime: Runtime | null) {
     view: "http://localhost:6080/vnc.html",
   };
 }
+
+/** Env for the computer proxy: which transport it should use. Both drivers
+ * mount the same proxy, so this is the single place that decides. */
+export function computerProxyEnv(
+  computer: { kind?: string; boxId?: string; token?: string; container?: string; runtime?: string },
+): Record<string, string> {
+  if (computer.kind === "container" && computer.container) {
+    return { OGB_CONTAINER: computer.container, OGB_RUNTIME: computer.runtime ?? "docker" };
+  }
+  return { OGB_BOX_ID: computer.boxId ?? "", OGB_BOX_TOKEN: computer.token ?? "" };
+}

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -99,7 +99,11 @@ export interface SendTurnInput {
   integrations?: {
     composio?: { url?: string; key: string };
     /** The bot's cloud computer (box.ascii.dev) for desktop/browser use. */
-    computer?: { boxId: string; token: string };
+    /** the bot's computer: a cloud box, or a container on this machine.
+     * Both end up as the same MCP toolset — only the transport differs. */
+    computer?:
+      | { kind?: "box"; boxId: string; token: string }
+      | { kind: "container"; container: string; runtime: string };
     /** Local computer use via the Electron-hosted cua-driver daemon —
      * spawn config comes verbatim from cua-connection.json (the daemon
      * MUST be spawned by Electron main; the harness only points the agent

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -30,6 +30,7 @@ import type {
   SendTurnInput,
 } from "../../contracts.ts";
 import { newEventId, newId } from "../../contracts.ts";
+import { computerProxyEnv } from "../../container-computer.ts";
 import { augmentedPath } from "../../env-path.ts";
 
 // the computer proxy entry: .ts in dev (node type stripping), .js in the
@@ -156,11 +157,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             name: "computer",
             command: process.execPath,
             args: [COMPUTER_PROXY_PATH],
-            env: acpEnv({
-              ELECTRON_RUN_AS_NODE: "1",
-              OGB_BOX_ID: computer.boxId,
-              OGB_BOX_TOKEN: computer.token,
-            }),
+            env: acpEnv({ ELECTRON_RUN_AS_NODE: "1", ...computerProxyEnv(computer) }),
           });
         } else if (turn.integrations?.localComputer) {
           const local = turn.integrations.localComputer;

--- a/server/drivers/boxagent.ts
+++ b/server/drivers/boxagent.ts
@@ -84,9 +84,16 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
 
     const sendTurn = async (turn: SendTurnInput) => {
       const { threadId } = turn;
-      const boxId = turn.integrations?.computer?.boxId;
+      const computer = turn.integrations?.computer;
+      const boxId = computer && (!computer.kind || computer.kind === "box") ? computer.boxId : undefined;
       if (!token) throw new Error('box not configured — add {"box":{"token":"…"}} to ~/.openmausbot/config.json');
-      if (!boxId) throw new Error("this bot has no computer yet — open the Computer panel and provision one");
+      if (!boxId) {
+        throw new Error(
+          computer?.kind === "container"
+            ? "this engine runs on a cloud box — switch this bot's computer to Cloud box, or pick another engine"
+            : "this bot has no computer yet — open the Computer panel and provision one",
+        );
+      }
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
       const turnId = newId();
       const model = turn.model || MODELS.default;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -27,6 +27,7 @@ import type {
   RuntimeEventListener,
   SendTurnInput,
 } from "../contracts.ts";
+import { computerProxyEnv } from "../container-computer.ts";
 import { newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
 
@@ -256,11 +257,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         mcpServers.computer = {
           command: process.execPath,
           args: [PROXY_PATH],
-          env: {
-            ...NODE_ENV_FLAG,
-            OGB_BOX_ID: turn.integrations.computer.boxId,
-            OGB_BOX_TOKEN: turn.integrations.computer.token,
-          },
+          env: { ...NODE_ENV_FLAG, ...computerProxyEnv(turn.integrations.computer) },
         };
         allowed.push("mcp__computer");
       } else if (turn.integrations?.localComputer) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -462,7 +462,33 @@ async function startTurn(
       const mountsComputer =
         instance.adapter.capabilities.computerMcp === true || instance.driverKind === "boxAgent";
       let previewBoxId: string | null = null;
-      if (wants !== "off" && wants !== "local" && box.boxConfigured(cfg)) {
+      // a Linux desktop in a container on this machine: free, disposable,
+      // and driven by the very same tools as the cloud box
+      if (wants === "vm" && mountsComputer) {
+        const local = await containerComputerStatus();
+        if (local.container === "running" && local.runtime) {
+          integrations.computer = {
+            kind: "container",
+            container: local.container_name,
+            runtime: local.runtime,
+          };
+        } else {
+          const why = !local.runtime
+            ? "no container runtime is installed"
+            : !local.daemonUp
+              ? `${local.runtime} isn't running`
+              : !local.image
+                ? "the desktop image hasn't been downloaded"
+                : "the computer container isn't started";
+          const note = store.appendMessage(bot.threadId, {
+            role: "bot",
+            kind: "activity",
+            tool: { name: `no local computer — ${why} (App Settings → Local computer)`, ok: false },
+          });
+          broadcast({ kind: "message", threadId: bot.threadId, message: note });
+        }
+      }
+      if (wants !== "off" && wants !== "local" && wants !== "vm" && box.boxConfigured(cfg)) {
         let b = await box.findBox(cfg, bot.id).catch(() => null);
         // the Computer driver runs ON the box — provision it on first use
         if (!b && instance.driverKind === "boxAgent") {

--- a/server/store.ts
+++ b/server/store.ts
@@ -131,7 +131,7 @@ export interface BotRecord {
   resumeCursors: Record<string, unknown>;
   /** which computer the bot acts on: its cloud box, this Mac (local CUA),
    * or none. Unset = auto (box when it exists, else local when available). */
-  computer?: "cloud" | "local" | "off";
+  computer?: "cloud" | "vm" | "local" | "off";
   /** Auto mode: the bot approves its own tool permissions and keeps
    * working instead of stopping to ask. Questions it asks YOU still come
    * through, and a short list of destructive commands still stops it. */

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -29,6 +29,8 @@ async function api(path: string, init?: RequestInit): Promise<any> {
 
 type Phase =
   | "checking"
+  | "vm"
+  | "vm-unready"
   | "unconfigured"
   | "starting"
   | "ready"
@@ -43,6 +45,12 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const localAvailable = capabilities.localComputer.available;
   const [phase, setPhase] = useState<Phase>("checking");
   const [boxState, setBoxState] = useState<string | null>(null);
+  const [vmStatus, setVmStatus] = useState<{
+    container?: string;
+    runtime?: string | null;
+    daemonUp?: boolean;
+    image?: boolean;
+  } | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<"join" | "sleep" | null>(null);
@@ -64,6 +72,18 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     }
     if (bot.computer === "local") {
       setPhase(capabilitiesReady && localAvailable ? "local" : "local-unavailable");
+      return;
+    }
+    // a local VM is a container on this machine — never provision a paid
+    // cloud box for it, and say plainly when it isn't set up yet
+    if (bot.computer === "vm") {
+      api("/api/local-computer")
+        .then((s: { container?: string; runtime?: string | null; daemonUp?: boolean; image?: boolean }) => {
+          if (!alive) return;
+          setVmStatus(s);
+          setPhase(s.container === "running" ? "vm" : "vm-unready");
+        })
+        .catch(() => alive && setPhase("vm-unready"));
       return;
     }
     if (bot.computer !== "cloud" && !capabilitiesReady) return;
@@ -175,8 +195,17 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       .finally(() => setPending(null));
   };
 
-  const emptyState: Record<Exclude<Phase, "ready" | "local">, string> = {
+  const vmMissing = !vmStatus?.runtime
+    ? "no container runtime is installed yet"
+    : !vmStatus.daemonUp
+      ? `${vmStatus.runtime} isn't running`
+      : !vmStatus.image
+        ? "the desktop image hasn't been downloaded"
+        : "the computer isn't started";
+
+  const emptyState: Record<Exclude<Phase, "ready" | "local" | "vm">, string> = {
     checking: "Checking…",
+    "vm-unready": `Local VM isn't ready — ${vmMissing}`,
     starting: "Starting your bot's computer…",
     unconfigured: "No cloud computer configured",
     "local-unavailable":
@@ -234,7 +263,9 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                     ? localMisses >= 3
                       ? "No frames yet — the preview needs Screen Recording permission. After granting, relaunch the app."
                       : "Capturing this computer's screen…"
-                    : emptyState[phase]}
+                    : phase === "vm"
+                      ? "Your bot's Linux desktop is running"
+                      : emptyState[phase]}
               </span>
               {phase === "local" && localMisses >= 3 && (
                 <button
@@ -253,6 +284,38 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             {error}
           </div>
         )}
+        {phase === "vm-unready" && (
+          <div className="mt-3 rounded-xl bg-card p-4">
+            <div className="mb-3 text-[13px] leading-relaxed text-ink-secondary">
+              A Local VM is a Linux desktop running on this machine — free, and separate from your own
+              desktop. It needs a one-time setup, and {vmMissing}.
+            </div>
+            <button
+              onClick={() => dispatch({ type: "toggleAppSettings", open: true, section: "computer" })}
+              className="rounded-lg bg-accent px-3 py-1.5 text-[13px] font-medium text-white hover:brightness-110"
+            >
+              Set up the Local VM
+            </button>
+          </div>
+        )}
+
+        {phase === "vm" && (
+          <div className="mt-3 rounded-xl bg-card p-4">
+            <div className="text-[13px] leading-relaxed text-ink-secondary">
+              This bot has a Linux desktop on this machine. Nothing it does touches your own desktop or
+              files.
+            </div>
+            <a
+              href="http://localhost:6080/vnc.html"
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised"
+            >
+              <ExternalLink size={13} /> Watch the screen
+            </a>
+          </div>
+        )}
+
         {phase === "unconfigured" && (
           <div className="mt-3 rounded-xl bg-card p-4">
             <div className="mb-3 text-[13px] text-ink-secondary">

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -298,12 +298,15 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 (localAvailable
                   ? "Auto uses a cloud box when one exists, otherwise this computer. "
                   : "Auto uses a cloud box when one is configured; otherwise computer use stays off. ")}
-              Pick where this bot's computer lives.
+              Pick where this bot's computer lives. <b className="text-ink">Local VM</b> is a Linux desktop
+              in a container on this machine — free and separate from your own desktop. Set it up in App
+              Settings → Local computer.
           </div>
           <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
             {(
               [
                 ["cloud", "Cloud box"],
+                ["vm", "Local VM"],
                 ["local", "This computer"],
                 ["off", "Off"],
               ] as const

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -124,8 +124,8 @@ export function CommandLine({ command }: { command: string }) {
 }
 
 export function SettingsModal() {
-  const { dispatch } = useStore();
-  const [section, setSection] = useState<SectionId>("general");
+  const { state, dispatch } = useStore();
+  const [section, setSection] = useState<SectionId>(state.appSettingsSection ?? "general");
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && dispatch({ type: "toggleAppSettings", open: false });

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -171,6 +171,8 @@ interface AppState {
   pluginsOpen: boolean;
   computerOpen: boolean;
   appSettingsOpen: boolean;
+  /** which settings section to land on when it opens */
+  appSettingsSection?: "general" | "connections" | "computer";
   /** latest live frame of a bot's computer, per botId */
   screens: Record<string, { png: string; mime: string }>;
   /** bots whose cloud computer is being provisioned */
@@ -235,7 +237,7 @@ type Action =
   | { type: "toggleSettings"; open?: boolean }
   | { type: "togglePlugins"; open?: boolean }
   | { type: "toggleComputer"; open?: boolean }
-  | { type: "toggleAppSettings"; open?: boolean }
+  | { type: "toggleAppSettings"; open?: boolean; section?: "general" | "connections" | "computer" }
   | {
       type: "updateBot";
       botId: string;
@@ -475,6 +477,7 @@ function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         appSettingsOpen: open,
+        appSettingsSection: open ? (action.section ?? state.appSettingsSection) : state.appSettingsSection,
         settingsOpen: open ? false : state.settingsOpen,
         computerOpen: open ? false : state.computerOpen,
         pluginsOpen: open ? false : state.pluginsOpen,

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -98,7 +98,7 @@ export interface Bot {
   busy?: boolean;
   modelSelection: ModelSelection;
   /** Where this bot's computer runs; unset = auto (cloud box if one exists, else local). */
-  computer?: "cloud" | "local" | "off";
+  computer?: "cloud" | "vm" | "local" | "off";
   /** auto mode: the bot approves its own tool permissions */
   autoApprove?: boolean;
   /** tools this bot may always use without asking */


### PR DESCRIPTION
> Stacked on #82 (the settings modal + setup panel). Review that one first.

The cloud box needs a paid plan, and "This computer" points the agent at the desktop the human is using. **Local VM** is the third option: a Linux desktop in a container on this machine — free, disposable, and separate from the user's own desktop and files.

### It cost almost no new code

The computer tools were never really coupled to the cloud: every tool runs a shell command and reads a file back. So only two functions learned a second transport — commands go through the runtime's `exec` instead of a REST endpoint, and a frame is read straight out of the container instead of over HTTP. Every tool schema, the coordinate scaling, `computer_batch` and the frame dedup are untouched.

### Verified end to end, on a real container

Pulled the image (4.25 GB unpacked, **native arm64**), started it with the exact command the settings panel prints, and drove the **real `computer-proxy.ts`** over MCP:

| | local container | cloud box (measured earlier) |
|---|---|---|
| screenshot | **72 ms** | ~4,000–5,000 ms |
| click, with the fused frame | 546 ms | ~5,900 ms |
| open_url + frame | 125 ms | ~3,500 ms+ |
| 3-action batch | 833 ms | ~6,000 ms |

Frames come back as 21 KB JPEGs. There is no network hop at all, which is where the difference comes from.

**Keystrokes provably reach applications**, not just the shell: the bot launched `xterm`, typed `echo LOCALVM_PROOF_9271 > /tmp/proof.txt` with synthetic keys, pressed Return, and reading that file back returned `LOCALVM_PROOF_9271`. Also confirmed the image ships the three binaries our shell strings call (`xdotool`, `scrot`, `convert`) and reports a 1024×768 display.

### Details

- **Runs on:** Cloud box · Local VM · This computer · Off
- Both drivers ask one helper what env the proxy needs, so the transport decision lives in one place — with a test asserting box credentials can never leak into a container turn
- Choosing Local VM before it's ready says *which* step is missing (no runtime / not started / image not pulled / container stopped) instead of failing inside the agent's turn
- The box-only Computer engine explains itself rather than throwing
- 8 new tests; **186 pass** overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)