### PR TITLE
Add the Generations library

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ it keeps the idea (AI as a *messaging app*: a roster of bots you chat with, each
 memory of its thread, model, computer, and apps) and rebuilds it open, local-first, and on the agents you
 already have:
 
-- **Bring your own agents.** Bots run on the `claude`, `codex`, and `grok` CLIs installed on your own machine
-  — your existing logins and subscriptions, no new accounts, no proxy in the middle.
+- **Bring your own agents and models.** Bots can run on the `claude`, `codex`, and `grok` CLIs installed on
+  your own machine, OpenRouter or Ollama Cloud, or any HTTP endpoint that implements the OpenAI chat
+  completions API (including local Ollama and vLLM servers).
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch
@@ -62,7 +63,8 @@ already have:
 ### 🧠 Pick a brain per bot
 
 A model picker with a provider rail — Claude and Codex models side by side, defaults marked, unavailable
-providers dimmed with the reason. Switch a bot's model mid-conversation.
+providers dimmed with the reason. Switch a bot's model mid-conversation. OpenRouter, Ollama Cloud, and
+custom OpenAI-compatible endpoints can be configured during onboarding or later in App Settings.
 
 <img src="docs/screenshots/model-picker.png" alt="Model picker with provider rail" width="100%">
 
@@ -198,9 +200,9 @@ pnpm dev           # app → http://127.0.0.1:5199
 pnpm dev:desktop   # Electron shell; keep the two commands above running
 ```
 
-Requirements: **macOS, Windows, or Ubuntu 24.04 x64**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code),
-[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
-in the model picker automatically.
+Requirements: **macOS, Windows, or Ubuntu 24.04 x64**, **Node 24+**, **pnpm**, and either an agent CLI — [`claude`](https://claude.com/claude-code),
+[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in, or one of
+the model endpoints below. Available models appear in the model picker automatically.
 
 Package the desktop application:
 
@@ -228,13 +230,17 @@ in the sidebar footer) when you want to enable its integration:
 
 | Credential | What it enables | Where to get it |
 |---|---|---|
+| OpenRouter API key | Chat through OpenRouter's OpenAI-compatible model catalog | [OpenRouter keys](https://openrouter.ai/settings/keys) |
+| Ollama Cloud API key | Chat with models hosted by Ollama Cloud | [Ollama Cloud](https://ollama.com/) |
+| OpenAI-compatible API key (optional) | Authenticate to a custom OpenAI-compatible endpoint; local Ollama and vLLM usually do not require one | Your endpoint operator |
 | Composio Connect key (`ck_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [Composio Connect setup guide](https://docs.composio.dev/docs/composio-connect) |
 | Composio API key (`ak_…`) | Browse the full app catalog with official names and logos | [Composio project API key guide](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
 | Box API key | Give bots an isolated remote Linux computer with a desktop and terminal | [Box API key guide](https://docs.ascii.dev/box/api-keys) |
 | ElevenLabs key | Read replies aloud, and call your bots | [ElevenLabs API keys](https://elevenlabs.io/app/settings/api-keys) |
 
-Composio and Box are third-party services with their own accounts and terms. Box is a paid service after
-its trial, and using a cloud computer may incur charges.
+OpenRouter, Ollama Cloud, Composio, and Box are third-party services with their own accounts and terms.
+Box is a paid service after its trial, and using a hosted model or cloud computer may incur charges. Custom
+OpenAI-compatible endpoint URLs and default model IDs are configured under **App Settings → Models**.
 
 ```sh
 pnpm typecheck     # app + server

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -6,6 +6,7 @@ import { startCua, stopCua, registerCuaIpc } from "./cua.mjs";
 import { startSpeech, stopSpeech } from "./speech.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
+import { isAllowedSubframeNavigation, isTrustedExternalOpen } from "./navigation-policy.mjs";
 
 const { desktopCapabilities } = capabilitiesModule;
 
@@ -147,9 +148,15 @@ function createWindow() {
     },
   });
 
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+  win.webContents.setWindowOpenHandler(({ url, referrer }) => {
+    if (isTrustedExternalOpen(url, referrer.url, win.webContents.getURL())) void shell.openExternal(url);
     return { action: "deny" };
+  });
+  // Artifact previews run in sandboxed srcdoc frames. Their CSP blocks
+  // subresources; this main-process guard also prevents model-authored
+  // scripts or links from navigating the frame to an outbound URL.
+  win.webContents.on("will-frame-navigate", (event, details) => {
+    if (!details.isMainFrame && !isAllowedSubframeNavigation(details.url)) event.preventDefault();
   });
 
   // Packaged CI smoke hook. It validates the real renderer/preload bridge and

--- a/electron/navigation-policy.mjs
+++ b/electron/navigation-policy.mjs
@@ -1,0 +1,20 @@
+const LOCAL_DOCUMENT_SCHEMES = new Set(["about:", "blob:", "data:"]);
+
+export function isAllowedSubframeNavigation(value) {
+  try {
+    return LOCAL_DOCUMENT_SCHEMES.has(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function isTrustedExternalOpen(targetValue, referrerValue, appValue) {
+  try {
+    const target = new URL(targetValue);
+    const referrer = new URL(referrerValue);
+    const app = new URL(appValue);
+    return (target.protocol === "http:" || target.protocol === "https:") && referrer.origin === app.origin;
+  } catch {
+    return false;
+  }
+}

--- a/electron/navigation-policy.test.mjs
+++ b/electron/navigation-policy.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { isAllowedSubframeNavigation, isTrustedExternalOpen } from "./navigation-policy.mjs";
+
+describe("artifact subframe navigation policy", () => {
+  it("allows only local opaque-document schemes", () => {
+    expect(isAllowedSubframeNavigation("about:srcdoc")).toBe(true);
+    expect(isAllowedSubframeNavigation("data:text/html,ok")).toBe(true);
+    expect(isAllowedSubframeNavigation("blob:http://127.0.0.1/id")).toBe(true);
+  });
+
+  it.each([
+    "https://attacker.example/collect",
+    "http://127.0.0.1:11434/admin",
+    "file:///etc/passwd",
+    "javascript:location='https://attacker.example'",
+  ])("blocks model-authored subframe navigation to %s", (url) => {
+    expect(isAllowedSubframeNavigation(url)).toBe(false);
+  });
+});
+
+describe("external window policy", () => {
+  it("opens web links only when the app's top document supplied the referrer", () => {
+    expect(isTrustedExternalOpen(
+      "https://docs.example/page",
+      "http://127.0.0.1:8799/chat",
+      "http://127.0.0.1:8799/",
+    )).toBe(true);
+    expect(isTrustedExternalOpen(
+      "https://attacker.example/collect?secret=x",
+      "",
+      "http://127.0.0.1:8799/",
+    )).toBe(false);
+    expect(isTrustedExternalOpen(
+      "file:///etc/passwd",
+      "http://127.0.0.1:8799/chat",
+      "http://127.0.0.1:8799/",
+    )).toBe(false);
+  });
+});

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -11,6 +11,9 @@ describe("model provider instance configuration", () => {
         key: "endpoint-key",
         url: "http://10.0.0.42:8000/v1",
         model: "org/open-model",
+        modelTasks: { "org/image-model": "image", "org/video-model": "video" },
+        imagePath: "/images/generations",
+        videoPath: "/videos",
       },
     });
 
@@ -26,7 +29,13 @@ describe("model provider instance configuration", () => {
     });
     expect(configs["openai-compatible"]).toMatchObject({
       driver: "openaiCompatible",
-      config: { url: "http://10.0.0.42:8000/v1", model: "org/open-model" },
+      config: {
+        url: "http://10.0.0.42:8000/v1",
+        model: "org/open-model",
+        modelTasks: { "org/image-model": "image", "org/video-model": "video" },
+        imagePath: "/images/generations",
+        videoPath: "/videos",
+      },
       environment: { OPENAI_COMPATIBLE_API_KEY: "endpoint-key" },
     });
   });

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { instanceConfigs } from "./config.ts";
+
+describe("model provider instance configuration", () => {
+  it("adds the API-backed providers to the default fleet", () => {
+    const configs = instanceConfigs({
+      openrouter: { key: "router-key" },
+      ollamaCloud: { key: "ollama-key" },
+      openaiCompatible: {
+        key: "endpoint-key",
+        url: "http://10.0.0.42:8000/v1",
+        model: "org/open-model",
+      },
+    });
+
+    expect(configs.openrouter).toMatchObject({
+      driver: "openrouter",
+      config: { url: "https://openrouter.ai/api/v1" },
+      environment: { OPENROUTER_API_KEY: "router-key" },
+    });
+    expect(configs["ollama-cloud"]).toMatchObject({
+      driver: "ollamaCloud",
+      config: { url: "https://ollama.com/v1" },
+      environment: { OLLAMA_API_KEY: "ollama-key" },
+    });
+    expect(configs["openai-compatible"]).toMatchObject({
+      driver: "openaiCompatible",
+      config: { url: "http://10.0.0.42:8000/v1", model: "org/open-model" },
+      environment: { OPENAI_COMPATIBLE_API_KEY: "endpoint-key" },
+    });
+  });
+
+  it("injects each provider credential only into its matching driver", () => {
+    const configs = instanceConfigs({
+      xai: { key: "xai-key" },
+      openrouter: { key: "router-key" },
+      ollamaCloud: { key: "ollama-key" },
+      openaiCompatible: { key: "endpoint-key" },
+      box: { token: "box-token" },
+      instances: {
+        grokApi: { driver: "grok" },
+        router: { driver: "openrouter" },
+        ollama: { driver: "ollamaCloud" },
+        endpoint: { driver: "openaiCompatible" },
+        computer: { driver: "boxAgent" },
+        unrelated: { driver: "claudeAgent" },
+      },
+    });
+
+    expect(configs.grokApi.environment).toEqual({ XAI_API_KEY: "xai-key" });
+    expect(configs.router.environment).toEqual({ OPENROUTER_API_KEY: "router-key" });
+    expect(configs.ollama.environment).toEqual({ OLLAMA_API_KEY: "ollama-key" });
+    expect(configs.endpoint.environment).toEqual({ OPENAI_COMPATIBLE_API_KEY: "endpoint-key" });
+    expect(configs.computer.environment).toEqual({ BOX_TOKEN: "box-token" });
+    expect(configs.unrelated.environment).toEqual({});
+  });
+
+  it("preserves explicit per-instance credential overrides", () => {
+    const configs = instanceConfigs({
+      openrouter: { key: "global-router-key" },
+      instances: {
+        router: {
+          driver: "openrouter",
+          environment: { OPENROUTER_API_KEY: "instance-router-key", EXISTING: "kept" },
+        },
+      },
+    });
+
+    expect(configs.router.environment).toEqual({
+      OPENROUTER_API_KEY: "instance-router-key",
+      EXISTING: "kept",
+    });
+  });
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -6,13 +6,22 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { writeFileAtomic } from "./atomic.ts";
-import type { InstanceConfigMap } from "./contracts.ts";
+import type { InstanceConfigMap, ModelTask } from "./contracts.ts";
+
+export interface OpenAICompatibleConfig {
+  key?: string;
+  url?: string;
+  model?: string;
+  modelTasks?: Record<string, ModelTask>;
+  imagePath?: string;
+  videoPath?: string;
+}
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
   openrouter?: { key?: string; url?: string; model?: string };
   ollamaCloud?: { key?: string; url?: string; model?: string };
-  openaiCompatible?: { key?: string; url?: string; model?: string };
+  openaiCompatible?: OpenAICompatibleConfig;
   /** key = ck_… Connect consumer key (connections + agent tools);
    * apiKey = ak_… project API key — optional, unlocks the full toolkit
    * catalog with official logos in the plugins marketplace. */
@@ -138,6 +147,9 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
             config: {
               url: cfg.openaiCompatible?.url,
               model: cfg.openaiCompatible?.model,
+              modelTasks: cfg.openaiCompatible?.modelTasks,
+              imagePath: cfg.openaiCompatible?.imagePath,
+              videoPath: cfg.openaiCompatible?.videoPath,
             },
           },
           antigravity: { driver: "antigravityAgent" },

--- a/server/config.ts
+++ b/server/config.ts
@@ -10,6 +10,9 @@ import type { InstanceConfigMap } from "./contracts.ts";
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
+  openrouter?: { key?: string; url?: string; model?: string };
+  ollamaCloud?: { key?: string; url?: string; model?: string };
+  openaiCompatible?: { key?: string; url?: string; model?: string };
   /** key = ck_… Connect consumer key (connections + agent tools);
    * apiKey = ak_… project API key — optional, unlocks the full toolkit
    * catalog with official logos in the plugins marketplace. */
@@ -51,6 +54,12 @@ export function loadConfig(): AppConfig {
     /* first run — env fallbacks below */
   }
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
+  cfg.openrouter = { key: process.env.OPENROUTER_API_KEY, ...cfg.openrouter };
+  cfg.ollamaCloud = { key: process.env.OLLAMA_API_KEY, ...cfg.ollamaCloud };
+  cfg.openaiCompatible = {
+    key: process.env.OPENAI_COMPATIBLE_API_KEY,
+    ...cfg.openaiCompatible,
+  };
   cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
   cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };
@@ -67,7 +76,16 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   } catch {
     /* first write */
   }
-  for (const key of ["xai", "composio", "box", "tts", "profile"] as const) {
+  for (const key of [
+    "xai",
+    "openrouter",
+    "ollamaCloud",
+    "openaiCompatible",
+    "composio",
+    "box",
+    "tts",
+    "profile",
+  ] as const) {
     if (patch[key] && typeof patch[key] === "object") {
       disk[key] = { ...(disk[key] as object), ...patch[key] };
     }
@@ -101,13 +119,43 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
           grok: { driver: "grokAgent" },
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
+          openrouter: {
+            driver: "openrouter",
+            config: {
+              url: cfg.openrouter?.url ?? "https://openrouter.ai/api/v1",
+              model: cfg.openrouter?.model,
+            },
+          },
+          "ollama-cloud": {
+            driver: "ollamaCloud",
+            config: {
+              url: cfg.ollamaCloud?.url ?? "https://ollama.com/v1",
+              model: cfg.ollamaCloud?.model,
+            },
+          },
+          "openai-compatible": {
+            driver: "openaiCompatible",
+            config: {
+              url: cfg.openaiCompatible?.url,
+              model: cfg.openaiCompatible?.model,
+            },
+          },
           antigravity: { driver: "antigravityAgent" },
           computer: { driver: "boxAgent" },
         };
   for (const entry of Object.values(map)) {
     entry.environment = {
-      ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
-      ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
+      ...(entry.driver === "grok" && cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
+      ...(entry.driver === "openrouter" && cfg.openrouter?.key
+        ? { OPENROUTER_API_KEY: cfg.openrouter.key }
+        : {}),
+      ...(entry.driver === "ollamaCloud" && cfg.ollamaCloud?.key
+        ? { OLLAMA_API_KEY: cfg.ollamaCloud.key }
+        : {}),
+      ...(entry.driver === "openaiCompatible" && cfg.openaiCompatible?.key
+        ? { OPENAI_COMPATIBLE_API_KEY: cfg.openaiCompatible.key }
+        : {}),
+      ...(entry.driver === "boxAgent" && cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
       ...entry.environment,
     };
   }

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -18,6 +18,50 @@ export interface ModelSelection {
   model: string;
 }
 
+export type ModelTask = "chat" | "image" | "video";
+export type MediaKind = "image" | "video";
+export type MediaStatus = "queued" | "generating" | "downloading" | "ready" | "failed" | "cancelled";
+
+export type MediaSource =
+  | { type: "base64"; data: string; mime?: string }
+  | { type: "bytes"; data: Uint8Array; mime?: string };
+
+export interface GeneratedMedia {
+  kind: MediaKind;
+  source: MediaSource;
+  mime?: string;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  providerJobId?: string;
+}
+
+export interface MediaOutput {
+  id: string;
+  kind: MediaKind;
+  status: MediaStatus;
+  mime?: string;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  bytes?: number;
+  progress?: number;
+  cacheKey?: string;
+  providerJobId?: string;
+  error?: string;
+}
+
+export interface GenerateMediaInput {
+  threadId: ThreadId;
+  task: MediaKind;
+  model: string;
+  prompt: string;
+  signal: AbortSignal;
+  /** Test and provider-specific tuning only; normal callers use the default. */
+  pollIntervalMs?: number;
+  onProgress?: (progress: { progress?: number; providerJobId?: string }) => void;
+}
+
 // ── instance configuration envelope ────────────────────────────────────
 // `driver` is any slug — NOT validated against known drivers; unknown
 // drivers round-trip and surface as unavailable shadow snapshots so a
@@ -157,7 +201,13 @@ export interface ProviderSnapshot {
 // a rejection to an unavailable shadow snapshot.
 export interface ModelCatalog {
   default: string;
-  options: Array<{ id: string; label: string }>;
+  options: Array<{
+    id: string;
+    label: string;
+    task?: ModelTask;
+    inputModalities?: string[];
+    outputModalities?: string[];
+  }>;
 }
 
 export interface DriverCreateInput<Config> {
@@ -178,6 +228,8 @@ export interface ProviderInstance {
   snapshot(): Promise<ProviderSnapshot>;
   /** Cheap one-shot text call (upstream TextGeneration) — titles, summaries. */
   generateText?(prompt: string): Promise<string>;
+  /** Direct image/video generation for an explicitly selected specialist. */
+  generateMedia?(input: GenerateMediaInput): Promise<GeneratedMedia[]>;
   dispose(): Promise<void>;
 }
 

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -38,12 +38,16 @@ describe("ACP turns (fake CLI)", () => {
   let recorder: EventRecorder;
   let scratch: string;
 
-  const create = async (driver = GrokAgentDriver, mode?: string) => {
+  const create = async (
+    driver = GrokAgentDriver,
+    mode?: string,
+    environment: Record<string, string> = {},
+  ) => {
     if (mode) process.env.FAKE_ACP_MODE = mode;
     instance = await driver.create({
       instanceId: "acp-test",
       displayName: "ACP Test",
-      environment: {},
+      environment,
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
     });
@@ -105,6 +109,52 @@ describe("ACP turns (fake CLI)", () => {
     expect(seen.argv).toContain("stdio");
     expect(seen.argv).toContain("--permission-mode");
     expect(seen.env.XAI_API_KEY).toBeUndefined();
+  });
+
+  it("redacts provider credentials and nested integration tokens from diagnostic dumps", async () => {
+    const dump = join(scratch, "redacted-dump.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await create(GrokAgentDriver, undefined, {
+      OPENROUTER_API_KEY: "router-secret",
+      OLLAMA_API_KEY: "ollama-secret",
+      OPENAI_COMPATIBLE_API_KEY: "endpoint-secret",
+      DIAGNOSTIC_LABEL: "visible",
+    });
+
+    await instance.adapter.sendTurn({
+      threadId: "t-redaction",
+      text: "go",
+      integrations: {
+        agents: {
+          command: process.execPath,
+          args: ["/fake/agents-proxy.js"],
+          env: { OMB_COMMS_TOKEN: "comms-secret", SAFE_VALUE: "visible" },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.env).toMatchObject({
+      OPENROUTER_API_KEY: "[REDACTED]",
+      OLLAMA_API_KEY: "[REDACTED]",
+      OPENAI_COMPATIBLE_API_KEY: "[REDACTED]",
+      DIAGNOSTIC_LABEL: "visible",
+    });
+    const sessionNew = (seen.requests ?? []).find((request: any) => request.method === "session/new");
+    expect(sessionNew).toMatchObject({
+      params: {
+        mcpServers: expect.arrayContaining([
+          expect.objectContaining({
+            name: "agents",
+            env: expect.arrayContaining([
+              { name: "OMB_COMMS_TOKEN", value: "[REDACTED]" },
+              { name: "SAFE_VALUE", value: "visible" },
+            ]),
+          }),
+        ]),
+      },
+    });
   });
 
   it("surfaces a permission ask as request.opened and completes once allowed", async () => {

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -8,6 +8,9 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { OllamaCloudDriver } from "./ollama-cloud.ts";
+import { OpenAIEndpointDriver } from "./openai-endpoint.ts";
+import { OpenRouterDriver } from "./openrouter.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -17,4 +20,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   CodexDriver,
   AntigravityDriver,
   BoxAgentDriver,
+  OpenRouterDriver,
+  OllamaCloudDriver,
+  OpenAIEndpointDriver,
 ];

--- a/server/drivers/ollama-cloud.ts
+++ b/server/drivers/ollama-cloud.ts
@@ -1,0 +1,10 @@
+import { createOpenAIEndpointDriver } from "./openai-compatible.ts";
+
+export const OllamaCloudDriver = createOpenAIEndpointDriver({
+  driverKind: "ollamaCloud",
+  displayName: "Ollama Cloud",
+  defaultUrl: "https://ollama.com/v1",
+  defaultModel: "gpt-oss:120b",
+  apiKeyEnv: "OLLAMA_API_KEY",
+  credentialRequired: true,
+});

--- a/server/drivers/openai-compatible.test.ts
+++ b/server/drivers/openai-compatible.test.ts
@@ -4,8 +4,10 @@ import { recordEvents } from "../testing/events.ts";
 import {
   OpenAICompatibleDriver,
   normalizeBaseUrl,
+  normalizeEndpointPath,
   type OpenAIEndpointConfig,
 } from "./openai-compatible.ts";
+import { OpenRouterDriver } from "./openrouter.ts";
 
 const createInstance = async (
   config: Partial<OpenAIEndpointConfig> = {},
@@ -44,11 +46,18 @@ describe("OpenAI-compatible endpoint validation", () => {
       }).apiKeyEnv,
     ).toBe("OPENAI_COMPATIBLE_API_KEY");
   });
+
+  it("keeps media routes same-origin and relative", () => {
+    expect(normalizeEndpointPath("/images/generations", "/images")).toBe("/images/generations");
+    expect(() => normalizeEndpointPath("https://attacker.example/images", "/images")).toThrow();
+    expect(() => normalizeEndpointPath("//attacker.example/images", "/images")).toThrow();
+    expect(() => normalizeEndpointPath("/images?target=internal", "/images")).toThrow();
+  });
 });
 
 describe("OpenAI-compatible text driver", () => {
   it("discovers models from an endpoint that does not require a key", async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
       new Response(JSON.stringify({ data: [{ id: "qwen2.5-coder" }, { id: "deepseek-r1" }] }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -141,6 +150,151 @@ describe("OpenAI-compatible text driver", () => {
     const instance = await createInstance({ url: "https://models.example/v1", model: "example-chat" });
 
     await expect(instance.generateText!("Hi")).rejects.toThrow(/response limit/i);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    await instance.dispose();
+  });
+});
+
+describe("OpenAI-compatible media generation", () => {
+  it("generates base64 images with an abortable provider request", async () => {
+    const tinyPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: [{ b64_json: tinyPng }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await createInstance({
+      url: "https://models.example/v1",
+      model: "example-chat",
+      modelTasks: { "example-image": "image" },
+    });
+    const controller = new AbortController();
+
+    const generated = await instance.generateMedia!({
+      threadId: "thread-image",
+      task: "image",
+      model: "example-image",
+      prompt: "a copper robot, 16:9",
+      signal: controller.signal,
+    });
+
+    expect(generated).toEqual([
+      expect.objectContaining({ kind: "image", source: { type: "base64", data: tinyPng, mime: "image/png" } }),
+    ]);
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://models.example/v1/images/generations");
+    expect((request as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(String((request as RequestInit).body))).toMatchObject({
+      model: "example-image",
+      prompt: "a copper robot, 16:9",
+      response_format: "b64_json",
+      aspect_ratio: "16:9",
+    });
+    await instance.dispose();
+  });
+
+  it("polls OpenRouter video jobs, forwards 9:16 and duration, and downloads only same-origin content", async () => {
+    const videoBytes = Buffer.from([0, 0, 0, 20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d]);
+    const fetchMock = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/videos")) {
+        return new Response(JSON.stringify({ id: "job-1", polling_url: "https://attacker.example/steal" }), {
+          status: 202,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/videos/job-1")) {
+        return new Response(JSON.stringify({ status: "completed", unsigned_urls: ["http://[::ffff:127.0.0.1]/admin"] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/videos/job-1/content?index=0")) {
+        return new Response(videoBytes, { status: 200, headers: { "content-type": "video/mp4" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await OpenRouterDriver.create({
+      instanceId: "openrouter",
+      displayName: "OpenRouter",
+      environment: { OPENROUTER_API_KEY: "router-secret" },
+      enabled: true,
+      config: OpenRouterDriver.decodeConfig({ model: "google/veo-3.1" }),
+    });
+
+    const generated = await instance.generateMedia!({
+      threadId: "thread-video",
+      task: "video",
+      model: "google/veo-3.1",
+      prompt: "Make a 5 second funny vertical video in 9:16",
+      signal: new AbortController().signal,
+      pollIntervalMs: 0,
+    });
+
+    const submit = fetchMock.mock.calls.find(([url]) => String(url).endsWith("/videos"))?.[1] as RequestInit;
+    expect(JSON.parse(String(submit.body))).toMatchObject({
+      model: "google/veo-3.1",
+      duration: 5,
+      aspect_ratio: "9:16",
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("attacker.example"))).toBe(false);
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("::ffff"))).toBe(false);
+    expect(generated[0]).toMatchObject({
+      kind: "video",
+      providerJobId: "job-1",
+      source: { type: "bytes", mime: "video/mp4" },
+    });
+    await instance.dispose();
+  });
+
+  it("propagates AbortSignal cancellation into media fetches", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        }),
+      ),
+    );
+    const instance = await createInstance({ modelTasks: { "slow-image": "image" } });
+    const controller = new AbortController();
+    const generation = instance.generateMedia!({
+      threadId: "thread-cancel",
+      task: "image",
+      model: "slow-image",
+      prompt: "slow image",
+      signal: controller.signal,
+    });
+
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    await expect(generation).rejects.toMatchObject({ name: "AbortError" });
+    await instance.dispose();
+  });
+
+  it("cancels oversized error response readers", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1_100_000));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 500 })));
+    const instance = await createInstance({ modelTasks: { "bad-image": "image" } });
+
+    await expect(
+      instance.generateMedia!({
+        threadId: "thread-large-error",
+        task: "image",
+        model: "bad-image",
+        prompt: "fail",
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/response limit/i);
     expect(cancel).toHaveBeenCalledTimes(1);
     await instance.dispose();
   });

--- a/server/drivers/openai-compatible.test.ts
+++ b/server/drivers/openai-compatible.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recordEvents } from "../testing/events.ts";
+import {
+  OpenAICompatibleDriver,
+  normalizeBaseUrl,
+  type OpenAIEndpointConfig,
+} from "./openai-compatible.ts";
+
+const createInstance = async (
+  config: Partial<OpenAIEndpointConfig> = {},
+  environment: Record<string, string> = {},
+) =>
+  OpenAICompatibleDriver.create({
+    instanceId: "endpoint",
+    displayName: "Endpoint",
+    environment,
+    enabled: true,
+    config: OpenAICompatibleDriver.decodeConfig(config),
+  });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OpenAI-compatible endpoint validation", () => {
+  it("normalizes an HTTP base URL without changing its path", () => {
+    expect(normalizeBaseUrl("http://127.0.0.1:11434/v1/")).toBe("http://127.0.0.1:11434/v1");
+  });
+
+  it.each([
+    "file:///tmp/provider",
+    "https://user:password@example.com/v1",
+    "https://example.com/v1?token=secret",
+    "https://example.com/v1#models",
+  ])("rejects unsafe or ambiguous base URL %s", (url) => {
+    expect(() => normalizeBaseUrl(url)).toThrow();
+  });
+
+  it("does not let endpoint config select another provider's credential", () => {
+    expect(
+      OpenAICompatibleDriver.decodeConfig({
+        apiKeyEnv: "OPENROUTER_API_KEY",
+      }).apiKeyEnv,
+    ).toBe("OPENAI_COMPATIBLE_API_KEY");
+  });
+});
+
+describe("OpenAI-compatible text driver", () => {
+  it("discovers models from an endpoint that does not require a key", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [{ id: "qwen2.5-coder" }, { id: "deepseek-r1" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await createInstance({ url: "http://192.168.1.20:8000/v1", model: "qwen2.5-coder" });
+
+    await expect(instance.snapshot()).resolves.toMatchObject({ state: "available", authenticated: true });
+    expect(instance.models).toEqual({
+      default: "qwen2.5-coder",
+      options: [
+        { id: "qwen2.5-coder", label: "qwen2.5-coder" },
+        { id: "deepseek-r1", label: "deepseek-r1" },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://192.168.1.20:8000/v1/models",
+      expect.objectContaining({ headers: expect.not.objectContaining({ authorization: expect.anything() }) }),
+    );
+    await instance.dispose();
+  });
+
+  it("streams a chat completion and sends only its configured credential", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hello "}}]}\n\n'));
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"world"}}],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n'));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(body, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const instance = await createInstance(
+      { url: "https://models.example/v1", model: "example-chat" },
+      { OPENAI_COMPATIBLE_API_KEY: "endpoint-secret" },
+    );
+    const events = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "thread-1", text: "Hi" });
+    const completed = await events.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: true });
+    expect(events.events.filter((event) => event.type === "content.delta")).toHaveLength(2);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "hello world" }),
+    );
+    const request = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(request.headers).toMatchObject({ authorization: "Bearer endpoint-secret" });
+    expect(JSON.parse(String(request.body))).toMatchObject({ model: "example-chat", stream: true });
+    events.stop();
+    await instance.dispose();
+  });
+
+  it("cancels the response reader when a streamed API error aborts parsing", async () => {
+    const cancel = vi.fn();
+    const encoder = new TextEncoder();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"error":{"message":"provider exploded"}}\n\n'));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 200 })));
+    const instance = await createInstance({ url: "https://models.example/v1", model: "example-chat" });
+    const events = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "thread-error", text: "Hi" });
+    const completed = await events.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: false, stopReason: "error" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    events.stop();
+    await instance.dispose();
+  });
+
+  it("cancels oversized HTTP error bodies instead of buffering them", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1_100_000));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 500 })));
+    const instance = await createInstance({ url: "https://models.example/v1", model: "example-chat" });
+
+    await expect(instance.generateText!("Hi")).rejects.toThrow(/response limit/i);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    await instance.dispose();
+  });
+});

--- a/server/drivers/openai-compatible.ts
+++ b/server/drivers/openai-compatible.ts
@@ -1,6 +1,9 @@
 import type {
   DriverCreateInput,
+  GeneratedMedia,
+  GenerateMediaInput,
   ModelCatalog,
+  ModelTask,
   ProviderDriver,
   ProviderInstance,
   ProviderSnapshot,
@@ -9,12 +12,16 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { newEventId, newId } from "../contracts.ts";
+import { mediaPromptOptions } from "../media-intent.ts";
 import { appendNative } from "./native.ts";
 
 export interface OpenAIEndpointConfig {
   url: string;
   model: string;
   apiKeyEnv: string;
+  modelTasks: Record<string, ModelTask>;
+  imagePath: string;
+  videoPath: string;
 }
 
 interface EndpointDriverSpec {
@@ -25,6 +32,10 @@ interface EndpointDriverSpec {
   apiKeyEnv: string;
   credentialRequired: boolean;
   headers?: Record<string, string>;
+  imageModelsPath?: string;
+  videoModelsPath?: string;
+  imagePath?: string;
+  videoPath?: string;
 }
 
 type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
@@ -42,6 +53,21 @@ export function normalizeBaseUrl(value: string): string {
   if (parsed.username || parsed.password) throw new Error("url must not contain embedded credentials");
   if (parsed.search || parsed.hash) throw new Error("url must not contain a query string or fragment");
   return parsed.href.replace(/\/+$/, "");
+}
+
+export function normalizeEndpointPath(value: unknown, fallback: string): string {
+  const candidate = typeof value === "string" && value.trim() ? value.trim() : fallback;
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    throw new Error("endpoint path must be a same-origin absolute path");
+  }
+  if (candidate.includes("?") || candidate.includes("#")) {
+    throw new Error("endpoint path must not contain a query string or fragment");
+  }
+  const segments = candidate.split("/");
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("endpoint path must not contain relative segments");
+  }
+  return `/${segments.filter(Boolean).join("/")}`;
 }
 
 function endpointUrl(baseUrl: string, path: string): string {
@@ -91,8 +117,9 @@ async function readResponseBytes(response: Response, limitBytes: number): Promis
   }
 }
 
-async function readJson(response: Response, limitBytes = 4 * 1024 * 1024): Promise<any> {
+async function readJson(response: Response, limitBytes = 2 * 1024 * 1024): Promise<any> {
   const bytes = await readResponseBytes(response, limitBytes);
+  if (!bytes.byteLength) return {};
   try {
     return JSON.parse(new TextDecoder().decode(bytes));
   } catch {
@@ -100,8 +127,23 @@ async function readJson(response: Response, limitBytes = 4 * 1024 * 1024): Promi
   }
 }
 
-async function boundedError(response: Response): Promise<string> {
-  return new TextDecoder().decode(await readResponseBytes(response, 1024 * 1024)).slice(0, 200);
+async function requireOk(response: Response, displayName: string): Promise<void> {
+  if (response.ok) return;
+  const bytes = await readResponseBytes(response, 1024 * 1024);
+  const body = new TextDecoder().decode(bytes).slice(0, 200);
+  throw new Error(`${displayName} HTTP ${response.status}${body ? `: ${body}` : ""}`);
+}
+
+function discoveredTask(entry: Record<string, unknown>): ModelTask | undefined {
+  const output = Array.isArray(entry.output_modalities)
+    ? entry.output_modalities
+    : entry.architecture && typeof entry.architecture === "object" &&
+        Array.isArray((entry.architecture as Record<string, unknown>).output_modalities)
+      ? ((entry.architecture as Record<string, unknown>).output_modalities as unknown[])
+      : [];
+  if (output.some((item) => item === "video")) return "video";
+  if (output.some((item) => item === "image")) return "image";
+  return undefined;
 }
 
 export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDriver<OpenAIEndpointConfig> {
@@ -111,6 +153,16 @@ export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDr
       url: normalizeBaseUrl(typeof value.url === "string" && value.url.trim() ? value.url.trim() : spec.defaultUrl),
       model: typeof value.model === "string" && value.model.trim() ? value.model.trim() : spec.defaultModel,
       apiKeyEnv: spec.apiKeyEnv,
+      modelTasks: value.modelTasks && typeof value.modelTasks === "object"
+        ? Object.fromEntries(
+            Object.entries(value.modelTasks as Record<string, unknown>).filter(
+              (entry): entry is [string, ModelTask] =>
+                Boolean(entry[0].trim()) && (entry[1] === "chat" || entry[1] === "image" || entry[1] === "video"),
+            ),
+          )
+        : {},
+      imagePath: normalizeEndpointPath(value.imagePath, spec.imagePath ?? "/images/generations"),
+      videoPath: normalizeEndpointPath(value.videoPath, spec.videoPath ?? "/videos"),
     };
   };
   const declaredModels: ModelCatalog = {
@@ -158,30 +210,61 @@ export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDr
         }
       };
 
-      const discoverModels = async () => {
-        requireCredential();
-        const response = await fetch(endpointUrl(config.url, "/models"), {
-          method: "GET",
-          headers: headers(),
-          signal: abortSignal(undefined, 15_000),
-        });
-        if (!response.ok) {
-          const body = await boundedError(response);
-          throw new Error(`${spec.displayName} models HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
-        }
-        const payload = (await readJson(response)) as Record<string, unknown>;
+      const parseModels = (payload: Record<string, unknown>, forcedTask?: ModelTask) => {
         const rawModels = Array.isArray(payload.data)
           ? payload.data
           : Array.isArray(payload.models)
             ? payload.models
             : [];
-        const discovered = rawModels.flatMap((entry): Array<{ id: string; label: string }> => {
-          if (typeof entry === "string") return [{ id: entry, label: entry }];
+        return rawModels.flatMap((entry): ModelCatalog["options"] => {
+          if (typeof entry === "string") {
+            const task = config.modelTasks[entry] ?? forcedTask;
+            return [{ id: entry, label: entry, ...(task ? { task } : {}) }];
+          }
           if (!entry || typeof entry !== "object") return [];
           const record = entry as Record<string, unknown>;
           const id = typeof record.id === "string" ? record.id : typeof record.name === "string" ? record.name : "";
-          return id ? [{ id, label: id }] : [];
+          if (!id) return [];
+          const task = config.modelTasks[id] ?? forcedTask ?? discoveredTask(record);
+          const architecture = record.architecture && typeof record.architecture === "object"
+            ? record.architecture as Record<string, unknown>
+            : {};
+          const inputModalities = Array.isArray(record.input_modalities)
+            ? record.input_modalities.filter((item): item is string => typeof item === "string")
+            : Array.isArray(architecture.input_modalities)
+              ? architecture.input_modalities.filter((item): item is string => typeof item === "string")
+              : undefined;
+          const outputModalities = Array.isArray(record.output_modalities)
+            ? record.output_modalities.filter((item): item is string => typeof item === "string")
+            : Array.isArray(architecture.output_modalities)
+              ? architecture.output_modalities.filter((item): item is string => typeof item === "string")
+              : undefined;
+          return [{ id, label: id, ...(task ? { task } : {}), ...(inputModalities ? { inputModalities } : {}), ...(outputModalities ? { outputModalities } : {}) }];
         });
+      };
+
+      const fetchModelCatalog = async (path: string, forcedTask?: ModelTask) => {
+        const response = await fetch(endpointUrl(config.url, path), {
+          method: "GET",
+          headers: headers(),
+          signal: abortSignal(undefined, 15_000),
+        });
+        await requireOk(response, `${spec.displayName} models`);
+        return parseModels(await readJson(response), forcedTask);
+      };
+
+      const discoverModels = async () => {
+        requireCredential();
+        const discovered = await fetchModelCatalog("/models");
+        if (spec.imageModelsPath) {
+          try { discovered.push(...await fetchModelCatalog(spec.imageModelsPath, "image")); } catch {}
+        }
+        if (spec.videoModelsPath) {
+          try { discovered.push(...await fetchModelCatalog(spec.videoModelsPath, "video")); } catch {}
+        }
+        for (const [id, task] of Object.entries(config.modelTasks)) {
+          discovered.push({ id, label: id, task });
+        }
         const unique = [...new Map(discovered.map((entry) => [entry.id, entry])).values()];
         models.options = unique.some((entry) => entry.id === config.model)
           ? unique
@@ -199,12 +282,9 @@ export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDr
           body: JSON.stringify({ model, messages, stream: options.stream }),
           signal: abortSignal(options.signal),
         });
-        if (!response.ok) {
-          const body = await boundedError(response);
-          throw new Error(`${spec.displayName} HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
-        }
+        await requireOk(response, spec.displayName);
         if (!options.stream) {
-          const payload = (await readJson(response)) as any;
+          const payload = (await readJson(response, 4 * 1024 * 1024)) as any;
           const apiError = errorMessage(payload);
           if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
           return {
@@ -269,6 +349,122 @@ export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDr
           reader.releaseLock();
         }
         return { text, usage };
+      };
+
+      const generateImage = async (request: GenerateMediaInput): Promise<GeneratedMedia[]> => {
+        const options = mediaPromptOptions(request.prompt);
+        const response = await fetch(endpointUrl(config.url, config.imagePath), {
+          method: "POST",
+          headers: headers(true),
+          body: JSON.stringify({
+            model: request.model,
+            prompt: request.prompt,
+            response_format: "b64_json",
+            ...(options.aspectRatio ? { aspect_ratio: options.aspectRatio } : {}),
+          }),
+          signal: abortSignal(request.signal, 3 * 60_000),
+        });
+        await requireOk(response, spec.displayName);
+        const payload = await readJson(response, 40 * 1024 * 1024) as Record<string, unknown>;
+        const apiError = errorMessage(payload);
+        if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
+        const data = Array.isArray(payload.data) ? payload.data : [];
+        const generated = data.flatMap((entry): GeneratedMedia[] => {
+          if (!entry || typeof entry !== "object") return [];
+          const record = entry as Record<string, unknown>;
+          const base64 = typeof record.b64_json === "string" ? record.b64_json : "";
+          if (!base64) return [];
+          const mime = typeof record.mime_type === "string" ? record.mime_type : "image/png";
+          return [{ kind: "image", source: { type: "base64", data: base64, mime }, mime }];
+        });
+        if (!generated.length) {
+          throw new Error(`${spec.displayName} did not return embedded image data`);
+        }
+        return generated;
+      };
+
+      const abortablePause = (milliseconds: number, signal: AbortSignal) =>
+        new Promise<void>((resolve, reject) => {
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          const timer = setTimeout(resolve, milliseconds);
+          timer.unref?.();
+          signal.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(signal.reason);
+          }, { once: true });
+        });
+
+      const generateVideo = async (request: GenerateMediaInput): Promise<GeneratedMedia[]> => {
+        const options = mediaPromptOptions(request.prompt);
+        const submit = await fetch(endpointUrl(config.url, config.videoPath), {
+          method: "POST",
+          headers: headers(true),
+          body: JSON.stringify({
+            model: request.model,
+            prompt: request.prompt,
+            ...(options.aspectRatio ? { aspect_ratio: options.aspectRatio } : {}),
+            ...(options.durationSeconds ? { duration: options.durationSeconds } : {}),
+          }),
+          signal: abortSignal(request.signal, 60_000),
+        });
+        await requireOk(submit, spec.displayName);
+        const submitted = await readJson(submit) as Record<string, unknown>;
+        const jobId = typeof submitted.id === "string"
+          ? submitted.id
+          : typeof submitted.job_id === "string"
+            ? submitted.job_id
+            : "";
+        if (!jobId) throw new Error(`${spec.displayName} did not return a video job id`);
+        request.onProgress?.({ providerJobId: jobId });
+        const statusPath = `${config.videoPath}/${encodeURIComponent(jobId)}`;
+        const interval = Math.max(0, request.pollIntervalMs ?? 2_000);
+
+        for (;;) {
+          if (interval) await abortablePause(interval, request.signal);
+          const statusResponse = await fetch(endpointUrl(config.url, statusPath), {
+            method: "GET",
+            headers: headers(),
+            signal: abortSignal(request.signal, 30_000),
+          });
+          await requireOk(statusResponse, spec.displayName);
+          const statusPayload = await readJson(statusResponse) as Record<string, unknown>;
+          const status = String(statusPayload.status ?? "").toLowerCase();
+          const progress = Number(statusPayload.progress);
+          request.onProgress?.({
+            providerJobId: jobId,
+            ...(Number.isFinite(progress) ? { progress: Math.max(0, Math.min(1, progress > 1 ? progress / 100 : progress)) } : {}),
+          });
+          if (["failed", "error", "cancelled", "canceled"].includes(status)) {
+            throw new Error(`${spec.displayName} video generation ${status}`);
+          }
+          if (["completed", "complete", "succeeded", "ready"].includes(status)) break;
+        }
+
+        const content = await fetch(endpointUrl(config.url, `${statusPath}/content?index=0`), {
+          method: "GET",
+          headers: headers(),
+          signal: abortSignal(request.signal, 3 * 60_000),
+        });
+        await requireOk(content, spec.displayName);
+        const mime = content.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() || "video/mp4";
+        const bytes = await readResponseBytes(content, 512 * 1024 * 1024);
+        if (!bytes.byteLength) throw new Error(`${spec.displayName} returned an empty video`);
+        return [{
+          kind: "video",
+          source: { type: "bytes", data: bytes, mime },
+          mime,
+          providerJobId: jobId,
+          ...(options.durationSeconds ? { durationSeconds: options.durationSeconds } : {}),
+        }];
+      };
+
+      const generateMedia = async (request: GenerateMediaInput): Promise<GeneratedMedia[]> => {
+        requireCredential();
+        request.signal.throwIfAborted();
+        return request.task === "image" ? generateImage(request) : generateVideo(request);
       };
 
       const sendTurn = async (turn: SendTurnInput) => {
@@ -400,6 +596,7 @@ export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDr
           });
           return result.text;
         },
+        generateMedia,
         dispose: async () => {
           for (const { abort } of active.values()) abort.abort();
           active.clear();

--- a/server/drivers/openai-compatible.ts
+++ b/server/drivers/openai-compatible.ts
@@ -1,0 +1,420 @@
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+export interface OpenAIEndpointConfig {
+  url: string;
+  model: string;
+  apiKeyEnv: string;
+}
+
+interface EndpointDriverSpec {
+  driverKind: string;
+  displayName: string;
+  defaultUrl: string;
+  defaultModel: string;
+  apiKeyEnv: string;
+  credentialRequired: boolean;
+  headers?: Record<string, string>;
+}
+
+type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
+
+export function normalizeBaseUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("url must be an absolute HTTP or HTTPS URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("url must use HTTP or HTTPS");
+  }
+  if (parsed.username || parsed.password) throw new Error("url must not contain embedded credentials");
+  if (parsed.search || parsed.hash) throw new Error("url must not contain a query string or fragment");
+  return parsed.href.replace(/\/+$/, "");
+}
+
+function endpointUrl(baseUrl: string, path: string): string {
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function errorMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const error = (value as { error?: unknown }).error;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && typeof (error as { message?: unknown }).message === "string") {
+    return (error as { message: string }).message;
+  }
+  return null;
+}
+
+function abortSignal(signal?: AbortSignal, timeoutMs = 120_000): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+async function readResponseBytes(response: Response, limitBytes: number): Promise<Uint8Array> {
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > limitBytes) throw new Error(`provider response exceeded the ${limitBytes} byte response limit`);
+      chunks.push(value);
+    }
+    const output = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readJson(response: Response, limitBytes = 4 * 1024 * 1024): Promise<any> {
+  const bytes = await readResponseBytes(response, limitBytes);
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new Error("provider returned invalid JSON");
+  }
+}
+
+async function boundedError(response: Response): Promise<string> {
+  return new TextDecoder().decode(await readResponseBytes(response, 1024 * 1024)).slice(0, 200);
+}
+
+export function createOpenAIEndpointDriver(spec: EndpointDriverSpec): ProviderDriver<OpenAIEndpointConfig> {
+  const decodeConfig = (raw: unknown): OpenAIEndpointConfig => {
+    const value = (raw ?? {}) as Record<string, unknown>;
+    return {
+      url: normalizeBaseUrl(typeof value.url === "string" && value.url.trim() ? value.url.trim() : spec.defaultUrl),
+      model: typeof value.model === "string" && value.model.trim() ? value.model.trim() : spec.defaultModel,
+      apiKeyEnv: spec.apiKeyEnv,
+    };
+  };
+  const declaredModels: ModelCatalog = {
+    default: spec.defaultModel,
+    options: [{ id: spec.defaultModel, label: spec.defaultModel }],
+  };
+
+  return {
+    driverKind: spec.driverKind,
+    metadata: { displayName: spec.displayName, supportsMultipleInstances: true },
+    models: declaredModels,
+    decodeConfig,
+    defaultConfig: () => decodeConfig({}),
+
+    async create(input: DriverCreateInput<OpenAIEndpointConfig>): Promise<ProviderInstance> {
+      const { instanceId, config } = input;
+      const apiKey = input.environment[config.apiKeyEnv] ?? "";
+      const listeners = new Set<RuntimeEventListener>();
+      const active = new Map<string, { abort: AbortController; turnId: string }>();
+      const models: ModelCatalog = {
+        default: config.model,
+        options: [{ id: config.model, label: config.model }],
+      };
+
+      const emit = (event: RuntimeEvent) => {
+        for (const listener of [...listeners]) listener(event);
+      };
+      const base = (threadId: string, turnId: string) => ({
+        eventId: newEventId(),
+        provider: spec.driverKind,
+        providerInstanceId: instanceId,
+        threadId,
+        turnId,
+        createdAt: new Date().toISOString(),
+      });
+      const headers = (json = false): Record<string, string> => ({
+        accept: "application/json",
+        ...(json ? { "content-type": "application/json" } : {}),
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+        ...spec.headers,
+      });
+      const requireCredential = () => {
+        if (spec.credentialRequired && !apiKey) {
+          throw new Error(`${spec.displayName} needs ${config.apiKeyEnv}`);
+        }
+      };
+
+      const discoverModels = async () => {
+        requireCredential();
+        const response = await fetch(endpointUrl(config.url, "/models"), {
+          method: "GET",
+          headers: headers(),
+          signal: abortSignal(undefined, 15_000),
+        });
+        if (!response.ok) {
+          const body = await boundedError(response);
+          throw new Error(`${spec.displayName} models HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+        }
+        const payload = (await readJson(response)) as Record<string, unknown>;
+        const rawModels = Array.isArray(payload.data)
+          ? payload.data
+          : Array.isArray(payload.models)
+            ? payload.models
+            : [];
+        const discovered = rawModels.flatMap((entry): Array<{ id: string; label: string }> => {
+          if (typeof entry === "string") return [{ id: entry, label: entry }];
+          if (!entry || typeof entry !== "object") return [];
+          const record = entry as Record<string, unknown>;
+          const id = typeof record.id === "string" ? record.id : typeof record.name === "string" ? record.name : "";
+          return id ? [{ id, label: id }] : [];
+        });
+        const unique = [...new Map(discovered.map((entry) => [entry.id, entry])).values()];
+        models.options = unique.some((entry) => entry.id === config.model)
+          ? unique
+          : [{ id: config.model, label: config.model }, ...unique];
+      };
+
+      const complete = async (
+        messages: ChatMessage[],
+        model: string,
+        options: { stream: boolean; signal?: AbortSignal; onDelta?: (delta: string) => void },
+      ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+        const response = await fetch(endpointUrl(config.url, "/chat/completions"), {
+          method: "POST",
+          headers: headers(true),
+          body: JSON.stringify({ model, messages, stream: options.stream }),
+          signal: abortSignal(options.signal),
+        });
+        if (!response.ok) {
+          const body = await boundedError(response);
+          throw new Error(`${spec.displayName} HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+        }
+        if (!options.stream) {
+          const payload = (await readJson(response)) as any;
+          const apiError = errorMessage(payload);
+          if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
+          return {
+            text: String(payload.choices?.[0]?.message?.content ?? ""),
+            usage: payload.usage
+              ? {
+                  input: Number(payload.usage.prompt_tokens ?? 0),
+                  output: Number(payload.usage.completion_tokens ?? 0),
+                }
+              : null,
+          };
+        }
+        if (!response.body) throw new Error(`${spec.displayName} returned an empty stream`);
+
+        let text = "";
+        let usage: { input: number; output: number } | null = null;
+        const parseLine = (rawLine: string) => {
+          const line = rawLine.trim();
+          if (!line.startsWith("data:")) return;
+          const data = line.slice(5).trim();
+          if (!data || data === "[DONE]") return;
+          const payload = JSON.parse(data) as any;
+          const apiError = errorMessage(payload);
+          if (apiError) throw new Error(`${spec.displayName}: ${apiError}`);
+          const delta = payload.choices?.[0]?.delta?.content;
+          if (typeof delta === "string" && delta) {
+            text += delta;
+            options.onDelta?.(delta);
+          }
+          if (payload.usage) {
+            usage = {
+              input: Number(payload.usage.prompt_tokens ?? 0),
+              output: Number(payload.usage.completion_tokens ?? 0),
+            };
+          }
+        };
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let received = 0;
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.byteLength;
+            if (received > 32 * 1024 * 1024) throw new Error("provider stream exceeded the response limit");
+            buffer += decoder.decode(value, { stream: true });
+            let newline = buffer.indexOf("\n");
+            while (newline !== -1) {
+              parseLine(buffer.slice(0, newline));
+              buffer = buffer.slice(newline + 1);
+              newline = buffer.indexOf("\n");
+            }
+          }
+          buffer += decoder.decode();
+          if (buffer.trim()) parseLine(buffer);
+        } catch (error) {
+          await reader.cancel().catch(() => {});
+          throw error;
+        } finally {
+          reader.releaseLock();
+        }
+        return { text, usage };
+      };
+
+      const sendTurn = async (turn: SendTurnInput) => {
+        requireCredential();
+        if (active.has(turn.threadId)) throw new Error("a turn is already running on this thread");
+        const turnId = newId();
+        const abort = new AbortController();
+        active.set(turn.threadId, { abort, turnId });
+        const model = turn.model || models.default;
+        const messages: ChatMessage[] = [
+          ...(turn.system ? [{ role: "system" as const, content: turn.system }] : []),
+          ...(turn.transcript ?? []).map((message) => ({
+            role: message.role === "assistant" ? ("assistant" as const) : ("user" as const),
+            content: message.text,
+          })),
+          { role: "user", content: turn.text },
+        ];
+        appendNative(turn.threadId, {
+          dir: "out",
+          source: `${spec.driverKind}.chat.completions`,
+          msg: { model, messages },
+        });
+        emit({ ...base(turn.threadId, turnId), type: "turn.started" });
+        emit({ ...base(turn.threadId, turnId), type: "session.started", sessionId: null, model });
+
+        void (async () => {
+          try {
+            const result = await complete(messages, model, {
+              stream: true,
+              signal: abort.signal,
+              onDelta: (delta) =>
+                emit({
+                  ...base(turn.threadId, turnId),
+                  type: "content.delta",
+                  streamKind: "assistant_text",
+                  delta,
+                }),
+            });
+            appendNative(turn.threadId, {
+              dir: "in",
+              source: `${spec.driverKind}.chat.completions`,
+              msg: result,
+            });
+            if (result.text.trim()) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "item.completed",
+                itemType: "assistant_text",
+                text: result.text,
+              });
+            }
+            if (result.usage) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "thread.token-usage.updated",
+                input: result.usage.input,
+                output: result.usage.output,
+              });
+            }
+            active.delete(turn.threadId);
+            emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
+          } catch (error) {
+            active.delete(turn.threadId);
+            const aborted = abort.signal.aborted || (error as Error).name === "AbortError";
+            if (!aborted) {
+              emit({
+                ...base(turn.threadId, turnId),
+                type: "runtime.error",
+                message: error instanceof Error ? error.message : String(error),
+              });
+            }
+            emit({
+              ...base(turn.threadId, turnId),
+              type: "turn.completed",
+              ok: false,
+              stopReason: aborted ? "interrupted" : "error",
+              cost: null,
+            });
+          }
+        })();
+        return { turnId };
+      };
+
+      const snapshot = async (): Promise<ProviderSnapshot> => {
+        if (!input.enabled) return { state: "unavailable", reason: `${spec.displayName} is disabled` };
+        if (spec.credentialRequired && !apiKey) {
+          return { state: "unavailable", reason: `${spec.displayName} needs ${config.apiKeyEnv}` };
+        }
+        try {
+          await discoverModels();
+          return { state: "available", authenticated: true, version: null };
+        } catch (error) {
+          return {
+            state: "unavailable",
+            authenticated: Boolean(apiKey) || !spec.credentialRequired,
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
+      };
+
+      return {
+        instanceId,
+        driverKind: spec.driverKind,
+        displayName: input.displayName,
+        enabled: input.enabled,
+        models,
+        snapshot,
+        adapter: {
+          provider: spec.driverKind,
+          capabilities: { sessionModelSwitch: "in-session" },
+          sendTurn,
+          interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+          respondToRequest: async () => {
+            throw new Error(`${spec.displayName} has no pending requests`);
+          },
+          hasSession: (threadId) => active.has(threadId),
+          stopAll: async () => {
+            for (const { abort } of active.values()) abort.abort();
+          },
+          onEvent: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+          },
+        },
+        generateText: async (prompt) => {
+          requireCredential();
+          const result = await complete([{ role: "user", content: prompt }], models.default, {
+            stream: false,
+          });
+          return result.text;
+        },
+        dispose: async () => {
+          for (const { abort } of active.values()) abort.abort();
+          active.clear();
+          listeners.clear();
+        },
+      };
+    },
+  };
+}
+
+export const OpenAICompatibleDriver = createOpenAIEndpointDriver({
+  driverKind: "openaiCompatible",
+  displayName: "OpenAI-compatible",
+  defaultUrl: "http://127.0.0.1:11434/v1",
+  defaultModel: "llama3.2",
+  apiKeyEnv: "OPENAI_COMPATIBLE_API_KEY",
+  credentialRequired: false,
+});

--- a/server/drivers/openai-endpoint.ts
+++ b/server/drivers/openai-endpoint.ts
@@ -1,0 +1,1 @@
+export { OpenAICompatibleDriver as OpenAIEndpointDriver } from "./openai-compatible.ts";

--- a/server/drivers/openrouter.ts
+++ b/server/drivers/openrouter.ts
@@ -1,0 +1,14 @@
+import { createOpenAIEndpointDriver } from "./openai-compatible.ts";
+
+export const OpenRouterDriver = createOpenAIEndpointDriver({
+  driverKind: "openrouter",
+  displayName: "OpenRouter",
+  defaultUrl: "https://openrouter.ai/api/v1",
+  defaultModel: "openrouter/auto",
+  apiKeyEnv: "OPENROUTER_API_KEY",
+  credentialRequired: true,
+  headers: {
+    "HTTP-Referer": "https://github.com/milind-soni/OpenMausBot",
+    "X-OpenRouter-Title": "OpenMausBot",
+  },
+});

--- a/server/drivers/openrouter.ts
+++ b/server/drivers/openrouter.ts
@@ -7,6 +7,10 @@ export const OpenRouterDriver = createOpenAIEndpointDriver({
   defaultModel: "openrouter/auto",
   apiKeyEnv: "OPENROUTER_API_KEY",
   credentialRequired: true,
+  imageModelsPath: "/images/models",
+  videoModelsPath: "/videos/models",
+  imagePath: "/images",
+  videoPath: "/videos",
   headers: {
     "HTTP-Referer": "https://github.com/milind-soni/OpenMausBot",
     "X-OpenRouter-Title": "OpenMausBot",

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -268,6 +268,54 @@ describe("harness HTTP API", () => {
     expect(nothing.status).toBe(400);
   });
 
+  it("persists provider settings without echoing credentials", async () => {
+    const before = await api("GET", "/api/config");
+    expect(before.body).toMatchObject({
+      openrouter: { configured: false },
+      ollamaCloud: { configured: false },
+      openaiCompatible: {
+        apiKeyConfigured: false,
+        url: "http://127.0.0.1:11434/v1",
+        model: "llama3.2",
+      },
+    });
+
+    const saved = await api("PUT", "/api/config", {
+      openrouter: { key: "router-secret" },
+      ollamaCloud: { key: "ollama-secret" },
+      openaiCompatible: {
+        key: "endpoint-secret",
+        url: "http://192.168.1.25:8000/v1",
+        model: "qwen2.5-coder",
+      },
+    });
+
+    expect(saved.status).toBe(200);
+    expect(saved.body).toMatchObject({
+      openrouter: { configured: true },
+      ollamaCloud: { configured: true },
+      openaiCompatible: {
+        apiKeyConfigured: true,
+        url: "http://192.168.1.25:8000/v1",
+        model: "qwen2.5-coder",
+      },
+    });
+    expect(JSON.stringify(saved.body)).not.toMatch(/router-secret|ollama-secret|endpoint-secret/);
+  });
+
+  it("rejects an invalid endpoint before persisting it", async () => {
+    const previous = await api("GET", "/api/config");
+    const persistedUrl = previous.body.openaiCompatible.url;
+    const rejected = await api("PUT", "/api/config", {
+      openaiCompatible: { url: "https://models.example/v1?credential=leak", model: "bad" },
+    });
+
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toContain("query string or fragment");
+    const after = await api("GET", "/api/config");
+    expect(after.body.openaiCompatible.url).toBe(persistedUrl);
+  });
+
   it("stores and echoes the user profile (not write-only, unlike keys)", async () => {
     const put = await api("PUT", "/api/config", { profile: { name: "Ada Lovelace", email: "Ada@Example.com" } });
     expect(put.status).toBe(200);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -170,6 +170,12 @@ describe("harness HTTP API", () => {
     expect(body.bots[0].messages.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("exposes a focused generations index without unrelated transcript messages", async () => {
+    const { status, body } = await api("GET", "/api/generations");
+    expect(status).toBe(200);
+    expect(body).toEqual({ sources: [] });
+  });
+
   it("describes the configured fleet, shadows included", async () => {
     const { status, body } = await api("GET", "/api/instances");
     expect(status).toBe(200);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -124,6 +124,25 @@ describe("harness HTTP API", () => {
     expect(unknownApi.body.error).toContain("/api/not-a-real-route");
   });
 
+  it("serves validated cached media with byte ranges", async () => {
+    const cacheKey = "11111111-1111-4111-8111-111111111111.png";
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      "base64",
+    );
+    writeFileSync(join(home, ".openmausbot", "media", "objects", cacheKey), png);
+
+    const full = await fetch(`${BASE}/api/media/${cacheKey}`);
+    expect(full.status).toBe(200);
+    expect(full.headers.get("content-type")).toBe("image/png");
+    expect(Buffer.from(await full.arrayBuffer())).toEqual(png);
+
+    const partial = await fetch(`${BASE}/api/media/${cacheKey}`, { headers: { range: "bytes=0-7" } });
+    expect(partial.status).toBe(206);
+    expect(partial.headers.get("content-range")).toBe(`bytes 0-7/${png.length}`);
+    expect(Buffer.from(await partial.arrayBuffer())).toEqual(png.subarray(0, 8));
+  });
+
   it("rejects malformed and oversized JSON bodies without hanging", async () => {
     const malformed = await fetch(`${BASE}/api/config`, {
       method: "PUT",
@@ -169,9 +188,10 @@ describe("harness HTTP API", () => {
     expect(created.status).toBe(201);
     const bot = created.body.bot;
 
-    const patched = await api("PATCH", `/api/bots/${bot.id}`, { name: "Renamed", pinned: true });
+    const specialists = { image: { instanceId: "ghost", model: "image-model" } };
+    const patched = await api("PATCH", `/api/bots/${bot.id}`, { name: "Renamed", pinned: true, specialists });
     expect(patched.status).toBe(200);
-    expect(patched.body.bot).toMatchObject({ name: "Renamed", pinned: true });
+    expect(patched.body.bot).toMatchObject({ name: "Renamed", pinned: true, specialists });
 
     const missing = await api("PATCH", "/api/bots/does-not-exist", { name: "x" });
     expect(missing.status).toBe(404);

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,10 +11,19 @@ import { approvalKey, autoDecision } from "./auto-approve.ts";
 import * as box from "./box.ts";
 import * as composio from "./composio.ts";
 import { containerComputerStatus, setupCommands } from "./container-computer.ts";
-import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
+import {
+  ensureDirs,
+  instanceConfigs,
+  loadConfig,
+  saveConfig,
+  EVENTS_DIR,
+  NATIVE_DIR,
+  type AppConfig,
+} from "./config.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
+import { normalizeBaseUrl } from "./drivers/openai-compatible.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { mentionedBots, Store, type Message } from "./store.ts";
@@ -787,6 +796,13 @@ function startGroupTurn(groupId: string, text: string) {
 function configStatus() {
   return {
     xai: { configured: Boolean(cfg.xai?.key) },
+    openrouter: { configured: Boolean(cfg.openrouter?.key) },
+    ollamaCloud: { configured: Boolean(cfg.ollamaCloud?.key) },
+    openaiCompatible: {
+      apiKeyConfigured: Boolean(cfg.openaiCompatible?.key),
+      url: cfg.openaiCompatible?.url ?? "http://127.0.0.1:11434/v1",
+      model: cfg.openaiCompatible?.model ?? "llama3.2",
+    },
     composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
     box: { configured: Boolean(cfg.box?.token) },
     // the chosen voice is a setting, not a secret; the key is reported the
@@ -1354,11 +1370,31 @@ const server = createServer(async (req, res) => {
     }
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
-      const patch: Record<string, object> = {};
-      for (const key of ["xai", "composio", "box", "tts", "profile"] as const) {
+      const patch: Partial<AppConfig> = {};
+      for (const key of [
+        "xai",
+        "openrouter",
+        "ollamaCloud",
+        "openaiCompatible",
+        "composio",
+        "box",
+        "tts",
+        "profile",
+      ] as const) {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });
+      for (const key of ["openrouter", "ollamaCloud", "openaiCompatible"] as const) {
+        const provider = patch[key];
+        if (provider?.url !== undefined) {
+          if (typeof provider.url !== "string") return json(res, 400, { error: `${key}.url must be a string` });
+          try {
+            provider.url = normalizeBaseUrl(provider.url);
+          } catch (error) {
+            return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
+        }
+      }
       // check a box token against the provider before storing it: a
       // rejected token used to save happily and only surface as a 401 in
       // another panel later, with nothing the user could act on

--- a/server/index.ts
+++ b/server/index.ts
@@ -140,6 +140,38 @@ const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
   tasks: store.tasks(bot.id).map(({ resumeCursors, ...task }) => task),
 });
 
+const HTML_FENCE = /^\s{0,3}(?:`{3,}|~{3,})\s*(?:html|htm|html_preview)\b/im;
+const generationMessages = (threadId: string) =>
+  store.messagesFor(threadId).filter((message) =>
+    message.kind === "media" ||
+    (message.role === "bot" && message.kind === "text" && Boolean(message.text && HTML_FENCE.test(message.text))),
+  );
+
+function generationSources() {
+  return [
+    ...store.bots.flatMap((bot) => store.tasks(bot.id).flatMap((task) => {
+      const messages = generationMessages(task.threadId);
+      return messages.length ? [{
+        ownerId: bot.id,
+        ownerName: bot.name,
+        contextTitle: task.title,
+        threadId: task.threadId,
+        messages,
+      }] : [];
+    })),
+    ...store.groups.flatMap((group) => {
+      const messages = generationMessages(group.threadId);
+      return messages.length ? [{
+        ownerId: group.id,
+        ownerName: group.name,
+        contextTitle: group.name,
+        threadId: group.threadId,
+        messages,
+      }] : [];
+    }),
+  ];
+}
+
 // ── SSE fan-out to clients ─────────────────────────────────────────────
 const sseClients = new Set<ServerResponse>();
 function broadcast(payload: unknown) {
@@ -1151,6 +1183,9 @@ const server = createServer(async (req, res) => {
         bots: store.bots.map(publicBot),
         groups: store.groups.map((g) => ({ ...g, messages: store.messagesFor(g.threadId) })),
       });
+    }
+    if (method === "GET" && path === "/api/generations") {
+      return json(res, 200, { sources: generationSources() });
     }
 
     // ── rooms (group chats) ─────────────────────────────────────────────

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@
 // (upstream rule): the React app dispatches typed commands over HTTP and
 // folds one SSE event stream; every provider process runs here.
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { createReadStream, existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,20 +16,24 @@ import {
   instanceConfigs,
   loadConfig,
   saveConfig,
+  DATA_DIR,
   EVENTS_DIR,
   NATIVE_DIR,
   type AppConfig,
 } from "./config.ts";
-import type { RuntimeEvent } from "./contracts.ts";
+import { newId, type RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
-import { normalizeBaseUrl } from "./drivers/openai-compatible.ts";
+import { normalizeBaseUrl, normalizeEndpointPath } from "./drivers/openai-compatible.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { mentionedBots, Store, type Message } from "./store.ts";
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { createMediaCache, parseRange } from "./media-cache.ts";
+import { detectMediaIntent } from "./media-intent.ts";
+import { MediaRunCoordinator } from "./media-runs.ts";
 import { RoutineManager, type RoutineRunOn } from "./routines.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
@@ -126,6 +130,8 @@ let bootSelection = { instanceId: "claude", model: "claude-sonnet-5" };
 const store = new Store(() => bootSelection);
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
+const mediaCache = createMediaCache({ rootDir: join(DATA_DIR, "media") });
+const mediaRuns = new MediaRunCoordinator();
 
 const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
   ...bot,
@@ -438,6 +444,81 @@ async function startTurn(
   const commsDepth = opts?.commsDepth ?? 0;
   // a task takes its name from the first thing you asked it to do
   if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text, threadId);
+
+  const mediaTask = !opts?.runOn ? detectMediaIntent(text) : null;
+  const specialist = mediaTask ? bot.specialists?.[mediaTask] : undefined;
+  if (mediaTask && specialist) {
+    const instance = registry.get(specialist.instanceId);
+    if (!instance?.generateMedia) {
+      throw Object.assign(new Error(`the selected ${mediaTask} specialist is unavailable`), { status: 409 });
+    }
+    let userMessage = opts?.userMessage;
+    if (!userMessage) {
+      userMessage = store.appendMessage(threadId, { role: "user", kind: "text", text });
+      broadcast({ kind: "message", threadId, message: userMessage });
+    }
+    const outputId = newId();
+    const message = store.appendMessage(threadId, {
+      role: "bot",
+      kind: "media",
+      media: [{ id: outputId, kind: mediaTask, status: "queued" }],
+    });
+    store.patchBot(bot.id, { busy: true, unread: false });
+    broadcast({ kind: "message", threadId, message });
+    broadcast({ kind: "bot", bot: store.bot(bot.id) });
+    mediaRuns.start({
+      botId: bot.id,
+      threadId,
+      messageId: message.id,
+      outputId,
+      task: mediaTask,
+      onPatch: (patch) => {
+        const updated = store.patchMediaOutput(
+          threadId,
+          message.id,
+          outputId,
+          ["queued", "generating", "downloading"],
+          patch,
+        );
+        if (updated) broadcast({ kind: "message.patch", threadId, message: updated });
+      },
+      execute: async (signal, onProgress) => {
+        const generated = await instance.generateMedia!({
+          threadId,
+          task: mediaTask,
+          model: specialist.model,
+          prompt: text,
+          signal,
+          onProgress,
+        });
+        const first = generated.find((item) => item.kind === mediaTask);
+        if (!first) throw new Error(`${instance.displayName} returned no ${mediaTask}`);
+        const downloading = store.patchMediaOutput(
+          threadId,
+          message.id,
+          outputId,
+          ["queued", "generating"],
+          { status: "downloading", providerJobId: first.providerJobId },
+        );
+        if (downloading) broadcast({ kind: "message.patch", threadId, message: downloading });
+        const cached = await mediaCache.store(first.source, { kind: mediaTask, signal });
+        return {
+          ...cached,
+          width: first.width,
+          height: first.height,
+          durationSeconds: first.durationSeconds,
+          providerJobId: first.providerJobId,
+        };
+      },
+      onDone: () => {
+        const current = store.bot(bot.id);
+        if (!current) return;
+        store.patchBot(bot.id, { busy: false });
+        broadcast({ kind: "bot", bot: store.bot(bot.id) });
+      },
+    });
+    return;
+  }
 
   const instance = opts?.runOn === "cloud"
     ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
@@ -802,6 +883,9 @@ function configStatus() {
       apiKeyConfigured: Boolean(cfg.openaiCompatible?.key),
       url: cfg.openaiCompatible?.url ?? "http://127.0.0.1:11434/v1",
       model: cfg.openaiCompatible?.model ?? "llama3.2",
+      modelTasks: cfg.openaiCompatible?.modelTasks ?? {},
+      imagePath: cfg.openaiCompatible?.imagePath ?? "/images/generations",
+      videoPath: cfg.openaiCompatible?.videoPath ?? "/videos",
     },
     composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
     box: { configured: Boolean(cfg.box?.token) },
@@ -816,6 +900,7 @@ function configStatus() {
 /** Rebuild the provider fleet after a config change so new keys take
  * effect without a server restart (kills any in-flight turns). */
 async function reloadProviders() {
+  mediaRuns.cancelAll();
   bus.detachAll();
   await registry.disposeAll();
   await registry.load(instanceConfigs(cfg));
@@ -885,6 +970,28 @@ const server = createServer(async (req, res) => {
   const path = url.pathname;
   const method = req.method ?? "GET";
   try {
+    const mediaMatch = path.match(/^\/api\/media\/([\w.-]+)$/);
+    if (mediaMatch && method === "GET") {
+      const media = mediaCache.resolve(mediaMatch[1]);
+      if (!media) return json(res, 404, { error: "no such media" });
+      const requestedRange = typeof req.headers.range === "string" ? req.headers.range : undefined;
+      const range = parseRange(requestedRange, media.bytes);
+      if (requestedRange && !range) {
+        res.writeHead(416, { "content-range": `bytes */${media.bytes}` });
+        return res.end();
+      }
+      const start = range?.start ?? 0;
+      const end = range?.end ?? media.bytes - 1;
+      res.writeHead(range ? 206 : 200, {
+        "content-type": media.mime,
+        "content-length": String(end - start + 1),
+        "accept-ranges": "bytes",
+        "cache-control": "private, max-age=31536000, immutable",
+        ...(range ? { "content-range": `bytes ${start}-${end}/${media.bytes}` } : {}),
+      });
+      return createReadStream(media.path, { start, end }).pipe(res);
+    }
+
     // ── internal peer-agent comms (localhost + shared token only) ──────
     // The agents-proxy (spawned inside a bot's agent process) calls these to
     // discover peers and hand a message to one. Not part of the public API.
@@ -1135,7 +1242,7 @@ const server = createServer(async (req, res) => {
     if (m && method === "PATCH") {
       const body = await readBody(req);
       const patch: Record<string, unknown> = {};
-      for (const key of ["name", "title", "description", "notifications", "modelSelection", "unread", "computer", "color", "mascotExpression", "pinned", "hidden", "speakReplies", "voice"] as const) {
+      for (const key of ["name", "title", "description", "notifications", "modelSelection", "specialists", "unread", "computer", "color", "mascotExpression", "pinned", "hidden", "speakReplies", "voice"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
       }
       // the two permission fields decide what runs unattended, so they are
@@ -1161,6 +1268,7 @@ const server = createServer(async (req, res) => {
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
       // a running turn dies with its bot
+      mediaRuns.cancel(bot.id);
       await registry.get(bot.modelSelection.instanceId)?.adapter.interruptTurn(bot.threadId).catch(() => {});
       stopScreenPoller(bot.id);
       routines!.disableForBot(bot.id);
@@ -1289,9 +1397,18 @@ const server = createServer(async (req, res) => {
         await routines!.cancelRun(routineRun.id);
         return json(res, 200, { ok: true });
       }
+      if (mediaRuns.cancel(bot.id)) return json(res, 200, { ok: true });
       const instance = registry.get(bot.modelSelection.instanceId);
       await instance?.adapter.interruptTurn(bot.threadId);
       return json(res, 200, { ok: true });
+    }
+    m = path.match(/^\/api\/bots\/([\w-]+)\/messages\/([\w-]+)\/cancel-media$/);
+    if (m && method === "POST") {
+      const bot = store.bot(m[1]);
+      if (!bot) return json(res, 404, { error: "no such bot" });
+      return mediaRuns.cancel(bot.id, m[2])
+        ? json(res, 200, { ok: true })
+        : json(res, 409, { error: "that generation is no longer running" });
     }
 
     // ── tasks: a bot's separate contexts ────────────────────────────────
@@ -1393,6 +1510,28 @@ const server = createServer(async (req, res) => {
           } catch (error) {
             return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
           }
+        }
+      }
+      if (patch.openaiCompatible) {
+        for (const key of ["imagePath", "videoPath"] as const) {
+          const value = patch.openaiCompatible[key];
+          if (value !== undefined) {
+            try {
+              patch.openaiCompatible[key] = normalizeEndpointPath(value, key === "imagePath" ? "/images/generations" : "/videos");
+            } catch (error) {
+              return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+            }
+          }
+        }
+        if (patch.openaiCompatible.modelTasks !== undefined) {
+          if (!patch.openaiCompatible.modelTasks || typeof patch.openaiCompatible.modelTasks !== "object" || Array.isArray(patch.openaiCompatible.modelTasks)) {
+            return json(res, 400, { error: "openaiCompatible.modelTasks must be an object" });
+          }
+          const modelTasks = Object.entries(patch.openaiCompatible.modelTasks);
+          if (modelTasks.some(([model, task]) => !model.trim() || !["chat", "image", "video"].includes(String(task)))) {
+            return json(res, 400, { error: "openaiCompatible.modelTasks contains an invalid model or task" });
+          }
+          patch.openaiCompatible.modelTasks = Object.fromEntries(modelTasks);
         }
       }
       // check a box token against the provider before storing it: a

--- a/server/media-api.test.ts
+++ b/server/media-api.test.ts
@@ -1,0 +1,145 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const PORT = 28800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+describe("media generation HTTP lifecycle", () => {
+  let child: ChildProcess;
+  let provider: Server;
+  let providerPort = 0;
+  let home: string;
+  let stderr = "";
+  const pendingPolls = new Set<ServerResponse>();
+
+  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+    const response = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: response.status, body: await response.json() };
+  };
+  const getBot = async (id: string) =>
+    (await api("GET", "/api/bots")).body.bots.find((bot: { id: string }) => bot.id === id);
+  const waitFor = async (predicate: () => Promise<boolean>, description: string) => {
+    const deadline = Date.now() + 15_000;
+    while (!(await predicate())) {
+      if (Date.now() > deadline) throw new Error(`timed out waiting for ${description}. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  };
+
+  beforeAll(async () => {
+    provider = createServer((request, response) => {
+      const path = new URL(request.url ?? "/", "http://provider.test").pathname;
+      response.setHeader("content-type", "application/json");
+      if (request.method === "GET" && path === "/v1/models") {
+        return response.end(JSON.stringify({ data: [
+          { id: "chat-model" },
+          { id: "video-model", output_modalities: ["video"] },
+        ] }));
+      }
+      if (request.method === "POST" && path === "/v1/videos") {
+        response.statusCode = 202;
+        return response.end(JSON.stringify({ id: "job-1" }));
+      }
+      if (request.method === "GET" && path === "/v1/videos/job-1") {
+        pendingPolls.add(response);
+        response.on("close", () => {
+          pendingPolls.delete(response);
+        });
+        return;
+      }
+      if (request.method === "POST" && path === "/v1/chat/completions") {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.write('data: {"choices":[{"delta":{"content":"after cancel"}}]}\n\n');
+        return response.end("data: [DONE]\n\n");
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => provider.listen(0, "127.0.0.1", resolve));
+    providerPort = (provider.address() as { port: number }).port;
+
+    home = mkdtempSync(join(tmpdir(), "omb-media-api-test-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(join(home, ".openmausbot", "config.json"), JSON.stringify({
+      instances: {
+        endpoint: {
+          driver: "openaiCompatible",
+          config: {
+            url: `http://127.0.0.1:${providerPort}/v1`,
+            model: "chat-model",
+            modelTasks: { "video-model": "video" },
+          },
+        },
+      },
+    }));
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: {
+        ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        HOME: home,
+        USERPROFILE: home,
+        OMB_PORT: String(PORT),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (chunk) => (stderr += chunk));
+    await waitFor(async () => {
+      try { return (await fetch(`${BASE}/api/health`)).ok; } catch { return false; }
+    }, "server startup");
+  }, 30_000);
+
+  afterAll(async () => {
+    for (const response of pendingPolls) response.destroy();
+    provider?.close();
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("cancels a stuck video and accepts the bot's next text turn", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    expect((await api("PATCH", `/api/bots/${bot.id}`, {
+      specialists: { video: { instanceId: "endpoint", model: "video-model" } },
+    })).status).toBe(200);
+    expect((await api("POST", `/api/bots/${bot.id}/messages`, {
+      text: "make me a 5 second video in 9:16",
+    })).status).toBe(202);
+
+    let mediaMessage: any;
+    await waitFor(async () => {
+      const current = await getBot(bot.id);
+      mediaMessage = current.messages.find((message: { kind: string }) => message.kind === "media");
+      return mediaMessage?.media?.[0]?.status === "generating";
+    }, "video generation");
+    const stableOutputId = mediaMessage.media[0].id;
+
+    expect((await api("POST", `/api/bots/${bot.id}/messages/${mediaMessage.id}/cancel-media`)).status).toBe(200);
+    await waitFor(async () => {
+      const current = await getBot(bot.id);
+      const output = current.messages.find((message: { id: string }) => message.id === mediaMessage.id)?.media?.[0];
+      return !current.busy && output?.status === "cancelled";
+    }, "terminal cancellation");
+    expect((await getBot(bot.id)).messages.find((message: { id: string }) => message.id === mediaMessage.id).media[0].id)
+      .toBe(stableOutputId);
+
+    expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "hello after the failed video" })).status).toBe(202);
+    await waitFor(async () => {
+      const current = await getBot(bot.id);
+      return !current.busy && current.messages.some((message: { text?: string }) => message.text === "after cancel");
+    }, "next text response");
+  }, 25_000);
+});

--- a/server/media-cache.test.ts
+++ b/server/media-cache.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMediaCache, parseRange } from "./media-cache.ts";
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "omb-media-cache-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("media cache", () => {
+  it("stores validated bytes behind an opaque key", async () => {
+    const cache = createMediaCache({ rootDir: tempRoot() });
+    const stored = await cache.store(
+      { type: "base64", data: TINY_PNG_BASE64, mime: "image/png" },
+      { kind: "image" },
+    );
+
+    expect(stored).toMatchObject({ mime: "image/png", bytes: 68 });
+    expect(stored.cacheKey).toMatch(/^[0-9a-f-]+\.png$/);
+    expect(cache.resolve(stored.cacheKey)).toMatchObject({ mime: "image/png", bytes: 68 });
+    expect(cache.resolve("../../config.json")).toBeNull();
+  });
+
+  it("rejects model-authored remote URLs instead of exposing an SSRF surface", async () => {
+    const root = tempRoot();
+    const cache = createMediaCache({ rootDir: root });
+    await expect(
+      cache.store(
+        { type: "url", url: "http://[::ffff:127.0.0.1]/admin" } as never,
+        { kind: "image" },
+      ),
+    ).rejects.toThrow(/remote media URLs are not accepted/i);
+    expect(readdirSync(join(root, "objects"))).toEqual([]);
+  });
+
+  it("rejects MIME mismatches and enforces byte limits", async () => {
+    const root = tempRoot();
+    const cache = createMediaCache({ rootDir: root, imageLimitBytes: 32 });
+    await expect(
+      cache.store(
+        { type: "base64", data: TINY_PNG_BASE64, mime: "image/jpeg" },
+        { kind: "image" },
+      ),
+    ).rejects.toThrow(/limit|does not match/i);
+    expect(readdirSync(join(root, "objects"))).toEqual([]);
+  });
+});
+
+describe("HTTP byte ranges", () => {
+  it("parses explicit, open-ended, and suffix ranges", () => {
+    expect(parseRange("bytes=2-5", 10)).toEqual({ start: 2, end: 5 });
+    expect(parseRange("bytes=7-", 10)).toEqual({ start: 7, end: 9 });
+    expect(parseRange("bytes=-3", 10)).toEqual({ start: 7, end: 9 });
+  });
+
+  it("rejects malformed or unsatisfiable ranges", () => {
+    expect(parseRange("bytes=0-1,4-5", 10)).toBeNull();
+    expect(parseRange("bytes=12-15", 10)).toBeNull();
+    expect(parseRange("bytes=8-2", 10)).toBeNull();
+  });
+});

--- a/server/media-cache.ts
+++ b/server/media-cache.ts
@@ -1,0 +1,151 @@
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join, resolve, sep } from "node:path";
+
+import type { MediaKind, MediaSource } from "./contracts.ts";
+
+const DEFAULT_IMAGE_LIMIT = 25 * 1024 * 1024;
+const DEFAULT_VIDEO_LIMIT = 512 * 1024 * 1024;
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+};
+const MIME_BY_EXTENSION = Object.fromEntries(
+  Object.entries(EXTENSION_BY_MIME).map(([mime, extension]) => [extension, mime]),
+);
+
+export interface StoredMedia {
+  cacheKey: string;
+  mime: string;
+  bytes: number;
+}
+
+export interface ResolvedMedia extends StoredMedia {
+  path: string;
+}
+
+export interface MediaCache {
+  store(source: MediaSource, context: { kind: MediaKind; signal?: AbortSignal }): Promise<StoredMedia>;
+  resolve(cacheKey: string): ResolvedMedia | null;
+}
+
+function detectedMime(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 &&
+    bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a
+  ) return "image/png";
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  const ascii = Buffer.from(bytes.subarray(0, 32)).toString("ascii");
+  if (ascii.startsWith("GIF87a") || ascii.startsWith("GIF89a")) return "image/gif";
+  if (bytes.length >= 12 && ascii.startsWith("RIFF") && ascii.slice(8, 12) === "WEBP") return "image/webp";
+  if (bytes.length >= 12 && ascii.slice(4, 8) === "ftyp") return "video/mp4";
+  if (bytes.length >= 4 && bytes[0] === 0x1a && bytes[1] === 0x45 && bytes[2] === 0xdf && bytes[3] === 0xa3) {
+    return "video/webm";
+  }
+  return null;
+}
+
+function strictBase64(value: string): Buffer {
+  const clean = value.replace(/\s/g, "");
+  if (!clean || !/^[A-Za-z0-9+/]*={0,2}$/.test(clean) || clean.length % 4 === 1) {
+    throw new Error("generated media contains invalid base64 data");
+  }
+  return Buffer.from(clean, "base64");
+}
+
+function normalizedMime(value: string | undefined): string | undefined {
+  return value?.split(";", 1)[0]?.trim().toLowerCase() || undefined;
+}
+
+export function parseRange(header: string | undefined, size: number): { start: number; end: number } | null {
+  if (!header || !Number.isSafeInteger(size) || size <= 0) return null;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match || (!match[1] && !match[2])) return null;
+  if (!match[1]) {
+    const suffix = Number(match[2]);
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) return null;
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+  const start = Number(match[1]);
+  const requestedEnd = match[2] ? Number(match[2]) : size - 1;
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(requestedEnd) || start < 0 || start >= size || requestedEnd < start) {
+    return null;
+  }
+  return { start, end: Math.min(requestedEnd, size - 1) };
+}
+
+export function createMediaCache(options: {
+  rootDir: string;
+  imageLimitBytes?: number;
+  videoLimitBytes?: number;
+}): MediaCache {
+  const objectsDir = join(options.rootDir, "objects");
+  mkdirSync(objectsDir, { recursive: true });
+
+  return {
+    async store(source, context) {
+      context.signal?.throwIfAborted();
+      if (source.type !== "base64" && source.type !== "bytes") {
+        throw new Error("remote media URLs are not accepted");
+      }
+      const data = source.type === "base64" ? strictBase64(source.data) : Buffer.from(source.data);
+      const limit = context.kind === "image"
+        ? (options.imageLimitBytes ?? DEFAULT_IMAGE_LIMIT)
+        : (options.videoLimitBytes ?? DEFAULT_VIDEO_LIMIT);
+      if (data.length > limit) throw new Error(`generated ${context.kind} exceeds the ${limit} byte cache limit`);
+      const actual = detectedMime(data);
+      if (!actual || !actual.startsWith(`${context.kind}/`)) {
+        throw new Error(`generated ${context.kind} has an unsupported file signature`);
+      }
+      const claimed = normalizedMime(source.mime);
+      if (claimed && claimed !== actual) {
+        throw new Error(`generated media MIME ${claimed} does not match its ${actual} bytes`);
+      }
+      const extension = EXTENSION_BY_MIME[actual];
+      if (!extension) throw new Error(`generated media type ${actual} is not supported`);
+      const partialPath = join(objectsDir, `${crypto.randomUUID()}.part`);
+      const cacheKey = `${crypto.randomUUID()}.${extension}`;
+      try {
+        writeFileSync(partialPath, data, { flag: "wx" });
+        context.signal?.throwIfAborted();
+        renameSync(partialPath, join(objectsDir, cacheKey));
+      } catch (error) {
+        try { unlinkSync(partialPath); } catch {}
+        throw error;
+      }
+      return { cacheKey, mime: actual, bytes: data.length };
+    },
+    resolve(cacheKey) {
+      if (basename(cacheKey) !== cacheKey || !/^[0-9a-f-]+\.(png|jpg|gif|webp|mp4|webm)$/.test(cacheKey)) return null;
+      const path = resolve(objectsDir, cacheKey);
+      if (!path.startsWith(resolve(objectsDir) + sep) || !existsSync(path)) return null;
+      const extension = cacheKey.slice(cacheKey.lastIndexOf(".") + 1);
+      const mime = MIME_BY_EXTENSION[extension];
+      if (!mime) return null;
+      const descriptor = openSync(path, "r");
+      try {
+        const head = Buffer.alloc(16);
+        const length = readSync(descriptor, head, 0, head.length, 0);
+        if (detectedMime(head.subarray(0, length)) !== mime) return null;
+      } finally {
+        closeSync(descriptor);
+      }
+      return { cacheKey, path, mime, bytes: statSync(path).size };
+    },
+  };
+}

--- a/server/media-intent.test.ts
+++ b/server/media-intent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { detectMediaIntent, mediaPromptOptions } from "./media-intent.ts";
+
+describe("automatic media routing", () => {
+  it("routes explicit creation requests without hijacking ordinary discussion", () => {
+    expect(detectMediaIntent("Make me an image of a copper robot")).toBe("image");
+    expect(detectMediaIntent("Generate a five second video of ocean waves in 9:16")).toBe("video");
+    expect(detectMediaIntent("How do image models work?")).toBeNull();
+    expect(detectMediaIntent("Write code that processes video frames")).toBeNull();
+  });
+
+  it("extracts supported aspect ratio and numeric duration hints", () => {
+    expect(mediaPromptOptions("make a 5 second vertical clip in 9:16")).toEqual({
+      aspectRatio: "9:16",
+      durationSeconds: 5,
+    });
+    expect(mediaPromptOptions("make a landscape image, 16:9")).toEqual({ aspectRatio: "16:9" });
+  });
+});

--- a/server/media-intent.ts
+++ b/server/media-intent.ts
@@ -1,0 +1,26 @@
+import type { MediaKind } from "./contracts.ts";
+
+const CREATION_VERB = /\b(?:create|generate|make|draw|render|produce|design|animate)\b/i;
+const IMAGE_NOUN = /\b(?:image|picture|photo|photograph|illustration|artwork|logo|poster)\b/i;
+const VIDEO_NOUN = /\b(?:video|clip|animation|movie|film)\b/i;
+const CODE_DISCUSSION = /\b(?:code|script|function|library|api|explain|how does|how do)\b/i;
+
+export function detectMediaIntent(text: string): MediaKind | null {
+  if (!CREATION_VERB.test(text) || CODE_DISCUSSION.test(text)) return null;
+  if (VIDEO_NOUN.test(text)) return "video";
+  if (IMAGE_NOUN.test(text)) return "image";
+  return null;
+}
+
+export function mediaPromptOptions(prompt: string): {
+  aspectRatio?: string;
+  durationSeconds?: number;
+} {
+  const aspectRatio = /\b(1:1|16:9|9:16|4:3|3:4|21:9|9:21)\b/.exec(prompt)?.[1];
+  const durationRaw = /\b(\d{1,2})\s*(?:seconds?|secs?|s)\b/i.exec(prompt)?.[1];
+  const duration = durationRaw ? Number(durationRaw) : undefined;
+  return {
+    ...(aspectRatio ? { aspectRatio } : {}),
+    ...(duration && duration >= 1 && duration <= 30 ? { durationSeconds: duration } : {}),
+  };
+}

--- a/server/media-runs.test.ts
+++ b/server/media-runs.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MediaRunCoordinator } from "./media-runs.ts";
+
+describe("MediaRunCoordinator", () => {
+  it("propagates cancellation and never lets late completion replace it", async () => {
+    let finish!: (value: { cacheKey: string; mime: string; bytes: number }) => void;
+    let observedSignal: AbortSignal | undefined;
+    const patches: Array<Record<string, unknown>> = [];
+    const onDone = vi.fn();
+    const runs = new MediaRunCoordinator({ imageTimeoutMs: 10_000, videoTimeoutMs: 10_000 });
+    const run = runs.start({
+      botId: "bot-1",
+      threadId: "thread-1",
+      messageId: "message-1",
+      outputId: "output-1",
+      task: "video",
+      execute: (signal) => {
+        observedSignal = signal;
+        return new Promise((resolve) => (finish = resolve));
+      },
+      onPatch: (patch) => patches.push(patch),
+      onDone,
+    });
+
+    expect(runs.cancel("bot-1", "message-1")).toBe(true);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(patches.at(-1)).toMatchObject({ status: "cancelled" });
+    expect(onDone).toHaveBeenCalledTimes(1);
+
+    finish({ cacheKey: "late.mp4", mime: "video/mp4", bytes: 10 });
+    await run.done;
+    expect(patches).not.toContainEqual(expect.objectContaining({ status: "ready" }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out by aborting the provider and recording a terminal failure", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    let finish!: (value: { cacheKey: string; mime: string; bytes: number }) => void;
+    const patches: Array<Record<string, unknown>> = [];
+    const onDone = vi.fn();
+    const runs = new MediaRunCoordinator({ imageTimeoutMs: 100, videoTimeoutMs: 100 });
+    const run = runs.start({
+      botId: "bot-1",
+      threadId: "thread-1",
+      messageId: "message-1",
+      outputId: "output-1",
+      task: "image",
+      execute: (signal) => {
+        observedSignal = signal;
+        return new Promise((resolve) => (finish = resolve));
+      },
+      onPatch: (patch) => patches.push(patch),
+      onDone,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(patches.at(-1)).toMatchObject({ status: "failed" });
+    expect(String(patches.at(-1)?.error)).toContain("timed out");
+    expect(onDone).toHaveBeenCalledTimes(1);
+    finish({ cacheKey: "too-late.png", mime: "image/png", bytes: 10 });
+    await run.done;
+    expect(patches).not.toContainEqual(expect.objectContaining({ status: "ready" }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/server/media-runs.ts
+++ b/server/media-runs.ts
@@ -1,0 +1,121 @@
+import type { MediaKind, MediaOutput } from "./contracts.ts";
+
+export interface ReadyMedia {
+  cacheKey: string;
+  mime: string;
+  bytes: number;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  providerJobId?: string;
+}
+
+interface StartMediaRun {
+  botId: string;
+  threadId: string;
+  messageId: string;
+  outputId: string;
+  task: MediaKind;
+  execute: (
+    signal: AbortSignal,
+    onProgress: (patch: Pick<MediaOutput, "progress" | "providerJobId">) => void,
+  ) => Promise<ReadyMedia>;
+  onPatch: (patch: Partial<MediaOutput>) => void;
+  onDone: () => void;
+}
+
+interface ActiveMediaRun extends StartMediaRun {
+  controller: AbortController;
+  timer: ReturnType<typeof setTimeout>;
+  timeout: boolean;
+  done: Promise<void>;
+}
+
+export class MediaRunCoordinator {
+  private readonly active = new Map<string, ActiveMediaRun>();
+  private readonly imageTimeoutMs: number;
+  private readonly videoTimeoutMs: number;
+
+  constructor(options: { imageTimeoutMs?: number; videoTimeoutMs?: number } = {}) {
+    this.imageTimeoutMs = options.imageTimeoutMs ?? 3 * 60_000;
+    this.videoTimeoutMs = options.videoTimeoutMs ?? 10 * 60_000;
+  }
+
+  start(input: StartMediaRun): ActiveMediaRun {
+    if (this.active.has(input.botId)) throw new Error("this bot is already generating media");
+    const controller = new AbortController();
+    const run: ActiveMediaRun = {
+      ...input,
+      controller,
+      timeout: false,
+      timer: undefined as unknown as ReturnType<typeof setTimeout>,
+      done: Promise.resolve(),
+    };
+    const timeoutMs = input.task === "image" ? this.imageTimeoutMs : this.videoTimeoutMs;
+    run.timer = setTimeout(() => {
+      if (this.active.get(input.botId) !== run) return;
+      run.timeout = true;
+      this.active.delete(input.botId);
+      controller.abort(new DOMException(`${input.task} generation timed out`, "TimeoutError"));
+      input.onPatch({
+        status: "failed",
+        error: `${input.task[0]!.toUpperCase()}${input.task.slice(1)} generation timed out`,
+      });
+      input.onDone();
+    }, timeoutMs);
+    run.timer.unref?.();
+    this.active.set(input.botId, run);
+    input.onPatch({ status: "generating" });
+
+    run.done = (async () => {
+      try {
+        const ready = await input.execute(controller.signal, (patch) => {
+          if (this.active.get(input.botId) === run && !controller.signal.aborted) input.onPatch(patch);
+        });
+        if (this.active.get(input.botId) !== run || controller.signal.aborted) return;
+        input.onPatch({ status: "ready", error: undefined, ...ready });
+      } catch (error) {
+        if (this.active.get(input.botId) !== run) return;
+        input.onPatch({
+          status: "failed",
+          error: run.timeout
+            ? `${input.task[0]!.toUpperCase()}${input.task.slice(1)} generation timed out`
+            : error instanceof Error
+              ? error.message
+              : String(error),
+        });
+      } finally {
+        if (this.active.get(input.botId) === run) this.finish(run);
+      }
+    })();
+    return run;
+  }
+
+  cancel(botId: string, messageId?: string): boolean {
+    const run = this.active.get(botId);
+    if (!run || (messageId && run.messageId !== messageId)) return false;
+    this.active.delete(botId);
+    clearTimeout(run.timer);
+    run.controller.abort(new DOMException("generation cancelled", "AbortError"));
+    run.onPatch({
+      status: "cancelled",
+      error: `${run.task[0]!.toUpperCase()}${run.task.slice(1)} generation cancelled`,
+    });
+    run.onDone();
+    return true;
+  }
+
+  cancelAll(): void {
+    for (const botId of [...this.active.keys()]) this.cancel(botId);
+  }
+
+  current(botId: string): ActiveMediaRun | undefined {
+    return this.active.get(botId);
+  }
+
+  private finish(run: ActiveMediaRun) {
+    clearTimeout(run.timer);
+    this.active.delete(run.botId);
+    run.onDone();
+  }
+}

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -61,6 +61,40 @@ describe("Store", () => {
     expect(store.patchMessage(bot.threadId, "nope", {})).toBeNull();
   });
 
+  it("persists stable media IDs and refuses to overwrite a terminal output", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const message = store.appendMessage(bot.threadId, {
+      role: "bot",
+      kind: "media",
+      media: [{ id: "stable-output-id", kind: "video", status: "generating" }],
+    });
+
+    const cancelled = store.patchMediaOutput(
+      bot.threadId,
+      message.id,
+      "stable-output-id",
+      ["generating"],
+      { status: "cancelled", error: "Video generation cancelled" },
+    );
+    expect(cancelled?.media?.[0]).toMatchObject({ id: "stable-output-id", status: "cancelled" });
+    expect(
+      store.patchMediaOutput(
+        bot.threadId,
+        message.id,
+        "stable-output-id",
+        ["generating", "downloading"],
+        { status: "ready", cacheKey: "late.mp4" },
+      ),
+    ).toBeNull();
+
+    const reloaded = new Store(selection);
+    expect(reloaded.messagesFor(bot.threadId).find((item) => item.id === message.id)?.media?.[0]).toMatchObject({
+      id: "stable-output-id",
+      status: "cancelled",
+    });
+  });
+
   it("deleteBot removes the bot and its transcript file", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -7,7 +7,14 @@ import { join } from "node:path";
 
 import { writeFileAtomic } from "./atomic.ts";
 import { DATA_DIR } from "./config.ts";
-import { newId, type ModelSelection, type ThreadId } from "./contracts.ts";
+import {
+  newId,
+  type MediaOutput,
+  type MediaStatus,
+  type ModelSelection,
+  type ThreadId,
+} from "./contracts.ts";
+export type { MediaOutput } from "./contracts.ts";
 import { pickBotName } from "./names.ts";
 
 export type MausColor =
@@ -49,7 +56,7 @@ export interface OptionCardData {
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen";
+  kind: "text" | "options" | "activity" | "screen" | "media";
   text?: string;
   card?: OptionCardData;
   /** activity messages: tool name + outcome. `spoken` is the same chip as
@@ -60,6 +67,7 @@ export interface Message {
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;
+  media?: MediaOutput[];
   at: number;
   /** the message this one follows; null = thread root. Edited messages
    * share a parentId with the version they replace — that's a fork. */
@@ -130,6 +138,7 @@ export interface BotRecord {
   mascotExpression?: MausExpression | null;
   unread: boolean;
   modelSelection: ModelSelection;
+  specialists?: { image?: ModelSelection; video?: ModelSelection };
   /** provider-native continuation per instance (e.g. claude session id) */
   resumeCursors: Record<string, unknown>;
   /** which computer the bot acts on: its cloud box, this Mac (local CUA),
@@ -447,6 +456,23 @@ export class Store {
     t.messages[idx] = { ...t.messages[idx], ...patch, card: patch.card ?? t.messages[idx].card };
     this.saveThread(threadId);
     return t.messages[idx];
+  }
+
+  patchMediaOutput(
+    threadId: string,
+    messageId: string,
+    outputId: string,
+    expectedStatuses: readonly MediaStatus[],
+    patch: Partial<MediaOutput>,
+  ): Message | null {
+    const message = this.thread(threadId).messages.find((candidate) => candidate.id === messageId);
+    const output = message?.media?.find((candidate) => candidate.id === outputId);
+    if (!message || !output || !expectedStatuses.includes(output.status)) return null;
+    return this.patchMessage(threadId, messageId, {
+      media: message.media!.map((candidate) =>
+        candidate.id === outputId ? { ...candidate, ...patch, id: candidate.id, kind: candidate.kind } : candidate,
+      ),
+    });
   }
 
   bot(id: string) {

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -22,9 +22,31 @@ if (argv.includes("--version")) {
   console.log("fake-acp 1.0.0");
   process.exit(0);
 }
-if (process.env.FAKE_ACP_DUMP) {
-  writeFileSync(process.env.FAKE_ACP_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
-}
+const SENSITIVE_KEY = /token|secret|password|api[_-]?key|authorization/i;
+const redact = (value: unknown, key = ""): unknown => {
+  if (SENSITIVE_KEY.test(key)) return "[REDACTED]";
+  if (Array.isArray(value)) return value.map((item) => redact(item));
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const redacted = Object.fromEntries(
+      Object.entries(record).map(([name, item]) => [name, redact(item, name)]),
+    );
+    if (typeof record.name === "string" && SENSITIVE_KEY.test(record.name) && "value" in record) {
+      redacted.value = "[REDACTED]";
+    }
+    return redacted;
+  }
+  return value;
+};
+const seenRequests: unknown[] = [];
+const dump = () => {
+  if (!process.env.FAKE_ACP_DUMP) return;
+  writeFileSync(
+    process.env.FAKE_ACP_DUMP,
+    JSON.stringify(redact({ argv, env: process.env, requests: seenRequests }), null, 2),
+  );
+};
+dump();
 
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
 const result = (id: unknown, res: unknown) => out({ jsonrpc: "2.0", id, result: res });
@@ -112,6 +134,10 @@ process.stdin.on("data", (c) => {
 });
 
 function handle(msg: any) {
+  if (msg.method) {
+    seenRequests.push(msg);
+    dump();
+  }
   // client's response to our permission request
   if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined) && msg.id === pendingPermissionId) {
     pendingPermissionId = null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsModal } from "@/components/SettingsModal";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { DesktopCapabilitiesProvider } from "@/components/DesktopCapabilities";
 import { RoutinesPage } from "@/components/RoutinesPage";
+import { GenerationsPage } from "@/components/GenerationsPage";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -56,6 +57,8 @@ function Shell() {
       <Sidebar />
       {state.activeView === "routines" ? (
         <RoutinesPage />
+      ) : state.activeView === "generations" ? (
+        <GenerationsPage />
       ) : group ? (
         <GroupView key={group.id} group={group} />
       ) : bot ? (

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,12 +6,30 @@ import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "composioApi" | "box";
+export type ConfigSection =
+  | "openrouter"
+  | "ollamaCloud"
+  | "openaiCompatible"
+  | "composio"
+  | "composioApi"
+  | "box";
 
 const SECTIONS: Record<
   ConfigSection,
   { body: (value: string) => unknown; flag: (config: ConfigStatus) => boolean }
 > = {
+  openrouter: {
+    body: (v) => ({ openrouter: { key: v } }),
+    flag: (c) => c.openrouter.configured,
+  },
+  ollamaCloud: {
+    body: (v) => ({ ollamaCloud: { key: v } }),
+    flag: (c) => c.ollamaCloud.configured,
+  },
+  openaiCompatible: {
+    body: (v) => ({ openaiCompatible: { key: v } }),
+    flag: (c) => c.openaiCompatible.apiKeyConfigured,
+  },
   composio: { body: (v) => ({ composio: { key: v } }), flag: (c) => c.composio.configured },
   composioApi: {
     body: (v) => ({ composio: { apiKey: v } }),
@@ -32,6 +50,30 @@ const CREDENTIALS: Record<
     warning?: string;
   }
 > = {
+  openrouter: {
+    label: "OpenRouter API key",
+    placeholder: "sk-or-v1-…",
+    description: "Use OpenRouter models through one account and API key.",
+    href: "https://openrouter.ai/keys",
+    linkLabel: "Open OpenRouter keys",
+    optional: true,
+  },
+  ollamaCloud: {
+    label: "Ollama Cloud API key",
+    placeholder: "Ollama API key",
+    description: "Run cloud-hosted Ollama models without managing a local server.",
+    href: "https://ollama.com/settings/keys",
+    linkLabel: "Open Ollama keys",
+    optional: true,
+  },
+  openaiCompatible: {
+    label: "Endpoint bearer token",
+    placeholder: "Optional for local Ollama",
+    description: "Optional bearer token for your custom OpenAI-compatible endpoint.",
+    href: "https://platform.openai.com/docs/api-reference/chat",
+    linkLabel: "Open API format reference",
+    optional: true,
+  },
   composio: {
     label: "Composio Connect key",
     placeholder: "ck_…",

--- a/src/components/ArtifactPanel.test.tsx
+++ b/src/components/ArtifactPanel.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { beginArtifactResize, ArtifactPanel } from "./ArtifactPanel";
+
+describe("ArtifactPanel", () => {
+  it("renders the artifact in an opaque, network-disabled sandbox", () => {
+    const html = renderToStaticMarkup(
+      <ArtifactPanel
+        artifact={{
+          id: "message-1:0",
+          messageId: "message-1",
+          index: 0,
+          language: "html",
+          html: "<button>Interactive</button>",
+          sourceLine: 1,
+        }}
+        width={560}
+        onWidthChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(html).toContain('sandbox="allow-scripts"');
+    expect(html).not.toContain("allow-same-origin");
+    expect(html).not.toContain("allow-popups");
+    expect(html).toContain("Content-Security-Policy");
+    expect(html).toContain("Network access disabled");
+    expect(html).toContain("Refresh preview");
+    expect(html).toContain("Copy HTML");
+    expect(html).toContain("Download HTML");
+    expect(html).toContain('role="separator"');
+  });
+
+  it("captures resize input and cleans up move, up, and cancel listeners", () => {
+    const listeners = new Map<string, Set<(event: { clientX: number }) => void>>();
+    const listen = (type: "pointermove" | "pointerup" | "pointercancel", listener: (event: { clientX: number }) => void) => {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+      return () => set.delete(listener);
+    };
+    const capture = vi.fn();
+    const release = vi.fn();
+    const onWidthChange = vi.fn();
+
+    const finish = beginArtifactResize({
+      startX: 600,
+      startWidth: 500,
+      maximumWidth: 700,
+      capture,
+      release,
+      listen,
+      onWidthChange,
+    });
+    expect(capture).toHaveBeenCalledTimes(1);
+    for (const listener of listeners.get("pointermove") ?? []) listener({ clientX: 450 });
+    expect(onWidthChange).toHaveBeenLastCalledWith(650);
+    for (const listener of [...(listeners.get("pointercancel") ?? [])]) listener({ clientX: 450 });
+    expect(release).toHaveBeenCalledTimes(1);
+    expect([...listeners.values()].every((set) => set.size === 0)).toBe(true);
+    finish();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ArtifactPanel.tsx
+++ b/src/components/ArtifactPanel.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { Check, Copy, Download, RefreshCw, ShieldCheck, X } from "lucide-react";
+
+import { buildArtifactDocument, type HtmlArtifact } from "@/lib/html-artifacts";
+
+const MIN_WIDTH = 320;
+
+interface ResizePoint {
+  clientX: number;
+}
+
+export function beginArtifactResize({
+  startX,
+  startWidth,
+  maximumWidth,
+  onWidthChange,
+  capture,
+  release,
+  listen,
+}: {
+  startX: number;
+  startWidth: number;
+  maximumWidth: number;
+  onWidthChange: (width: number) => void;
+  capture: () => void;
+  release: () => void;
+  listen: (
+    type: "pointermove" | "pointerup" | "pointercancel",
+    listener: (event: ResizePoint) => void,
+  ) => () => void;
+}): () => void {
+  let finished = false;
+  const removeListeners: Array<() => void> = [];
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    for (const remove of removeListeners.splice(0)) remove();
+    release();
+  };
+  const clamp = (value: number) => Math.min(maximumWidth, Math.max(MIN_WIDTH, Math.round(value)));
+
+  capture();
+  removeListeners.push(
+    listen("pointermove", (event) => onWidthChange(clamp(startWidth - (event.clientX - startX)))),
+    listen("pointerup", finish),
+    listen("pointercancel", finish),
+  );
+  return finish;
+}
+
+export function ArtifactPanel({
+  artifact,
+  width,
+  onWidthChange,
+  onClose,
+}: {
+  artifact: HtmlArtifact;
+  width: number;
+  onWidthChange: (width: number) => void;
+  onClose: () => void;
+}) {
+  const [revision, setRevision] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const finishResize = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => () => finishResize.current(), []);
+
+  const maximum = () => Math.max(MIN_WIDTH, Math.floor(window.innerWidth * 0.7));
+  const clamp = (value: number) => Math.min(maximum(), Math.max(MIN_WIDTH, Math.round(value)));
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    finishResize.current();
+    const target = event.currentTarget;
+    const pointerId = event.pointerId;
+    const listen = (
+      type: "pointermove" | "pointerup" | "pointercancel",
+      listener: (point: ResizePoint) => void,
+    ) => {
+      const browserListener = listener as unknown as EventListener;
+      window.addEventListener(type, browserListener);
+      return () => window.removeEventListener(type, browserListener);
+    };
+    finishResize.current = beginArtifactResize({
+      startX: event.clientX,
+      startWidth: width,
+      maximumWidth: maximum(),
+      onWidthChange,
+      capture: () => target.setPointerCapture?.(pointerId),
+      release: () => {
+        if (target.hasPointerCapture?.(pointerId)) target.releasePointerCapture(pointerId);
+      },
+      listen,
+    });
+  };
+
+  const copy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(artifact.html);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const download = () => {
+    const url = URL.createObjectURL(new Blob([artifact.html], { type: "text/html;charset=utf-8" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `artifact-${artifact.index + 1}.html`;
+    anchor.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  };
+
+  return (
+    <aside
+      className="relative flex h-full shrink-0 flex-col border-l border-hairline/50 bg-panel max-[799px]:fixed max-[799px]:inset-0 max-[799px]:z-40 max-[799px]:!w-full"
+      style={{ width }}
+      aria-label="HTML artifact workspace"
+    >
+      <div
+        role="separator"
+        aria-label="Resize artifact workspace"
+        aria-orientation="vertical"
+        aria-valuemin={MIN_WIDTH}
+        aria-valuemax={typeof window === "undefined" ? 1200 : maximum()}
+        aria-valuenow={width}
+        tabIndex={0}
+        onPointerDown={startResize}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowLeft") onWidthChange(clamp(width + 24));
+          else if (event.key === "ArrowRight") onWidthChange(clamp(width - 24));
+          else if (event.key === "Home") onWidthChange(MIN_WIDTH);
+          else if (event.key === "End") onWidthChange(maximum());
+          else return;
+          event.preventDefault();
+        }}
+        className="absolute inset-y-0 -left-1 z-10 w-2 cursor-col-resize outline-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:bg-transparent hover:after:bg-accent focus-visible:after:bg-accent max-[799px]:hidden"
+      />
+      <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-hairline/40 px-3">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-ink">artifact-{artifact.index + 1}.html</div>
+          <div className="text-[10px] text-ink-secondary">Interactive preview</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <span
+            className="mr-1 rounded p-1 text-ink-secondary"
+            title="Network access disabled"
+            aria-label="Network access disabled"
+          >
+            <ShieldCheck size={14} />
+          </span>
+          <button
+            type="button"
+            onClick={() => setRevision((value) => value + 1)}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Refresh preview"
+          >
+            <RefreshCw size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Copy HTML"
+          >
+            {copied ? <Check size={15} className="text-success" /> : <Copy size={15} />}
+          </button>
+          <button
+            type="button"
+            onClick={download}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Download HTML"
+          >
+            <Download size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+            title="Close preview"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+      <iframe
+        key={`${artifact.id}:${revision}`}
+        title={`Preview of artifact ${artifact.index + 1}`}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        srcDoc={buildArtifactDocument(artifact.html)}
+        className="min-h-0 flex-1 border-0 bg-white"
+      />
+    </aside>
+  );
+}

--- a/src/components/ChatMarkdown.test.tsx
+++ b/src/components/ChatMarkdown.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ChatMarkdown } from "./ChatMarkdown";
+
+describe("ChatMarkdown HTML artifacts", () => {
+  it("renders streaming HTML in a compact expandable card", () => {
+    const code = Array.from({ length: 12 }, (_, index) => `<div>Line ${index + 1}</div>`).join("\n");
+    const html = renderToStaticMarkup(<ChatMarkdown text={`Building\n\`\`\`html\n${code}`} streaming />);
+
+    expect(html).toContain("Building artifact");
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain("max-h-[9.75rem]");
+    expect(html).toContain("Expand");
+  });
+
+  it("honors expansion state owned by the chat while streaming text changes", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Still writing"}
+        streaming
+        streamingHtmlExpanded
+        onStreamingHtmlExpandedChange={() => {}}
+      />,
+    );
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("Collapse");
+    expect(html).not.toContain("max-h-[9.75rem]");
+    expect(html).toContain("min-h-[20rem]");
+    expect(html).toContain("max-h-[60vh]");
+  });
+
+  it("only marks the unfinished fence as the live artifact", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Finished</main>\n```\nthen\n```html\n<section>Live</section>"}
+        streaming
+      />,
+    );
+    expect(html.match(/Building artifact/g)).toHaveLength(1);
+    expect(html).toContain("&lt;main&gt;Finished&lt;/main&gt;");
+    expect(html).toContain("&lt;section&gt;Live&lt;/section&gt;");
+  });
+
+  it("renders completed HTML as a collapsed card with a permanent Open action", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<main>Hidden source</main>\n```"}
+        messageId="m-1"
+        onPreviewArtifact={() => {}}
+      />,
+    );
+
+    expect(html).toContain("HTML artifact");
+    expect(html).toContain(">Open<");
+    expect(html).toContain("View code");
+    expect(html).not.toContain("&lt;main&gt;Hidden source&lt;/main&gt;");
+  });
+
+  it("labels only the selected artifact as closable", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        text={"```html\n<p>One</p>\n```\n```html\n<p>Two</p>\n```"}
+        messageId="m-2"
+        selectedArtifactId="m-2:0"
+        onPreviewArtifact={() => {}}
+      />,
+    );
+    expect(html.match(/>Close</g)).toHaveLength(1);
+    expect(html.match(/>Open</g)).toHaveLength(1);
+    expect(html).not.toContain("Reopen");
+  });
+});

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -4,10 +4,11 @@
 // HTML: no rehype-raw, so HTML in the text renders as text; Shiki's output is
 // generator-escaped. While a message is still streaming, code blocks render
 // as plain <pre> and nothing is cached — partial fences would poison it.
-import { memo, useEffect, useState, type ReactNode } from "react";
+import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Check, Copy } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Code2, Copy, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { extractHtmlArtifacts, findStreamingHtmlFence, type HtmlArtifact } from "@/lib/html-artifacts";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed, capped, never written while streaming
@@ -22,12 +23,41 @@ const hash = (s: string) => {
   return (h >>> 0).toString(36);
 };
 
-function CodeBlock({ code, lang, streaming }: { code: string; lang: string; streaming: boolean }) {
+function CodeBlock({
+  code,
+  lang,
+  messageStreaming,
+  streamingArtifact,
+  artifact,
+  selected,
+  onPreview,
+  streamingExpanded,
+  onStreamingExpandedChange,
+}: {
+  code: string;
+  lang: string;
+  messageStreaming: boolean;
+  streamingArtifact: boolean;
+  artifact?: HtmlArtifact;
+  selected?: boolean;
+  onPreview?: (artifact: HtmlArtifact) => void;
+  streamingExpanded?: boolean;
+  onStreamingExpandedChange?: (expanded: boolean) => void;
+}) {
   const [html, setHtml] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [sourceExpanded, setSourceExpanded] = useState(false);
+  const controlledStreamingExpansion =
+    streamingArtifact && streamingExpanded !== undefined && Boolean(onStreamingExpandedChange);
+  const expanded = controlledStreamingExpansion ? streamingExpanded : sourceExpanded;
+  const setExpanded = (value: boolean | ((current: boolean) => boolean)) => {
+    const next = typeof value === "function" ? value(Boolean(expanded)) : value;
+    if (controlledStreamingExpansion) onStreamingExpandedChange?.(next);
+    else setSourceExpanded(next);
+  };
 
   useEffect(() => {
-    if (streaming) return;
+    if (messageStreaming) return;
     const key = `${lang}:${hash(code)}`;
     const cached = highlightCache.get(key);
     if (cached) return setHtml(cached);
@@ -54,45 +84,156 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
     return () => {
       alive = false;
     };
-  }, [code, lang, streaming]);
+  }, [code, lang, messageStreaming]);
 
-  const copy = () => {
-    void navigator.clipboard?.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+  const copy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
   };
+
+  const source = html ? (
+    <div
+      className="overflow-x-auto text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:m-0 [&_pre]:p-3"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  ) : (
+    <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
+  );
+
+  if (streamingArtifact) {
+    return (
+      <div className="my-2 overflow-hidden rounded-lg border border-accent/20 bg-inset">
+        <div className="flex items-center justify-between border-b border-hairline/30 px-3 py-1.5">
+          <span className="flex items-center gap-1.5 text-[11px] font-medium text-accent">
+            <Code2 size={13} /> Building artifact…
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={Boolean(expanded)}
+              className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+              {expanded ? "Collapse" : "Expand"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+              title="Copy code"
+            >
+              {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+            </button>
+          </div>
+        </div>
+        <div className={expanded ? "min-h-[20rem] max-h-[60vh] overflow-auto" : "max-h-[9.75rem] overflow-auto"}>
+          <pre className="p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  if (artifact) {
+    return (
+      <div className="my-2 overflow-hidden rounded-xl border border-accent/20 bg-inset">
+        <div className="flex items-center gap-3 px-3 py-2.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+            <Code2 size={17} />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[13px] font-medium text-ink">HTML artifact</span>
+            <span className="block truncate text-[11px] text-ink-secondary">artifact-{artifact.index + 1}.html</span>
+          </span>
+          <div className="flex shrink-0 items-center gap-1">
+            {onPreview && (
+              <button
+                type="button"
+                onClick={() => onPreview(artifact)}
+                className="flex items-center gap-1 rounded-md bg-accent px-2 py-1.5 text-[11px] font-medium text-white hover:opacity-90"
+                title={selected ? "Close HTML preview" : "Open HTML preview"}
+              >
+                {selected ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
+                <span>{selected ? "Close" : "Open"}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={Boolean(expanded)}
+              className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              {expanded ? "Hide code" : "View code"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+              title="Copy HTML"
+            >
+              {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+            </button>
+          </div>
+        </div>
+        {expanded && <div className="border-t border-hairline/30">{source}</div>}
+      </div>
+    );
+  }
 
   return (
     <div className="my-2 overflow-hidden rounded-lg border border-hairline/40 bg-inset">
       <div className="flex items-center justify-between border-b border-hairline/30 px-3 py-1">
         <span className="text-[11px] uppercase tracking-wide text-ink-secondary">{lang || "code"}</span>
         <button
-          onClick={copy}
+          type="button"
+          onClick={() => void copy()}
           className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink"
           title="Copy code"
         >
           {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
         </button>
       </div>
-      {html ? (
-        <div
-          className="overflow-x-auto text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:m-0 [&_pre]:p-3"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ) : (
-        <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed text-ink">{code}</pre>
-      )}
+      {source}
     </div>
   );
 }
 
-function ChatMarkdownComponent({ text, streaming = false }: { text: string; streaming?: boolean }) {
+interface ChatMarkdownProps {
+  text: string;
+  streaming?: boolean;
+  messageId?: string;
+  selectedArtifactId?: string | null;
+  onPreviewArtifact?: (artifact: HtmlArtifact) => void;
+  streamingHtmlExpanded?: boolean;
+  onStreamingHtmlExpandedChange?: (expanded: boolean) => void;
+}
+
+function ChatMarkdownComponent({
+  text,
+  streaming = false,
+  messageId,
+  selectedArtifactId,
+  onPreviewArtifact,
+  streamingHtmlExpanded,
+  onStreamingHtmlExpandedChange,
+}: ChatMarkdownProps) {
+  const artifacts = useMemo(
+    () => (!streaming && messageId ? extractHtmlArtifacts(text, messageId) : []),
+    [messageId, streaming, text],
+  );
+  const streamingHtml = useMemo(() => (streaming ? findStreamingHtmlFence(text) : null), [streaming, text]);
   return (
     <div className="chat-md min-w-0 [&>*+*]:mt-2">
       <Markdown
         remarkPlugins={[remarkGfm]}
         components={{
-          pre({ children }: { children?: ReactNode }) {
+          pre({ children, node }: { children?: ReactNode; node?: { position?: { start: { line: number } } } }) {
             // fenced code arrives as <pre><code class="language-x">…</code></pre>
             const child: any = Array.isArray(children) ? children[0] : children;
             const className: string = child?.props?.className ?? "";
@@ -102,7 +243,25 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
             const flat = (n: any): string =>
               typeof n === "string" ? n : Array.isArray(n) ? n.map(flat).join("") : (n?.props?.children ? flat(n.props.children) : "");
             const code = flat(child?.props?.children).replace(/\n$/, "");
-            return <CodeBlock code={code} lang={lang} streaming={streaming} />;
+            const sourceLine = node?.position?.start.line;
+            const htmlLanguage = /^(?:html|htm|html_preview)$/i.test(lang);
+            const artifact = htmlLanguage
+              ? artifacts.find((candidate) => candidate.sourceLine === sourceLine)
+              : undefined;
+            const streamingArtifact = Boolean(streamingHtml && htmlLanguage && streamingHtml.sourceLine === sourceLine);
+            return (
+              <CodeBlock
+                code={streamingArtifact ? streamingHtml!.code : code}
+                lang={lang}
+                messageStreaming={streaming}
+                streamingArtifact={streamingArtifact}
+                artifact={artifact}
+                selected={artifact?.id === selectedArtifactId}
+                onPreview={onPreviewArtifact}
+                streamingExpanded={streamingHtmlExpanded}
+                onStreamingExpandedChange={onStreamingHtmlExpandedChange}
+              />
+            );
           },
           img({ src, alt }: { src?: string; alt?: string }) {
             return (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -10,6 +10,8 @@ import {
   Copy,
   Loader2,
   Monitor,
+  PanelRightClose,
+  PanelRightOpen,
   Pencil,
   RefreshCw,
   Square,
@@ -24,6 +26,13 @@ import { ApprovalCard } from "./ApprovalCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
 import { TaskPicker } from "./TaskPicker";
+import { ArtifactPanel } from "./ArtifactPanel";
+import {
+  artifactHeaderMode,
+  extractHtmlArtifacts,
+  toggleArtifactSelection,
+  type HtmlArtifact,
+} from "@/lib/html-artifacts";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { SpeakButton } from "./SpeakButton";
 import { CallButton, CallOverlay } from "./CallView";
@@ -224,6 +233,8 @@ function Bubble({
   onCancelEdit,
   onSubmitEdit,
   onRegenerate,
+  selectedArtifactId,
+  onPreviewArtifact,
 }: {
   bot: Bot;
   message: Message;
@@ -233,6 +244,8 @@ function Bubble({
   onCancelEdit: () => void;
   onSubmitEdit: (text: string) => void;
   onRegenerate?: () => void;
+  selectedArtifactId?: string | null;
+  onPreviewArtifact?: (artifact: HtmlArtifact) => void;
 }) {
   const { dispatch } = useStore();
   const user = message.role === "user";
@@ -300,7 +313,12 @@ function Bubble({
             </>
           ) : (
             <MessageBoundary fallbackText={text}>
-              <ChatMarkdown text={text} />
+              <ChatMarkdown
+                text={text}
+                messageId={message.id}
+                selectedArtifactId={selectedArtifactId}
+                onPreviewArtifact={onPreviewArtifact}
+              />
             </MessageBoundary>
           )}
         </div>
@@ -416,7 +434,15 @@ function ScreenFrame({ png, mime }: { png: string; mime?: string }) {
   );
 }
 
-function StreamingBubble({ text }: { text: string }) {
+function StreamingBubble({
+  text,
+  htmlExpanded,
+  onHtmlExpandedChange,
+}: {
+  text: string;
+  htmlExpanded: boolean;
+  onHtmlExpandedChange: (expanded: boolean) => void;
+}) {
   // markdown re-parses on a deferred value: when tokens arrive faster than
   // the parser keeps up, React lags the parse instead of janking the frame
   const deferred = useDeferredValue(text);
@@ -424,7 +450,12 @@ function StreamingBubble({ text }: { text: string }) {
     <div className="flex w-full justify-start">
       <div className="max-w-[70%] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed text-ink">
         <MessageBoundary fallbackText={deferred}>
-          <ChatMarkdown text={deferred} streaming />
+          <ChatMarkdown
+            text={deferred}
+            streaming
+            streamingHtmlExpanded={htmlExpanded}
+            onStreamingHtmlExpandedChange={onHtmlExpandedChange}
+          />
         </MessageBoundary>
         <span className="animate-caret ml-0.5 inline-block h-[14px] w-[2px] bg-ink align-middle" />
       </div>
@@ -463,6 +494,8 @@ const MessagesList = memo(function MessagesList({
   onCancelEdit,
   onSubmitEdit,
   onRegenerate,
+  selectedArtifactId,
+  onPreviewArtifact,
 }: {
   bot: Bot;
   messages: Message[];
@@ -473,6 +506,8 @@ const MessagesList = memo(function MessagesList({
   onCancelEdit: () => void;
   onSubmitEdit: (id: string, text: string) => void;
   onRegenerate: () => void;
+  selectedArtifactId: string | null;
+  onPreviewArtifact: (artifact: HtmlArtifact) => void;
 }) {
   return (
     <>
@@ -521,6 +556,8 @@ const MessagesList = memo(function MessagesList({
                   onCancelEdit={onCancelEdit}
                   onSubmitEdit={(text) => onSubmitEdit(m.id, text)}
                   onRegenerate={onRegenerate}
+                  selectedArtifactId={selectedArtifactId}
+                  onPreviewArtifact={onPreviewArtifact}
                 />
               );
           }
@@ -549,6 +586,63 @@ export function ChatView({ bot }: { bot: Bot }) {
 
   // only the active branch is rendered; forks stay reachable via ‹ › nav
   const messages = useMemo(() => visibleMessages(bot), [bot]);
+  const artifacts = useMemo(
+    () =>
+      messages.flatMap((message) =>
+        message.role === "bot" && message.kind === "text" && message.text
+          ? extractHtmlArtifacts(message.text, message.id)
+          : [],
+      ),
+    [messages],
+  );
+  const newestArtifact = artifacts.at(-1);
+  const [artifactSelections, setArtifactSelections] = useState<Record<string, string | null>>({});
+  const autoOpenedArtifact = useRef<Record<string, string>>({});
+  useEffect(() => {
+    if (!newestArtifact || autoOpenedArtifact.current[bot.threadId] === newestArtifact.id) return;
+    autoOpenedArtifact.current[bot.threadId] = newestArtifact.id;
+    setArtifactSelections((current) => ({ ...current, [bot.threadId]: newestArtifact.id }));
+  }, [bot.threadId, newestArtifact]);
+  const selectedArtifactId = artifactSelections[bot.threadId] ?? null;
+  const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+  const artifactAction = artifactHeaderMode(newestArtifact?.id, selectedArtifact?.id);
+  const openArtifact = useCallback(
+    (artifact: HtmlArtifact) => {
+      setArtifactSelections((current) => ({
+        ...current,
+        [bot.threadId]: toggleArtifactSelection(current[bot.threadId] ?? null, artifact.id),
+      }));
+    },
+    [bot.threadId],
+  );
+  const closeArtifact = useCallback(() => {
+    setArtifactSelections((current) => ({ ...current, [bot.threadId]: null }));
+  }, [bot.threadId]);
+  const [streamingHtmlExpanded, setStreamingHtmlExpanded] = useState(false);
+  useEffect(() => {
+    if (!streaming) setStreamingHtmlExpanded(false);
+  }, [bot.threadId, streaming]);
+  const [artifactWidth, setArtifactWidth] = useState(() => {
+    const maximum = Math.max(320, Math.floor(window.innerWidth * 0.7));
+    try {
+      const stored = Number(window.localStorage.getItem("openmausbot.artifactWidth"));
+      return Number.isFinite(stored) && stored > 0
+        ? Math.min(maximum, Math.max(320, stored))
+        : Math.min(maximum, 560);
+    } catch {
+      return Math.min(maximum, 560);
+    }
+  });
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem("openmausbot.artifactWidth", String(artifactWidth));
+      } catch {
+        // The preview still resizes when storage is disabled.
+      }
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [artifactWidth]);
   const lastBotTextId = useMemo(
     () => [...messages].reverse().find((m) => m.role === "bot" && m.kind === "text")?.id,
     [messages],
@@ -618,6 +712,7 @@ export function ChatView({ bot }: { bot: Bot }) {
   const noDrag = isWin ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
   return (
+    <div className="flex h-full min-w-0 flex-1">
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
       {/* Call mode covers the thread while the bot is on the line */}
       <CallOverlay bot={bot} />
@@ -651,6 +746,24 @@ export function ChatView({ bot }: { bot: Bot }) {
             >
               <Square size={12} className="fill-current" />
               Stop
+            </button>
+          )}
+          {artifactAction !== "hidden" && newestArtifact && (
+            <button
+              type="button"
+              onClick={() => {
+                if (artifactAction === "close") closeArtifact();
+                else openArtifact(newestArtifact);
+              }}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full border border-hairline/40 bg-raised/60 px-2.5 py-1 text-[13px] hover:bg-raised hover:text-ink",
+                artifactAction === "close" ? "text-accent" : "text-ink-secondary",
+              )}
+              aria-label={artifactAction === "close" ? "Close artifact" : "Open artifact"}
+              title={artifactAction === "close" ? "Close the artifact preview" : "Open the latest artifact"}
+            >
+              {artifactAction === "close" ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
+              {artifactAction === "close" ? "Close artifact" : "Open artifact"}
             </button>
           )}
           <TaskPicker bot={bot} />
@@ -712,6 +825,8 @@ export function ChatView({ bot }: { bot: Bot }) {
             onCancelEdit={cancelEdit}
             onSubmitEdit={submitEdit}
             onRegenerate={regenerate}
+            selectedArtifactId={selectedArtifact?.id ?? null}
+            onPreviewArtifact={openArtifact}
           />
           {provisioning && (
             <div className="flex justify-start">
@@ -723,7 +838,11 @@ export function ChatView({ bot }: { bot: Bot }) {
           )}
           {reasoning && bot.busy && <ThinkingStrip text={reasoning} active={!streaming} />}
           {streaming ? (
-            <StreamingBubble text={streaming} />
+            <StreamingBubble
+              text={streaming}
+              htmlExpanded={streamingHtmlExpanded}
+              onHtmlExpandedChange={setStreamingHtmlExpanded}
+            />
           ) : (
             bot.busy && (
               <div className="flex justify-start">
@@ -764,5 +883,14 @@ export function ChatView({ bot }: { bot: Bot }) {
       />
 
     </main>
+    {selectedArtifact && (
+      <ArtifactPanel
+        artifact={selectedArtifact}
+        width={artifactWidth}
+        onWidthChange={setArtifactWidth}
+        onClose={closeArtifact}
+      />
+    )}
+    </div>
   );
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -25,6 +25,7 @@ import { OptionCard } from "./OptionCard";
 import { ApprovalCard } from "./ApprovalCard";
 import { Composer } from "./Composer";
 import { ModelPicker } from "./ModelPicker";
+import { MediaMessage } from "./MediaMessage";
 import { TaskPicker } from "./TaskPicker";
 import { ArtifactPanel } from "./ArtifactPanel";
 import {
@@ -496,6 +497,7 @@ const MessagesList = memo(function MessagesList({
   onRegenerate,
   selectedArtifactId,
   onPreviewArtifact,
+  onCancelMedia,
 }: {
   bot: Bot;
   messages: Message[];
@@ -508,6 +510,7 @@ const MessagesList = memo(function MessagesList({
   onRegenerate: () => void;
   selectedArtifactId: string | null;
   onPreviewArtifact: (artifact: HtmlArtifact) => void;
+  onCancelMedia: (messageId: string) => void;
 }) {
   return (
     <>
@@ -545,6 +548,8 @@ const MessagesList = memo(function MessagesList({
               );
             case "screen":
               return m.png ? <ScreenFrame png={m.png} mime={m.mime} /> : null;
+            case "media":
+              return m.media ? <MediaMessage messageId={m.id} outputs={m.media} onCancel={onCancelMedia} /> : null;
             default:
               return (
                 <Bubble
@@ -672,6 +677,15 @@ export function ChatView({ bot }: { bot: Bot }) {
       dispatch({ type: "editMessage", botId: bot.id, messageId: lastUserMessage.id, text: lastUserMessage.text });
     }
   }, [lastUserMessage, bot.busy, bot.id, dispatch]);
+  const cancelMedia = useCallback(
+    (messageId: string) => dispatch({ type: "cancelMedia", botId: bot.id, messageId }),
+    [bot.id, dispatch],
+  );
+  const mediaBusy = useMemo(
+    () => messages.some((message) => message.kind === "media" && message.media?.some((output) =>
+      output.status === "queued" || output.status === "generating" || output.status === "downloading")),
+    [messages],
+  );
 
   // Scroll pinning: follow the bottom while the user hasn't scrolled away.
   // Follow breaks ONLY on an upward user gesture (wheel/touch), never on
@@ -827,6 +841,7 @@ export function ChatView({ bot }: { bot: Bot }) {
             onRegenerate={regenerate}
             selectedArtifactId={selectedArtifact?.id ?? null}
             onPreviewArtifact={openArtifact}
+            onCancelMedia={cancelMedia}
           />
           {provisioning && (
             <div className="flex justify-start">
@@ -836,7 +851,7 @@ export function ChatView({ bot }: { bot: Bot }) {
               </div>
             </div>
           )}
-          {reasoning && bot.busy && <ThinkingStrip text={reasoning} active={!streaming} />}
+          {reasoning && bot.busy && !mediaBusy && <ThinkingStrip text={reasoning} active={!streaming} />}
           {streaming ? (
             <StreamingBubble
               text={streaming}
@@ -844,7 +859,7 @@ export function ChatView({ bot }: { bot: Bot }) {
               onHtmlExpandedChange={setStreamingHtmlExpanded}
             />
           ) : (
-            bot.busy && (
+            bot.busy && !mediaBusy && (
               <div className="flex justify-start">
                 <div className="flex items-center gap-2.5 rounded-2xl bg-raised px-4 py-3">
                   <span className="flex items-center gap-1.5">

--- a/src/components/GenerationsPage.test.tsx
+++ b/src/components/GenerationsPage.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { GenerationCard } from "./GenerationsPage";
+
+describe("GenerationCard", () => {
+  it("renders cached images as an accessible open control", () => {
+    const html = renderToStaticMarkup(
+      <GenerationCard
+        item={{
+          id: "media:image-1",
+          kind: "image",
+          createdAt: 100,
+          ownerId: "bot-1",
+          ownerName: "Builder",
+          contextTitle: "Campaign",
+          threadId: "thread-1",
+          messageId: "message-1",
+          output: { id: "image-1", kind: "image", status: "ready", cacheKey: "safe.png", mime: "image/png" },
+        }}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('src="/api/media/safe.png"');
+    expect(html).toContain('aria-label="Open image generation from Builder"');
+    expect(html).toContain("Campaign");
+  });
+
+  it("labels HTML creations without executing them in the grid", () => {
+    const html = renderToStaticMarkup(
+      <GenerationCard
+        item={{
+          id: "html:message-1:0",
+          kind: "html",
+          createdAt: 100,
+          ownerId: "bot-1",
+          ownerName: "Builder",
+          contextTitle: "Landing page",
+          threadId: "thread-1",
+          messageId: "message-1",
+          artifact: {
+            id: "message-1:0",
+            messageId: "message-1",
+            index: 0,
+            language: "html",
+            html: "<script>window.__ran = true</script><h1>Preview</h1>",
+            sourceLine: 1,
+          },
+        }}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("HTML creation");
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toContain("window.__ran = true");
+  });
+});

--- a/src/components/GenerationsPage.tsx
+++ b/src/components/GenerationsPage.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Code2, Film, Image as ImageIcon, Loader2, RefreshCw, Search, Sparkles } from "lucide-react";
+
+import { ArtifactPanel } from "./ArtifactPanel";
+import { MediaViewer } from "./MediaMessage";
+import { api } from "@/state/store";
+import { collectGenerations, type GenerationItem, type GenerationSource } from "@/lib/generations";
+import { cn } from "@/lib/cn";
+
+function htmlSummary(html: string) {
+  return html
+    .replace(/<(script|style|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120) || "Interactive HTML preview";
+}
+
+export function GenerationCard({ item, onOpen }: { item: GenerationItem; onOpen: (item: GenerationItem) => void }) {
+  const title = item.kind === "html" ? "HTML creation" : item.kind === "image" ? "Image" : "Video";
+  const url = item.kind === "html" ? "" : `/api/media/${encodeURIComponent(item.output.cacheKey!)}`;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(item)}
+      aria-label={`Open ${item.kind} generation from ${item.ownerName}`}
+      className="group overflow-hidden rounded-2xl border border-hairline/40 bg-card text-left transition hover:-translate-y-0.5 hover:border-hairline hover:shadow-xl hover:shadow-black/20"
+    >
+      <div className="flex aspect-[4/3] items-center justify-center overflow-hidden bg-inset">
+        {item.kind === "html" ? (
+          <div className="flex size-full flex-col justify-between bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,.16),transparent_55%)] p-5">
+            <Code2 size={24} className="text-accent" />
+            <div className="line-clamp-4 text-[14px] leading-relaxed text-ink-secondary">
+              {htmlSummary(item.artifact.html)}
+            </div>
+          </div>
+        ) : item.kind === "image" ? (
+          <img src={url} alt="" loading="lazy" className="size-full object-cover transition duration-300 group-hover:scale-[1.02]" />
+        ) : (
+          <div className="relative size-full">
+            <video src={url} muted preload="metadata" className="size-full object-cover" />
+            <span className="absolute inset-0 flex items-center justify-center bg-black/20">
+              <span className="rounded-full bg-black/65 p-3 text-white"><Film size={22} /></span>
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="p-3.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-1.5 text-[14px] font-medium text-ink">
+            {item.kind === "html" ? <Code2 size={14} /> : item.kind === "image" ? <ImageIcon size={14} /> : <Film size={14} />}
+            {title}
+          </span>
+          <span className="shrink-0 text-[11px] text-ink-secondary">
+            {new Date(item.createdAt).toLocaleDateString([], { month: "short", day: "numeric" })}
+          </span>
+        </div>
+        <div className="mt-1 truncate text-[12px] text-ink-secondary">{item.ownerName} · {item.contextTitle}</div>
+      </div>
+    </button>
+  );
+}
+
+type Filter = "all" | "html" | "image" | "video";
+
+export function GenerationsPage() {
+  const [sources, setSources] = useState<GenerationSource[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<GenerationItem | null>(null);
+  const [artifactWidth, setArtifactWidth] = useState(() => Math.min(Math.max(320, window.innerWidth * 0.42), 640));
+
+  const refresh = useCallback(() => {
+    setRefreshing(true);
+    setError(null);
+    return api("/api/generations")
+      .then((result) => setSources(result.sources ?? []))
+      .catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)))
+      .finally(() => setRefreshing(false));
+  }, []);
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const items = useMemo(() => collectGenerations(sources ?? []), [sources]);
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return items.filter((item) =>
+      (filter === "all" || item.kind === filter) &&
+      (!needle || `${item.ownerName} ${item.contextTitle} ${item.kind}`.toLowerCase().includes(needle)),
+    );
+  }, [filter, items, query]);
+  const open = (item: GenerationItem) => setSelected(item);
+
+  return (
+    <main className="flex h-full min-w-0 flex-1 bg-app">
+      <section className="min-w-0 flex-1 overflow-y-auto px-7 py-6">
+        <div className="mx-auto max-w-[1120px]">
+          <header className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 text-[20px] font-semibold text-ink">
+                <Sparkles size={20} className="text-accent" /> Generations
+              </div>
+              <div className="mt-1 text-[13px] text-ink-secondary">
+                Reopen HTML, images, and videos created across every bot and task.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              disabled={refreshing}
+              className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+              aria-label="Refresh generations"
+              title="Refresh generations"
+            >
+              <RefreshCw size={17} className={cn(refreshing && "animate-spin")} />
+            </button>
+          </header>
+
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            <div className="flex rounded-xl bg-card p-1">
+              {(["all", "html", "image", "video"] as const).map((value) => (
+                <button
+                  type="button"
+                  key={value}
+                  onClick={() => setFilter(value)}
+                  className={cn(
+                    "rounded-lg px-3 py-1.5 text-[13px] capitalize",
+                    filter === value ? "bg-raised text-ink" : "text-ink-secondary hover:text-ink",
+                  )}
+                >
+                  {value === "all" ? `All ${items.length ? `(${items.length})` : ""}` : value === "html" ? "HTML" : value}
+                </button>
+              ))}
+            </div>
+            <label className="ml-auto flex min-w-[220px] items-center gap-2 rounded-xl bg-card px-3 py-2">
+              <Search size={15} className="text-ink-secondary" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search generations"
+                className="min-w-0 flex-1 bg-transparent text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
+              />
+            </label>
+          </div>
+
+          {error && <div className="mt-5 rounded-xl border border-danger/30 bg-danger/10 px-4 py-3 text-[13px] text-danger">{error}</div>}
+          {sources === null && !error ? (
+            <div className="flex items-center justify-center gap-2 py-24 text-[13px] text-ink-secondary">
+              <Loader2 size={16} className="animate-spin" /> Loading generations…
+            </div>
+          ) : visible.length ? (
+            <div className="mt-5 grid grid-cols-2 gap-4 min-[1180px]:grid-cols-3">
+              {visible.map((item) => <GenerationCard key={item.id} item={item} onOpen={open} />)}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <Sparkles size={28} className="text-ink-secondary/50" />
+              <div className="mt-3 text-[15px] font-medium text-ink">No generations here yet</div>
+              <div className="mt-1 max-w-[360px] text-[13px] text-ink-secondary">
+                Ask a bot with a configured specialist for an image or video, or have it build an HTML creation.
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {selected?.kind === "html" && (
+        <ArtifactPanel
+          artifact={selected.artifact}
+          width={artifactWidth}
+          onWidthChange={setArtifactWidth}
+          onClose={() => setSelected(null)}
+        />
+      )}
+      {selected && selected.kind !== "html" && (
+        <MediaViewer output={selected.output} onClose={() => setSelected(null)} />
+      )}
+    </main>
+  );
+}

--- a/src/components/MediaMessage.test.tsx
+++ b/src/components/MediaMessage.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { MediaMessage, MediaViewer } from "./MediaMessage";
+
+describe("MediaMessage", () => {
+  it("offers a per-message stop control while a video is running", () => {
+    const html = renderToStaticMarkup(
+      <MediaMessage
+        messageId="message-1"
+        outputs={[{ id: "output-1", kind: "video", status: "generating", progress: 0.42 }]}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Generating video");
+    expect(html).toContain("42%");
+    expect(html).toContain("Stop");
+  });
+
+  it("renders cached media without trusting a provider URL", () => {
+    const html = renderToStaticMarkup(
+      <MediaMessage
+        messageId="message-2"
+        outputs={[{ id: "output-2", kind: "image", status: "ready", cacheKey: "safe.png", mime: "image/png" }]}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('src="/api/media/safe.png"');
+    expect(html).toContain("Open image");
+  });
+});
+
+describe("MediaViewer", () => {
+  it("has dialog semantics and an explicit close control", () => {
+    const html = renderToStaticMarkup(
+      <MediaViewer
+        output={{ id: "output-2", kind: "image", status: "ready", cacheKey: "safe.png", mime: "image/png" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('aria-label="Close media viewer"');
+  });
+});

--- a/src/components/MediaMessage.tsx
+++ b/src/components/MediaMessage.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle, Expand, LoaderCircle, Square, X } from "lucide-react";
+
+import type { MediaOutput } from "@/state/store";
+import { cn } from "@/lib/cn";
+
+function mediaUrl(output: MediaOutput) {
+  return output.cacheKey ? `/api/media/${encodeURIComponent(output.cacheKey)}` : "";
+}
+
+export function MediaViewer({ output, onClose }: { output: MediaOutput; onClose: () => void }) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const returnFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    returnFocus.current = document.activeElement as HTMLElement | null;
+    dialogRef.current?.querySelector<HTMLElement>("button")?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = [...dialogRef.current.querySelectorAll<HTMLElement>("button, video[controls]")]
+        .filter((element) => !element.hasAttribute("disabled"));
+      if (!focusable.length) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      returnFocus.current?.focus();
+    };
+  }, [onClose]);
+
+  const url = mediaUrl(output);
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6"
+      onMouseDown={(event) => event.target === event.currentTarget && onClose()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${output.kind} viewer`}
+        className="relative flex max-h-full max-w-full items-center justify-center rounded-xl bg-black p-2 shadow-2xl"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close media viewer"
+          className="absolute right-3 top-3 z-10 rounded-full bg-black/70 p-2 text-white hover:bg-black"
+        >
+          <X size={18} />
+        </button>
+        {output.kind === "image" ? (
+          <img src={url} alt="Generated image" className="max-h-[88vh] max-w-[90vw] object-contain" />
+        ) : (
+          <video src={url} controls autoPlay className="max-h-[88vh] max-w-[90vw]" tabIndex={0} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function MediaMessage({
+  messageId,
+  outputs,
+  onCancel,
+}: {
+  messageId: string;
+  outputs: MediaOutput[];
+  onCancel: (messageId: string) => void;
+}) {
+  const [viewing, setViewing] = useState<MediaOutput | null>(null);
+
+  return (
+    <div className="flex max-w-[680px] flex-col gap-2">
+      {outputs.map((output) => {
+        const active = output.status === "queued" || output.status === "generating" || output.status === "downloading";
+        const percent = output.progress !== undefined ? `${Math.round(output.progress * 100)}%` : "";
+        if (active) {
+          return (
+            <div key={output.id} className="flex min-w-[320px] items-center gap-3 rounded-xl bg-card px-4 py-3 text-[13px] text-ink">
+              <LoaderCircle size={16} className="animate-spin text-accent" />
+              <span className="flex-1">
+                {output.status === "downloading" ? "Saving" : "Generating"} {output.kind}… {percent}
+              </span>
+              <button
+                type="button"
+                onClick={() => onCancel(messageId)}
+                className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+              >
+                <Square size={10} fill="currentColor" /> Stop
+              </button>
+            </div>
+          );
+        }
+        if (output.status === "failed" || output.status === "cancelled") {
+          return (
+            <div
+              key={output.id}
+              className={cn(
+                "flex items-center gap-2 rounded-xl border px-4 py-3 text-[13px]",
+                output.status === "failed" ? "border-danger/40 bg-danger/10 text-danger" : "border-hairline/40 bg-card text-ink-secondary",
+              )}
+            >
+              <AlertTriangle size={15} /> {output.error ?? `${output.kind} generation ${output.status}`}
+            </div>
+          );
+        }
+        const url = mediaUrl(output);
+        if (!url) return null;
+        return (
+          <div key={output.id} className="group relative overflow-hidden rounded-xl bg-card">
+            {output.kind === "image" ? (
+              <button type="button" onClick={() => setViewing(output)} aria-label="Open image" className="block">
+                <img src={url} alt="Generated image" className="max-h-[620px] w-auto max-w-full object-contain" />
+              </button>
+            ) : (
+              <video src={url} controls preload="metadata" className="max-h-[620px] max-w-full" />
+            )}
+            <button
+              type="button"
+              onClick={() => setViewing(output)}
+              aria-label={`Open ${output.kind}`}
+              className="absolute right-3 top-3 flex items-center gap-1.5 rounded-lg bg-black/70 px-2.5 py-1.5 text-[12px] text-white opacity-90 hover:bg-black group-hover:opacity-100"
+            >
+              <Expand size={14} /> Open
+            </button>
+          </div>
+        );
+      })}
+      {viewing && <MediaViewer output={viewing} onClose={() => setViewing(null)} />}
+    </div>
+  );
+}

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,34 +1,49 @@
-// Model picker: an instance rail + model list, backed by /api/instances.
-// Routing is by exact instanceId only — an entry is never inferred from a
-// driver kind, and unavailable instances render disabled with the reason.
-import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
-import { useStore, type Bot, type InstanceInfo } from "@/state/store";
+// Model picker: exact instance/model routing for a bot's primary model or
+// optional image/video specialists. Unknown-task models stay pickable for
+// custom OpenAI-compatible servers whose catalog exposes only model IDs.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, X } from "lucide-react";
+import { useStore, type Bot, type InstanceInfo, type ModelTask } from "@/state/store";
 import { ProviderMark } from "./ProviderIcons";
 import { cn } from "@/lib/cn";
 
 function modelLabel(instance: InstanceInfo | undefined, model: string): string {
-  return instance?.models.options.find((o) => o.id === model)?.label ?? model;
+  return instance?.models.options.find((option) => option.id === model)?.label ?? model;
 }
 
-export function ModelPicker({ bot, className }: { bot: Bot; className?: string }) {
+function supportsTask(option: InstanceInfo["models"]["options"][number], role: ModelTask) {
+  if (role === "chat") return !option.task || option.task === "chat";
+  return !option.task || option.task === role;
+}
+
+export function ModelPicker({
+  bot,
+  role = "chat",
+  className,
+}: {
+  bot: Bot;
+  role?: ModelTask;
+  className?: string;
+}) {
   const { state, dispatch } = useStore();
   const [open, setOpen] = useState(false);
   const [railId, setRailId] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-
-  const selection = bot.modelSelection;
-  const active = state.instances.find((i) => i.instanceId === selection.instanceId);
+  const selection = role === "chat" ? bot.modelSelection : bot.specialists?.[role];
+  const active = state.instances.find((instance) => instance.instanceId === selection?.instanceId);
+  const eligible = useMemo(
+    () => state.instances.filter((instance) => instance.models.options.some((option) => supportsTask(option, role))),
+    [role, state.instances],
+  );
   const railInstance =
-    state.instances.find((i) => i.instanceId === (railId ?? selection.instanceId)) ??
-    state.instances[0];
+    eligible.find((instance) => instance.instanceId === (railId ?? selection?.instanceId)) ?? eligible[0];
 
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    const onDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
     };
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    const onKey = (event: KeyboardEvent) => event.key === "Escape" && setOpen(false);
     window.addEventListener("mousedown", onDown);
     window.addEventListener("keydown", onKey);
     return () => {
@@ -38,47 +53,58 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
   }, [open]);
 
   const pick = (instance: InstanceInfo, model: string) => {
-    dispatch({ type: "setModel", botId: bot.id, selection: { instanceId: instance.instanceId, model } });
+    const next = { instanceId: instance.instanceId, model };
+    if (role === "chat") dispatch({ type: "setModel", botId: bot.id, selection: next });
+    else dispatch({
+      type: "updateBot",
+      botId: bot.id,
+      patch: { specialists: { ...bot.specialists, [role]: next } },
+    });
     setOpen(false);
   };
 
+  const clear = () => {
+    if (role === "chat") return;
+    const specialists = { ...bot.specialists };
+    delete specialists[role];
+    dispatch({ type: "updateBot", botId: bot.id, patch: { specialists } });
+    setOpen(false);
+  };
+
+  const placeholder = role === "chat" ? "Choose model" : `Auto (${role} off)`;
   return (
     <div ref={rootRef} className={cn("relative", className)}>
       <button
+        type="button"
         onClick={() => {
-          setRailId(selection.instanceId);
-          setOpen((o) => !o);
+          setRailId(selection?.instanceId ?? eligible[0]?.instanceId ?? null);
+          setOpen((value) => !value);
         }}
-        className="flex items-center gap-1.5 rounded-full border border-hairline/40 bg-raised/60 py-1 pl-2 pr-2.5 text-[13px] text-ink hover:bg-raised"
-        title={active ? `${active.displayName} · ${modelLabel(active, selection.model)}` : selection.model}
+        className="flex max-w-[210px] items-center gap-1.5 rounded-full border border-hairline/40 bg-raised/60 py-1 pl-2 pr-2.5 text-[13px] text-ink hover:bg-raised"
+        title={active && selection ? `${active.displayName} · ${modelLabel(active, selection.model)}` : placeholder}
       >
         {active && <ProviderMark driverKind={active.driverKind} size={14} />}
-        <span className="max-w-[160px] truncate">{modelLabel(active, selection.model)}</span>
-        <ChevronDown size={14} className="text-ink-secondary" />
+        <span className="truncate">{selection ? modelLabel(active, selection.model) : placeholder}</span>
+        <ChevronDown size={14} className="shrink-0 text-ink-secondary" />
       </button>
 
       {open && (
         <div
           data-model-picker-content
-          className="absolute right-0 top-full z-30 mt-2 flex w-[320px] overflow-hidden rounded-xl border border-hairline/50 bg-card shadow-2xl shadow-black/50"
+          className="absolute right-0 top-full z-30 mt-2 flex w-[340px] overflow-hidden rounded-xl border border-hairline/50 bg-card shadow-2xl shadow-black/50"
         >
-          {/* instance rail */}
           <div className="flex flex-col gap-1 border-r border-hairline/40 bg-panel p-2">
-            {state.instances.map((instance) => {
+            {eligible.map((instance) => {
               const unavailable = instance.snapshot.state !== "available";
-              const onRail = instance.instanceId === railInstance?.instanceId;
               return (
                 <button
+                  type="button"
                   key={instance.instanceId}
                   onClick={() => setRailId(instance.instanceId)}
-                  title={
-                    unavailable
-                      ? `${instance.displayName} — ${instance.snapshot.reason ?? "unavailable"}`
-                      : instance.displayName
-                  }
+                  title={unavailable ? `${instance.displayName} — ${instance.snapshot.reason ?? "unavailable"}` : instance.displayName}
                   className={cn(
                     "flex size-9 items-center justify-center rounded-lg",
-                    onRail ? "bg-raised" : "hover:bg-raised/60",
+                    instance.instanceId === railInstance?.instanceId ? "bg-raised" : "hover:bg-raised/60",
                     unavailable && "opacity-40",
                   )}
                 >
@@ -88,8 +114,16 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
             })}
           </div>
 
-          {/* model list for the rail-selected instance */}
           <div className="min-w-0 flex-1 p-2">
+            {role !== "chat" && selection && (
+              <button
+                type="button"
+                onClick={clear}
+                className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] text-ink-secondary hover:bg-raised/60 hover:text-ink"
+              >
+                <X size={14} /> Use primary chat instead
+              </button>
+            )}
             {railInstance ? (
               <>
                 <div className="px-2 pb-1 pt-1">
@@ -100,12 +134,12 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                       : (railInstance.snapshot.reason ?? "unavailable")}
                   </div>
                 </div>
-                {railInstance.models.options.map((option) => {
-                  const current =
-                    selection.instanceId === railInstance.instanceId && selection.model === option.id;
+                {railInstance.models.options.filter((option) => supportsTask(option, role)).map((option) => {
+                  const current = selection?.instanceId === railInstance.instanceId && selection.model === option.id;
                   const disabled = railInstance.snapshot.state !== "available";
                   return (
                     <button
+                      type="button"
                       key={option.id}
                       disabled={disabled}
                       onClick={() => pick(railInstance, option.id)}
@@ -115,23 +149,14 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                         current && "bg-raised",
                       )}
                     >
-                      <span className="flex min-w-0 items-center gap-2">
-                        <span className="truncate">{option.label}</span>
-                        {option.id === railInstance.models.default && (
-                          <span className="shrink-0 rounded bg-inset px-1 py-px text-[10px] text-ink-secondary">
-                            default
-                          </span>
-                        )}
-                      </span>
+                      <span className="min-w-0 truncate">{option.label}</span>
                       {current && <Check size={14} className="shrink-0 text-accent" />}
                     </button>
                   );
                 })}
               </>
             ) : (
-              <div className="px-2 py-3 text-[13px] text-ink-secondary">
-                No providers — is the server running?
-              </div>
+              <div className="px-2 py-3 text-[13px] text-ink-secondary">No matching provider models found.</div>
             )}
           </div>
         </div>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -3,6 +3,7 @@ import { Check, AlertTriangle, Loader2, Mic } from "lucide-react";
 import { MausAvatar } from "./Avatar";
 import { identifyEmail, setEmailGateDone, track } from "@/lib/analytics";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { ProviderSetupOptions } from "./ProviderSetupOptions";
 
 // Three-step first-run onboarding: who you are (email), what's installed
 // (live engine checks from the harness), what the app may use (TCC).
@@ -98,7 +99,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-app">
-      <div className="flex w-[460px] flex-col rounded-2xl border border-hairline/40 bg-panel p-8">
+      <div className="flex max-h-[90vh] w-[460px] flex-col overflow-y-auto rounded-2xl border border-hairline/40 bg-panel p-8">
         {step === 0 && (
           <div className="flex flex-col items-center">
             <MausAvatar color="green" state="happy" size={72} />
@@ -199,6 +200,10 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                         : "Optional. Install: see antigravity.google/docs/cli"
                     }
                   />
+                  <div className="mt-2">
+                    <div className="mb-2 text-[13px] font-medium text-ink">Optional API providers</div>
+                    <ProviderSetupOptions />
+                  </div>
                 </>
               )}
             </div>

--- a/src/components/OpenAIEndpointFields.tsx
+++ b/src/components/OpenAIEndpointFields.tsx
@@ -6,15 +6,28 @@ export function OpenAIEndpointFields({ compact = false }: { compact?: boolean })
   const { state, dispatch } = useStore();
   const serverUrl = state.config?.openaiCompatible.url ?? "http://127.0.0.1:11434/v1";
   const serverModel = state.config?.openaiCompatible.model ?? "llama3.2";
+  const serverTasks = state.config?.openaiCompatible.modelTasks ?? {};
+  const serverImageModel = Object.entries(serverTasks).find(([, task]) => task === "image")?.[0] ?? "";
+  const serverVideoModel = Object.entries(serverTasks).find(([, task]) => task === "video")?.[0] ?? "";
+  const serverImagePath = state.config?.openaiCompatible.imagePath ?? "/images/generations";
+  const serverVideoPath = state.config?.openaiCompatible.videoPath ?? "/videos";
   const [url, setUrl] = useState(serverUrl);
   const [model, setModel] = useState(serverModel);
+  const [imageModel, setImageModel] = useState(serverImageModel);
+  const [videoModel, setVideoModel] = useState(serverVideoModel);
+  const [imagePath, setImagePath] = useState(serverImagePath);
+  const [videoPath, setVideoPath] = useState(serverVideoPath);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setUrl(serverUrl);
     setModel(serverModel);
-  }, [serverUrl, serverModel]);
+    setImageModel(serverImageModel);
+    setVideoModel(serverVideoModel);
+    setImagePath(serverImagePath);
+    setVideoPath(serverVideoPath);
+  }, [serverUrl, serverModel, serverImageModel, serverVideoModel, serverImagePath, serverVideoPath]);
 
   const save = () => {
     if (saving || !url.trim() || !model.trim()) return;
@@ -23,7 +36,18 @@ export function OpenAIEndpointFields({ compact = false }: { compact?: boolean })
     api("/api/config", {
       method: "PUT",
       body: JSON.stringify({
-        openaiCompatible: { url: url.trim(), model: model.trim() },
+        openaiCompatible: {
+          url: url.trim(),
+          model: model.trim(),
+          ...(!compact ? {
+            modelTasks: {
+              ...(imageModel.trim() ? { [imageModel.trim()]: "image" } : {}),
+              ...(videoModel.trim() ? { [videoModel.trim()]: "video" } : {}),
+            },
+            imagePath: imagePath.trim(),
+            videoPath: videoPath.trim(),
+          } : {}),
+        },
       }),
     })
       .then((config: ConfigStatus) => dispatch({ type: "configStatus", config }))
@@ -59,6 +83,48 @@ export function OpenAIEndpointFields({ compact = false }: { compact?: boolean })
           spellCheck={false}
           className={inputClass}
         />
+        {!compact && (
+          <div className="mt-2 rounded-lg border border-hairline/40 bg-panel/60 p-3">
+            <div className="mb-1 text-[12px] font-medium text-ink">Optional media endpoints</div>
+            <div className="mb-2 text-[11px] leading-relaxed text-ink-secondary">
+              Add model IDs your endpoint uses for images or video. Routes must stay on this base URL.
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                value={imageModel}
+                onChange={(event) => setImageModel(event.target.value)}
+                placeholder="Image model ID"
+                aria-label="OpenAI-compatible image model ID"
+                spellCheck={false}
+                className={inputClass}
+              />
+              <input
+                value={imagePath}
+                onChange={(event) => setImagePath(event.target.value)}
+                placeholder="/images/generations"
+                aria-label="OpenAI-compatible image route"
+                spellCheck={false}
+                className={inputClass}
+              />
+              <input
+                value={videoModel}
+                onChange={(event) => setVideoModel(event.target.value)}
+                placeholder="Video model ID"
+                aria-label="OpenAI-compatible video model ID"
+                spellCheck={false}
+                className={inputClass}
+              />
+              <input
+                value={videoPath}
+                onChange={(event) => setVideoPath(event.target.value)}
+                placeholder="/videos"
+                aria-label="OpenAI-compatible video route"
+                spellCheck={false}
+                className={inputClass}
+              />
+            </div>
+          </div>
+        )}
         <button
           type="button"
           onClick={save}

--- a/src/components/OpenAIEndpointFields.tsx
+++ b/src/components/OpenAIEndpointFields.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+
+import { api, useStore, type ConfigStatus } from "@/state/store";
+
+export function OpenAIEndpointFields({ compact = false }: { compact?: boolean }) {
+  const { state, dispatch } = useStore();
+  const serverUrl = state.config?.openaiCompatible.url ?? "http://127.0.0.1:11434/v1";
+  const serverModel = state.config?.openaiCompatible.model ?? "llama3.2";
+  const [url, setUrl] = useState(serverUrl);
+  const [model, setModel] = useState(serverModel);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUrl(serverUrl);
+    setModel(serverModel);
+  }, [serverUrl, serverModel]);
+
+  const save = () => {
+    if (saving || !url.trim() || !model.trim()) return;
+    setSaving(true);
+    setError(null);
+    api("/api/config", {
+      method: "PUT",
+      body: JSON.stringify({
+        openaiCompatible: { url: url.trim(), model: model.trim() },
+      }),
+    })
+      .then((config: ConfigStatus) => dispatch({ type: "configStatus", config }))
+      .catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)))
+      .finally(() => setSaving(false));
+  };
+
+  const inputClass =
+    "w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 text-[13px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none";
+  return (
+    <div>
+      {!compact && <div className="mb-2 text-[13px] font-medium text-ink">Custom OpenAI-compatible endpoint</div>}
+      <div className="mb-3 text-[12px] leading-relaxed text-ink-secondary">
+        Local Ollama, a vLLM server on your LAN, or a remote service exposing <code>/v1/models</code> and{" "}
+        <code>/v1/chat/completions</code>.
+      </div>
+      <div className="flex flex-col gap-2">
+        <input
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && save()}
+          placeholder="http://192.168.1.25:8000/v1"
+          aria-label="OpenAI-compatible base URL"
+          spellCheck={false}
+          className={inputClass}
+        />
+        <input
+          value={model}
+          onChange={(event) => setModel(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && save()}
+          placeholder="Model ID, e.g. qwen2.5-coder"
+          aria-label="OpenAI-compatible default model ID"
+          spellCheck={false}
+          className={inputClass}
+        />
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving || !url.trim() || !model.trim()}
+          className="self-end rounded-lg bg-raised px-3 py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save endpoint"}
+        </button>
+      </div>
+      {error && <div className="mt-1 text-[12px] text-danger">{error}</div>}
+    </div>
+  );
+}

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -1,5 +1,5 @@
 // Provider brand marks, keyed by driver kind. Dark-theme fills.
-import { Monitor } from "lucide-react";
+import { Cloud, Monitor, Network, Server } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface IconProps {
@@ -36,6 +36,18 @@ export function ComputerMark({ size = 16, className }: IconProps) {
   return <Monitor size={size} className={cn("text-ink-secondary", className)} />;
 }
 
+export function OpenRouterMark({ size = 16, className }: IconProps) {
+  return <Network size={size} className={cn("text-[#7c8cff]", className)} />;
+}
+
+export function OllamaCloudMark({ size = 16, className }: IconProps) {
+  return <Cloud size={size} className={cn("text-[#f5f5f5]", className)} />;
+}
+
+export function OpenAIEndpointMark({ size = 16, className }: IconProps) {
+  return <Server size={size} className={cn("text-[#38d591]", className)} />;
+}
+
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {
   switch (driverKind) {
     case "grok":
@@ -45,6 +57,12 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <ClaudeMark size={size} className={className} />;
     case "codex":
       return <CodexMark size={size} className={className} />;
+    case "openrouter":
+      return <OpenRouterMark size={size} className={className} />;
+    case "ollamaCloud":
+      return <OllamaCloudMark size={size} className={className} />;
+    case "openaiCompatible":
+      return <OpenAIEndpointMark size={size} className={className} />;
     case "boxAgent":
       return <ComputerMark size={size} className={className} />;
     default:

--- a/src/components/ProviderSetupOptions.test.tsx
+++ b/src/components/ProviderSetupOptions.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { StoreProvider } from "@/state/store";
+import { ProviderSetupOptions } from "./ProviderSetupOptions";
+
+describe("ProviderSetupOptions", () => {
+  it("offers cloud and custom providers without requiring setup during onboarding", () => {
+    const html = renderToStaticMarkup(
+      <StoreProvider>
+        <ProviderSetupOptions />
+      </StoreProvider>,
+    );
+
+    expect(html).toContain("OpenRouter");
+    expect(html).toContain("Ollama Cloud");
+    expect(html).toContain("Custom OpenAI-compatible");
+    expect(html).toContain("Set up later in App Settings");
+    expect(html).toContain('type="password"');
+    expect(html).toContain("http://127.0.0.1:11434/v1");
+    expect(html).not.toContain("Image path");
+    expect(html).not.toContain("Video path");
+  });
+});

--- a/src/components/ProviderSetupOptions.tsx
+++ b/src/components/ProviderSetupOptions.tsx
@@ -1,0 +1,39 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { ApiKeyRow } from "./ApiKeys";
+import { OpenAIEndpointFields } from "./OpenAIEndpointFields";
+
+function ProviderDisclosure({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <details className="group overflow-hidden rounded-xl border border-hairline/40 bg-card">
+      <summary className="flex cursor-pointer list-none items-center justify-between px-3.5 py-3 text-[13.5px] font-medium text-ink [&::-webkit-details-marker]:hidden">
+        {title}
+        <ChevronRight size={15} className="text-ink-secondary transition-transform group-open:rotate-90" />
+      </summary>
+      <div className="border-t border-hairline/30 px-3.5 py-3">{children}</div>
+    </details>
+  );
+}
+
+export function ProviderSetupOptions() {
+  return (
+    <div>
+      <div className="flex flex-col gap-2">
+        <ProviderDisclosure title="OpenRouter">
+          <ApiKeyRow section="openrouter" />
+        </ProviderDisclosure>
+        <ProviderDisclosure title="Ollama Cloud">
+          <ApiKeyRow section="ollamaCloud" />
+        </ProviderDisclosure>
+        <ProviderDisclosure title="Custom OpenAI-compatible">
+          <div className="flex flex-col gap-3">
+            <OpenAIEndpointFields compact />
+            <ApiKeyRow section="openaiCompatible" />
+          </div>
+        </ProviderDisclosure>
+      </div>
+      <div className="mt-2 text-[11.5px] text-ink-secondary">Set up later in App Settings</div>
+    </div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,7 +3,7 @@
 // is the stuff shared by every bot: who you are, your keys, and the
 // machine your bots can borrow.
 import { useEffect, useRef, useState } from "react";
-import { KeyRound, Monitor, User, Volume2, X } from "lucide-react";
+import { Cpu, KeyRound, Monitor, User, Volume2, X } from "lucide-react";
 import { useStore } from "@/state/store";
 import { ApiKeyRow } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
@@ -11,11 +11,13 @@ import { LocalComputerSection } from "./LocalComputerSection";
 import { Card } from "./SettingsPrimitives";
 import { VoiceSettings } from "./VoiceSettings";
 import { cn } from "@/lib/cn";
+import { OpenAIEndpointFields } from "./OpenAIEndpointFields";
 
-type SectionId = "general" | "connections" | "voice" | "computer";
+type SectionId = "general" | "models" | "connections" | "voice" | "computer";
 
 const SECTIONS: Array<{ id: SectionId; label: string; icon: typeof User }> = [
   { id: "general", label: "General", icon: User },
+  { id: "models", label: "Model providers", icon: Cpu },
   { id: "connections", label: "Connections", icon: KeyRound },
   { id: "voice", label: "Voice", icon: Volume2 },
   { id: "computer", label: "Local computer", icon: Monitor },
@@ -213,6 +215,29 @@ export function SettingsModal() {
                   <ApiKeyRow section="box" />
                 </div>
               </Card>
+            )}
+
+            {section === "models" && (
+              <>
+                <Card
+                  title="Cloud model providers"
+                  subtitle="Keys stay on this computer. Model lists are discovered after connecting."
+                >
+                  <div className="flex flex-col gap-4">
+                    <ApiKeyRow section="openrouter" />
+                    <ApiKeyRow section="ollamaCloud" />
+                  </div>
+                </Card>
+                <Card
+                  title="OpenAI-compatible endpoint"
+                  subtitle="Use local Ollama, vLLM on your network, or a remote OpenAI-standard server."
+                >
+                  <div className="flex flex-col gap-4">
+                    <OpenAIEndpointFields />
+                    <ApiKeyRow section="openaiCompatible" />
+                  </div>
+                </Card>
+              </>
             )}
 
             {section === "voice" && <VoiceSettings />}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -47,6 +47,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "autoApprove"
         | "speakReplies"
         | "voice"
+        | "specialists"
       >
     >,
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
@@ -179,14 +180,25 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             />
           </Field>
 
-          <div className="flex items-center justify-between gap-4 rounded-xl bg-card p-4">
-            <div>
-              <div className="text-[15px] font-medium text-ink">Model</div>
-              <div className="mt-0.5 text-[13px] text-ink-secondary">
-                Which provider and model this bot runs on
+          <div className="rounded-xl bg-card p-4">
+            <div className="text-[15px] font-medium text-ink">Model team</div>
+            <div className="mt-0.5 text-[13px] text-ink-secondary">
+              Keep chat and coding on one provider, then route explicit image or video requests to specialists.
+            </div>
+            <div className="mt-3 flex flex-col gap-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px] text-ink-secondary">Chat & coding</span>
+                <ModelPicker bot={bot} role="chat" />
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px] text-ink-secondary">Images</span>
+                <ModelPicker bot={bot} role="image" />
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px] text-ink-secondary">Video</span>
+                <ModelPicker bot={bot} role="video" />
               </div>
             </div>
-            <ModelPicker bot={bot} />
           </div>
 
           <div className="rounded-xl bg-card p-4">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   RefreshCw,
   Search,
   Settings,
+  Sparkles,
   Puzzle,
   Trash2,
   Users,
@@ -589,6 +590,16 @@ export function Sidebar() {
           {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
             <span className="size-2 rounded-full bg-danger" />
           )}
+        </button>
+        <button
+          onClick={() => dispatch({ type: "showGenerations" })}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition-colors",
+            state.activeView === "generations" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+          )}
+        >
+          <Sparkles size={20} className={state.activeView === "generations" ? "text-accent" : "text-ink-secondary"} />
+          <span className="text-[14px]">Generations</span>
         </button>
         <button
           onClick={() => dispatch({ type: "togglePlugins", open: true })}

--- a/src/lib/generations.test.ts
+++ b/src/lib/generations.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { collectGenerations, type GenerationSource } from "./generations";
+
+describe("collectGenerations", () => {
+  it("collects completed HTML and ready cached media across conversations", () => {
+    const sources: GenerationSource[] = [
+      {
+        ownerId: "bot-1",
+        ownerName: "Builder",
+        contextTitle: "Launch page",
+        threadId: "thread-1",
+        messages: [
+          {
+            id: "html-message",
+            role: "bot",
+            kind: "text",
+            text: "Done\n```html\n<h1>Launch</h1>\n```",
+            at: 100,
+          },
+          {
+            id: "media-message",
+            role: "bot",
+            kind: "media",
+            at: 200,
+            media: [
+              { id: "image-ready", kind: "image", status: "ready", cacheKey: "safe.png", mime: "image/png" },
+              { id: "video-cancelled", kind: "video", status: "cancelled" },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(collectGenerations(sources)).toEqual([
+      expect.objectContaining({ id: "media:image-ready", kind: "image", createdAt: 200, ownerName: "Builder" }),
+      expect.objectContaining({ id: "html:html-message:0", kind: "html", createdAt: 100, contextTitle: "Launch page" }),
+    ]);
+  });
+
+  it("uses stable output IDs and deterministic newest-first ordering", () => {
+    const sources: GenerationSource[] = [
+      {
+        ownerId: "room-1",
+        ownerName: "Design room",
+        contextTitle: "Design room",
+        threadId: "thread-room",
+        messages: [{
+          id: "media-message",
+          role: "bot",
+          kind: "media",
+          at: 300,
+          media: [
+            { id: "video-b", kind: "video", status: "ready", cacheKey: "b.mp4", mime: "video/mp4" },
+            { id: "image-a", kind: "image", status: "ready", cacheKey: "a.png", mime: "image/png" },
+          ],
+        }],
+      },
+    ];
+
+    expect(collectGenerations(sources).map((item) => item.id)).toEqual(["media:image-a", "media:video-b"]);
+  });
+});

--- a/src/lib/generations.ts
+++ b/src/lib/generations.ts
@@ -1,0 +1,61 @@
+import type { MediaOutput, Message } from "@/state/store";
+import { extractHtmlArtifacts, type HtmlArtifact } from "./html-artifacts";
+
+export interface GenerationSource {
+  ownerId: string;
+  ownerName: string;
+  contextTitle: string;
+  threadId: string;
+  messages: Message[];
+}
+
+interface GenerationBase {
+  id: string;
+  kind: "html" | "image" | "video";
+  createdAt: number;
+  ownerId: string;
+  ownerName: string;
+  contextTitle: string;
+  threadId: string;
+  messageId: string;
+}
+
+export interface HtmlGeneration extends GenerationBase {
+  kind: "html";
+  artifact: HtmlArtifact;
+}
+
+export interface MediaGeneration extends GenerationBase {
+  kind: "image" | "video";
+  output: MediaOutput;
+}
+
+export type GenerationItem = HtmlGeneration | MediaGeneration;
+
+export function collectGenerations(sources: GenerationSource[]): GenerationItem[] {
+  const items: GenerationItem[] = [];
+  for (const source of sources) {
+    for (const message of source.messages) {
+      const base = {
+        createdAt: message.at,
+        ownerId: source.ownerId,
+        ownerName: message.from?.name ?? source.ownerName,
+        contextTitle: source.contextTitle,
+        threadId: source.threadId,
+        messageId: message.id,
+      };
+      if (message.role === "bot" && message.kind === "text" && message.text) {
+        for (const artifact of extractHtmlArtifacts(message.text, message.id)) {
+          items.push({ ...base, id: `html:${artifact.id}`, kind: "html", artifact });
+        }
+      }
+      if (message.role === "bot" && message.kind === "media") {
+        for (const output of message.media ?? []) {
+          if (output.status !== "ready" || !output.cacheKey) continue;
+          items.push({ ...base, id: `media:${output.id}`, kind: output.kind, output });
+        }
+      }
+    }
+  }
+  return items.sort((left, right) => right.createdAt - left.createdAt || left.id.localeCompare(right.id));
+}

--- a/src/lib/html-artifacts.test.ts
+++ b/src/lib/html-artifacts.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  artifactHeaderMode,
+  buildArtifactDocument,
+  extractHtmlArtifacts,
+  findStreamingHtmlFence,
+  toggleArtifactSelection,
+} from "./html-artifacts";
+
+describe("HTML artifact extraction", () => {
+  it("extracts completed HTML fences with stable message-based IDs", () => {
+    expect(extractHtmlArtifacts("Before\n```html\n<h1>Hello</h1>\n```\nAfter", "message-1")).toEqual([
+      {
+        id: "message-1:0",
+        messageId: "message-1",
+        index: 0,
+        language: "html",
+        html: "<h1>Hello</h1>",
+        sourceLine: 2,
+      },
+    ]);
+  });
+
+  it("ignores partial fences and non-HTML source", () => {
+    expect(extractHtmlArtifacts("```html\n<p>partial", "message-1")).toEqual([]);
+    expect(extractHtmlArtifacts("```js\ndocument.body.innerHTML = 'x'\n```", "message-1")).toEqual([]);
+    expect(extractHtmlArtifacts("Use <main>inline HTML</main> here", "message-1")).toEqual([]);
+  });
+
+  it("supports tilde, case-insensitive, and longer fences", () => {
+    const markdown = [
+      "~~~~HTM",
+      "<pre>``` stays inside</pre>",
+      "~~~~",
+      "~~~html_preview",
+      "<button>Go</button>",
+      "~~~",
+    ].join("\n");
+    expect(extractHtmlArtifacts(markdown, "message-2")).toEqual([
+      {
+        id: "message-2:0",
+        messageId: "message-2",
+        index: 0,
+        language: "htm",
+        html: "<pre>``` stays inside</pre>",
+        sourceLine: 1,
+      },
+      {
+        id: "message-2:1",
+        messageId: "message-2",
+        index: 1,
+        language: "html_preview",
+        html: "<button>Go</button>",
+        sourceLine: 4,
+      },
+    ]);
+  });
+
+  it("identifies the exact unfinished HTML fence at the end of a stream", () => {
+    expect(findStreamingHtmlFence("Intro\n```html\n<section>work")).toEqual({
+      language: "html",
+      code: "<section>work",
+      sourceLine: 2,
+    });
+    expect(findStreamingHtmlFence("```html\nready\n```\ntext\n~~~HTM\n<p>still writing")).toEqual({
+      language: "htm",
+      code: "<p>still writing",
+      sourceLine: 5,
+    });
+    expect(findStreamingHtmlFence("```js\nwork")).toBeNull();
+    expect(findStreamingHtmlFence("```html\nready\n```")).toBeNull();
+  });
+});
+
+describe("artifact document isolation", () => {
+  it("keeps inline scripts interactive while blocking all outbound requests", () => {
+    const document = buildArtifactDocument("<script>document.body.textContent='ready'</script>");
+    expect(document).toContain("Content-Security-Policy");
+    expect(document).toContain("script-src 'unsafe-inline'");
+    expect(document).toContain("connect-src 'none'");
+    expect(document).toContain("navigate-to 'none'");
+    expect(document).toContain("img-src data: blob:");
+    expect(document).toContain("media-src data: blob:");
+    expect(document).not.toContain("img-src data: blob: http:");
+    expect(document).not.toContain("script-src 'unsafe-inline' http:");
+    expect(document).not.toContain("connect-src http:");
+    expect(document).toContain("form-action 'none'");
+    expect(document).toContain('<meta name="referrer" content="no-referrer">');
+  });
+
+  it("inserts metadata into a real head without mistaking script text for markup", () => {
+    const input = '<!doctype html><html><body><script>const example = "<head>";</script><p>Hi</p></body></html>';
+    const document = buildArtifactDocument(input);
+    expect(document.match(/<html/gi)).toHaveLength(1);
+    expect(document).toContain('const example = "<head>";');
+    expect(document.indexOf("Content-Security-Policy")).toBeLessThan(document.indexOf("<body"));
+  });
+});
+
+describe("artifact selection", () => {
+  it("keeps the header in close mode when an older artifact is open", () => {
+    expect(artifactHeaderMode("message-new:0", "message-old:0")).toBe("close");
+    expect(artifactHeaderMode("message-new:0", null)).toBe("open");
+    expect(artifactHeaderMode(undefined, null)).toBe("hidden");
+  });
+
+  it("closes the selected artifact and switches directly to a different one", () => {
+    expect(toggleArtifactSelection("message-1:0", "message-1:0")).toBeNull();
+    expect(toggleArtifactSelection("message-1:0", "message-2:0")).toBe("message-2:0");
+  });
+});

--- a/src/lib/html-artifacts.ts
+++ b/src/lib/html-artifacts.ts
@@ -1,0 +1,197 @@
+export interface HtmlArtifact {
+  id: string;
+  messageId: string;
+  index: number;
+  language: "html" | "htm" | "html_preview";
+  html: string;
+  sourceLine: number;
+}
+
+const HTML_LANGUAGES = new Set<HtmlArtifact["language"]>(["html", "htm", "html_preview"]);
+
+export interface StreamingHtmlFence {
+  language: HtmlArtifact["language"];
+  code: string;
+  sourceLine: number;
+}
+
+export function findStreamingHtmlFence(markdown: string): StreamingHtmlFence | null {
+  const lines = markdown.split(/\r?\n/);
+  for (let lineIndex = lines.length - 1; lineIndex >= 0; lineIndex--) {
+    const opening = /^\s{0,3}(`{3,}|~{3,})\s*([^\s]*)?.*$/.exec(lines[lineIndex]!);
+    if (!opening) continue;
+    const fence = opening[1]!;
+    const language = (opening[2] ?? "").toLowerCase();
+    if (!HTML_LANGUAGES.has(language as HtmlArtifact["language"])) continue;
+    const character = fence[0]!;
+    const closing = new RegExp(`^\\s{0,3}${character === "`" ? "`" : "~"}{${fence.length},}\\s*$`);
+    const body = lines.slice(lineIndex + 1);
+    if (body.some((line) => closing.test(line))) return null;
+    return {
+      language: language as HtmlArtifact["language"],
+      code: body.join("\n"),
+      sourceLine: lineIndex + 1,
+    };
+  }
+  return null;
+}
+
+export function extractHtmlArtifacts(markdown: string, messageId: string): HtmlArtifact[] {
+  const lines = markdown.split(/\r?\n/);
+  const artifacts: HtmlArtifact[] = [];
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const opening = /^\s{0,3}(`{3,}|~{3,})\s*([^\s]*)?.*$/.exec(lines[lineIndex]!);
+    if (!opening) continue;
+    const sourceLine = lineIndex + 1;
+    const fence = opening[1]!;
+    const language = (opening[2] ?? "").toLowerCase();
+    const character = fence[0]!;
+    const closing = new RegExp(`^\\s{0,3}${character === "`" ? "`" : "~"}{${fence.length},}\\s*$`);
+    const body: string[] = [];
+    let closedAt = -1;
+    for (let cursor = lineIndex + 1; cursor < lines.length; cursor++) {
+      if (closing.test(lines[cursor]!)) {
+        closedAt = cursor;
+        break;
+      }
+      body.push(lines[cursor]!);
+    }
+    if (closedAt === -1) continue;
+    lineIndex = closedAt;
+    if (!HTML_LANGUAGES.has(language as HtmlArtifact["language"])) continue;
+    const index = artifacts.length;
+    artifacts.push({
+      id: `${messageId}:${index}`,
+      messageId,
+      index,
+      language: language as HtmlArtifact["language"],
+      html: body.join("\n"),
+      sourceLine,
+    });
+  }
+  return artifacts;
+}
+
+export type ArtifactHeaderMode = "hidden" | "open" | "close";
+
+export function artifactHeaderMode(
+  latestArtifactId: string | undefined,
+  selectedArtifactId: string | null | undefined,
+): ArtifactHeaderMode {
+  if (selectedArtifactId) return "close";
+  return latestArtifactId ? "open" : "hidden";
+}
+
+export function toggleArtifactSelection(selectedArtifactId: string | null, requestedArtifactId: string): string | null {
+  return selectedArtifactId === requestedArtifactId ? null : requestedArtifactId;
+}
+
+const ARTIFACT_CSP = [
+  "default-src 'none'",
+  "img-src data: blob:",
+  "media-src data: blob:",
+  "style-src 'unsafe-inline'",
+  "font-src data:",
+  "script-src 'unsafe-inline'",
+  "connect-src 'none'",
+  "navigate-to 'none'",
+  "form-action 'none'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "frame-src 'none'",
+].join("; ");
+
+const isolationMetadata =
+  `<meta http-equiv="Content-Security-Policy" content="${ARTIFACT_CSP}">` +
+  '<meta name="referrer" content="no-referrer">' +
+  "<style>html{color-scheme:light dark}body{margin:0}</style>";
+
+function domParsedDocument(html: string): string | null {
+  if (typeof DOMParser === "undefined") return null;
+  const document = new DOMParser().parseFromString(html, "text/html");
+  const csp = document.createElement("meta");
+  csp.setAttribute("http-equiv", "Content-Security-Policy");
+  csp.setAttribute("content", ARTIFACT_CSP);
+  const referrer = document.createElement("meta");
+  referrer.setAttribute("name", "referrer");
+  referrer.setAttribute("content", "no-referrer");
+  const style = document.createElement("style");
+  style.textContent = "html{color-scheme:light dark}body{margin:0}";
+  document.head.prepend(csp, referrer, style);
+  return `<!doctype html>${document.documentElement.outerHTML}`;
+}
+
+const RAW_TEXT_TAGS = new Set(["script", "style", "textarea", "title"]);
+
+/** Find an actual opening tag while ignoring comments and raw script/style text.
+ * The browser path above uses DOMParser; this deterministic fallback keeps the
+ * helper safe and testable in Node, where DOMParser is not available. */
+function openingTagEnd(source: string, wanted: string): number | null {
+  const lower = source.toLowerCase();
+  let cursor = 0;
+  while (cursor < source.length) {
+    const start = source.indexOf("<", cursor);
+    if (start === -1) return null;
+    if (source.startsWith("<!--", start)) {
+      const end = source.indexOf("-->", start + 4);
+      cursor = end === -1 ? source.length : end + 3;
+      continue;
+    }
+    if (source[start + 1] === "!" || source[start + 1] === "?") {
+      const end = source.indexOf(">", start + 2);
+      cursor = end === -1 ? source.length : end + 1;
+      continue;
+    }
+    const match = /^<\s*(\/?)\s*([a-z][\w:-]*)/i.exec(source.slice(start));
+    if (!match) {
+      cursor = start + 1;
+      continue;
+    }
+    let end = start + match[0].length;
+    let quote = "";
+    for (; end < source.length; end++) {
+      const character = source[end]!;
+      if (quote) {
+        if (character === quote) quote = "";
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        break;
+      }
+    }
+    if (end >= source.length) return null;
+    const closing = Boolean(match[1]);
+    const name = match[2]!.toLowerCase();
+    if (!closing && name === wanted) return end + 1;
+    if (!closing && RAW_TEXT_TAGS.has(name)) {
+      const closeStart = lower.indexOf(`</${name}`, end + 1);
+      if (closeStart === -1) return null;
+      const closeEnd = source.indexOf(">", closeStart + name.length + 2);
+      cursor = closeEnd === -1 ? source.length : closeEnd + 1;
+    } else {
+      cursor = end + 1;
+    }
+  }
+  return null;
+}
+
+export function buildArtifactDocument(html: string): string {
+  const parsed = domParsedDocument(html);
+  if (parsed) return parsed;
+
+  const headEnd = openingTagEnd(html, "head");
+  if (headEnd !== null) return `${html.slice(0, headEnd)}${isolationMetadata}${html.slice(headEnd)}`;
+
+  const htmlEnd = openingTagEnd(html, "html");
+  if (htmlEnd !== null) {
+    return `${html.slice(0, htmlEnd)}<head>${isolationMetadata}</head>${html.slice(htmlEnd)}`;
+  }
+
+  return [
+    "<!doctype html>",
+    "<html>",
+    `<head>${isolationMetadata}</head>`,
+    `<body>${html}</body>`,
+    "</html>",
+  ].join("");
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -148,6 +148,13 @@ export function messageVersions(bot: Bot, message: Message): Message[] {
 /** GET /api/config — configured flags only; secrets are never echoed. */
 export interface ConfigStatus {
   xai?: { configured: boolean };
+  openrouter: { configured: boolean };
+  ollamaCloud: { configured: boolean };
+  openaiCompatible: {
+    apiKeyConfigured: boolean;
+    url: string;
+    model: string;
+  };
   composio: { configured: boolean; apiKeyConfigured?: boolean };
   box: { configured: boolean };
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND
@@ -1128,6 +1135,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             type: "configStatus",
             config: {
               xai: frame.xai,
+              openrouter: frame.openrouter,
+              ollamaCloud: frame.ollamaCloud,
+              openaiCompatible: frame.openaiCompatible,
               composio: frame.composio,
               box: frame.box,
               tts: frame.tts,

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -219,7 +219,7 @@ interface AppState {
   config: ConfigStatus | null;
   /** selected chat — a bot id OR a group id */
   selectedId: string;
-  activeView: "chat" | "routines";
+  activeView: "chat" | "routines" | "generations";
   routines: Routine[];
   routineRuns: RoutineRun[];
   settingsOpen: boolean;
@@ -242,6 +242,7 @@ interface AppState {
 type Action =
   | { type: "hydrate"; bots: Bot[]; groups: Group[] }
   | { type: "showRoutines" }
+  | { type: "showGenerations" }
   | { type: "routinesHydrated"; routines: Routine[]; runs: RoutineRun[] }
   | { type: "routinePatched"; routine: Routine }
   | { type: "routineDeleted"; routineId: string }
@@ -366,6 +367,15 @@ function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         activeView: "routines",
+        settingsOpen: false,
+        computerOpen: false,
+        appSettingsOpen: false,
+        pluginsOpen: false,
+      };
+    case "showGenerations":
+      return {
+        ...state,
+        activeView: "generations",
         settingsOpen: false,
         computerOpen: false,
         appSettingsOpen: false,

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -38,7 +38,7 @@ export interface OptionCardData {
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen";
+  kind: "text" | "options" | "activity" | "screen" | "media";
   text?: string;
   card?: OptionCardData;
   /** activity messages: tool name + outcome. `spoken` is the server's
@@ -47,6 +47,7 @@ export interface Message {
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;
+  media?: MediaOutput[];
   at: number;
   /** the message this one follows; null = thread root. Edited messages
    * share a parentId with the version they replace — that's a fork. */
@@ -79,6 +80,25 @@ export interface ModelSelection {
   model: string;
 }
 
+export type ModelTask = "chat" | "image" | "video";
+export type MediaKind = "image" | "video";
+export type MediaStatus = "queued" | "generating" | "downloading" | "ready" | "failed" | "cancelled";
+
+export interface MediaOutput {
+  id: string;
+  kind: MediaKind;
+  status: MediaStatus;
+  mime?: string;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  bytes?: number;
+  progress?: number;
+  cacheKey?: string;
+  providerJobId?: string;
+  error?: string;
+}
+
 /** One of a bot's separate contexts: its own thread, transcript and
  * provider session. The bot's threadId points at the active one. */
 export interface Task {
@@ -101,6 +121,7 @@ export interface Bot {
   unread: boolean;
   busy?: boolean;
   modelSelection: ModelSelection;
+  specialists?: { image?: ModelSelection; video?: ModelSelection };
   /** Where this bot's computer runs; unset = auto (cloud box if one exists, else local). */
   computer?: "cloud" | "local" | "off";
   /** auto mode: the bot approves its own tool permissions */
@@ -154,6 +175,9 @@ export interface ConfigStatus {
     apiKeyConfigured: boolean;
     url: string;
     model: string;
+    modelTasks: Record<string, ModelTask>;
+    imagePath: string;
+    videoPath: string;
   };
   composio: { configured: boolean; apiKeyConfigured?: boolean };
   box: { configured: boolean };
@@ -176,7 +200,16 @@ export interface InstanceInfo {
     authenticated?: boolean;
     version?: string | null;
   };
-  models: { default: string; options: Array<{ id: string; label: string }> };
+  models: {
+    default: string;
+    options: Array<{
+      id: string;
+      label: string;
+      task?: ModelTask;
+      inputModalities?: string[];
+      outputModalities?: string[];
+    }>;
+  };
 }
 
 interface AppState {
@@ -263,6 +296,7 @@ type Action =
   | { type: "provisioning"; botId: string; on: boolean }
   | { type: "setModel"; botId: string; selection: ModelSelection }
   | { type: "interrupt"; botId: string }
+  | { type: "cancelMedia"; botId: string; messageId: string }
   | { type: "connected"; value: boolean }
   | { type: "error"; message: string | null }
   | { type: "toggleSettings"; open?: boolean }
@@ -287,6 +321,7 @@ type Action =
           | "voice"
           | "pinned"
           | "hidden"
+          | "specialists"
         >
       >;
     };
@@ -620,6 +655,7 @@ function reducer(state: AppState, action: Action): AppState {
     case "newBot":
     case "duplicateBot":
     case "interrupt":
+    case "cancelMedia":
     case "createGroup":
     case "sendGroup":
     case "deleteGroup":
@@ -945,6 +981,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
         case "interrupt":
           api(`/api/bots/${action.botId}/interrupt`, { method: "POST" }).catch(showError);
+          break;
+        case "cancelMedia":
+          api(`/api/bots/${action.botId}/messages/${action.messageId}/cancel-media`, { method: "POST" }).catch(showError);
           break;
         // tasks: the server answers with the bot AND the live transcript,
         // because switching changes which conversation is on screen

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts", "electron/**/*.test.mjs", "src/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx", "electron/**/*.test.mjs"],
     setupFiles: ["server/testing/setup.ts"],
     // the suite spawns fake provider CLIs and a real harness server;
     // parallel files introduce load-sensitive flakes for no win


### PR DESCRIPTION
## What changed

- Added **Generations** above Plugins in the sidebar.
- Added a read-only server index across bot tasks and rooms for completed HTML artifacts and ready cached image/video outputs.
- Added search and type filters for HTML, images, and videos.
- Kept HTML cards inert in the library; opening one uses the hardened artifact panel rather than executing code in the grid.
- Opened media in the accessible viewer shared with chat.

## Why

Generated outputs remain useful after a conversation moves on. This focused slice provides one discoverable library without introducing a second persistence system or weakening the artifact/media safety boundaries established by its parent PRs.

## How it was verified

- `pnpm test` — 316 passed, 7 skipped
- `pnpm build`
- Coverage for cross-task indexing, completed/ready-state filtering, search/type filters, inert HTML cards, and viewer opening
- Manual Electron smoke test of the reviewed full stack
- `git diff --check codex/media-generation..HEAD`

## Screenshots (UI changes)

![Generations above Plugins with HTML, image, and video outputs](https://raw.githubusercontent.com/zenacquire/OpenMausBot/codex/model-providers/docs/screenshots/provider-media-creations.png)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server index behavior and UI filtering have tests
- [x] No `dist-server/` edits or dependency/lockfile churn
- [x] HTML does not execute inside the Generations grid
- [x] No secrets in logs, responses, events, or argv

## Stack

- Depends on #95 (and transitively #94 and #93).
- This is the final slice of the replacement stack for #74.

This fork-based stack targets upstream `main`; this PR will be rebased as its parents land so its visible diff collapses to this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenRouter, Ollama Cloud, and custom OpenAI-compatible endpoints.
  * Added image and video generation, specialist model selection, progress tracking, cancellation, and cached media playback.
  * Added a Generations gallery with filtering, search, previews, and artifact viewing.
  * Added interactive HTML artifact previews with resizing, copying, downloading, and safer sandboxing.
* **Security**
  * Improved protection against untrusted navigation and external links.
  * Sensitive provider credentials are now redacted from diagnostic information.
* **Documentation**
  * Updated setup and credential guidance for supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->