### PR TITLE
Composer: persist long pastes as per-conversation attachment chips

### DIFF
--- a/server/composer-attachments.test.ts
+++ b/server/composer-attachments.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PASTE_CHARS,
+  PASTE_LINES,
+  byteLength,
+  composeMessage,
+  isAttachment,
+  isLongPaste,
+  pasteAttachment,
+  pasteSummary,
+} from "../src/lib/composer-attachments.ts";
+
+describe("composer paste attachments", () => {
+  it("classifies long character and line pastes without changing short text", () => {
+    expect(isLongPaste("x".repeat(PASTE_CHARS - 1))).toBe(false);
+    expect(isLongPaste("x".repeat(PASTE_CHARS))).toBe(true);
+    expect(isLongPaste(Array.from({ length: PASTE_LINES }, () => "x").join("\n"))).toBe(true);
+  });
+
+  it("measures UTF-8 once and reports a useful summary", () => {
+    const attachment = pasteAttachment("héllo\n世界");
+    expect(attachment.size).toBe(byteLength(attachment.text));
+    expect(attachment.size).toBeGreaterThan(attachment.text.length);
+    expect(attachment.lines).toBe(2);
+    expect(pasteSummary(attachment)).toMatch(/^2 lines, /);
+  });
+
+  it("composes attachment-only and mixed messages in a stable order", () => {
+    const first = pasteAttachment("first");
+    const second = pasteAttachment("second");
+    expect(composeMessage("", [first])).toBe(
+      '<pasted-text index="1">\nfirst\n</pasted-text>',
+    );
+    expect(composeMessage("  intro  ", [first, second])).toBe(
+      'intro\n\n<pasted-text index="1">\nfirst\n</pasted-text>\n\n' +
+        '<pasted-text index="2">\nsecond\n</pasted-text>',
+    );
+  });
+
+  it("rejects malformed persisted attachments", () => {
+    expect(isAttachment({ kind: "paste", id: "a", text: "ok", size: 2, lines: 1 })).toBe(true);
+    expect(isAttachment({ kind: "paste", id: "a", text: "missing size" })).toBe(false);
+    expect(isAttachment({ kind: "file", id: "a", text: "wrong kind", size: 2 })).toBe(false);
+  });
+});

--- a/server/drafts.test.ts
+++ b/server/drafts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDraft,
+  getDraftAttachments,
+  setDraft,
+  setDraftAttachments,
+} from "../src/lib/drafts.ts";
+import { pasteAttachment } from "../src/lib/composer-attachments.ts";
+
+function memoryStore() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => void values.set(key, value),
+  };
+}
+
+describe("composer drafts", () => {
+  it("keeps text and attachments isolated per bot or room", () => {
+    const store = memoryStore();
+    const paste = pasteAttachment("bot paste");
+    setDraft(store, "bot:one", "hello");
+    setDraftAttachments(store, "bot:one", [paste]);
+    setDraft(store, "group:two", "room text");
+
+    expect(getDraft(store, "bot:one")).toBe("hello");
+    expect(getDraftAttachments(store, "bot:one")).toEqual([paste]);
+    expect(getDraft(store, "group:two")).toBe("room text");
+    expect(getDraftAttachments(store, "group:two")).toEqual([]);
+  });
+
+  it("clears empty entries and ignores malformed stored attachments", () => {
+    const store = memoryStore();
+    setDraft(store, "bot:one", "hello");
+    setDraft(store, "bot:one", "");
+    store.setItem(
+      "omb-draft-attachments",
+      JSON.stringify({ "bot:one": [{ kind: "paste", id: "broken" }] }),
+    );
+
+    expect(getDraft(store, "bot:one")).toBe("");
+    expect(getDraftAttachments(store, "bot:one")).toEqual([]);
+  });
+});

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,10 +1,16 @@
 import { track } from "@/lib/analytics";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, Clock, Mic, Square, X } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
-import { useDraft } from "@/lib/drafts";
+import { useComposerDraft } from "@/lib/drafts";
 import { MausAvatar } from "./Avatar";
