### PR TITLE
Add a workspace-wide Chief of Staff

### DIFF
--- a/server/chief-of-staff.test.ts
+++ b/server/chief-of-staff.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { chiefOfStaffSystemPrompt } from "./chief-of-staff.ts";
+
+describe("chiefOfStaffSystemPrompt", () => {
+  const bots = [
+    { id: "chief", name: "Atlas", title: "Operations" },
+    { id: "writer", name: "Quill", title: "Writer", description: "Drafts concise copy" },
+    { id: "coder", name: "Patch", title: "Engineer", busy: true },
+    { id: "hidden", name: "Secret", hidden: true },
+  ];
+
+  it("describes visible teammates, roles, and availability", () => {
+    const prompt = chiefOfStaffSystemPrompt("chief", bots, true);
+
+    expect(prompt).toContain("one Chief of Staff");
+    expect(prompt).toContain("Quill — Writer: Drafts concise copy (available)");
+    expect(prompt).toContain("Patch — Engineer (working right now)");
+    expect(prompt).not.toContain("Secret");
+    expect(prompt).not.toContain("Atlas —");
+    expect(prompt).toContain("Use ask_bot");
+  });
+
+  it("does not promise delegation when the engine cannot mount agent tools", () => {
+    const prompt = chiefOfStaffSystemPrompt("chief", bots, false);
+
+    expect(prompt).toContain("cannot contact teammates");
+    expect(prompt).not.toContain("Use ask_bot");
+  });
+});

