### PR TITLE
Integrate #58: safe structured computer observations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
     "test": "vitest run",
+    "bench:observation": "node --experimental-strip-types scripts/bench-observation.ts",
     "test:watch": "vitest",
     "preview": "vite preview",
     "build:server": "tsc -p tsconfig.server.build.json",

--- a/scripts/bench-observation.ts
+++ b/scripts/bench-observation.ts
@@ -1,0 +1,18 @@
+import { ObservationCoordinator } from "../server/computer-observation.ts";
+
+// Stable fixture: old strategy sends a full screenshot after every read. The
+// new policy captures after each deterministic action but only sends an image
+// when pixels change; repeated reads without actions reuse the observation.
+const frames = ["initial", "initial", "after-click", "after-click", "after-submit", "after-submit", "after-submit"];
+const oldSent = frames.length;
+const coordinator = new ObservationCoordinator();
+for (const [index, frame] of frames.entries()) {
+  if (index === 0 || index === 2 || index === 4) coordinator.noteAction();
+  if (coordinator.needsCapture()) coordinator.observeFrame(frame, null);
+}
+const metrics = coordinator.metrics;
+const reduction = ((1 - metrics.screenshotsSentToModel / oldSent) * 100).toFixed(1);
+console.log("Computer observation benchmark (offline deterministic fixture)");
+console.log(`Screenshot observations sent to model: ${oldSent} → ${metrics.screenshotsSentToModel} (${reduction}% reduction)`);
+console.log(`Screenshots captured: ${metrics.screenshotsCaptured}; stable reads reused: ${frames.length - metrics.screenshotsCaptured}`);
+console.log("Reliability note: every deterministic action still triggers one fresh capture; unchanged pixels suppress only redundant vision payloads.");

--- a/scripts/bench-observation.ts
+++ b/scripts/bench-observation.ts
@@ -4,7 +4,7 @@ import { ObservationCoordinator } from "../server/computer-observation.ts";
 // can update asynchronously. Only byte-identical frames are withheld from the
 // model; deterministic actions therefore always receive fresh evidence.
 const frames = ["initial", "initial", "after-click", "after-click", "after-submit", "after-submit", "after-submit"];
-const oldSent = frames.length;
+const baselineSent = frames.length;
 const coordinator = new ObservationCoordinator();
 for (const [index, frame] of frames.entries()) {
   // index 1 deliberately models an action whose pixels do not change: it
@@ -13,11 +13,11 @@ for (const [index, frame] of frames.entries()) {
   coordinator.observeFrame(frame, null);
 }
 const metrics = coordinator.metrics;
-const reduction = ((1 - metrics.screenshotsSentToModel / oldSent) * 100).toFixed(1);
+const reduction = ((1 - metrics.screenshotsSentToModel / baselineSent) * 100).toFixed(1);
 const suppressed = metrics.screenshotsCaptured - metrics.screenshotsSentToModel;
 if (suppressed < 1 || metrics.screenshotsCaptured !== frames.length) {
   throw new Error("fixture failed to capture every observation or suppress a duplicate");
 }
 console.log("Computer observation benchmark (offline deterministic fixture)");
-console.log(`Screenshot observations sent to model: ${oldSent} → ${metrics.screenshotsSentToModel} (${reduction}% reduction)`);
+console.log(`Screenshot observations sent to model: ${baselineSent} → ${metrics.screenshotsSentToModel} (${reduction}% reduction)`);
 console.log(`Actions: ${metrics.computerActions}; screenshots captured: ${metrics.screenshotsCaptured}; duplicate captures suppressed: ${suppressed}`);

--- a/server/computer-observation.test.ts
+++ b/server/computer-observation.test.ts
@@ -40,6 +40,9 @@ describe("computer observation coordinator", () => {
       height: 100,
     });
     expect(normalizeCrop({ x: -1, y: 0, width: 200, height: 100 }, 1280, 720)).toBeNull();
+    expect(normalizeCrop({ x: 0, y: 0, width: 31, height: 100 }, 1280, 720)).toBeNull();
+    expect(normalizeCrop({ x: 0, y: 0, width: 100, height: 31 }, 1280, 720)).toBeNull();
+    expect(normalizeCrop({ x: 0, y: 0, width: "wide", height: 100 }, 1280, 720)).toBeNull();
     expect(normalizeCrop({ x: 1200, y: 0, width: 200, height: 100 }, 1280, 720)).toBeNull();
     expect(normalizeCrop({ x: 0, y: 700, width: 100, height: 50 }, 1280, 720)).toBeNull();
   });
