### PR TITLE
Integrate #69: drag-and-drop file attachments

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,6 +1,6 @@
 // Renderer bridge. contextIsolation stays on; the renderer only ever sees
 // this narrow surface (window.ogb), never Node or ipcRenderer itself.
-const { contextBridge, ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer, webUtils } = require("electron");
 
 contextBridge.exposeInMainWorld("ogb", {
   /** Host platform ("darwin" | "win32" | "linux") — for platform-aware UI. */
@@ -18,6 +18,15 @@ contextBridge.exposeInMainWorld("ogb", {
     const handler = (_event, info) => cb(info);
     ipcRenderer.on("speech:end", handler);
     return () => ipcRenderer.removeListener("speech:end", handler);
+  },
+  /** Absolute path of a dropped File — Electron 32 removed File.path, and
+   * only the preload can ask. "" when the drag carried no file on disk. */
+  getPathForFile: (file) => {
+    try {
+      return webUtils.getPathForFile(file);
+    } catch {
+      return "";
+    }
   },
   /** {mic} TCC status strings: granted|denied|not-determined|unknown.
    * No screen field — macOS 15+ caches that status per-process, so any

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,6 +1,6 @@
 // Renderer bridge. contextIsolation stays on; the renderer only ever sees
 // this narrow surface (window.ogb), never Node or ipcRenderer itself.
-const { contextBridge, ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer, webUtils } = require("electron");
 
 contextBridge.exposeInMainWorld("ogb", {
   /** Host platform ("darwin" | "win32" | "linux") — for platform-aware UI. */
@@ -19,6 +19,15 @@ contextBridge.exposeInMainWorld("ogb", {
     const handler = (_event, info) => cb(info);
     ipcRenderer.on("speech:end", handler);
     return () => ipcRenderer.removeListener("speech:end", handler);
+  },
+  /** Absolute path of a dropped File — Electron 32 removed File.path, and
+   * only the preload can ask. "" when the drag carried no file on disk. */
+  getPathForFile: (file) => {
+    try {
+      return webUtils.getPathForFile(file);
+    } catch {
+      return "";
+    }
   },
   /** {mic} TCC status strings: granted|denied|not-determined|unknown.
    * No screen field — macOS 15+ caches that status per-process, so any

--- a/server/composer-attachments.test.ts
+++ b/server/composer-attachments.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   PASTE_CHARS,
   PASTE_LINES,
+  attachmentsFromDroppedFiles,
   byteLength,
   composeMessage,
+  fileAttachment,
   isAttachment,
   isLongPaste,
   pasteAttachment,
@@ -38,9 +40,56 @@ describe("composer paste attachments", () => {
     );
   });
 
+  it("keeps unusual file paths inside the attachment attribute", () => {
+    const file = fileAttachment("report.txt", '/tmp/a"&<>\t\n\r.txt', 42);
+    expect(composeMessage("", [file])).toBe(
+      '<attached-file path="/tmp/a&quot;&amp;&lt;&gt;&#9;&#10;&#13;.txt" />',
+    );
+  });
+
+  it("preserves drop order and falls back to small pathless text", async () => {
+    const dropped = [
+      {
+        name: "on-disk.md",
+        size: 12,
+        type: "text/markdown",
+        path: "/tmp/on-disk.md",
+        text: async () => "not read",
+      },
+      {
+        name: "browser.txt",
+        size: 7,
+        type: "text/plain",
+        path: "",
+        text: async () => "browser",
+      },
+      {
+        name: "image.png",
+        size: 10,
+        type: "image/png",
+        path: "",
+        text: async () => "not text",
+      },
+    ];
+
+    const result = await attachmentsFromDroppedFiles(dropped, (file) => file.path);
+    expect(result.attachments.map((attachment) => attachment.kind)).toEqual(["file", "paste"]);
+    expect(result.attachments[0]).toMatchObject({
+      kind: "file",
+      name: "on-disk.md",
+      path: "/tmp/on-disk.md",
+    });
+    expect(result.attachments[1]).toMatchObject({ kind: "paste", text: "browser" });
+    expect(result.rejectedNames).toEqual(["image.png"]);
+  });
+
   it("rejects malformed persisted attachments", () => {
     expect(isAttachment({ kind: "paste", id: "a", text: "ok", size: 2, lines: 1 })).toBe(true);
+    expect(
+      isAttachment({ kind: "file", id: "f", name: "notes.txt", path: "/tmp/notes.txt", size: 2 }),
+    ).toBe(true);
     expect(isAttachment({ kind: "paste", id: "a", text: "missing size" })).toBe(false);
     expect(isAttachment({ kind: "file", id: "a", text: "wrong kind", size: 2 })).toBe(false);
+    expect(isAttachment({ kind: "file", id: "f", name: "empty", path: "", size: 0 })).toBe(false);
   });
 });

--- a/server/drafts.test.ts
+++ b/server/drafts.test.ts
@@ -6,7 +6,7 @@ import {
   setDraft,
   setDraftAttachments,
 } from "../src/lib/drafts.ts";
-import { pasteAttachment } from "../src/lib/composer-attachments.ts";
+import { fileAttachment, pasteAttachment } from "../src/lib/composer-attachments.ts";
 
 function memoryStore() {
   const values = new Map<string, string>();
@@ -20,12 +20,13 @@ describe("composer drafts", () => {
   it("keeps text and attachments isolated per bot or room", () => {
     const store = memoryStore();
     const paste = pasteAttachment("bot paste");
+    const file = fileAttachment("notes.txt", "/tmp/notes.txt", 12);
     setDraft(store, "bot:one", "hello");
-    setDraftAttachments(store, "bot:one", [paste]);
+    setDraftAttachments(store, "bot:one", [paste, file]);
     setDraft(store, "group:two", "room text");
 
     expect(getDraft(store, "bot:one")).toBe("hello");
-    expect(getDraftAttachments(store, "bot:one")).toEqual([paste]);
+    expect(getDraftAttachments(store, "bot:one")).toEqual([paste, file]);
     expect(getDraft(store, "group:two")).toBe("room text");
     expect(getDraftAttachments(store, "group:two")).toEqual([]);
   });

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -47,6 +47,10 @@ export function Composer({
   // pastes too long for the input ride along as chips and fold back
   // into the message on send
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const addAttachments = useCallback(
+    (next: Attachment[]) => setAttachments((prev) => [...prev, ...next]),
+    [],
+  );
   const removeAttachment = useCallback(
     (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
     [],
@@ -222,7 +226,11 @@ export function Composer({
             ))}
           </div>
         )}
-        <ComposerAttachments items={attachments} onRemove={removeAttachment} />
+        <ComposerAttachments
+          items={attachments}
+          onAdd={addAttachments}
+          onRemove={removeAttachment}
+        />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea
           ref={inputRef}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -10,6 +10,7 @@ import {
   composeMessage,
   isLongPaste,
   pasteAttachment,
+  type Attachment,
 } from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
@@ -60,6 +61,10 @@ export function Composer({
   // text and its attachment chips have to outlive it (see lib/drafts).
   const [text, setText, attachments, setAttachments] = useComposerDraft(
     group ? `group:${group.id}` : `bot:${bot?.id ?? ""}`,
+  );
+  const addAttachments = useCallback(
+    (next: Attachment[]) => setAttachments((prev) => [...prev, ...next]),
+    [setAttachments],
   );
   const removeAttachment = useCallback(
     (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
@@ -252,7 +257,11 @@ export function Composer({
             />
           </div>
         )}
-        <ComposerAttachments items={attachments} onRemove={removeAttachment} />
+        <ComposerAttachments
+          items={attachments}
+          onAdd={addAttachments}
+          onRemove={removeAttachment}
+        />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea
           ref={inputRef}

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -1,55 +1,186 @@
-// Chips for what is attached to the next message, shown above the input.
-// A long paste collapses into a card of its first lines instead of
-// flooding the composer with a wall of text.
-import { ClipboardPaste, X } from "lucide-react";
+// Chips for what is attached to the next message, plus the window-wide
+// file drop that creates them. A long paste collapses into a card of its
+// first lines instead of flooding the composer; a file dropped anywhere
+// on the window attaches by path.
+import { useEffect, useRef, useState } from "react";
+import { ClipboardPaste, File as FileIcon, X } from "lucide-react";
 import { cn } from "@/lib/cn";
-import { pasteSummary, type Attachment } from "@/lib/composer-attachments";
+import {
+  fileAttachment,
+  formatSize,
+  pasteAttachment,
+  pasteSummary,
+  type Attachment,
+} from "@/lib/composer-attachments";
+
+// A drag out of a web page carries no file on disk, so there is no path to
+// attach; small text still has content worth keeping, so it lands as a paste.
+const INLINE_LIMIT = 512 * 1024;
+const isTextish = (f: File) => f.type.startsWith("text/") || f.type === "application/json";
+
+/** Electron 32 removed File.path — only the preload can name a file. */
+function pathForFile(file: File): string {
+  return window.ogb?.getPathForFile?.(file) ?? "";
+}
 
 export function ComposerAttachments({
   items,
+  onAdd,
   onRemove,
 }: {
   items: Attachment[];
+  onAdd: (attachments: Attachment[]) => void;
   onRemove: (id: string) => void;
 }) {
-  if (!items.length) return null;
+  const [dragging, setDragging] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  // dragenter/dragleave fire once per element crossed, so the overlay
+  // tracks depth rather than the last event it happened to see
+  const depth = useRef(0);
+
+  useEffect(() => {
+    const carriesFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
+    const onEnter = (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      depth.current += 1;
+      setDragging(true);
+    };
+    const onLeave = (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setDragging(false);
+    };
+    // without preventDefault the window navigates to the dropped file and
+    // the app is simply gone
+    const onOver = (e: DragEvent) => {
+      if (carriesFiles(e)) e.preventDefault();
+    };
+    const onDrop = (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      e.preventDefault();
+      depth.current = 0;
+      setDragging(false);
+      const made: Attachment[] = [];
+      const pathless: string[] = [];
+      for (const f of Array.from(e.dataTransfer?.files ?? [])) {
+        const path = pathForFile(f);
+        if (path) made.push(fileAttachment(f.name, path, f.size));
+        else if (isTextish(f) && f.size <= INLINE_LIMIT) {
+          void f.text().then((t) => onAdd([pasteAttachment(t)]));
+        } else pathless.push(f.name);
+      }
+      if (made.length) onAdd(made);
+      setNotice(
+        pathless.length
+          ? `${pathless.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder.`
+          : null,
+      );
+    };
+
+    window.addEventListener("dragenter", onEnter);
+    window.addEventListener("dragleave", onLeave);
+    window.addEventListener("dragover", onOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onEnter);
+      window.removeEventListener("dragleave", onLeave);
+      window.removeEventListener("dragover", onOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [onAdd]);
+
   return (
-    <div className="mb-2 flex flex-wrap gap-2">
-      {items.map((a) => (
-        <PasteChip key={a.id} item={a} onRemove={() => onRemove(a.id)} />
-      ))}
-    </div>
+    <>
+      {dragging && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-10">
+          <div className="rounded-2xl border-2 border-dashed border-accent/70 bg-panel/90 px-8 py-6 text-[14px] font-medium text-ink shadow-2xl">
+            Drop to attach — the bot gets the file path
+          </div>
+        </div>
+      )}
+
+      {notice && (
+        <div className="mb-2 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+          <span className="min-w-0 flex-1">{notice}</span>
+          <button
+            onClick={() => setNotice(null)}
+            aria-label="Dismiss"
+            className="shrink-0 rounded p-0.5"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {items.map((a) =>
+            a.kind === "paste" ? (
+              <Chip
+                key={a.id}
+                label="PASTED"
+                title={a.text.slice(0, 4000)}
+                onRemove={() => onRemove(a.id)}
+              >
+                <div className="relative h-[76px] overflow-hidden">
+                  <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
+                    {a.text.slice(0, 400)}
+                  </pre>
+                  <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
+                </div>
+                <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(a)}</div>
+              </Chip>
+            ) : (
+              <Chip key={a.id} label="FILE" title={a.path} onRemove={() => onRemove(a.id)}>
+                <div className="flex h-[76px] items-center gap-2">
+                  <FileIcon size={16} className="shrink-0 text-ink-secondary" />
+                  <div className="min-w-0">
+                    <div className="truncate text-[12px] text-ink">{a.name}</div>
+                    <div className="text-[10.5px] text-ink-secondary/70">{formatSize(a.size)}</div>
+                  </div>
+                </div>
+              </Chip>
+            ),
+          )}
+        </div>
+      )}
+    </>
   );
 }
 
-function PasteChip({ item, onRemove }: { item: Attachment; onRemove: () => void }) {
-  const { text } = item;
+function Chip({
+  children,
+  label,
+  title,
+  onRemove,
+}: {
+  children: React.ReactNode;
+  label: "PASTED" | "FILE";
+  title: string;
+  onRemove: () => void;
+}) {
+  const Icon = label === "PASTED" ? ClipboardPaste : FileIcon;
   return (
     <div
-      title={text.slice(0, 4000)}
+      title={title}
       className={cn(
         "group relative w-[172px] rounded-xl border border-hairline/40 bg-raised px-2.5 py-2",
         "transition-colors hover:border-hairline",
       )}
     >
-      <div className="relative h-[76px] overflow-hidden">
-        <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
-          {text.slice(0, 400)}
-        </pre>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
-      </div>
-      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(item)}</div>
+      {children}
       <div className="mt-1 flex items-center gap-1">
-        <ClipboardPaste size={11} className="text-ink-secondary/70" />
+        <Icon size={11} className="text-ink-secondary/70" />
         <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
-          PASTED
+          {label}
         </span>
       </div>
       {/* hover reveals it, but so must focus: `hidden` would take the only
           way to drop a chip out of reach of the keyboard */}
       <button
         onClick={onRemove}
-        aria-label="Remove pasted text"
+        aria-label={`Remove ${label === "PASTED" ? "pasted text" : "file"}`}
         className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary opacity-0 transition-opacity hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
       >
         <X size={11} />

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -1,55 +1,176 @@
-// Chips for what is attached to the next message, shown above the input.
-// A long paste collapses into a card of its first lines instead of
-// flooding the composer with a wall of text.
-import { ClipboardPaste, X } from "lucide-react";
+// Chips for what is attached to the next message, plus the window-wide
+// file drop that creates them. A long paste collapses into a card of its
+// first lines instead of flooding the composer; a file dropped anywhere
+// on the window attaches by path.
+import { useEffect, useRef, useState } from "react";
+import { ClipboardPaste, File as FileIcon, X } from "lucide-react";
 import { cn } from "@/lib/cn";
-import { pasteSummary, type Attachment } from "@/lib/composer-attachments";
+import {
+  attachmentsFromDroppedFiles,
+  formatSize,
+  pasteSummary,
+  type Attachment,
+} from "@/lib/composer-attachments";
+
+/** Electron 32 removed File.path — only the preload can name a file. */
+function pathForFile(file: File): string {
+  return window.ogb?.getPathForFile?.(file) ?? "";
+}
 
 export function ComposerAttachments({
   items,
+  onAdd,
   onRemove,
 }: {
   items: Attachment[];
+  onAdd: (attachments: Attachment[]) => void;
   onRemove: (id: string) => void;
 }) {
-  if (!items.length) return null;
+  const [dragging, setDragging] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  // dragenter/dragleave fire once per element crossed, so the overlay
+  // tracks depth rather than the last event it happened to see
+  const depth = useRef(0);
+
+  useEffect(() => {
+    let active = true;
+    const carriesFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
+    const onEnter = (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      depth.current += 1;
+      setDragging(true);
+    };
+    const onLeave = (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setDragging(false);
+    };
+    // without preventDefault the window navigates to the dropped file and
+    // the app is simply gone
+    const onOver = (e: DragEvent) => {
+      if (carriesFiles(e)) e.preventDefault();
+    };
+    const onDrop = async (e: DragEvent) => {
+      if (!carriesFiles(e)) return;
+      e.preventDefault();
+      depth.current = 0;
+      setDragging(false);
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(files, pathForFile);
+      if (!active) return;
+      if (attachments.length) onAdd(attachments);
+      setNotice(
+        rejectedNames.length
+          ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder.`
+          : null,
+      );
+    };
+
+    window.addEventListener("dragenter", onEnter);
+    window.addEventListener("dragleave", onLeave);
+    window.addEventListener("dragover", onOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      active = false;
+      window.removeEventListener("dragenter", onEnter);
+      window.removeEventListener("dragleave", onLeave);
+      window.removeEventListener("dragover", onOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [onAdd]);
+
   return (
-    <div className="mb-2 flex flex-wrap gap-2">
-      {items.map((a) => (
-        <PasteChip key={a.id} item={a} onRemove={() => onRemove(a.id)} />
-      ))}
-    </div>
+    <>
+      {dragging && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-10">
+          <div className="rounded-2xl border-2 border-dashed border-accent/70 bg-panel/90 px-8 py-6 text-[14px] font-medium text-ink shadow-2xl">
+            Drop to attach — the bot gets the file path
+          </div>
+        </div>
+      )}
+
+      {notice && (
+        <div className="mb-2 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+          <span className="min-w-0 flex-1">{notice}</span>
+          <button
+            onClick={() => setNotice(null)}
+            aria-label="Dismiss"
+            className="shrink-0 rounded p-0.5"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {items.map((a) =>
+            a.kind === "paste" ? (
+              <Chip
+                key={a.id}
+                label="PASTED"
+                title={a.text.slice(0, 4000)}
+                onRemove={() => onRemove(a.id)}
+              >
+                <div className="relative h-[76px] overflow-hidden">
+                  <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
+                    {a.text.slice(0, 400)}
+                  </pre>
+                  <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
+                </div>
+                <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(a)}</div>
+              </Chip>
+            ) : (
+              <Chip key={a.id} label="FILE" title={a.path} onRemove={() => onRemove(a.id)}>
+                <div className="flex h-[76px] items-center gap-2">
+                  <FileIcon size={16} className="shrink-0 text-ink-secondary" />
+                  <div className="min-w-0">
+                    <div className="truncate text-[12px] text-ink">{a.name}</div>
+                    <div className="text-[10.5px] text-ink-secondary/70">{formatSize(a.size)}</div>
+                  </div>
+                </div>
+              </Chip>
+            ),
+          )}
+        </div>
+      )}
+    </>
   );
 }
 
-function PasteChip({ item, onRemove }: { item: Attachment; onRemove: () => void }) {
-  const { text } = item;
+function Chip({
+  children,
+  label,
+  title,
+  onRemove,
+}: {
+  children: React.ReactNode;
+  label: "PASTED" | "FILE";
+  title: string;
+  onRemove: () => void;
+}) {
+  const Icon = label === "PASTED" ? ClipboardPaste : FileIcon;
   return (
     <div
-      title={text.slice(0, 4000)}
+      title={title}
       className={cn(
         "group relative w-[172px] rounded-xl border border-hairline/40 bg-raised px-2.5 py-2",
         "transition-colors hover:border-hairline",
       )}
     >
-      <div className="relative h-[76px] overflow-hidden">
-        <pre className="whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-ink-secondary">
-          {text.slice(0, 400)}
-        </pre>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
-      </div>
-      <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(item)}</div>
+      {children}
       <div className="mt-1 flex items-center gap-1">
-        <ClipboardPaste size={11} className="text-ink-secondary/70" />
+        <Icon size={11} className="text-ink-secondary/70" />
         <span className="rounded border border-hairline/60 px-1 py-px text-[9.5px] font-medium tracking-wide text-ink-secondary">
-          PASTED
+          {label}
         </span>
       </div>
       {/* hover reveals it, but so must focus: `hidden` would take the only
           way to drop a chip out of reach of the keyboard */}
       <button
         onClick={onRemove}
-        aria-label="Remove pasted text"
+        aria-label={`Remove ${label === "PASTED" ? "pasted text" : "file"}`}
         className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-hairline/60 bg-panel text-ink-secondary opacity-0 transition-opacity hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
       >
         <X size={11} />

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,7 +1,10 @@
-// Text pasted into the composer that is too long to live in the input.
-// It rides along as a chip and folds back into the message on send —
-// nothing here reaches the server, so every driver still sees a prompt.
-export type Attachment = { kind: "paste"; id: string; text: string; size: number };
+// What is attached to the next message: a paste too long to live in the
+// input, and files dropped onto the window. Both ride along as chips and
+// fold back into the message on send — nothing here reaches the server,
+// so every driver still sees a plain prompt.
+export type Attachment =
+  | { kind: "paste"; id: string; text: string; size: number }
+  | { kind: "file"; id: string; path: string; name: string; size: number };
 
 /** Past this, a paste stops reading as typing and becomes an attachment.
  * Long-but-narrow (a stack trace, a log) counts by line, not just chars. */
@@ -16,8 +19,16 @@ export function countLines(text: string): number {
   return text.split("\n").length;
 }
 
+function newId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+}
+
+export function fileAttachment(name: string, path: string, size: number): Attachment {
+  return { kind: "file", id: newId(), path, name, size };
+}
+
 export function pasteAttachment(text: string): Attachment {
-  const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+  const id = newId();
   // measured once, here: a chip re-renders on every keystroke in the
   // composer, and encoding half a megabyte each time would be felt
   return { kind: "paste", id, text, size: byteLength(text) };
@@ -40,13 +51,18 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-/** The prompt the bot receives: what was typed, then one block per paste.
- * Tagged blocks rather than fences — pasted code and markdown carry fences
- * of their own, and nesting them loses the boundary. */
+/** The prompt the bot receives: what was typed, then one block per
+ * attachment. Tagged blocks rather than fences — pasted code and markdown
+ * carry fences of their own, and nesting them loses the boundary. A file
+ * needs only its path: every driver here is an agent that can open it. */
 export function composeMessage(text: string, attachments: Attachment[]): string {
   const parts = [text.trim()];
   attachments.forEach((a, i) => {
-    parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+    if (a.kind === "paste") {
+      parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+    } else {
+      parts.push(`<attached-file path="${a.path}" />`);
+    }
   });
   return parts.filter(Boolean).join("\n\n");
 }

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -1,7 +1,7 @@
-// Text pasted into the composer that is too long to live in the input.
-// It rides along as a chip and folds back into the message on send —
-// nothing here reaches the server, so every driver still sees a prompt.
-export type Attachment = {
+// What is attached to the next message: text too long for the input or a
+// file dropped onto the window. Chips fold back into a normal prompt on
+// send, so every driver receives the same message shape.
+export type PasteAttachment = {
   kind: "paste";
   id: string;
   text: string;
@@ -9,20 +9,40 @@ export type Attachment = {
   lines: number;
 };
 
+export type FileAttachment = {
+  kind: "file";
+  id: string;
+  path: string;
+  name: string;
+  size: number;
+};
+
+export type Attachment = PasteAttachment | FileAttachment;
+
 export function isAttachment(value: unknown): value is Attachment {
   if (!value || typeof value !== "object") return false;
-  const attachment = value as Partial<Attachment>;
-  return (
-    attachment.kind === "paste" &&
-    typeof attachment.id === "string" &&
-    typeof attachment.text === "string" &&
-    typeof attachment.size === "number" &&
-    Number.isFinite(attachment.size) &&
-    attachment.size >= 0 &&
-    typeof attachment.lines === "number" &&
-    Number.isInteger(attachment.lines) &&
-    attachment.lines >= 1
-  );
+  const attachment = value as Record<string, unknown>;
+  if (typeof attachment.id !== "string" || !validSize(attachment.size)) return false;
+  if (attachment.kind === "paste") {
+    return (
+      typeof attachment.text === "string" &&
+      typeof attachment.lines === "number" &&
+      Number.isInteger(attachment.lines) &&
+      attachment.lines >= 1
+    );
+  }
+  if (attachment.kind === "file") {
+    return (
+      typeof attachment.path === "string" &&
+      attachment.path.length > 0 &&
+      typeof attachment.name === "string"
+    );
+  }
+  return false;
+}
+
+function validSize(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
 /** Past this, a paste stops reading as typing and becomes an attachment.
@@ -38,11 +58,65 @@ export function countLines(text: string): number {
   return text.split("\n").length;
 }
 
-export function pasteAttachment(text: string): Attachment {
-  const id = globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+function newId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
+}
+
+export function fileAttachment(name: string, path: string, size: number): FileAttachment {
+  return { kind: "file", id: newId(), path, name, size };
+}
+
+export function pasteAttachment(text: string): PasteAttachment {
+  const id = newId();
   // measured once, here: a chip re-renders on every keystroke in the
   // composer, and encoding half a megabyte each time would be felt
   return { kind: "paste", id, text, size: byteLength(text), lines: countLines(text) };
+}
+
+export const INLINE_DROP_LIMIT = 512 * 1024;
+
+export type DroppedFile = Pick<File, "name" | "size" | "type" | "text">;
+
+/** Turn a browser drop into composer attachments. Electron-backed files
+ * keep their disk path; small pathless text drops keep their contents.
+ * Promise.all preserves the user's drop order even when text reads finish
+ * in a different order. */
+export async function attachmentsFromDroppedFiles<T extends DroppedFile>(
+  files: readonly T[],
+  getPath: (file: T) => string,
+): Promise<{ attachments: Attachment[]; rejectedNames: string[] }> {
+  const results = await Promise.all(
+    files.map(async (file) => {
+      let path = "";
+      try {
+        path = getPath(file);
+      } catch {
+        // A browser or older desktop shell has no disk path to expose.
+      }
+      if (path) return { attachment: fileAttachment(file.name, path, file.size) };
+      if (isInlineText(file) && file.size <= INLINE_DROP_LIMIT) {
+        try {
+          return { attachment: pasteAttachment(await file.text()) };
+        } catch {
+          // Treat an unreadable browser drag like any other pathless file.
+        }
+      }
+      return { rejectedName: file.name };
+    }),
+  );
+
+  return {
+    attachments: results.flatMap((result) =>
+      "attachment" in result && result.attachment ? [result.attachment] : [],
+    ),
+    rejectedNames: results.flatMap((result) =>
+      "rejectedName" in result && result.rejectedName ? [result.rejectedName] : [],
+    ),
+  };
+}
+
+function isInlineText(file: DroppedFile): boolean {
+  return file.type.startsWith("text/") || file.type === "application/json";
 }
 
 /** What the paste actually weighs — String#length counts UTF-16 units, so
@@ -62,13 +136,31 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-/** The prompt the bot receives: what was typed, then one block per paste.
- * Tagged blocks rather than fences — pasted code and markdown carry fences
- * of their own, and nesting them loses the boundary. */
+/** The prompt the bot receives: what was typed, then one block per
+ * attachment. Tagged blocks rather than fences — pasted code and markdown
+ * carry fences of their own, and nesting them loses the boundary. A file
+ * needs only its path: every driver here is an agent that can open it. */
 export function composeMessage(text: string, attachments: Attachment[]): string {
   const parts = [text.trim()];
   attachments.forEach((a, i) => {
-    parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+    if (a.kind === "paste") {
+      parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+    } else {
+      parts.push(`<attached-file path="${escapeAttribute(a.path)}" />`);
+    }
   });
   return parts.filter(Boolean).join("\n\n");
+}
+
+/** File paths are untrusted prompt content. Keep them inside the quoted
+ * attribute even when a filename contains XML characters or line breaks. */
+export function escapeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\t", "&#9;")
+    .replaceAll("\r", "&#13;")
+    .replaceAll("\n", "&#10;");
 }

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -12,6 +12,9 @@ declare global {
         cb: (line: { partial?: boolean; text?: string; error?: string }) => void,
       ): () => void;
       onSpeechEnd(cb: (info: { code: number | null }) => void): () => void;
+      /** Absolute path of a dropped File ("" when the drag carried no
+       * file on disk). Absent in older builds of the shell. */
+      getPathForFile?(file: File): string;
       /** {mic} TCC status: granted|denied|not-determined|unknown. Screen
        * status is deliberately absent — macOS 15+ caches it per-process,
        * so it lies for the whole session after a grant. */

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -39,6 +39,9 @@ declare global {
         cb: (line: { partial?: boolean; text?: string; error?: string }) => void,
       ): () => void;
       onSpeechEnd(cb: (info: { code: number | null; reason?: string }) => void): () => void;
+      /** Absolute path of a dropped File ("" when the drag carried no
+       * file on disk). Absent in older builds of the shell. */
+      getPathForFile?(file: File): string;
       /** {mic} TCC status: granted|denied|not-determined|unknown. Screen
        * status is deliberately absent — macOS 15+ caches it per-process,
        * so it lies for the whole session after a grant. */


### PR DESCRIPTION
Closes #69.

This preserves the original contribution as a merge parent and integrates it with the current composer.

Review fixes included:
- persist file chips with the correct bot or room draft
- safely encode quotes, ampersands, angle brackets, tabs, and line breaks in file paths
- preserve drop order while resolving browser-only text files
- cancel late async drop updates when the composer changes
- keep pending approvals, dictation, queued sends, and long-paste behavior intact
- validate persisted file attachments and cover file drops, path encoding, and conversation isolation with tests

Local verification:
- 206 tests passed; 7 skipped
- production build passed
- Electron syntax checks passed