+import { ComposerAttachments } from "./ComposerAttachments";
+import {
+  composeMessage,
+  isLongPaste,
+  pasteAttachment,
+} from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
@@ -50,9 +56,15 @@ export function Composer({
   const busyName = group
     ? (members?.find((b) => b.id === group.busyBotId)?.name ?? "A bot")
     : (bot?.name ?? "The bot");
-  // per-thread draft: switching bots unmounts this component, so the text
-  // has to outlive it (see lib/drafts)
-  const [text, setText] = useDraft(group ? `group:${group.id}` : `bot:${bot?.id ?? ""}`);
+  // Per-thread draft: switching bots unmounts this component, so both the
+  // text and its attachment chips have to outlive it (see lib/drafts).
+  const [text, setText, attachments, setAttachments] = useComposerDraft(
+    group ? `group:${group.id}` : `bot:${bot?.id ?? ""}`,
+  );
+  const removeAttachment = useCallback(
+    (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
+    [setAttachments],
+  );
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [caret, setCaret] = useState(0);
@@ -103,12 +115,15 @@ export function Composer({
   // One message may be queued while the bot works; it auto-sends the moment
   // the turn settles. Enter during a turn queues instead of silently dying.
   const [queued, setQueued] = useState<string | null>(null);
+  // a chip on its own is a message: the send control has to appear for it
+  const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
-    const t = text.trim();
+    const t = composeMessage(text, attachments);
     if (!t) return;
     if (busy) {
       setQueued(t);
       setText("");
+      setAttachments([]);
       return;
     }
     if (group) {
@@ -119,6 +134,7 @@ export function Composer({
       track("message_sent", { driver: bot.modelSelection?.instanceId });
     }
     setText("");
+    setAttachments([]);
   };
   useEffect(() => {
     if (!busy && queued) {
@@ -236,6 +252,7 @@ export function Composer({
             />
           </div>
         )}
+        <ComposerAttachments items={attachments} onRemove={removeAttachment} />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea
           ref={inputRef}
@@ -245,6 +262,21 @@ export function Composer({
             setText(e.target.value);
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
+          }}
+          onPaste={(e) => {
+            // a wall of text becomes a chip instead of burying the input
+            const pasted = e.clipboardData.getData("text/plain");
+            if (!isLongPaste(pasted)) return;
+            e.preventDefault();
+            // Preserve native paste replacement semantics: if text was
+            // selected, the attachment replaces that selection.
+            const start = e.currentTarget.selectionStart;
+            const end = e.currentTarget.selectionEnd;
+            if (start !== end) {
+              setText(`${text.slice(0, start)}${text.slice(end)}`);
+              setCaret(start);
+            }
+            setAttachments((prev) => [...prev, pasteAttachment(pasted)]);
           }}
           onKeyUp={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
@@ -268,7 +300,7 @@ export function Composer({
               }
             }
             // an empty composer + ArrowUp = edit your last message (like a chat app)
-            if (e.key === "ArrowUp" && !text && onEditLast) {
+            if (e.key === "ArrowUp" && !hasContent && onEditLast) {
               e.preventDefault();
               onEditLast();
               return;
@@ -308,7 +340,7 @@ export function Composer({
             <Square size={14} className="fill-current" />
           </button>
         )}
-        {!busy && !text.trim() && capabilities.dictation.available && (
+        {!busy && !hasContent && capabilities.dictation.available && (
           <button
             onClick={toggleMic}
             aria-label={recording ? "Stop dictation" : "Start dictation"}
@@ -323,7 +355,7 @@ export function Composer({
             <Mic size={18} />
           </button>
         )}
-        {text.trim() && (
+        {hasContent && (
           <button
             onClick={send}
             aria-label={busy ? "Queue message" : "Send message"}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,9 +1,16 @@
 import { track } from "@/lib/analytics";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, Clock, Mic, Square, X } from "lucide-react";
 import { useStore, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { MausAvatar } from "./Avatar";
+import { ComposerAttachments } from "./ComposerAttachments";
+import {
+  composeMessage,
+  isLongPaste,
+  pasteAttachment,
+  type Attachment,
+} from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
 
 /** The active @mention query at the caret: the text between an `@` that
@@ -37,6 +44,13 @@ export function Composer({
     ? (members?.find((b) => b.id === group.busyBotId)?.name ?? "A bot")
     : (bot?.name ?? "The bot");
   const [text, setText] = useState("");
+  // pastes too long for the input ride along as chips and fold back
+  // into the message on send
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const removeAttachment = useCallback(
+    (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
+    [],
+  );
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [caret, setCaret] = useState(0);
@@ -88,11 +102,12 @@ export function Composer({
   // the turn settles. Enter during a turn queues instead of silently dying.
   const [queued, setQueued] = useState<string | null>(null);
   const send = () => {
-    const t = text.trim();
+    const t = composeMessage(text, attachments);
     if (!t) return;
     if (busy) {
       setQueued(t);
       setText("");
+      setAttachments([]);
       return;
     }
     if (group) {
@@ -103,6 +118,7 @@ export function Composer({
       track("message_sent", { driver: bot.modelSelection?.instanceId });
     }
     setText("");
+    setAttachments([]);
   };
   useEffect(() => {
     if (!busy && queued) {
@@ -204,6 +220,7 @@ export function Composer({
             ))}
           </div>
         )}
+        <ComposerAttachments items={attachments} onRemove={removeAttachment} />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea
           ref={inputRef}
@@ -213,6 +230,13 @@ export function Composer({
             setText(e.target.value);
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
+          }}
+          onPaste={(e) => {
+            // a wall of text becomes a chip instead of burying the input
+            const pasted = e.clipboardData.getData("text/plain");
+            if (!isLongPaste(pasted)) return;
+            e.preventDefault();
+            setAttachments((prev) => [...prev, pasteAttachment(pasted)]);
           }}
           onKeyUp={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -101,6 +101,8 @@ export function Composer({
   // One message may be queued while the bot works; it auto-sends the moment
   // the turn settles. Enter during a turn queues instead of silently dying.
   const [queued, setQueued] = useState<string | null>(null);
+  // a chip on its own is a message: the send control has to appear for it
+  const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
     const t = composeMessage(text, attachments);
     if (!t) return;
@@ -297,7 +299,7 @@ export function Composer({
             <Square size={14} className="fill-current" />
           </button>
         )}
-        {!busy && !text.trim() && (
+        {!busy && !hasContent && (
           <button
             onClick={toggleMic}
             aria-label={recording ? "Stop dictation" : "Start dictation"}
@@ -312,7 +314,7 @@ export function Composer({
             <Mic size={18} />
           </button>
         )}
-        {text.trim() && (
+        {hasContent && (
           <button
             onClick={send}
             aria-label={busy ? "Queue message" : "Send message"}

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -16,13 +16,14 @@ export function ComposerAttachments({
   return (
     <div className="mb-2 flex flex-wrap gap-2">
       {items.map((a) => (
-        <PasteChip key={a.id} text={a.text} onRemove={() => onRemove(a.id)} />
+        <PasteChip key={a.id} item={a} onRemove={() => onRemove(a.id)} />
       ))}
     </div>
   );
 }
 
-function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
+function PasteChip({ item, onRemove }: { item: Attachment; onRemove: () => void }) {
+  const { text } = item;
   return (
     <div
       title={text.slice(0, 4000)}
@@ -37,17 +38,19 @@ function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
         </pre>
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
       </div>
-      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(text)}</div>
+      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(item)}</div>
       <div className="mt-1 flex items-center gap-1">
         <ClipboardPaste size={11} className="text-ink-secondary/70" />
         <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
           PASTED
         </span>
       </div>
+      {/* hover reveals it, but so must focus: `hidden` would take the only
+          way to drop a chip out of reach of the keyboard */}
       <button
         onClick={onRemove}
         aria-label="Remove pasted text"
-        className="absolute -right-1.5 -top-1.5 hidden size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary hover:text-ink group-hover:flex"
+        className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary opacity-0 transition-opacity hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
       >
         <X size={11} />
       </button>

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -1,0 +1,56 @@
+// Chips for what is attached to the next message, shown above the input.
+// A long paste collapses into a card of its first lines instead of
+// flooding the composer with a wall of text.
+import { ClipboardPaste, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { pasteSummary, type Attachment } from "@/lib/composer-attachments";
+
+export function ComposerAttachments({
+  items,
+  onRemove,
+}: {
+  items: Attachment[];
+  onRemove: (id: string) => void;
+}) {
+  if (!items.length) return null;
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {items.map((a) => (
+        <PasteChip key={a.id} text={a.text} onRemove={() => onRemove(a.id)} />
+      ))}
+    </div>
+  );
+}
+
+function PasteChip({ text, onRemove }: { text: string; onRemove: () => void }) {
+  return (
+    <div
+      title={text.slice(0, 4000)}
+      className={cn(
+        "group relative w-[172px] rounded-xl border border-hairline/40 bg-raised px-2.5 py-2",
+        "transition-colors hover:border-hairline",
+      )}
+    >
+      <div className="relative h-[76px] overflow-hidden">
+        <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
+          {text.slice(0, 400)}
+        </pre>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
+      </div>
+      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(text)}</div>
+      <div className="mt-1 flex items-center gap-1">
+        <ClipboardPaste size={11} className="text-ink-secondary/70" />
+        <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
+          PASTED
+        </span>
+      </div>
+      <button
+        onClick={onRemove}
+        aria-label="Remove pasted text"
+        className="absolute -right-1.5 -top-1.5 hidden size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary hover:text-ink group-hover:flex"
+      >
+        <X size={11} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -1,0 +1,59 @@
+// Chips for what is attached to the next message, shown above the input.
+// A long paste collapses into a card of its first lines instead of
+// flooding the composer with a wall of text.
+import { ClipboardPaste, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { pasteSummary, type Attachment } from "@/lib/composer-attachments";
+
+export function ComposerAttachments({
+  items,
+  onRemove,
+}: {
+  items: Attachment[];
+  onRemove: (id: string) => void;
+}) {
+  if (!items.length) return null;
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {items.map((a) => (
+        <PasteChip key={a.id} item={a} onRemove={() => onRemove(a.id)} />
+      ))}
+    </div>
+  );
+}
+
+function PasteChip({ item, onRemove }: { item: Attachment; onRemove: () => void }) {
+  const { text } = item;
+  return (
+    <div
+      title={text.slice(0, 4000)}
+      className={cn(
+        "group relative w-[172px] rounded-xl border border-hairline/40 bg-raised px-2.5 py-2",
+        "transition-colors hover:border-hairline",
+      )}
+    >
+      <div className="relative h-[76px] overflow-hidden">
+        <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
+          {text.slice(0, 400)}
+        </pre>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
+      </div>
+      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(item)}</div>
+      <div className="mt-1 flex items-center gap-1">
+        <ClipboardPaste size={11} className="text-ink-secondary/70" />
+        <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
+          PASTED
+        </span>
+      </div>
+      {/* hover reveals it, but so must focus: `hidden` would take the only
+          way to drop a chip out of reach of the keyboard */}
+      <button
+        onClick={onRemove}
+        aria-label="Remove pasted text"
+        className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary opacity-0 transition-opacity hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
+      >
+        <X size={11} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,0 +1,74 @@
+// Text pasted into the composer that is too long to live in the input.
+// It rides along as a chip and folds back into the message on send —
+// nothing here reaches the server, so every driver still sees a prompt.
+export type Attachment = {
+  kind: "paste";
+  id: string;
+  text: string;
+  size: number;
+  lines: number;
+};
+
+export function isAttachment(value: unknown): value is Attachment {
+  if (!value || typeof value !== "object") return false;
+  const attachment = value as Partial<Attachment>;
+  return (
+    attachment.kind === "paste" &&
+    typeof attachment.id === "string" &&
+    typeof attachment.text === "string" &&
+    typeof attachment.size === "number" &&
+    Number.isFinite(attachment.size) &&
+    attachment.size >= 0 &&
+    typeof attachment.lines === "number" &&
+    Number.isInteger(attachment.lines) &&
+    attachment.lines >= 1
+  );
+}
+
+/** Past this, a paste stops reading as typing and becomes an attachment.
+ * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
+export const PASTE_CHARS = 900;
+export const PASTE_LINES = 12;
+
+export function isLongPaste(text: string): boolean {
+  return text.length >= PASTE_CHARS || countLines(text) >= PASTE_LINES;
+}
+
+export function countLines(text: string): number {
+  return text.split("\n").length;
+}
+
+export function pasteAttachment(text: string): Attachment {
+  const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+  // measured once, here: a chip re-renders on every keystroke in the
+  // composer, and encoding half a megabyte each time would be felt
+  return { kind: "paste", id, text, size: byteLength(text), lines: countLines(text) };
+}
+
+/** What the paste actually weighs — String#length counts UTF-16 units, so
+ * it reads a third under on accented text and half under on CJK. */
+export function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+/** "12 lines, 3.4 KB" — what the chip says under the preview. */
+export function pasteSummary(a: { lines: number; size: number }): string {
+  return `${a.lines} lines, ${formatSize(a.size)}`;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** The prompt the bot receives: what was typed, then one block per paste.
+ * Tagged blocks rather than fences — pasted code and markdown carry fences
+ * of their own, and nesting them loses the boundary. */
+export function composeMessage(text: string, attachments: Attachment[]): string {
+  const parts = [text.trim()];
+  attachments.forEach((a, i) => {
+    parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+  });
+  return parts.filter(Boolean).join("\n\n");
+}

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,7 +1,7 @@
 // Text pasted into the composer that is too long to live in the input.
 // It rides along as a chip and folds back into the message on send —
 // nothing here reaches the server, so every driver still sees a prompt.
-export type Attachment = { kind: "paste"; id: string; text: string };
+export type Attachment = { kind: "paste"; id: string; text: string; size: number };
 
 /** Past this, a paste stops reading as typing and becomes an attachment.
  * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
@@ -18,12 +18,20 @@ export function countLines(text: string): number {
 
 export function pasteAttachment(text: string): Attachment {
   const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
-  return { kind: "paste", id, text };
+  // measured once, here: a chip re-renders on every keystroke in the
+  // composer, and encoding half a megabyte each time would be felt
+  return { kind: "paste", id, text, size: byteLength(text) };
+}
+
+/** What the paste actually weighs — String#length counts UTF-16 units, so
+ * it reads a third under on accented text and half under on CJK. */
+export function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
 }
 
 /** "12 lines, 3.4 KB" — what the chip says under the preview. */
-export function pasteSummary(text: string): string {
-  return `${countLines(text)} lines, ${formatSize(text.length)}`;
+export function pasteSummary(a: { text: string; size: number }): string {
+  return `${countLines(a.text)} lines, ${formatSize(a.size)}`;
 }
 
 export function formatSize(bytes: number): string {

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,0 +1,44 @@
+// Text pasted into the composer that is too long to live in the input.
+// It rides along as a chip and folds back into the message on send —
+// nothing here reaches the server, so every driver still sees a prompt.
+export type Attachment = { kind: "paste"; id: string; text: string };
+
+/** Past this, a paste stops reading as typing and becomes an attachment.
+ * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
+export const PASTE_CHARS = 900;
+export const PASTE_LINES = 12;
+
+export function isLongPaste(text: string): boolean {
+  return text.length >= PASTE_CHARS || countLines(text) >= PASTE_LINES;
+}
+
+export function countLines(text: string): number {
+  return text.split("\n").length;
+}
+
+export function pasteAttachment(text: string): Attachment {
+  const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+  return { kind: "paste", id, text };
+}
+
+/** "12 lines, 3.4 KB" — what the chip says under the preview. */
+export function pasteSummary(text: string): string {
+  return `${countLines(text)} lines, ${formatSize(text.length)}`;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** The prompt the bot receives: what was typed, then one block per paste.
+ * Tagged blocks rather than fences — pasted code and markdown carry fences
+ * of their own, and nesting them loses the boundary. */
+export function composeMessage(text: string, attachments: Attachment[]): string {
+  const parts = [text.trim()];
+  attachments.forEach((a, i) => {
+    parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+  });
+  return parts.filter(Boolean).join("\n\n");
+}

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -2,32 +2,34 @@
 // id, so switching threads unmounts it and its local text state dies with
 // it. Drafts live in localStorage, so coming back to a bot — in this
 // session or after a restart — finds what you were typing still there.
-import { useCallback, useState } from "react";
+import { useCallback, useState, type SetStateAction } from "react";
+import { isAttachment, type Attachment } from "./composer-attachments.js";
 
 const KEY = "omb-drafts";
+const ATTACHMENTS_KEY = "omb-draft-attachments";
 
-type Drafts = Record<string, string>;
+type Values = Record<string, unknown>;
 type Store = Pick<Storage, "getItem" | "setItem"> | undefined;
 
 // Storage is best-effort: a full quota, a locked-down origin, or a garbled
 // value must never cost a keystroke — every failure reads as "no drafts".
-function read(store: Store): Drafts {
+function read(store: Store, key: string): Values {
   try {
-    const raw = store?.getItem(KEY);
+    const raw = store?.getItem(key);
     const parsed = raw ? JSON.parse(raw) : null;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Drafts) : {};
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Values) : {};
   } catch {
     return {};
   }
 }
 
 export function getDraft(store: Store, id: string): string {
-  const text = read(store)[id];
+  const text = read(store, KEY)[id];
   return typeof text === "string" ? text : "";
 }
 
 export function setDraft(store: Store, id: string, text: string): void {
-  const drafts = read(store);
+  const drafts = read(store, KEY);
   // an emptied composer drops its entry rather than storing "" forever
   if (text) drafts[id] = text;
   else delete drafts[id];
@@ -35,6 +37,22 @@ export function setDraft(store: Store, id: string, text: string): void {
     store?.setItem(KEY, JSON.stringify(drafts));
   } catch {
     /* quota / private mode — the draft just doesn't outlive the mount */
+  }
+}
+
+export function getDraftAttachments(store: Store, id: string): Attachment[] {
+  const attachments = read(store, ATTACHMENTS_KEY)[id];
+  return Array.isArray(attachments) ? attachments.filter(isAttachment) : [];
+}
+
+export function setDraftAttachments(store: Store, id: string, attachments: Attachment[]): void {
+  const drafts = read(store, ATTACHMENTS_KEY);
+  if (attachments.length) drafts[id] = attachments;
+  else delete drafts[id];
+  try {
+    store?.setItem(ATTACHMENTS_KEY, JSON.stringify(drafts));
+  } catch {
+    /* quota / private mode — attachments remain in component state */
   }
 }
 
@@ -60,4 +78,30 @@ export function useDraft(id: string): [string, (next: string) => void] {
     [store, id],
   );
   return [text, set];
+}
+
+/** A conversation's complete composer draft. Attachment storage is separate
+ * from text so typing does not stringify a large pasted payload per keypress. */
+export function useComposerDraft(
+  id: string,
+): [
+  string,
+  (next: string) => void,
+  Attachment[],
+  (next: SetStateAction<Attachment[]>) => void,
+] {
+  const store = getStore();
+  const [text, setText] = useDraft(id);
+  const [attachments, setAttachmentState] = useState(() => getDraftAttachments(store, id));
+  const setAttachments = useCallback(
+    (next: SetStateAction<Attachment[]>) => {
+      setAttachmentState((previous) => {
+        const value = typeof next === "function" ? next(previous) : next;
+        setDraftAttachments(store, id, value);
+        return value;
+      });
+    },
+    [store, id],
+  );
+  return [text, setText, attachments, setAttachments];
 }


### PR DESCRIPTION
Integrates #68 with the per-conversation draft and approval/dictation behavior now on `main`.

- turn long pastes into removable, keyboard-accessible chips
- send or queue attachment-only messages correctly
- preserve pasted attachments independently for each bot and room, including across remounts
- keep text and attachment storage separate so typing does not reserialize large pasted payloads
- compute UTF-8 size and line count once at paste time
- preserve native selection-replacement behavior for long pastes
- prevent Arrow Up from editing history when a chip makes the composer non-empty
- add utility and per-conversation persistence tests

Local verification: 204 tests passed (7 platform-specific skips), typecheck, Electron syntax checks, and production build.

Closes #68