### PR TITLE
Add secure, reopenable HTML artifact previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ it keeps the idea (AI as a *messaging app*: a roster of bots you chat with, each
 memory of its thread, model, computer, and apps) and rebuilds it open, local-first, and on the agents you
 already have:
 
-- **Bring your own agents.** Bots run on the `claude`, `codex`, and `grok` CLIs installed on your own machine
-  — your existing logins and subscriptions, no new accounts, no proxy in the middle.
+- **Bring your own agents and models.** Bots can run on the `claude`, `codex`, and `grok` CLIs installed on
+  your own machine, OpenRouter or Ollama Cloud, or any HTTP endpoint that implements the OpenAI chat
+  completions API (including local Ollama and vLLM servers).
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch
@@ -62,7 +63,8 @@ already have:
 ### 🧠 Pick a brain per bot
 
 A model picker with a provider rail — Claude and Codex models side by side, defaults marked, unavailable
-providers dimmed with the reason. Switch a bot's model mid-conversation.
+providers dimmed with the reason. Switch a bot's model mid-conversation. OpenRouter, Ollama Cloud, and
+custom OpenAI-compatible endpoints can be configured during onboarding or later in App Settings.
 
 <img src="docs/screenshots/model-picker.png" alt="Model picker with provider rail" width="100%">
 
