### PR TITLE
Local VM: let a bot drive the Linux desktop on this machine

### DIFF
--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -26,6 +26,7 @@
 //     type, Enter) in one round trip with one frame at the end.
 //
 // stdout is the MCP channel — never console.log here.
+import { spawn } from "node:child_process";
 import {
   normalizeBrowserUrl,
   normalizeCrop,
@@ -39,6 +40,14 @@ import {
 const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
+// The same desktop lives either in a cloud box or in a container on this
+// machine. Only the two functions below know which — every tool above
+// them just runs shell and reads a file back.
+const container = process.env.OGB_CONTAINER ?? "";
+const runtime = process.env.OGB_RUNTIME || "docker";
+const local = Boolean(container);
+// the desktop images run X on :1; a cloud box uses :0
+const CONTAINER_DISPLAY = process.env.OGB_DISPLAY || ":1";
 
 /** The coordinate space the model sees: frames are downscaled to this
  * width, and clicks are scaled back up to the real display box-side. */
@@ -84,7 +93,38 @@ async function resumeBox(): Promise<boolean> {
   return false;
 }
 
+/** Run a command inside the local container. No network and no waking: a
+ * stopped container is reported plainly instead of hanging. */
+function runInContainer(command: string, timeoutMs: number): Promise<RunOut> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      runtime,
+      ["exec", "-e", `DISPLAY=${CONTAINER_DISPLAY}`, container, "bash", "-lc", command],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    child.stdout.on("data", (c) => (stdout += c));
+    child.stderr.on("data", (c) => (stderr += c));
+    child.on("error", (e) =>
+      resolve({ ok: false, exitCode: null, stdout: "", stderr: `${runtime} not available: ${e.message}` }),
+    );
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        ok: code === 0,
+        exitCode: code,
+        stdout,
+        stderr:
+          code === 0 ? stderr : stderr || `the local computer isn't running — start it: ${runtime} start ${container}`,
+      });
+    });
+  });
+}
+
 async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): Promise<RunOut> {
+  if (local) return runInContainer(command, timeoutMs);
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
@@ -148,7 +188,7 @@ async function waitForNavigation(
   return { ok: false, targets };
 }
 
-const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+const ENV = local ? `export DISPLAY=${CONTAINER_DISPLAY}` : 'export DISPLAY=${DISPLAY:-:0}';
 /** Resolve the real display size into $W/$H for box-side click scaling. */
 const GEOMETRY = [
   "g=$(xdotool getdisplaygeometry 2>/dev/null)",
@@ -228,6 +268,13 @@ function wholeImage(bytes: Buffer, expectedBytes?: number): boolean {
  * envelope second. Both are validated — an error page served with a 200
  * must fall through, not reach the model as an "image". */
 async function fetchFrame(expectedBytes?: number): Promise<string | null> {
+  if (local) {
+    // no HTTP hop at all — read the bytes straight out of the container
+    const out = await runInContainer(`base64 -w0 ${SHOT_PATH}`, 30_000);
+    const data = out.stdout.trim();
+    if (!data) return null;
+    return wholeImage(Buffer.from(data, "base64"), expectedBytes) ? data : null;
+  }
   const auth = { authorization: `Bearer ${token}` };
   try {
     const res = await fetch(

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   CONTAINER,
   IMAGE,
+  computerProxyEnv,
   containerComputerStatus,
   setupCommands,
   type CommandRunner,
@@ -146,5 +147,28 @@ describe("setupCommands", () => {
     expect(setupCommands(null, "win32").install).toBe(
       "winget install -e --id RedHat.Podman-Desktop",
     );
+  });
+});
+
+describe("computerProxyEnv", () => {
+  it("hands the proxy a container when the bot runs on a local VM", () => {
+    expect(computerProxyEnv({ kind: "container", container: CONTAINER, runtime: "podman" })).toEqual({
+      OGB_CONTAINER: CONTAINER,
+      OGB_RUNTIME: "podman",
+    });
+  });
+
+  it("defaults the runtime rather than shipping an empty command", () => {
+    expect(computerProxyEnv({ kind: "container", container: "c" }).OGB_RUNTIME).toBe("docker");
+  });
+
+  it("hands the proxy a box otherwise — the cloud path is unchanged", () => {
+    expect(computerProxyEnv({ boxId: "bx_1", token: "t" })).toEqual({ OGB_BOX_ID: "bx_1", OGB_BOX_TOKEN: "t" });
+  });
+
+  it("never lets box credentials travel with a container turn", () => {
+    const env = computerProxyEnv({ kind: "container", container: "c", runtime: "docker" });
+    expect(env.OGB_BOX_TOKEN).toBeUndefined();
+    expect(env.OGB_BOX_ID).toBeUndefined();
   });
 });

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -235,7 +235,10 @@ export function setupCommands(
     pull: `${runtime} pull ${IMAGE}`,
     // 6080 is the desktop in a browser, 5900 for a native VNC viewer
     run: `${runtime} run -d --name ${CONTAINER} -p 127.0.0.1:6080:6080 -p 127.0.0.1:5900:5900 ${IMAGE}`,
-    start: `${runtime} start ${CONTAINER}`,
+    // NOT `start`: this image leaves an X11 lock behind, so a stopped
+    // container fails to resume with "Xvfb is already running on display
+    // :1" and exits. Recreating is the only reliable way back.
+    start: `${runtime} rm --force ${CONTAINER} && ${runtime} run -d --name ${CONTAINER} -p 127.0.0.1:6080:6080 -p 127.0.0.1:5900:5900 ${IMAGE}`,
     stop: `${runtime} stop ${CONTAINER}`,
     remove:
       runtime === "container"
@@ -243,4 +246,20 @@ export function setupCommands(
         : `${runtime} rm -f ${CONTAINER}`,
     view: "http://localhost:6080/vnc.html",
   };
+}
+
+/** Env for the computer proxy: which transport it should use. Both drivers
+ * mount the same proxy, so this is the only place that decides — and box
+ * credentials must never travel with a container turn. */
+export function computerProxyEnv(computer: {
+  kind?: string;
+  boxId?: string;
+  token?: string;
+  container?: string;
+  runtime?: string;
+}): Record<string, string> {
+  if (computer.kind === "container" && computer.container) {
+    return { OGB_CONTAINER: computer.container, OGB_RUNTIME: computer.runtime ?? "docker" };
+  }
+  return { OGB_BOX_ID: computer.boxId ?? "", OGB_BOX_TOKEN: computer.token ?? "" };
 }

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -101,7 +101,11 @@ export interface SendTurnInput {
   integrations?: {
     composio?: { url?: string; key: string };
     /** The bot's cloud computer (box.ascii.dev) for desktop/browser use. */
-    computer?: { boxId: string; token: string };
+    /** the bot's computer: a cloud box, or a container on this machine.
+     * Both become the same MCP toolset — only the transport differs. */
+    computer?:
+      | { kind?: "box"; boxId: string; token: string }
+      | { kind: "container"; container: string; runtime: string };
     /** Local computer use via the Electron-hosted cua-driver daemon —
      * spawn config comes verbatim from cua-connection.json (the daemon
      * MUST be spawned by Electron main; the harness only points the agent

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -31,6 +31,7 @@ import type {
   SendTurnInput,
 } from "../../contracts.ts";
 import { newEventId, newId } from "../../contracts.ts";
+import { computerProxyEnv } from "../../container-computer.ts";
 import { augmentedPath } from "../../env-path.ts";
 
 // the computer proxy entry: .ts in dev (node type stripping), .js in the
@@ -160,11 +161,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             name: "computer",
             command: process.execPath,
             args: [COMPUTER_PROXY_PATH],
-            env: acpEnv({
-              ELECTRON_RUN_AS_NODE: "1",
-              OGB_BOX_ID: computer.boxId,
-              OGB_BOX_TOKEN: computer.token,
-            }),
+            env: acpEnv({ ELECTRON_RUN_AS_NODE: "1", ...computerProxyEnv(computer) }),
           });
         } else if (turn.integrations?.localComputer) {
           const local = turn.integrations.localComputer;

--- a/server/drivers/boxagent.ts
+++ b/server/drivers/boxagent.ts
@@ -84,9 +84,16 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
 
     const sendTurn = async (turn: SendTurnInput) => {
       const { threadId } = turn;
-      const boxId = turn.integrations?.computer?.boxId;
+      const computer = turn.integrations?.computer;
+      const boxId = computer && (!computer.kind || computer.kind === "box") ? computer.boxId : undefined;
       if (!token) throw new Error('box not configured — add {"box":{"token":"…"}} to ~/.openmausbot/config.json');
-      if (!boxId) throw new Error("this bot has no computer yet — open the Computer panel and provision one");
+      if (!boxId) {
+        throw new Error(
+          computer?.kind === "container"
+            ? "this engine runs on a cloud box — switch this bot's computer to Cloud box, or pick another engine"
+            : "this bot has no computer yet — open the Computer panel and provision one",
+        );
+      }
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
       const turnId = newId();
       const model = turn.model || MODELS.default;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -27,6 +27,7 @@ import type {
   RuntimeEventListener,
   SendTurnInput,
 } from "../contracts.ts";
+import { computerProxyEnv } from "../container-computer.ts";
 import { newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
 
@@ -273,11 +274,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         mcpServers.computer = {
           command: process.execPath,
           args: [PROXY_PATH],
-          env: {
-            ...NODE_ENV_FLAG,
-            OGB_BOX_ID: turn.integrations.computer.boxId,
-            OGB_BOX_TOKEN: turn.integrations.computer.token,
-          },
+          env: { ...NODE_ENV_FLAG, ...computerProxyEnv(turn.integrations.computer) },
         };
         allowed.push("mcp__computer");
       } else if (turn.integrations?.localComputer) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -516,7 +516,31 @@ async function startTurn(
       const mountsComputer =
         instance.adapter.capabilities.computerMcp === true || instance.driverKind === "boxAgent";
       let previewBoxId: string | null = null;
-      if (wants !== "off" && wants !== "local" && box.boxConfigured(cfg)) {
+      // a Linux desktop in a container on this machine: free, disposable,
+      // and driven by exactly the same tools as the cloud box
+      if (wants === "vm" && mountsComputer) {
+        const vm = await containerComputerStatus();
+        if (vm.container === "running" && vm.runtime && vm.network !== "unsafe") {
+          integrations.computer = { kind: "container", container: vm.container_name, runtime: vm.runtime };
+        } else {
+          const why = !vm.runtime
+            ? "no container runtime is installed"
+            : !vm.daemonUp
+              ? `${vm.runtime} isn't running`
+              : !vm.image
+                ? "the desktop image hasn't been downloaded"
+                : vm.network === "unsafe"
+                  ? "its desktop ports are open beyond this machine — recreate it with loopback-only ports"
+                  : "the computer isn't started";
+          const note = store.appendMessage(bot.threadId, {
+            role: "bot",
+            kind: "activity",
+            tool: { name: `no local computer — ${why} (App Settings → Local computer)`, ok: false },
+          });
+          broadcast({ kind: "message", threadId: bot.threadId, message: note });
+        }
+      }
+      if (wants !== "off" && wants !== "local" && wants !== "vm" && box.boxConfigured(cfg)) {
         let b = await box.findBox(cfg, bot.id).catch(() => null);
         // the Computer driver runs ON the box — provision it on first use
         if (!b && instance.driverKind === "boxAgent") {

--- a/server/store.ts
+++ b/server/store.ts
@@ -136,7 +136,7 @@ export interface BotRecord {
   resumeCursors: Record<string, unknown>;
   /** which computer the bot acts on: its cloud box, this Mac (local CUA),
    * or none. Unset = auto (box when it exists, else local when available). */
-  computer?: "cloud" | "local" | "off";
+  computer?: "cloud" | "vm" | "local" | "off";
   /** Auto mode: the bot approves its own tool permissions and keeps
    * working instead of stopping to ask. Questions it asks YOU still come
    * through, and a short list of destructive commands still stops it. */

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -33,6 +33,8 @@ async function api(path: string, init?: RequestInit): Promise<any> {
 
 type Phase =
   | "checking"
+  | "vm"
+  | "vm-unready"
   | "unconfigured"
   | "starting"
   | "ready"
@@ -75,6 +77,13 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const localAvailable = capabilities.localComputer.available;
   const [phase, setPhase] = useState<Phase>("checking");
   const [boxState, setBoxState] = useState<string | null>(null);
+  const [vmStatus, setVmStatus] = useState<{
+    container?: string;
+    runtime?: string | null;
+    daemonUp?: boolean;
+    image?: boolean;
+    network?: string;
+  } | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<"join" | "sleep" | null>(null);
@@ -113,6 +122,16 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     setError(null);
     if (bot.computer === "off") {
       setPhase("off");
+      return;
+    }
+    if (bot.computer === "vm") {
+      api("/api/local-computer")
+        .then((v: { container?: string; runtime?: string | null; daemonUp?: boolean; image?: boolean; network?: string }) => {
+          if (!alive) return;
+          setVmStatus(v);
+          setPhase(v.container === "running" && v.network !== "unsafe" ? "vm" : "vm-unready");
+        })
+        .catch(() => alive && setPhase("vm-unready"));
       return;
     }
     if (bot.computer === "local") {
@@ -228,8 +247,20 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       .finally(() => setPending(null));
   };
 
+  const vmMissing = !vmStatus?.runtime
+    ? "no container runtime is installed yet"
+    : !vmStatus.daemonUp
+      ? `${vmStatus.runtime} isn't running`
+      : !vmStatus.image
+        ? "the desktop image hasn't been downloaded"
+        : vmStatus.network === "unsafe"
+          ? "its desktop ports are open beyond this machine"
+          : "the computer isn't started";
+
   const emptyState: Record<Exclude<Phase, "ready" | "local">, string> = {
     checking: "Checking…",
+    vm: "Your bot's Linux desktop is running",
+    "vm-unready": `Local VM isn't ready — ${vmMissing}`,
     starting: "Starting your bot's computer…",
     unconfigured: "No cloud computer configured",
     "local-unavailable":
@@ -306,6 +337,21 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             {error}
           </div>
         )}
+        {phase === "vm-unready" && (
+          <div className="mt-3 rounded-xl bg-card p-4">
+            <div className="mb-3 text-[13px] leading-relaxed text-ink-secondary">
+              A Local VM is a Linux desktop running on this machine — free, and separate from your own
+              desktop. It needs a one-time setup, and {vmMissing}.
+            </div>
+            <button
+              onClick={() => dispatch({ type: "toggleAppSettings", open: true })}
+              className="rounded-lg bg-accent px-3 py-1.5 text-[13px] font-medium text-white hover:brightness-110"
+            >
+              Open Local computer setup
+            </button>
+          </div>
+        )}
+
         {phase === "unconfigured" && (
           <div className="mt-3 rounded-xl bg-card p-4">
             <div className="mb-3 text-[13px] text-ink-secondary">
@@ -357,6 +403,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             {(
               [
                 ["cloud", "Cloud box"],
+                ["vm", "Local VM"],
                 ["local", "This computer"],
                 ["off", "Off"],
               ] as const

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -197,7 +197,7 @@ export function LocalComputerSection() {
               unsafe
                 ? "Recreate the computer with local-only ports"
                 : status?.container === "stopped"
-                  ? "Start the computer again"
+                  ? "Recreate the computer (this image can't resume)"
                   : "Start the computer"
             }
             done={ready}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -104,7 +104,7 @@ export interface Bot {
   busy?: boolean;
   modelSelection: ModelSelection;
   /** Where this bot's computer runs; unset = auto (cloud box if one exists, else local). */
-  computer?: "cloud" | "local" | "off";
+  computer?: "cloud" | "vm" | "local" | "off";
   /** auto mode: the bot approves its own tool permissions */
   autoApprove?: boolean;
   /** tools this bot may always use without asking */


### PR DESCRIPTION
Replaces #87, which conflicted after `container-computer.ts` was rewritten. Rather than force a rebase, I re-applied the transport **on top of** the newer module — its platform-aware runtime detection, Apple `container` support and loopback-only port checking are better than what I had, and one of those checks now does real work here.

### What it adds

The setup panel prepares a Linux desktop; this connects a bot to it.

The tools were never really coupled to the cloud — each one runs a shell command and reads a file back. So only two functions learned a second transport: commands go through the runtime's `exec`, and the frame is read straight out of the container instead of over HTTP. There is no network hop at all, which is why it's faster than the cloud path.

- **Runs on:** Cloud box · **Local VM** · This computer · Off
- Both drivers ask one helper what env the proxy needs, so the transport decision lives in exactly one place — with a test that box credentials can never travel with a container turn
- **A container whose desktop ports are open beyond this machine is refused** as a bot's computer. The panel already detected that state; now it's enforced where it matters
- Picking Local VM before it's ready names the missing step (no runtime / not started / image not downloaded / not started / ports unsafe) instead of failing mid-turn, and never touches the cloud provisioner

### Measured on a real container

| | Local VM | Cloud box |
|---|---|---|
| screenshot | **60–88 ms** | ~4–5 s |
| click with fused frame | 557 ms | ~5.9 s |
| 3-action batch | 829 ms | ~6 s |

Driven through the real `computer-proxy.ts` over MCP, against main's current toolset (including the new `browser_state` / `observation_metrics` tools). Earlier verification also proved synthetic keystrokes reach applications: the bot typed a command into `xterm` and the file it created read back correctly.

### A bug this found

**This desktop image cannot resume.** `docker start` on a stopped container exits immediately — `Xvfb is already running on display :1`, because the X lock survives the stop. Our panel was telling users to run exactly that. It now tells them to recreate the container, with the reason recorded in the code.

263 tests pass; typecheck and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Local VM as a computer option for supported bots and providers.
  * Added VM readiness checks, setup diagnostics, and a link to Local computer settings.
  * Local VM sessions now use the configured container runtime and display.

* **Bug Fixes**
  * Improved handling of stopped local computers by recreating them when necessary.
  * Cloud computer behavior and credentials remain isolated from local VM sessions.
  * Added clearer messaging when a VM is unavailable or requires setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->