@@ -48,6 +51,7 @@ describe("computer observation coordinator", () => {
     const raw = "https://user:password@example.com/a?token=secret#fragment";
     expect(safeBrowserUrl(raw)).toBe("https://example.com/a");
     expect(normalizeBrowserUrl(raw)).toBe("https://example.com/a?token=secret#fragment");
+    expect(safeBrowserUrl(`https://example.com/${"a".repeat(2_048)}`)).toBeNull();
     expect(parseBrowserTargets(JSON.stringify([
       { id: "one", type: "page", title: " Example page ", url: raw },
       { id: "two", type: "service_worker", url: "https://example.com/worker" },

--- a/server/computer-observation.test.ts
+++ b/server/computer-observation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCrop, ObservationCoordinator, parseBrowserTargets, safeBrowserUrl } from "./computer-observation.ts";
+
+describe("computer observation coordinator", () => {
+  it("captures after actions but sends vision only for changed pixels", () => {
+    const coordinator = new ObservationCoordinator();
+    expect(coordinator.needsCapture()).toBe(true);
+    expect(coordinator.observeFrame("frame-a", null)).toMatchObject({ changed: true });
+    expect(coordinator.needsCapture()).toBe(false);
+    coordinator.noteAction();
+    expect(coordinator.needsCapture()).toBe(true);
+    expect(coordinator.observeFrame("frame-a", null)).toMatchObject({ changed: false });
+    coordinator.noteAction();
+    expect(coordinator.observeFrame("frame-b", { x: 20, y: 20, width: 100, height: 100 })).toMatchObject({ changed: true });
+    expect(coordinator.metrics).toMatchObject({ screenshotsCaptured: 3, screenshotsSentToModel: 2, fullScreenObservations: 1, croppedObservations: 1, computerActions: 2 });
+  });
+
+  it("accepts bounded crop regions and rejects invalid ones", () => {
+    expect(normalizeCrop({ x: 10, y: 20, width: 200, height: 100 })).toEqual({ x: 10, y: 20, width: 200, height: 100 });
+    expect(normalizeCrop({ x: -1, y: 0, width: 200, height: 100 })).toBeNull();
+    expect(normalizeCrop({ x: 1200, y: 0, width: 200, height: 100 })).toBeNull();
+  });
+
+  it("uses safe structured Chrome targets without query-string data", () => {
+    expect(safeBrowserUrl("https://example.com/a?token=secret#fragment")).toBe("https://example.com/a");
+    expect(parseBrowserTargets(JSON.stringify([
+      { id: "one", type: "page", title: " Example page ", url: "https://example.com/a?token=secret" },
+      { id: "two", type: "service_worker", url: "https://example.com/worker" },
+    ]))).toEqual([{ id: "one", title: "Example page", url: "https://example.com/a" }]);
+  });
+});

--- a/server/computer-observation.ts
+++ b/server/computer-observation.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+
+/** Provider-neutral policy for deciding when a computer observation needs vision. */
+export interface ObservationMetrics {
+  screenshotsCaptured: number;
+  screenshotsSentToModel: number;
+  fullScreenObservations: number;
+  croppedObservations: number;
+  structuredBrowserObservations: number;
+  computerActions: number;
+  retries: number;
+  verificationSuccesses: number;
+  verificationFailures: number;
+}
+
+export interface CropRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BrowserTarget {
+  id: string;
+  title: string;
+  url: string;
+}
+
+export const emptyObservationMetrics = (): ObservationMetrics => ({
+  screenshotsCaptured: 0,
+  screenshotsSentToModel: 0,
+  fullScreenObservations: 0,
+  croppedObservations: 0,
+  structuredBrowserObservations: 0,
+  computerActions: 0,
+  retries: 0,
+  verificationSuccesses: 0,
+  verificationFailures: 0,
+});
+
+export function normalizeCrop(raw: unknown, maxWidth = 1280): CropRegion | null {
+  if (!raw || typeof raw !== "object") return null;
+  const value = raw as Record<string, unknown>;
+  const x = Math.round(Number(value.x));
+  const y = Math.round(Number(value.y));
+  const width = Math.round(Number(value.width));
+  const height = Math.round(Number(value.height));
+  if (![x, y, width, height].every(Number.isFinite) || x < 0 || y < 0 || width < 32 || height < 32) return null;
+  if (x + width > maxWidth || height > 4_000) return null;
+  return { x, y, width, height };
+}
+
+/** Removes query/fragment data before browser state reaches a model or log. */
+export function safeBrowserUrl(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  try {
+    const url = new URL(value);
+    if (!/^https?:$/.test(url.protocol)) return null;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Parses Chrome's /json/list response into a small, safe structured observation. */
+export function parseBrowserTargets(raw: string): BrowserTarget[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const value = item as Record<string, unknown>;
+      const url = safeBrowserUrl(value.url);
+      if (value.type !== "page" || !url || typeof value.id !== "string") return [];
+      const title = typeof value.title === "string" ? value.title.replace(/\s+/g, " ").trim().slice(0, 200) : "";
+      return [{ id: value.id.slice(0, 100), title, url }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Keeps observations cheap without claiming the screen is immutable: an action
+ * marks the frame dirty; the next screenshot captures once, hashes pixels, and
+ * only returns an image if the pixels changed. Repeated reads without an action
+ * reuse the verified observation instead of capturing/sending another image.
+ */
+export class ObservationCoordinator {
+  metrics = emptyObservationMetrics();
+  private lastHash: string | null = null;
+  private dirty = true;
+
+  noteAction() {
+    this.metrics.computerActions += 1;
+    this.dirty = true;
+  }
+
+  noteRetry() {
+    this.metrics.retries += 1;
+  }
+
+  needsCapture(force = false) {
+    return force || this.dirty || this.lastHash === null;
+  }
+
+  observeFrame(base64: string, crop: CropRegion | null) {
+    this.metrics.screenshotsCaptured += 1;
+    const hash = createHash("sha256").update(base64).digest("hex");
+    const changed = hash !== this.lastHash;
+    this.lastHash = hash;
+    this.dirty = false;
+    if (changed) {
+      this.metrics.screenshotsSentToModel += 1;
+      if (crop) this.metrics.croppedObservations += 1;
+      else this.metrics.fullScreenObservations += 1;
+    }
+    return { changed, hash };
+  }
+
+  noteStructuredObservation() {
+    this.metrics.structuredBrowserObservations += 1;
+  }
+
+  noteVerification(ok: boolean) {
+    if (ok) this.metrics.verificationSuccesses += 1;
+    else this.metrics.verificationFailures += 1;
+  }
+}

--- a/server/computer-observation.ts
+++ b/server/computer-observation.ts
@@ -86,7 +86,8 @@ export function safeBrowserUrl(value: unknown): string | null {
   const url = new URL(normalized);
   url.search = "";
   url.hash = "";
-  return url.toString().slice(0, 2_048);
+  const safe = url.toString();
+  return safe.length <= 2_048 ? safe : null;
 }
 
 /** Parses Chrome's /json/list response into a small, safe structured observation. */

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -235,6 +235,8 @@ describe("computer proxy (fake box)", () => {
 
   it("does not verify a different query or an invalid expected URL", async () => {
     browserUrl = "https://example.com/path?step=2#done";
+    rpc({ jsonrpc: "2.0", id: 90, method: "tools/call", params: { name: "observation_metrics", arguments: {} } });
+    const metricsBefore = JSON.parse((await waitFor(90)).result.content[0].text);
     const beforeInvalid = commands.length;
     rpc({
       jsonrpc: "2.0",
@@ -272,9 +274,20 @@ describe("computer proxy (fake box)", () => {
     expect(exact.result.isError).not.toBe(true);
     expect(exact.result.content[0].text).toMatch(/verified/i);
     expect(exact.result.content[0].text).not.toContain("step=2");
+
+    rpc({ jsonrpc: "2.0", id: 91, method: "tools/call", params: { name: "observation_metrics", arguments: {} } });
+    const metricsAfter = JSON.parse((await waitFor(91)).result.content[0].text);
+    expect(metricsAfter.structuredBrowserObservations).toBe(metricsBefore.structuredBrowserObservations);
   });
 
   it("rejects out-of-height crops and fails closed when conversion fails", async () => {
+    rpc({
+      jsonrpc: "2.0",
+      id: 120,
+      method: "tools/call",
+      params: { name: "screenshot", arguments: {} },
+    });
+    await waitFor(120);
     const beforeBounds = commands.length;
     rpc({
       jsonrpc: "2.0",
@@ -306,6 +319,33 @@ describe("computer proxy (fake box)", () => {
     expect(failed.result.content[0].text).toMatch(/crop failed/i);
 
     cropFails = false;
+  });
+
+  it("uses a private Chrome profile, strips URL credentials, and reports redirects", async () => {
+    browserUrl = "https://example.com/landed?private=value#done";
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 130,
+      method: "tools/call",
+      params: {
+        name: "open_url",
+        arguments: {
+          url: "https://user:password@example.com/requested?token=secret#fragment",
+          observe: false,
+        },
+      },
+    });
+    const result = await waitFor(130);
+    const issued = commands.slice(before);
+    expect(issued).toHaveLength(2);
+    expect(issued[0]).toContain('mkdir -p "$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('chmod 700 "$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('--user-data-dir="$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).not.toContain("user:password@");
+    expect(issued[0]).toContain("'https://example.com/requested?token=secret#fragment'");
+    expect(result.result.content[0].text).toContain("https://example.com/landed");
+    expect(result.result.content[0].text).not.toMatch(/private|value|token|secret|fragment/);
   });
 
   it("hashes the full frame while treating distinct crops as distinct observations", async () => {

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -49,8 +49,11 @@ const SHOT_PATH = "/tmp/ogb-shot.jpg";
 const SETTLE_MS = 350;
 /** Gap between batched actions so focus changes land before typing. */
 const ACTION_GAP_MS = 120;
+const CHROME_PROFILE = "$HOME/.openmausbot/chrome-profile";
 const CHROME_DEBUG_FLAGS =
-  "--user-data-dir=/tmp/omb-chrome --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222";
+  `--user-data-dir="${CHROME_PROFILE}" --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
+const CHROME_PROFILE_SETUP =
+  `mkdir -p "${CHROME_PROFILE}" && chmod 700 "${CHROME_PROFILE}"`;
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -111,12 +114,12 @@ function metricsText(): string {
   return JSON.stringify(observations.metrics);
 }
 
-async function browserTargets(): Promise<BrowserTarget[]> {
+async function browserTargets(countObservation = true): Promise<BrowserTarget[]> {
   // DevTools stays loopback-only inside the box. Only redacted fields are
   // ever formatted into tool output; comparisonUrl remains internal.
   const out = await runOnBox("curl -sf --max-time 2 http://127.0.0.1:9222/json/list", 5_000);
   const targets = out.ok ? parseBrowserTargets(out.stdout) : [];
-  if (targets.length) observations.noteStructuredObservation();
+  if (countObservation && targets.length) observations.noteStructuredObservation();
   return targets;
 }
 
@@ -135,7 +138,7 @@ async function waitForNavigation(
       observations.noteRetry();
       await new Promise((resolve) => setTimeout(resolve, 1_000));
     }
-    targets = await browserTargets();
+    targets = await browserTargets(false);
     if (targets.some((target) => target.comparisonUrl === expected)) {
       observations.noteVerification(true);
       return { ok: true, targets };
@@ -698,23 +701,25 @@ async function call(id: unknown, name: string, args: any) {
     const normalized = normalizeBrowserUrl(url);
     const publicUrl = safeBrowserUrl(url);
     if (!normalized || !publicUrl) return text(id, "only valid http(s) URLs", true);
-    const q = shellQuote(url);
+    const q = shellQuote(normalized);
     const observe = wantsFrame(args);
     // launch, then poll for a browser window instead of a blind sleep —
     // a fast page returns in a fraction of the old fixed 3s
     const command = [
       ENV,
       GEOMETRY,
+      CHROME_PROFILE_SETUP,
       `(google-chrome ${CHROME_DEBUG_FLAGS} ${q} || chromium ${CHROME_DEBUG_FLAGS} ${q} || chromium-browser ${CHROME_DEBUG_FLAGS} ${q} || xdg-open ${q}) >/dev/null 2>&1 &`,
       'for i in 1 2 3 4 5 6 7 8 9 10 11 12; do xdotool search --onlyvisible --class "chrom" >/dev/null 2>&1 && break; sleep 0.25; done',
       observe ? captureBlock(600) : "true",
     ].join("; ");
     observations.noteAction();
     const out = await runOnBox(command, 60_000);
-    const verification = await waitForNavigation(url);
+    const verification = await waitForNavigation(normalized, 1);
+    const current = verification.targets.map((target) => target.url).join(", ") || "unavailable";
     const note = verification.ok
       ? `opened and navigation verified: ${publicUrl}`
-      : `opened ${publicUrl}, but structured navigation was not verified`;
+      : `opened ${publicUrl}, but the exact destination was not verified. Current structured state: ${current}`;
     if (!observe) return text(id, note);
     return observed(id, note, await frameFrom(out));
   }

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -11,6 +11,8 @@
 // CUA itself uses on Linux.
 //
 // stdout is the MCP channel — never console.log here.
+import { normalizeCrop, ObservationCoordinator, parseBrowserTargets, safeBrowserUrl } from "./computer-observation.ts";
+
 const BOX_API = "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
@@ -55,6 +57,39 @@ const X = "export DISPLAY=${DISPLAY:-:0}; ";
 // capture to a file on the box, read back via the files API — base64 over
 // command stdout corrupts (probed 2026-08-12), never ship binary that way
 const SHOT_WIDTH = 1280;
+const observations = new ObservationCoordinator();
+
+function metricsText() {
+  return JSON.stringify(observations.metrics);
+}
+
+async function browserTargets() {
+  // Chrome's DevTools target list is structured state: titles/URLs tell an
+  // agent whether navigation happened without burning a screenshot. It is
+  // intentionally best-effort; ordinary desktop use still works without CDP.
+  const out = await runOnBox("curl -sf --max-time 2 http://127.0.0.1:9222/json/list", 5_000);
+  const targets = out.ok ? parseBrowserTargets(out.stdout) : [];
+  if (targets.length) observations.noteStructuredObservation();
+  return targets;
+}
+
+async function waitForNavigation(url: string, attempts = 3) {
+  const expected = safeBrowserUrl(url);
+  let targets: Awaited<ReturnType<typeof browserTargets>> = [];
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt) {
+      observations.noteRetry();
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+    targets = await browserTargets();
+    if (!expected || targets.some((target) => target.url === expected)) {
+      observations.noteVerification(true);
+      return { ok: true, targets };
+    }
+  }
+  observations.noteVerification(false);
+  return { ok: false, targets };
+}
 const SHOT_CMD = [
   "export DISPLAY=${DISPLAY:-:0}",
   "f=/tmp/ogb-shot.png",
@@ -91,7 +126,33 @@ const TOOLS = [
   {
     name: "screenshot",
     description:
-      "See the bot's cloud computer screen (returns an image). Call before and after acting to ground yourself — the desktop runs Chrome and a full Linux GUI.",
+      "See the bot's cloud computer only when visual state is needed. First use browser_state for Chrome navigation/title/URL checks; repeated stable reads reuse a verified frame, and unchanged pixels return text instead of another image.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        force: { type: "boolean", description: "Capture even when no computer action has marked the screen dirty." },
+        region: {
+          type: "object",
+          description: "Optional screenshot-space crop within the 1280px-wide observation.",
+          properties: { x: { type: "number" }, y: { type: "number" }, width: { type: "number" }, height: { type: "number" } },
+          required: ["x", "y", "width", "height"],
+        },
+      },
+    },
+  },
+  {
+    name: "browser_state",
+    description: "Read safe structured Chrome state (page titles and URLs with query strings removed) through local DevTools. Use before screenshots to verify navigation and identify the current page.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "wait_for_navigation",
+    description: "Boundedly verify Chrome reached an http(s) URL using structured DevTools state. Retries at most three times.",
+    inputSchema: { type: "object", properties: { url: { type: "string" } }, required: ["url"] },
+  },
+  {
+    name: "observation_metrics",
+    description: "Return this turn's screenshot, structured-observation, action, retry, and verification metrics.",
     inputSchema: { type: "object", properties: {} },
   },
   {
@@ -140,25 +201,43 @@ const TOOLS = [
   },
   {
     name: "open_url",
-    description: "Open a URL in the computer's own Chrome, then screenshot to see the result.",
+    description: "Open a URL in the computer's own Chrome and boundedly verify navigation through structured browser state before requesting a screenshot.",
     inputSchema: { type: "object", properties: { url: { type: "string" } }, required: ["url"] },
   },
 ];
 
 async function call(id: unknown, name: string, args: any) {
   if (name === "screenshot") {
-    const out = await runOnBox(SHOT_CMD, 60_000);
+    const force = args.force === true;
+    if (!observations.needsCapture(force)) return text(id, `screen unchanged since the last verified observation; no screenshot captured or sent. metrics: ${metricsText()}`);
+    const crop = args.region === undefined ? null : normalizeCrop(args.region, SHOT_WIDTH);
+    if (args.region !== undefined && !crop) return text(id, "region must be a bounded x,y,width,height crop within the 1280px-wide screenshot", true);
+    const cropCommand = crop ? `; convert "$f" -crop ${crop.width}x${crop.height}+${crop.x}+${crop.y} +repage "$f" 2>/dev/null || true` : "";
+    const out = await runOnBox(`${SHOT_CMD}${cropCommand}`, 60_000);
     if (!/captured/.test(out.stdout)) {
       return text(id, `screenshot failed: ${out.stderr.slice(0, 200) || "capture produced no file"}`, true);
     }
     const data = await readBoxFile("/tmp/ogb-shot.png");
     if (!data) return text(id, "screenshot failed: could not read the frame back", true);
+    const observed = observations.observeFrame(data, crop);
+    if (!observed.changed) return text(id, `screen pixels are unchanged after the action; no image sent. metrics: ${metricsText()}`);
     return send({
       jsonrpc: "2.0",
       id,
-      result: { content: [{ type: "image", data, mimeType: "image/png" }] },
+      result: { content: [{ type: "image", data, mimeType: "image/png" }, { type: "text", text: `${crop ? "cropped" : "full-screen"} observation captured. metrics: ${metricsText()}` }] },
     });
   }
+  if (name === "browser_state") {
+    const targets = await browserTargets();
+    return text(id, targets.length ? `Structured browser state:\n${targets.map((target) => `- ${target.title || "Untitled"}: ${target.url}`).join("\n")}\nmetrics: ${metricsText()}` : "Structured browser state unavailable. Use screenshot only if visual state is necessary.");
+  }
+  if (name === "wait_for_navigation") {
+    const url = String(args.url ?? "");
+    if (!safeBrowserUrl(url)) return text(id, "wait_for_navigation needs an http(s) URL", true);
+    const result = await waitForNavigation(url);
+    return text(id, result.ok ? `navigation verified: ${safeBrowserUrl(url)}. metrics: ${metricsText()}` : `navigation not verified after 3 checks. Current structured state: ${result.targets.map((target) => target.url).join(", ") || "unavailable"}. Use screenshot only if needed. metrics: ${metricsText()}`, !result.ok);
+  }
+  if (name === "observation_metrics") return text(id, metricsText());
   if (name === "click") {
     const x = Math.round(Number(args.x));
     const y = Math.round(Number(args.y));
@@ -176,6 +255,7 @@ async function call(id: unknown, name: string, args: any) {
     const rep = args.double ? "--repeat 2 --delay 150 " : "";
     const out = await runOnBox(`${X}xdotool mousemove ${sx} ${sy} click ${rep}${btn}`);
     if (!out.ok) return text(id, `click failed: ${out.stderr.slice(0, 200)}`, true);
+    observations.noteAction();
     return text(
       id,
       `clicked ${x},${y}${scale !== 1 ? ` (scaled to ${sx},${sy} on the ${geometry!.width}x${geometry!.height} display)` : ""}${args.double ? " (double)" : ""}${args.button === "right" ? " (right)" : ""} — screenshot to verify`,
@@ -190,13 +270,16 @@ async function call(id: unknown, name: string, args: any) {
       const out = await runOnBox(`${X}xdotool type --delay 12 '${safe}'`);
       if (!out.ok) return text(id, `type failed: ${out.stderr.slice(0, 200)}`, true);
     }
+    observations.noteAction();
     return text(id, `typed ${t.length} chars`);
   }
   if (name === "press_key") {
     const keys = String(args.keys ?? "").replace(/[^\w+]/g, "");
     if (!keys) return text(id, "press_key needs keys", true);
     const out = await runOnBox(`${X}xdotool key ${keys}`);
-    return out.ok ? text(id, `pressed ${keys}`) : text(id, `key failed: ${out.stderr.slice(0, 200)}`, true);
+    if (!out.ok) return text(id, `key failed: ${out.stderr.slice(0, 200)}`, true);
+    observations.noteAction();
+    return text(id, `pressed ${keys}`);
   }
   if (name === "scroll") {
     const clicks = Math.min(Math.max(Math.round(Number(args.clicks) || 3), 1), 20);
@@ -207,10 +290,12 @@ async function call(id: unknown, name: string, args: any) {
       const out = await runOnBox(`${X}xdotool click --repeat ${clicks} ${btn}`);
       if (!out.ok) return text(id, `scroll failed: ${out.stderr.slice(0, 200)}`, true);
     }
+    observations.noteAction();
     return text(id, `scrolled ${args.direction} ${clicks}`);
   }
   if (name === "computer_exec") {
     const out = await runOnBox(String(args.command ?? "").slice(0, 4000), 120_000);
+    observations.noteAction();
     return text(
       id,
       `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`,
@@ -221,10 +306,13 @@ async function call(id: unknown, name: string, args: any) {
     if (!/^https?:\/\//.test(url)) return text(id, "only http(s) URLs", true);
     const q = url.replace(/'/g, "%27");
     await runOnBox(
-      `${X}(google-chrome '${q}' || chromium '${q}' || chromium-browser '${q}' || xdg-open '${q}') >/dev/null 2>&1 & sleep 3; echo opened`,
+      `${X}(google-chrome --user-data-dir=/tmp/omb-chrome --no-first-run --remote-debugging-port=9222 '${q}' || chromium --user-data-dir=/tmp/omb-chrome --no-first-run --remote-debugging-port=9222 '${q}' || chromium-browser --user-data-dir=/tmp/omb-chrome --no-first-run --remote-debugging-port=9222 '${q}' || xdg-open '${q}') >/dev/null 2>&1 & sleep 2; echo opened`,
       30_000,
     );
-    return text(id, `opened ${url} — take a screenshot to see it`);
+    observations.noteAction();
+    const verification = await waitForNavigation(url, 3);
+    if (verification.ok) return text(id, `opened and navigation verified: ${safeBrowserUrl(url)}. Prefer browser_state before a screenshot. metrics: ${metricsText()}`);
+    return text(id, `opened ${safeBrowserUrl(url)}, but structured navigation was not verified. Use browser_state or a screenshot if visual state is necessary. metrics: ${metricsText()}`);
   }
   return text(id, `unknown tool ${name}`, true);
 }


### PR DESCRIPTION
Closes #58.

This preserves the contributor commit as a merge parent while adapting the observation work to the current one-round-trip JPEG computer proxy.

Review fixes included:
- strip URL credentials, queries, and fragments from model-facing browser state
- compare full normalized URLs internally so query and fragment changes cannot verify incorrectly
- reject invalid expected URLs
- validate crops against the real scaled screenshot width and height
- hash the canonical full frame before cropping
- fail closed when downscaling or crop conversion fails
- keep every explicit observation fresh, suppressing only byte-identical model payloads
- use a custom Chrome data directory and loopback-only remote debugging
- cover all public metrics, navigation mismatches, crop failures, credential redaction, and distinct crop behavior

Local verification:
- 214 tests passed; 7 skipped
- production build and Electron checks passed
- deterministic observation benchmark passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser observation with structured page titles and safely redacted URLs.
  * Added navigation verification with bounded retries and status metrics.
  * Added validated screenshot cropping, duplicate-frame suppression, and observation caching.
  * Added tools for screenshots, browser state, navigation waits, and observation metrics.

* **Bug Fixes**
  * Improved handling of invalid screenshot crops, browser targets, redirects, and navigation failures.

* **Tests**
  * Expanded coverage for URL privacy, crop validation, frame deduplication, navigation verification, and browser observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->