@@ -198,9 +200,9 @@ pnpm dev           # app → http://127.0.0.1:5199
 pnpm dev:desktop   # Electron shell; keep the two commands above running
 ```
 
-Requirements: **macOS, Windows, or Ubuntu 24.04 x64**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code),
-[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
-in the model picker automatically.
+Requirements: **macOS, Windows, or Ubuntu 24.04 x64**, **Node 24+**, **pnpm**, and either an agent CLI — [`claude`](https://claude.com/claude-code),
+[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in, or one of
+the model endpoints below. Available models appear in the model picker automatically.
 
 Package the desktop application:
 
@@ -228,13 +230,17 @@ in the sidebar footer) when you want to enable its integration:
 
 | Credential | What it enables | Where to get it |
 |---|---|---|
+| OpenRouter API key | Chat through OpenRouter's OpenAI-compatible model catalog | [OpenRouter keys](https://openrouter.ai/settings/keys) |
+| Ollama Cloud API key | Chat with models hosted by Ollama Cloud | [Ollama Cloud](https://ollama.com/) |
+| OpenAI-compatible API key (optional) | Authenticate to a custom OpenAI-compatible endpoint; local Ollama and vLLM usually do not require one | Your endpoint operator |
 | Composio Connect key (`ck_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [Composio Connect setup guide](https://docs.composio.dev/docs/composio-connect) |
 | Composio API key (`ak_…`) | Browse the full app catalog with official names and logos | [Composio project API key guide](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
 | Box API key | Give bots an isolated remote Linux computer with a desktop and terminal | [Box API key guide](https://docs.ascii.dev/box/api-keys) |
 | ElevenLabs key | Read replies aloud, and call your bots | [ElevenLabs API keys](https://elevenlabs.io/app/settings/api-keys) |
 
-Composio and Box are third-party services with their own accounts and terms. Box is a paid service after
-its trial, and using a cloud computer may incur charges.
+OpenRouter, Ollama Cloud, Composio, and Box are third-party services with their own accounts and terms.
+Box is a paid service after its trial, and using a hosted model or cloud computer may incur charges. Custom
+OpenAI-compatible endpoint URLs and default model IDs are configured under **App Settings → Models**.
 
 ```sh
 pnpm typecheck     # app + server

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -6,6 +6,7 @@ import { startCua, stopCua, registerCuaIpc } from "./cua.mjs";
 import { startSpeech, stopSpeech } from "./speech.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
+import { isAllowedSubframeNavigation, isTrustedExternalOpen } from "./navigation-policy.mjs";
 
 const { desktopCapabilities } = capabilitiesModule;
 
@@ -147,9 +148,15 @@ function createWindow() {
     },
   });
 
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+  win.webContents.setWindowOpenHandler(({ url, referrer }) => {
+    if (isTrustedExternalOpen(url, referrer.url, win.webContents.getURL())) void shell.openExternal(url);
     return { action: "deny" };
+  });
+  // Artifact previews run in sandboxed srcdoc frames. Their CSP blocks
+  // subresources; this main-process guard also prevents model-authored
+  // scripts or links from navigating the frame to an outbound URL.
+  win.webContents.on("will-frame-navigate", (event, details) => {
+    if (!details.isMainFrame && !isAllowedSubframeNavigation(details.url)) event.preventDefault();
   });
 
   // Packaged CI smoke hook. It validates the real renderer/preload bridge and

--- a/electron/navigation-policy.mjs
+++ b/electron/navigation-policy.mjs
@@ -1,0 +1,20 @@
+const LOCAL_DOCUMENT_SCHEMES = new Set(["about:", "blob:", "data:"]);
+
+export function isAllowedSubframeNavigation(value) {
+  try {
+    return LOCAL_DOCUMENT_SCHEMES.has(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function isTrustedExternalOpen(targetValue, referrerValue, appValue) {
+  try {
+    const target = new URL(targetValue);
+    const referrer = new URL(referrerValue);
+    const app = new URL(appValue);
+    return (target.protocol === "http:" || target.protocol === "https:") && referrer.origin === app.origin;
+  } catch {
+    return false;
+  }
+}

--- a/electron/navigation-policy.test.mjs
+++ b/electron/navigation-policy.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { isAllowedSubframeNavigation, isTrustedExternalOpen } from "./navigation-policy.mjs";
+
+describe("artifact subframe navigation policy", () => {
+  it("allows only local opaque-document schemes", () => {
+    expect(isAllowedSubframeNavigation("about:srcdoc")).toBe(true);
+    expect(isAllowedSubframeNavigation("data:text/html,ok")).toBe(true);
+    expect(isAllowedSubframeNavigation("blob:http://127.0.0.1/id")).toBe(true);
+  });
+
+  it.each([
+    "https://attacker.example/collect",
+    "http://127.0.0.1:11434/admin",
+    "file:///etc/passwd",
+    "javascript:location='https://attacker.example'",
+  ])("blocks model-authored subframe navigation to %s", (url) => {
+    expect(isAllowedSubframeNavigation(url)).toBe(false);
+  });
+});
+
+describe("external window policy", () => {
+  it("opens web links only when the app's top document supplied the referrer", () => {
+    expect(isTrustedExternalOpen(
+      "https://docs.example/page",
+      "http://127.0.0.1:8799/chat",
+      "http://127.0.0.1:8799/",
+    )).toBe(true);
+    expect(isTrustedExternalOpen(
+      "https://attacker.example/collect?secret=x",
+      "",
+      "http://127.0.0.1:8799/",
+    )).toBe(false);
+    expect(isTrustedExternalOpen(
+      "file:///etc/passwd",
+      "http://127.0.0.1:8799/chat",
+      "http://127.0.0.1:8799/",
+    )).toBe(false);
+  });
+});

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { instanceConfigs } from "./config.ts";
+
+describe("model provider instance configuration", () => {
+  it("adds the API-backed providers to the default fleet", () => {
+    const configs = instanceConfigs({
+      openrouter: { key: "router-key" },
+      ollamaCloud: { key: "ollama-key" },
+      openaiCompatible: {
+        key: "endpoint-key",
+        url: "http://10.0.0.42:8000/v1",
+        model: "org/open-model",
+      },
+    });
+
+    expect(configs.openrouter).toMatchObject({
+      driver: "openrouter",
+      config: { url: "https://openrouter.ai/api/v1" },
+      environment: { OPENROUTER_API_KEY: "router-key" },
+    });
+    expect(configs["ollama-cloud"]).toMatchObject({
+      driver: "ollamaCloud",
+      config: { url: "https://ollama.com/v1" },
+      environment: { OLLAMA_API_KEY: "ollama-key" },
+    });
+    expect(configs["openai-compatible"]).toMatchObject({
+      driver: "openaiCompatible",
+      config: { url: "http://10.0.0.42:8000/v1", model: "org/open-model" },
+      environment: { OPENAI_COMPATIBLE_API_KEY: "endpoint-key" },
+    });
+  });
+
+  it("injects each provider credential only into its matching driver", () => {
+    const configs = instanceConfigs({
+      xai: { key: "xai-key" },
+      openrouter: { key: "router-key" },
+      ollamaCloud: { key: "ollama-key" },
+      openaiCompatible: { key: "endpoint-key" },
+      box: { token: "box-token" },
+      instances: {
+        grokApi: { driver: "grok" },
+        router: { driver: "openrouter" },
+        ollama: { driver: "ollamaCloud" },
+        endpoint: { driver: "openaiCompatible" },
+        computer: { driver: "boxAgent" },
+        unrelated: { driver: "claudeAgent" },
+      },
+    });
+
+    expect(configs.grokApi.environment).toEqual({ XAI_API_KEY: "xai-key" });
+    expect(configs.router.environment).toEqual({ OPENROUTER_API_KEY: "router-key" });
+    expect(configs.ollama.environment).toEqual({ OLLAMA_API_KEY: "ollama-key" });
+    expect(configs.endpoint.environment).toEqual({ OPENAI_COMPATIBLE_API_KEY: "endpoint-key" });
+    expect(configs.computer.environment).toEqual({ BOX_TOKEN: "box-token" });
+    expect(configs.unrelated.environment).toEqual({});
+  });
+
+  it("preserves explicit per-instance credential overrides", () => {
+    const configs = instanceConfigs({
+      openrouter: { key: "global-router-key" },
+      instances: {
+        router: {
+          driver: "openrouter",
+          environment: { OPENROUTER_API_KEY: "instance-router-key", EXISTING: "kept" },
+        },
+      },
+    });
+
+    expect(configs.router.environment).toEqual({
+      OPENROUTER_API_KEY: "instance-router-key",
+      EXISTING: "kept",
+    });
+  });
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -10,6 +10,9 @@ import type { InstanceConfigMap } from "./contracts.ts";
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
+  openrouter?: { key?: string; url?: string; model?: string };
+  ollamaCloud?: { key?: string; url?: string; model?: string };
+  openaiCompatible?: { key?: string; url?: string; model?: string };
   /** key = ck_… Connect consumer key (connections + agent tools);
    * apiKey = ak_… project API key — optional, unlocks the full toolkit
    * catalog with official logos in the plugins marketplace. */
@@ -51,6 +54,12 @@ export function loadConfig(): AppConfig {
     /* first run — env fallbacks below */
   }
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
+  cfg.openrouter = { key: process.env.OPENROUTER_API_KEY, ...cfg.openrouter };
+  cfg.ollamaCloud = { key: process.env.OLLAMA_API_KEY, ...cfg.ollamaCloud };
+  cfg.openaiCompatible = {
+    key: process.env.OPENAI_COMPATIBLE_API_KEY,
+    ...cfg.openaiCompatible,
+  };
   cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
   cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };
@@ -67,7 +76,16 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   } catch {
     /* first write */
   }
-  for (const key of ["xai", "composio", "box", "tts", "profile"] as const) {
+  for (const key of [
+    "xai",
+    "openrouter",
+    "ollamaCloud",
+    "openaiCompatible",
+    "composio",
+    "box",
+    "tts",
+    "profile",
+  ] as const) {
     if (patch[key] && typeof patch[key] === "object") {
       disk[key] = { ...(disk[key] as object), ...patch[key] };
     }
@@ -101,13 +119,43 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
           grok: { driver: "grokAgent" },
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
+          openrouter: {
+            driver: "openrouter",
+            config: {
+              url: cfg.openrouter?.url ?? "https://openrouter.ai/api/v1",
+              model: cfg.openrouter?.model,
+            },
+          },
+          "ollama-cloud": {
+            driver: "ollamaCloud",
+            config: {
+              url: cfg.ollamaCloud?.url ?? "https://ollama.com/v1",
+              model: cfg.ollamaCloud?.model,
+            },
+          },
+          "openai-compatible": {
+            driver: "openaiCompatible",
+            config: {
+              url: cfg.openaiCompatible?.url,
+              model: cfg.openaiCompatible?.model,
+            },
+          },
           antigravity: { driver: "antigravityAgent" },
           computer: { driver: "boxAgent" },
         };
   for (const entry of Object.values(map)) {
     entry.environment = {
-      ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
-      ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
+      ...(entry.driver === "grok" && cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
+      ...(entry.driver === "openrouter" && cfg.openrouter?.key
+        ? { OPENROUTER_API_KEY: cfg.openrouter.key }
+        : {}),
+      ...(entry.driver === "ollamaCloud" && cfg.ollamaCloud?.key
+        ? { OLLAMA_API_KEY: cfg.ollamaCloud.key }
+        : {}),
+      ...(entry.driver === "openaiCompatible" && cfg.openaiCompatible?.key
+        ? { OPENAI_COMPATIBLE_API_KEY: cfg.openaiCompatible.key }
+        : {}),
+      ...(entry.driver === "boxAgent" && cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
       ...entry.environment,
     };
   }

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -38,12 +38,16 @@ describe("ACP turns (fake CLI)", () => {
   let recorder: EventRecorder;
   let scratch: string;
 
-  const create = async (driver = GrokAgentDriver, mode?: string) => {
+  const create = async (
+    driver = GrokAgentDriver,
+    mode?: string,
+    environment: Record<string, string> = {},
+  ) => {
     if (mode) process.env.FAKE_ACP_MODE = mode;
     instance = await driver.create({
       instanceId: "acp-test",
       displayName: "ACP Test",
-      environment: {},
+      environment,
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
     });
@@ -105,6 +109,52 @@ describe("ACP turns (fake CLI)", () => {
     expect(seen.argv).toContain("stdio");
     expect(seen.argv).toContain("--permission-mode");
     expect(seen.env.XAI_API_KEY).toBeUndefined();
+  });
+
+  it("redacts provider credentials and nested integration tokens from diagnostic dumps", async () => {
+    const dump = join(scratch, "redacted-dump.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await create(GrokAgentDriver, undefined, {
+      OPENROUTER_API_KEY: "router-secret",
+      OLLAMA_API_KEY: "ollama-secret",
+      OPENAI_COMPATIBLE_API_KEY: "endpoint-secret",
+      DIAGNOSTIC_LABEL: "visible",
+    });
+
+    await instance.adapter.sendTurn({
+      threadId: "t-redaction",
+      text: "go",
+      integrations: {
+        agents: {
+          command: process.execPath,
+          args: ["/fake/agents-proxy.js"],
+          env: { OMB_COMMS_TOKEN: "comms-secret", SAFE_VALUE: "visible" },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.env).toMatchObject({
+      OPENROUTER_API_KEY: "[REDACTED]",
+      OLLAMA_API_KEY: "[REDACTED]",
+      OPENAI_COMPATIBLE_API_KEY: "[REDACTED]",
+      DIAGNOSTIC_LABEL: "visible",
+    });
+    const sessionNew = (seen.requests ?? []).find((request: any) => request.method === "session/new");
+    expect(sessionNew).toMatchObject({
+      params: {
+        mcpServers: expect.arrayContaining([
+          expect.objectContaining({
+            name: "agents",
+            env: expect.arrayContaining([
+              { name: "OMB_COMMS_TOKEN", value: "[REDACTED]" },
+              { name: "SAFE_VALUE", value: "visible" },
+            ]),
+          }),
+        ]),
+      },
+    });
   });
 
   it("surfaces a permission ask as request.opened and completes once allowed", async () => {

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -8,6 +8,9 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { OllamaCloudDriver } from "./ollama-cloud.ts";
+import { OpenAIEndpointDriver } from "./openai-endpoint.ts";
+import { OpenRouterDriver } from "./openrouter.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -17,4 +20,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   CodexDriver,
   AntigravityDriver,
   BoxAgentDriver,
+  OpenRouterDriver,
+  OllamaCloudDriver,
+  OpenAIEndpointDriver,
 ];

--- a/server/drivers/ollama-cloud.ts
+++ b/server/drivers/ollama-cloud.ts
@@ -1,0 +1,10 @@
+import { createOpenAIEndpointDriver } from "./openai-compatible.ts";
+
+export const OllamaCloudDriver = createOpenAIEndpointDriver({
+  driverKind: "ollamaCloud",
+  displayName: "Ollama Cloud",
+  defaultUrl: "https://ollama.com/v1",
+  defaultModel: "gpt-oss:120b",
+  apiKeyEnv: "OLLAMA_API_KEY",
+  credentialRequired: true,
+});

--- a/server/drivers/openai-compatible.test.ts
+++ b/server/drivers/openai-compatible.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recordEvents } from "../testing/events.ts";
+import {
+  OpenAICompatibleDriver,
+  normalizeBaseUrl,
+  type OpenAIEndpointConfig,
+} from "./openai-compatible.ts";
+
+const createInstance = async (
+  config: Partial<OpenAIEndpointConfig> = {},
+  environment: Record<string, string> = {},
+) =>
+  OpenAICompatibleDriver.create({
+    instanceId: "endpoint",
+    displayName: "Endpoint",
+    environment,
+    enabled: true,
+    config: OpenAICompatibleDriver.decodeConfig(config),
+  });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OpenAI-compatible endpoint validation", () => {
+  it("normalizes an HTTP base URL without changing its path", () => {
+    expect(normalizeBaseUrl("http://127.0.0.1:11434/v1/")).toBe("http://127.0.0.1:11434/v1");
+  });
+
+  it.each([
+    "file:///tmp/provider",
+    "https://user:password@example.com/v1",
+    "https://example.com/v1?token=secret",
+    "https://example.com/v1#models",
+  ])("rejects unsafe or ambiguous base URL %s", (url) => {
+    expect(() => normalizeBaseUrl(url)).toThrow();
+  });
+
+  it("does not let endpoint config select another provider's credential", () => {
+    expect(
+      OpenAICompatibleDriver.decodeConfig({
+        apiKeyEnv: "OPENROUTER_API_KEY",
+      }).apiKeyEnv,
+    ).toBe("OPENAI_COMPATIBLE_API_KEY");
+  });
+});
+
+describe("OpenAI-compatible text driver", () => {
+  it("discovers models from an endpoint that does not require a key", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [{ id: "qwen2.5-coder" }, { id: "deepseek-r1" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await createInstance({ url: "http://192.168.1.20:8000/v1", model: "qwen2.5-coder" });
+
+    await expect(instance.snapshot()).resolves.toMatchObject({ state: "available", authenticated: true });
+    expect(instance.models).toEqual({
+      default: "qwen2.5-coder",
+      options: [
+        { id: "qwen2.5-coder", label: "qwen2.5-coder" },
+        { id: "deepseek-r1", label: "deepseek-r1" },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://192.168.1.20:8000/v1/models",
+      expect.objectContaining({ headers: expect.not.objectContaining({ authorization: expect.anything() }) }),
+    );
+    await instance.dispose();
+  });
+
+  it("streams a chat completion and sends only its configured credential", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hello "}}]}\n\n'));
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"world"}}],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n'));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(body, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await createInstance(
+      { url: "https://models.example/v1", model: "example-chat" },
+      { OPENAI_COMPATIBLE_API_KEY: "endpoint-secret" },
+    );
+    const events = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "thread-1", text: "Hi" });
+    const completed = await events.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: true });
+    expect(events.events.filter((event) => event.type === "content.delta")).toHaveLength(2);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "hello world" }),
+    );
+    const request = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(request.headers).toMatchObject({ authorization: "Bearer endpoint-secret" });
+    expect(JSON.parse(String(request.body))).toMatchObject({ model: "example-chat", stream: true });
+    events.stop();
+    await instance.dispose();
+  });
+
+  it("cancels the response reader when a streamed API error aborts parsing", async () => {
+    const cancel = vi.fn();
+    const encoder = new TextEncoder();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"error":{"message":"provider exploded"}}\n\n'));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 200 })));
+    const instance = await createInstance({ url: "https://models.example/v1", model: "example-chat" });
+    const events = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "thread-error", text: "Hi" });
+    const completed = await events.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: false, stopReason: "error" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    events.stop();
+    await instance.dispose();
+  });
+
+  it("cancels oversized HTTP error bodies instead of buffering them", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1_100_000));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 500 })));
+    const instance = await createInstance({ url: "https://models.example/v1", model: "example-chat" });
+
+    await expect(instance.generateText!("Hi")).rejects.toThrow(/response limit/i);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    await instance.dispose();
+  });
+});

--- a/server/drivers/openai-compatible.ts
+++ b/server/drivers/openai-compatible.ts
@@ -1,0 +1,420 @@
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+export interface OpenAIEndpointConfig {
+  url: string;
+  model: string;
+  apiKeyEnv: string;
+}
+
+interface EndpointDriverSpec {
+  driverKind: string;
+  displayName: string;
+  defaultUrl: string;
+  defaultModel: string;
+  apiKeyEnv: string;
+  credentialRequired: boolean;
+  headers?: Record<string, string>;
+}
+
+type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
+
+export function normalizeBaseUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("url must be an absolute HTTP or HTTPS URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("url must use HTTP or HTTPS");
+  }
+  if (parsed.username || parsed.password) throw new Error("url must not contain embedded credentials");
+  if (parsed.search || parsed.hash) throw new Error("url must not contain a query string or fragment");
+  return parsed.href.replace(/\/+$/, "");
+}
+
+function endpointUrl(baseUrl: string, path: string): string {
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function errorMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const error = (value as { error?: unknown }).error;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && typeof (error as { message?: unknown }).message === "string") {
+    return (error as { message: string }).message;
+  }
+  return null;
+}
+
+function abortSignal(signal?: AbortSignal, timeoutMs = 120_000): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+async function readResponseBytes(response: Response, limitBytes: number): Promise<Uint8Array> {
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > limitBytes) throw new Error(`provider response exceeded the ${limitBytes} byte response limit`);
+      chunks.push(value);
+    }
+    const output = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readJson(response: Response, limitBytes = 4 * 1024 * 1024): Promise<any> {
+  const bytes = await readResponseBytes(response, limitBytes);
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new Error("provider returned invalid JSON");
+  }
+}
+
+async function boundedError(response: Response): Promise<string> {
+  return new TextDecoder().decode(await readResponseBytes(response, 1024 * 1024)).slice(0, 200);
+}
+
+export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDriver<OpenAIEndpointConfig> {
+  const decodeConfig = (raw: unknown): OpenAIEndpointConfig => {
+    const value = (raw ?? {}) as Record<string, unknown>;
+    return {
+      url: normalizeBaseUrl(typeof value.url === "string" && value.url.trim() ? value.url.trim() : spec.defaultUrl),
+      model: typeof value.model === "string" && value.model.trim() ? value.model.trim() : spec.defaultModel,
+      apiKeyEnv: spec.apiKeyEnv,
+    };
+  };
+  const declaredModels: ModelCatalog = {
+    default: spec.defaultModel,
+    options: [{ id: spec.defaultModel, label: spec.defaultModel }],
+  };
+
+  return {
+    driverKind: spec.driverKind,
+    metadata: { displayName: spec.displayName, supportsMultipleInstances: true },
+    models: declaredModels,
+    decodeConfig,
+    defaultConfig: () => decodeConfig({}),
+
+    async create(input: DriverCreateInput<OpenAIEndpointConfig>): Promise<ProviderInstance> {
+      const { instanceId, config } = input;
+      const apiKey = input.environment[config.apiKeyEnv] ?? "";
+      const listeners = new Set<RuntimeEventListener>();
+      const active = new Map<string, { abort: AbortController; turnId: string }>();
+      const models: ModelCatalog = {
+        default: config.model,
+        options: [{ id: config.model, label: config.model }],
+      };
+
+      const emit = (event: RuntimeEvent) => {
+        for (const listener of [...listeners]) listener(event);
+      };
+      const base = (threadId: string, turnId: string) => ({
+        eventId: newEventId(),
+        provider: spec.driverKind,
+        providerInstanceId: instanceId,
+        threadId,
+        turnId,
+        createdAt: new Date().toISOString(),
+      });
+      const headers = (json = false): Record<string, string> => ({
+        accept: "application/json",
+        ...(json ? { "content-type": "application/json" } : {}),
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+        ...spec.headers,
+      });
+      const requireCredential = () => {
+        if (spec.credentialRequired && !apiKey) {
+          throw new Error(`${spec.displayName} needs ${config.apiKeyEnv}`);
+        }
+      };
+
+      const discoverModels = async () => {
+        requireCredential();
+        const response = await fetch(endpointUrl(config.url, "/models"), {
+          method: "GET",
+          headers: headers(),
+          signal: abortSignal(undefined, 15_000),
+        });
+        if (!response.ok) {
+          const body = await boundedError(response);
+          throw new Error(`${spec.displayName} models HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+        }
+        const payload = (await readJson(response)) as Record<string, unknown>;
+        const rawModels = Array.isArray(payload.data)
+          ? payload.data
+          : Array.isArray(payload.models)
+            ? payload.models
+            : [];
+        const discovered = rawModels.flatMap((entry): Array<{ id: string; label: string }> => {
+          if (typeof entry === "string") return [{ id: entry, label: entry }];
+          if (!entry || typeof entry !== "object") return [];
+          const record = entry as Record<string, unknown>;
+          const id = typeof record.id === "string" ? record.id : typeof record.name === "string" ? record.name : "";
+          return id ? [{ id, label: id }] : [];
+        });
+        const unique = [...new Map(discovered.map((entry) => [entry.id, entry])).values()];
+        models.options = unique.some((entry) => entry.id === config.model)
+          ? unique
+          : [{ id: config.model, label: config.model }, ...unique];
+      };
+
+      const complete = async (
+        messages: ChatMessage[],
+        model: string,
+        options: { stream: boolean; signal?: AbortSignal; onDelta?: (delta: string) => void },
+      ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+        const response = await fetch(endpointUrl(config.url, "/chat/completions"), {
+          method: "POST",
+          headers: headers(true),
+          body: JSON.stringify({ model, messages, stream: options.stream }),
+          signal: abortSignal(options.signal),
+        });
+        if (!response.ok) {
+          const body = await boundedError(response);
+          throw new Error(`${spec.displayName} HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+        }
+        if (!options.stream) {
+          const payload = (await readJson(response)) as any;
+          const apiError = errorMessage(payload);
+          if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
+          return {
+            text: String(payload.choices?.[0]?.message?.content ?? ""),
+            usage: payload.usage
+              ? {
+                  input: Number(payload.usage.prompt_tokens ?? 0),
+                  output: Number(payload.usage.completion_tokens ?? 0),
+                }
+              : null,
+          };
+        }
+        if (!response.body) throw new Error(`${spec.displayName} returned an empty stream`);
+
+        let text = "";
+        let usage: { input: number; output: number } | null = null;
+        const parseLine = (rawLine: string) => {
+          const line = rawLine.trim();
+          if (!line.startsWith("data:")) return;
+          const data = line.slice(5).trim();
+          if (!data || data === "[DONE]") return;
+          const payload = JSON.parse(data) as any;
+          const apiError = errorMessage(payload);
+          if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
+          const delta = payload.choices?.[0]?.delta?.content;
+          if (typeof delta === "string" && delta) {
+            text += delta;
+            options.onDelta?.(delta);
+          }
+          if (payload.usage) {
+            usage = {
+              input: Number(payload.usage.prompt_tokens ?? 0),
+              output: Number(payload.usage.completion_tokens ?? 0),
+            };
+          }
+        };
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let received = 0;
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.byteLength;
+            if (received > 32 * 1024 * 1024) throw new Error("provider stream exceeded the response limit");
+            buffer += decoder.decode(value, { stream: true });
+            let newline = buffer.indexOf("\n");
+            while (newline !== -1) {
+              parseLine(buffer.slice(0, newline));
+              buffer = buffer.slice(newline + 1);
+              newline = buffer.indexOf("\n");
+            }
+          }
+          buffer += decoder.decode();
+          if (buffer.trim()) parseLine(buffer);
+        } catch (error) {
+          await reader.cancel().catch(() => {});
+          throw error;
+        } finally {
+          reader.releaseLock();
+        }
+        return { text, usage };
+      };
+
+      const sendTurn = async (turn: SendTurnInput) => {
+        requireCredential();
+        if (active.has(turn.threadId)) throw new Error("a turn is already running on this thread");
+        const turnId = newId();
+        const abort = new AbortController();
+        active.set(turn.threadId, { abort, turnId });
+        const model = turn.model || models.default;
+        const messages: ChatMessage[] = [
+          ...(turn.system ? [{ role: "system" as const, content: turn.system }] : []),
+          ...(turn.transcript ?? []).map((message) => ({
+            role: message.role === "assistant" ? ("assistant" as const) : ("user" as const),
+            content: message.text,
+          })),
+          { role: "user", content: turn.text },
+        ];
+        appendNative(turn.threadId, {
+          dir: "out",
+          source: `${spec.driverKind}.chat.completions`,
+          msg: { model, messages },
+        });
+        emit({ ...base(turn.threadId, turnId), type: "turn.started" });
+        emit({ ...base(turn.threadId, turnId), type: "session.started", sessionId: null, model });
+
+        void (async () => {
+          try {
+            const result = await complete(messages, model, {
+              stream: true,
+              signal: abort.signal,
+              onDelta: (delta) =>
+                emit({
+                  ...base(turn.threadId, turnId),
+                  type: "content.delta",
+                  streamKind: "assistant_text",
+                  delta,
+                }),
+            });
+            appendNative(turn.threadId, {
+              dir: "in",
+              source: `${spec.driverKind}.chat.completions`,
+              msg: result,
+            });
+            if (result.text.trim()) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "item.completed",
+                itemType: "assistant_text",
+                text: result.text,
+              });
+            }
+            if (result.usage) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "thread.token-usage.updated",
+                input: result.usage.input,
+                output: result.usage.output,
+              });
+            }
+            active.delete(turn.threadId);
+            emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
+          } catch (error) {
+            active.delete(turn.threadId);
+            const aborted = abort.signal.aborted || (error as Error).name === "AbortError";
+            if (!aborted) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "runtime.error",
+                message: error instanceof Error ? error.message : String(error),
+              });
+            }
+            emit({
+              ...base(turn.threadId, turnId),
+              type: "turn.completed",
+              ok: false,
+              stopReason: aborted ? "interrupted" : "error",
+              cost: null,
+            });
+          }
+        })();
+        return { turnId };
+      };
+
+      const snapshot = async (): Promise<ProviderSnapshot> => {
+        if (!input.enabled) return { state: "unavailable", reason: `${spec.displayName} is disabled` };
+        if (spec.credentialRequired && !apiKey) {
+          return { state: "unavailable", reason: `${spec.displayName} needs ${config.apiKeyEnv}` };
+        }
+        try {
+          await discoverModels();
+          return { state: "available", authenticated: true, version: null };
+        } catch (error) {
+          return {
+            state: "unavailable",
+            authenticated: Boolean(apiKey) || !spec.credentialRequired,
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
+      };
+
+      return {
+        instanceId,
+        driverKind: spec.driverKind,
+        displayName: input.displayName,
+        enabled: input.enabled,
+        models,
+        snapshot,
+        adapter: {
+          provider: spec.driverKind,
+          capabilities: { sessionModelSwitch: "in-session" },
+          sendTurn,
+          interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+          respondToRequest: async () => {
+            throw new Error(`${spec.displayName} has no pending requests`);
+          },
+          hasSession: (threadId) => active.has(threadId),
+          stopAll: async () => {
+            for (const { abort } of active.values()) abort.abort();
+          },
+          onEvent: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+          },
+        },
+        generateText: async (prompt) => {
+          requireCredential();
+          const result = await complete([{ role: "user", content: prompt }], models.default, {
+            stream: false,
+          });
+          return result.text;
+        },
+        dispose: async () => {
+          for (const { abort } of active.values()) abort.abort();
+          active.clear();
+          listeners.clear();
+        },
+      };
+    },
+  };
+}
+
+export const OpenAICompatibleDriver = createOpenAIEndpointDriver({
+  driverKind: "openaiCompatible",
+  displayName: "OpenAI-compatible",
+  defaultUrl: "http://127.0.0.1:11434/v1",
+  defaultModel: "llama3.2",
+  apiKeyEnv: "OPENAI_COMPATIBLE_API_KEY",
+  credentialRequired: false,
+});

--- a/server/drivers/openai-endpoint.ts
+++ b/server/drivers/openai-endpoint.ts
@@ -1,0 +1,1 @@
+export { OpenAICompatibleDriver as OpenAIEndpointDriver } from "./openai-compatible.ts";

--- a/server/drivers/openrouter.ts
+++ b/server/drivers/openrouter.ts
@@ -1,0 +1,14 @@
+import { createOpenAIEndpointDriver } from "./openai-compatible.ts";
+
+export const OpenRouterDriver = createOpenAIEndpointDriver({
+  driverKind: "openrouter",
+  displayName: "OpenRouter",
+  defaultUrl: "https://openrouter.ai/api/v1",
+  defaultModel: "openrouter/auto",
+  apiKeyEnv: "OPENROUTER_API_KEY",
+  credentialRequired: true,
+  headers: {
+    "HTTP-Referer": "https://github.com/milind-soni/OpenMausBot",
+    "X-OpenRouter-Title": "OpenMausBot",
+  },
+});

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -268,6 +268,54 @@ describe("harness HTTP API", () => {
     expect(nothing.status).toBe(400);
   });
 
+  it("persists provider settings without echoing credentials", async () => {
+    const before = await api("GET", "/api/config");
+    expect(before.body).toMatchObject({
+      openrouter: { configured: false },
+      ollamaCloud: { configured: false },
+      openaiCompatible: {
+        apiKeyConfigured: false,
+        url: "http://127.0.0.1:11434/v1",
+        model: "llama3.2",
+      },
+    });
+
+    const saved = await api("PUT", "/api/config", {
+      openrouter: { key: "router-secret" },
+      ollamaCloud: { key: "ollama-secret" },
+      openaiCompatible: {
+        key: "endpoint-secret",
+        url: "http://192.168.1.25:8000/v1",
+        model: "qwen2.5-coder",
+      },
+    });
+
+    expect(saved.status).toBe(200);
+    expect(saved.body).toMatchObject({
+      openrouter: { configured: true },
+      ollamaCloud: { configured: true },
+      openaiCompatible: {
+        apiKeyConfigured: true,
+        url: "http://192.168.1.25:8000/v1",
+        model: "qwen2.5-coder",
+      },
+    });
+    expect(JSON.stringify(saved.body)).not.toMatch(/router-secret|ollama-secret|endpoint-secret/);
+  });
+
+  it("rejects an invalid endpoint before persisting it", async () => {
+    const previous = await api("GET", "/api/config");
+    const persistedUrl = previous.body.openaiCompatible.url;
+    const rejected = await api("PUT", "/api/config", {
+      openaiCompatible: { url: "https://models.example/v1?credential=leak", model: "bad" },
+    });
+
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toContain("query string or fragment");
+    const after = await api("GET", "/api/config");
+    expect(after.body.openaiCompatible.url).toBe(persistedUrl);
+  });
+
   it("stores and echoes the user profile (not write-only, unlike keys)", async () => {
     const put = await api("PUT", "/api/config", { profile: { name: "Ada Lovelace", email: "Ada@Example.com" } });
     expect(put.status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,10 +11,19 @@ import { approvalKey, autoDecision } from "./auto-approve.ts";
 import * as box from "./box.ts";
 import * as composio from "./composio.ts";
 import { containerComputerStatus, setupCommands } from "./container-computer.ts";
-import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
+import {
+  ensureDirs,
+  instanceConfigs,
+  loadConfig,
+  saveConfig,
+  EVENTS_DIR,
+  NATIVE_DIR,
+  type AppConfig,
+} from "./config.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
+import { normalizeBaseUrl } from "./drivers/openai-compatible.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { mentionedBots, Store, type Message } from "./store.ts";
@@ -787,6 +796,13 @@ function startGroupTurn(groupId: string, text: string) {
 function configStatus() {
   return {
     xai: { configured: Boolean(cfg.xai?.key) },
+    openrouter: { configured: Boolean(cfg.openrouter?.key) },
+    ollamaCloud: { configured: Boolean(cfg.ollamaCloud?.key) },
+    openaiCompatible: {
+      apiKeyConfigured: Boolean(cfg.openaiCompatible?.key),
+      url: cfg.openaiCompatible?.url ?? "http://127.0.0.1:11434/v1",
+      model: cfg.openaiCompatible?.model ?? "llama3.2",
+    },
     composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
     box: { configured: Boolean(cfg.box?.token) },
     // the chosen voice is a setting, not a secret; the key is reported the
@@ -1354,11 +1370,31 @@ const server = createServer(async (req, res) => {
     }
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
-      const patch: Record<string, object> = {};
-      for (const key of ["xai", "composio", "box", "tts", "profile"] as const) {
+      const patch: Partial<AppConfig> = {};
+      for (const key of [
+        "xai",
+        "openrouter",
+        "ollamaCloud",
+        "openaiCompatible",
+        "composio",
+        "box",
+        "tts",
+        "profile",
+      ] as const) {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });
+      for (const key of ["openrouter", "ollamaCloud", "openaiCompatible"] as const) {
+        const provider = patch[key];
+        if (provider?.url !== undefined) {
+          if (typeof provider.url !== "string") return json(res, 400, { error: `${key}.url must be a string` });
+          try {
+            provider.url = normalizeBaseUrl(provider.url);
+          } catch (error) {
+            return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
+        }
+      }
       // check a box token against the provider before storing it: a
       // rejected token used to save happily and only surface as a 401 in
       // another panel later, with nothing the user could act on

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -22,9 +22,31 @@ if (argv.includes("--version")) {
   console.log("fake-acp 1.0.0");
   process.exit(0);
 }
-if (process.env.FAKE_ACP_DUMP) {
-  writeFileSync(process.env.FAKE_ACP_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
-}
+const SENSITIVE_KEY = /token|secret|password|api[_-]?key|authorization/i;
+const redact = (value: unknown, key = ""): unknown => {
+  if (SENSITIVE_KEY.test(key)) return "[REDACTED]";
+  if (Array.isArray(value)) return value.map((item) => redact(item));
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const redacted = Object.fromEntries(
+      Object.entries(record).map(([name, item]) => [name, redact(item, name)]),
+    );
+    if (typeof record.name === "string" && SENSITIVE_KEY.test(record.name) && "value" in record) {
+      redacted.value = "[REDACTED]";
+    }
+    return redacted;
+  }
+  return value;
+};
+const seenRequests: unknown[] = [];
+const dump = () => {
+  if (!process.env.FAKE_ACP_DUMP) return;
+  writeFileSync(
+    process.env.FAKE_ACP_DUMP,
+    JSON.stringify(redact({ argv, env: process.env, requests: seenRequests }), null, 2),
+  );
+};
+dump();
 
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
 const result = (id: unknown, res: unknown) => out({ jsonrpc: "2.0", id, result: res });
@@ -112,6 +134,10 @@ process.stdin.on("data", (c) => {
 });
 
 function handle(msg: any) {
+  if (msg.method) {
+    seenRequests.push(msg);
+    dump();
+  }
   // client's response to our permission request
   if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined) && msg.id === pendingPermissionId) {
     pendingPermissionId = null;

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,12 +6,30 @@ import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "composioApi" | "box";
+export type ConfigSection =
+  | "openrouter"
+  | "ollamaCloud"
+  | "openaiCompatible"
+  | "composio"
+  | "composioApi"
+  | "box";
 
 const SECTIONS: Record<
   ConfigSection,
   { body: (value: string) => unknown; flag: (config: ConfigStatus) => boolean }
 > = {
+  openrouter: {
+    body: (v) => ({ openrouter: { key: v } }),
+    flag: (c) => c.openrouter.configured,
+  },
+  ollamaCloud: {
+    body: (v) => ({ ollamaCloud: { key: v } }),
+    flag: (c) => c.ollamaCloud.configured,
+  },
+  openaiCompatible: {
+    body: (v) => ({ openaiCompatible: { key: v } }),
+    flag: (c) => c.openaiCompatible.apiKeyConfigured,
+  },
   composio: { body: (v) => ({ composio: { key: v } }), flag: (c) => c.composio.configured },
   composioApi: {
     body: (v) => ({ composio: { apiKey: v } }),
@@ -32,6 +50,30 @@ const CREDENTIALS: Record<
     warning?: string;
   }
 > = {
+  openrouter: {
+    label: "OpenRouter API key",
+    placeholder: "sk-or-v1-…",
+    description: "Use OpenRouter models through one account and API key.",
+    href: "https://openrouter.ai/keys",
+    linkLabel: "Open OpenRouter keys",
+    optional: true,
+  },
+  ollamaCloud: {
+    label: "Ollama Cloud API key",
+    placeholder: "Ollama API key",
+    description: "Run cloud-hosted Ollama models without managing a local server.",
+    href: "https://ollama.com/settings/keys",
+    linkLabel: "Open Ollama keys",
+    optional: true,
+  },
+  openaiCompatible: {
+    label: "Endpoint bearer token",
+    placeholder: "Optional for local Ollama",
+    description: "Optional bearer token for your custom OpenAI-compatible endpoint.",
+    href: "https://platform.openai.com/docs/api-reference/chat",
+    linkLabel: "Open API format reference",
+    optional: true,
+  },
   composio: {
     label: "Composio Connect key",
     placeholder: "ck_…",

--- a/src/components/ArtifactPanel.test.tsx
+++ b/src/components/ArtifactPanel.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { beginArtifactResize, ArtifactPanel } from "./ArtifactPanel";
+
+describe("ArtifactPanel", () => {
+  it("renders the artifact in an opaque, network-disabled sandbox", () => {
+    const html = renderToStaticMarkup(
+      <ArtifactPanel
+        artifact={{
+          id: "message-1:0",
+          messageId: "message-1",
+          index: 0,
+          language: "html",
+          html: "<button>Interactive</button>",
+          sourceLine: 1,
+        }}
+        width={560}
+        onWidthChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(html).toContain('sandbox="allow-scripts"');
+    expect(html).not.toContain("allow-same-origin");
+    expect(html).not.toContain("allow-popups");
+    expect(html).toContain("Content-Security-Policy");
+    expect(html).toContain("Network access disabled");
+    expect(html).toContain("Refresh preview");
+    expect(html).toContain("Copy HTML");
+    expect(html).toContain("Download HTML");
+    expect(html).toContain('role="separator"');
+  });
+
+  it("captures resize input and cleans up move, up, and cancel listeners", () => {
+    const listeners = new Map<string, Set<(event: { clientX: number }) => void>>();
+    const listen = (type: "pointermove" | "pointerup" | "pointercancel", listener: (event: { clientX: number }) => void) => {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+      return () => set.delete(listener);
+    };
+    const capture = vi.fn();
+    const release = vi.fn();
+    const onWidthChange = vi.fn();
+
+    const finish = beginArtifactResize({
+      startX: 600,
+      startWidth: 500,
+      maximumWidth: 700,
+      capture,
+      release,
+      listen,
+      onWidthChange,
+    });
+    expect(capture).toHaveBeenCalledTimes(1);
+    for (const listener of listeners.get("pointermove") ?? []) listener({ clientX: 450 });
+    expect(onWidthChange).toHaveBeenLastCalledWith(650);
+    for (const listener of [...(listeners.get("pointercancel") ?? [])]) listener({ clientX: 450 });
+    expect(release).toHaveBeenCalledTimes(1);
+    expect([...listeners.values()].every((set) => set.size === 0)).toBe(true);
+    finish();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ArtifactPanel.tsx
+++ b/src/components/ArtifactPanel.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { Check, Copy, Download, RefreshCw, ShieldCheck, X } from "lucide-react";
+
+import { buildArtifactDocument, type HtmlArtifact } from "@/lib/html-artifacts";
+
+const MIN_WIDTH = 320;
+
+interface ResizePoint {
+  clientX: number;
+}
+
+export function beginArtifactResize({
+  startX,
+  startWidth,
+  maximumWidth,
+  onWidthChange,
+  capture,
+  release,
+  listen,
+}: {
+  startX: number;
+  startWidth: number;
+  maximumWidth: number;
+  onWidthChange: (width: number) => void;
+  capture: () => void;
+  release: () => void;
+  listen: (
+    type: "pointermove" | "pointerup" | "pointercancel",
+    listener: (event: ResizePoint) => void,
+  ) => () => void;
+}): () => void {
+  let finished = false;
+  const removeListeners: Array<() => void> = [];
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    for (const remove of removeListeners.splice(0)) remove();
+    release();
+  };
+  const clamp = (value: number) => Math.min(maximumWidth, Math.max(MIN_WIDTH, Math.round(value)));
+
+  capture();
+  removeListeners.push(
+    listen("pointermove", (event) => onWidthChange(clamp(startWidth - (event.clientX - startX)))),
+    listen("pointerup", finish),
+    listen("pointercancel", finish),
+  );
+  return finish;
+}
+
+export function ArtifactPanel({
+  artifact,
+  width,
+  onWidthChange,
+  onClose,
+}: {
+  artifact: HtmlArtifact;
+  width: number;
+  onWidthChange: (width: number) => void;
+  onClose: () => void;
+}) {
+  const [revision, setRevision] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const finishResize = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => () => finishResize.current(), []);
+
+  const maximum = () => Math.max(MIN_WIDTH, Math.floor(window.innerWidth * 0.7));
+  const clamp = (value: number) => Math.min(maximum(), Math.max(MIN_WIDTH, Math.round(value)));
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    finishResize.current();
+    const target = event.currentTarget;
+    const pointerId = event.pointerId;
+    const listen = (
+      type: "pointermove" | "pointerup" | "pointercancel",
+      listener: (point: ResizePoint) => void,
+    ) => {
+      const browserListener = listener as unknown as EventListener;
+      window.addEventListener(type, browserListener);
+      return () => window.removeEventListener(type, browserListener);
+    };
+    finishResize.current = beginArtifactResize({
+      startX: event.clientX,
+      startWidth: width,
+      maximumWidth: maximum(),
+      onWidthChange,
+      capture: () => target.setPointerCapture?.(pointerId),
+      release: () => {
+        if (target.hasPointerCapture?.(pointerId)) target.releasePointerCapture(pointerId);
+      },
+      listen,
+    });
+  };
+
+  const copy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(artifact.html);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const download = () => {
+    const url = URL.createObjectURL(new Blob([artifact.html], { type: "text/html;charset=utf-8" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `artifact-${artifact.index + 1}.html`;
+    anchor.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  };
+
+  return (
+    <aside
+      className="relative flex h-full shrink-0 flex-col border-l border-hairline/50 bg-panel max-[799px]:fixed max-[799px]:inset-0 max-[799px]:z-40 max-[799px]:!w-full"
+      style={{ width }}
+      aria-label="HTML artifact workspace"
+    >
+      <div
+        role="separator"
+        aria-label="Resize artifact workspace"
+        aria-orientation="vertical"
+        aria-valuemin={MIN_WIDTH}
+        aria-valuemax={typeof window === "undefined" ? 1200 : maximum()}
+        aria-valuenow={width}
+        tabIndex={0}
+        onPointerDown={startResize}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowLeft") onWidthChange(clamp(width + 24));
+          else if (event.key === "ArrowRight") onWidthChange(clamp(width - 24));
+          else if (event.key === "Home") onWidthChange(MIN_WIDTH);
+          else if (event.key === "End") onWidthChange(maximum());
+          else return;
+          event.preventDefault();
+        }}
+        className="absolute inset-y-0 -left-1 z-10 w-2 cursor-col-resize outline-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:bg-transparent hover:after:bg-accent focus-visible:after:bg-accent max-[799px]:hidden"
+      />
+      <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-hairline/40 px-3">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-ink">artifact-{artifact.index + 1}.html</div>
+          <div className="text-[10px] text-ink-secondary">Interactive preview</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <span
+            className="mr-1 rounded p-1 text-ink-secondary"
+            title="Network access disabled"
+            aria-label="Network access disabled"
+          >
+            <ShieldCheck size={14} />
+          </span>
+          <button
+            type="button"
+            onClick={() => setRevision((value) => value + 1)}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Refresh preview"
+          >
+            <RefreshCw size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Copy HTML"
+          >
+            {copied ? <Check size={15} className="text-success" /> : <Copy size={15} />}
+          </button>
+          <button
+            type="button"
+            onClick={download}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Download HTML"
+          >
+            <Download size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Close preview"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+      <iframe
+        key={`${artifact.id}:${revision}`}
+        title={`Preview of artifact ${artifact.index + 1}`}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        srcDoc={buildArtifactDocument(artifact.html)}
+        className="min-h-0 flex-1 border-0 bg-white"
+      />
+    </aside>
+  );
+}

--- a/src/components/ChatMarkdown.test.tsx
+++ b/src/components/ChatMarkdown.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ChatMarkdown } from "./ChatMarkdown";
+
+describe("ChatMarkdown HTML artifacts", () => {
+  it("renders streaming HTML in a compact expandable card", () => {
+    const code = Array.from({ length: 12 }, (_, index) => `<div>Line ${index + 1}</div>`).join("\n");
+    const html = renderToStaticMarkup(<ChatMarkdown text={`Building\n\`\`\`html\n${code}`} streaming />);
+
+    expect(html).toContain("Building artifact");
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain("max-h-[9.75rem]");
+    expect(html).toContain("Expand");
+  });
+
+  it("honors expansion state owned by the chat while streaming text changes", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Still writing"}
+        streaming
+        streamingHtmlExpanded
+        onStreamingHtmlExpandedChange={() => {}}
+      />,
+    );
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("Collapse");
+    expect(html).not.toContain("max-h-[9.75rem]");
+    expect(html).toContain("min-h-[20rem]");
+    expect(html).toContain("max-h-[60vh]");
+  });
+
+  it("only marks the unfinished fence as the live artifact", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Finished</main>\n```\nthen\n```html\n<section>Live</section>"}
+        streaming
+      />,
+    );
+    expect(html.match(/Building artifact/g)).toHaveLength(1);
+    expect(html).toContain("&lt;main&gt;Finished&lt;/main&gt;");
+    expect(html).toContain("&lt;section&gt;Live&lt;/section&gt;");
+  });
+
+  it("renders completed HTML as a collapsed card with a permanent Open action", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Hidden source</main>\n```"}
+        messageId="m-1"
+        onPreviewArtifact={() => {}}
+      />,
+    );
+
+    expect(html).toContain("HTML artifact");
+    expect(html).toContain(">Open<");
+    expect(html).toContain("View code");
+    expect(html).not.toContain("&lt;main&gt;Hidden source&lt;/main&gt;");
+  });
+
+  it("labels only the selected artifact as closable", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<p>One</p>\n```\n```html\n<p>Two</p>\n```"}
+        messageId="m-2"
+        selectedArtifactId="m-2:0"
+        onPreviewArtifact={() => {}}
+      />,
+    );
+    expect(html.match(/>Close</g)).toHaveLength(1);
+    expect(html.match(/>Open</g)).toHaveLength(1);
+    expect(html).not.toContain("Reopen");
+  });
+});

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -4,10 +4,11 @@
 // HTML: no rehype-raw, so HTML in the text renders as text; Shiki's output is
 // generator-escaped. While a message is still streaming, code blocks render
 // as plain <pre> and nothing is cached — partial fences would poison it.
