### PR TITLE
feat(ui): slide the sidebar into a drawer below md

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Loader2, Menu } from "lucide-react";
 import { StoreProvider, useStore } from "@/state/store";
 import { Onboarding } from "@/components/Onboarding";
@@ -17,9 +17,13 @@ import { NoEngines } from "@/components/NoEngines";
 
 function Shell() {
   const { state, dispatch } = useStore();
-  // Mobile-only drawer state. Above md the sidebar is always in flow and this
-  // value has no effect — the md: variants cancel every mobile class.
+  // Mobile-only drawer state. Above md, none of these properties are emitted
+  // at all — Sidebar scopes every mobile class with max-md: rather than
+  // cancelling them with md:, which would still emit a translate value and
+  // turn the aside into a containing block for its fixed descendants (see
+  // Sidebar.tsx's className comment).
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const group = state.groups.find((g) => g.id === state.selectedId);
   const bot = group ? undefined : (state.bots.find((b) => b.id === state.selectedId) ?? state.bots[0]);
 
@@ -62,6 +66,16 @@ function Shell() {
     return () => window.removeEventListener("keydown", onKey);
   }, [state.bots, state.selectedId, dispatch]);
 
+  // Picking a conversation closes the drawer: on a phone the chat is what you
+  // asked for, and leaving the list up would hide it. Watching activeView too
+  // catches re-selecting the bot that is already current from another view —
+  // the reducer switches the view without changing selectedId. pluginsOpen
+  // and settingsOpen cover the same idea from a different trigger: close the
+  // drawer whenever an action opens something over the chat.
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [state.selectedId, state.activeView, state.pluginsOpen, state.settingsOpen]);
+
   return (
     <div className="flex h-full flex-col">
       {/* fixed-position popup, bottom-left — outside the layout flow */}
@@ -69,6 +83,7 @@ function Shell() {
       <div className="relative flex min-h-0 flex-1">
       <button
         type="button"
+        ref={menuButtonRef}
         aria-label="Open bot list"
         aria-expanded={drawerOpen}
         onClick={() => setDrawerOpen(true)}
@@ -83,7 +98,13 @@ function Shell() {
           className="absolute inset-0 z-30 bg-black/50 md:hidden"
         />
       )}
-      <Sidebar open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <Sidebar
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          menuButtonRef.current?.focus();
+        }}
+      />
       {state.activeView === "routines" ? (
         <RoutinesPage />
       ) : noEngines ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Menu } from "lucide-react";
 import { StoreProvider, useStore } from "@/state/store";
 import { Onboarding } from "@/components/Onboarding";
 import { emailGateDone, initAnalytics } from "@/lib/analytics";