--- a/server/chief-of-staff.ts
+++ b/server/chief-of-staff.ts
@@ -1,0 +1,46 @@
+export interface ChiefTeamMember {
+  id: string;
+  name: string;
+  title?: string;
+  description?: string;
+  busy?: boolean;
+  hidden?: boolean;
+}
+
+/** Dynamic system context for the one workspace-wide Chief of Staff.
+ * It names the current team on every turn, while list_bots remains the
+ * authoritative tool for IDs and live availability at delegation time. */
+export function chiefOfStaffSystemPrompt(
+  chiefId: string,
+  bots: ChiefTeamMember[],
+  canDelegate: boolean,
+): string {
+  const team = bots.filter((bot) => bot.id !== chiefId && !bot.hidden);
+  const roster = team.length
+    ? team
+        .map((bot) => {
+          const role = bot.title?.trim() || "General assistant";
+          const about = bot.description?.trim();
+          const availability = bot.busy ? "working right now" : "available";
+          return `- ${bot.name} — ${role}${about ? `: ${about}` : ""} (${availability})`;
+        })
+        .join("\n")
+    : "- No other visible bots are available yet.";
+
+  const delegation = canDelegate
+    ? [
+        "Use list_bots to confirm the live roster and IDs. Use ask_bot when a teammate is better suited to part of the request.",
+        "Delegate with a clear, self-contained brief and wait for the teammate's actual reply before claiming its work is complete.",
+        "You may consult more than one teammate when the request genuinely benefits, then combine their results into one coherent answer.",
+      ].join(" ")
+    : "Your current engine cannot contact teammates. Be honest about that limitation and ask the user to choose a delegation-compatible engine before promising coordinated work.";
+
+  return [
+    "You are the workspace's one Chief of Staff. You are the user's primary contact across their team of bots.",
+    "Own the outcome: understand the request, decide what to handle yourself, coordinate the right specialists when useful, and return one concise consolidated answer.",
+    "Do not delegate trivial work merely to appear busy. Never invent a teammate's progress or result. Normal permission and approval rules still apply.",
+    delegation,
+    "Current workspace team:",
+    roster,
+  ].join("\n");
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { approvalKey, autoDecision } from "./auto-approve.ts";
 import * as box from "./box.ts";
 import * as composio from "./composio.ts";
+import { chiefOfStaffSystemPrompt } from "./chief-of-staff.ts";
 import {
   containerComputerAction,
   containerComputerMcp,
@@ -623,6 +624,11 @@ async function startTurn(
             store.bots.filter((b) => b.id !== bot.id),
           )
         : [];
+      const coordinationPrompt = bot.chiefOfStaff
+        ? chiefOfStaffSystemPrompt(bot.id, store.bots, Boolean(integrations.agents))
+        : integrations.agents
+          ? "You can work with the user's other bots through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
+          : "";
 
       await instance.adapter.sendTurn({
         threadId,
@@ -642,9 +648,7 @@ async function startTurn(
               : computerKind === "local"
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
               : "") +
-          (integrations.agents
-            ? " You can work with the user's other bots through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
-            : "") +
+          (coordinationPrompt ? ` ${coordinationPrompt}` : "") +
           (tagged.length
             ? ` The user tagged ${tagged
                 .map((t) => `@${t.name} (ask_bot bot_id ${t.id})`)
@@ -1208,6 +1212,13 @@ const server = createServer(async (req, res) => {
       ) {
         return json(res, 400, { error: "computer must be cloud, vm, local, or off" });
       }
+      if (body.chiefOfStaff !== undefined && typeof body.chiefOfStaff !== "boolean") {
+        return json(res, 400, { error: "chiefOfStaff must be true or false" });
+      }
+      const existing = store.bot(m[1]);
+      if (body.hidden === true && existing?.chiefOfStaff && body.chiefOfStaff !== false) {
+        return json(res, 400, { error: "choose another Chief of Staff before hiding this bot" });
+      }
       // the two permission fields decide what runs unattended, so they are
       // type-checked rather than copied through: a string alwaysAllow would
       // still answer .includes() — with substring matches, not tool names
@@ -1223,7 +1234,16 @@ const server = createServer(async (req, res) => {
       }
       const bot = store.patchBot(m[1], patch);
       if (!bot) return json(res, 404, { error: "no such bot" });
-      broadcast({ kind: "bot", bot });
+      const chiefChanges =
+        body.chiefOfStaff === true
+          ? store.setChiefOfStaff(bot.id)
+          : body.chiefOfStaff === false && bot.chiefOfStaff
+            ? store.setChiefOfStaff(null)
+            : [];
+      if (chiefChanges === null) return json(res, 404, { error: "no such bot" });
+      const changed = new Map([[bot.id, store.bot(bot.id)!]]);
+      for (const changedBot of chiefChanges) changed.set(changedBot.id, changedBot);
+      for (const changedBot of changed.values()) broadcast({ kind: "bot", bot: changedBot });
       return json(res, 200, { bot });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)$/);

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -77,6 +77,25 @@ describe("Store", () => {
     expect(messages.at(-1)).toMatchObject({ role: "user", text: "hi there" });
   });
 
+  it("keeps exactly one persisted Chief of Staff and supports handoff", () => {
+    const store = new Store(selection);
+    const first = store.createBot();
+    const second = store.createBot();
+
+    expect(store.setChiefOfStaff(first.id)?.map((bot) => bot.id)).toEqual([first.id]);
+    expect(store.bot(first.id)?.chiefOfStaff).toBe(true);
+
+    const changed = store.setChiefOfStaff(second.id)!;
+    expect(changed.map((bot) => bot.id).sort()).toEqual([first.id, second.id].sort());
+    expect(store.bot(first.id)?.chiefOfStaff).toBe(false);
+    expect(store.bot(second.id)?.chiefOfStaff).toBe(true);
+
+    const reloaded = new Store(selection);
+    expect(reloaded.bots.filter((bot) => bot.chiefOfStaff).map((bot) => bot.id)).toEqual([second.id]);
+    expect(reloaded.setChiefOfStaff(null)?.map((bot) => bot.id)).toEqual([second.id]);
+    expect(reloaded.bots.some((bot) => bot.chiefOfStaff)).toBe(false);
+  });
+
   it("patchMessage merges card patches and returns null for unknown ids", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -164,6 +164,9 @@ export interface BotRecord {
   rewound?: boolean;
   pinned?: boolean;
   hidden?: boolean;
+  /** The single workspace-wide coordinator. The store enforces that at
+   * most one bot owns this role, even if an older/corrupt file says more. */
+  chiefOfStaff?: boolean;
   busy?: boolean;
   createdAt: number;
 }
@@ -289,14 +292,30 @@ export class Store {
     }
     // busy never survives a restart — no turn does either. Rooms saved
     // before default responders existed adopt their first member as lead.
+    let botsMigrated = false;
+    let chiefSeen = false;
     let groupsMigrated = false;
     for (const b of this.bots) b.busy = false;
+    for (const b of this.bots) {
+      if (!b.chiefOfStaff) continue;
+      if (!chiefSeen) {
+        chiefSeen = true;
+        if (b.hidden) {
+          b.hidden = false;
+          botsMigrated = true;
+        }
+        continue;
+      }
+      b.chiefOfStaff = false;
+      botsMigrated = true;
+    }
     for (const g of this.groups) {
       g.busyBotId = null;
       const normalized = normalizeGroupDefaultResponder(g.defaultResponder, g.memberIds, Boolean(g.dm));
       if (JSON.stringify(normalized) !== JSON.stringify(g.defaultResponder)) groupsMigrated = true;
       g.defaultResponder = normalized;
     }
+    if (botsMigrated) this.saveBots();
     if (groupsMigrated) this.saveGroups();
     // bots saved before tasks existed have one endless thread; adopt it as
     // their first task so nothing is lost and nothing special-cases it
@@ -572,6 +591,28 @@ export class Store {
     Object.assign(bot, patch);
     this.saveBots();
     return bot;
+  }
+
+  /** Elect one Chief of Staff (or clear the role) as one persisted change.
+   * The changed records are returned so the server can update every open
+   * window, including the bot that just handed the role over. */
+  setChiefOfStaff(id: string | null): BotRecord[] | null {
+    if (id && !this.bot(id)) return null;
+    const changed: BotRecord[] = [];
+    for (const bot of this.bots) {
+      const next = bot.id === id;
+      if (Boolean(bot.chiefOfStaff) === next && !(next && bot.hidden)) continue;
+      if (next) {
+        bot.chiefOfStaff = true;
+        // The workspace's main contact must stay reachable in the sidebar.
+        bot.hidden = false;
+      } else {
+        bot.chiefOfStaff = false;
+      }
+      changed.push(bot);
+    }
+    if (changed.length) this.saveBots();
+    return changed;
   }
 
   setResumeCursor(botId: string, instanceId: string, cursor: unknown, threadId?: string) {

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -8,6 +8,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Copy,
+  Crown,
   Loader2,
   Monitor,
   Pencil,
@@ -673,6 +674,11 @@ export function ChatView({ bot }: { bot: Bot }) {
             motionKey={mascotMotion?.nonce ?? 0}
           />
           <span className="text-[15px] font-semibold text-ink">{bot.name}</span>
+          {bot.chiefOfStaff && (
+            <span className="flex items-center gap-1 rounded-full bg-accent/12 px-2 py-0.5 text-[11px] font-medium text-accent">
+              <Crown size={11} /> Chief of Staff
+            </span>
+          )}
           {bot.busy && <Loader2 size={14} className="animate-spin text-ink-secondary" />}
         </button>
         <div className="flex items-center gap-2" style={noDrag}>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, X } from "lucide-react";
+import { ChevronLeft, Crown, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api, useStore, type Bot } from "@/state/store";
 import { MausAvatar } from "./Avatar";
@@ -47,11 +47,15 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "autoApprove"
         | "speakReplies"
         | "voice"
+        | "chiefOfStaff"
       >
     >,
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
   const activeState = stateForBot(bot);
   const mascotMotion = state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
+  const engine = state.instances.find((instance) => instance.instanceId === bot.modelSelection.instanceId);
+  const canCoordinate = engine?.capabilities?.agentsMcp === true;
+  const currentChief = state.bots.find((candidate) => candidate.chiefOfStaff);
 
   useEffect(() => {
     if (!state.config?.tts?.configured) {
@@ -178,6 +182,54 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               onChange={(e) => patch({ description: e.target.value })}
             />
           </Field>
+
+          <div className={cn(
+            "rounded-xl border p-4",
+            bot.chiefOfStaff ? "border-accent/40 bg-accent/10" : "border-hairline/40 bg-card",
+          )}>
+            <div className="flex items-center gap-3">
+              <span className={cn(
+                "flex size-8 shrink-0 items-center justify-center rounded-lg",
+                bot.chiefOfStaff ? "bg-accent text-white" : "bg-raised text-ink-secondary",
+              )}>
+                <Crown size={17} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[15px] font-medium text-ink">Chief of Staff</div>
+                <div className="text-[11.5px] text-ink-secondary">One per workspace</div>
+              </div>
+              <button
+                role="switch"
+                aria-checked={Boolean(bot.chiefOfStaff)}
+                aria-label="Chief of Staff"
+                disabled={!bot.chiefOfStaff && !canCoordinate}
+                onClick={() => patch({ chiefOfStaff: !bot.chiefOfStaff })}
+                title={!bot.chiefOfStaff && !canCoordinate ? "This engine cannot contact other bots" : undefined}
+                className={cn(
+                  "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40",
+                  bot.chiefOfStaff ? "bg-accent" : "bg-raised",
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute top-[3px] size-5 rounded-full bg-white transition-all",
+                    bot.chiefOfStaff ? "left-[21px]" : "left-[3px]",
+                  )}
+                />
+              </button>
+            </div>
+            <div className="mt-3 text-[13px] leading-relaxed text-ink-secondary">
+              {bot.chiefOfStaff && !canCoordinate
+                ? "This bot still holds the role, but its current engine cannot contact teammates. Choose a Claude or ACP engine to restore coordination."
+                : bot.chiefOfStaff
+                  ? "This is your primary contact. It can coordinate the other bots and combine their work into one answer."
+                : !canCoordinate
+                  ? "Choose a Claude or ACP engine to let this bot coordinate teammates."
+                  : currentChief
+                    ? `Make this bot your primary contact and hand the role over from ${currentChief.name}.`
+                    : "Make this bot your primary contact for work that may involve several bots."}
+            </div>
+          </div>
 
           <div className="flex items-center justify-between gap-4 rounded-xl bg-card p-4">
             <div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   ClipboardCopy,
   Copy,
+  Crown,
   EyeOff,
   FolderPlus,
   Loader2,
@@ -339,8 +340,10 @@ function BotContextMenu({ menu, onClose }: { menu: MenuState; onClose: () => voi
   }, [onClose]);
 
   if (!bot) return null;
+  const engine = state.instances.find((instance) => instance.instanceId === bot.modelSelection.instanceId);
+  const canCoordinate = engine?.capabilities?.agentsMcp === true;
   // keep the menu on-screen near the click
-  const top = Math.min(menu.y, window.innerHeight - 340);
+  const top = Math.max(8, Math.min(menu.y, window.innerHeight - 380));
   const left = Math.min(menu.x, window.innerWidth - 240);
 
   const item = (
@@ -381,6 +384,15 @@ function BotContextMenu({ menu, onClose }: { menu: MenuState; onClose: () => voi
           bot.pinned ? "Unpin" : "Pin",
           () => dispatch({ type: "updateBot", botId: bot.id, patch: { pinned: !bot.pinned } }),
         ),
+        item(
+          <Crown size={16} className={bot.chiefOfStaff ? "text-accent" : "text-ink-secondary"} />,
+          bot.chiefOfStaff ? "Remove Chief of Staff" : "Make Chief of Staff",
+          () => dispatch({ type: "updateBot", botId: bot.id, patch: { chiefOfStaff: !bot.chiefOfStaff } }),
+          {
+            disabled: !bot.chiefOfStaff && !canCoordinate,
+            hint: !bot.chiefOfStaff && !canCoordinate ? "Choose a Claude or ACP engine first" : undefined,
+          },
+        ),
         item(<FolderPlus size={16} className="text-ink-secondary" />, "Move to new section", undefined, {
           disabled: true,
           hint: "Coming soon",
@@ -401,8 +413,14 @@ function BotContextMenu({ menu, onClose }: { menu: MenuState; onClose: () => voi
           void navigator.clipboard?.writeText(bot.threadId);
         }),
         divider("d3"),
-        item(<EyeOff size={16} className="text-ink-secondary" />, "Hide from sidebar", () =>
-          dispatch({ type: "updateBot", botId: bot.id, patch: { hidden: true } }),
+        item(
+          <EyeOff size={16} className="text-ink-secondary" />,
+          "Hide from sidebar",
+          () => dispatch({ type: "updateBot", botId: bot.id, patch: { hidden: true } }),
+          {
+            disabled: Boolean(bot.chiefOfStaff),
+            hint: bot.chiefOfStaff ? "Choose another Chief of Staff first" : undefined,
+          },
         ),
         item(<Trash2 size={16} />, "Delete", () => dispatch({ type: "deleteBot", botId: bot.id }), {
           danger: true,
@@ -427,8 +445,14 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
         onMenu({ botId: bot.id, x: e.clientX, y: e.clientY });
       }}
       className={cn(
-        "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left",
-        selected ? "bg-raised" : "hover:bg-raised/50",
+        "flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left",
+        bot.chiefOfStaff
+          ? selected
+            ? "border-accent/40 bg-accent/15"
+            : "border-accent/25 bg-accent/5 hover:bg-accent/10"
+          : selected
+            ? "border-transparent bg-raised"
+            : "border-transparent hover:bg-raised/50",
       )}
     >
       <MausAvatar
@@ -451,8 +475,14 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
           )}
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span className="truncate text-[13px] text-ink-secondary">
-            {preview(bot)}
+          <span className="flex min-w-0 items-center gap-1.5 truncate text-[13px] text-ink-secondary">
+            {bot.chiefOfStaff && (
+              <span className="flex shrink-0 items-center gap-1 text-[11.5px] font-medium text-accent">
+                <Crown size={11} /> Chief of Staff
+              </span>
+            )}
+            {bot.chiefOfStaff && preview(bot) && <span className="shrink-0 text-ink-secondary/60">·</span>}
+            <span className="truncate">{preview(bot)}</span>
           </span>
           {bot.unread && (
             <span className="size-2 shrink-0 rounded-full bg-accent" />
@@ -475,7 +505,7 @@ export function Sidebar() {
   const browser = capabilities.host.label === "Browser";
 
   const q = query.trim().toLowerCase();
-  const visibleBots = state.bots
+  const matchingBots = state.bots
     .filter((b) => !b.hidden)
     .filter(
       (b) =>
@@ -483,7 +513,10 @@ export function Sidebar() {
         b.name.toLowerCase().includes(q) ||
         (b.title ?? "").toLowerCase().includes(q) ||
         preview(b).toLowerCase().includes(q),
-    )
+    );
+  const chiefBot = matchingBots.find((bot) => bot.chiefOfStaff);
+  const visibleBots = matchingBots
+    .filter((bot) => !bot.chiefOfStaff)
     .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
   const visibleGroups = state.groups.filter((g) => !q || g.name.toLowerCase().includes(q));
 
@@ -563,8 +596,13 @@ export function Sidebar() {
       {/* Bot list */}
       <div className="flex-1 overflow-y-auto px-2">
         <div className="flex flex-col gap-0.5">
-          {visibleBots.length === 0 && visibleGroups.length === 0 && q && (
+          {!chiefBot && visibleBots.length === 0 && visibleGroups.length === 0 && q && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
+          )}
+          {chiefBot && (
+            <div className="mb-1.5">
+              <BotListItem bot={chiefBot} onMenu={setMenu} />
+            </div>
           )}
           {visibleGroups.map((g) => (
             <GroupListItem key={g.id} group={g} onMenu={setRoomMenu} />

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -121,6 +121,8 @@ export interface Bot {
   voice?: string;
   pinned?: boolean;
   hidden?: boolean;
+  /** The workspace's one primary coordinator. */
+  chiefOfStaff?: boolean;
   messages: Message[];
   /** leaf of the visible conversation branch (see visibleMessages) */
   activeLeafId?: string | null;
@@ -307,6 +309,7 @@ type Action =
           | "voice"
           | "pinned"
           | "hidden"
+          | "chiefOfStaff"
         >
       >;
     };
@@ -443,7 +446,15 @@ function reducer(state: AppState, action: Action): AppState {
             : action.bot.busy === false && before?.busy
               ? "celebrate"
               : null;
-      const next = kind ? withMascotMotion(state, action.bot.id, kind) : state;
+      const animated = kind ? withMascotMotion(state, action.bot.id, kind) : state;
+      const next = action.bot.chiefOfStaff
+        ? {
+            ...animated,
+            bots: animated.bots.map((b) =>
+              b.id === action.bot.id ? b : { ...b, chiefOfStaff: false },
+            ),
+          }
+        : animated;
       return updateBot(next, action.bot.id, (b) => ({ ...b, ...action.bot, messages: b.messages }));
     }
     case "messageAdded": {
@@ -580,9 +591,17 @@ function reducer(state: AppState, action: Action): AppState {
       const mascotChanged =
         Object.prototype.hasOwnProperty.call(action.patch, "color") ||
         Object.prototype.hasOwnProperty.call(action.patch, "mascotExpression");
-      const next = mascotChanged
+      const animated = mascotChanged
         ? withMascotMotion(state, action.botId, "customize")
         : state;
+      const next = action.patch.chiefOfStaff
+        ? {
+            ...animated,
+            bots: animated.bots.map((b) =>
+              b.id === action.botId ? b : { ...b, chiefOfStaff: false },
+            ),
+          }
+        : animated;
       return updateBot(next, action.botId, (b) => ({ ...b, ...action.patch }));
     }
     case "threadActive": {


### PR DESCRIPTION
## What changed

- Adds one persisted, workspace-wide Chief of Staff role that can be assigned to any bot using a delegation-capable engine.
- Enforces a single holder and supports an immediate handoff when another bot is promoted.
- Gives the Chief a live roster of visible teammates, their roles, descriptions, and availability on every turn.
- Uses the existing secure `list_bots` / `ask_bot` path to delegate work, wait for real results, and return one consolidated answer.
- Adds a dedicated top sidebar card, chat-header badge, settings switch, and bot-menu action.
- Keeps handoffs and bot-to-bot work visible through the existing conversation chips and pair channels.

## Why

Groups coordinate a particular conversation, but there was no single primary contact for the whole workspace. The Chief of Staff role gives the user one bot that understands the team and can bring in specialists without requiring the user to manage every handoff.

## Safety and behavior

- Normal permission and approval gates continue to apply.
- Existing one-hop communication limits prevent recursive bot loops.
- Hidden bots are excluded from the roster.
- The UI only offers promotion when the selected engine can mount bot-to-bot tools, and explains how to restore coordination if the engine is later changed.
- A Chief cannot be hidden accidentally; deleting it simply leaves the workspace without a Chief until another is selected.

## Validation

- `pnpm test` — 35 files passed, 287 tests passed, 8 skipped
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run check:electron`
- Browser QA: promotion, exclusive handoff, sidebar/header/settings states, and narrow-panel layout
- Real end-to-end QA: the promoted Chief discovered a specialist, delegated a question, waited for the reply, created a visible pair channel, and returned a consolidated answer