-import { memo, useEffect, useState, type ReactNode } from "react";
+import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Check, Copy } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Code2, Copy, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { extractHtmlArtifacts, findStreamingHtmlFence, type HtmlArtifact } from "@/lib/html-artifacts";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed, capped, never written while streaming
@@ -22,12 +23,41 @@ const hash = (s: string) => {
   return (h >>> 0).toString(36);
 };
 
-function CodeBlock({ code, lang, streaming }: { code: string; lang: string; streaming: boolean }) {
+function CodeBlock({
+  code,
+  lang,
+  messageStreaming,
+  streamingArtifact,
+  artifact,
+  selected,
+  onPreview,
+  streamingExpanded,
+  onStreamingExpandedChange,
+}: {
+  code: string;
+  lang: string;
+  messageStreaming: boolean;
+  streamingArtifact: boolean;
+  artifact?: HtmlArtifact;
+  selected?: boolean;
+  onPreview?: (artifact: HtmlArtifact) => void;
+  streamingExpanded?: boolean;
+  onStreamingExpandedChange?: (expanded: boolean) => void;
+}) {
   const [html, setHtml] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [sourceExpanded, setSourceExpanded] = useState(false);
+  const controlledStreamingExpansion =
+    streamingArtifact && streamingExpanded !== undefined && Boolean(onStreamingExpandedChange);
+  const expanded = controlledStreamingExpansion ? streamingExpanded : sourceExpanded;
+  const setExpanded = (value: boolean | ((current: boolean) => boolean)) => {
+    const next = typeof value === "function" ? value(Boolean(expanded)) : value;
+    if (controlledStreamingExpansion) onStreamingExpandedChange?.(next);
+    else setSourceExpanded(next);
+  };
 
   useEffect(() => {
-    if (streaming) return;
+    if (messageStreaming) return;
     const key = `${lang}:${hash(code)}`;
     const cached = highlightCache.get(key);
     if (cached) return setHtml(cached);
@@ -54,45 +84,156 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
     return () => {
       alive = false;
     };
-  }, [code, lang, streaming]);
+  }, [code, lang, messageStreaming]);
 
