### PR TITLE
Add default responders to group chats

### DIFF
--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -16,7 +16,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { mentionedBots } from "./store.ts";
+import { mentionedBots, normalizeGroupDefaultResponder, roomResponders } from "./store.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
@@ -47,6 +47,33 @@ describe("mentionedBots", () => {
   it("requires a word boundary at the end of the name", () => {
     expect(mentionedBots("ask @New Bottle about it", peers)).toEqual([]);
     expect(mentionedBots("@Milindo is someone else", peers)).toEqual([]);
+  });
+});
+
+describe("roomResponders", () => {
+  const members = [
+    { id: "atlas", name: "Atlas" },
+    { id: "milind", name: "Milind" },
+  ];
+
+  it("routes an unmentioned message to the configured lead", () => {
+    expect(roomResponders("hello there", members, { kind: "member", botId: "atlas" })).toEqual([members[0]]);
+  });
+
+  it("lets explicit mentions override the configured lead", () => {
+    expect(roomResponders("@Milind take this", members, { kind: "member", botId: "atlas" })).toEqual([members[1]]);
+  });
+
+  it("supports everyone and mentions-only room policies", () => {
+    expect(roomResponders("hello", members, { kind: "everyone" })).toEqual(members);
+    expect(roomResponders("hello", members, { kind: "mentions" })).toEqual([]);
+    expect(roomResponders("@everyone hello", members, { kind: "mentions" })).toEqual(members);
+  });
+
+  it("keeps bot-to-bot channels on their last-speaker routing", () => {
+    expect(normalizeGroupDefaultResponder({ kind: "everyone" }, members.map((member) => member.id), true)).toEqual({
+      kind: "mentions",
+    });
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,7 +25,7 @@ import type { RuntimeEvent } from "./contracts.ts";
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
-import { mentionedBots, Store, type Message } from "./store.ts";
+import { mentionedBots, roomResponders, Store, type GroupDefaultResponder, type Message } from "./store.ts";
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
@@ -702,11 +702,11 @@ routines.start();
 
 // ── config hot-reload ─────────────────────────────────────────────────
 // ── group turn engine ──────────────────────────────────────────────────
-// The Buzz rule: in a room, a bot replies only when @mentioned. Mentioned
-// members run SEQUENTIALLY (one speaker at a time — the transcript and the
-// streaming bubble stay coherent), each on a fresh session with the recent
-// room conversation serialized into its prompt. A member's reply may
-// @mention teammates; those get one chained turn (hop 1), never deeper.
+// Room messages go to the configured default responder unless the user
+// explicitly @mentions members. Responders run SEQUENTIALLY (one speaker at
+// a time — the transcript and streaming bubble stay coherent), each on a
+// fresh session with recent room context. A member's reply may @mention
+// teammates; those get one chained turn (hop 1), never deeper.
 const groupQueues = new Map<string, Promise<void>>();
 const GROUP_CONTEXT_MESSAGES = 30;
 const MAX_GROUP_HOPS = 1;
@@ -812,7 +812,7 @@ async function runGroupMemberTurn(
     const members = group.memberIds
       .map((id) => store.bot(id))
       .filter((b): b is NonNullable<typeof b> => Boolean(b) && b!.id !== bot.id);
-    for (const next of mentionedBots(replyText, members)) {
+    for (const next of roomResponders(replyText, members, { kind: "mentions" })) {
       if (spoken.has(next.id)) continue;
       await runGroupMemberTurn(groupId, next.id, hop + 1, spoken);
     }
@@ -828,10 +828,7 @@ function startGroupTurn(groupId: string, text: string) {
   const members = group.memberIds
     .map((id) => store.bot(id))
     .filter((b): b is NonNullable<typeof b> => Boolean(b));
-  const mentioned = mentionedBots(text, members);
-  // Buzz rule: nobody replies unless mentioned — except a one-member room,
-  // where the single bot obviously IS the addressee
-  let responders = mentioned.length ? mentioned : members.length === 1 ? members : [];
+  let responders = roomResponders(text, members, group.defaultResponder);
   // bot⇄bot channels: chipping in without a tag addresses the last speaker
   if (!responders.length && group.dm) {
     const lastSpeakerId = [...store.messagesFor(group.threadId)]
@@ -1118,6 +1115,8 @@ const server = createServer(async (req, res) => {
     m = path.match(/^\/api\/groups\/([\w-]+)$/);
     if (m && method === "PATCH") {
       const body = await readBody(req);
+      const existing = store.group(m[1]);
+      if (!existing) return json(res, 404, { error: "no such room" });
       const patch: Record<string, unknown> = {};
       for (const key of ["name", "bulletin", "unread"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
@@ -1125,6 +1124,18 @@ const server = createServer(async (req, res) => {
       if (Array.isArray(body.memberIds)) {
         const ids = body.memberIds.filter((id: unknown): id is string => typeof id === "string" && Boolean(store.bot(id)));
         if (ids.length) patch.memberIds = ids;
+      }
+      if (body.defaultResponder !== undefined) {
+        const value = body.defaultResponder as { kind?: unknown; botId?: unknown } | null;
+        const memberIds = (patch.memberIds as string[] | undefined) ?? existing.memberIds;
+        let responder: GroupDefaultResponder | null = null;
+        if (value?.kind === "everyone") responder = { kind: "everyone" };
+        else if (value?.kind === "mentions") responder = { kind: "mentions" };
+        else if (value?.kind === "member" && typeof value.botId === "string" && memberIds.includes(value.botId)) {
+          responder = { kind: "member", botId: value.botId };
+        }
+        if (!responder) return json(res, 400, { error: "invalid default responder" });
+        patch.defaultResponder = responder;
       }
       const group = store.patchGroup(m[1], patch);
       if (!group) return json(res, 404, { error: "no such room" });

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -35,6 +35,34 @@ describe("Store", () => {
     expect(first.color).not.toBe(second.color);
   });
 
+  it("defaults a room to its first member and repairs the lead when membership changes", () => {
+    const store = new Store(selection);
+    const first = store.createBot();
+    const second = store.createBot();
+    const group = store.createGroup("Team", [first.id, second.id]);
+
+    expect(group.defaultResponder).toEqual({ kind: "member", botId: first.id });
+    store.patchGroup(group.id, { memberIds: [second.id] });
+    expect(group.defaultResponder).toEqual({ kind: "member", botId: second.id });
+
+    const reloaded = new Store(selection);
+    expect(reloaded.group(group.id)?.defaultResponder).toEqual({ kind: "member", botId: second.id });
+  });
+
+  it("migrates old rooms without routing to their first member", () => {
+    const store = new Store(selection);
+    const first = store.createBot();
+    const second = store.createBot();
+    const group = store.createGroup("Legacy team", [first.id, second.id]);
+    const groupsFile = join(DATA_DIR, "groups.json");
+    const saved = JSON.parse(readFileSync(groupsFile, "utf8"));
+    delete saved[0].defaultResponder;
+    writeFileSync(groupsFile, JSON.stringify(saved));
+
+    const reloaded = new Store(selection);
+    expect(reloaded.group(group.id)?.defaultResponder).toEqual({ kind: "member", botId: first.id });
+  });
+
   it("persists bots and messages across a restart, resetting busy", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -75,14 +75,21 @@ export interface Message {
   comm?: { groupId: string; withBotId: string; withName: string; withColor: string };
 }
 
-/** A room: a shared thread where several bots + the user talk. Bots reply
- * only when @mentioned (the Buzz rule). The bulletin is the room's shared
- * instructions — every member's turn gets it as part of its system prompt. */
+export type GroupDefaultResponder =
+  | { kind: "member"; botId: string }
+  | { kind: "everyone" }
+  | { kind: "mentions" };
+
+/** A room: a shared thread where several bots + the user talk. Plain
+ * messages follow `defaultResponder`; explicit @mentions always override it.
+ * The bulletin is the room's shared instructions — every member's turn gets
+ * it as part of its system prompt. */
 export interface GroupRecord {
   id: string;
   threadId: ThreadId;
   name: string;
   memberIds: string[];
+  defaultResponder: GroupDefaultResponder;
   bulletin: string;
   unread: boolean;
   createdAt: number;
@@ -204,6 +211,50 @@ export function mentionedBots<T extends { name: string; hidden?: boolean }>(text
   return found;
 }
 
+/** Normalize persisted or API-provided routing. Old rooms did not have this
+ * field; giving them their first member as lead fixes the old silent-send
+ * behavior without making every prompt fan out to every model. */
+export function normalizeGroupDefaultResponder(
+  value: unknown,
+  memberIds: string[],
+  dm = false,
+): GroupDefaultResponder {
+  if (dm) return { kind: "mentions" };
+  if (value && typeof value === "object") {
+    const candidate = value as { kind?: unknown; botId?: unknown };
+    if (candidate.kind === "everyone") return { kind: "everyone" };
+    if (candidate.kind === "mentions") return { kind: "mentions" };
+    if (
+      candidate.kind === "member" &&
+      typeof candidate.botId === "string" &&
+      memberIds.includes(candidate.botId)
+    ) {
+      return { kind: "member", botId: candidate.botId };
+    }
+  }
+  if (memberIds.length === 0) return { kind: "mentions" };
+  return { kind: "member", botId: memberIds[0] };
+}
+
+/** Resolve the bots invoked by a human room message. Explicit targets win;
+ * otherwise the room policy chooses one member, everyone, or nobody. */
+export function roomResponders<T extends { id: string; name: string; hidden?: boolean }>(
+  text: string,
+  members: T[],
+  defaultResponder: GroupDefaultResponder,
+): T[] {
+  const available = members.filter((member) => !member.hidden);
+  if (/(?:^|\s)@everyone\b/i.test(text)) return available;
+  const mentioned = mentionedBots(text, available);
+  if (mentioned.length) return mentioned;
+  if (defaultResponder.kind === "everyone") return available;
+  if (defaultResponder.kind === "member") {
+    const lead = available.find((member) => member.id === defaultResponder.botId);
+    return lead ? [lead] : [];
+  }
+  return [];
+}
+
 const onboardingCard = (): OptionCardData => ({
   title: "What do you mostly want help with?",
   subtitle: "Pick whatever's closest; we can always expand from there.",
@@ -236,9 +287,17 @@ export class Store {
     } catch {
       this.groups = [];
     }
-    // busy never survives a restart — no turn does either
+    // busy never survives a restart — no turn does either. Rooms saved
+    // before default responders existed adopt their first member as lead.
+    let groupsMigrated = false;
     for (const b of this.bots) b.busy = false;
-    for (const g of this.groups) g.busyBotId = null;
+    for (const g of this.groups) {
+      g.busyBotId = null;
+      const normalized = normalizeGroupDefaultResponder(g.defaultResponder, g.memberIds, Boolean(g.dm));
+      if (JSON.stringify(normalized) !== JSON.stringify(g.defaultResponder)) groupsMigrated = true;
+      g.defaultResponder = normalized;
+    }
+    if (groupsMigrated) this.saveGroups();
     // bots saved before tasks existed have one endless thread; adopt it as
     // their first task so nothing is lost and nothing special-cases it
     for (const b of this.bots) {
@@ -277,6 +336,7 @@ export class Store {
       threadId: newId(),
       name,
       memberIds,
+      defaultResponder: dm ? { kind: "mentions" } : { kind: "member", botId: memberIds[0] },
       bulletin: "",
       unread: false,
       createdAt: Date.now(),
@@ -295,10 +355,15 @@ export class Store {
     );
   }
 
-  patchGroup(id: string, patch: Partial<Pick<GroupRecord, "name" | "memberIds" | "bulletin" | "unread" | "busyBotId">>): GroupRecord | null {
+  patchGroup(id: string, patch: Partial<Pick<GroupRecord, "name" | "memberIds" | "defaultResponder" | "bulletin" | "unread" | "busyBotId">>): GroupRecord | null {
     const group = this.group(id);
     if (!group) return null;
     Object.assign(group, patch);
+    group.defaultResponder = normalizeGroupDefaultResponder(
+      group.defaultResponder,
+      group.memberIds,
+      Boolean(group.dm),
+    );
     this.saveGroups();
     return group;
   }

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { track } from "@/lib/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowUp, Clock, Mic, Square, X } from "lucide-react";
+import { ArrowUp, Clock, Mic, Square, Users, X } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { useComposerDraft } from "@/lib/drafts";
@@ -13,6 +13,7 @@ import {
   type Attachment,
 } from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
+import { groupComposerHint } from "@/lib/group-routing";
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 
@@ -28,6 +29,8 @@ function mentionQueryAt(text: string, caret: number): { start: number; query: st
   return { start: at, query };
 }
 
+type MentionChoice = { id: string; name: string; bot?: Bot };
+
 export function Composer({
   bot,
   group,
@@ -42,7 +45,8 @@ export function Composer({
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   // Unified target: a 1:1 bot thread or a room. In a room the @ picker
-  // offers the members (Buzz rule: only mentioned bots reply).
+  // offers members plus @everyone; explicit mentions override the room's
+  // configured default responder.
   const busy = group ? Boolean(group.busyBotId) : Boolean(bot?.busy);
   // a pending approval blocks the prompt until it is answered
   const threadId = group?.threadId ?? bot?.threadId ?? "";
@@ -83,7 +87,14 @@ export function Composer({
   const mention = mentionQueryAt(text, caret);
   const candidates = useMemo(() => {
     if (!mention || mention.start === dismissedAt) return [];
-    const pool = group ? (members ?? []) : state.bots.filter((b) => b.id !== bot?.id && !b.hidden);
+    const pool: MentionChoice[] = group
+      ? [
+          { id: "__everyone__", name: "everyone" },
+          ...(members ?? []).map((member) => ({ id: member.id, name: member.name, bot: member })),
+        ]
+      : state.bots
+          .filter((member) => member.id !== bot?.id && !member.hidden)
+          .map((member) => ({ id: member.id, name: member.name, bot: member }));
     const q = mention.query.trim().toLowerCase();
     // "@Scout " — the full name plus a space — is a COMPLETED tag, not a
     // search: keep the picker closed so Enter sends instead of re-picking
@@ -102,7 +113,7 @@ export function Composer({
     el.style.height = `${el.scrollHeight}px`;
   }, [text]);
 
-  const pickMention = (peer: Bot) => {
+  const pickMention = (peer: MentionChoice) => {
     if (!mention) return;
     const after = text.slice(caret);
     const next = `${text.slice(0, mention.start)}@${peer.name} ${after}`;
@@ -234,9 +245,19 @@ export function Composer({
                   i === highlight ? "bg-raised-hover" : "",
                 )}
               >
-                <MausAvatar color={peer.color} state={normalizeState(peer.mascotExpression) ?? "happy"} size={24} />
+                {peer.bot ? (
+                  <MausAvatar
+                    color={peer.bot.color}
+                    state={normalizeState(peer.bot.mascotExpression) ?? "happy"}
+                    size={24}
+                  />
+                ) : (
+                  <span className="flex size-6 items-center justify-center rounded-full bg-raised text-ink-secondary">
+                    <Users size={14} aria-hidden="true" />
+                  </span>
+                )}
                 <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{peer.name}</span>
-                <span className="shrink-0 text-xs text-ink-secondary">Agent</span>
+                <span className="shrink-0 text-xs text-ink-secondary">{peer.bot ? "Agent" : "Room"}</span>
               </button>
             ))}
           </div>
@@ -330,7 +351,7 @@ export function Composer({
               : busy
                 ? `${busyName} is working — Enter queues your message`
                 : group
-                  ? `Message ${group.name} — @ to bring a bot in`
+                  ? `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`
                   : `Message ${bot?.name ?? ""}`
           }
           aria-label={`Message ${group ? group.name : (bot?.name ?? "")}`}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -1,13 +1,21 @@
 // A room: several bots + you in one shared thread. Minimal by design — the
 // mauses are the only expressive element. Members sit in the header (their
 // idle/working motion IS the status), the bulletin is one pinned line, and
-// bot messages carry a small maus + name cluster label. Bots reply only
-// when @mentioned (the composer's @ picker knows the members).
+// bot messages carry a small maus + name cluster label. Plain messages go
+// to the room's default responder; @mentions override that routing.
 import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Pin } from "lucide-react";
-import { useStore, useStreaming, formatTime, type Bot, type Group } from "@/state/store";
+import { ArrowDown, ChevronDown, Pin } from "lucide-react";
+import {
+  useStore,
+  useStreaming,
+  formatTime,
+  type Bot,
+  type Group,
+  type GroupDefaultResponder,
+} from "@/state/store";
 import { MausAvatar } from "./Avatar";
 import { normalizeState } from "@/lib/mascot";
+import { effectiveDefaultResponder, groupResponseHint } from "@/lib/group-routing";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { Composer } from "./Composer";
 import { ReactionBar, ReactionChips } from "./Reactions";
@@ -129,6 +137,55 @@ function StreamingBubble({ text }: { text: string }) {
   );
 }
 
+function DefaultResponderSelect({ group, members }: { group: Group; members: Bot[] }) {
+  const { dispatch } = useStore();
+  const responder = effectiveDefaultResponder(group, members);
+  const value = responder.kind === "member" ? `member:${responder.botId}` : responder.kind;
+  const lead = responder.kind === "member" ? members.find((member) => member.id === responder.botId) : undefined;
+  const title =
+    responder.kind === "everyone"
+      ? "Plain messages go to every room member; @mentions override this"
+      : responder.kind === "mentions"
+        ? "Only explicitly @mentioned bots respond"
+        : `Plain messages go to ${lead?.name ?? "the lead bot"}; @mentions override this`;
+
+  const change = (nextValue: string) => {
+    let next: GroupDefaultResponder;
+    if (nextValue === "everyone") next = { kind: "everyone" };
+    else if (nextValue === "mentions") next = { kind: "mentions" };
+    else next = { kind: "member", botId: nextValue.slice("member:".length) };
+    dispatch({ type: "patchGroup", groupId: group.id, patch: { defaultResponder: next } });
+  };
+
+  return (
+    <div className="relative shrink-0" title={title}>
+      <select
+        aria-label="Default responder"
+        value={value}
+        onChange={(event) => change(event.target.value)}
+        className="h-8 max-w-[190px] appearance-none truncate rounded-full border border-hairline/40 bg-raised/60 py-1 pl-3 pr-7 text-[12.5px] font-medium text-ink outline-none hover:bg-raised focus:border-accent"
+      >
+        <optgroup label="Room lead">
+          {members.map((member) => (
+            <option key={member.id} value={`member:${member.id}`}>
+              Lead: {member.name}
+            </option>
+          ))}
+        </optgroup>
+        <optgroup label="Room behavior">
+          <option value="everyone">Everyone responds</option>
+          <option value="mentions">Mentions only</option>
+        </optgroup>
+      </select>
+      <ChevronDown
+        size={13}
+        aria-hidden="true"
+        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-ink-secondary"
+      />
+    </div>
+  );
+}
+
 export function GroupView({ group }: { group: Group }) {
   const { state, dispatch } = useStore();
   const stream = useStreaming();
@@ -173,6 +230,7 @@ export function GroupView({ group }: { group: Group }) {
       <div className={cn("flex items-center justify-between px-5 py-3", isWin && "pr-[148px]")} style={drag}>
         <span className="text-[15px] font-semibold text-ink">{group.name}</span>
         <div className="flex items-center gap-1.5" style={noDrag}>
+          {!group.dm && <DefaultResponderSelect group={group} members={members} />}
           {members.map((b) => (
             <span key={b.id} title={`${b.name}${group.busyBotId === b.id ? " — working…" : ""}`}>
               <MausAvatar
@@ -255,7 +313,7 @@ export function GroupView({ group }: { group: Group }) {
               </div>
               <div className="text-[17px] font-semibold text-ink">{group.name}</div>
               <div className="max-w-[380px] text-[14px] text-ink-secondary">
-                Mention a bot with @ to bring them in — they see the whole conversation.
+                {groupResponseHint(group, members)}
               </div>
             </div>
           )}

--- a/src/lib/group-routing.ts
+++ b/src/lib/group-routing.ts
@@ -1,0 +1,33 @@
+import type { Bot, Group, GroupDefaultResponder } from "@/state/store";
+
+/** Be defensive around rooms loaded while an older server is still running,
+ * and around a lead removed by another client before the group patch arrives. */
+export function effectiveDefaultResponder(group: Group, members: Bot[]): GroupDefaultResponder {
+  const value = group.defaultResponder;
+  if (value?.kind === "everyone" || value?.kind === "mentions") return value;
+  if (value?.kind === "member" && members.some((member) => member.id === value.botId)) return value;
+  return members[0] ? { kind: "member", botId: members[0].id } : { kind: "mentions" };
+}
+
+export function defaultResponderName(group: Group, members: Bot[]): string | null {
+  const value = effectiveDefaultResponder(group, members);
+  if (value.kind !== "member") return null;
+  return members.find((member) => member.id === value.botId)?.name ?? null;
+}
+
+export function groupResponseHint(group: Group, members: Bot[]): string {
+  if (group.dm) return "Reply here to continue the bot-to-bot conversation.";
+  const value = effectiveDefaultResponder(group, members);
+  if (value.kind === "everyone") return "Everyone responds unless you @mention specific bots.";
+  if (value.kind === "mentions") return "Mention a bot with @ to bring them in.";
+  const name = defaultResponderName(group, members) ?? "The lead bot";
+  return `${name} responds by default — @mention someone else to choose them instead.`;
+}
+
+export function groupComposerHint(group: Group, members: Bot[]): string {
+  if (group.dm) return "continue the conversation";
+  const value = effectiveDefaultResponder(group, members);
+  if (value.kind === "everyone") return "everyone responds";
+  if (value.kind === "mentions") return "@ to bring a bot in";
+  return `${defaultResponderName(group, members) ?? "Lead"} responds`;
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -61,12 +61,18 @@ export interface Message {
   comm?: { groupId: string; withBotId: string; withName: string; withColor: MausColor };
 }
 
+export type GroupDefaultResponder =
+  | { kind: "member"; botId: string }
+  | { kind: "everyone" }
+  | { kind: "mentions" };
+
 /** A room: several bots + you in one shared thread. */
 export interface Group {
   id: string;
   threadId: string;
   name: string;
   memberIds: string[];
+  defaultResponder: GroupDefaultResponder;
   bulletin: string;
   unread: boolean;
   createdAt: number;
@@ -233,7 +239,11 @@ type Action =
   | { type: "groupDeleted"; groupId: string }
   | { type: "createGroup"; memberIds: string[]; name?: string }
   | { type: "sendGroup"; groupId: string; text: string }
-  | { type: "patchGroup"; groupId: string; patch: Partial<Pick<Group, "name" | "bulletin" | "memberIds">> }
+  | {
+      type: "patchGroup";
+      groupId: string;
+      patch: Partial<Pick<Group, "name" | "bulletin" | "memberIds" | "defaultResponder">>;
+    }
   | { type: "deleteGroup"; groupId: string }
   | { type: "toggleReaction"; threadId: string; messageId: string; emoji: string }
   | { type: "interruptGroup"; groupId: string }


### PR DESCRIPTION
## What changed

- Add a persisted **Default responder** control to group-chat headers.
- Let rooms route plain messages to a selected lead, everyone, or mentions only.
- Make explicit `@mentions` override the room default and add `@everyone` to the mention picker.
- Migrate existing rooms to their first member as lead, fixing the previous silent-send behavior.
- Keep bot-to-bot channels on their existing last-speaker routing.
- Update empty-state and composer hints so the active routing rule is visible.

## Why

Previously, a message sent to a multi-bot room without an explicit mention was stored but invoked no bot. That looked like group chat was broken. A room-level default makes ordinary conversation work while preserving precise mention-based routing when needed.

## Validation

- `pnpm exec vitest run server/comms.test.ts server/store.test.ts` — 27 passed
- Full test suite — 276 passed, 8 skipped
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:electron`
- Browser QA for lead selection, Everyone, Mentions only, persistence after reload, and the `@everyone` picker
