### PR TITLE
Run routines from the Computer panel and cloud VMs

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { mentionedBots, Store, type Message } from "./store.ts";
 import { readCuaConnection } from "./local-computer.ts";
-import { RoutineManager } from "./routines.ts";
+import { RoutineManager, type RoutineRunOn } from "./routines.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
@@ -214,7 +214,9 @@ bus.subscribe((event: RuntimeEvent) => {
         ? autoDecision(asker, event.tool, event.summary)
         : null;
       if (settled && asker && event.requestId) {
-        const instance = registry.get(asker.modelSelection.instanceId);
+        const instance = event.providerInstanceId
+          ? registry.get(event.providerInstanceId)
+          : registry.get(asker.modelSelection.instanceId);
         const requestId = event.requestId;
         const { tool, summary } = event;
         // The chip is written only AFTER the provider takes the answer.
@@ -399,6 +401,9 @@ async function startTurn(
     userMessage?: Message;
     /** Routines run in detached tasks; pin the destination for the whole turn. */
     threadId?: string;
+    /** Cloud routines run the whole agent inside the bot's Box VM instead
+     * of merely mounting that VM's computer tools on the MAUS's provider. */
+    runOn?: RoutineRunOn;
     onDispatchError?: (message: string) => void;
   },
 ) {
@@ -412,13 +417,21 @@ async function startTurn(
   // a task takes its name from the first thing you asked it to do
   if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text, threadId);
 
-  const instance = registry.get(bot.modelSelection.instanceId);
+  const instance = opts?.runOn === "cloud"
+    ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
+    : registry.get(bot.modelSelection.instanceId);
   if (!instance) {
     throw Object.assign(
-      new Error(`provider instance "${bot.modelSelection.instanceId}" is unavailable — pick another model in settings`),
+      new Error(
+        opts?.runOn === "cloud"
+          ? "the Cloud VM runner is unavailable — configure Box in App Settings"
+          : `provider instance "${bot.modelSelection.instanceId}" is unavailable — pick another model in settings`,
+      ),
       { status: 409 },
     );
   }
+  const instanceId = instance.instanceId;
+  const model = opts?.runOn === "cloud" ? instance.models.default : bot.modelSelection.model;
 
   // an edit hands us its already-branched user message; a plain send appends
   let userMessage = opts?.userMessage;
@@ -473,7 +486,7 @@ async function startTurn(
     try {
       const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
       if (cfg.composio?.key) integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
-      const wants = bot.computer; // 'cloud' | 'local' | 'off' | undefined(auto)
+      const wants = opts?.runOn === "cloud" ? "cloud" : bot.computer; // cloud routine overrides the MAUS default
       // only drivers that can mount the computer MCP server get the tools
       // (and the prompt about them) — but every bot with a box still gets
       // the live screen preview, which is a UI feature, not a tool
@@ -535,11 +548,11 @@ async function startTurn(
       await instance.adapter.sendTurn({
         threadId,
         text: turnText,
-        model: bot.modelSelection.model,
+        model,
         // a rewound thread never resumes the abandoned branch's session
         // the active task's own session — another task's cursor would
         // resume the wrong conversation and defeat the context bubble
-        resumeCursor: rewound ? undefined : task.resumeCursors[bot.modelSelection.instanceId],
+        resumeCursor: rewound ? undefined : task.resumeCursors[instanceId],
         transcript,
         system:
           persona +
@@ -591,11 +604,15 @@ routines = new RoutineManager({
     if (task && bot) broadcast({ kind: "bot", bot: publicBot(bot) });
     return task;
   },
-  startTurn: (botId, threadId, prompt, onDispatchError) =>
-    startTurn(botId, prompt, { threadId, onDispatchError }),
-  interruptTurn: async (botId, threadId) => {
+  startTurn: (botId, threadId, prompt, runOn, onDispatchError) =>
+    startTurn(botId, prompt, { threadId, runOn, onDispatchError }),
+  interruptTurn: async (botId, threadId, runOn) => {
     const bot = store.bot(botId);
-    const instance = bot ? registry.get(bot.modelSelection.instanceId) : null;
+    const instance = runOn === "cloud"
+      ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
+      : bot
+        ? registry.get(bot.modelSelection.instanceId)
+        : null;
     await instance?.adapter.interruptTurn(threadId);
   },
 });

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -18,6 +18,7 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
   let bot: "ready" | "busy" | "missing" = "ready";
   let task = 0;
   const started: Array<{ botId: string; threadId: string; prompt: string }> = [];
+  const runOns: string[] = [];
   const emitted: any[] = [];
   const options: RoutineManagerOptions = {
     file: tempFile(),
@@ -25,8 +26,9 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
     emit: (payload) => emitted.push(payload),
     botState: () => bot,
     createTask: () => ({ threadId: `thread-${++task}` }),
-    startTurn: async (botId, threadId, prompt) => {
+    startTurn: async (botId, threadId, prompt, runOn) => {
       started.push({ botId, threadId, prompt });
+      runOns.push(runOn);
     },
   };
   const manager = new RoutineManager(options);
@@ -35,6 +37,7 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
     options,
     emitted,
     started,
+    runOns,
     setNow: (value: number) => (now = value),
     setBot: (value: typeof bot) => (bot = value),
   };
@@ -145,6 +148,28 @@ describe("RoutineManager", () => {
       routineName: "Original brief",
       prompt: "Use the original instructions",
     });
+  });
+
+  it("snapshots and dispatches the selected execution machine", async () => {
+    const h = harness();
+    h.setBot("busy");
+    const routine = h.manager.create({
+      name: "VM review",
+      prompt: "Review the project on the virtual machine",
+      botId: "maus-cloud",
+      runOn: "cloud",
+      schedule: { type: "once", at: new Date(2026, 7, 17, 8, 1).getTime() },
+    });
+    h.setNow(routine.nextRunAt!);
+    await h.manager.tick();
+    h.manager.update(routine.id, { runOn: "maus" });
+
+    h.setBot("ready");
+    await h.manager.tick();
+
+    expect(h.runOns).toEqual(["cloud"]);
+    expect(h.manager.listRuns()[0]).toMatchObject({ runOn: "cloud" });
+    expect(h.manager.listRoutines()[0]).toMatchObject({ runOn: "maus" });
   });
 
   it("folds provider lifecycle events into the calendar receipt", async () => {

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -9,6 +9,11 @@ export type RoutineSchedule =
   | { type: "once"; at: number }
   | { type: "daily"; time: string; weekdays: number[] };
 
+/** `cloud` runs the agent itself inside the bot's Box VM. `maus` keeps
+ * using the provider selected on the MAUS and only borrows its configured
+ * computer tools, if any. */
+export type RoutineRunOn = "maus" | "cloud";
+
 export type RoutineRunStatus =
   | "queued"
   | "running"
@@ -23,6 +28,7 @@ export interface Routine {
   name: string;
   prompt: string;
   botId: string;
+  runOn: RoutineRunOn;
   enabled: boolean;
   schedule: RoutineSchedule;
   durationMinutes: number;
@@ -39,6 +45,7 @@ export interface RoutineRun {
   prompt?: string;
   durationMinutes?: number;
   botId: string;
+  runOn: RoutineRunOn;
   scheduledFor: number;
   status: RoutineRunStatus;
   manual: boolean;
@@ -57,6 +64,7 @@ export interface RoutineInput {
   name: string;
   prompt: string;
   botId: string;
+  runOn?: RoutineRunOn;
   enabled?: boolean;
   schedule: RoutineSchedule;
   durationMinutes?: number;
@@ -78,9 +86,10 @@ export interface RoutineManagerOptions {
     botId: string,
     threadId: string,
     prompt: string,
+    runOn: RoutineRunOn,
     onDispatchError: (message: string) => void,
   ) => Promise<void>;
-  interruptTurn?: (botId: string, threadId: string) => Promise<void>;
+  interruptTurn?: (botId: string, threadId: string, runOn: RoutineRunOn) => Promise<void>;
 }
 
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
@@ -128,10 +137,13 @@ function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | 
   if (!name) throw new Error("Give the routine a name");
   if (!prompt) throw new Error("Tell the bot what to do");
   if (!botId) throw new Error("Choose a bot");
+  const runOn = input.runOn ?? "maus";
+  if (runOn !== "maus" && runOn !== "cloud") throw new Error("Choose where this routine runs");
   return {
     name,
     prompt,
     botId,
+    runOn,
     enabled: input.enabled !== false,
     schedule: cleanSchedule(input.schedule),
     durationMinutes: Math.min(240, Math.max(15, Math.round(Number(input.durationMinutes) || 30))),
@@ -153,8 +165,12 @@ export class RoutineManager {
     this.now = options.now ?? Date.now;
     try {
       const disk = JSON.parse(readFileSync(this.file, "utf8")) as Partial<RoutineFile>;
-      this.routines = Array.isArray(disk.routines) ? disk.routines : [];
-      this.runs = Array.isArray(disk.runs) ? disk.runs : [];
+      this.routines = Array.isArray(disk.routines)
+        ? disk.routines.map((routine) => ({ ...routine, runOn: routine.runOn ?? "maus" }))
+        : [];
+      this.runs = Array.isArray(disk.runs)
+        ? disk.runs.map((run) => ({ ...run, runOn: run.runOn ?? "maus" }))
+        : [];
     } catch {
       this.routines = [];
       this.runs = [];
@@ -220,6 +236,7 @@ export class RoutineManager {
       name: patch.name ?? routine.name,
       prompt: patch.prompt ?? routine.prompt,
       botId: patch.botId ?? routine.botId,
+      runOn: patch.runOn ?? routine.runOn,
       enabled: patch.enabled ?? routine.enabled,
       schedule: patch.schedule ?? routine.schedule,
       durationMinutes: patch.durationMinutes ?? routine.durationMinutes,
@@ -275,7 +292,7 @@ export class RoutineManager {
       run.finishedAt = this.now();
       run.error = "The assigned bot was deleted";
       this.emitRun(run);
-      if (run.threadId) void this.options.interruptTurn?.(run.botId, run.threadId).catch(() => {});
+      if (run.threadId) void this.options.interruptTurn?.(run.botId, run.threadId, run.runOn ?? "maus").catch(() => {});
       changed = true;
     }
     if (changed) this.save();
@@ -298,7 +315,7 @@ export class RoutineManager {
     run.finishedAt = this.now();
     this.save();
     this.emitRun(run);
-    if (run.threadId) await this.options.interruptTurn?.(run.botId, run.threadId).catch(() => {});
+    if (run.threadId) await this.options.interruptTurn?.(run.botId, run.threadId, run.runOn ?? "maus").catch(() => {});
     queueMicrotask(() => void this.tick());
     return { ...run };
   }
@@ -387,7 +404,7 @@ export class RoutineManager {
             this.failThread(task.threadId, "The routine was deleted before it could start");
             continue;
           }
-          await this.options.startTurn(run.botId, task.threadId, prompt, (message) =>
+          await this.options.startTurn(run.botId, task.threadId, prompt, run.runOn ?? "maus", (message) =>
             this.failThread(task.threadId, message),
           );
         } catch (error) {
@@ -448,6 +465,7 @@ export class RoutineManager {
       prompt: routine.prompt,
       durationMinutes: routine.durationMinutes,
       botId: routine.botId,
+      runOn: routine.runOn ?? "maus",
       scheduledFor,
       status: "queued",
       manual,

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -6,19 +6,23 @@
 // prefers the cloud box when one exists, else local inside the app.
 import { useEffect, useRef, useState } from "react";
 import {
+  CalendarDays,
   CalendarClock,
   ExternalLink,
   Loader2,
   Monitor,
   Moon,
+  Plus,
   Power,
   Settings,
   X,
 } from "lucide-react";
 import { useStore, type Bot } from "@/state/store";
+import type { Routine } from "@/lib/routines";
 import { ApiKeyRow } from "./ApiKeys";
 import { cn } from "@/lib/cn";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { RoutineEditor } from "./RoutinesPage";
 
 async function api(path: string, init?: RequestInit): Promise<any> {
   const res = await fetch(path, { headers: { "content-type": "application/json" }, ...init });
@@ -37,6 +41,34 @@ type Phase =
   | "off"
   | "error";
 
+function routineScheduleLabel(routine: Routine) {
+  if (routine.schedule.type === "once") {
+    return new Date(routine.schedule.at).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  const days = routine.schedule.weekdays;
+  const cadence =
+    days.length === 7
+      ? "Every day"
+      : days.join(",") === "1,2,3,4,5"
+        ? "Weekdays"
+        : days.map((day) => ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][day]).join(", ");
+  const [hour, minute] = routine.schedule.time.split(":").map(Number);
+  return `${cadence} · ${new Date(2000, 0, 1, hour, minute).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
+}
+
+function nextRunLabel(at: number | null) {
+  if (at == null) return "Paused";
+  const date = new Date(at);
+  const today = new Date();
+  const sameDay = date.toDateString() === today.toDateString();
+  return `${sameDay ? "Today" : date.toLocaleDateString([], { month: "short", day: "numeric" })}, ${date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
+}
+
 export function ComputerPanel({ bot }: { bot: Bot }) {
   const { state, dispatch } = useStore();
   const { capabilities, ready: capabilitiesReady } = useDesktopCapabilities();
@@ -47,8 +79,25 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<"join" | "sleep" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [creatingRoutine, setCreatingRoutine] = useState(false);
   // bumped when a Box API key is saved inline, to re-run the spin-up flow
   const [retry, setRetry] = useState(0);
+  const botRoutines = state.routines
+    .filter((routine) => routine.botId === bot.id)
+    .sort((a, b) => Number(b.enabled) - Number(a.enabled) || (a.nextRunAt ?? Infinity) - (b.nextRunAt ?? Infinity));
+  const activeRoutineRun = state.routineRuns.find(
+    (run) => run.botId === bot.id && ["queued", "running", "waiting"].includes(run.status),
+  );
+  const computerDestination =
+    bot.computer === "cloud"
+      ? "this cloud box"
+      : bot.computer === "local"
+        ? "this computer"
+        : bot.computer === "off"
+          ? null
+          : phase === "ready"
+            ? "the cloud box selected by Auto"
+            : "this computer selected by Auto";
 
   // resolve the mode on open; box endpoints are only ever hit on the
   // cloud path, so local/off can never render a JSON error as an image
@@ -338,22 +387,82 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
 
         {/* Routines */}
         <div className="mt-4 rounded-xl bg-card p-4">
-          <div className="flex items-center gap-2 text-[15px] font-medium text-ink">
-            <CalendarClock size={16} className="text-ink-secondary" />
-            Routines
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-[15px] font-medium text-ink">
+              <CalendarClock size={16} className="text-accent" />
+              Routines
+            </div>
+            {botRoutines.length > 0 && (
+              <span className="rounded-full bg-raised px-2 py-0.5 text-[10px] font-medium text-ink-secondary">
+                {botRoutines.length}
+              </span>
+            )}
           </div>
           <div className="mt-0.5 text-[13px] text-ink-secondary">
-            Routines are recurring tasks this agent runs on a schedule.
+            Schedule work for {bot.name}. Each run becomes its own task
+            {computerDestination ? ` and can use ${computerDestination}.` : "."}
           </div>
-          <button
-            disabled
-            className="mt-3 w-full cursor-not-allowed rounded-lg bg-raised py-2 text-[13px] text-ink-secondary opacity-60"
-            title="Coming soon"
-          >
-            Create Routine
-          </button>
+          {!computerDestination && (
+            <div className="mt-3 flex items-start gap-2 rounded-lg border border-warning/25 bg-warning/10 px-3 py-2 text-[11.5px] leading-relaxed text-warning">
+              <Power size={13} className="mt-0.5 shrink-0" />
+              Computer access is off. The routine can still run, but it cannot act on a desktop until you change “Runs on”.
+            </div>
+          )}
+          {activeRoutineRun && (
+            <button
+              onClick={() => dispatch({ type: "showRoutines" })}
+              className="mt-3 flex w-full items-center gap-2 rounded-lg border border-accent/25 bg-accent/10 px-3 py-2 text-left text-[12px] text-accent hover:bg-accent/15"
+            >
+              <Loader2 size={13} className={activeRoutineRun.status === "queued" ? "" : "animate-spin"} />
+              <span className="min-w-0 flex-1 truncate">
+                {activeRoutineRun.routineName} · {activeRoutineRun.status === "waiting" ? "needs you" : activeRoutineRun.status}
+              </span>
+            </button>
+          )}
+          {botRoutines.length > 0 && (
+            <div className="mt-3 space-y-1.5">
+              {botRoutines.slice(0, 3).map((routine) => (
+                <button
+                  key={routine.id}
+                  onClick={() => dispatch({ type: "showRoutines" })}
+                  className="flex w-full items-center gap-2 rounded-lg bg-inset px-3 py-2 text-left hover:bg-raised/60"
+                >
+                  <span className={cn("size-1.5 shrink-0 rounded-full", routine.enabled ? "bg-success" : "bg-ink-secondary/40")} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[12.5px] font-medium text-ink">{routine.name}</span>
+                    <span className="block truncate text-[10.5px] text-ink-secondary">{routineScheduleLabel(routine)}</span>
+                  </span>
+                  <span className="shrink-0 text-[10px] text-ink-secondary">{nextRunLabel(routine.nextRunAt)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex gap-2">
+            <button
+              onClick={() => setCreatingRoutine(true)}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-2 text-[13px] font-medium text-white hover:brightness-110"
+            >
+              <Plus size={14} />
+              Create routine
+            </button>
+            <button
+              onClick={() => dispatch({ type: "showRoutines" })}
+              className="flex items-center justify-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
+              title="Open routines calendar"
+            >
+              <CalendarDays size={14} />
+              Calendar
+            </button>
+          </div>
         </div>
       </div>
+      {creatingRoutine && (
+        <RoutineEditor
+          bots={[bot]}
+          lockedBotId={bot.id}
+          onClose={() => setCreatingRoutine(false)}
+        />
+      )}
     </aside>
   );
 }

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -85,6 +85,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const botRoutines = state.routines
     .filter((routine) => routine.botId === bot.id)
     .sort((a, b) => Number(b.enabled) - Number(a.enabled) || (a.nextRunAt ?? Infinity) - (b.nextRunAt ?? Infinity));
+  const cloudRoutineReady = Boolean(
+    state.config?.box.configured &&
+      state.instances.some((instance) => instance.driverKind === "boxAgent" && instance.snapshot.state === "available"),
+  );
   const activeRoutineRun = state.routineRuns.find(
     (run) => run.botId === bot.id && ["queued", "running", "waiting"].includes(run.status),
   );
@@ -399,13 +403,12 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             )}
           </div>
           <div className="mt-0.5 text-[13px] text-ink-secondary">
-            Schedule work for {bot.name}. Each run becomes its own task
-            {computerDestination ? ` and can use ${computerDestination}.` : "."}
+            Schedule work for {bot.name}. Use its current setup, or run the whole job inside its cloud VM.
           </div>
           {!computerDestination && (
             <div className="mt-3 flex items-start gap-2 rounded-lg border border-warning/25 bg-warning/10 px-3 py-2 text-[11.5px] leading-relaxed text-warning">
               <Power size={13} className="mt-0.5 shrink-0" />
-              Computer access is off. The routine can still run, but it cannot act on a desktop until you change “Runs on”.
+              MAUS-setup routines will not have desktop access while this is Off. Choose Cloud VM in the routine editor to run the whole job there.
             </div>
           )}
           {activeRoutineRun && (
@@ -430,7 +433,9 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                   <span className={cn("size-1.5 shrink-0 rounded-full", routine.enabled ? "bg-success" : "bg-ink-secondary/40")} />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[12.5px] font-medium text-ink">{routine.name}</span>
-                    <span className="block truncate text-[10.5px] text-ink-secondary">{routineScheduleLabel(routine)}</span>
+                    <span className="block truncate text-[10.5px] text-ink-secondary">
+                      {routineScheduleLabel(routine)}{routine.runOn === "cloud" ? " · runs on VM" : ""}
+                    </span>
                   </span>
                   <span className="shrink-0 text-[10px] text-ink-secondary">{nextRunLabel(routine.nextRunAt)}</span>
                 </button>
@@ -460,6 +465,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         <RoutineEditor
           bots={[bot]}
           lockedBotId={bot.id}
+          defaultRunOn={cloudRoutineReady ? "cloud" : "maus"}
           onClose={() => setCreatingRoutine(false)}
         />
       )}

--- a/src/components/RoutinesPage.tsx
+++ b/src/components/RoutinesPage.tsx
@@ -284,11 +284,21 @@ function CalendarGrid({
   );
 }
 
-function RoutineEditor({ routine, bots, onClose }: { routine?: Routine; bots: Bot[]; onClose: () => void }) {
+export function RoutineEditor({
+  routine,
+  bots,
+  lockedBotId,
+  onClose,
+}: {
+  routine?: Routine;
+  bots: Bot[];
+  lockedBotId?: string;
+  onClose: () => void;
+}) {
   const { dispatch } = useStore();
   const [name, setName] = useState(routine?.name ?? "");
   const [prompt, setPrompt] = useState(routine?.prompt ?? "");
-  const [botId, setBotId] = useState(routine?.botId ?? bots[0]?.id ?? "");
+  const [botId, setBotId] = useState(lockedBotId ?? routine?.botId ?? bots[0]?.id ?? "");
   const [kind, setKind] = useState<"once" | "daily">(routine?.schedule.type ?? "daily");
   const [at, setAt] = useState(
     toInputDateTime(routine?.schedule.type === "once" ? routine.schedule.at : nextHour()),
@@ -335,7 +345,7 @@ function RoutineEditor({ routine, bots, onClose }: { routine?: Routine; bots: Bo
         <div className="sticky top-0 z-10 flex items-center justify-between border-b border-hairline/40 bg-panel/95 px-5 py-4 backdrop-blur">
           <div>
             <div className="text-[17px] font-semibold text-ink">{routine ? "Edit routine" : "New routine"}</div>
-            <div className="mt-0.5 text-[12px] text-ink-secondary">Give a MAUS recurring work with a calendar you can trust.</div>
+            <div className="mt-0.5 text-[12px] text-ink-secondary">Give a MAUS scheduled work with a calendar you can trust.</div>
           </div>
           <button onClick={onClose} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button>
         </div>
@@ -346,11 +356,12 @@ function RoutineEditor({ routine, bots, onClose }: { routine?: Routine; bots: Bo
           </label>
           <div>
             <div className="mb-2 text-[12px] font-medium text-ink-secondary">Who does it?</div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            <div className={cn("grid gap-2", lockedBotId ? "grid-cols-1" : "grid-cols-2 sm:grid-cols-3")}>
               {bots.map((bot) => (
-                <button key={bot.id} type="button" onClick={() => setBotId(bot.id)} className={cn("flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left", botId === bot.id ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60")}>
+                <button key={bot.id} type="button" disabled={Boolean(lockedBotId)} onClick={() => setBotId(bot.id)} className={cn("flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left", botId === bot.id ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60")}>
                   <MausAvatar color={bot.color} state={botId === bot.id ? "happy" : "idle"} size={38} animated={false} />
-                  <span className="truncate text-[13px] font-medium text-ink">{bot.name}</span>
+                  <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">{bot.name}</span>
+                  {lockedBotId && <span className="text-[11px] text-ink-secondary">Assigned from Computer</span>}
                 </button>
               ))}
             </div>

--- a/src/components/RoutinesPage.tsx
+++ b/src/components/RoutinesPage.tsx
@@ -6,7 +6,9 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleAlert,
+  Cloud,
   ExternalLink,
+  Laptop,
   Loader2,
   Pause,
   Play,
@@ -18,7 +20,7 @@ import {
 import { MausAvatar } from "@/components/Avatar";
 import { cn } from "@/lib/cn";
 import { MAUS_COLORS, type MausState } from "@/lib/mascot";
-import type { Routine, RoutineInput, RoutineRun, RoutineRunStatus } from "@/lib/routines";
+import type { Routine, RoutineInput, RoutineRun, RoutineRunOn, RoutineRunStatus } from "@/lib/routines";
 import { api, useStore, type Bot } from "@/state/store";
 
 const HOUR_HEIGHT = 68;
@@ -202,7 +204,10 @@ function RoutineCard({ item, bot, compact, onOpen }: { item: CalendarItem; bot: 
             {animated && <Loader2 size={10} className="animate-spin" />}
             <span>{niceTime(item.at)}</span>
             <span>·</span>
-            <span className="truncate">{status ? status.replace("waiting", "needs you") : bot.name}</span>
+            <span className="truncate">
+              {status ? status.replace("waiting", "needs you") : bot.name}
+              {(item.routine?.runOn ?? item.run?.runOn) === "cloud" ? " · VM" : ""}
+            </span>
           </div>
         </div>
         {status === "failed" && !item.run?.seenAt && <span className="size-2 shrink-0 rounded-full bg-danger" />}
@@ -288,17 +293,20 @@ export function RoutineEditor({
   routine,
   bots,
   lockedBotId,
+  defaultRunOn,
   onClose,
 }: {
   routine?: Routine;
   bots: Bot[];
   lockedBotId?: string;
+  defaultRunOn?: RoutineRunOn;
   onClose: () => void;
 }) {
-  const { dispatch } = useStore();
+  const { state, dispatch } = useStore();
   const [name, setName] = useState(routine?.name ?? "");
   const [prompt, setPrompt] = useState(routine?.prompt ?? "");
   const [botId, setBotId] = useState(lockedBotId ?? routine?.botId ?? bots[0]?.id ?? "");
+  const [runOn, setRunOn] = useState<RoutineRunOn>(routine?.runOn ?? defaultRunOn ?? "maus");
   const [kind, setKind] = useState<"once" | "daily">(routine?.schedule.type ?? "daily");
   const [at, setAt] = useState(
     toInputDateTime(routine?.schedule.type === "once" ? routine.schedule.at : nextHour()),
@@ -310,12 +318,15 @@ export function RoutineEditor({
   const [durationMinutes, setDurationMinutes] = useState(routine?.durationMinutes ?? 30);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const cloudInstance = state.instances.find((instance) => instance.driverKind === "boxAgent");
+  const cloudReady = Boolean(state.config?.box.configured && cloudInstance?.snapshot.state === "available");
 
   const save = async () => {
     const input: RoutineInput = {
       name,
       prompt,
       botId,
+      runOn,
       enabled: routine ? undefined : true,
       durationMinutes,
       schedule:
@@ -354,6 +365,41 @@ export function RoutineEditor({
             <span className="mb-1.5 block text-[12px] font-medium text-ink-secondary">Routine name</span>
             <input autoFocus value={name} onChange={(event) => setName(event.target.value)} placeholder="Morning research brief" className="w-full rounded-xl border border-hairline/60 bg-inset px-3.5 py-2.5 text-[14px] text-ink outline-none placeholder:text-ink-secondary/60 focus:border-accent/70" />
           </label>
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-ink-secondary">Where does it run?</div>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setRunOn("maus")}
+                className={cn(
+                  "rounded-xl border p-3 text-left transition",
+                  runOn === "maus" ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60",
+                )}
+              >
+                <div className="flex items-center gap-2 text-[13px] font-medium text-ink"><Laptop size={15} />MAUS setup</div>
+                <div className="mt-1 text-[11px] leading-relaxed text-ink-secondary">Uses this MAUS's selected model and computer setting.</div>
+              </button>
+              <button
+                type="button"
+                disabled={!cloudReady && runOn !== "cloud"}
+                onClick={() => setRunOn("cloud")}
+                className={cn(
+                  "rounded-xl border p-3 text-left transition disabled:cursor-not-allowed disabled:opacity-45",
+                  runOn === "cloud" ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60",
+                )}
+              >
+                <div className="flex items-center gap-2 text-[13px] font-medium text-ink"><Cloud size={15} />Cloud VM</div>
+                <div className="mt-1 text-[11px] leading-relaxed text-ink-secondary">Runs the MAUS and its tools inside its Box virtual machine.</div>
+              </button>
+            </div>
+            {runOn === "cloud" && (
+              <div className={cn("mt-2 rounded-lg px-3 py-2 text-[11.5px] leading-relaxed", cloudReady ? "bg-accent/10 text-ink-secondary" : "border border-warning/25 bg-warning/10 text-warning")}>
+                {cloudReady
+                  ? "The VM wakes automatically for each run. Keep OpenMausBot running so its scheduler can launch the job."
+                  : "Cloud VM needs a working Box API key in App Settings before this routine can run."}
+              </div>
+            )}
+          </div>
           <div>
             <div className="mb-2 text-[12px] font-medium text-ink-secondary">Who does it?</div>
             <div className={cn("grid gap-2", lockedBotId ? "grid-cols-1" : "grid-cols-2 sm:grid-cols-3")}>
@@ -453,6 +499,7 @@ function RoutineDetails({ item, bot, onClose, onEdit }: { item: CalendarItem; bo
           {routine && (
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-xl bg-inset p-3"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Schedule</div><div className="mt-1 text-[13px] text-ink">{scheduleLabel(routine)}</div></div>
+              <div className="rounded-xl bg-inset p-3"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Runs on</div><div className="mt-1 flex items-center gap-1.5 text-[13px] text-ink">{routine.runOn === "cloud" ? <Cloud size={13} /> : <Laptop size={13} />}{routine.runOn === "cloud" ? "Cloud VM" : "MAUS setup"}</div></div>
               <div className="rounded-xl bg-inset p-3"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Duration</div><div className="mt-1 text-[13px] text-ink">{routine.durationMinutes} minutes</div></div>
             </div>
           )}

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -2,6 +2,8 @@ export type RoutineSchedule =
   | { type: "once"; at: number }
   | { type: "daily"; time: string; weekdays: number[] };
 
+export type RoutineRunOn = "maus" | "cloud";
+
 export type RoutineRunStatus =
   | "queued"
   | "running"
@@ -16,6 +18,7 @@ export interface Routine {
   name: string;
   prompt: string;
   botId: string;
+  runOn: RoutineRunOn;
   enabled: boolean;
   schedule: RoutineSchedule;
   durationMinutes: number;
@@ -31,6 +34,7 @@ export interface RoutineRun {
   prompt?: string;
   durationMinutes?: number;
   botId: string;
+  runOn: RoutineRunOn;
   scheduledFor: number;
   status: RoutineRunStatus;
   manual: boolean;
@@ -49,6 +53,7 @@ export interface RoutineInput {
   name: string;
   prompt: string;
   botId: string;
+  runOn?: RoutineRunOn;
   enabled?: boolean;
   schedule: RoutineSchedule;
   durationMinutes?: number;


### PR DESCRIPTION
## What changed

- Replaces the disabled Routines placeholder in the Computer sidebar with the real routine list, active-run status, calendar shortcut, and bot-locked editor.
- Adds an explicit execution choice to each routine:
  - **MAUS setup** uses the MAUS's selected model and computer setting.
  - **Cloud VM** runs the MAUS itself and its tools inside its persistent Box computer.
- Makes Cloud VM the default when creating a routine from the Computer panel and Box is configured.
- Snapshots the execution target into each run receipt, so editing a queued routine cannot change where an existing occurrence executes.
- Routes cancellation and automatic permission handling through the provider that actually owns the run.
- Migrates existing routine data to the backwards-compatible `maus` execution target.

## Why

The Computer panel still showed a disabled “Coming soon” routine card even after the routines calendar shipped. More importantly, a routine could borrow cloud computer tools, but there was no explicit way to say that the full agent job should execute on the virtual machine.

This makes that distinction visible and real while keeping the current scheduling boundary honest: the Box wakes automatically for a VM run, but OpenMausBot's local scheduler must be running to launch it.

## Impact

Users can schedule a MAUS directly from its Computer panel, choose Cloud VM, and see the VM target on calendar cards, routine details, and sidebar rows. Every run still appears as its own task with the existing receipts and controls.

## Validation

- `pnpm test` — 23 files passed, 199 tests passed, 7 skipped
- `pnpm build`
- `pnpm typecheck`
- `git diff --check`
- Real UI inspection of the Computer panel and Cloud VM editor state
- Reversible API smoke test confirming `runOn: "cloud"` survives create/list/delete