-  const copy = () => {
-    void navigator.clipboard?.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+  const copy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
   };
+
+  const source = html ? (
+    <div
+      className="overflow-x-auto text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:m-0 [&_pre]:p-3"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  ) : (
+    <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
+  );
+
+  if (streamingArtifact) {
+    return (
+      <div className="my-2 overflow-hidden rounded-lg border border-accent/20 bg-inset">
+        <div className="flex items-center justify-between border-b border-hairline/30 px-3 py-1.5">
+          <span className="flex items-center gap-1.5 text-[11px] font-medium text-accent">
+            <Code2 size={13} /> Building artifact…
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={Boolean(expanded)}
+              className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+              {expanded ? "Collapse" : "Expand"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+              title="Copy code"
+            >
+              {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+            </button>
+          </div>
+        </div>
+        <div className={expanded ? "min-h-[20rem] max-h-[60vh] overflow-auto" : "max-h-[9.75rem] overflow-auto"}>
+          <pre className="p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  if (artifact) {
+    return (
+      <div className="my-2 overflow-hidden rounded-xl border border-accent/20 bg-inset">
+        <div className="flex items-center gap-3 px-3 py-2.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+            <Code2 size={17} />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[13px] font-medium text-ink">HTML artifact</span>
+            <span className="block truncate text-[11px] text-ink-secondary">artifact-{artifact.index + 1}.html</span>
+          </span>
+          <div className="flex shrink-0 items-center gap-1">
+            {onPreview && (
+              <button
+                type="button"
+                onClick={() => onPreview(artifact)}
+                className="flex items-center gap-1 rounded-md bg-accent px-2 py-1.5 text-[11px] font-medium text-white hover:opacity-90"
+                title={selected ? "Close HTML preview" : "Open HTML preview"}
+              >
+                {selected ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
+                <span>{selected ? "Close" : "Open"}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={Boolean(expanded)}
+              className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              {expanded ? "Hide code" : "View code"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+              title="Copy HTML"
+            >
+              {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+            </button>
+          </div>
+        </div>
+        {expanded && <div className="border-t border-hairline/30">{source}</div>}
+      </div>
+    );
+  }
 
   return (
     <div className="my-2 overflow-hidden rounded-lg border border-hairline/40 bg-inset">
       <div className="flex items-center justify-between border-b border-hairline/30 px-3 py-1">
         <span className="text-[11px] uppercase tracking-wide text-ink-secondary">{lang || "code"}</span>
         <button
-          onClick={copy}
+          type="button"
+          onClick={() => void copy()}
           className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink"
           title="Copy code"
         >
           {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
         </button>
       </div>
-      {html ? (
-        <div
-          className="overflow-x-auto text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:m-0 [&_pre]:p-3"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ) : (
-        <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
-      )}
+      {source}
     </div>
   );
 }
 
-function ChatMarkdownComponent({ text, streaming = false }: { text: string; streaming?: boolean }) {
+interface ChatMarkdownProps {
+  text: string;
+  streaming?: boolean;
+  messageId?: string;
+  selectedArtifactId?: string | null;
+  onPreviewArtifact?: (artifact: HtmlArtifact) => void;
+  streamingHtmlExpanded?: boolean;
+  onStreamingHtmlExpandedChange?: (expanded: boolean) => void;
+}
+
+function ChatMarkdownComponent({
+  text,
+  streaming = false,
+  messageId,
+  selectedArtifactId,
+  onPreviewArtifact,
+  streamingHtmlExpanded,
+  onStreamingHtmlExpandedChange,
+}: ChatMarkdownProps) {
+  const artifacts = useMemo(
+    () => (!streaming && messageId ? extractHtmlArtifacts(text, messageId) : []),
+    [messageId, streaming, text],
+  );
+  const streamingHtml = useMemo(() => (streaming ? findStreamingHtmlFence(text) : null), [streaming, text]);
   return (
     <div className="chat-md min-w-0 [&>*+*]:mt-2">
       <Markdown
         remarkPlugins={[remarkGfm]}
         components={{
-          pre({ children }: { children?: ReactNode }) {
+          pre({ children, node }: { children?: ReactNode; node?: { position?: { start: { line: number } } } }) {
             // fenced code arrives as <pre><code class="language-x">…</code></pre>
             const child: any = Array.isArray(children) ? children[0] : children;
             const className: string = child?.props?.className ?? "";
@@ -102,7 +243,25 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
             const flat = (n: any): string =>
               typeof n === "string" ? n : Array.isArray(n) ? n.map(flat).join("") : (n?.props?.children ? flat(n.props.children) : "");
             const code = flat(child?.props?.children).replace(/\n$/, "");
-            return <CodeBlock code={code} lang={lang} streaming={streaming} />;
+            const sourceLine = node?.position?.start.line;
+            const htmlLanguage = /^(?:html|htm|html_preview)$/i.test(lang);
+            const artifact = htmlLanguage
+              ? artifacts.find((candidate) => candidate.sourceLine === sourceLine)
+              : undefined;
+            const streamingArtifact = Boolean(streamingHtml && htmlLanguage && streamingHtml.sourceLine === sourceLine);
+            return (
+              <CodeBlock
+                code={streamingArtifact ? streamingHtml!.code : code}
+                lang={lang}
+                messageStreaming={streaming}
+                streamingArtifact={streamingArtifact}
+                artifact={artifact}
+                selected={artifact?.id === selectedArtifactId}
+                onPreview={onPreviewArtifact}
+                streamingExpanded={streamingHtmlExpanded}
+                onStreamingExpandedChange={onStreamingHtmlExpandedChange}
+              />
+            );
           },
           img({ src, alt }: { src?: string; alt?: string }) {
             return (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -10,6 +10,8 @@ import {
   Copy,
   Loader2,
   Monitor,
+  PanelRightClose,
+  PanelRightOpen,
   Pencil,
   RefreshCw,
   Square,
@@ -24,6 +26,13 @@ import { ApprovalCard } from "./ApprovalCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
 import { TaskPicker } from "./TaskPicker";
+import { ArtifactPanel } from "./ArtifactPanel";
+import {
+  artifactHeaderMode,
+  extractHtmlArtifacts,
+  toggleArtifactSelection,
+  type HtmlArtifact,
+} from "@/lib/html-artifacts";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { SpeakButton } from "./SpeakButton";
 import { CallButton, CallOverlay } from "./CallView";
@@ -224,6 +233,8 @@ function Bubble({
   onCancelEdit,
   onSubmitEdit,
   onRegenerate,
+  selectedArtifactId,
+  onPreviewArtifact,
 }: {
   bot: Bot;
   message: Message;
@@ -233,6 +244,8 @@ function Bubble({
   onCancelEdit: () => void;
   onSubmitEdit: (text: string) => void;
   onRegenerate?: () => void;
+  selectedArtifactId?: string | null;
+  onPreviewArtifact?: (artifact: HtmlArtifact) => void;
 }) {
   const { dispatch } = useStore();
   const user = message.role === "user";
@@ -300,7 +313,12 @@ function Bubble({
             </>
           ) : (
             <MessageBoundary fallbackText={text}>
-              <ChatMarkdown text={text} />
+              <ChatMarkdown
+                text={text}
+                messageId={message.id}
+                selectedArtifactId={selectedArtifactId}
+                onPreviewArtifact={onPreviewArtifact}
+              />
             </MessageBoundary>
           )}
         </div>
@@ -416,7 +434,15 @@ function ScreenFrame({ png, mime }: { png: string; mime?: string }) {
   );
 }
 
-function StreamingBubble({ text }: { text: string }) {
+function StreamingBubble({
+  text,
+  htmlExpanded,
+  onHtmlExpandedChange,
+}: {
+  text: string;
+  htmlExpanded: boolean;
+  onHtmlExpandedChange: (expanded: boolean) => void;
+}) {
   // markdown re-parses on a deferred value: when tokens arrive faster than
   // the parser keeps up, React lags the parse instead of janking the frame
   const deferred = useDeferredValue(text);
@@ -424,7 +450,12 @@ function StreamingBubble({ text }: { text: string }) {
     <div className="flex w-full justify-start">
       <div className="max-w-[70%] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed text-ink">
         <MessageBoundary fallbackText={deferred}>
-          <ChatMarkdown text={deferred} streaming />
+          <ChatMarkdown
+            text={deferred}
+            streaming
+            streamingHtmlExpanded={htmlExpanded}
+            onStreamingHtmlExpandedChange={onHtmlExpandedChange}
+          />
         </MessageBoundary>
         <span className="animate-caret ml-0.5 inline-block h-[14px] w-[2px] bg-ink align-middle" />
       </div>
@@ -463,6 +494,8 @@ const MessagesList = memo(function MessagesList({
   onCancelEdit,
   onSubmitEdit,
   onRegenerate,
+  selectedArtifactId,
+  onPreviewArtifact,
 }: {
   bot: Bot;
   messages: Message[];
@@ -473,6 +506,8 @@ const MessagesList = memo(function MessagesList({
   onCancelEdit: () => void;
   onSubmitEdit: (id: string, text: string) => void;
   onRegenerate: () => void;
+  selectedArtifactId: string | null;
+  onPreviewArtifact: (artifact: HtmlArtifact) => void;
 }) {
   return (
     <>
@@ -521,6 +556,8 @@ const MessagesList = memo(function MessagesList({
                   onCancelEdit={onCancelEdit}
                   onSubmitEdit={(text) => onSubmitEdit(m.id, text)}
                   onRegenerate={onRegenerate}
+                  selectedArtifactId={selectedArtifactId}
+                  onPreviewArtifact={onPreviewArtifact}
                 />
               );
           }
@@ -549,6 +586,63 @@ export function ChatView({ bot }: { bot: Bot }) {
 
   // only the active branch is rendered; forks stay reachable via ‹ › nav
   const messages = useMemo(() => visibleMessages(bot), [bot]);
+  const artifacts = useMemo(
+    () =>
+      messages.flatMap((message) =>
+        message.role === "bot" && message.kind === "text" && message.text
+          ? extractHtmlArtifacts(message.text, message.id)
+          : [],
+      ),
+    [messages],
+  );
+  const newestArtifact = artifacts.at(-1);
+  const [artifactSelections, setArtifactSelections] = useState<Record<string, string | null>>({});
+  const autoOpenedArtifact = useRef<Record<string, string>>({});
+  useEffect(() => {
+    if (!newestArtifact || autoOpenedArtifact.current[bot.threadId] === newestArtifact.id) return;
+    autoOpenedArtifact.current[bot.threadId] = newestArtifact.id;
+    setArtifactSelections((current) => ({ ...current, [bot.threadId]: newestArtifact.id }));
+  }, [bot.threadId, newestArtifact]);
+  const selectedArtifactId = artifactSelections[bot.threadId] ?? null;
+  const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+  const artifactAction = artifactHeaderMode(newestArtifact?.id, selectedArtifact?.id);
+  const openArtifact = useCallback(
+    (artifact: HtmlArtifact) => {
+      setArtifactSelections((current) => ({
+        ...current,
+        [bot.threadId]: toggleArtifactSelection(current[bot.threadId] ?? null, artifact.id),
+      }));
+    },
+    [bot.threadId],
+  );
+  const closeArtifact = useCallback(() => {
+    setArtifactSelections((current) => ({ ...current, [bot.threadId]: null }));
+  }, [bot.threadId]);
+  const [streamingHtmlExpanded, setStreamingHtmlExpanded] = useState(false);
+  useEffect(() => {
+    if (!streaming) setStreamingHtmlExpanded(false);
+  }, [bot.threadId, streaming]);
+  const [artifactWidth, setArtifactWidth] = useState(() => {
+    const maximum = Math.max(320, Math.floor(window.innerWidth * 0.7));
+    try {
+      const stored = Number(window.localStorage.getItem("openmausbot.artifactWidth"));
+      return Number.isFinite(stored) && stored > 0
+        ? Math.min(maximum, Math.max(320, stored))
+        : Math.min(maximum, 560);
+    } catch {
+      return Math.min(maximum, 560);
+    }
+  });
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem("openmausbot.artifactWidth", String(artifactWidth));
+      } catch {
+        // The preview still resizes when storage is disabled.
+      }
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [artifactWidth]);
   const lastBotTextId = useMemo(
     () => [...messages].reverse().find((m) => m.role === "bot" && m.kind === "text")?.id,
     [messages],
@@ -618,6 +712,7 @@ export function ChatView({ bot }: { bot: Bot }) {
   const noDrag = isWin ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
   return (
+    <div className="flex h-full min-w-0 flex-1">
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
       {/* Call mode covers the thread while the bot is on the line */}
       <CallOverlay bot={bot} />
@@ -651,6 +746,24 @@ export function ChatView({ bot }: { bot: Bot }) {
             >
               <Square size={12} className="fill-current" />
               Stop
+            </button>
+          )}
+          {artifactAction !== "hidden" && newestArtifact && (
+            <button
+              type="button"
+              onClick={() => {
+                if (artifactAction === "close") closeArtifact();
+                else openArtifact(newestArtifact);
+              }}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full border border-hairline/40 bg-raised/60 px-2.5 py-1 text-[13px] hover:bg-raised hover:text-ink",
+                artifactAction === "close" ? "text-accent" : "text-ink-secondary",
+              )}
+              aria-label={artifactAction === "close" ? "Close artifact" : "Open artifact"}
+              title={artifactAction === "close" ? "Close the artifact preview" : "Open the latest artifact"}
+            >
+              {artifactAction === "close" ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
+              {artifactAction === "close" ? "Close artifact" : "Open artifact"}
             </button>
           )}
           <TaskPicker bot={bot} />
@@ -712,6 +825,8 @@ export function ChatView({ bot }: { bot: Bot }) {
             onCancelEdit={cancelEdit}
             onSubmitEdit={submitEdit}
             onRegenerate={regenerate}
+            selectedArtifactId={selectedArtifact?.id ?? null}
+            onPreviewArtifact={openArtifact}
           />
           {provisioning && (
             <div className="flex justify-start">
@@ -723,7 +838,11 @@ export function ChatView({ bot }: { bot: Bot }) {
           )}
           {reasoning && bot.busy && <ThinkingStrip text={reasoning} active={!streaming} />}
           {streaming ? (
-            <StreamingBubble text={streaming} />
+            <StreamingBubble
+              text={streaming}
+              htmlExpanded={streamingHtmlExpanded}
+              onHtmlExpandedChange={setStreamingHtmlExpanded}
+            />
           ) : (
             bot.busy && (
               <div className="flex justify-start">
@@ -764,5 +883,14 @@ export function ChatView({ bot }: { bot: Bot }) {
       />
 
     </main>
+    {selectedArtifact && (
+      <ArtifactPanel
+        artifact={selectedArtifact}
+        width={artifactWidth}
+        onWidthChange={setArtifactWidth}
+        onClose={closeArtifact}
+      />
+    )}
+    </div>
   );
 }

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -3,6 +3,7 @@ import { Check, AlertTriangle, Loader2, Mic } from "lucide-react";
 import { MausAvatar } from "./Avatar";
 import { identifyEmail, setEmailGateDone, track } from "@/lib/analytics";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { ProviderSetupOptions } from "./ProviderSetupOptions";
 
 // Three-step first-run onboarding: who you are (email), what's installed
 // (live engine checks from the harness), what the app may use (TCC).
@@ -98,7 +99,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-app">
-      <div className="flex w-[460px] flex-col rounded-2xl border border-hairline/40 bg-panel p-8">
+      <div className="flex max-h-[90vh] w-[460px] flex-col overflow-y-auto rounded-2xl border border-hairline/40 bg-panel p-8">
         {step === 0 && (
           <div className="flex flex-col items-center">
             <MausAvatar color="green" state="happy" size={72} />
@@ -199,6 +200,10 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                         : "Optional. Install: see antigravity.google/docs/cli"
                     }
                   />
+                  <div className="mt-2">
+                    <div className="mb-2 text-[13px] font-medium text-ink">Optional API providers</div>
+                    <ProviderSetupOptions />
+                  </div>
                 </>
               )}
             </div>

--- a/src/components/OpenAIEndpointFields.tsx
+++ b/src/components/OpenAIEndpointFields.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+
+import { api, useStore, type ConfigStatus } from "@/state/store";
+
+export function OpenAIEndpointFields({ compact = false }: { compact?: boolean }) {
+  const { state, dispatch } = useStore();
+  const serverUrl = state.config?.openaiCompatible.url ?? "http://127.0.0.1:11434/v1";
+  const serverModel = state.config?.openaiCompatible.model ?? "llama3.2";
+  const [url, setUrl] = useState(serverUrl);
+  const [model, setModel] = useState(serverModel);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUrl(serverUrl);
+    setModel(serverModel);
+  }, [serverUrl, serverModel]);
+
+  const save = () => {
+    if (saving || !url.trim() || !model.trim()) return;
+    setSaving(true);
+    setError(null);
+    api("/api/config", {
+      method: "PUT",
+      body: JSON.stringify({
+        openaiCompatible: { url: url.trim(), model: model.trim() },
+      }),
+    })
+      .then((config: ConfigStatus) => dispatch({ type: "configStatus", config }))
+      .catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)))
+      .finally(() => setSaving(false));
+  };
+
+  const inputClass =
+    "w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 text-[13px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none";
+  return (
+    <div>
+      {!compact && <div className="mb-2 text-[13px] font-medium text-ink">Custom OpenAI-compatible endpoint</div>}
+      <div className="mb-3 text-[12px] leading-relaxed text-ink-secondary">
+        Local Ollama, a vLLM server on your LAN, or a remote service exposing <code>/v1/models</code> and{" "}
+        <code>/v1/chat/completions</code>.
+      </div>
+      <div className="flex flex-col gap-2">
+        <input
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && save()}
+          placeholder="http://192.168.1.25:8000/v1"
+          aria-label="OpenAI-compatible base URL"
+          spellCheck={false}
+          className={inputClass}
+        />
+        <input
+          value={model}
+          onChange={(event) => setModel(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && save()}
+          placeholder="Model ID, e.g. qwen2.5-coder"
+          aria-label="OpenAI-compatible default model ID"
+          spellCheck={false}
+          className={inputClass}
+        />
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving || !url.trim() || !model.trim()}
+          className="self-end rounded-lg bg-raised px-3 py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save endpoint"}
+        </button>
+      </div>
+      {error && <div className="mt-1 text-[12px] text-danger">{error}</div>}
+    </div>
+  );
+}

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -1,5 +1,5 @@
 // Provider brand marks, keyed by driver kind. Dark-theme fills.
-import { Monitor } from "lucide-react";
+import { Cloud, Monitor, Network, Server } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface IconProps {
@@ -36,6 +36,18 @@ export function ComputerMark({ size = 16, className }: IconProps) {
   return <Monitor size={size} className={cn("text-ink-secondary", className)} />;
 }
 
+export function OpenRouterMark({ size = 16, className }: IconProps) {
+  return <Network size={size} className={cn("text-[#7c8cff]", className)} />;
+}
+
+export function OllamaCloudMark({ size = 16, className }: IconProps) {
+  return <Cloud size={size} className={cn("text-[#f5f5f5]", className)} />;
+}
+
+export function OpenAIEndpointMark({ size = 16, className }: IconProps) {
+  return <Server size={size} className={cn("text-[#38d591]", className)} />;
+}
+
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {
   switch (driverKind) {
     case "grok":
@@ -45,6 +57,12 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <ClaudeMark size={size} className={className} />;
     case "codex":
       return <CodexMark size={size} className={className} />;
+    case "openrouter":
+      return <OpenRouterMark size={size} className={className} />;
+    case "ollamaCloud":
+      return <OllamaCloudMark size={size} className={className} />;
+    case "openaiCompatible":
+      return <OpenAIEndpointMark size={size} className={className} />;
     case "boxAgent":
       return <ComputerMark size={size} className={className} />;
     default:

--- a/src/components/ProviderSetupOptions.test.tsx
+++ b/src/components/ProviderSetupOptions.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { StoreProvider } from "@/state/store";
+import { ProviderSetupOptions } from "./ProviderSetupOptions";
+
+describe("ProviderSetupOptions", () => {
+  it("offers cloud and custom providers without requiring setup during onboarding", () => {
+    const html = renderToStaticMarkup(
+      <StoreProvider>
+        <ProviderSetupOptions />
+      </StoreProvider>,
+    );
+
+    expect(html).toContain("OpenRouter");
+    expect(html).toContain("Ollama Cloud");
+    expect(html).toContain("Custom OpenAI-compatible");
+    expect(html).toContain("Set up later in App Settings");
+    expect(html).toContain('type="password"');
+    expect(html).toContain("http://127.0.0.1:11434/v1");
+    expect(html).not.toContain("Image path");
+    expect(html).not.toContain("Video path");
+  });
+});

--- a/src/components/ProviderSetupOptions.tsx
+++ b/src/components/ProviderSetupOptions.tsx
@@ -1,0 +1,39 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { ApiKeyRow } from "./ApiKeys";
+import { OpenAIEndpointFields } from "./OpenAIEndpointFields";
+
+function ProviderDisclosure({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <details className="group overflow-hidden rounded-xl border border-hairline/40 bg-card">
+      <summary className="flex cursor-pointer list-none items-center justify-between px-3.5 py-3 text-[13.5px] font-medium text-ink [&::-webkit-details-marker]:hidden">
+        {title}
+        <ChevronRight size={15} className="text-ink-secondary transition-transform group-open:rotate-90" />
+      </summary>
+      <div className="border-t border-hairline/30 px-3.5 py-3">{children}</div>
+    </details>
+  );
+}
+
+export function ProviderSetupOptions() {
+  return (
+    <div>
+      <div className="flex flex-col gap-2">
+        <ProviderDisclosure title="OpenRouter">
+          <ApiKeyRow section="openrouter" />
+        </ProviderDisclosure>
+        <ProviderDisclosure title="Ollama Cloud">
+          <ApiKeyRow section="ollamaCloud" />
+        </ProviderDisclosure>
+        <ProviderDisclosure title="Custom OpenAI-compatible">
+          <div className="flex flex-col gap-3">
+            <OpenAIEndpointFields compact />
+            <ApiKeyRow section="openaiCompatible" />
+          </div>
+        </ProviderDisclosure>
+      </div>
+      <div className="mt-2 text-[11.5px] text-ink-secondary">Set up later in App Settings</div>
+    </div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,7 +3,7 @@
 // is the stuff shared by every bot: who you are, your keys, and the
 // machine your bots can borrow.
 import { useEffect, useRef, useState } from "react";
-import { KeyRound, Monitor, User, Volume2, X } from "lucide-react";
+import { Cpu, KeyRound, Monitor, User, Volume2, X } from "lucide-react";
 import { useStore } from "@/state/store";
 import { ApiKeyRow } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
@@ -11,11 +11,13 @@ import { LocalComputerSection } from "./LocalComputerSection";
 import { Card } from "./SettingsPrimitives";
 import { VoiceSettings } from "./VoiceSettings";
 import { cn } from "@/lib/cn";
+import { OpenAIEndpointFields } from "./OpenAIEndpointFields";
 
-type SectionId = "general" | "connections" | "voice" | "computer";
+type SectionId = "general" | "models" | "connections" | "voice" | "computer";
 
 const SECTIONS: Array<{ id: SectionId; label: string; icon: typeof User }> = [
   { id: "general", label: "General", icon: User },
+  { id: "models", label: "Model providers", icon: Cpu },
   { id: "connections", label: "Connections", icon: KeyRound },
   { id: "voice", label: "Voice", icon: Volume2 },
   { id: "computer", label: "Local computer", icon: Monitor },
@@ -213,6 +215,29 @@ export function SettingsModal() {
                   <ApiKeyRow section="box" />
                 </div>
               </Card>
+            )}
+
+            {section === "models" && (
+              <>
+                <Card
+                  title="Cloud model providers"
+                  subtitle="Keys stay on this computer. Model lists are discovered after connecting."
+                >
+                  <div className="flex flex-col gap-4">
+                    <ApiKeyRow section="openrouter" />
+                    <ApiKeyRow section="ollamaCloud" />
+                  </div>
+                </Card>
+                <Card
+                  title="OpenAI-compatible endpoint"
+                  subtitle="Use local Ollama, vLLM on your network, or a remote OpenAI-standard server."
+                >
+                  <div className="flex flex-col gap-4">
+                    <OpenAIEndpointFields />
+                    <ApiKeyRow section="openaiCompatible" />
+                  </div>
+                </Card>
+              </>
             )}
 
             {section === "voice" && <VoiceSettings />}

--- a/src/lib/html-artifacts.test.ts
+++ b/src/lib/html-artifacts.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  artifactHeaderMode,
+  buildArtifactDocument,
+  extractHtmlArtifacts,
+  findStreamingHtmlFence,
+  toggleArtifactSelection,
+} from "./html-artifacts";
+
+describe("HTML artifact extraction", () => {
+  it("extracts completed HTML fences with stable message-based IDs", () => {
+    expect(extractHtmlArtifacts("Before\n```html\n<h1>Hello</h1>\n```\nAfter", "message-1")).toEqual([
+      {
+        id: "message-1:0",
+        messageId: "message-1",
+        index: 0,
+        language: "html",
+        html: "<h1>Hello</h1>",
+        sourceLine: 2,
+      },
+    ]);
+  });
+
+  it("ignores partial fences and non-HTML source", () => {
+    expect(extractHtmlArtifacts("```html\n<p>partial", "message-1")).toEqual([]);
+    expect(extractHtmlArtifacts("```js\ndocument.body.innerHTML = 'x'\n```", "message-1")).toEqual([]);
+    expect(extractHtmlArtifacts("Use <main>inline HTML</main> here", "message-1")).toEqual([]);
+  });
+
+  it("supports tilde, case-insensitive, and longer fences", () => {
+    const markdown = [
+      "~~~~HTM",
+      "<pre>``` stays inside</pre>",
+      "~~~~",
+      "~~~html_preview",
+      "<button>Go</button>",
+      "~~~",
+    ].join("\n");
+    expect(extractHtmlArtifacts(markdown, "message-2")).toEqual([
+      {
+        id: "message-2:0",
+        messageId: "message-2",
+        index: 0,
+        language: "htm",
+        html: "<pre>``` stays inside</pre>",
+        sourceLine: 1,
+      },
+      {
+        id: "message-2:1",
+        messageId: "message-2",
+        index: 1,
+        language: "html_preview",
+        html: "<button>Go</button>",
+        sourceLine: 4,
+      },
+    ]);
+  });
+
+  it("identifies the exact unfinished HTML fence at the end of a stream", () => {
+    expect(findStreamingHtmlFence("Intro\n```html\n<section>work")).toEqual({
+      language: "html",
+      code: "<section>work",
+      sourceLine: 2,
+    });
+    expect(findStreamingHtmlFence("```html\nready\n```\ntext\n~~~HTM\n<p>still writing")).toEqual({
+      language: "htm",
+      code: "<p>still writing",
+      sourceLine: 5,
+    });
+    expect(findStreamingHtmlFence("```js\nwork")).toBeNull();
+    expect(findStreamingHtmlFence("```html\nready\n```")).toBeNull();
+  });
+});
+
+describe("artifact document isolation", () => {
+  it("keeps inline scripts interactive while blocking all outbound requests", () => {
+    const document = buildArtifactDocument("<script>document.body.textContent='ready'</script>");
+    expect(document).toContain("Content-Security-Policy");
+    expect(document).toContain("script-src 'unsafe-inline'");
+    expect(document).toContain("connect-src 'none'");
+    expect(document).toContain("navigate-to 'none'");
+    expect(document).toContain("img-src data: blob:");
+    expect(document).toContain("media-src data: blob:");
+    expect(document).not.toContain("img-src data: blob: http:");
+    expect(document).not.toContain("script-src 'unsafe-inline' http:");
+    expect(document).not.toContain("connect-src http:");
+    expect(document).toContain("form-action 'none'");
+    expect(document).toContain('<meta name="referrer" content="no-referrer">');
+  });
+
+  it("inserts metadata into a real head without mistaking script text for markup", () => {
+    const input = '<!doctype html><html><body><script>const example = "<head>";</script><p>Hi</p></body></html>';
+    const document = buildArtifactDocument(input);
+    expect(document.match(/<html/gi)).toHaveLength(1);
+    expect(document).toContain('const example = "<head>";');
+    expect(document.indexOf("Content-Security-Policy")).toBeLessThan(document.indexOf("<body"));
+  });
+});
+
+describe("artifact selection", () => {
+  it("keeps the header in close mode when an older artifact is open", () => {
+    expect(artifactHeaderMode("message-new:0", "message-old:0")).toBe("close");
+    expect(artifactHeaderMode("message-new:0", null)).toBe("open");
+    expect(artifactHeaderMode(undefined, null)).toBe("hidden");
+  });
+
+  it("closes the selected artifact and switches directly to a different one", () => {
+    expect(toggleArtifactSelection("message-1:0", "message-1:0")).toBeNull();
+    expect(toggleArtifactSelection("message-1:0", "message-2:0")).toBe("message-2:0");
+  });
+});

--- a/src/lib/html-artifacts.ts
+++ b/src/lib/html-artifacts.ts
@@ -1,0 +1,197 @@
+export interface HtmlArtifact {
+  id: string;
+  messageId: string;
+  index: number;
+  language: "html" | "htm" | "html_preview";
+  html: string;
+  sourceLine: number;
+}
+
+const HTML_LANGUAGES = new Set<HtmlArtifact["language"]>(["html", "htm", "html_preview"]);
+
+export interface StreamingHtmlFence {
+  language: HtmlArtifact["language"];
+  code: string;
+  sourceLine: number;
+}
+
+export function findStreamingHtmlFence(markdown: string): StreamingHtmlFence | null {
+  const lines = markdown.split(/\r?\n/);
+  for (let lineIndex = lines.length - 1; lineIndex >= 0; lineIndex--) {
+    const opening = /^\s{0,3}(`{3,}|~{3,})\s*([^\s]*)?.*$/.exec(lines[lineIndex]!);
+    if (!opening) continue;
+    const fence = opening[1]!;
+    const language = (opening[2] ?? "").toLowerCase();
+    if (!HTML_LANGUAGES.has(language as HtmlArtifact["language"])) continue;
+    const character = fence[0]!;
+    const closing = new RegExp(`^\\s{0,3}${character === "`" ? "`" : "~"}{${fence.length},}\\s*$`);
+    const body = lines.slice(lineIndex + 1);
+    if (body.some((line) => closing.test(line))) return null;
+    return {
+      language: language as HtmlArtifact["language"],
+      code: body.join("\n"),
+      sourceLine: lineIndex + 1,
+    };
+  }
+  return null;
+}
+
+export function extractHtmlArtifacts(markdown: string, messageId: string): HtmlArtifact[] {
+  const lines = markdown.split(/\r?\n/);
+  const artifacts: HtmlArtifact[] = [];
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const opening = /^\s{0,3}(`{3,}|~{3,})\s*([^\s]*)?.*$/.exec(lines[lineIndex]!);
+    if (!opening) continue;
+    const sourceLine = lineIndex + 1;
+    const fence = opening[1]!;
+    const language = (opening[2] ?? "").toLowerCase();
+    const character = fence[0]!;
+    const closing = new RegExp(`^\\s{0,3}${character === "`" ? "`" : "~"}{${fence.length},}\\s*$`);
+    const body: string[] = [];
+    let closedAt = -1;
+    for (let cursor = lineIndex + 1; cursor < lines.length; cursor++) {
+      if (closing.test(lines[cursor]!)) {
+        closedAt = cursor;
+        break;
+      }
+      body.push(lines[cursor]!);
+    }
+    if (closedAt === -1) continue;
+    lineIndex = closedAt;
+    if (!HTML_LANGUAGES.has(language as HtmlArtifact["language"])) continue;
+    const index = artifacts.length;
+    artifacts.push({
+      id: `${messageId}:${index}`,
+      messageId,
+      index,
+      language: language as HtmlArtifact["language"],
+      html: body.join("\n"),
+      sourceLine,
+    });
+  }
+  return artifacts;
+}
+
+export type ArtifactHeaderMode = "hidden" | "open" | "close";
+
+export function artifactHeaderMode(
+  latestArtifactId: string | undefined,
+  selectedArtifactId: string | null | undefined,
+): ArtifactHeaderMode {
+  if (selectedArtifactId) return "close";
+  return latestArtifactId ? "open" : "hidden";
+}
+
+export function toggleArtifactSelection(selectedArtifactId: string | null, requestedArtifactId: string): string | null {
+  return selectedArtifactId === requestedArtifactId ? null : requestedArtifactId;
+}
+
+const ARTIFACT_CSP = [
+  "default-src 'none'",
+  "img-src data: blob:",
+  "media-src data: blob:",
+  "style-src 'unsafe-inline'",
+  "font-src data:",
+  "script-src 'unsafe-inline'",
+  "connect-src 'none'",
+  "navigate-to 'none'",
+  "form-action 'none'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "frame-src 'none'",
+].join("; ");
+
+const isolationMetadata =
+  `<meta http-equiv="Content-Security-Policy" content="${ARTIFACT_CSP}">` +
+  '<meta name="referrer" content="no-referrer">' +
+  "<style>html{color-scheme:light dark}body{margin:0}</style>";
+
+function domParsedDocument(html: string): string | null {
+  if (typeof DOMParser === "undefined") return null;
+  const document = new DOMParser().parseFromString(html, "text/html");
+  const csp = document.createElement("meta");
+  csp.setAttribute("http-equiv", "Content-Security-Policy");
+  csp.setAttribute("content", ARTIFACT_CSP);
+  const referrer = document.createElement("meta");
+  referrer.setAttribute("name", "referrer");
+  referrer.setAttribute("content", "no-referrer");
+  const style = document.createElement("style");
+  style.textContent = "html{color-scheme:light dark}body{margin:0}";
+  document.head.prepend(csp, referrer, style);
+  return `<!doctype html>${document.documentElement.outerHTML}`;
+}
+
+const RAW_TEXT_TAGS = new Set(["script", "style", "textarea", "title"]);
+
+/** Find an actual opening tag while ignoring comments and raw script/style text.
+ * The browser path above uses DOMParser; this deterministic fallback keeps the
+ * helper safe and testable in Node, where DOMParser is not available. */
+function openingTagEnd(source: string, wanted: string): number | null {
+  const lower = source.toLowerCase();
+  let cursor = 0;
+  while (cursor < source.length) {
+    const start = source.indexOf("<", cursor);
+    if (start === -1) return null;
+    if (source.startsWith("<!--", start)) {
+      const end = source.indexOf("-->", start + 4);
+      cursor = end === -1 ? source.length : end + 3;
+      continue;
+    }
+    if (source[start + 1] === "!" || source[start + 1] === "?") {
+      const end = source.indexOf(">", start + 2);
+      cursor = end === -1 ? source.length : end + 1;
+      continue;
+    }
+    const match = /^<\s*(\/?)\s*([a-z][\w:-]*)/i.exec(source.slice(start));
+    if (!match) {
+      cursor = start + 1;
+      continue;
+    }
+    let end = start + match[0].length;
+    let quote = "";
+    for (; end < source.length; end++) {
+      const character = source[end]!;
+      if (quote) {
+        if (character === quote) quote = "";
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        break;
+      }
+    }
+    if (end >= source.length) return null;
+    const closing = Boolean(match[1]);
+    const name = match[2]!.toLowerCase();
+    if (!closing && name === wanted) return end + 1;
+    if (!closing && RAW_TEXT_TAGS.has(name)) {
+      const closeStart = lower.indexOf(`</${name}`, end + 1);
+      if (closeStart === -1) return null;
+      const closeEnd = source.indexOf(">", closeStart + name.length + 2);
+      cursor = closeEnd === -1 ? source.length : closeEnd + 1;
+    } else {
+      cursor = end + 1;
+    }
+  }
+  return null;
+}
+
+export function buildArtifactDocument(html: string): string {
+  const parsed = domParsedDocument(html);
+  if (parsed) return parsed;
+
+  const headEnd = openingTagEnd(html, "head");
+  if (headEnd !== null) return `${html.slice(0, headEnd)}${isolationMetadata}${html.slice(headEnd)}`;
+
+  const htmlEnd = openingTagEnd(html, "html");
+  if (htmlEnd !== null) {
+    return `${html.slice(0, htmlEnd)}<head>${isolationMetadata}</head>${html.slice(htmlEnd)}`;
+  }
+
+  return [
+    "<!doctype html>",
+    "<html>",
+    `<head>${isolationMetadata}</head>`,
+    `<body>${html}</body>`,
+    "</html>",
+  ].join("");
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -148,6 +148,13 @@ export function messageVersions(bot: Bot, message: Message): Message[] {
 /** GET /api/config — configured flags only; secrets are never echoed. */
 export interface ConfigStatus {
   xai?: { configured: boolean };
+  openrouter: { configured: boolean };
+  ollamaCloud: { configured: boolean };
+  openaiCompatible: {
+    apiKeyConfigured: boolean;
+    url: string;
+    model: string;
+  };
   composio: { configured: boolean; apiKeyConfigured?: boolean };
   box: { configured: boolean };
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND
@@ -1128,6 +1135,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             type: "configStatus",
             config: {
               xai: frame.xai,
+              openrouter: frame.openrouter,
+              ollamaCloud: frame.ollamaCloud,
+              openaiCompatible: frame.openaiCompatible,
               composio: frame.composio,
               box: frame.box,
               tts: frame.tts,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts", "electron/**/*.test.mjs", "src/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx", "electron/**/*.test.mjs"],
     setupFiles: ["server/testing/setup.ts"],
     // the suite spawns fake provider CLIs and a real harness server;
     // parallel files introduce load-sensitive flakes for no win


### PR DESCRIPTION
## What changed

- Added compact HTML creation cards that can expand while code is still streaming.
- Added persistent chat controls to open, close, and reopen the artifact that belongs to that message.
- Added a side-by-side, keyboard- and pointer-resizable artifact panel with cleanup on close.
- Isolated model-authored HTML with an opaque iframe sandbox and a restrictive `srcdoc` CSP that blocks outbound network access.
- Added Electron subframe navigation protection and trusted external-link handling.

## Why

Generated HTML should behave like a reopenable artifact without letting model-authored scripts inherit application privileges or silently contact external hosts. The previous streaming and settled states also used different controls, which caused expansion and multi-artifact state bugs.

## How it was verified

- `pnpm test` — 291 passed, 7 skipped
- `pnpm build`
- Component coverage for streaming expansion, settled reopen/close state, panel resizing, and cleanup
- Electron navigation-policy and HTML-sanitization/CSP coverage
- `git diff --check codex/provider-configuration..HEAD`

## Screenshots (UI changes)

The artifact flow was manually exercised in the local Electron app during [PR #74](https://github.com/milind-soni/OpenMausBot/pull/74). This split retains only the HTML artifact implementation and its security boundary.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] New behavior includes component and Electron policy tests
- [x] No `dist-server/` edits or dependency/lockfile churn
- [x] macOS-only behavior remains Electron-gated
- [x] Model-authored scripts cannot make outbound requests from the preview

## Stack

- Depends on #93 for the rebased provider foundation.
- Media generation and the Generations library follow as separate draft PRs.

This fork-based stack targets upstream `main`; this PR will be rebased after #93 lands so its visible diff collapses to this slice.
