### PR TITLE
feat: Telegram gateway — chat with your bots from your phone

### DIFF
--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -1,0 +1,34 @@
+# Telegram gateway — chat with your bots from your phone
+
+OpenMausBot keeps the messaging-app shape — the Telegram gateway extends it off the Mac. It is an **optional standalone process** that rides the harness HTTP+SSE contract: nothing in the app or server changes, the gateway is just another client.
+
+```
+Telegram ⇄ gateway (long polling) ⇄ harness 127.0.0.1:8799 (HTTP + SSE)
+```
+
+## What you get
+
+- **Talk to any bot** from Telegram: `/start` (or `/bots`) shows your roster as buttons; pick one, then just type. Replies stream in live — the message grows by edits while the bot writes.
+- **Approve from your phone**: permission asks arrive as inline keyboards — `✅ Allow` / `❌ Deny` — wired straight to `/api/bots/:id/respond`. Questions offer the agent's choices as buttons, or free-text answers as a reply. Approvals from **every** bot come through (non-active bots are named); replies stream only for the bot you're talking to.
+- `/stop` interrupts the active bot's turn.
+
+## Setup
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) and copy the token.
+2. Start the harness (`pnpm dev:server` or the app), then:
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:ABC-… pnpm gateway:telegram
+```
+
+The token can also live in `~/.openmausbot/config.json` as `{"telegram": {"token": "…"}}`.
+
+3. Open your bot in Telegram and send `/start`.
+
+## Security model
+
+The **first chat that sends `/start` becomes the owner** — the binding persists in `~/.openmausbot/telegram-gateway.json`, and every other chat is refused. This gateway can approve shell commands, so it is deliberately single-user. To rebind, delete the state file and `/start` again. Timed-out asks keep the harness's fail-closed behavior (deny with a keep-moving note); the gateway then tells you it was resolved without you.
+
+## Scope (v1)
+
+Text turns, streamed replies, approvals/questions, interrupt. Not yet: rooms, voice, images/screens, multi-user.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "companion": "node --experimental-strip-types companion/src/index.ts",
     "dev:server": "node --experimental-strip-types server/index.ts",
     "dev:desktop": "node scripts/prepare-cloudflared.mjs --current && electron .",
+    "gateway:telegram": "node server/gateway/telegram.ts",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
     "test": "node scripts/test-floor.mjs && pnpm broker:test && pnpm test:updater && pnpm test:desktop-viewer && pnpm test:package-link && pnpm test:save-file && pnpm test:server-boot-probe && pnpm test:packaged-server",

--- a/server/gateway/telegram.test.ts
+++ b/server/gateway/telegram.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { askHeader, chunkText, keyboardFor, TELEGRAM_MAX } from "./telegram.ts";
+import { askHeader, backoffMs, chunkText, describeError, keyboardFor, TELEGRAM_MAX } from "./telegram.ts";
 
 describe("chunkText", () => {
   it("returns short text as a single chunk", () => {
@@ -55,6 +55,29 @@ describe("keyboardFor", () => {
   it("offers a free-text prompt when a question has no choices", () => {
     const kb = keyboardFor({ requestId: "r3", requestType: "question", tool: "ask_user", summary: "Anything?" });
     expect(kb[0][0].callback_data).toBe("req:r3:prompt");
+  });
+});
+
+describe("describeError", () => {
+  it("surfaces the cause fetch hides behind 'fetch failed'", () => {
+    const e = Object.assign(new Error("fetch failed"), { cause: { code: "ECONNRESET" } });
+    expect(describeError(e)).toBe("fetch failed (ECONNRESET)");
+  });
+
+  it("falls back to the message when there is no cause", () => {
+    expect(describeError(new Error("no body"))).toBe("no body");
+  });
+});
+
+describe("backoffMs", () => {
+  it("grows exponentially from the base", () => {
+    expect(backoffMs(1)).toBe(2000);
+    expect(backoffMs(2)).toBe(4000);
+    expect(backoffMs(3)).toBe(8000);
+  });
+
+  it("never exceeds the ceiling, however long the outage", () => {
+    expect(backoffMs(50)).toBe(60_000);
   });
 });
 

--- a/server/gateway/telegram.test.ts
+++ b/server/gateway/telegram.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { askHeader, chunkText, keyboardFor, TELEGRAM_MAX } from "./telegram.ts";
+
+describe("chunkText", () => {
+  it("returns short text as a single chunk", () => {
+    expect(chunkText("hello")).toEqual(["hello"]);
+  });
+
+  it("splits at the telegram limit", () => {
+    const text = "a".repeat(TELEGRAM_MAX + 10);
+    const chunks = chunkText(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(TELEGRAM_MAX);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("prefers newline boundaries when one is close enough", () => {
+    const first = "x".repeat(3000);
+    const text = `${first}\n${"y".repeat(2000)}`;
+    const chunks = chunkText(text);
+    expect(chunks[0]).toBe(first);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("hard-cuts when the only newline would waste half the budget", () => {
+    const text = `ab\n${"z".repeat(TELEGRAM_MAX * 2)}`;
+    const chunks = chunkText(text);
+    expect(chunks[0]).toHaveLength(TELEGRAM_MAX);
+    expect(chunks.join("")).toBe(text);
+  });
+});
+
+describe("keyboardFor", () => {
+  it("gives permissions Allow/Deny wired to the requestId", () => {
+    const kb = keyboardFor({ requestId: "r1", requestType: "permission", tool: "shell", summary: "rm -rf /tmp/x" });
+    expect(kb).toEqual([[
+      { text: "✅ Allow", callback_data: "req:r1:allow" },
+      { text: "❌ Deny", callback_data: "req:r1:deny" },
+    ]]);
+  });
+
+  it("gives questions one button per choice, capped at 5", () => {
+    const kb = keyboardFor({
+      requestId: "r2",
+      requestType: "question",
+      tool: "ask_user",
+      summary: "Which color?",
+      choices: ["red", "green", "blue", "black", "white", "extra"],
+    });
+    expect(kb).toHaveLength(5);
+    expect(kb[0][0]).toEqual({ text: "red", callback_data: "req:r2:choice:0" });
+  });
+
+  it("offers a free-text prompt when a question has no choices", () => {
+    const kb = keyboardFor({ requestId: "r3", requestType: "question", tool: "ask_user", summary: "Anything?" });
+    expect(kb[0][0].callback_data).toBe("req:r3:prompt");
+  });
+});
+
+describe("askHeader", () => {
+  it("names the bot and the tool for permissions", () => {
+    const line = askHeader("Pixel", { requestId: "r", requestType: "permission", tool: "shell", summary: "git push" });
+    expect(line).toContain("Pixel");
+    expect(line).toContain("shell");
+    expect(line).toContain("git push");
+  });
+});

--- a/server/gateway/telegram.ts
+++ b/server/gateway/telegram.ts
@@ -1,0 +1,437 @@
+// Telegram gateway — chat with your bots from your phone. A standalone
+// process that rides the harness HTTP+SSE contract (no new transports in
+// the app): it long-polls api.telegram.org, binds one Telegram chat to the
+// Mac's owner, maps that chat onto one active bot at a time, folds the
+// canonical runtime event stream into Telegram messages (streaming replies
+// via throttled message edits), and turns permission/question asks into
+// inline keyboards wired straight to /api/bots/:id/respond — approve from
+// your phone.
+//
+//   TELEGRAM_BOT_TOKEN=123:abc pnpm gateway:telegram
+//
+// The token can also live in ~/.openmausbot/config.json as
+// {"telegram": {"token": "…"}}. Gateway state (owner chat, active bot)
+// persists in ~/.openmausbot/telegram-gateway.json. The FIRST chat that
+// sends /start becomes the owner; every other chat is refused — this
+// gateway can approve shell commands, so it is bound to one human.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { DATA_DIR } from "../config.ts";
+
+const SERVER = process.env.OMB_SERVER_URL ?? "http://127.0.0.1:8799";
+const STATE_PATH = join(DATA_DIR, "telegram-gateway.json");
+const EDIT_THROTTLE_MS = 1500;
+/** Telegram hard limit is 4096 chars per message. */
+export const TELEGRAM_MAX = 4096;
+
+// ── pure helpers (unit-tested) ─────────────────────────────────────────
+
+/** Split text into Telegram-sized chunks, preferring newline boundaries. */
+export function chunkText(text: string, max = TELEGRAM_MAX): string[] {
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > max) {
+    let cut = rest.lastIndexOf("\n", max);
+    if (cut < max * 0.5) cut = max;
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut);
+  }
+  if (rest) chunks.push(rest);
+  return chunks;
+}
+
+export interface AskEvent {
+  requestId?: string;
+  requestType: "permission" | "question";
+  tool: string;
+  summary: string;
+  choices?: string[];
+}
+
+/** Inline keyboard for an ask. Permissions get Allow/Deny; questions get
+ * one button per offered choice (free-text answers arrive as a reply). */
+export function keyboardFor(ask: AskEvent): Array<Array<{ text: string; callback_data: string }>> {
+  const id = ask.requestId ?? "";
+  if (ask.requestType === "permission") {
+    return [[
+      { text: "✅ Allow", callback_data: `req:${id}:allow` },
+      { text: "❌ Deny", callback_data: `req:${id}:deny` },
+    ]];
+  }
+  const choices = (ask.choices ?? []).slice(0, 5);
+  if (!choices.length) return [[{ text: "✍️ Answer in chat (reply to this)", callback_data: `req:${id}:prompt` }]];
+  return choices.map((c, i) => [{ text: c.slice(0, 60), callback_data: `req:${id}:choice:${i}` }]);
+}
+
+/** One human-readable header line for an ask message. */
+export function askHeader(botName: string, ask: AskEvent): string {
+  const kind = ask.requestType === "permission" ? "wants to use" : "asks";
+  return `🔐 ${botName} ${kind} ${ask.requestType === "permission" ? ask.tool : "you"}:\n${ask.summary}`;
+}
+
+// ── config + state ─────────────────────────────────────────────────────
+
+function botToken(): string {
+  if (process.env.TELEGRAM_BOT_TOKEN) return process.env.TELEGRAM_BOT_TOKEN;
+  try {
+    const cfg = JSON.parse(readFileSync(join(DATA_DIR, "config.json"), "utf8"));
+    if (typeof cfg?.telegram?.token === "string" && cfg.telegram.token) return cfg.telegram.token;
+  } catch {
+    /* no config file yet */
+  }
+  console.error("telegram gateway: no token — set TELEGRAM_BOT_TOKEN or add {\"telegram\":{\"token\":\"…\"}} to ~/.openmausbot/config.json");
+  process.exit(1);
+}
+
+interface GatewayState {
+  ownerChatId?: number;
+  activeBotId?: string;
+}
+
+function loadState(): GatewayState {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function saveState(s: GatewayState) {
+  try {
+    writeFileSync(STATE_PATH, JSON.stringify(s, null, 2));
+  } catch {}
+}
+
+// ── harness API ────────────────────────────────────────────────────────
+
+interface Bot {
+  id: string;
+  threadId: string;
+  name: string;
+  busy?: boolean;
+  modelSelection: { instanceId: string; model: string };
+}
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${SERVER}${path}`, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (!res.ok) throw new Error(`${path} → ${res.status} ${await res.text().catch(() => "")}`.trim());
+  return (await res.json()) as T;
+}
+
+const listBots = async () => (await api<{ bots: Bot[] }>("/api/bots")).bots;
+
+// ── telegram API (zero-dependency long polling) ────────────────────────
+
+function telegram(token: string) {
+  const base = `https://api.telegram.org/bot${token}`;
+  const call = async (method: string, payload: Record<string, unknown>) => {
+    const res = await fetch(`${base}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const body = (await res.json().catch(() => ({}))) as { ok?: boolean; result?: any; description?: string };
+    if (!body.ok) throw new Error(`telegram ${method}: ${body.description ?? res.status}`);
+    return body.result;
+  };
+  return {
+    send: (chatId: number, text: string, keyboard?: unknown): Promise<{ message_id: number }> =>
+      call("sendMessage", {
+        chat_id: chatId,
+        text,
+        ...(keyboard ? { reply_markup: { inline_keyboard: keyboard } } : {}),
+      }),
+    edit: (chatId: number, messageId: number, text: string) =>
+      call("editMessageText", { chat_id: chatId, message_id: messageId, text }).catch(() => {}),
+    clearKeyboard: (chatId: number, messageId: number) =>
+      call("editMessageReplyMarkup", { chat_id: chatId, message_id: messageId, reply_markup: { inline_keyboard: [] } }).catch(() => {}),
+    answerCallback: (id: string, text?: string) => call("answerCallbackQuery", { callback_query_id: id, text }).catch(() => {}),
+    updates: (offset: number) => call("getUpdates", { offset, timeout: 50, allowed_updates: ["message", "callback_query"] }),
+  };
+}
+
+// ── the gateway loop ───────────────────────────────────────────────────
+
+async function main() {
+  const tg = telegram(botToken());
+  const state = loadState();
+
+  // streaming reply state for the active bot's thread: one Telegram
+  // message that grows by throttled edits until the turn settles
+  let stream: { messageId: number; text: string; lastEdit: number; timer?: ReturnType<typeof setTimeout> } | null = null;
+  // requestId → the ask's Telegram message (to clear its keyboard) + shape
+  const asks = new Map<string, { messageId: number; ask: AskEvent; botId: string }>();
+  // question asks answered by a text reply instead of a button
+  let promptingAsk: string | null = null;
+
+  const owner = () => state.ownerChatId;
+
+  const activeBot = async (): Promise<Bot | null> => {
+    const bots = await listBots();
+    return bots.find((b) => b.id === state.activeBotId) ?? bots[0] ?? null;
+  };
+
+  const botKeyboard = (bots: Bot[]) =>
+    bots.map((b) => [{ text: `${b.busy ? "⏳ " : ""}${b.name}`, callback_data: `bot:${b.id}` }]);
+
+  const flushStream = (chatId: number) => {
+    if (!stream) return;
+    const s = stream;
+    if (s.timer) clearTimeout(s.timer);
+    s.timer = undefined;
+    s.lastEdit = Date.now();
+    void tg.edit(chatId, s.messageId, chunkText(s.text).at(-1)!);
+  };
+
+  const onDelta = async (chatId: number, delta: string) => {
+    if (!stream) {
+      const sent = await tg.send(chatId, delta.trim() || "…");
+      stream = { messageId: sent.message_id, text: delta, lastEdit: Date.now() };
+      return;
+    }
+    stream.text += delta;
+    // Telegram edits are rate-limited — batch deltas on a timer. When the
+    // text outgrows one message, finalize it and start a fresh bubble.
+    if (stream.text.length > TELEGRAM_MAX) {
+      const parts = chunkText(stream.text);
+      await tg.edit(chatId, stream.messageId, parts[0]);
+      const sent = await tg.send(chatId, parts.slice(1).join("") || "…");
+      stream = { messageId: sent.message_id, text: parts.slice(1).join(""), lastEdit: Date.now() };
+      return;
+    }
+    if (!stream.timer) {
+      const due = Math.max(0, EDIT_THROTTLE_MS - (Date.now() - stream.lastEdit));
+      stream.timer = setTimeout(() => flushStream(chatId), due);
+      stream.timer.unref?.();
+    }
+  };
+
+  // ── SSE: fold runtime events into the chat ───────────────────────────
+  const consumeEvents = async () => {
+    for (;;) {
+      try {
+        const res = await fetch(`${SERVER}/api/events`);
+        if (!res.body) throw new Error("no body");
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          let sep;
+          while ((sep = buf.indexOf("\n\n")) !== -1) {
+            const frame = buf.slice(0, sep);
+            buf = buf.slice(sep + 2);
+            const data = frame
+              .split("\n")
+              .filter((l) => l.startsWith("data: "))
+              .map((l) => l.slice(6))
+              .join("\n");
+            if (!data) continue;
+            let payload: any;
+            try {
+              payload = JSON.parse(data);
+            } catch {
+              continue;
+            }
+            await handleBroadcast(payload).catch((e) => console.error("gateway handle:", e));
+          }
+        }
+      } catch (e) {
+        console.error("gateway SSE:", (e as Error).message);
+      }
+      stream = null;
+      await new Promise((r) => setTimeout(r, 2000)); // reconnect backoff
+    }
+  };
+
+  const handleBroadcast = async (payload: any) => {
+    const chatId = owner();
+    if (!chatId || payload.kind !== "runtime") return;
+    const event = payload.event ?? {};
+    const bots = await listBots();
+    const eventBot = bots.find((b) => b.threadId === event.threadId);
+    if (!eventBot) return;
+    const isActive = eventBot.id === (state.activeBotId ?? bots[0]?.id);
+
+    switch (event.type) {
+      case "content.delta":
+        if (isActive && event.streamKind === "assistant_text" && event.delta) await onDelta(chatId, event.delta);
+        break;
+      case "item.completed":
+        if (isActive && event.itemType === "assistant_text" && event.text) {
+          if (stream) {
+            stream.text = event.text;
+            flushStream(chatId);
+            for (const part of chunkText(event.text).slice(1)) await tg.send(chatId, part);
+          } else {
+            for (const part of chunkText(event.text)) await tg.send(chatId, part);
+          }
+          stream = null;
+        }
+        break;
+      case "request.opened": {
+        // approvals from EVERY bot come through — that is the point of
+        // having the fleet in your pocket. Non-active bots are named.
+        const ask: AskEvent = {
+          requestId: event.requestId,
+          requestType: event.requestType === "question" ? "question" : "permission",
+          tool: event.tool ?? "tool",
+          summary: event.summary ?? "",
+          choices: event.choices,
+        };
+        const sent = await tg.send(chatId, askHeader(eventBot.name, ask), keyboardFor(ask));
+        if (ask.requestId) asks.set(ask.requestId, { messageId: sent.message_id, ask, botId: eventBot.id });
+        break;
+      }
+      case "request.resolved": {
+        const pending = event.requestId ? asks.get(event.requestId) : undefined;
+        if (pending) {
+          asks.delete(event.requestId);
+          await tg.clearKeyboard(chatId, pending.messageId);
+          if (event.source !== "user") await tg.send(chatId, `⏱️ Resolved without you: ${event.behavior}`);
+        }
+        break;
+      }
+      case "turn.completed":
+        if (isActive) {
+          flushStream(chatId);
+          stream = null;
+          if (event.ok === false) await tg.send(chatId, `⚠️ ${eventBot.name}: turn failed (${event.stopReason ?? "unknown"})`);
+        } else if (event.ok !== false) {
+          await tg.send(chatId, `📬 ${eventBot.name} finished — /bots to switch over`);
+        }
+        break;
+      case "runtime.error":
+        if (isActive && event.message) await tg.send(chatId, `⚠️ ${String(event.message).slice(0, 300)}`);
+        break;
+    }
+  };
+
+  // ── long-poll telegram updates ───────────────────────────────────────
+  const consumeUpdates = async () => {
+    let offset = 0;
+    for (;;) {
+      try {
+        const updates: any[] = await tg.updates(offset);
+        for (const u of updates) {
+          offset = Math.max(offset, u.update_id + 1);
+          await handleUpdate(u).catch((e) => console.error("gateway update:", e));
+        }
+      } catch (e) {
+        console.error("gateway poll:", (e as Error).message);
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+    }
+  };
+
+  const handleUpdate = async (u: any) => {
+    const msg = u.message;
+    const cb = u.callback_query;
+    const chatId: number | undefined = msg?.chat?.id ?? cb?.message?.chat?.id;
+    if (!chatId) return;
+
+    // first /start claims the gateway; everyone else is turned away
+    if (!state.ownerChatId) {
+      if (msg?.text?.startsWith("/start")) {
+        state.ownerChatId = chatId;
+        saveState(state);
+        console.log(`telegram gateway: owner bound to chat ${chatId}`);
+      } else {
+        return;
+      }
+    }
+    if (chatId !== state.ownerChatId) {
+      if (msg) await tg.send(chatId, "This gateway is bound to its owner.");
+      return;
+    }
+
+    if (cb) {
+      const [kind, ...rest] = String(cb.data ?? "").split(":");
+      if (kind === "bot") {
+        state.activeBotId = rest[0];
+        saveState(state);
+        stream = null;
+        const bot = (await listBots()).find((b) => b.id === rest[0]);
+        await tg.answerCallback(cb.id, bot ? `Now talking to ${bot.name}` : "Bot is gone");
+        if (bot) await tg.send(chatId, `🤖 Now talking to ${bot.name} (${bot.modelSelection.model}). Just type.`);
+      } else if (kind === "req") {
+        const [requestId, action, choiceIx] = rest;
+        const pending = asks.get(requestId);
+        if (!pending) {
+          await tg.answerCallback(cb.id, "Already resolved");
+          return;
+        }
+        if (action === "prompt") {
+          promptingAsk = requestId;
+          await tg.answerCallback(cb.id, "Reply with your answer");
+          await tg.send(chatId, "✍️ Type your answer:");
+          return;
+        }
+        const body =
+          action === "choice"
+            ? { requestId, behavior: "answer", message: pending.ask.choices?.[Number(choiceIx)] ?? "" }
+            : { requestId, behavior: action };
+        await api(`/api/bots/${pending.botId}/respond`, { method: "POST", body: JSON.stringify(body) });
+        await tg.answerCallback(cb.id, action === "deny" ? "Denied" : "Sent");
+      }
+      return;
+    }
+
+    const text: string = (msg?.text ?? "").trim();
+    if (!text) return;
+
+    if (text.startsWith("/start") || text.startsWith("/bots")) {
+      const bots = await listBots();
+      if (!bots.length) return void (await tg.send(chatId, "No bots yet — create one in the app first."));
+      await tg.send(chatId, "Your bots — pick who to talk to:", botKeyboard(bots));
+      return;
+    }
+    if (text.startsWith("/stop")) {
+      const bot = await activeBot();
+      if (bot) {
+        await api(`/api/bots/${bot.id}/interrupt`, { method: "POST", body: "{}" });
+        await tg.send(chatId, `🛑 Stopped ${bot.name}.`);
+      }
+      return;
+    }
+    // a pending free-text question answer takes the next message
+    if (promptingAsk) {
+      const pending = asks.get(promptingAsk);
+      promptingAsk = null;
+      if (pending) {
+        await api(`/api/bots/${pending.botId}/respond`, {
+          method: "POST",
+          body: JSON.stringify({ requestId: pending.ask.requestId, behavior: "answer", message: text }),
+        });
+        await tg.send(chatId, "Answer sent.");
+        return;
+      }
+    }
+    const bot = await activeBot();
+    if (!bot) return void (await tg.send(chatId, "No bots yet — create one in the app first."));
+    if (!state.activeBotId) {
+      state.activeBotId = bot.id;
+      saveState(state);
+    }
+    stream = null;
+    await api(`/api/bots/${bot.id}/messages`, { method: "POST", body: JSON.stringify({ text }) });
+  };
+
+  // sanity: the harness must be up, and the token must be valid
+  await api("/api/health");
+  console.log(`telegram gateway: bridging ${SERVER} — waiting for /start`);
+  await Promise.all([consumeEvents(), consumeUpdates()]);
+}
+
+// only run the loops when executed directly (not when imported by tests)
+if (process.argv[1]?.endsWith("telegram.ts") || process.argv[1]?.endsWith("telegram.js")) {
+  main().catch((e) => {
+    console.error("telegram gateway:", e);
+    process.exit(1);
+  });
+}

--- a/server/gateway/telegram.ts
+++ b/server/gateway/telegram.ts
@@ -41,6 +41,20 @@ export function chunkText(text: string, max = TELEGRAM_MAX): string[] {
   return chunks;
 }
 
+/** Exponential backoff with a ceiling: quick retries for a blip, patient
+ * ones for an outage, never longer than a minute so recovery stays fast. */
+export function backoffMs(failures: number, base = 2000, ceiling = 60_000): number {
+  return Math.min(ceiling, base * 2 ** Math.min(failures - 1, 10));
+}
+
+/** `fetch` rejects with a bare "fetch failed" and hides the real reason in
+ * `cause` — a gateway that only logs the message is undebuggable. */
+export function describeError(e: unknown): string {
+  const err = e as { message?: string; cause?: { code?: string; message?: string } };
+  const cause = err?.cause?.code ?? err?.cause?.message;
+  return cause ? `${err.message} (${cause})` : String(err?.message ?? e);
+}
+
 export interface AskEvent {
   requestId?: string;
   requestType: "permission" | "question";
@@ -99,7 +113,12 @@ function loadState(): GatewayState {
 function saveState(s: GatewayState) {
   try {
     writeFileSync(STATE_PATH, JSON.stringify(s, null, 2));
-  } catch {}
+  } catch (e) {
+    // a silent failure here is a security hole, not an inconvenience: the
+    // owner binding would not survive a restart, and the next chat to send
+    // /start could claim a gateway that approves shell commands
+    console.error(`telegram gateway: CANNOT PERSIST STATE to ${STATE_PATH} — the owner binding will not survive a restart: ${describeError(e)}`);
+  }
 }
 
 // ── harness API ────────────────────────────────────────────────────────
@@ -169,21 +188,50 @@ async function main() {
 
   const owner = () => state.ownerChatId;
 
+  // threadId → bot lookups happen once per runtime event, and deltas
+  // arrive per token — so the roster is cached and only re-fetched when a
+  // thread is unknown (a bot created since the last refresh).
+  let botCache: Bot[] = [];
+  const refreshBots = async () => {
+    botCache = await listBots();
+    return botCache;
+  };
+  const botForThread = async (threadId: string): Promise<Bot | undefined> => {
+    const hit = botCache.find((b) => b.threadId === threadId);
+    if (hit) return hit;
+    return (await refreshBots()).find((b) => b.threadId === threadId);
+  };
+
+  /** The bot the owner is talking to. A stored id that no longer resolves
+   * (deleted bot) is REPAIRED here — leaving it dangling would make every
+   * `isActive` check false and silently drop the whole reply stream. */
   const activeBot = async (): Promise<Bot | null> => {
-    const bots = await listBots();
-    return bots.find((b) => b.id === state.activeBotId) ?? bots[0] ?? null;
+    const bots = await refreshBots();
+    const chosen = bots.find((b) => b.id === state.activeBotId) ?? bots[0] ?? null;
+    if (chosen && state.activeBotId !== chosen.id) {
+      state.activeBotId = chosen.id;
+      saveState(state);
+    }
+    return chosen;
   };
 
   const botKeyboard = (bots: Bot[]) =>
     bots.map((b) => [{ text: `${b.busy ? "⏳ " : ""}${b.name}`, callback_data: `bot:${b.id}` }]);
 
-  const flushStream = (chatId: number) => {
+  /** Settle the streaming bubble: the bubble holds the FIRST chunk (it is
+   * the message that has been growing), any remainder goes out as further
+   * messages, in order. Awaited by every caller so bubbles can never
+   * overtake each other. */
+  const flushStream = async (chatId: number) => {
     if (!stream) return;
     const s = stream;
     if (s.timer) clearTimeout(s.timer);
     s.timer = undefined;
     s.lastEdit = Date.now();
-    void tg.edit(chatId, s.messageId, chunkText(s.text).at(-1)!);
+    const [head, ...rest] = chunkText(s.text);
+    await tg.edit(chatId, s.messageId, head ?? "…");
+    for (const part of rest) await tg.send(chatId, part);
+    stream = null;
   };
 
   const onDelta = async (chatId: number, delta: string) => {
@@ -194,27 +242,35 @@ async function main() {
     }
     stream.text += delta;
     // Telegram edits are rate-limited — batch deltas on a timer. When the
-    // text outgrows one message, finalize it and start a fresh bubble.
+    // text outgrows one message, settle the full chunks and keep only the
+    // tail growing: re-joining the remainder would rebuild a body over the
+    // 4096 limit, which Telegram rejects and every later edit repeats.
     if (stream.text.length > TELEGRAM_MAX) {
-      const parts = chunkText(stream.text);
-      await tg.edit(chatId, stream.messageId, parts[0]);
-      const sent = await tg.send(chatId, parts.slice(1).join("") || "…");
-      stream = { messageId: sent.message_id, text: parts.slice(1).join(""), lastEdit: Date.now() };
+      const [head, ...rest] = chunkText(stream.text);
+      const tail = rest.pop() ?? "";
+      if (stream.timer) clearTimeout(stream.timer);
+      await tg.edit(chatId, stream.messageId, head);
+      for (const part of rest) await tg.send(chatId, part);
+      const sent = await tg.send(chatId, tail || "…");
+      stream = { messageId: sent.message_id, text: tail, lastEdit: Date.now() };
       return;
     }
     if (!stream.timer) {
       const due = Math.max(0, EDIT_THROTTLE_MS - (Date.now() - stream.lastEdit));
-      stream.timer = setTimeout(() => flushStream(chatId), due);
+      stream.timer = setTimeout(() => void flushStream(chatId), due);
       stream.timer.unref?.();
     }
   };
 
   // ── SSE: fold runtime events into the chat ───────────────────────────
   const consumeEvents = async () => {
+    let failures = 0;
     for (;;) {
       try {
         const res = await fetch(`${SERVER}/api/events`);
         if (!res.body) throw new Error("no body");
+        console.log(`telegram gateway: event stream connected${failures ? ` (after ${failures} failed attempt(s))` : ""}`);
+        failures = 0;
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
         let buf = "";
@@ -238,14 +294,20 @@ async function main() {
             } catch {
               continue;
             }
-            await handleBroadcast(payload).catch((e) => console.error("gateway handle:", e));
+            await handleBroadcast(payload).catch((e) => console.error("gateway handle:", describeError(e)));
           }
         }
+        // the stream ended without throwing — the harness restarted or
+        // dropped us; that is a failed attempt too, so the backoff grows
+        failures += 1;
       } catch (e) {
-        console.error("gateway SSE:", (e as Error).message);
+        failures += 1;
+        if (failures <= 3 || failures % 10 === 0) {
+          console.error(`gateway SSE (attempt ${failures}): ${describeError(e)}`);
+        }
       }
       stream = null;
-      await new Promise((r) => setTimeout(r, 2000)); // reconnect backoff
+      await new Promise((r) => setTimeout(r, backoffMs(failures)));
     }
   };
 
@@ -253,10 +315,9 @@ async function main() {
     const chatId = owner();
     if (!chatId || payload.kind !== "runtime") return;
     const event = payload.event ?? {};
-    const bots = await listBots();
-    const eventBot = bots.find((b) => b.threadId === event.threadId);
+    const eventBot = await botForThread(event.threadId);
     if (!eventBot) return;
-    const isActive = eventBot.id === (state.activeBotId ?? bots[0]?.id);
+    const isActive = eventBot.id === (state.activeBotId ?? botCache[0]?.id);
 
     switch (event.type) {
       case "content.delta":
@@ -264,14 +325,13 @@ async function main() {
         break;
       case "item.completed":
         if (isActive && event.itemType === "assistant_text" && event.text) {
+          // the settled text supersedes whatever the deltas built
           if (stream) {
             stream.text = event.text;
-            flushStream(chatId);
-            for (const part of chunkText(event.text).slice(1)) await tg.send(chatId, part);
+            await flushStream(chatId);
           } else {
             for (const part of chunkText(event.text)) await tg.send(chatId, part);
           }
-          stream = null;
         }
         break;
       case "request.opened": {
@@ -285,6 +345,9 @@ async function main() {
           choices: event.choices,
         };
         const sent = await tg.send(chatId, askHeader(eventBot.name, ask), keyboardFor(ask));
+        // an unanswered approval is the one thing a user MUST see — say so
+        // in the log, so "did it even go out?" is never a guess
+        console.log(`telegram gateway: sent ${ask.requestType} card for ${eventBot.name} (${ask.tool}) → message ${sent.message_id}`);
         if (ask.requestId) asks.set(ask.requestId, { messageId: sent.message_id, ask, botId: eventBot.id });
         break;
       }
@@ -299,8 +362,7 @@ async function main() {
       }
       case "turn.completed":
         if (isActive) {
-          flushStream(chatId);
-          stream = null;
+          await flushStream(chatId);
           if (event.ok === false) await tg.send(chatId, `⚠️ ${eventBot.name}: turn failed (${event.stopReason ?? "unknown"})`);
         } else if (event.ok !== false) {
           await tg.send(chatId, `📬 ${eventBot.name} finished — /bots to switch over`);
@@ -313,18 +375,33 @@ async function main() {
   };
 
   // ── long-poll telegram updates ───────────────────────────────────────
+  // A long poll that outlives its socket is normal (laptop sleeps, wifi
+  // drops, Telegram closes an idle connection). What is NOT acceptable is
+  // hammering the API every 3s forever and logging an unreadable "fetch
+  // failed" each time: back off, name the real cause, and say when the
+  // connection came back so a quiet log means a healthy gateway.
   const consumeUpdates = async () => {
     let offset = 0;
+    let failures = 0;
     for (;;) {
       try {
         const updates: any[] = await tg.updates(offset);
+        if (failures) {
+          console.log(`telegram gateway: polling recovered after ${failures} failed attempt(s)`);
+          failures = 0;
+        }
         for (const u of updates) {
           offset = Math.max(offset, u.update_id + 1);
-          await handleUpdate(u).catch((e) => console.error("gateway update:", e));
+          await handleUpdate(u).catch((e) => console.error("gateway update:", describeError(e)));
         }
       } catch (e) {
-        console.error("gateway poll:", (e as Error).message);
-        await new Promise((r) => setTimeout(r, 3000));
+        failures += 1;
+        // log the first few, then every tenth — an overnight outage must
+        // not bury the one line that matters when you come back
+        if (failures <= 3 || failures % 10 === 0) {
+          console.error(`gateway poll (attempt ${failures}): ${describeError(e)}`);
+        }
+        await new Promise((r) => setTimeout(r, backoffMs(failures)));
       }
     }
   };
@@ -356,7 +433,7 @@ async function main() {
         state.activeBotId = rest[0];
         saveState(state);
         stream = null;
-        const bot = (await listBots()).find((b) => b.id === rest[0]);
+        const bot = (await refreshBots()).find((b) => b.id === rest[0]);
         await tg.answerCallback(cb.id, bot ? `Now talking to ${bot.name}` : "Bot is gone");
         if (bot) await tg.send(chatId, `🤖 Now talking to ${bot.name} (${bot.modelSelection.model}). Just type.`);
       } else if (kind === "req") {
@@ -376,7 +453,16 @@ async function main() {
           action === "choice"
             ? { requestId, behavior: "answer", message: pending.ask.choices?.[Number(choiceIx)] ?? "" }
             : { requestId, behavior: action };
-        await api(`/api/bots/${pending.botId}/respond`, { method: "POST", body: JSON.stringify(body) });
+        // a failed answer must NOT look like a delivered one — the bot is
+        // still waiting, so say so and leave the keyboard usable for a retry
+        try {
+          await api(`/api/bots/${pending.botId}/respond`, { method: "POST", body: JSON.stringify(body) });
+        } catch (e) {
+          console.error(`gateway respond: ${describeError(e)}`);
+          await tg.answerCallback(cb.id, "Could not deliver — try again");
+          await tg.send(chatId, `⚠️ Your answer did not reach ${pending.ask.tool}: ${describeError(e)}`);
+          return;
+        }
         await tg.answerCallback(cb.id, action === "deny" ? "Denied" : "Sent");
       }
       return;
@@ -386,7 +472,7 @@ async function main() {
     if (!text) return;
 
     if (text.startsWith("/start") || text.startsWith("/bots")) {
-      const bots = await listBots();
+      const bots = await refreshBots();
       if (!bots.length) return void (await tg.send(chatId, "No bots yet — create one in the app first."));
       await tg.send(chatId, "Your bots — pick who to talk to:", botKeyboard(bots));
       return;
@@ -404,11 +490,16 @@ async function main() {
       const pending = asks.get(promptingAsk);
       promptingAsk = null;
       if (pending) {
-        await api(`/api/bots/${pending.botId}/respond`, {
-          method: "POST",
-          body: JSON.stringify({ requestId: pending.ask.requestId, behavior: "answer", message: text }),
-        });
-        await tg.send(chatId, "Answer sent.");
+        try {
+          await api(`/api/bots/${pending.botId}/respond`, {
+            method: "POST",
+            body: JSON.stringify({ requestId: pending.ask.requestId, behavior: "answer", message: text }),
+          });
+          await tg.send(chatId, "Answer sent.");
+        } catch (e) {
+          console.error(`gateway respond: ${describeError(e)}`);
+          await tg.send(chatId, `⚠️ Your answer did not get through: ${describeError(e)}`);
+        }
         return;
       }
     }


### PR DESCRIPTION
## What

A **Telegram gateway** — chat with your bots from your phone. OpenMausBot keeps the messaging-app shape, but only on the Mac; the thing that makes the original compelling is that the bots live in your pocket. This closes that gap without building a mobile app.

It is an optional standalone process (`pnpm gateway:telegram`) that rides the existing harness HTTP+SSE contract — **zero changes to the app or server**, zero new dependencies (plain `fetch` long polling against api.telegram.org).

## How it works

```
Telegram ⇄ gateway (long polling) ⇄ harness 127.0.0.1:8799 (HTTP + SSE)
```

- `/start` / `/bots` shows the roster as inline buttons; pick a bot, then just type. Replies stream in live — the Telegram message grows by throttled edits (4096-char chunking rolls into fresh bubbles).
- Permission asks become inline keyboards — `✅ Allow / ❌ Deny` wired straight to `/api/bots/:id/respond`. Questions offer the agent's choices as buttons, or free-text via reply. Asks from **every** bot come through (named); replies stream only for the active one, other bots' finished turns arrive as a `📬 <name> finished` nudge.
- `/stop` interrupts the active bot. Timed-out asks keep the harness's fail-closed behavior — the gateway then tells you it was resolved without you.
- **Security:** the first chat that sends `/start` becomes the owner (persisted in `~/.openmausbot/telegram-gateway.json`); every other chat is refused. This thing can approve shell commands, so it is deliberately single-user.

Token via `TELEGRAM_BOT_TOKEN` env or `{"telegram": {"token": "…"}}` in `~/.openmausbot/config.json`. Docs in `docs/telegram-gateway.md`.

## Verified

- `pnpm typecheck` clean; `pnpm test` 267 passed / 8 skipped (8 new gateway tests: chunking, keyboards, ask headers).
- **Live end-to-end** against a real Telegram bot + an 8-bot fleet: owner binding, roster keyboard, bot switching from both sides, streamed replies, a file-writing task driven entirely from Telegram, cross-bot `📬 finished` nudges, and SSE auto-reconnect straight through a harness restart.
- **The approval path is now proven live too.** A `rm -rf` on a throwaway directory is refused by `autoDecision` (destructive), so it reached the phone: gateway logged `sent permission card … → message 44`, the ✅ Allow tap came back through the callback, the harness recorded `answered=allow`, the command ran (`Bash ok=true`) and the directory is gone from the filesystem. Deny and the 15-minute broker timeout were exercised on earlier runs and behave as designed (nothing executed, keyboard cleared, user told it was resolved without them).
- Getting there took several tries for an instructive reason: routine tool permissions never reach a human at all — `auto-approve.ts` settles them server-side, and the agent CLIs classify most read-only commands as safe. Only genuinely destructive commands, secret-adjacent paths and questions surface. Worth knowing when testing this.

## Scope (v1)

Text turns, streamed replies, approvals/questions, interrupt. Not yet: rooms, voice, images/screens, multi-user — happy to follow up if this shape fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional Telegram gateway for interacting with the harness.
  - Supports streamed replies, bot selection, stopping active turns, and permission or question prompts.
  - Splits long messages automatically and reconnects after temporary service interruptions.
  - The first chat to use `/start` becomes the sole authorized chat.
  - Added a command to launch the Telegram gateway.

- **Documentation**
  - Added setup instructions and documented single-chat limitations, including no rooms, voice, images, or screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