@@ -17,6 +17,9 @@ import { NoEngines } from "@/components/NoEngines";
 
 function Shell() {
   const { state, dispatch } = useStore();
+  // Mobile-only drawer state. Above md the sidebar is always in flow and this
+  // value has no effect — the md: variants cancel every mobile class.
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const group = state.groups.find((g) => g.id === state.selectedId);
   const bot = group ? undefined : (state.bots.find((b) => b.id === state.selectedId) ?? state.bots[0]);
 
@@ -64,7 +67,23 @@ function Shell() {
       {/* fixed-position popup, bottom-left — outside the layout flow */}
       <UpdateBanner />
       <div className="relative flex min-h-0 flex-1">
-      <Sidebar />
+      <button
+        type="button"
+        aria-label="Open bot list"
+        aria-expanded={drawerOpen}
+        onClick={() => setDrawerOpen(true)}
+        className="absolute left-3 top-3 z-30 rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink md:hidden"
+      >
+        <Menu size={18} />
+      </button>
+      {drawerOpen && (
+        <div
+          aria-hidden
+          onMouseDown={(e) => e.target === e.currentTarget && setDrawerOpen(false)}
+          className="absolute inset-0 z-30 bg-black/50 md:hidden"
+        />
+      )}
+      <Sidebar open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       {state.activeView === "routines" ? (
         <RoutinesPage />
       ) : noEngines ? (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -657,7 +657,12 @@ export function ChatView({ bot }: { bot: Bot }) {
       <CallOverlay bot={bot} />
       {/* Header */}
       <div
-        className={cn("flex items-center justify-between px-5 py-3", isWin && "pr-[148px]")}
+        className={cn(
+          "flex items-center justify-between px-5 py-3",
+          // Room for the drawer button, which overlays this corner below md.
+          "pl-11 md:pl-5",
+          isWin && "pr-[148px]",
+        )}
         style={drag}
       >
         <button

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -229,7 +229,15 @@ export function GroupView({ group }: { group: Group }) {
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
       <GroupCallOverlay group={group} members={members} />
       {/* Header: static member mauses; a ring + dot marks the working bot. */}
-      <div className={cn("flex items-center justify-between px-5 py-3", isWin && "pr-[148px]")} style={drag}>
+      <div
+        className={cn(
+          "flex items-center justify-between px-5 py-3",
+          // Room for the drawer button, which overlays this corner below md.
+          "pl-11 md:pl-5",
+          isWin && "pr-[148px]",
+        )}
+        style={drag}
+      >
         <span className="text-[15px] font-semibold text-ink">{group.name}</span>
         <div className="flex items-center gap-1.5" style={noDrag}>
           <GroupCallButton group={group} members={members} />

--- a/src/components/RoutinesPage.tsx
+++ b/src/components/RoutinesPage.tsx
@@ -594,7 +594,13 @@ export function RoutinesPage() {
 
   return (
     <main className="flex h-full min-w-0 flex-1 flex-col bg-app">
-      <header className="shrink-0 px-5 pb-4 pt-4">
+      <header
+        className={cn(
+          "shrink-0 px-5 pb-4 pt-4",
+          // Room for the drawer button, which overlays this corner below md.
+          "pl-11 md:pl-5",
+        )}
+      >
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <div className="flex items-center gap-2.5"><CalendarDays size={21} className="text-accent" /><h1 className="text-[20px] font-semibold tracking-tight text-ink">Routines</h1></div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -493,7 +493,7 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
   );
 }
 
-export function Sidebar() {
+export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const [menu, setMenu] = useState<MenuState | null>(null);
@@ -501,6 +501,18 @@ export function Sidebar() {
   const [plusOpen, setPlusOpen] = useState(false);
   const [newRoom, setNewRoom] = useState(false);
   const [query, setQuery] = useState("");
+
+  // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Only bound while the
+  // drawer is open, so it never competes with the panels' own Esc handling.
+  useEffect(() => {
+    if (!open) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [open, onClose]);
+
   const macInset = capabilities.windowChrome === "mac-inset";
   const browser = capabilities.host.label === "Browser";
 
@@ -521,7 +533,21 @@ export function Sidebar() {
   const visibleGroups = state.groups.filter((g) => !q || g.name.toLowerCase().includes(q));
 
   return (
-    <aside className="flex h-full w-[320px] shrink-0 flex-col border-r border-hairline/40 bg-panel">
+    <aside
+      className={cn(
+        "flex h-full w-[320px] shrink-0 flex-col border-r border-hairline/40 bg-panel",
+        // Below md only: the sidebar leaves the flow and slides in over the chat.
+        // Scoped with max-md: rather than cancelled with md: on purpose — Tailwind
+        // v4 emits the native `translate` property, and any value other than
+        // `none` turns this element into a containing block for its `fixed`
+        // descendants. Cancelling with md:translate-x-0 still emits a value, which
+        // silently reparents NewRoomPanel's overlay and the "+" menu backdrop on
+        // desktop.
+        "max-md:absolute max-md:inset-y-0 max-md:left-0 max-md:z-40",
+        "max-md:transition-transform max-md:duration-200",
+        open ? "max-md:translate-x-0" : "max-md:-translate-x-full",
+      )}
+    >
       {/* macOS owns inset traffic lights; Linux/Windows use native chrome. */}
       <div
         className="flex items-center justify-between px-4 pt-3.5 pb-1"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -502,8 +502,10 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   const [newRoom, setNewRoom] = useState(false);
   const [query, setQuery] = useState("");
 
-  // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Only bound while the
-  // drawer is open, so it never competes with the panels' own Esc handling.
+  // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Bound only while the
+  // drawer is open — on mobile, exactly when a bot/room context menu or the
+  // New Room panel can be open on top of it, so the same Escape press closes
+  // them together. Fine, since both directions are "get me out of here."
   useEffect(() => {
     if (!open) return;
     const closeOnEscape = (event: KeyboardEvent) => {
@@ -540,7 +542,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         // Scoped with max-md: rather than cancelled with md: on purpose — Tailwind
         // v4 emits the native `translate` property, and any value other than
         // `none` turns this element into a containing block for its `fixed`
-        // descendants. Cancelling with md:translate-x-0 still emits a value, which
+        // descendants. Cancelling it with an `md:` prefix still emits a value, which
         // silently reparents NewRoomPanel's overlay and the "+" menu backdrop on
         // desktop.
         "max-md:absolute max-md:inset-y-0 max-md:left-0 max-md:z-40",

--- a/src/styles.css
+++ b/src/styles.css
@@ -89,6 +89,8 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .animate-caret, .animate-msg-in, .animate-shimmer { animation: none; }
   .thinking-shimmer { background: none; color: var(--color-ink-secondary); }
+  /* The drawer still moves, it just arrives instantly. */
+  aside { transition: none; }
 }
 
 /* SupaMaus vector motion. The fast horizontal compression is the edge-on


### PR DESCRIPTION
Closes #114

## The problem

`Sidebar.tsx` declares the sidebar `w-[320px] shrink-0`. On a 360px viewport
that leaves **40px** for the conversation.

`src/` has no media queries — the four in the repo are in
`mascot-preview.css` — and one Tailwind breakpoint in total. The rest of the CSS
is fine (24 `max-w-[…]`, 59 `w-full`); content already adapts. This is the one
declaration in the way.

## What this does

Below `md`, the sidebar leaves the flow and slides in over the chat behind a
scrim, opened from a button in the top-left. Four ways out: tap the scrim, press
Escape, press the button, or pick a conversation.

Above `md`, nothing changes.

## Why `max-md:` and not `md:` cancellation

This is the part worth reviewing carefully.

My first version applied the mobile classes at the base and cancelled them with
`md:relative md:translate-x-0`. That is broken, and not obviously so.

Tailwind v4 emits the native `translate` property, and `translate-x-0` is
`translate: 0px 0px` — a real value, not `none`. Per spec, any `translate` other
than `none` makes the element a **containing block for its `fixed`
descendants**. So `md:translate-x-0` does not cancel anything; it reparents
them. Four `fixed` surfaces are JSX descendants of this `aside` (there are no
React portals in the codebase), and two of them broke **on desktop**:
`NewRoomPanel`'s `inset-0` overlay collapsed to the 320px column, and the `+`
menu backdrop stopped catching clicks over the chat.

Scoping with `max-md:` means none of these properties are emitted above the
breakpoint at all. The desktop guarantee is an absence, not a cancellation — and
a reviewer can verify it by reading the classes rather than reasoning about
state.

Neither `tsc` nor the test suite can catch that class of bug. It only exists at
render time.

## Verification

**Desktop is pixel-identical.** Rendered 1280×800 from a worktree on `main` and
from this branch, against the same harness server, and compared with
`ImageChops.difference` — `getbbox()` returns `None`.

`pnpm typecheck` and `pnpm test` pass (287 passed, 8 skipped).

No automated test is added: `vite.config.ts` declares `environment: "node"`, the
only test dependency is `vitest`, and the four tests under `src/` cover pure
logic without mounting components. Standing up a DOM harness would be a second
concern; per CONTRIBUTING, UI changes are verified with screenshots instead.

Manually checked: all four dismissal paths, focus returning to the button on
Escape, the sidebar's context menu still layering above the drawer, and the
animation stopping under `prefers-reduced-motion`.

## Screenshots

Attached in the comment below: before/after at 360px (drawer closed and open),
the desktop pair at 1280px, and a video of the drawer opening, dismissing on a
scrim tap, and reopening.

## Known limits, deliberately not addressed here

- **Below `md`, the aside is a containing block for its `fixed` descendants** —
  `translate` is what animates the drawer, so this is inherent to the approach.
  Opening the New Room dialog or the `+` menu *from the drawer* resolves their
  `inset-0` against the 320px column rather than the viewport. The dialogs still
  render and still dismiss (Escape, their own controls, tapping inside the
  column); what is lost is tap-outside-to-dismiss over the rest of the screen.
  Fixing it needs a portal, which this codebase does not have and which belongs
  with the overlay work.
- **The closed drawer stays in the tab order and the accessibility tree** below
  `md`. `inert`/`aria-hidden` keyed on the open state would break desktop, where
  the state is always closed but the sidebar must stay interactive; the CSS-only
  route (`visibility` in the transition) flips at 50% of the duration by spec,
  which would blank the drawer mid-slide.
- **Re-picking the conversation you are already on** from another view closes
  the drawer via `activeView`, but re-picking it from the chat view does not
  change any watched value. The scrim remains the way out.
- **Overlay surfaces** — settings modal, approval cards, Computer panel — still
  overflow below the breakpoint. That is the follow-up PR.
- Unrelated observation while touching that block: `animate-panel-in` is not
  covered by `prefers-reduced-motion`. Happy to open a separate issue.

## Notes

Commits are split so the reduced-motion change can be reviewed on its own. Tell
me if you would rather have it squashed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile menu button that opens the sidebar as a sliding drawer.
  * Added backdrop and Escape-key controls for closing the mobile sidebar.
  * Sidebar navigation now closes automatically after navigation or overlay changes.
  * Restored focus to the menu button after the sidebar closes.

* **Accessibility**
  * Disabled sidebar transitions when reduced-motion preferences are enabled.
  * Improved mobile header spacing for clearer navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->