### PR TITLE
Make a machine with no AI CLI installed recoverable

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, desktopCapturer, ipcMain, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, ipcMain, session, shell, systemPreferences, utilityProcess } from "electron";
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -220,6 +221,57 @@ ipcMain.handle("screen:frame", async () => {
 // (screen:frame above / getDisplayMedia via the handler below) — macOS
 // prompts then, attributed correctly, at the moment of actual use. The
 // perm:open-settings deep link stays as the repair path for denials.
+// Open a terminal with an engine's install command typed in, NOT executed.
+//
+// Two reasons it stops short of running: the user should read a command
+// before it touches their machine (these fetch and run remote installers),
+// and installing is only half the job — every CLI then needs an interactive
+// sign-in, which has to happen in a terminal anyway. Landing them there with
+// the command ready covers both steps in one place.
+//
+// The command is put on the clipboard first, so if a terminal can't be
+// launched the user can still paste it. Returns false when the renderer
+// should fall back to showing the command itself.
+ipcMain.handle("engine:open-terminal", (_event, command) => {
+  if (typeof command !== "string" || !command.trim()) return false;
+  clipboard.writeText(command);
+  try {
+    if (process.platform === "darwin") {
+      // `do script` runs it; keystroke would need Accessibility permission,
+      // so macOS is the one platform where the command does execute. It is
+      // still visible in the scrollback before output appears.
+      execFile("osascript", [
+        "-e",
+        `tell application "Terminal" to do script ${JSON.stringify(command)}`,
+        "-e",
+        'tell application "Terminal" to activate',
+      ]);
+      return true;
+    }
+    if (process.platform === "win32") {
+      // -NoExit keeps the window open after the install so the sign-in step
+      // can run in the same shell. Windows Terminal isn't guaranteed to be
+      // present, so go through PowerShell directly.
+      execFile("cmd", ["/c", "start", "powershell", "-NoExit", "-Command", command], {
+        windowsHide: true,
+      });
+      return true;
+    }
+    // Linux has no single terminal; try the common ones and give up quietly.
+    for (const term of ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]) {
+      try {
+        execFile(term, ["-e", `bash -lc ${JSON.stringify(`${command}; exec bash`)}`]);
+        return true;
+      } catch {
+        /* try the next one */
+      }
+    }
+    return false;
+  } catch {
+    return false; // clipboard still has it
+  }
+});
+
 ipcMain.handle("perm:status", () => ({
   mic:
     process.platform === "darwin"

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,10 +1,10 @@
 import { app, BrowserWindow, clipboard, desktopCapturer, ipcMain, session, shell, systemPreferences, utilityProcess } from "electron";
-import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { startCua, stopCua, registerCuaIpc } from "./cua.mjs";
 import { startSpeech, stopSpeech } from "./speech.mjs";
+import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
@@ -221,55 +221,13 @@ ipcMain.handle("screen:frame", async () => {
 // (screen:frame above / getDisplayMedia via the handler below) — macOS
 // prompts then, attributed correctly, at the moment of actual use. The
 // perm:open-settings deep link stays as the repair path for denials.
-// Open a terminal with an engine's install command typed in, NOT executed.
-//
-// Two reasons it stops short of running: the user should read a command
-// before it touches their machine (these fetch and run remote installers),
-// and installing is only half the job — every CLI then needs an interactive
-// sign-in, which has to happen in a terminal anyway. Landing them there with
-// the command ready covers both steps in one place.
-//
-// The command is put on the clipboard first, so if a terminal can't be
-// launched the user can still paste it. Returns false when the renderer
-// should fall back to showing the command itself.
-ipcMain.handle("engine:open-terminal", (_event, command) => {
+// Copy the engine command, then open a blank terminal. Renderer-controlled
+// text must never become a process argument: the user reviews and pastes it.
+// Returns false when the renderer should show the clipboard fallback.
+ipcMain.handle("engine:open-terminal", async (_event, command) => {
   if (typeof command !== "string" || !command.trim()) return false;
   clipboard.writeText(command);
-  try {
-    if (process.platform === "darwin") {
-      // `do script` runs it; keystroke would need Accessibility permission,
-      // so macOS is the one platform where the command does execute. It is
-      // still visible in the scrollback before output appears.
-      execFile("osascript", [
-        "-e",
-        `tell application "Terminal" to do script ${JSON.stringify(command)}`,
-        "-e",
-        'tell application "Terminal" to activate',
-      ]);
-      return true;
-    }
-    if (process.platform === "win32") {
-      // -NoExit keeps the window open after the install so the sign-in step
-      // can run in the same shell. Windows Terminal isn't guaranteed to be
-      // present, so go through PowerShell directly.
-      execFile("cmd", ["/c", "start", "powershell", "-NoExit", "-Command", command], {
-        windowsHide: true,
-      });
-      return true;
-    }
-    // Linux has no single terminal; try the common ones and give up quietly.
-    for (const term of ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]) {
-      try {
-        execFile(term, ["-e", `bash -lc ${JSON.stringify(`${command}; exec bash`)}`]);
-        return true;
-      } catch {
-        /* try the next one */
-      }
-    }
-    return false;
-  } catch {
-    return false; // clipboard still has it
-  }
+  return openBlankTerminal();
 });
 
 ipcMain.handle("perm:status", () => ({

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -38,6 +38,11 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Opens System Settings on the given privacy pane: mic|screen|speech. */
   permOpenSettings: (pane) => ipcRenderer.invoke("perm:open-settings", pane),
 
+  /** Opens a terminal with an engine's install command ready, and copies it
+   * to the clipboard either way. Resolves false if no terminal could be
+   * launched — the caller should then show the command to paste. */
+  openInstallTerminal: (command) => ipcRenderer.invoke("engine:open-terminal", command),
+
   /** In-app auto-update. State object:
    *  { status: "idle"|"checking"|"available"|"downloading"|"downloaded"|"error",
    *    version?, percent?, message? }. onState fires immediately with the

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -38,9 +38,8 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Opens System Settings on the given privacy pane: mic|screen|speech. */
   permOpenSettings: (pane) => ipcRenderer.invoke("perm:open-settings", pane),
 
-  /** Opens a terminal with an engine's install command ready, and copies it
-   * to the clipboard either way. Resolves false if no terminal could be
-   * launched — the caller should then show the command to paste. */
+  /** Copies an engine install command and opens a blank terminal. Resolves
+   * false if no terminal could be launched; the clipboard still has it. */
   openInstallTerminal: (command) => ipcRenderer.invoke("engine:open-terminal", command),
 
   /** In-app auto-update. State object:

--- a/electron/terminal-launch.mjs
+++ b/electron/terminal-launch.mjs
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+
+/** Resolve only after the launcher really spawns or reports an error. */
+function launch(executable, args, options, run = execFile) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = run(executable, args, options);
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (ok) child.unref?.();
+      resolve(ok);
+    };
+    child.once("spawn", () => finish(true));
+    child.once("error", () => finish(false));
+  });
+}
+
+/** Open a blank terminal. Installer text is deliberately not accepted here,
+ * so renderer-controlled input can never become a process argument. */
+export async function openBlankTerminal(platform = process.platform, run = execFile) {
+  if (platform === "darwin") {
+    return launch(
+      "osascript",
+      ["-e", 'tell application "Terminal" to activate'],
+      undefined,
+      run,
+    );
+  }
+  if (platform === "win32") {
+    return launch("powershell.exe", ["-NoExit"], { windowsHide: false }, run);
+  }
+  if (platform === "linux") {
+    for (const terminal of ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]) {
+      if (await launch(terminal, [], undefined, run)) return true;
+    }
+  }
+  return false;
+}

--- a/electron/terminal-launch.test.mjs
+++ b/electron/terminal-launch.test.mjs
@@ -1,0 +1,62 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+
+import { openBlankTerminal } from "./terminal-launch.mjs";
+
+function launcher(outcomes) {
+  const calls = [];
+  const run = (executable, args, options) => {
+    calls.push({ executable, args, options });
+    const child = new EventEmitter();
+    child.unref = () => {};
+    const outcome = outcomes.shift() ?? "spawn";
+    queueMicrotask(() => {
+      if (outcome === "throw") child.emit("error", new Error("missing terminal"));
+      else child.emit("spawn");
+    });
+    return child;
+  };
+  return { calls, run };
+}
+
+describe("blank terminal launcher", () => {
+  it("opens Terminal on macOS without a command argument", async () => {
+    const fake = launcher(["spawn"]);
+    await expect(openBlankTerminal("darwin", fake.run)).resolves.toBe(true);
+    expect(fake.calls).toEqual([
+      {
+        executable: "osascript",
+        args: ["-e", 'tell application "Terminal" to activate'],
+        options: undefined,
+      },
+    ]);
+  });
+
+  it("opens a blank PowerShell window on Windows", async () => {
+    const fake = launcher(["spawn"]);
+    await expect(openBlankTerminal("win32", fake.run)).resolves.toBe(true);
+    expect(fake.calls[0]).toMatchObject({ executable: "powershell.exe", args: ["-NoExit"] });
+  });
+
+  it("tries the next Linux terminal after an asynchronous launch error", async () => {
+    const fake = launcher(["throw", "spawn"]);
+    await expect(openBlankTerminal("linux", fake.run)).resolves.toBe(true);
+    expect(fake.calls.map((call) => call.executable)).toEqual([
+      "x-terminal-emulator",
+      "gnome-terminal",
+    ]);
+    expect(fake.calls.every((call) => call.args.length === 0)).toBe(true);
+  });
+
+  it("returns false when no Linux terminal launches", async () => {
+    const fake = launcher(["throw", "throw", "throw", "throw"]);
+    await expect(openBlankTerminal("linux", fake.run)).resolves.toBe(false);
+  });
+
+  it("returns false when the launcher throws synchronously", async () => {
+    const run = () => {
+      throw new Error("launch failed");
+    };
+    await expect(openBlankTerminal("darwin", run)).resolves.toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "vitest run",
     "bench:observation": "node --experimental-strip-types scripts/bench-observation.ts",
     "test:watch": "vitest",
-    "check:electron": "node --check electron/main.mjs && node --check electron/preload.cjs && node --check electron/capabilities.cjs && node --check electron/cua-connection.cjs && node --check electron/cua.mjs && node --check electron/speech.mjs",
+    "check:electron": "node --check electron/main.mjs && node --check electron/terminal-launch.mjs && node --check electron/preload.cjs && node --check electron/capabilities.cjs && node --check electron/cua-connection.cjs && node --check electron/cua.mjs && node --check electron/speech.mjs",
     "preview": "vite preview",
     "build:server": "tsc -p tsconfig.server.build.json",
     "build:speech": "node electron/build-speech-helper.mjs",

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -76,7 +76,9 @@ export type RuntimeEvent = RuntimeEventBase &
       }
     | { type: "request.resolved"; behavior: string; source: string }
     | { type: "thread.token-usage.updated"; input: number; output: number }
-    | { type: "runtime.error"; message: string }
+    // `setup: true` marks a failure the user fixes by installing or
+    // configuring something, not by retrying — the UI offers setup instead.
+    | { type: "runtime.error"; message: string; setup?: boolean }
   );
 
 export type RuntimeEventListener = (event: RuntimeEvent) => void;
@@ -151,6 +153,28 @@ export interface ProviderSnapshot {
   version?: string | null;
 }
 
+// ── engine install descriptor ───────────────────────────────────────────
+// How a user gets this engine onto their machine. Declared by the driver so
+// that adding a provider stays "one file in drivers/ plus a registration":
+// onboarding, the model picker, and settings all render from this instead of
+// hardcoding per-engine copy in the UI.
+//
+// Installing is rarely the whole job — most CLIs then need an interactive
+// sign-in, which is why signInCommand exists and why the UI sends people to a
+// terminal rather than trying to shell out silently.
+export interface EngineInstall {
+  /** One-liner per platform. Omit a platform that has no such command —
+   * the UI falls back to docsUrl rather than offering something that
+   * cannot work there (a curl|bash line is not a Windows command). */
+  command?: Partial<Record<"darwin" | "win32" | "linux", string>>;
+  /** Docs or download page. The only route for GUI-installed engines. */
+  docsUrl?: string;
+  /** Interactive sign-in run after installing, when install isn't enough. */
+  signInCommand?: string;
+  /** `command` needs npm on PATH, so the UI can say so when Node is absent. */
+  needsNode?: boolean;
+}
+
 // ── driver SPI (upstream ProviderDriver — a plain record, not a service) ─
 // `create` owns ALL per-instance state; two create calls share nothing.
 // Failures must reject, never throw synchronously — the registry downgrades
@@ -184,6 +208,9 @@ export interface ProviderInstance {
 export interface ProviderDriver<Config = unknown> {
   readonly driverKind: DriverKind;
   readonly metadata: { displayName: string; supportsMultipleInstances?: boolean };
+  /** How to get this engine installed. Omit for engines that need no local
+   * binary (API-key drivers), which is what makes it optional. */
+  readonly install?: EngineInstall;
   /** Decode the opaque config envelope; throw on invalid (→ shadow). */
   decodeConfig(raw: unknown): Config;
   defaultConfig(): Config;

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -18,10 +18,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { execCli, killCliTree, spawnCli } from "../../procs.ts";
+import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../procs.ts";
 
 import type {
   DriverCreateInput,
+  EngineInstall,
   ProviderDriver,
   ProviderInstance,
   ProviderSnapshot,
@@ -58,6 +59,8 @@ export interface AcpSupport {
   nativeSource: string;
   /** Message shown when the CLI is present but not signed in. */
   loginNote: string;
+  /** How a user installs this harness's CLI; surfaced by the setup UI. */
+  install?: EngineInstall;
   /** CLI argv AFTER the binary name to enter ACP stdio mode. */
   spawnArgs(config: AcpConfig, turn: SendTurnInput): string[];
   /** Mutate the child env in place (e.g. strip a key). Optional. */
@@ -99,6 +102,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
   return {
     driverKind: DRIVER_KIND,
     metadata: { displayName: support.displayName, supportsMultipleInstances: true },
+    install: support.install,
     models: support.models,
     decodeConfig,
     defaultConfig: () => decodeConfig({}),
@@ -393,7 +397,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           if (stderr.length > 8192) stderr = stderr.slice(-8192);
         });
         child.on("error", (e) => {
-          emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+          emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
           settle(false, "spawn_error");
         });
         child.on("close", (code) => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -487,8 +487,17 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           } catch (e) {
             if (!state.settled) {
               const message = (e as Error).message;
-              emit({ ...base(threadId, turnId), type: "runtime.error", message });
-              settle(false, message === support.loginNote ? "auth_required" : "rpc_error");
+              // "not signed in" is a setup problem like a missing binary: the
+              // fix is a command in a terminal, not another attempt. Flagging
+              // it lets the error card show the sign-in step.
+              const needsAuth = message === support.loginNote;
+              emit({
+                ...base(threadId, turnId),
+                type: "runtime.error",
+                message,
+                ...(needsAuth ? { setup: true } : {}),
+              });
+              settle(false, needsAuth ? "auth_required" : "rpc_error");
             }
           }
         })();

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -27,6 +27,18 @@ const support: AcpSupport = {
   nativeSource: "grok.acp",
   loginNote: "Grok CLI is not signed in — run `grok login` in a terminal",
 
+  // No Windows one-liner: the installer is a POSIX shell script, and offering
+  // `curl … | bash` there would be advice that cannot run. Windows falls back
+  // to docsUrl, which is honest rather than broken.
+  install: {
+    command: {
+      darwin: "curl -fsSL https://x.ai/cli/install.sh | bash",
+      linux: "curl -fsSL https://x.ai/cli/install.sh | bash",
+    },
+    docsUrl: "https://x.ai/cli",
+    signInCommand: "grok login",
+  },
+
   // --permission-mode must always be explicit: ~/.grok/config.toml may set
   // permission_mode = "always-approve", which would silently make every
   // session yolo and never fire session/request_permission.

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -17,6 +17,16 @@ import { AntigravityDriver } from "./antigravity.ts";
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-agy-cli.ts");
 
 describe("Antigravity decodeConfig", () => {
+  it("publishes the official installer for every supported platform", () => {
+    expect(AntigravityDriver.install).toMatchObject({
+      command: {
+        darwin: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+        linux: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+        win32: "irm https://antigravity.google/cli/install.ps1 | iex",
+      },
+    });
+  });
+
   it("defaults to the agy binary and fullAuto on", () => {
     expect(AntigravityDriver.decodeConfig({})).toEqual({ cli: "agy", fullAuto: true });
     expect(AntigravityDriver.decodeConfig(undefined)).toEqual({ cli: "agy", fullAuto: true });

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -10,7 +10,7 @@
 // `request-review` auto-denies; `--dangerously-skip-permissions` (fullAuto)
 // approves everything. Real per-action approval cards are a future path via
 // native ACP (agy issue #31), which would reuse acp/core.ts like grok/gemini.
-import { execCli, killCliTree, spawnCli } from "../procs.ts";
+import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -74,6 +74,9 @@ function decodeConfig(raw: unknown): AntigravityConfig {
 export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Antigravity", supportsMultipleInstances: true },
+  // A GUI download rather than a package install — no command on any
+  // platform, so the setup UI can only send people to the download page.
+  install: { docsUrl: "https://antigravity.google/download" },
   models: MODELS,
   decodeConfig,
   defaultConfig: () => decodeConfig({}),
@@ -274,7 +277,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       });
 
       child.on("error", (e) => {
-        emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+        emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
 

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -74,9 +74,14 @@ function decodeConfig(raw: unknown): AntigravityConfig {
 export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Antigravity", supportsMultipleInstances: true },
-  // A GUI download rather than a package install — no command on any
-  // platform, so the setup UI can only send people to the download page.
-  install: { docsUrl: "https://antigravity.google/download" },
+  install: {
+    command: {
+      darwin: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+      linux: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+      win32: "irm https://antigravity.google/cli/install.ps1 | iex",
+    },
+    docsUrl: "https://github.com/google-antigravity/antigravity-cli#installation",
+  },
   models: MODELS,
   decodeConfig,
   defaultConfig: () => decodeConfig({}),

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 
 import { DATA_DIR } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
-import { brokerSocketPath, execCli, killCliTree, spawnCli } from "../procs.ts";
+import { brokerSocketPath, describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 
 import type {
   DriverCreateInput,
@@ -202,6 +202,18 @@ function firstText(content: unknown): string {
 export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Claude", supportsMultipleInstances: true },
+  // npm on all three: the one recipe that is genuinely cross-platform. The
+  // native installers differ per OS and would need verifying separately.
+  install: {
+    command: {
+      darwin: "npm install -g @anthropic-ai/claude-code",
+      linux: "npm install -g @anthropic-ai/claude-code",
+      win32: "npm install -g @anthropic-ai/claude-code",
+    },
+    needsNode: true,
+    docsUrl: "https://claude.com/claude-code",
+    signInCommand: "claude",
+  },
   models: MODELS,
   decodeConfig,
   defaultConfig: () => decodeConfig({}),
@@ -437,7 +449,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       });
 
       child.on("error", (e) => {
-        emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+        emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
 

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -11,7 +11,7 @@
 // and falls back to a fresh thread/start.
 import { homedir } from "node:os";
 
-import { execCli, killCliTree, spawnCli } from "../procs.ts";
+import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 
 import type {
   DriverCreateInput,
@@ -58,6 +58,16 @@ const DENY_TIMEOUT_NOTE =
 export const CodexDriver: ProviderDriver<CodexConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Codex", supportsMultipleInstances: true },
+  install: {
+    command: {
+      darwin: "npm install -g @openai/codex",
+      linux: "npm install -g @openai/codex",
+      win32: "npm install -g @openai/codex",
+    },
+    needsNode: true,
+    docsUrl: "https://github.com/openai/codex",
+    signInCommand: "codex",
+  },
   models: MODELS,
   decodeConfig,
   defaultConfig: () => decodeConfig({}),
@@ -331,7 +341,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         if (stderr.length > 8192) stderr = stderr.slice(-8192);
       });
       child.on("error", (e) => {
-        emit({ ...base(threadId, turnId), type: "runtime.error", message: `spawn failed: ${e.message}` });
+        emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
       child.on("close", (code) => {

--- a/server/env-path.test.ts
+++ b/server/env-path.test.ts
@@ -79,7 +79,7 @@ describe("augmentedPath", () => {
 
   it.skipIf(process.platform !== "win32")("finds Antigravity installed after launch", () => {
     const previous = process.env.LOCALAPPDATA;
-    const localAppData = join(homedir(), "AppData", "Local");
+    const localAppData = mkdtempSync(join(tmpdir(), "omb-localappdata-"));
     try {
       process.env.LOCALAPPDATA = localAppData;
       const agyBin = join(localAppData, "agy", "bin");
@@ -90,6 +90,7 @@ describe("augmentedPath", () => {
       if (previous === undefined) delete process.env.LOCALAPPDATA;
       else process.env.LOCALAPPDATA = previous;
       resetPathCacheForTests();
+      rmSync(localAppData, { recursive: true, force: true });
     }
   });
 });

--- a/server/env-path.test.ts
+++ b/server/env-path.test.ts
@@ -76,6 +76,22 @@ describe("augmentedPath", () => {
     // temp home: .volta was never created, so it must not appear
     expect(parts).not.toContain(join(homedir(), ".volta", "bin"));
   });
+
+  it.skipIf(process.platform !== "win32")("finds Antigravity installed after launch", () => {
+    const previous = process.env.LOCALAPPDATA;
+    const localAppData = join(homedir(), "AppData", "Local");
+    try {
+      process.env.LOCALAPPDATA = localAppData;
+      const agyBin = join(localAppData, "agy", "bin");
+      mkdirSync(agyBin, { recursive: true });
+      resetPathCacheForTests();
+      expect(augmentedPath().split(delimiter)).toContain(agyBin);
+    } finally {
+      if (previous === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = previous;
+      resetPathCacheForTests();
+    }
+  });
 });
 
 // Windows CLI resolution — spawn(cli) alone finds nothing on Windows (no

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -44,8 +44,36 @@ function knownDirs(): string[] {
   ];
 }
 
+/** Windows equivalents of knownDirs. A GUI app inherits the user PATH at
+ * launch, but only at launch: a CLI installed while the app is running is
+ * invisible until it restarts, because Windows never pushes PATH changes
+ * into a live process. Scanning the standard install locations recovers
+ * those without a restart — `~/.grok/bin` (the x.ai installer) and
+ * `%APPDATA%\npm` (global npm shims) between them cover every engine we
+ * ship an install command for. */
+function windowsKnownDirs(): string[] {
+  const home = homedir();
+  const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+  return [
+    join(appData, "npm"), // npm -g shims: claude, codex
+    join(home, ".grok", "bin"), // x.ai installer
+    join(home, ".local", "bin"), // claude native installer
+    join(home, ".claude", "local"),
+    join(home, ".bun", "bin"),
+    join(home, ".deno", "bin"),
+    join(home, "go", "bin"),
+  ];
+}
+
 let cached: string | null = null;
 let probed = false;
+
+/** Drop the memoized PATH so the next augmentedPath() rescans. Called when
+ * the app re-probes engines, so "check again" can find something installed
+ * since launch instead of answering from the PATH we booted with. */
+export function resetPathCache(): void {
+  cached = null;
+}
 
 /** Current best PATH, synchronously. Cheap after the first call. */
 export function augmentedPath(): string {
@@ -53,9 +81,10 @@ export function augmentedPath(): string {
     cached = mergePaths([
       ...(process.env.OMB_EXTRA_PATH ? process.env.OMB_EXTRA_PATH.split(delimiter) : []),
       ...(process.env.PATH ? process.env.PATH.split(delimiter) : []),
-      // GUI apps on Windows inherit the user PATH already; the unix
-      // install-dir scan and shell probe are the darwin/linux cure
-      ...(process.platform === "win32" ? [] : knownDirs().filter((d) => existsSync(d))),
+      // Both platforms scan their standard install locations; only the
+      // login-shell probe below stays unix-only, since Windows has no
+      // equivalent rc file to source.
+      ...(process.platform === "win32" ? windowsKnownDirs() : knownDirs()).filter((d) => existsSync(d)),
     ]);
   }
   // belt-and-braces: fold in the login shell's PATH once, in the

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -49,14 +49,16 @@ function knownDirs(): string[] {
  * invisible until it restarts, because Windows never pushes PATH changes
  * into a live process. Scanning the standard install locations recovers
  * those without a restart — `~/.grok/bin` (the x.ai installer) and
- * `%APPDATA%\npm` (global npm shims) between them cover every engine we
- * ship an install command for. */
+ * `%APPDATA%\npm` (global npm shims), plus `%LOCALAPPDATA%\agy\bin`, cover
+ * every engine we ship an install command for. */
 function windowsKnownDirs(): string[] {
   const home = homedir();
   const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+  const localAppData = process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
   return [
     join(appData, "npm"), // npm -g shims: claude, codex
     join(home, ".grok", "bin"), // x.ai installer
+    join(localAppData, "agy", "bin"), // Antigravity installer
     join(home, ".local", "bin"), // claude native installer
     join(home, ".claude", "local"),
     join(home, ".bun", "bin"),

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -96,6 +96,8 @@ export class ProviderRegistry {
             displayName: entry.shadow.displayName ?? entry.shadow.driverKind,
             snapshot: { state: "unavailable", reason: entry.shadow.reason } satisfies ProviderSnapshot,
             models: { default: "", options: [] },
+            // an unknown driver has no driver record, hence no install path
+            install: this.driversByKind.get(entry.shadow.driverKind)?.install,
           };
         }
         const inst = entry.live;
@@ -111,6 +113,7 @@ export class ProviderRegistry {
           displayName: inst.displayName ?? inst.driverKind,
           snapshot,
           models: inst.models,
+          install: this.driversByKind.get(inst.driverKind)?.install,
         };
       }),
     );

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ import * as box from "./box.ts";
 import * as composio from "./composio.ts";
 import { containerComputerStatus, setupCommands } from "./container-computer.ts";
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
+import { resetPathCache } from "./env-path.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
@@ -1354,6 +1355,11 @@ const server = createServer(async (req, res) => {
 
     // ── provider instances (model picker) ──
     if (method === "GET" && path === "/api/instances") {
+      // Rescan PATH first: this endpoint is how the app answers "what can I
+      // run?", and the interesting case is a CLI installed since launch.
+      // Windows never pushes PATH changes into a live process, so without
+      // this the answer is frozen at boot and "check again" is a no-op.
+      resetPathCache();
       return json(res, 200, { instances: await registry.describe() });
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -110,10 +110,15 @@ function askBotAndWait(targetBotId: string, message: string, depth: number): Pro
 async function defaultSelection() {
   const described = await registry.describe();
   const available = described.filter((d) => d.snapshot.state === "available");
-  const pick = available.find((d) => d.driverKind === "claudeAgent") ?? available[0] ?? described[0];
-  return { instanceId: pick?.instanceId ?? "claude", model: pick?.models.default || "claude-sonnet-5" };
+  // Deliberately NO fallback to described[0]. Handing a bot an engine whose
+  // CLI isn't installed makes it look ready and then fail on send with a raw
+  // spawn ENOENT — the single worst first-run experience, and the one every
+  // user with no CLIs used to get. An empty selection is honest: the UI shows
+  // the setup path instead of a bot that cannot answer.
+  const pick = available.find((d) => d.driverKind === "claudeAgent") ?? available[0];
+  return { instanceId: pick?.instanceId ?? "", model: pick?.models.default ?? "" };
 }
-let bootSelection = { instanceId: "claude", model: "claude-sonnet-5" };
+let bootSelection = { instanceId: "", model: "" };
 const store = new Store(() => bootSelection);
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
@@ -300,7 +305,11 @@ bus.subscribe((event: RuntimeEvent) => {
       break;
     }
     case "runtime.error":
-      pushMessage({ role: "bot", kind: "activity", tool: { name: `error: ${event.message.slice(0, 160)}`, ok: false } });
+      pushMessage({
+        role: "bot",
+        kind: "activity",
+        tool: { name: `error: ${event.message.slice(0, 160)}`, ok: false, setup: event.setup },
+      });
       break;
     case "turn.completed": {
       if (bot) {

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -49,6 +49,24 @@ export function execCli(
   );
 }
 
+/** Human wording for a failed CLI spawn.
+ *
+ * Node reports these as bare errno strings — "spawn grok ENOENT" — which
+ * reads as a crash. On a CLI spawn the common codes mean exactly one thing
+ * each, and both are setup problems the user can fix, so say which. The
+ * `setup` flag lets the UI offer "Install" instead of a "Retry" that is
+ * guaranteed to fail the same way. */
+export function describeSpawnFailure(
+  err: NodeJS.ErrnoException,
+  cli: string,
+): { message: string; setup: boolean } {
+  if (err.code === "ENOENT")
+    return { message: `\`${cli}\` isn't installed, or isn't on this app's PATH`, setup: true };
+  if (err.code === "EACCES" || err.code === "EPERM")
+    return { message: `\`${cli}\` isn't executable — check its file permissions`, setup: true };
+  return { message: `spawn failed: ${err.message}`, setup: false };
+}
+
 /** Stop a CLI and every process it spawned (MCP proxies included). */
 export function killCliTree(child: ChildProcess): void {
   const pid = child.pid;

--- a/server/store.ts
+++ b/server/store.ts
@@ -56,7 +56,9 @@ export interface Message {
    * a phrase a voice can read ("reading a file") — computed once here so
    * call mode never has to re-derive it from the raw tool name, and absent
    * for chips not worth interrupting the ear for. */
-  tool?: { name: string; ok?: boolean; spoken?: string };
+  /** `setup` marks an error the user fixes by installing or configuring
+   * something — the UI offers setup instead of a retry that cannot work. */
+  tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,9 @@ function Shell() {
   const noEngines =
     state.connected &&
     state.instances.length > 0 &&
-    !state.instances.some((i) => i.snapshot.state === "available");
+    !state.instances.some(
+      (i) => i.snapshot.state === "available" && i.snapshot.authenticated !== false,
+    );
 
   // App-wide shortcuts: ⌘N new bot · ⌘1–9 jump to bot · ⌘⇧[ / ⌘⇧] prev/next.
   // Kept deliberately small; every panel already closes on Esc.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,20 @@ import { SettingsModal } from "@/components/SettingsModal";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { DesktopCapabilitiesProvider } from "@/components/DesktopCapabilities";
 import { RoutinesPage } from "@/components/RoutinesPage";
+import { NoEngines } from "@/components/NoEngines";
 
 function Shell() {
   const { state, dispatch } = useStore();
   const group = state.groups.find((g) => g.id === state.selectedId);
   const bot = group ? undefined : (state.bots.find((b) => b.id === state.selectedId) ?? state.bots[0]);
+
+  // Nothing on this machine can run a bot. Wait for the first /api/instances
+  // response before deciding — an empty list means "not asked yet", and
+  // flashing the setup screen at every launch would be worse than the bug.
+  const noEngines =
+    state.connected &&
+    state.instances.length > 0 &&
+    !state.instances.some((i) => i.snapshot.state === "available");
 
   // App-wide shortcuts: ⌘N new bot · ⌘1–9 jump to bot · ⌘⇧[ / ⌘⇧] prev/next.
   // Kept deliberately small; every panel already closes on Esc.
@@ -56,6 +65,8 @@ function Shell() {
       <Sidebar />
       {state.activeView === "routines" ? (
         <RoutinesPage />
+      ) : noEngines ? (
+        <NoEngines />
       ) : group ? (
         <GroupView key={group.id} group={group} />
       ) : bot ? (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -128,9 +128,11 @@ function ThinkingStrip({ text, active }: { text: string; active: boolean }) {
 
 /** A failed turn: a real error block with a retry, not a truncated pill.
  *
- * A `setup` error — the engine's CLI isn't installed — gets the install
- * instructions instead of a Retry, because retrying spawns the same missing
- * binary and fails identically every time. */
+ * A `setup` error — CLI missing, or installed but not signed in — shows what
+ * to do instead of a Retry, because retrying hits the same wall every time.
+ * Once the engine reports itself fixed the card flips back to Retry, which
+ * (with the on-focus re-probe) happens by itself when the user returns from
+ * the terminal. */
 function ErrorRow({
   message,
   onRetry,
@@ -147,7 +149,8 @@ function ErrorRow({
           <AlertTriangle size={15} className="mt-0.5 shrink-0" />
           <span className="min-w-0 break-words">{message}</span>
         </div>
-        {setupInstance ? (
+        {setupInstance &&
+        !(setupInstance.snapshot.state === "available" && setupInstance.snapshot.authenticated !== false) ? (
           <EngineSetup instance={setupInstance} className="mt-2 text-ink-secondary" />
         ) : (
           onRetry && (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -15,7 +15,17 @@ import {
   Square,
   X,
 } from "lucide-react";
-import { useStore, useStreaming, formatTime, messageVersions, visibleMessages, type Bot, type Message } from "@/state/store";
+import {
+  useStore,
+  useStreaming,
+  formatTime,
+  messageVersions,
+  visibleMessages,
+  type Bot,
+  type InstanceInfo,
+  type Message,
+} from "@/state/store";
+import { EngineSetup } from "./EngineSetup";
 import { MausAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { ChatMarkdown } from "./ChatMarkdown";
@@ -116,8 +126,20 @@ function ThinkingStrip({ text, active }: { text: string; active: boolean }) {
   );
 }
 
-/** A failed turn: a real error block with a retry, not a truncated pill. */
-function ErrorRow({ message, onRetry }: { message: string; onRetry?: () => void }) {
+/** A failed turn: a real error block with a retry, not a truncated pill.
+ *
+ * A `setup` error — the engine's CLI isn't installed — gets the install
+ * instructions instead of a Retry, because retrying spawns the same missing
+ * binary and fails identically every time. */
+function ErrorRow({
+  message,
+  onRetry,
+  setupInstance,
+}: {
+  message: string;
+  onRetry?: () => void;
+  setupInstance?: InstanceInfo;
+}) {
   return (
     <div className="flex justify-start">
       <div className="max-w-[70%] rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-2.5 text-[13.5px] text-danger">
@@ -125,13 +147,17 @@ function ErrorRow({ message, onRetry }: { message: string; onRetry?: () => void 
           <AlertTriangle size={15} className="mt-0.5 shrink-0" />
           <span className="min-w-0 break-words">{message}</span>
         </div>
-        {onRetry && (
-          <button
-            onClick={onRetry}
-            className="mt-1.5 flex items-center gap-1.5 rounded-full border border-danger/30 px-2.5 py-1 text-[12.5px] hover:bg-danger/15"
-          >
-            <RefreshCw size={12} /> Retry
-          </button>
+        {setupInstance ? (
+          <EngineSetup instance={setupInstance} className="mt-2 text-ink-secondary" />
+        ) : (
+          onRetry && (
+            <button
+              onClick={onRetry}
+              className="mt-1.5 flex items-center gap-1.5 rounded-full border border-danger/30 px-2.5 py-1 text-[12.5px] hover:bg-danger/15"
+            >
+              <RefreshCw size={12} /> Retry
+            </button>
+          )
         )}
       </div>
     </div>
@@ -459,6 +485,7 @@ const MessagesList = memo(function MessagesList({
   editingId,
   lastBotTextId,
   canRetryLast,
+  engine,
   onStartEdit,
   onCancelEdit,
   onSubmitEdit,
@@ -469,6 +496,8 @@ const MessagesList = memo(function MessagesList({
   editingId: string | null;
   lastBotTextId: string | undefined;
   canRetryLast: boolean;
+  /** This bot's engine, for rendering setup help on a `setup` error. */
+  engine: InstanceInfo | undefined;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
   onSubmitEdit: (id: string, text: string) => void;
@@ -504,6 +533,7 @@ const MessagesList = memo(function MessagesList({
                 <ErrorRow
                   message={m.tool.name.slice(6).trim()}
                   onRetry={m.id === messages.at(-1)?.id && canRetryLast ? onRegenerate : undefined}
+                  setupInstance={m.tool.setup ? engine : undefined}
                 />
               ) : (
                 <ActivityChip message={m} />
@@ -708,6 +738,7 @@ export function ChatView({ bot }: { bot: Bot }) {
             editingId={editingId}
             lastBotTextId={lastBotTextId}
             canRetryLast={!bot.busy && Boolean(lastUserMessage)}
+            engine={state.instances.find((i) => i.instanceId === bot.modelSelection.instanceId)}
             onStartEdit={startEdit}
             onCancelEdit={cancelEdit}
             onSubmitEdit={submitEdit}

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -1,0 +1,173 @@
+// Setup UI for an engine that isn't ready — shared by onboarding, the model
+// picker, and the chat's "engine missing" card so all three say the same
+// thing from the same data.
+//
+// Everything here is driven by the driver-declared install descriptor
+// (server/contracts.ts EngineInstall), never by per-engine copy in the UI.
+// An engine with no command for this platform shows its docs link instead of
+// an instruction that cannot run there.
+//
+// Installing is only half the job: most CLIs then need an interactive
+// sign-in, which is why the terminal is the destination rather than a
+// background `npm install` the user never sees.
+import { useState } from "react";
+import { Check, Copy, ExternalLink, TerminalSquare } from "lucide-react";
+import type { EngineInstall, InstanceInfo } from "@/state/store";
+import { cn } from "@/lib/cn";
+
+type Platform = "darwin" | "win32" | "linux";
+
+function hostPlatform(): Platform {
+  const p = window.ogb?.platform;
+  if (p === "darwin" || p === "win32" || p === "linux") return p;
+  // browser/dev shell — guess from the UA so the copy button still offers
+  // something sensible, since there's no bridge to ask
+  const ua = navigator.userAgent;
+  if (ua.includes("Mac")) return "darwin";
+  if (ua.includes("Win")) return "win32";
+  return "linux";
+}
+
+/** The install command for this machine, or null when the engine has none
+ * here (a GUI download, or a POSIX-only installer viewed on Windows). */
+export function installCommandFor(install: EngineInstall | undefined): string | null {
+  return install?.command?.[hostPlatform()] ?? null;
+}
+
+/** True when the engine is installed but not yet signed in — the state that
+ * looks ready in the picker but still can't answer a message. */
+export function needsSignIn(instance: InstanceInfo | undefined): boolean {
+  return instance?.snapshot.state === "available" && instance.snapshot.authenticated === false;
+}
+
+function CommandRow({ command }: { command: string }) {
+  const [done, setDone] = useState<"copied" | "opened" | null>(null);
+  const canOpen = Boolean(window.ogb?.openInstallTerminal);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setDone("copied");
+      setTimeout(() => setDone(null), 2000);
+    } catch {
+      /* clipboard blocked — the command is on screen to select by hand */
+    }
+  };
+
+  const openTerminal = async () => {
+    // the bridge copies to the clipboard too, so a failed launch still
+    // leaves the user able to paste
+    const ok = await window.ogb!.openInstallTerminal!(command);
+    setDone(ok ? "opened" : "copied");
+    setTimeout(() => setDone(null), 2500);
+  };
+
+  return (
+    <div className="mt-2 flex flex-col gap-1.5">
+      <code className="block overflow-x-auto rounded-lg bg-app px-2.5 py-2 font-mono text-[12px] leading-relaxed text-ink-secondary">
+        {command}
+      </code>
+      <div className="flex items-center gap-1.5">
+        {canOpen && (
+          <button
+            onClick={openTerminal}
+            className="flex items-center gap-1.5 rounded-lg bg-accent px-2.5 py-1.5 text-[12.5px] font-medium text-white"
+          >
+            <TerminalSquare size={13} /> Open in Terminal
+          </button>
+        )}
+        <button
+          onClick={copy}
+          className={cn(
+            "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12.5px]",
+            canOpen ? "text-ink-secondary hover:bg-raised hover:text-ink" : "bg-raised text-ink hover:bg-raised-hover",
+          )}
+        >
+          {done ? <Check size={13} /> : <Copy size={13} />}
+          {done === "copied" ? "Copied" : done === "opened" ? "Opened" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function EngineSetup({
+  instance,
+  className,
+}: {
+  instance: InstanceInfo;
+  className?: string;
+}) {
+  const install = instance.install;
+  const command = installCommandFor(install);
+  const signIn = install?.signInCommand;
+  const signInOnly = needsSignIn(instance);
+
+  // No install descriptor at all means this isn't something you install —
+  // the Box cloud runner is configured with a token in settings, not a CLI.
+  // Claiming it "isn't installed" would send the user hunting for a package
+  // that doesn't exist, so defer to whatever the driver reported instead.
+  if (!install) {
+    return (
+      <div className={cn("text-[12.5px] leading-relaxed text-ink-secondary", className)}>
+        {instance.snapshot.reason ?? "Not available on this machine."}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("text-[12.5px] leading-relaxed text-ink-secondary", className)}>
+      {signInOnly ? (
+        <>
+          <p>
+            {instance.displayName} is installed but not signed in yet. Run this once, then come back.
+          </p>
+          {signIn && <CommandRow command={signIn} />}
+        </>
+      ) : (
+        <>
+          {command ? (
+            <>
+              <p>
+                {instance.displayName} isn&rsquo;t installed. Run this in a terminal
+                {signIn ? `, then \`${signIn}\` to sign in` : ""}.
+              </p>
+              <CommandRow command={command} />
+              {install?.needsNode && (
+                <p className="mt-1.5 text-[11.5px] text-ink-secondary/70">
+                  Needs Node.js — install it first if <code className="font-mono">npm</code> isn&rsquo;t
+                  found.
+                </p>
+              )}
+            </>
+          ) : (
+            <p>
+              {instance.displayName} isn&rsquo;t installed, and has no one-line installer for this
+              platform.
+            </p>
+          )}
+        </>
+      )}
+
+      {install?.docsUrl && (
+        <a
+          href={install.docsUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex items-center gap-1.5 text-[12.5px] text-accent hover:underline"
+        >
+          <ExternalLink size={12} /> Setup guide
+        </a>
+      )}
+
+      {/* A newly installed CLI lands on a PATH the running app never saw.
+          macOS re-probes the login shell, but Windows only reads the user
+          PATH at process start — so a restart is the reliable cure there. */}
+      {!signInOnly && command && (
+        <p className="mt-2 text-[11.5px] text-ink-secondary/70">
+          Already installed it? Restart OpenMausBot so it picks up the new PATH.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -73,7 +73,7 @@ function CommandRow({ command }: { command: string }) {
             onClick={openTerminal}
             className="flex items-center gap-1.5 rounded-lg bg-accent px-2.5 py-1.5 text-[12.5px] font-medium text-white"
           >
-            <TerminalSquare size={13} /> Open in Terminal
+            <TerminalSquare size={13} /> Copy &amp; Open Terminal
           </button>
         )}
         <button
@@ -84,7 +84,7 @@ function CommandRow({ command }: { command: string }) {
           )}
         >
           {done ? <Check size={13} /> : <Copy size={13} />}
-          {done === "copied" ? "Copied" : done === "opened" ? "Opened" : "Copy"}
+          {done === "copied" ? "Copied" : done === "opened" ? "Copied — paste" : "Copy"}
         </button>
       </div>
     </div>
@@ -158,15 +158,6 @@ export function EngineSetup({
         >
           <ExternalLink size={12} /> Setup guide
         </a>
-      )}
-
-      {/* A newly installed CLI lands on a PATH the running app never saw.
-          macOS re-probes the login shell, but Windows only reads the user
-          PATH at process start — so a restart is the reliable cure there. */}
-      {!signInOnly && command && (
-        <p className="mt-2 text-[11.5px] text-ink-secondary/70">
-          Already installed it? Restart OpenMausBot so it picks up the new PATH.
-        </p>
       )}
     </div>
   );

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -13,7 +13,7 @@ function modelLabel(instance: InstanceInfo | undefined, model: string): string {
 }
 
 export function ModelPicker({ bot, className }: { bot: Bot; className?: string }) {
-  const { state, dispatch } = useStore();
+  const { state, dispatch, refreshInstances } = useStore();
   const [open, setOpen] = useState(false);
   const [railId, setRailId] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -23,6 +23,13 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
   const railInstance =
     state.instances.find((i) => i.instanceId === (railId ?? selection.instanceId)) ??
     state.instances[0];
+
+  // Opening the picker is the user asking "what can I run?" — re-probe rather
+  // than answer from a snapshot taken at launch, which is stale the moment
+  // they install or sign in to anything.
+  useEffect(() => {
+    if (open) void refreshInstances();
+  }, [open, refreshInstances]);
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -73,7 +73,8 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
           {/* instance rail */}
           <div className="flex flex-col gap-1 border-r border-hairline/40 bg-panel p-2">
             {state.instances.map((instance) => {
-              const unavailable = instance.snapshot.state !== "available";
+              const unavailable =
+                instance.snapshot.state !== "available" || instance.snapshot.authenticated === false;
               const onRail = instance.instanceId === railInstance?.instanceId;
               return (
                 <button
@@ -81,7 +82,10 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                   onClick={() => setRailId(instance.instanceId)}
                   title={
                     unavailable
-                      ? `${instance.displayName} — ${instance.snapshot.reason ?? "unavailable"}`
+                      ? `${instance.displayName} — ${
+                          instance.snapshot.reason ??
+                          (instance.snapshot.authenticated === false ? "sign-in required" : "unavailable")
+                        }`
                       : instance.displayName
                   }
                   className={cn(
@@ -103,9 +107,10 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                 <div className="px-2 pb-1 pt-1">
                   <div className="text-[13px] font-semibold text-ink">{railInstance.displayName}</div>
                   <div className="truncate text-[11px] text-ink-secondary">
-                    {railInstance.snapshot.state === "available"
+                    {railInstance.snapshot.state === "available" &&
+                    railInstance.snapshot.authenticated !== false
                       ? (railInstance.snapshot.version ?? "ready")
-                      : (railInstance.snapshot.reason ?? "unavailable")}
+                      : (railInstance.snapshot.reason ?? "sign-in required")}
                   </div>
                 </div>
                 {/* An unavailable engine used to be a dead end here: dimmed
@@ -119,7 +124,9 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                 {railInstance.models.options.map((option) => {
                   const current =
                     selection.instanceId === railInstance.instanceId && selection.model === option.id;
-                  const disabled = railInstance.snapshot.state !== "available";
+                  const disabled =
+                    railInstance.snapshot.state !== "available" ||
+                    railInstance.snapshot.authenticated === false;
                   return (
                     <button
                       key={option.id}

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
 import { useStore, type Bot, type InstanceInfo } from "@/state/store";
 import { ProviderMark } from "./ProviderIcons";
+import { EngineSetup, needsSignIn } from "./EngineSetup";
 import { cn } from "@/lib/cn";
 
 function modelLabel(instance: InstanceInfo | undefined, model: string): string {
@@ -100,6 +101,14 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                       : (railInstance.snapshot.reason ?? "unavailable")}
                   </div>
                 </div>
+                {/* An unavailable engine used to be a dead end here: dimmed
+                    rows and the reason hidden in a tooltip, at exactly the
+                    moment the user is trying to fix it. Show the way out. */}
+                {(railInstance.snapshot.state !== "available" || needsSignIn(railInstance)) && (
+                  <div className="border-b border-hairline/40 px-2 pb-2.5">
+                    <EngineSetup instance={railInstance} />
+                  </div>
+                )}
                 {railInstance.models.options.map((option) => {
                   const current =
                     selection.instanceId === railInstance.instanceId && selection.model === option.id;

--- a/src/components/NoEngines.tsx
+++ b/src/components/NoEngines.tsx
@@ -1,0 +1,69 @@
+// Shown instead of a chat when nothing on this machine can run a bot.
+//
+// The alternative — which is what used to happen — is a chat that looks
+// completely functional until the first message, then fails with a raw spawn
+// error. Every engine unavailable is a setup state, not an error state, so it
+// gets a screen that says what to do rather than a bot that can't answer.
+import { Loader2, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { useStore } from "@/state/store";
+import { EngineSetup, installCommandFor } from "@/components/EngineSetup";
+
+export function NoEngines() {
+  const { state, refreshInstances } = useStore();
+  const [rechecking, setRechecking] = useState(false);
+
+  // Only things you actually install belong on a "get started" screen. The
+  // Box cloud runner also reports unavailable here, but it's configured with
+  // a token in settings rather than installed, so listing it would just be a
+  // dead end alongside the real options.
+  const engines = state.instances
+    .filter((i) => i.install)
+    // An engine with a command for this platform is one the user can act on
+    // right now; the rest (GUI downloads, POSIX-only installers on Windows)
+    // sort below so the actionable path is the obvious one.
+    .sort((a, b) => {
+      const aCmd = installCommandFor(a.install) ? 0 : 1;
+      const bCmd = installCommandFor(b.install) ? 0 : 1;
+      return aCmd - bCmd;
+    });
+
+  const recheck = async () => {
+    setRechecking(true);
+    try {
+      await refreshInstances();
+    } finally {
+      setRechecking(false);
+    }
+  };
+
+  return (
+    <main className="flex h-full min-w-0 flex-1 flex-col overflow-y-auto bg-app">
+      <div className="mx-auto w-full max-w-[560px] px-6 py-12">
+        <h1 className="text-[20px] font-semibold text-ink">Install an AI engine to get started</h1>
+        <p className="mt-1.5 text-[13.5px] leading-relaxed text-ink-secondary">
+          OpenMausBot doesn&rsquo;t ship a model of its own — your bots run on an AI CLI installed on
+          this computer, using your existing login. Set up any one of these and your bots come alive.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-2.5">
+          {engines.map((instance) => (
+            <div key={instance.instanceId} className="rounded-xl border border-hairline/40 bg-card p-3.5">
+              <div className="text-[14px] font-medium text-ink">{instance.displayName}</div>
+              <EngineSetup instance={instance} className="mt-0.5" />
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={recheck}
+          disabled={rechecking}
+          className="mt-6 flex items-center gap-2 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-60"
+        >
+          {rechecking ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+          {rechecking ? "Checking…" : "Check again"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -92,12 +92,26 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
 
   useEffect(() => {
     track("onboarding_step", { step });
-    if (step === 1 && !instances) {
+  }, [step]);
+
+  useEffect(() => {
+    if (step !== 1) return;
+    let active = true;
+    const refresh = () => {
       fetch("/api/instances")
         .then((r) => r.json())
-        .then((d) => setInstances(d.instances ?? []))
-        .catch(() => setInstances([]));
-    }
+        .then((d) => active && setInstances(d.instances ?? []))
+        .catch(() => active && setInstances([]));
+    };
+    refresh();
+    window.addEventListener("focus", refresh);
+    return () => {
+      active = false;
+      window.removeEventListener("focus", refresh);
+    };
+  }, [step]);
+
+  useEffect(() => {
     if (step === 2 && capabilities.dictation.available) {
       const poll = () => window.ogb?.permStatus?.().then(setPerms).catch(() => {});
       poll();
@@ -105,7 +119,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
       const t = setInterval(poll, 2000);
       return () => clearInterval(t);
     }
-  }, [step, instances, capabilities.dictation.available]);
+  }, [step, capabilities.dictation.available]);
 
   const finish = () => {
     track("onboarding_completed", {

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,30 +1,29 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Check, AlertTriangle, Loader2, Mic } from "lucide-react";
 import { MausAvatar } from "./Avatar";
 import { identifyEmail, setEmailGateDone, track } from "@/lib/analytics";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { EngineSetup } from "./EngineSetup";
+import type { InstanceInfo } from "@/state/store";
 
 // Three-step first-run onboarding: who you are (email), what's installed
 // (live engine checks from the harness), what the app may use (TCC).
 // Every check is skippable — onboarding must never brick the app.
 
-type InstanceRow = {
-  instanceId: string;
-  driverKind: string;
-  displayName: string;
-  snapshot: { state: "available" | "unavailable"; reason?: string; version?: string | null; authenticated?: boolean };
-};
+type InstanceRow = InstanceInfo;
 
 function StatusRow({
   ok,
   warn,
   title,
   detail,
+  children,
 }: {
   ok: boolean;
   warn?: boolean;
   title: string;
-  detail: string;
+  detail?: string;
+  children?: ReactNode;
 }) {
   return (
     <div className="flex items-start gap-3 rounded-xl bg-card p-3.5">
@@ -35,11 +34,38 @@ function StatusRow({
       >
         {ok ? <Check size={14} /> : <AlertTriangle size={13} />}
       </span>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="text-[14px] font-medium text-ink">{title}</div>
-        <div className="mt-0.5 text-[12.5px] leading-relaxed text-ink-secondary">{detail}</div>
+        {detail && <div className="mt-0.5 text-[12.5px] leading-relaxed text-ink-secondary">{detail}</div>}
+        {children}
       </div>
     </div>
+  );
+}
+
+/** One engine's onboarding row. Ready states get a sentence; anything the
+ * user has to act on gets the shared setup UI, so the instructions come from
+ * the driver and are correct for this platform. */
+function EngineRow({
+  instance,
+  label,
+  readyNote,
+}: {
+  instance: InstanceRow | undefined;
+  label: string;
+  readyNote: string;
+}) {
+  const ready = instance?.snapshot.state === "available" && instance.snapshot.authenticated !== false;
+  const version = instance?.snapshot.version ? ` · ${instance.snapshot.version.split(" ")[0]}` : "";
+  return (
+    <StatusRow ok={ready} warn title={`${label}${version}`} detail={ready ? readyNote : undefined}>
+      {!ready &&
+        (instance ? (
+          <EngineSetup instance={instance} className="mt-0.5" />
+        ) : (
+          <div className="mt-0.5 text-[12.5px] text-ink-secondary">Not configured on this machine.</div>
+        ))}
+    </StatusRow>
   );
 }
 
@@ -155,49 +181,21 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                 </div>
               ) : (
                 <>
-                  <StatusRow
-                    ok={claude?.snapshot.state === "available"}
-                    warn
-                    title={`Claude Code ${claude?.snapshot.version ? `· ${claude.snapshot.version.split(" ")[0]}` : ""}`}
-                    detail={
-                      claude?.snapshot.state === "available"
-                        ? claude.snapshot.authenticated
-                          ? "Installed and signed in — ready to power bots."
-                          : "Installed. Run `claude` once in a terminal to sign in."
-                        : "Not found. Install: npm i -g @anthropic-ai/claude-code"
-                    }
+                  <EngineRow
+                    instance={claude}
+                    label="Claude Code"
+                    readyNote="Installed and signed in — ready to power bots."
                   />
-                  <StatusRow
-                    ok={codex?.snapshot.state === "available"}
-                    warn
-                    title={`Codex ${codex?.snapshot.version ? `· ${codex.snapshot.version.replace("codex-cli ", "")}` : ""}`}
-                    detail={
-                      codex?.snapshot.state === "available"
-                        ? "Installed — bots can run on Codex too."
-                        : "Optional. Install: npm i -g @openai/codex"
-                    }
+                  <EngineRow instance={codex} label="Codex" readyNote="Installed — bots can run on Codex too." />
+                  <EngineRow
+                    instance={grok}
+                    label="Grok Build"
+                    readyNote="Installed and signed in — bots can run on Grok too."
                   />
-                  <StatusRow
-                    ok={grok?.snapshot.state === "available"}
-                    warn
-                    title={`Grok Build ${grok?.snapshot.version ? `· ${grok.snapshot.version.split(" ")[1]}` : ""}`}
-                    detail={
-                      grok?.snapshot.state === "available"
-                        ? grok.snapshot.authenticated
-                          ? "Installed and signed in — bots can run on Grok too."
-                          : "Installed. Run `grok login` in a terminal to sign in."
-                        : "Optional. Install: curl -fsSL https://x.ai/cli/install.sh | bash"
-                    }
-                  />
-                  <StatusRow
-                    ok={antigravity?.snapshot.state === "available"}
-                    warn
-                    title={`Antigravity ${antigravity?.snapshot.version ? `· ${antigravity.snapshot.version.split(" ")[0]}` : ""}`}
-                    detail={
-                      antigravity?.snapshot.state === "available"
-                        ? "Installed — bots can run on Antigravity too."
-                        : "Optional. Install: see antigravity.google/docs/cli"
-                    }
+                  <EngineRow
+                    instance={antigravity}
+                    label="Antigravity"
+                    readyNote="Installed — bots can run on Antigravity too."
                   />
                 </>
               )}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -97,11 +97,13 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   useEffect(() => {
     if (step !== 1) return;
     let active = true;
+    let latestRequest = 0;
     const refresh = () => {
+      const request = ++latestRequest;
       fetch("/api/instances")
         .then((r) => r.json())
-        .then((d) => active && setInstances(d.instances ?? []))
-        .catch(() => active && setInstances([]));
+        .then((d) => active && request === latestRequest && setInstances(d.instances ?? []))
+        .catch(() => active && request === latestRequest && setInstances([]));
     };
     refresh();
     window.addEventListener("focus", refresh);

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1173,6 +1173,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  // Installing a CLI or signing one in happens in a terminal, outside this
+  // window — so the moment the user comes back is exactly when our engine
+  // snapshot is most likely stale. Re-probe on focus, throttled so that
+  // ordinary alt-tabbing doesn't spawn a `--version` call per switch.
+  const lastFocusProbe = useRef(0);
+  useEffect(() => {
+    const onFocus = () => {
+      const now = Date.now();
+      if (now - lastFocusProbe.current < 3000) return;
+      lastFocusProbe.current = now;
+      void refreshInstances();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refreshInstances]);
+
   const value = useMemo(() => ({ state, dispatch, refreshInstances }), [state, dispatch, refreshInstances]);
   return (
     <StoreContext.Provider value={value}>

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -4,6 +4,7 @@
 // pure; everything async lives in the wrapped dispatch + SSE fold.
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -43,7 +44,8 @@ export interface Message {
   card?: OptionCardData;
   /** activity messages: tool name + outcome. `spoken` is the server's
    * narration of the same chip ("reading a file"), used by call mode. */
-  tool?: { name: string; ok?: boolean; spoken?: string };
+  /** `setup` marks an error fixed by installing something, not by retrying. */
+  tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;
@@ -158,6 +160,16 @@ export interface ConfigStatus {
   profile?: { name: string; email: string };
 }
 
+/** How an engine gets installed — declared by its driver, mirrors
+ * EngineInstall in server/contracts.ts. Absent for engines that need no
+ * local binary. `command` omits platforms that have no one-liner. */
+export interface EngineInstall {
+  command?: Partial<Record<"darwin" | "win32" | "linux", string>>;
+  docsUrl?: string;
+  signInCommand?: string;
+  needsNode?: boolean;
+}
+
 /** One row of GET /api/instances — the model picker's data. */
 export interface InstanceInfo {
   instanceId: string;
@@ -170,6 +182,7 @@ export interface InstanceInfo {
     version?: string | null;
   };
   models: { default: string; options: Array<{ id: string; label: string }> };
+  install?: EngineInstall;
 }
 
 interface AppState {
@@ -681,6 +694,8 @@ export function useStreaming() {
 const StoreContext = createContext<{
   state: AppState;
   dispatch: React.Dispatch<Action>;
+  /** Re-fetch engine availability — after an install, without a restart. */
+  refreshInstances: () => Promise<void>;
 } | null>(null);
 
 export function StoreProvider({ children }: { children: ReactNode }) {
@@ -1146,7 +1161,19 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const value = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+  // Re-probe the engines on demand. A CLI installed while the app is running
+  // is invisible until something asks again — the setup screens expose this
+  // as "Check again" so the user isn't told to restart when a refresh will do.
+  const refreshInstances = useCallback(async () => {
+    try {
+      const { instances } = await api("/api/instances");
+      rawDispatch({ type: "instances", instances });
+    } catch {
+      /* offline or server down — the existing list stays */
+    }
+  }, []);
+
+  const value = useMemo(() => ({ state, dispatch, refreshInstances }), [state, dispatch, refreshInstances]);
   return (
     <StoreContext.Provider value={value}>
       <StreamContext.Provider value={stream}>{children}</StreamContext.Provider>

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -52,6 +52,10 @@ declare global {
       permRequestMic(): Promise<boolean>;
       /** Opens System Settings on a privacy pane: mic|screen|speech. */
       permOpenSettings(pane: "mic" | "screen" | "speech"): Promise<void>;
+      /** Opens a terminal with an engine install command ready, copying it to
+       * the clipboard either way. False when no terminal could be launched —
+       * show the command to paste instead. */
+      openInstallTerminal?(command: string): Promise<boolean>;
       /** In-app auto-update (packaged app only; dormant in dev). onState
        * fires immediately with the current state, then on transitions. */
       updater?: {

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -52,9 +52,8 @@ declare global {
       permRequestMic(): Promise<boolean>;
       /** Opens System Settings on a privacy pane: mic|screen|speech. */
       permOpenSettings(pane: "mic" | "screen" | "speech"): Promise<void>;
-      /** Opens a terminal with an engine install command ready, copying it to
-       * the clipboard either way. False when no terminal could be launched —
-       * show the command to paste instead. */
+      /** Copies an engine install command and opens a blank terminal. False
+       * when no terminal could be launched; the clipboard still has it. */
       openInstallTerminal?(command: string): Promise<boolean>;
       /** In-app auto-update (packaged app only; dormant in dev). onState
        * fires immediately with the current state, then on transitions. */


### PR DESCRIPTION
From a Windows user report: a fresh install shows a normal-looking chat, and the first message fails with `spawn failed: spawn grok ENOENT` and a **Retry** that can never succeed. Every other engine in the picker is dimmed too, so there is no way forward from inside the app.

## Root cause

`defaultSelection`'s `?? described[0]` fallback. With no CLI installed nothing is available, so it assigned the first *described* provider regardless of state and seeded a bot pointing at an engine that cannot run.

Nothing downstream objected: the pre-flight guard checks that the instance **exists**, not that it is **available**, so the turn proceeded to spawn and surfaced Node's raw errno.

The fix is to remove the fallback. With nothing available the selection stays empty and the app says so, instead of shipping a bot that looks ready and isn't.

## Engines declare their own setup

`EngineInstall` in `contracts.ts`, surfaced through `registry.describe`, rendered by one shared component in onboarding, the picker, and the chat error card. Adding a provider stays one file.

It is **per-platform**, which matters: onboarding previously told everyone to run `curl -fsSL https://x.ai/cli/install.sh | bash`, which is not a command on Windows. Where there is no one-liner — Antigravity is a GUI download, the Grok installer is POSIX-only — the UI shows the docs link instead of something that cannot work.

Engines with no install descriptor at all (the Box cloud runner, configured by token rather than installed) fall through to their reported reason and stay off the setup screen. Found by reading the real `/api/instances` payload rather than trusting the shape.

## Detecting engines that appear while running

Two follow-ups, both from testing the flow with a real install rather than a mock:

**PATH.** Installing grok put it in `~/.grok/bin` and added that to the user PATH, but the running app still reported `` `grok` CLI not found ``. Windows never pushes PATH changes into a live process, so the app was frozen on the PATH it booted with — and `env-path` only scanned standard install locations on unix, the win32 branch being empty on the assumption that GUI apps "inherit the user PATH already". True only at launch.

Windows now gets the same scan. Verified by starting the harness with `~/.grok/bin` absent from PATH: `grok` is not resolvable there, and the snapshot still reports it available.

**Re-probing.** After `grok login` succeeded the app kept showing the pre-login error, because nothing re-checked. The store now re-probes on window focus (throttled) and when the picker opens — installing and signing in both happen in a terminal, so coming back to the window is exactly when the snapshot is most likely stale. `/api/instances` resets the memoized PATH first, so "check again" can find something installed since launch instead of repeating a cached answer.

## Errors

`ENOENT`/`EACCES` become sentences instead of errno strings, and carry a `setup` flag — as does an auth failure, since both are fixed by a command in a terminal rather than another attempt. The card shows what to do while the engine is unusable and flips back to **Retry** once it reports itself ready, which with the on-focus re-probe happens by itself.

## Install commands

"Open in Terminal" puts the command in a terminal without executing it, and on the clipboard either way. Deliberately not a silent background install: the user should read a command that fetches and runs a remote installer, and every CLI needs an interactive sign-in afterwards, so the terminal is where this ends up regardless.

## Testing

- `pnpm typecheck` and `pnpm check:electron` clean
- `pnpm test` — 254 passed. `antigravity.test.ts` fails on Windows, confirmed identical on unmodified `main` (it spawns a fake shebang script, which cannot execute there; the `skipIf(win32)` guard was removed in an earlier change). Not from this branch.
- Built and installed the packaged Windows app, and walked the whole path on a real machine: engine missing → install → detected → not signed in → `grok login` → working reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided setup for unavailable or unauthenticated AI engines.
  * Installation commands can be copied or opened directly in a terminal.
  * Added platform-specific installation instructions, sign-in guidance, documentation links, and Node.js requirements.
  * Added refresh controls and automatic engine availability updates.
  * Added a dedicated screen when no runnable engines are available.
  * Unavailable engine models remain visible but disabled.

* **Bug Fixes**
  * Improved error messages for missing, inaccessible, or failed engine launches.
  * Prevented fallback to unavailable default engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->