### PR TITLE
feat: add Factory Droid driver over ACP stdio

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -100,6 +100,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
       : {
           grok: { driver: "grokAgent" },
           kimi: { driver: "kimiAgent" },
+          droid: { driver: "droidAgent" },
           claude: { driver: "claudeAgent" },
           codex: { driver: "codex" },
           antigravity: { driver: "antigravityAgent" },

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -18,6 +18,7 @@ import { recordEvents, type EventRecorder } from "../../testing/events.ts";
 import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 import { KimiAgentDriver } from "./kimi.ts";
+import { DroidAgentDriver } from "./droid.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
 
@@ -36,6 +37,15 @@ describe("ACP decodeConfig", () => {
       win32: expect.stringContaining("install.ps1"),
     });
     expect(KimiAgentDriver.install?.signInCommand).toBe("kimi login");
+  });
+  it("droid defaults to the droid binary and declares cross-platform setup", () => {
+    expect(DroidAgentDriver.decodeConfig(undefined)).toEqual({ cli: "droid", fullAuto: false, workspace: undefined });
+    expect(DroidAgentDriver.install?.command).toMatchObject({
+      darwin: expect.stringContaining("factory.ai/cli"),
+      linux: expect.stringContaining("factory.ai/cli"),
+      win32: expect.stringContaining("factory.ai/cli"),
+    });
+    expect(DroidAgentDriver.install?.signInCommand).toBe("droid");
   });
   it("fullAuto only when explicitly true", () => {
     expect(GrokAgentDriver.decodeConfig({ fullAuto: "yes" }).fullAuto).toBe(false);
@@ -115,6 +125,85 @@ describe("ACP turns (fake CLI)", () => {
     expect(seen.argv).toContain("stdio");
     expect(seen.argv).toContain("--permission-mode");
     expect(seen.env.XAI_API_KEY).toBeUndefined();
+  });
+
+  it("droid takes model and autonomy over the wire, never through argv", async () => {
+    // `droid exec -m <id> -o acp` ignores the flag (verified against 0.196.0),
+    // so a model that only reached argv would silently run the CLI's own pick.
+    instance = await DroidAgentDriver.create({
+      instanceId: "droid-test",
+      displayName: "Droid Test",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    recorder = recordEvents(instance.adapter);
+    const dump = join(scratch, "droid-dump.json");
+    process.env.FAKE_ACP_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-droid", text: "go", model: "claude-sonnet-5" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).toEqual(["exec", "-o", "acp"]);
+    expect(seen.argv).not.toContain("-m");
+
+    const applied = JSON.parse(readFileSync(`${dump}.config.json`, "utf8"));
+    expect(applied).toEqual([
+      { method: "session/set_mode", params: { sessionId: "fake-acp-session", modeId: "auto-high" } },
+      { method: "session/set_model", params: { sessionId: "fake-acp-session", modelId: "claude-sonnet-5" } },
+    ]);
+  });
+
+  it("droid pins read-only mode when fullAuto is off", async () => {
+    instance = await DroidAgentDriver.create({
+      instanceId: "droid-safe",
+      displayName: "Droid Safe",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    recorder = recordEvents(instance.adapter);
+    const dump = join(scratch, "droid-safe.json");
+    process.env.FAKE_ACP_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-droid-safe", text: "go" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    // Both settings are explicit even with nothing on the turn: whatever
+    // ~/.factory/settings.json pinned (including a `custom:` provider with its
+    // own endpoint) must never be what the session silently runs on.
+    expect(JSON.parse(readFileSync(`${dump}.config.json`, "utf8"))).toEqual([
+      { method: "session/set_mode", params: { sessionId: "fake-acp-session", modeId: "normal" } },
+      { method: "session/set_model", params: { sessionId: "fake-acp-session", modelId: "claude-opus-5" } },
+    ]);
+  });
+
+  it("droid names the rejected setting when the agent predates session config", async () => {
+    // The realistic failure is version skew: an older droid answers -32601 to
+    // session/set_mode, and core surfaces the RPC message verbatim. A bare
+    // "method not found" tells the user nothing, so the driver wraps it.
+    process.env.FAKE_ACP_MODE = "no-session-config";
+    instance = await DroidAgentDriver.create({
+      instanceId: "droid-old-cli",
+      displayName: "Droid Old CLI",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    recorder = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "t-droid-skew", text: "go" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+
+    expect(done).toMatchObject({ ok: false, stopReason: "rpc_error" });
+    const err = recorder.events.find((e) => e.type === "runtime.error")!;
+    expect(err.message).toContain("session/set_mode");
+    expect(err.message).toContain('autonomy mode "normal"');
+    expect(err.message).toMatch(/`droid` is current/);
+    // The session id still reached the client, so the thread can resume rather
+    // than orphaning the session droid just created.
+    expect(recorder.events.some((e) => e.type === "session.started")).toBe(true);
   });
 
   it("surfaces a permission ask as request.opened and completes once allowed", async () => {
@@ -207,6 +296,126 @@ describe("ACP snapshot", () => {
       mkdirSync(join(kimiHome, "credentials"), { recursive: true });
       writeFileSync(join(kimiHome, "credentials", "kimi-code.json"), "{}");
       expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("droid resolves the signed-in CLI before falling back to FACTORY_API_KEY", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-droid-auth-"));
+    // FACTORY_HOME_OVERRIDE replaces the CLI's HOME, not its data root: droid
+    // writes <home>/.factory/auth.v2.file either way (verified against 0.196.0).
+    const overrideHome = join(scratch, "custom-home");
+    const childHome = join(scratch, "child-home");
+    mkdirSync(join(childHome, ".factory"), { recursive: true });
+    writeFileSync(join(childHome, ".factory", "auth.v2.file"), "{}");
+
+    // The child env inherits process.env (core.ts childEnv), so a developer
+    // machine with a real FACTORY_API_KEY exported would otherwise satisfy
+    // every case here and prove nothing about the on-disk lookup.
+    const make = (environment: Record<string, string>) =>
+      DroidAgentDriver.create({
+        instanceId: "droid-auth",
+        displayName: undefined,
+        environment: { FACTORY_API_KEY: "", ...environment },
+        enabled: true,
+        config: { cli: FAKE_CLI, fullAuto: false },
+      });
+
+    const instances: ProviderInstance[] = [];
+    try {
+      // FACTORY_HOME_OVERRIDE wins: the child HOME's credential must not count.
+      const overridden = await make({ FACTORY_HOME_OVERRIDE: overrideHome, HOME: childHome });
+      instances.push(overridden);
+      expect((await overridden.snapshot()).authenticated).toBe(false);
+      mkdirSync(join(overrideHome, ".factory"), { recursive: true });
+      writeFileSync(join(overrideHome, ".factory", "auth.v2.file"), "{}");
+      expect((await overridden.snapshot()).authenticated).toBe(true);
+
+      // A logged-out override is not rescued by a key on the way past it, but
+      // the key alone still authenticates when nothing is signed in on disk.
+      const loggedOutWithKey = await make({
+        FACTORY_HOME_OVERRIDE: join(scratch, "empty-home"),
+        HOME: childHome,
+        FACTORY_API_KEY: "fk-test",
+      });
+      instances.push(loggedOutWithKey);
+      expect((await loggedOutWithKey.snapshot()).authenticated).toBe(true);
+
+      const fromHome = await make({ HOME: childHome });
+      instances.push(fromHome);
+      expect((await fromHome.snapshot()).authenticated).toBe(true);
+
+      // secure_auth_storage writes the keychain/keyring variant instead of
+      // auth.v2.file, so a fresh macOS login has only this one.
+      const keychainHome = join(scratch, "keychain-home");
+      mkdirSync(join(keychainHome, ".factory"), { recursive: true });
+      writeFileSync(join(keychainHome, ".factory", "auth.v2.loginkeychain"), "{}");
+      const fromKeychain = await make({ HOME: keychainHome });
+      instances.push(fromKeychain);
+      expect((await fromKeychain.snapshot()).authenticated).toBe(true);
+
+      const neither = await make({ HOME: join(scratch, "empty") });
+      instances.push(neither);
+      expect((await neither.snapshot()).authenticated).toBe(false);
+    } finally {
+      for (const i of instances) await i.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("droid reads custom models, favourites order, and the configured default", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-droid-models-"));
+    mkdirSync(join(scratch, ".factory"), { recursive: true });
+    writeFileSync(
+      join(scratch, ".factory", "settings.json"),
+      JSON.stringify({
+        customModels: [
+          { id: "custom:LMStudio-Qwen-0", displayName: "Qwen (local)" },
+          { id: "custom:Azure-Opus-0", displayName: "Azure Opus" },
+        ],
+        modelFavorites: ["custom:Azure-Opus-0", "custom:LMStudio-Qwen-0"],
+        sessionDefaultSettings: { model: "custom:LMStudio-Qwen-0" },
+      }),
+    );
+
+    const instance = await DroidAgentDriver.create({
+      instanceId: "droid-models",
+      displayName: undefined,
+      environment: { HOME: scratch },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      // favourites first in the user's own order, then the built-in slice
+      expect(instance.models.options.slice(0, 2)).toEqual([
+        { id: "custom:Azure-Opus-0", label: "Azure Opus" },
+        { id: "custom:LMStudio-Qwen-0", label: "Qwen (local)" },
+      ]);
+      expect(instance.models.options.some((o) => o.id === "claude-opus-5")).toBe(true);
+      expect(instance.models.default).toBe("custom:LMStudio-Qwen-0");
+    } finally {
+      await instance.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("droid falls back to the built-in catalog when settings.json is unreadable", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-droid-nosettings-"));
+    mkdirSync(join(scratch, ".factory"), { recursive: true });
+    writeFileSync(join(scratch, ".factory", "settings.json"), "{ not json");
+
+    const instance = await DroidAgentDriver.create({
+      instanceId: "droid-models-fallback",
+      displayName: undefined,
+      environment: { HOME: scratch },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect(instance.models.default).toBe("claude-opus-5");
+      expect(instance.models.options.every((o) => !o.id.startsWith("custom:"))).toBe(true);
     } finally {
       await instance.dispose();
       rmSync(scratch, { recursive: true, force: true });

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -74,11 +74,26 @@ export interface AcpSupport {
   authFailure: "fail" | "continue";
   /** snapshot(): is the CLI signed in? (env already carries the merged config) */
   isAuthenticated(env: Record<string, string | undefined>): boolean;
+  /** Per-instance model catalog, for CLIs whose real catalog is user-local
+   * (custom providers, favourites) rather than a fixed vendor list. Falls
+   * back to the static `models` when absent or when it throws. */
+  resolveModels?(env: Record<string, string | undefined>): AcpSupport["models"];
   /** Compose the session/prompt text. Default prepends the persona. */
   buildPromptText?(turn: SendTurnInput): string;
+  /** Apply per-session settings between session/new (or session/load) and the
+   * first session/prompt. Some CLIs ignore argv and take the model/mode over
+   * the wire instead (droid), so this is the only place the pick can land; a
+   * throw here fails the turn rather than silently running another model. */
+  configureSession?(ctx: {
+    request: (method: string, params: unknown, timeoutMs?: number) => Promise<any>;
+    sessionId: string;
+    config: AcpConfig;
+    turn: SendTurnInput;
+  }): Promise<void>;
 }
 
 const INIT_TIMEOUT = 20_000;
+const SESSION_CONFIG_TIMEOUT = 20_000; // configureSession's per-request default
 const NEW_SESSION_TIMEOUT = 30_000;
 const LOAD_SESSION_TIMEOUT = 120_000; // history replay on a long thread is slow
 
@@ -138,6 +153,18 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         };
         support.transformEnv?.(env);
         return env;
+      };
+
+      // A user-local catalog must never be able to break the picker: any
+      // failure reading it falls back to the driver's static list.
+      const instanceModels = () => {
+        if (!support.resolveModels) return support.models;
+        try {
+          const resolved = support.resolveModels(childEnv());
+          return resolved.options.length ? resolved : support.models;
+        } catch {
+          return support.models;
+        }
       };
 
       // ACP session mcpServers: stdio is the baseline every ACP agent
@@ -452,12 +479,25 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
               sessionId = typeof started?.sessionId === "string" ? started.sessionId : null;
               if (!sessionId) throw new Error("session/new returned no sessionId");
             }
+            // Emit BEFORE configureSession: session.started is the only place
+            // the resume cursor is recorded, so a hook that rejects (or an
+            // interrupt landing mid-config) must not strand the session that
+            // was just created — the next turn would start a fresh one and
+            // lose the thread's history.
             emit({
               ...base(threadId, turnId),
               type: "session.started",
               sessionId,
               model: init?._meta?.modelState?.currentModelId ?? turn.model ?? null,
             });
+            if (support.configureSession) {
+              await support.configureSession({
+                request: (method, params, timeoutMs) => request(method, params, timeoutMs ?? SESSION_CONFIG_TIMEOUT),
+                sessionId,
+                config,
+                turn,
+              });
+            }
             state.promptSent = true;
             const text = support.buildPromptText
               ? support.buildPromptText(turn)
@@ -518,7 +558,9 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         driverKind: DRIVER_KIND,
         displayName: input.displayName,
         enabled: input.enabled,
-        models: support.models,
+        // Read once per instance: the picker reads this synchronously, and a
+        // user-local catalog changes about as often as the CLI is reinstalled.
+        models: instanceModels(),
         snapshot,
         adapter: {
           provider: DRIVER_KIND,

--- a/server/drivers/acp/droid.ts
+++ b/server/drivers/acp/droid.ts
@@ -1,0 +1,176 @@
+// Factory Droid harness support — the `droid` CLI over ACP stdio
+// (`droid exec -o acp`), on the Factory login (~/.factory/auth.v2.file) or a
+// FACTORY_API_KEY. The generic protocol runtime lives in acp/core.ts; this
+// file is only the per-harness quirks. Verified against droid 0.196.0:
+// initialize reports protocolVersion 1, loadSession:true (session/load resume
+// works), promptCapabilities image+embeddedContext, and authMethods
+// device-pairing + factory-api-key.
+//
+// UNLIKE every other ACP harness here, droid ignores argv for session
+// settings. `droid exec --help` says so under "Stream JSON-RPC Mode": "CLI
+// flags do not configure JSON-RPC sessions: -m/--model, --auto,
+// -r/--reasoning-effort, and --disable-builtin-skills are still validated,
+// but session settings come from JSON-RPC requests." So a `-m` that only
+// reaches argv is accepted and then ignored, and the session runs whatever
+// ~/.factory/settings.json selected. Model and autonomy are session config
+// options set over the wire (session/set_model, session/set_mode), which is
+// why both live in configureSession() below and NOT in spawnArgs.
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+
+// FACTORY_HOME_OVERRIDE replaces the HOME the CLI resolves, NOT the data root:
+// droid builds every path as <home>/.factory/… (verified against 0.196.0 —
+// `FACTORY_HOME_OVERRIDE=/tmp/x droid exec -o acp` created /tmp/x/.factory/).
+// Kimi's KIMI_CODE_HOME is a data root; this one is not, so the `.factory`
+// segment stays on both branches.
+//
+// Which credential file exists depends on the `secure_auth_storage` feature
+// flag droid fetches for the account: with secure storage on it writes
+// auth.v2.loginkeychain (macOS) or auth.v2.keyring (keytar), and only falls
+// back to auth.v2.file when that write fails. droid's own check tries all of
+// them, so checking one name alone reports a fresh signed-in login as logged
+// out. Names read from the 0.196.0 binary.
+const AUTH_FILES = ["auth.v2.file", "auth.v2.loginkeychain", "auth.v2.keyring"];
+
+function authFilePaths(env: Record<string, string | undefined>) {
+  const home = env.FACTORY_HOME_OVERRIDE || env.HOME || homedir();
+  return AUTH_FILES.map((name) => join(home, ".factory", name));
+}
+
+// droid's real catalog is half user-local: `custom:` providers (Azure, a
+// local LM Studio server, …) live in ~/.factory/settings.json, the user
+// orders the picker with modelFavorites, and sessionDefaultSettings.model is
+// the model the CLI itself starts on. None of that can be enumerated from a
+// static list, so read it and fall back to the built-in slice if unreadable.
+interface FactorySettings {
+  customModels?: Array<{ id?: string; displayName?: string }>;
+  modelFavorites?: string[];
+  sessionDefaultSettings?: { model?: string };
+}
+
+function readSettings(env: Record<string, string | undefined>): FactorySettings {
+  const home = env.FACTORY_HOME_OVERRIDE || env.HOME || homedir();
+  return JSON.parse(readFileSync(join(home, ".factory", "settings.json"), "utf8")) as FactorySettings;
+}
+
+function resolveModels(env: Record<string, string | undefined>) {
+  let settings: FactorySettings;
+  try {
+    settings = readSettings(env);
+  } catch {
+    return MODELS; // no settings file yet, or unreadable: ship the built-ins
+  }
+
+  const custom = (settings.customModels ?? []).flatMap((m) =>
+    m.id ? [{ id: m.id, label: m.displayName || m.id }] : [],
+  );
+  const merged = [...custom, ...MODELS.options.filter((o) => !custom.some((c) => c.id === o.id))];
+
+  // Favourites first, in the user's own order; everything else keeps its
+  // existing order (Array.prototype.sort is stable).
+  const rank = new Map((settings.modelFavorites ?? []).map((id, i) => [id, i]));
+  const options = merged.sort((a, b) => (rank.get(a.id) ?? Infinity) - (rank.get(b.id) ?? Infinity));
+
+  const configured = settings.sessionDefaultSettings?.model;
+  const fallback = options[0]?.id ?? MODELS.default;
+  return { default: configured && options.some((o) => o.id === configured) ? configured : fallback, options };
+}
+
+// droid answers a rejected setting with a bare JSON-RPC message ("Model not
+// recognized", "Method not found") that reaches the error card verbatim,
+// naming neither the engine nor the setting that failed. Say what we asked for.
+async function applySetting(
+  request: (method: string, params: unknown, timeoutMs?: number) => Promise<any>,
+  method: string,
+  params: Record<string, unknown>,
+  what: string,
+) {
+  try {
+    await request(method, params);
+  } catch (e) {
+    throw new Error(
+      `Droid rejected ${what} via ${method}: ${(e as Error).message}. ` +
+        `Check that \`droid\` is current (0.196.0+ supports it) and that this account can use that value.`,
+    );
+  }
+}
+
+// Autonomy maps onto droid's session modes (session/new advertises
+// normal | spec | auto-low | auto-medium | auto-high). Always set it
+// explicitly: ~/.factory/settings.json can pin a mode, and inheriting it
+// would either make every session yolo or make fullAuto silently ask.
+const MODE_DEFAULT = "normal"; // auto-approves reads only; everything else asks
+const MODE_FULL_AUTO = "auto-high";
+
+// A curated slice of `droid exec -m <bogus>`'s built-in catalog (0.196.0 lists
+// 43). Custom models from ~/.factory/settings.json are per-machine and carry a
+// `custom:` prefix, so they can't be enumerated statically; a bot can still be
+// switched onto one through the model picker (PATCH /api/bots/:id).
+const MODELS = {
+  default: "claude-opus-5",
+  options: [
+    { id: "auto", label: "Auto (Factory picks)" },
+    { id: "claude-opus-5", label: "Claude Opus 5" },
+    { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+    { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+    { id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+    { id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+    { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro" },
+    { id: "glm-5.2", label: "GLM 5.2" },
+    { id: "kimi-k3", label: "Kimi K3" },
+    { id: "grok-4.6", label: "Grok 4.6" },
+  ],
+};
+
+const support: AcpSupport = {
+  driverKind: "droidAgent",
+  displayName: "Droid",
+  models: MODELS,
+  defaultCli: "droid",
+  nativeSource: "droid.acp",
+  loginNote: "Droid CLI is not signed in — run `droid` once and log in, or set FACTORY_API_KEY",
+
+  install: {
+    command: {
+      darwin: "curl -fsSL https://app.factory.ai/cli | sh",
+      linux: "curl -fsSL https://app.factory.ai/cli | sh",
+      win32: "irm https://app.factory.ai/cli/windows | iex",
+    },
+    docsUrl: "https://docs.factory.ai/droid-cli/quickstart",
+    signInCommand: "droid",
+  },
+
+  // No model/mode flags here on purpose: see the header note. `-o acp` is the
+  // ACP entry point; everything else is negotiated over the protocol.
+  spawnArgs: () => ["exec", "-o", "acp"],
+
+  // The advertised methods are device-pairing (a browser flow that cannot be
+  // driven over ACP) and factory-api-key (read from the child env, no
+  // authenticate call needed). Ride the ambient login instead, like Kimi.
+  pickAuthMethod: () => null,
+  authFailure: "continue",
+  // The signed-in CLI is the primary source; FACTORY_API_KEY is the fallback
+  // droid itself advertises, and it is checked last so an ambient key can
+  // never be what makes an otherwise logged-out instance look ready.
+  isAuthenticated: (env) => authFilePaths(env).some(existsSync) || Boolean(env.FACTORY_API_KEY),
+  resolveModels,
+
+  async configureSession({ request, sessionId, config, turn }) {
+    const modeId = config.fullAuto ? MODE_FULL_AUTO : MODE_DEFAULT;
+    await applySetting(request, "session/set_mode", { sessionId, modeId }, `autonomy mode "${modeId}"`);
+    // Pin the model for the same reason as the mode: with no set_model the
+    // session runs whatever ~/.factory/settings.json selected, which can be a
+    // `custom:` provider pointing at its own endpoint and key.
+    const modelId = turn.model || MODELS.default;
+    await applySetting(request, "session/set_model", { sessionId, modelId }, `model "${modelId}"`);
+  },
+
+  // House convention for ACP harnesses (grok, gemini, kimi all do this): the
+  // persona rides in the prompt text rather than a CLI system-prompt flag.
+  buildPromptText: (turn) => (turn.system ? `${turn.system}\n\n${turn.text}` : turn.text),
+};
+
+export const DroidAgentDriver = createAcpDriver(support);

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -9,12 +9,14 @@ import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
 import { KimiAgentDriver } from "./acp/kimi.ts";
+import { DroidAgentDriver } from "./acp/droid.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
   GrokAgentDriver,
   GeminiAgentDriver,
   KimiAgentDriver,
+  DroidAgentDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -61,6 +61,7 @@ function windowsKnownDirs(): string[] {
     join(localAppData, "agy", "bin"), // Antigravity installer
     join(home, ".local", "bin"), // claude native installer
     join(home, ".claude", "local"),
+    join(home, "bin"), // Factory droid installer (%USERPROFILE%\bin)
     join(home, ".bun", "bin"),
     join(home, ".deno", "bin"),
     join(home, "go", "bin"),

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -6,6 +6,8 @@
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
 //   FAKE_ACP_MODE   happy (default) | exit-early | hang | no-auth | permission
+//                   | no-session-config (reject session/set_mode + set_model
+//                     with -32601, i.e. an agent predating those methods)
 //                   | ask-peer (spawn the injected "agents" MCP server from
 //                     session/new's mcpServers, call list_bots + ask_bot on a
 //                     peer, and reply with what the peer said — the comms e2e)
@@ -28,6 +30,9 @@ if (process.env.FAKE_ACP_DUMP) {
 
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
 const result = (id: unknown, res: unknown) => out({ jsonrpc: "2.0", id, result: res });
+
+// session/set_mode + session/set_model calls seen this run
+const configCalls: Array<{ method: string; params: unknown }> = [];
 
 // pending server→client permission request id → resolver
 let pendingPermissionId: number | null = null;
@@ -142,6 +147,23 @@ function handle(msg: any) {
     case "session/load":
       result(msg.id, {});
       break;
+    // per-session settings (droid sets model/autonomy here, not via argv).
+    // Recorded next to FAKE_ACP_DUMP so a test can assert what was applied.
+    // NOTE: last writer wins — each turn spawns a fresh child, so a two-turn
+    // test would only ever see the final turn's calls.
+    case "session/set_mode":
+    case "session/set_model": {
+      if (mode === "no-session-config") {
+        // an older agent that predates these methods
+        return out({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "method not found" } });
+      }
+      configCalls.push({ method: msg.method, params: msg.params });
+      if (process.env.FAKE_ACP_DUMP) {
+        writeFileSync(`${process.env.FAKE_ACP_DUMP}.config.json`, JSON.stringify(configCalls, null, 2));
+      }
+      result(msg.id, {});
+      break;
+    }
     case "session/prompt": {
       if (mode === "hang") {
         // never resolve the prompt — lets tests exercise interrupt

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -188,6 +188,15 @@ function handle(msg: any) {
         // an older agent that predates these methods
         return out({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "method not found" } });
       }
+      const settingId = msg.method === "session/set_mode" ? "modeId" : "modelId";
+      if (typeof msg.params?.sessionId !== "string" || typeof msg.params?.[settingId] !== "string") {
+        out({
+          jsonrpc: "2.0",
+          id: msg.id,
+          error: { code: -32602, message: `Invalid params: sessionId and ${settingId} must be strings` },
+        });
+        break;
+      }
       configCalls.push({ method: msg.method, params: msg.params });
       if (process.env.FAKE_ACP_DUMP) {
         writeFileSync(`${process.env.FAKE_ACP_DUMP}.config.json`, JSON.stringify(configCalls, null, 2));


### PR DESCRIPTION
## What changed

Adds Factory Droid as an engine: `server/drivers/acp/droid.ts` (`droidAgent`, over
`droid exec -o acp`), the registration in `builtIn.ts`, and a default-instance entry
in `config.ts`, matching how Kimi landed in #98.

Two optional hooks on `AcpSupport` in `acp/core.ts`, both no-ops for the existing
harnesses:

- `configureSession()` runs between `session/new` (or `session/load`) and the first
  `session/prompt`.
- `resolveModels()` supplies a per-instance model catalog, falling back to the
  driver's static list if it is absent or throws.

`windowsKnownDirs()` in `env-path.ts` gains `~/bin`, which is where the Windows
installer puts `droid.exe`.

## Why

Droid is the one ACP harness here that does not take session settings from argv.
`droid exec --help` says so under "Stream JSON-RPC Mode": *"CLI flags do not
configure JSON-RPC sessions: -m/--model, --auto, -r/--reasoning-effort ... are
still validated, but session settings come from JSON-RPC requests."* Confirmed
against 0.196.0: `droid exec -m claude-haiku-4-5-20251001 --auto high -o acp` still
reported `currentModelId` and `currentModeId` from the CLI's own config. So a model
that only reaches `spawnArgs` is accepted and then ignored, and the turn silently
runs whatever `~/.factory/settings.json` selected. `configureSession()` is the only
place the pick can land; a rejected setting fails the turn rather than quietly
running something else, with a message naming the engine, the setting and the
method. Autonomy is set the same way, and both are always explicit so a mode or
model pinned in settings.json can neither make a session yolo nor make `fullAuto`
ask.

`resolveModels()` exists because droid's catalog is half user-local: `custom:`
providers (Azure, a local LM Studio server, ...), `modelFavorites` ordering, and
`sessionDefaultSettings.model` all live in `settings.json`, and none of it can be
enumerated statically. Without it the picker shows a list that does not match what
`droid` itself offers.

Sign-in detection checks all three credential filenames droid can write
(`auth.v2.file`, `auth.v2.loginkeychain`, `auth.v2.keyring`): which one exists
depends on the account's `secure_auth_storage` flag, so checking only the first
reports a freshly signed-in macOS user as signed out. `FACTORY_HOME_OVERRIDE`
replaces the CLI's HOME, not its data root, so the `.factory` segment is kept on
both branches (verified: `FACTORY_HOME_OVERRIDE=/tmp/x` produces
`/tmp/x/.factory/`).

## How it was verified

`pnpm typecheck`, `pnpm test` (35 files, 295 passed / 8 skipped) and
`pnpm check:electron` green on macOS 15 (Apple silicon), against droid 0.196.0.

Against the real CLI:

- `initialize`: protocolVersion 1, `loadSession: true`, promptCapabilities
  image + embeddedContext, authMethods `device-pairing` + `factory-api-key`
- `session/new` advertises modes `normal | spec | auto-low | auto-medium |
  auto-high`; `normal` is "Auto-approves only read operations", `auto-high` is
  "Auto-approves all actions"
- `session/set_mode` and `session/set_model` both accepted; unknown values return
  `-32602` ("Invalid autonomy mode", "Model not recognized"), which is the failure
  the driver wraps
- A full turn in `normal` mode against a local provider: droid raised
  `session/request_permission` for a file write with `allow_once` /
  `allow_always` / `reject_once`, rejecting it left the file uncreated, and the
  turn settled `end_turn`
- Install one-liners fetched: the POSIX script is `#!/usr/bin/env sh` and installs
  to `~/.local/bin` (already covered by `knownDirs()`); the Windows PowerShell
  installer writes `droid.exe` to `%USERPROFILE%\bin`, hence the `env-path.ts` line
- `~/.factory/settings.json` is byte-identical after every `set_mode`/`set_model`,
  so these are session-scoped and do not rewrite the user's CLI config

New tests cover argv hygiene (no `-m` in argv, exactly `["exec","-o","acp"]`), the
mode/model calls landing over the wire in both `fullAuto` states, the wrapped error
when an agent predates the methods (a new `no-session-config` mode in the scripted
fake CLI), credential resolution across `FACTORY_HOME_OVERRIDE` / child `HOME` /
`FACTORY_API_KEY` / the keychain filename, and catalog resolution plus its fallback.

## Screenshots (UI changes)

None; no UI changes in this PR. Droid does not get an Onboarding row, matching Kimi
today. Happy to add rows for both if you want that step to cover every default-fleet
engine, or to make it render from `instances` instead, but that felt like a separate
concern from adding the driver.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md, Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

## Notes

`FACTORY_API_KEY` is left in the child environment rather than stripped the way
`grok.ts` and `kimi.ts` strip their vendor keys, because droid advertises it as an
auth method and an API-key-only user has no other route. It is checked last in
`isAuthenticated`, so an ambient key can never be the thing that makes a
logged-out instance look ready. Say the word if you would rather it be stripped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Factory Droid as a built-in agent.
  - Droid supports authentication through API keys or local credentials.
  - Added configurable model selection and autonomy settings.
  - Added cross-platform installation detection, including Windows executable paths.
  - Droid now applies model and autonomy settings during session setup.

- **Bug Fixes**
  - Improved fallback handling when model settings are unavailable or unreadable.
  - Added clearer errors for unsupported or incompatible session configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->