### PR TITLE
Remove duplicate Local VM settings tab

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,7 +17,6 @@ const SECTIONS: Array<{ id: AppSettingsSection; label: string; icon: typeof User
   { id: "connections", label: "Connections", icon: KeyRound },
   { id: "computer", label: "Local VM", icon: Monitor },
   { id: "voice", label: "Voice", icon: Volume2 },
-  { id: "computer", label: "Local VM", icon: Monitor },
 ];
 
 /** Name + email, persisted to /api/config {profile} on blur. */


### PR DESCRIPTION
## What changed

- remove the duplicate Local VM entry from App Settings
- keep the original Local VM tab and its setup screen unchanged

## Root cause

The settings section list contained the same `computer` entry twice after the VM and voice changes were reconciled.

## User impact

App Settings now shows exactly one Local VM tab.

## Verification

- `pnpm typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “Local VM” option from the Settings modal navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->