### PR TITLE
feat: add Kimi Code driver over ACP stdio

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -99,6 +99,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
       ? cfg.instances
       : {
           grok: { driver: "grokAgent" },
+          kimi: { driver: "kimiAgent" },
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
           antigravity: { driver: "antigravityAgent" },

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -6,7 +6,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly —
 // resolveCliSpawn turns it into `node <script>`, so these run everywhere.
-import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +17,7 @@ import type { ProviderInstance } from "../../contracts.ts";
 import { recordEvents, type EventRecorder } from "../../testing/events.ts";
 import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
+import { KimiAgentDriver } from "./kimi.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
 
@@ -26,6 +27,15 @@ describe("ACP decodeConfig", () => {
   });
   it("gemini defaults to the gemini binary", () => {
     expect(GeminiAgentDriver.decodeConfig(undefined)).toEqual({ cli: "gemini", fullAuto: false, workspace: undefined });
+  });
+  it("kimi defaults to the kimi binary and declares cross-platform setup", () => {
+    expect(KimiAgentDriver.decodeConfig(undefined)).toEqual({ cli: "kimi", fullAuto: false, workspace: undefined });
+    expect(KimiAgentDriver.install?.command).toMatchObject({
+      darwin: expect.stringContaining("install.sh"),
+      linux: expect.stringContaining("install.sh"),
+      win32: expect.stringContaining("install.ps1"),
+    });
+    expect(KimiAgentDriver.install?.signInCommand).toBe("kimi login");
   });
   it("fullAuto only when explicitly true", () => {
     expect(GrokAgentDriver.decodeConfig({ fullAuto: "yes" }).fullAuto).toBe(false);
@@ -176,5 +186,51 @@ describe("ACP snapshot", () => {
     const snap = await instance.snapshot();
     expect(snap.state).toBe("unavailable");
     await instance.dispose();
+  });
+
+  it("kimi checks KIMI_CODE_HOME before the child HOME", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-kimi-auth-"));
+    const kimiHome = join(scratch, "custom-kimi-home");
+    const childHome = join(scratch, "child-home");
+    mkdirSync(join(childHome, ".kimi-code", "credentials"), { recursive: true });
+    writeFileSync(join(childHome, ".kimi-code", "credentials", "kimi-code.json"), "{}");
+
+    const instance = await KimiAgentDriver.create({
+      instanceId: "kimi-custom-home",
+      displayName: undefined,
+      environment: { KIMI_CODE_HOME: kimiHome, HOME: childHome },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(false);
+      mkdirSync(join(kimiHome, "credentials"), { recursive: true });
+      writeFileSync(join(kimiHome, "credentials", "kimi-code.json"), "{}");
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("kimi resolves default credentials from the child HOME", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-kimi-home-"));
+    const credentialDir = join(scratch, ".kimi-code", "credentials");
+    mkdirSync(credentialDir, { recursive: true });
+    writeFileSync(join(credentialDir, "kimi-code.json"), "{}");
+
+    const instance = await KimiAgentDriver.create({
+      instanceId: "kimi-child-home",
+      displayName: undefined,
+      environment: { HOME: scratch },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
   });
 });

--- a/server/drivers/acp/kimi.ts
+++ b/server/drivers/acp/kimi.ts
@@ -12,6 +12,11 @@ import { join } from "node:path";
 
 import { createAcpDriver, type AcpSupport } from "./core.ts";
 
+function credentialsPath(env: Record<string, string | undefined>) {
+  const dataRoot = env.KIMI_CODE_HOME || join(env.HOME || homedir(), ".kimi-code");
+  return join(dataRoot, "credentials", "kimi-code.json");
+}
+
 const support: AcpSupport = {
   driverKind: "kimiAgent",
   displayName: "Kimi",
@@ -30,6 +35,19 @@ const support: AcpSupport = {
   nativeSource: "kimi.acp",
   loginNote: "Kimi Code CLI is not signed in — run `kimi login` in a terminal",
 
+  // Official installers put the binary on PATH without requiring an existing
+  // Node install. Keep the commands platform-specific so Windows never gets a
+  // POSIX-only curl|bash instruction.
+  install: {
+    command: {
+      darwin: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+      linux: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+      win32: "irm https://code.kimi.com/kimi-code/install.ps1 | iex",
+    },
+    docsUrl: "https://moonshotai.github.io/kimi-code/en/guides/getting-started.html",
+    signInCommand: "kimi login",
+  },
+
   // -m is a global commander option and must precede the `acp` subcommand
   // (verified against 0.29.1).
   spawnArgs: (_config, turn) => [...(turn.model ? ["-m", turn.model] : []), "acp"],
@@ -46,7 +64,9 @@ const support: AcpSupport = {
   // the ambient login from a prior `kimi login` instead.
   pickAuthMethod: () => null,
   authFailure: "continue",
-  isAuthenticated: () => existsSync(join(homedir(), ".kimi-code", "credentials", "kimi-code.json")),
+  // Match the child CLI's own data-root precedence. A custom instance HOME or
+  // KIMI_CODE_HOME must not be checked against the server user's home instead.
+  isAuthenticated: (env) => existsSync(credentialsPath(env)),
 
   buildPromptText: (turn) => (turn.system ? `${turn.system}\n\n${turn.text}` : turn.text),
 };

--- a/server/drivers/acp/kimi.ts
+++ b/server/drivers/acp/kimi.ts
@@ -1,0 +1,54 @@
+// Kimi Code harness support — Moonshot's `kimi` CLI over ACP stdio
+// (`kimi acp`), on the Kimi Code subscription login
+// (~/.kimi-code/credentials/kimi-code.json), not a Moonshot API key.
+// The generic protocol runtime lives in acp/core.ts; this file is only the
+// per-harness quirks. Verified against kimi-code 0.29.1: initialize reports
+// loadSession:true (session/load resume works), mcpCapabilities http+sse,
+// and a full session/new → session/prompt roundtrip streams
+// agent_thought_chunk + agent_message_chunk and settles with end_turn.
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+
+const support: AcpSupport = {
+  driverKind: "kimiAgent",
+  displayName: "Kimi",
+  // Aliases from the CLI's own catalog (~/.kimi-code/config.toml
+  // [models."kimi-code/…"] — `kimi provider list` reports the same four).
+  models: {
+    default: "kimi-code/k3",
+    options: [
+      { id: "kimi-code/k3", label: "Kimi K3" },
+      { id: "kimi-code/k3-256k", label: "Kimi K3 256K" },
+      { id: "kimi-code/kimi-for-coding", label: "Kimi for Coding" },
+      { id: "kimi-code/kimi-for-coding-highspeed", label: "Kimi for Coding Highspeed" },
+    ],
+  },
+  defaultCli: "kimi",
+  nativeSource: "kimi.acp",
+  loginNote: "Kimi Code CLI is not signed in — run `kimi login` in a terminal",
+
+  // -m is a global commander option and must precede the `acp` subcommand
+  // (verified against 0.29.1).
+  spawnArgs: (_config, turn) => [...(turn.model ? ["-m", turn.model] : []), "acp"],
+
+  // Subscription CLI: a leaked Moonshot/Kimi API key must not flip billing
+  // to pay-as-you-go inside the spawned agent (mirrors claude/grok).
+  transformEnv: (env) => {
+    delete env.MOONSHOT_API_KEY;
+    delete env.KIMI_API_KEY;
+  },
+
+  // The only advertised authMethod is {id:"login", type:"terminal"} — a
+  // device-code flow that cannot be driven over ACP. Never pick it; ride
+  // the ambient login from a prior `kimi login` instead.
+  pickAuthMethod: () => null,
+  authFailure: "continue",
+  isAuthenticated: () => existsSync(join(homedir(), ".kimi-code", "credentials", "kimi-code.json")),
+
+  buildPromptText: (turn) => (turn.system ? `${turn.system}\n\n${turn.text}` : turn.text),
+};
+
+export const KimiAgentDriver = createAcpDriver(support);

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -8,11 +8,13 @@ import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
+import { KimiAgentDriver } from "./acp/kimi.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
   GrokAgentDriver,
   GeminiAgentDriver,
+  KimiAgentDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,


### PR DESCRIPTION
## What

Adds Moonshot's **Kimi Code CLI** (`kimi`) as a new agent provider, riding the generic ACP runtime in `server/drivers/acp/core.ts` — the same path as Grok Build and Gemini. One support object (`server/drivers/acp/kimi.ts`), one registration line, one default-fleet instance.

## Why ACP (not Kimi's `--output-format stream-json`)

Verified empirically against kimi-code 0.29.1: the CLI's own stream-json mode emits bare `{"role":"assistant","content":…}` lines — no tool events, no permission protocol. `kimi acp` however is a full ACP server: `initialize` reports `loadSession: true` (session resume works), `mcpCapabilities` http+sse, and a `session/new` → `session/prompt` roundtrip streams `agent_thought_chunk` + `agent_message_chunk` and settles with `end_turn`. So Kimi gets inline permission cards, thinking-stream rendering, and session continuity for free via the existing core.

## Per-harness quirks encoded

- **Auth:** the only advertised authMethod is `{id: "login", type: "terminal"}` (device-code flow) — it can't be driven over ACP, so `pickAuthMethod` returns `null` and turns ride the ambient login from a prior `kimi login` (`~/.kimi-code/credentials/kimi-code.json`), `authFailure: "continue"`.
- **Model selection:** `-m` is a global commander option and must precede the `acp` subcommand (verified on 0.29.1). Catalog mirrors the CLI's own aliases (`kimi-code/k3` default, `k3-256k`, `kimi-for-coding`, `kimi-for-coding-highspeed`).
- **Billing guard:** `MOONSHOT_API_KEY` / `KIMI_API_KEY` are stripped from the child env so a subscription CLI can't silently flip to pay-as-you-go (mirrors the claude/grok drivers).

## Verified

- `pnpm typecheck` clean, `pnpm test` 259 passed / 8 skipped on current main.
- Live end-to-end through the harness API: bot created with `modelSelection {instanceId: "kimi", model: "kimi-code/k3"}`, turn sent, streamed reply with thought chunks, `turn.completed ok` — persona injection via `buildPromptText` confirmed working.
- `/api/instances` snapshot: `kimi → available, authenticated: true, version 0.29.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi Code assistant.
  * Added Kimi as a built-in assistant option with model selection.
  * Added platform-specific installation and sign-in guidance.
  * Kimi authentication is detected automatically when valid credentials are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->