### PR TITLE
Add group conference calls

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { startCua, stopCua, registerCuaIpc } from "./cua.mjs";
-import { startSpeech, stopSpeech } from "./speech.mjs";
+import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
@@ -271,6 +271,9 @@ ipcMain.handle("speech:start", (event, options) => {
 });
 ipcMain.handle("speech:stop", () => {
   if (process.platform === "darwin") stopSpeech();
+});
+ipcMain.handle("speech:finish", () => {
+  if (process.platform === "darwin") finishSpeech();
 });
 
 ipcMain.handle("desktop:capabilities", async () =>

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld("ogb", {
   screenFrame: () => ipcRenderer.invoke("screen:frame"),
   speechStart: (options) => ipcRenderer.invoke("speech:start", options),
   speechStop: () => ipcRenderer.invoke("speech:stop"),
+  speechFinish: () => ipcRenderer.invoke("speech:finish"),
   onSpeechTranscript: (cb) => {
     const handler = (_event, line) => cb(line);
     ipcRenderer.on("speech:transcript", handler);

--- a/electron/resources/speech-helper.swift
+++ b/electron/resources/speech-helper.swift
@@ -45,6 +45,12 @@ let stopFile: String? = {
   return args[index + 1]
 }()
 
+let finishFile: String? = {
+  let args = CommandLine.arguments
+  guard let index = args.firstIndex(of: "--finish-file"), index + 1 < args.count else { return nil }
+  return args[index + 1]
+}()
+
 // LaunchServices gives the helper the bundle identity TCC needs, but it also
 // means the parent cannot terminate it by killing the `open -W` process. A
 // per-session stop marker keeps intentional mute/hang-up deterministic.
@@ -56,6 +62,23 @@ if let stopFile {
     if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
   }
   stopTimer = timer
+  timer.resume()
+}
+
+// Push-to-talk release must finalize recognition rather than cancel it. The
+// handler is installed once the audio engine exists; the timer keeps polling
+// if an unusually fast key release beats authorization/setup.
+var finishHandler: (() -> Void)?
+var finishTimer: DispatchSourceTimer?
+if let finishFile {
+  let timer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+  timer.schedule(deadline: .now() + .milliseconds(50), repeating: .milliseconds(50))
+  timer.setEventHandler {
+    guard FileManager.default.fileExists(atPath: finishFile), let finish = finishHandler else { return }
+    timer.cancel()
+    finish()
+  }
+  finishTimer = timer
   timer.resume()
 }
 
@@ -125,17 +148,24 @@ SFSpeechRecognizer.requestAuthorization { status in
 
   let engine = AVAudioEngine()
   let node = engine.inputNode
+  var audioFinished = false
+  let finishAudio = {
+    DispatchQueue.main.async {
+      guard !audioFinished else { return }
+      audioFinished = true
+      engine.stop()
+      node.removeTap(onBus: 0)
+      request.endAudio()
+    }
+  }
+  finishHandler = finishAudio
   var endpointer: SilenceEndpointer?
   if endpointMs > 0 {
     endpointer = SilenceEndpointer(gapMs: endpointMs) {
       // Stop capture before ending the request: appending another audio
       // buffer after endAudio() can make the recognition task fail instead
       // of delivering its final transcript.
-      DispatchQueue.main.async {
-        engine.stop()
-        node.removeTap(onBus: 0)
-        request.endAudio()
-      }
+      finishAudio()
     }
     endpointer?.start()
   }

--- a/electron/speech.mjs
+++ b/electron/speech.mjs
@@ -80,6 +80,7 @@ export function startSpeech(win, options = {}) {
   const outputPath = path.join(sessionDir, "stdout.ndjson");
   const errorPath = path.join(sessionDir, "stderr.log");
   const stopPath = path.join(sessionDir, "stop");
+  const finishPath = path.join(sessionDir, "finish");
   writeFileSync(outputPath, "");
   writeFileSync(errorPath, "");
 
@@ -100,6 +101,8 @@ export function startSpeech(win, options = {}) {
         ...args,
         "--stop-file",
         stopPath,
+        "--finish-file",
+        finishPath,
       ],
       { stdio: "ignore" },
     );
@@ -109,7 +112,7 @@ export function startSpeech(win, options = {}) {
     return;
   }
 
-  const speechSession = { proc, outputPath, errorPath, stopPath, sessionDir };
+  const speechSession = { proc, outputPath, errorPath, stopPath, finishPath, sessionDir };
   child = speechSession;
   let buf = "";
   let offset = 0;
@@ -184,5 +187,14 @@ export function stopSpeech() {
   child = null;
   try {
     writeFileSync(speechSession.stopPath, "stop");
+  } catch {}
+}
+
+/** Finalize the active request and keep it owned until the recognizer emits
+ * its final transcript. Used by push-to-talk key release. */
+export function finishSpeech() {
+  if (!child) return;
+  try {
+    writeFileSync(child.finishPath, "finish");
   } catch {}
 }

--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -24,6 +24,7 @@ import { useStore, visibleMessages, type Bot } from "@/state/store";
 import { currentCall, deferCallCleanup, endCall, startCall, useOnCall } from "@/lib/call";
 import { speaker } from "@/lib/tts";
 import { useSpeech } from "@/lib/tts/useSpeech";
+import { usePushToTalk } from "@/lib/push-to-talk";
 import { MausAvatar } from "./Avatar";
 import { pendingApprovals } from "./PendingApproval";
 import { cn } from "@/lib/cn";
@@ -40,12 +41,34 @@ type Phase = "listening" | "sending" | "working" | "speaking";
 const CALL_ENDPOINT_MS = 850;
 
 export function CallButton({ bot }: { bot: Bot }) {
+  return (
+    <CallTargetButton
+      targetId={bot.id}
+      targetName={bot.name}
+      voices={[bot.voice]}
+      onStart={() => track("call_started", { driver: bot.modelSelection?.instanceId })}
+    />
+  );
+}
+
+export function CallTargetButton({
+  targetId,
+  targetName,
+  voices,
+  onStart,
+}: {
+  targetId: string;
+  targetName: string;
+  voices: Array<string | undefined>;
+  onStart: () => void;
+}) {
   const { state, dispatch } = useStore();
   const { capabilities, ready: capabilitiesReady } = useDesktopCapabilities();
-  const active = useOnCall() === bot.id;
+  const active = useOnCall() === targetId;
   const supported = capabilities.dictation.available && Boolean(window.ogb?.speechStart);
   const configured = Boolean(state.config?.tts?.configured);
-  const voiceReady = configured && Boolean(state.config?.tts?.ready || bot.voice);
+  const voiceReady =
+    configured && Boolean(state.config?.tts?.ready || (voices.length > 0 && voices.every((voice) => Boolean(voice))));
   const unavailable = !active && (!capabilitiesReady || !supported || !voiceReady);
   const voiceSetupRequired = capabilitiesReady && supported && !voiceReady;
   const [helpOpen, setHelpOpen] = useState(false);
@@ -53,7 +76,7 @@ export function CallButton({ bot }: { bot: Bot }) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const helpId = useId();
   const label = active
-    ? `Hang up on ${bot.name}`
+    ? `Hang up on ${targetName}`
     : !capabilitiesReady
       ? "Checking call availability"
       : !supported
@@ -62,7 +85,7 @@ export function CallButton({ bot }: { bot: Bot }) {
           ? "Add an ElevenLabs key in App Settings to make calls"
           : !voiceReady
             ? "Pick a voice in App Settings to make calls"
-            : `Call ${bot.name}`;
+            : `Call ${targetName}`;
 
   const reason = !capabilitiesReady
     ? "Checking whether this device can make calls."
@@ -73,7 +96,9 @@ export function CallButton({ bot }: { bot: Bot }) {
         : !configured
           ? "Add an ElevenLabs API key so the bot can speak during calls."
           : !voiceReady
-            ? "Choose an ElevenLabs voice before starting a call."
+            ? voices.length > 1
+              ? "Choose an app voice, or give every room member their own ElevenLabs voice."
+              : "Choose an ElevenLabs voice before starting a call."
             : "";
 
   useEffect(() => {
@@ -99,13 +124,13 @@ export function CallButton({ bot }: { bot: Bot }) {
       <button
         ref={buttonRef}
         onClick={() => {
-          if (active) return endCall(bot.id);
+          if (active) return endCall(targetId);
           if (unavailable) {
             setHelpOpen((open) => !open);
             return;
           }
-          track("call_started", { driver: bot.modelSelection?.instanceId });
-          startCall(bot.id);
+          onStart();
+          startCall(targetId);
         }}
         aria-expanded={unavailable ? helpOpen : undefined}
         aria-controls={unavailable ? helpId : undefined}
@@ -166,6 +191,9 @@ function Call({ bot }: { bot: Bot }) {
   const [phase, setPhase] = useState<Phase>(initialPhase);
   const [heard, setHeard] = useState("");
   const [note, setNote] = useState<string | null>(null);
+  const pushToTalk = usePushToTalk(bot.id, phase === "listening", () => {
+    setNote("Push to talk couldn't start. Check Microphone and Speech Recognition access.");
+  });
 
   const messages = visibleMessages(bot);
   const approval = pendingApprovals(messages)[0];
@@ -431,7 +459,9 @@ function Call({ bot }: { bot: Bot }) {
     phase === "listening" ? "listening" : phase === "speaking" ? "sending" : phase === "sending" ? "thinking" : "working";
   const status =
     phase === "listening"
-      ? "Listening"
+      ? pushToTalk
+        ? "Push to talk"
+        : "Listening"
       : phase === "sending"
         ? "One moment"
         : phase === "speaking"
@@ -461,7 +491,11 @@ function Call({ bot }: { bot: Bot }) {
       {/* one line, whichever is current: what you're saying, or what it is */}
       <div className="min-h-[3.5rem] max-w-[560px] px-6 text-center text-[15px] leading-relaxed text-ink">
         {phase === "listening" ? (
-          heard || <span className="text-ink-secondary">Say something…</span>
+          heard || (
+            <span className="text-ink-secondary">
+              {pushToTalk ? "Release Control + Option to send…" : "Say something…"}
+            </span>
+          )
         ) : (
           speech.caption
         )}
@@ -501,7 +535,9 @@ function Call({ bot }: { bot: Bot }) {
         </button>
       </div>
 
-      <div className="text-[11.5px] text-ink-secondary/70">Space interrupts · Esc hangs up</div>
+      <div className="text-[11.5px] text-ink-secondary/70">
+        Hold Control + Option to talk · Space interrupts · Esc hangs up
+      </div>
     </div>
   );
 }

--- a/src/components/GroupCallView.tsx
+++ b/src/components/GroupCallView.tsx
@@ -1,0 +1,503 @@
+// Conference call mode — one microphone, several room members.
+//
+// Capture stays half-duplex for the same reason as one-to-one calls: the
+// native recognizer has no acoustic echo cancellation. Bot replies are
+// explicitly queued so a fast second member never cuts off the first.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, PhoneOff, X } from "lucide-react";
+
+import { currentCall, deferCallCleanup, endCall, useOnCall } from "@/lib/call";
+import { routeSpokenGroupMessage } from "@/lib/group-call";
+import { track } from "@/lib/analytics";
+import { normalizeState } from "@/lib/mascot";
+import { speaker } from "@/lib/tts";
+import { useSpeech } from "@/lib/tts/useSpeech";
+import { usePushToTalk } from "@/lib/push-to-talk";
+import { useStore, type Bot, type Group, type Message } from "@/state/store";
+import { cn } from "@/lib/cn";
+import { MausAvatar } from "./Avatar";
+import { CallTargetButton } from "./CallView";
+import { pendingApprovals } from "./PendingApproval";
+
+const YES = /^(yes|yeah|yep|yup|sure|ok|okay|go ahead|do it|allow|approve|approved|fine|please do)\b/i;
+const NO = /^(no|nope|don'?t|do not|stop|deny|denied|cancel|never|skip it)\b/i;
+const CALL_ENDPOINT_MS = 850;
+
+type Phase = "listening" | "sending" | "working" | "speaking";
+
+export function GroupCallButton({ group, members }: { group: Group; members: Bot[] }) {
+  if (group.dm) return null;
+  return (
+    <CallTargetButton
+      targetId={group.id}
+      targetName={group.name}
+      voices={members.map((member) => member.voice)}
+      onStart={() => track("group_call_started", { memberCount: members.length })}
+    />
+  );
+}
+
+export function GroupCallOverlay({ group, members }: { group: Group; members: Bot[] }) {
+  const active = useOnCall() === group.id;
+  if (!active) return null;
+  return <GroupCall group={group} members={members} />;
+}
+
+function questionIn(messages: Message[]): Message | undefined {
+  return messages.find(
+    (message) =>
+      message.kind === "options" &&
+      message.card?.requestId &&
+      !message.card.tool &&
+      !message.card.answered &&
+      !message.card.dismissed,
+  );
+}
+
+function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
+  const { dispatch } = useStore();
+  const speech = useSpeech();
+  const initialPhase: Phase = group.busyBotId ? "working" : "listening";
+  const [phase, setPhase] = useState<Phase>(initialPhase);
+  const [heard, setHeard] = useState("");
+  const [note, setNote] = useState<string | null>(null);
+  const [speakingMemberId, setSpeakingMemberId] = useState<string | null>(null);
+  const pushToTalk = usePushToTalk(group.id, phase === "listening", () => {
+    setNote("Push to talk couldn't start. Check Microphone and Speech Recognition access.");
+  });
+
+  const messages = group.messages;
+  const approval = pendingApprovals(messages)[0];
+  const question = questionIn(messages);
+  const membersRef = useRef(members);
+  const busyRef = useRef(Boolean(group.busyBotId));
+  const defaultResponderRef = useRef(group.defaultResponder);
+  membersRef.current = members;
+  busyRef.current = Boolean(group.busyBotId);
+  defaultResponderRef.current = group.defaultResponder;
+
+  const spokenIds = useRef<Set<string>>(new Set());
+  const started = useRef(false);
+  if (!started.current) {
+    started.current = true;
+    for (const message of messages) spokenIds.current.add(message.id);
+  }
+
+  const askedApproval = useRef<{ requestId: string; member?: Bot } | null>(null);
+  const askedQuestion = useRef<{ requestId: string; member?: Bot } | null>(null);
+  const phaseRef = useRef<Phase>(initialPhase);
+  const alive = useRef(true);
+  const sayGeneration = useRef(0);
+  const queueGeneration = useRef(0);
+  const queue = useRef<Promise<void>>(Promise.resolve());
+  const queuedJobs = useRef(new Set<number>());
+  const nextJobId = useRef(0);
+  const listenWhenDrained = useRef(false);
+  const listenTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const allowBargeIn = useRef(false);
+
+  const move = useCallback((next: Phase) => {
+    phaseRef.current = next;
+    if (alive.current) setPhase(next);
+  }, []);
+
+  const hush = useCallback(() => {
+    void window.ogb?.speechStop();
+  }, []);
+
+  const listen = useCallback(() => {
+    if (!alive.current || currentCall() !== group.id) return;
+    move("listening");
+    setSpeakingMemberId(null);
+    setHeard("");
+    setNote(null);
+    void window.ogb?.speechStart({ endpointMs: CALL_ENDPOINT_MS }).catch(() => {
+      if (alive.current && currentCall() === group.id) {
+        setNote("The microphone couldn't start. Check Microphone and Speech Recognition access.");
+      }
+    });
+  }, [group.id, move]);
+
+  const scheduleListen = useCallback(
+    (force = false, delay = 140) => {
+      if (listenTimer.current) clearTimeout(listenTimer.current);
+      listenTimer.current = setTimeout(() => {
+        listenTimer.current = null;
+        if (!alive.current || currentCall() !== group.id || queuedJobs.current.size) return;
+        if (force || allowBargeIn.current || !busyRef.current) listen();
+      }, delay);
+    },
+    [group.id, listen],
+  );
+
+  const say = useCallback(
+    async (text: string, member?: Bot) => {
+      if (!alive.current || currentCall() !== group.id) return false;
+      const mine = ++sayGeneration.current;
+      move("speaking");
+      setSpeakingMemberId(member?.id ?? null);
+      hush();
+      await speaker.speak(text, { botId: member?.id, voiceId: member?.voice });
+      return alive.current && currentCall() === group.id && sayGeneration.current === mine;
+    },
+    [group.id, hush, move],
+  );
+
+  const enqueueSpeech = useCallback(
+    (text: string, member?: Bot, answerAfter = false) => {
+      const generation = queueGeneration.current;
+      const jobId = ++nextJobId.current;
+      queuedJobs.current.add(jobId);
+      if (answerAfter) listenWhenDrained.current = true;
+      queue.current = queue.current
+        .catch(() => {})
+        .then(async () => {
+          if (generation !== queueGeneration.current) return;
+          await say(text, member);
+        })
+        .finally(() => {
+          if (generation !== queueGeneration.current) return;
+          queuedJobs.current.delete(jobId);
+          if (queuedJobs.current.size) return;
+          setSpeakingMemberId(null);
+          const force = listenWhenDrained.current;
+          listenWhenDrained.current = false;
+          scheduleListen(force);
+        });
+    },
+    [say, scheduleListen],
+  );
+
+  const interruptSpeech = useCallback(() => {
+    const wasBusy = busyRef.current;
+    queueGeneration.current += 1;
+    queue.current = Promise.resolve();
+    queuedJobs.current.clear();
+    listenWhenDrained.current = false;
+    sayGeneration.current += 1;
+    speaker.stop();
+    setSpeakingMemberId(null);
+    allowBargeIn.current = true;
+    if (wasBusy) dispatch({ type: "interruptGroup", groupId: group.id });
+    listen();
+  }, [dispatch, group.id, listen]);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+      queueGeneration.current += 1;
+      sayGeneration.current += 1;
+      if (listenTimer.current) clearTimeout(listenTimer.current);
+      deferCallCleanup(group.id, () => alive.current);
+    };
+  }, [group.id]);
+
+  useEffect(() => {
+    const bridge = window.ogb;
+    if (!bridge) return;
+    const offTranscript = bridge.onSpeechTranscript((line) => {
+      if (!alive.current || currentCall() !== group.id || phaseRef.current !== "listening") return;
+      if (line.error) {
+        setNote("Dictation stopped unexpectedly. Check Microphone and Speech Recognition access.");
+        return;
+      }
+      if (typeof line.text !== "string") return;
+      setHeard(line.text);
+      if (line.partial !== false) return;
+      const said = line.text.trim();
+      if (!said) return listen();
+
+      const openApproval = askedApproval.current;
+      if (openApproval) {
+        if (YES.test(said) || NO.test(said)) {
+          const allow = YES.test(said);
+          askedApproval.current = null;
+          allowBargeIn.current = false;
+          dispatch({
+            type: "decideRequest",
+            threadId: group.threadId,
+            requestId: openApproval.requestId,
+            behavior: allow ? "allow" : "deny",
+            message: allow ? undefined : "Denied by the user, on a group call.",
+          });
+          move("working");
+          return;
+        }
+        enqueueSpeech("Sorry — is that a yes or a no?", openApproval.member, true);
+        return;
+      }
+
+      const openQuestion = askedQuestion.current;
+      if (openQuestion) {
+        askedQuestion.current = null;
+        allowBargeIn.current = false;
+        dispatch({
+          type: "decideRequest",
+          threadId: group.threadId,
+          requestId: openQuestion.requestId,
+          behavior: "answer",
+          message: said,
+        });
+        move("working");
+        return;
+      }
+
+      const routed = routeSpokenGroupMessage(said, membersRef.current);
+      if (defaultResponderRef.current.kind === "mentions" && !routed.addressed) {
+        listen();
+        const names = membersRef.current.map((member) => member.name).join(", ");
+        setNote("Say a member's name" + (names ? " — " + names : "") + " — or say everyone.");
+        return;
+      }
+
+      allowBargeIn.current = false;
+      move(busyRef.current ? "working" : "sending");
+      dispatch({ type: "sendGroup", groupId: group.id, text: routed.text });
+      scheduleListen(false, 600);
+    });
+    const offEnd = bridge.onSpeechEnd(({ code, reason }) => {
+      if (!alive.current || currentCall() !== group.id) return;
+      if (code === 2) {
+        setNote("Calls need macOS dictation, which isn't available here yet.");
+        return;
+      }
+      if (code === 1) {
+        setNote(
+          reason === "helper-build-failed"
+            ? "The dictation helper couldn't be built. Install Apple's Command Line Tools and try again."
+            : "Dictation needs Microphone + Speech Recognition access in System Settings.",
+        );
+        return;
+      }
+      if (phaseRef.current === "listening") listen();
+    });
+    if (group.busyBotId && !approval && !question) move("working");
+    else listen();
+    return () => {
+      offTranscript();
+      offEnd();
+      void window.ogb?.speechStop();
+    };
+    // Live busy/card changes are handled below without restarting native capture.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, enqueueSpeech, group.id, group.threadId, listen, move, scheduleListen]);
+
+  useEffect(() => {
+    if (askedApproval.current && approval?.requestId !== askedApproval.current.requestId) {
+      askedApproval.current = null;
+    }
+    if (askedQuestion.current && question?.card?.requestId !== askedQuestion.current.requestId) {
+      askedQuestion.current = null;
+    }
+
+    if (approval && askedApproval.current?.requestId !== approval.requestId) {
+      const member = members.find((candidate) => candidate.id === approval.message.from?.botId);
+      askedApproval.current = { requestId: approval.requestId, member };
+      spokenIds.current.add(approval.message.id);
+      const name = member?.name ?? approval.message.from?.name ?? "A room member";
+      enqueueSpeech(
+        name + " wants to " + approval.tool + ". " + approval.detail + ". Should I allow it?",
+        member,
+        true,
+      );
+    }
+
+    if (question?.card?.requestId && askedQuestion.current?.requestId !== question.card.requestId) {
+      const member = members.find((candidate) => candidate.id === question.from?.botId);
+      askedQuestion.current = { requestId: question.card.requestId, member };
+      spokenIds.current.add(question.id);
+      const name = member?.name ?? question.from?.name ?? "A room member";
+      const detail = question.card.subtitle.trim();
+      const choices = question.card.options.length
+        ? " The options are " + question.card.options.join(", ") + "."
+        : "";
+      enqueueSpeech(
+        name + " asks: " + detail + (/[.!?]$/.test(detail) ? "" : ".") + choices,
+        member,
+        true,
+      );
+    }
+
+    const fresh = messages.filter((message) => !spokenIds.current.has(message.id));
+    if (!fresh.length) return;
+    for (const message of fresh) spokenIds.current.add(message.id);
+
+    const replies = fresh.filter(
+      (message) => message.role === "bot" && message.kind === "text" && message.text?.trim(),
+    );
+    for (const reply of replies) {
+      const member = members.find((candidate) => candidate.id === reply.from?.botId);
+      enqueueSpeech(reply.text!, member);
+    }
+    if (!replies.length) {
+      const chip = [...fresh].reverse().find((message) => message.kind === "activity" && message.tool?.spoken);
+      if (chip?.tool?.spoken) {
+        const member = members.find((candidate) => candidate.id === chip.from?.botId);
+        enqueueSpeech(chip.tool.spoken, member);
+      }
+    }
+  }, [approval, enqueueSpeech, members, messages, question]);
+
+  useEffect(() => {
+    const busy = Boolean(group.busyBotId);
+    busyRef.current = busy;
+    if (busy) {
+      if (
+        (phaseRef.current === "listening" || phaseRef.current === "sending") &&
+        !askedApproval.current &&
+        !askedQuestion.current &&
+        !allowBargeIn.current
+      ) {
+        move("working");
+        hush();
+      }
+      return;
+    }
+    allowBargeIn.current = false;
+    if (
+      (phaseRef.current === "working" || phaseRef.current === "sending") &&
+      !askedApproval.current &&
+      !askedQuestion.current
+    ) {
+      scheduleListen();
+    }
+  }, [group.busyBotId, hush, move, scheduleListen]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        endCall(group.id);
+      } else if (event.code === "Space" && speaker.isSpeaking()) {
+        event.preventDefault();
+        interruptSpeech();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [group.id, interruptSpeech]);
+
+  const speakingMember = members.find((member) => member.id === speakingMemberId);
+  const workingMember = members.find((member) => member.id === group.busyBotId);
+  const focusId = speakingMember?.id ?? workingMember?.id;
+  const status =
+    phase === "listening"
+      ? pushToTalk
+        ? "Push to talk"
+        : "Listening"
+      : phase === "sending"
+        ? "Bringing the room in"
+        : phase === "speaking"
+          ? (speakingMember?.name ?? "Room member") + " is speaking"
+          : workingMember
+            ? workingMember.name + " is working"
+            : "Working";
+
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-app/95 px-8 backdrop-blur-sm">
+      <button
+        onClick={() => endCall(group.id)}
+        aria-label="Hang up"
+        className="absolute right-5 top-5 rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink"
+      >
+        <X size={18} />
+      </button>
+
+      <div className="max-w-full overflow-x-auto px-4 py-3">
+        <div className="flex min-w-max items-end justify-center gap-3">
+          {members.map((member) => {
+            const focused = member.id === focusId;
+            const state =
+              speakingMember?.id === member.id
+                ? "sending"
+                : workingMember?.id === member.id
+                  ? "working"
+                  : phase === "listening"
+                    ? "listening"
+                    : normalizeState(member.mascotExpression) ?? "happy";
+            return (
+              <div
+                key={member.id}
+                className={cn(
+                  "flex w-[124px] flex-col items-center gap-2 rounded-3xl px-2 py-3 transition-all duration-200",
+                  focused ? "scale-105 bg-raised/70 shadow-lg" : "opacity-75",
+                )}
+              >
+                <MausAvatar
+                  color={member.color}
+                  state={state}
+                  size={94}
+                  animated
+                  motion={workingMember?.id === member.id ? "working" : "none"}
+                  motionKey={workingMember?.id === member.id ? 1 : 0}
+                />
+                <span className={cn("text-[13px] font-medium", focused ? "text-ink" : "text-ink-secondary")}>
+                  {member.name}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-1.5 text-center">
+        <div className="text-[20px] font-medium text-ink">{group.name}</div>
+        <div className="flex items-center gap-2 text-[13.5px] text-ink-secondary">
+          {(phase === "working" || phase === "sending") && <Loader2 size={13} className="animate-spin" />}
+          {status}
+        </div>
+      </div>
+
+      <div className="min-h-[3.5rem] max-w-[620px] text-center text-[15px] leading-relaxed text-ink">
+        {phase === "listening" ? (
+          heard || (
+            <span className="text-ink-secondary">
+              {pushToTalk
+                ? "Release Control + Option to send…"
+                : "Say a name, say “everyone,” or just talk to the room…"}
+            </span>
+          )
+        ) : phase === "speaking" ? (
+          speech.caption
+        ) : (
+          <span className="text-ink-secondary">{workingMember ? "You’ll hear each response in turn." : ""}</span>
+        )}
+      </div>
+
+      {note && (
+        <div className="flex max-w-[520px] flex-col items-center gap-2 text-center text-[12.5px] text-warning">
+          <span>{note}</span>
+          <button
+            onClick={listen}
+            className="rounded-full border border-warning/40 px-3 py-1.5 text-[12px] hover:bg-warning/10"
+          >
+            Try microphone again
+          </button>
+        </div>
+      )}
+      {speech.error && <div className="max-w-[460px] text-center text-[12.5px] text-danger">{speech.error}</div>}
+
+      <div className="flex items-center gap-3">
+        {speaker.isSpeaking() && (
+          <button
+            onClick={interruptSpeech}
+            className="rounded-full border border-hairline/50 px-4 py-2 text-[13.5px] text-ink hover:bg-raised"
+          >
+            Interrupt
+          </button>
+        )}
+        <button
+          onClick={() => endCall(group.id)}
+          className="flex items-center gap-2 rounded-full bg-danger px-5 py-2.5 text-[14px] font-medium text-white hover:brightness-110"
+        >
+          <PhoneOff size={16} /> Hang up
+        </button>
+      </div>
+
+      <div className="text-[11.5px] text-ink-secondary/70">
+        Hold Control + Option to talk · Say a member’s name to direct the turn · Space interrupts · Esc hangs up
+      </div>
+    </div>
+  );
+}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -18,6 +18,7 @@ import { normalizeState } from "@/lib/mascot";
 import { effectiveDefaultResponder, groupResponseHint } from "@/lib/group-routing";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { Composer } from "./Composer";
+import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
@@ -226,10 +227,12 @@ export function GroupView({ group }: { group: Group }) {
 
   return (
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
+      <GroupCallOverlay group={group} members={members} />
       {/* Header: name left, member mauses right — their motion IS the status */}
       <div className={cn("flex items-center justify-between px-5 py-3", isWin && "pr-[148px]")} style={drag}>
         <span className="text-[15px] font-semibold text-ink">{group.name}</span>
         <div className="flex items-center gap-1.5" style={noDrag}>
+          <GroupCallButton group={group} members={members} />
           {!group.dm && <DefaultResponderSelect group={group} members={members} />}
           {members.map((b) => (
             <span key={b.id} title={`${b.name}${group.busyBotId === b.id ? " — working…" : ""}`}>

--- a/src/lib/call.ts
+++ b/src/lib/call.ts
@@ -1,4 +1,4 @@
-// Who is on a call, window-wide.
+// Which conversation is on a call, window-wide.
 //
 // It lives in lib rather than inside the call UI because two very
 // different places need it: the overlay that renders the call, and the SSE
@@ -17,25 +17,25 @@ function notify() {
   for (const fn of [...watchers]) fn();
 }
 
-/** The bot on a call, or null. Safe to read outside React. */
+/** The bot or room on a call, or null. Safe to read outside React. */
 export function currentCall(): string | null {
   return current;
 }
 
-export function startCall(botId: string) {
-  if (current === botId) return;
+export function startCall(targetId: string) {
+  if (current === targetId) return;
   // Switching calls must silence both halves before ownership changes; the
   // old overlay may not unmount until React's next render.
   speaker.stop();
   void window.ogb?.speechStop();
-  current = botId;
+  current = targetId;
   notify();
 }
 
-/** End the current call. A botId makes cleanup ownership-safe: an async
+/** End the current call. A targetId makes cleanup ownership-safe: an async
  * teardown from call A cannot hang up a newer call B. */
-export function endCall(botId?: string): boolean {
-  if (botId && current !== botId) return false;
+export function endCall(targetId?: string): boolean {
+  if (targetId && current !== targetId) return false;
   if (current === null) return false;
   current = null;
   speaker.stop();
@@ -47,9 +47,9 @@ export function endCall(botId?: string): boolean {
 /** React StrictMode probes effects with setup -> cleanup -> setup in
  * development. Defer ownership cleanup so that probe can remount first;
  * a genuine unmount remains inactive and releases the call. */
-export function deferCallCleanup(botId: string, isMounted: () => boolean): void {
+export function deferCallCleanup(targetId: string, isMounted: () => boolean): void {
   queueMicrotask(() => {
-    if (!isMounted()) endCall(botId);
+    if (!isMounted()) endCall(targetId);
   });
 }
 

--- a/src/lib/group-call.test.ts
+++ b/src/lib/group-call.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { Bot } from "@/state/store";
+import { routeSpokenGroupMessage } from "./group-call";
+
+const members = [
+  { id: "atlas", name: "Atlas" },
+  { id: "milind", name: "Milind" },
+  { id: "research", name: "Deep Research" },
+] as Bot[];
+
+describe("routeSpokenGroupMessage", () => {
+  it("turns a spoken member name into an explicit mention", () => {
+    expect(routeSpokenGroupMessage("Atlas, can you take this?", members)).toEqual({
+      text: "@Atlas can you take this?",
+      addressed: true,
+    });
+    expect(routeSpokenGroupMessage("Hey Deep Research: find the source", members)).toEqual({
+      text: "@Deep Research find the source",
+      addressed: true,
+    });
+    expect(routeSpokenGroupMessage("Atlas", members)).toEqual({
+      text: "@Atlas",
+      addressed: true,
+    });
+  });
+
+  it("turns natural room-wide addresses into @everyone", () => {
+    expect(routeSpokenGroupMessage("Everyone, give me your view", members)).toEqual({
+      text: "@everyone give me your view",
+      addressed: true,
+    });
+    expect(routeSpokenGroupMessage("everyone", members)).toEqual({
+      text: "@everyone",
+      addressed: true,
+    });
+  });
+
+  it("preserves explicit tags and ordinary speech", () => {
+    expect(routeSpokenGroupMessage("@Milind please continue", members)).toEqual({
+      text: "@Milind please continue",
+      addressed: true,
+    });
+    expect(routeSpokenGroupMessage("What should we build next?", members)).toEqual({
+      text: "What should we build next?",
+      addressed: false,
+    });
+  });
+});

--- a/src/lib/group-call.ts
+++ b/src/lib/group-call.ts
@@ -1,0 +1,42 @@
+import type { Bot } from "@/state/store";
+
+export interface SpokenGroupMessage {
+  text: string;
+  addressed: boolean;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Turn a natural spoken address into the room's existing mention syntax.
+ * Apple dictation commonly returns “Atlas, …” rather than “@Atlas …”. */
+export function routeSpokenGroupMessage(text: string, members: Bot[]): SpokenGroupMessage {
+  const trimmed = text.trim();
+  if (!trimmed) return { text: "", addressed: false };
+
+  if (/(?:^|\s)@everyone\b/i.test(trimmed)) return { text: trimmed, addressed: true };
+  const explicitlyMentioned = members.some((member) => {
+    const tag = new RegExp("(?:^|\\s)@" + escapeRegExp(member.name) + "(?=\\s|[,.!?:;]|$)", "i");
+    return tag.test(trimmed);
+  });
+  if (explicitlyMentioned) return { text: trimmed, addressed: true };
+
+  const everyone = trimmed.match(/^(?:hey\s+)?(?:everyone|everybody|all)(?:[\s,:-]+(.*))?$/i);
+  if (everyone) {
+    const rest = everyone[1]?.trim();
+    return { text: rest ? "@everyone " + rest : "@everyone", addressed: true };
+  }
+
+  const candidates = [...members].sort((a, b) => b.name.length - a.name.length);
+  for (const member of candidates) {
+    const addressed = trimmed.match(
+      new RegExp("^(?:hey\\s+)?" + escapeRegExp(member.name) + "(?:[\\s,:-]+(.*))?$", "i"),
+    );
+    if (!addressed) continue;
+    const rest = addressed[1]?.trim();
+    return { text: rest ? "@" + member.name + " " + rest : "@" + member.name, addressed: true };
+  }
+
+  return { text: trimmed, addressed: false };
+}

--- a/src/lib/push-to-talk.test.ts
+++ b/src/lib/push-to-talk.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { isPushToTalkPress } from "./push-to-talk";
+
+describe("isPushToTalkPress", () => {
+  it("starts only when Control and Option are held on a modifier keydown", () => {
+    expect(isPushToTalkPress({ code: "ControlLeft", ctrlKey: true, altKey: true, repeat: false })).toBe(true);
+    expect(isPushToTalkPress({ code: "AltRight", ctrlKey: true, altKey: true, repeat: false })).toBe(true);
+    expect(isPushToTalkPress({ code: "KeyK", ctrlKey: true, altKey: true, repeat: false })).toBe(false);
+    expect(isPushToTalkPress({ code: "ControlLeft", ctrlKey: true, altKey: false, repeat: false })).toBe(false);
+    expect(isPushToTalkPress({ code: "ControlLeft", ctrlKey: true, altKey: true, repeat: true })).toBe(false);
+  });
+});

--- a/src/lib/push-to-talk.ts
+++ b/src/lib/push-to-talk.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+
+import { currentCall } from "./call";
+
+type ModifierEvent = Pick<KeyboardEvent, "altKey" | "ctrlKey" | "code" | "repeat">;
+
+export function isPushToTalkPress(event: ModifierEvent): boolean {
+  const modifier =
+    event.code === "AltLeft" ||
+    event.code === "AltRight" ||
+    event.code === "ControlLeft" ||
+    event.code === "ControlRight";
+  return modifier && event.altKey && event.ctrlKey && !event.repeat;
+}
+
+/** Hold Control + Option to replace automatic endpointing with a manually
+ * finalized utterance. The ordinary call listener remains the default. */
+export function usePushToTalk(targetId: string, enabled: boolean, onError: () => void): boolean {
+  const [active, setActive] = useState(false);
+  const held = useRef(false);
+  const enabledRef = useRef(enabled);
+  const onErrorRef = useRef(onError);
+  enabledRef.current = enabled;
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    if (enabled) return;
+    held.current = false;
+    setActive(false);
+  }, [enabled]);
+
+  useEffect(() => {
+    const bridge = window.ogb;
+    if (!bridge?.speechFinish) return;
+
+    const finish = () => {
+      if (!held.current) return;
+      held.current = false;
+      setActive(false);
+      void bridge.speechFinish?.();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        held.current ||
+        !enabledRef.current ||
+        currentCall() !== targetId ||
+        !isPushToTalkPress(event)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      held.current = true;
+      setActive(true);
+      void bridge.speechStart().catch(() => {
+        held.current = false;
+        setActive(false);
+        onErrorRef.current();
+      });
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (!held.current || (event.altKey && event.ctrlKey)) return;
+      event.preventDefault();
+      finish();
+    };
+    const onBlur = () => finish();
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      held.current = false;
+    };
+  }, [targetId]);
+
+  return active;
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -262,7 +262,7 @@ type Action =
       type: "decideRequest";
       threadId: string;
       requestId: string;
-      behavior: "allow" | "deny";
+      behavior: "allow" | "deny" | "answer";
       message?: string;
       /** remember this exact grant (the server's allowKey) for the bot */
       alwaysAllow?: { botId: string; key: string };
@@ -1058,10 +1058,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             // Auto-speak lives HERE rather than in the chat view so a bot
             // you switched away from still reads its answer out — which is
             // the whole point of listening while you do something else. A
-            // bot on a call is excluded: call mode speaks in its own order,
-            // around its own microphone, and the two would fight.
+            // Auto-speak is disabled during any call. Call mode owns both the
+            // singleton speaker and microphone ordering for its whole lifetime.
             const owner = stateRef.current.bots.find((b) => b.threadId === frame.threadId);
-            if (owner?.speakReplies && currentCall() !== owner.id && frame.message.text?.trim()) {
+            if (owner?.speakReplies && currentCall() === null && frame.message.text?.trim()) {
               void speaker.speak(frame.message.text, {
                 botId: owner.id,
                 messageId: frame.message.id,

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -37,6 +37,8 @@ declare global {
        * finalizes a turn; composer dictation omits it and remains manual. */
       speechStart(options?: { endpointMs?: number }): Promise<void>;
       speechStop(): Promise<void>;
+      /** Finish capture and emit the recognizer's final transcript. */
+      speechFinish?(): Promise<void>;
       onSpeechTranscript(
         cb: (line: { partial?: boolean; text?: string; error?: string }) => void,
       ): () => void;


### PR DESCRIPTION
## Depends on

- #103 — group default responders and mention routing

This PR is intentionally stacked on `codex/group-default-responder` so its diff contains only conference-call work.

## What changed

- Add a call button and full conference-call overlay to normal group rooms.
- Send spoken turns through the room's existing lead/everyone/mentions-only routing.
- Convert natural spoken addresses such as “Atlas, …” and “everyone, …” into explicit room mentions.
- Queue bot replies so members speak sequentially, each using their own configured voice.
- Highlight the member currently working or speaking and preserve spoken approvals/questions.
- Allow interruption to stop queued speech and redirect an in-progress room turn.
- Add hold-to-talk with **Control + Option** to both one-to-one and group calls.
- Add a native speech “finish” path so releasing push-to-talk calls Apple's `endAudio()` and produces a final transcript instead of cancelling capture.
- Suppress unrelated auto-speak while any call owns the shared microphone/speaker.

## VAD / push-to-talk decision

Automatic silence endpointing remains the default. Push-to-talk provides deterministic turn boundaries in noisy environments without adding an ONNX runtime or VAD model to the packaged app. A model such as Silero can remain a later opt-in if real-world testing shows the lightweight endpoint is insufficient.

## Validation

- `pnpm test` — 284 passed, 8 skipped
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:electron`
- `pnpm build:speech`
- Browser QA of the group call button and three-member conference overlay
- Native Swift helper compilation with finalize-on-release support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group calling with member-directed messaging, speaking states, interruptions, and call controls.
  * Added push-to-talk using Control+Option, with automatic speech finalization on key release or window blur.
  * Added natural voice addressing for individual members and everyone in group conversations.
  * Added support for finalizing speech capture while preserving the final transcript.
* **Improvements**
  * Expanded calls to support multiple voice options and clearer availability messaging.
  * Disabled automatic speech while any call is active.
  * Added “answer” as a permission request response option.
* **Tests**
  * Added coverage for group message routing and push-to-talk behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->