### PR TITLE
feat: add DeepSeek Harness driver (drive bots with dsh ACP)

### DIFF
--- a/docs/deepseek-harness.md
+++ b/docs/deepseek-harness.md
@@ -1,0 +1,86 @@
+# DeepSeek Harness driver
+
+OpenMausBot can drive DeepSeek models through
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`)
+instead of the claude/codex/grok CLIs. Each bot is backed by a real DeepSeek
+agent (e.g. `deepseek-v4-pro`), using the same `DEEPSEEK_API_KEY` that
+`dsh web` already reads from `~/.dsh/.credentials.yaml` — no new account or
+login.
+
+## How it works
+
+DeepSeek Harness ships an automation-only
+[Agent Client Protocol](https://agentclientprotocol.com) server
+(`@deepseek-ai/dsh-acp`) over JSON-RPC stdio. The `deepseek` driver rides
+OpenMausBot's generic ACP runtime (`server/drivers/acp/core.ts`); its "CLI" is
+the bundled `deepseek-acp` launcher, which:
+
+1. reads `DEEPSEEK_API_KEY` from `~/.dsh/.credentials.yaml` (or the environment),
+2. boots a built `dsh` checkout's ACP server
+   (`packages/examples/acp-demo/lib/bin.js --config examples/acp-agent/cordis.yml`),
+3. forwards stdio so the ACP JSON-RPC stream reaches the driver unchanged.
+
+```
+bot message → OpenMausBot → deepseek driver → deepseek-acp → dsh ACP server → DeepSeek model
+```
+
+## Prerequisites
+
+- a **built** DeepSeek Harness checkout (`pnpm install && pnpm run build`),
+  pointed at by `DSH_HOME`;
+- `DEEPSEEK_API_KEY` in `~/.dsh/.credentials.yaml` (the same file `dsh web`
+  uses) or in the environment;
+- Node 24+ (the OpenMausBot baseline).
+
+## Configuration
+
+Add a DeepSeek instance to `~/.openmausbot/config.json`:
+
+```json
+{
+  "instances": {
+    "deepseek": {
+      "driver": "deepseek",
+      "config": {
+        "cli": "<repo>/server/drivers/acp/deepseek-acp.mjs",
+        "workspace": "/absolute/path/to/agent/cwd"
+      },
+      "environment": {
+        "DSH_HOME": "/path/to/deepseek-harness"
+      }
+    }
+  }
+}
+```
+
+- `cli` — the launcher path (defaults to `deepseek-acp` on `PATH`).
+- `workspace` — the agent's working directory; must be absolute. The `dsh`
+  agent's bash and filesystem tools are sandboxed to this directory.
+- `DSH_HOME` — the built checkout; defaults to `~/deepseek-harness`.
+
+## Models
+
+`deepseek-v4-pro` (default) and `deepseek-v4-flash`. A non-default model is
+applied by deriving a config with the `model:` line swapped. The derived
+config is written under the checkout's `examples/acp-agent/` (not `/tmp`)
+because `dsh`'s pnpm layout resolves the `@deepseek-ai/*` workspace packages
+relative to the config file's directory, not the process cwd.
+
+## Conversation history
+
+`dsh`'s ACP server has no `session/load` — every turn is a fresh agent
+session. The driver therefore replays the settled transcript inline (the same
+shape as the `grok` API driver), so a bot remembers its conversation without
+provider-side resume. The harness routes rewinds through that same
+transcript-replay path for `deepseek`.
+
+## Limitations
+
+- **No computer / connected-app tooling.** The driver advertises
+  `computerMcp`/`agentsMcp` as off because `dsh`'s ACP server rejects
+  non-empty `mcpServers`; the UI must never promise tooling the agent cannot
+  mount. Chat works fully.
+- **Committed answers.** `dsh` streams committed assistant message blocks
+  rather than token-level deltas, so replies arrive at message granularity.
+- **Model fixed at boot.** The ACP server resolves the model from its config;
+  switching a bot's model restarts the ACP server for that turn.

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -76,6 +76,11 @@ export interface AcpSupport {
   isAuthenticated(env: Record<string, string | undefined>): boolean;
   /** Compose the session/prompt text. Default prepends the persona. */
   buildPromptText?(turn: SendTurnInput): string;
+  /** Adapter capabilities override. The generic default advertises
+   * agentsMcp/computerMcp; a harness whose ACP server rejects non-empty
+   * mcpServers (DSH) must turn both off so the UI never promises tooling the
+   * agent cannot actually mount. */
+  capabilities?: { agentsMcp?: boolean; computerMcp?: boolean };
 }
 
 const INIT_TIMEOUT = 20_000;
@@ -522,7 +527,11 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         snapshot,
         adapter: {
           provider: DRIVER_KIND,
-          capabilities: { sessionModelSwitch: "unsupported", agentsMcp: true, computerMcp: true },
+          capabilities: {
+            sessionModelSwitch: "unsupported",
+            agentsMcp: support.capabilities?.agentsMcp ?? true,
+            computerMcp: support.capabilities?.computerMcp ?? true,
+          },
           sendTurn,
           interruptTurn: async (threadId) => active.get(threadId)?.interrupt(),
           respondToRequest: async (threadId, requestId, decision) => {

--- a/server/drivers/acp/deepseek-acp.mjs
+++ b/server/drivers/acp/deepseek-acp.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// DeepSeek Harness ACP launcher for OpenMausBot.
+//
+// Boots DeepSeek Harness's automation ACP server (Agent Client Protocol over
+// JSON-RPC stdio) and forwards stdio + exit status, so the OpenMausBot
+// `deepseek` driver can drive DeepSeek agents exactly like the claude/codex/
+// grok CLIs.
+//
+//   --version   print one version line and exit (driver snapshot detection)
+//   --model id  override the ACP agent model (default: deepseek-v4-pro)
+//
+// DEEPSEEK_API_KEY is read from the process environment, or from
+// ~/.dsh/.credentials.yaml (the same file `dsh web` uses) when absent.
+// DSH_HOME points at a built deepseek-harness checkout (defaults to
+// ~/deepseek-harness).
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const VERSION = "deepseek-harness-acp 0.1.0-rc.5";
+const DSH_HOME = process.env.DSH_HOME || join(homedir(), "deepseek-harness");
+const DEFAULT_MODEL = "deepseek-v4-pro";
+
+const args = process.argv.slice(2);
+if (args.includes("--version")) {
+  console.log(VERSION);
+  process.exit(0);
+}
+
+let model = DEFAULT_MODEL;
+const mi = args.indexOf("--model");
+if (mi !== -1 && args[mi + 1]) model = args[mi + 1];
+
+if (!process.env.DEEPSEEK_API_KEY) {
+  const cred = join(homedir(), ".dsh", ".credentials.yaml");
+  if (existsSync(cred)) {
+    try {
+      const m = readFileSync(cred, "utf8").match(/^\s*DEEPSEEK_API_KEY:\s*(.+?)\s*$/m);
+      if (m) process.env.DEEPSEEK_API_KEY = m[1].replace(/^["']|["']$/g, "");
+    } catch {
+      /* unreadable credentials file — leave the key unset and let dsh fail loud */
+    }
+  }
+}
+
+const acpBin = join(DSH_HOME, "packages", "examples", "acp-demo", "lib", "bin.js");
+const stockConfig = join(DSH_HOME, "examples", "acp-agent", "cordis.yml");
+
+// The stock acp-agent config hardcodes `model: deepseek-v4-pro`. A different
+// model needs a derived config with that one line swapped. It MUST live under
+// examples/acp-agent/ — DSH's pnpm layout links the @deepseek-ai workspace
+// packages under examples/node_modules, and the Loader resolves those from the
+// config file's directory, not the process cwd.
+let configPath = stockConfig;
+if (model && model !== DEFAULT_MODEL) {
+  const safeModel = model.replace(/[^a-zA-Z0-9._-]/g, "-");
+  const yml = readFileSync(stockConfig, "utf8").replace(
+    /^(\s*model:)\s*deepseek-v4-pro\s*$/m,
+    `$1 ${model}`,
+  );
+  configPath = join(DSH_HOME, "examples", "acp-agent", `cordis.openmausbot-${safeModel}.yml`);
+  writeFileSync(configPath, yml);
+}
+
+const child = spawn(process.execPath, [acpBin, "--config", configPath], {
+  cwd: DSH_HOME,
+  env: process.env,
+  stdio: "inherit",
+});
+child.on("exit", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
+child.on("error", (err) => {
+  process.stderr.write(`deepseek-acp: ${err.message}\n`);
+  process.exit(1);
+});

--- a/server/drivers/acp/deepseek.ts
+++ b/server/drivers/acp/deepseek.ts
@@ -1,0 +1,89 @@
+// DeepSeek Harness support — drives DeepSeek agents through the DeepSeek
+// Harness (dsh) automation ACP server (Agent Client Protocol over JSON-RPC
+// stdio). Unlike the CLI-based drivers, the "CLI" is the deepseek-acp
+// launcher, which boots a built dsh checkout's ACP server and reads
+// DEEPSEEK_API_KEY from ~/.dsh/.credentials.yaml (the same file `dsh web`
+// uses) — no claude/codex/grok binary or login.
+//
+// The instance config points the driver at the launcher and checkout:
+//   { "instances": { "deepseek": {
+//       "driver": "deepseek",
+//       "config": { "cli": "<repo>/server/drivers/acp/deepseek-acp.mjs",
+//                   "workspace": "<agent cwd>" },
+//       "environment": { "DSH_HOME": "<built dsh checkout>" } } } }
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+
+function dshCredentialsPath(): string {
+  return join(homedir(), ".dsh", ".credentials.yaml");
+}
+
+function hasCredentials(env: Record<string, string | undefined>): boolean {
+  if (env.DEEPSEEK_API_KEY) return true;
+  try {
+    return (
+      existsSync(dshCredentialsPath()) &&
+      /^\s*DEEPSEEK_API_KEY:\s*\S/m.test(readFileSync(dshCredentialsPath(), "utf8"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+const support: AcpSupport = {
+  driverKind: "deepseek",
+  displayName: "DeepSeek",
+  models: {
+    default: "deepseek-v4-pro",
+    options: [
+      { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+      { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+    ],
+  },
+  defaultCli: "deepseek-acp",
+  nativeSource: "deepseek.acp",
+  loginNote:
+    "DeepSeek Harness isn't configured — set DEEPSEEK_API_KEY in ~/.dsh/.credentials.yaml and DSH_HOME to a built dsh checkout",
+
+  install: {
+    command: {
+      darwin:
+        "git clone https://github.com/deepseek-ai/deepseek-harness.git ~/deepseek-harness && cd ~/deepseek-harness && pnpm install && pnpm run build",
+      linux:
+        "git clone https://github.com/deepseek-ai/deepseek-harness.git ~/deepseek-harness && cd ~/deepseek-harness && pnpm install && pnpm run build",
+    },
+    docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
+    needsNode: true,
+  },
+
+  // The DSH ACP server advertises no auth methods; the key rides the
+  // launcher's environment, so auth is always ambient.
+  pickAuthMethod: () => null,
+  authFailure: "continue",
+  isAuthenticated: hasCredentials,
+
+  // DSH ACP rejects non-empty mcpServers (session/new accepts only empty
+  // additionalDirectories and mcpServers), so computer/agents tooling must
+  // not be advertised for this driver.
+  capabilities: { agentsMcp: false, computerMcp: false },
+
+  // dsh's ACP server has no session/load, so every turn is a fresh session.
+  // Replay the settled transcript inline (same shape as the grok API driver)
+  // instead of relying on provider-side resume.
+  buildPromptText: (turn) => {
+    const parts: string[] = [];
+    if (turn.system) parts.push(turn.system);
+    for (const m of turn.transcript ?? []) {
+      parts.push(`${m.role === "user" ? "User" : "Assistant"}: ${m.text}`);
+    }
+    parts.push(`User: ${turn.text}`);
+    return parts.join("\n\n");
+  },
+
+  spawnArgs: (_config, turn) => (turn.model ? ["--model", turn.model] : []),
+};
+
+export const DeepSeekDriver = createAcpDriver(support);

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -9,12 +9,14 @@ import { GrokDriver } from "./grok.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
 import { KimiAgentDriver } from "./acp/kimi.ts";
+import { DeepSeekDriver } from "./acp/deepseek.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
   GrokAgentDriver,
   GeminiAgentDriver,
   KimiAgentDriver,
+  DeepSeekDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,

--- a/server/index.ts
+++ b/server/index.ts
@@ -493,7 +493,7 @@ async function startTurn(
   // would cost the next attempt its history if this dispatch fails.
   const rewound = threadId === bot.threadId && Boolean(bot.rewound);
   const turnText =
-    rewound && instance.driverKind !== "grok" && transcript.length
+    rewound && instance.driverKind !== "grok" && instance.driverKind !== "deepseek" && transcript.length
       ? [
           "[The user rewound this conversation (edited a message or switched to another version). Everything before this point was replaced by the following history:]",
           "",


### PR DESCRIPTION
## What

Adds a `deepseek` provider so a bot can run on DeepSeek models
(`deepseek-v4-pro` / `deepseek-v4-flash`) through DeepSeek Harness's automation
[ACP](https://agentclientprotocol.com) server — no claude/codex/grok CLI or
login, just the `DEEPSEEK_API_KEY` that `dsh web` already reads from
`~/.dsh/.credentials.yaml`.

## Why

Lets OpenMausBot users who already run DeepSeek Harness point bots at it instead
of installing a separate agent CLI.

## How

- `server/drivers/acp/deepseek.ts` — driver over the existing generic ACP runtime.
- `server/drivers/acp/deepseek-acp.mjs` — launcher that reads the key and boots a
  built `dsh` checkout's ACP server (deriving a config for non-default models).
- `server/drivers/acp/core.ts` — lets a driver override the advertised
  `agentsMcp`/`computerMcp` capabilities (`dsh` ACP rejects non-empty `mcpServers`,
  so computer/agents tooling is off for this driver).
- `server/drivers/builtIn.ts` — registers the driver.
- `server/index.ts` — routes `deepseek` rewinds through transcript-replay like the
  grok API driver (`dsh` ACP has no `session/load`, so history is replayed inline).
- `docs/deepseek-harness.md` — integration doc.

## Verified

End-to-end against a live `dsh` checkout + DeepSeek API: streaming reply,
permission flow, and multi-turn memory (transcript replay) all work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek Harness as a built-in AI provider.
  * Supports DeepSeek V4 model selection, API-key discovery, transcript replay, and JSON-RPC communication.
  * Added setup and usage documentation, including prerequisites, configuration, supported models, and limitations.

* **Bug Fixes**
  * Prevented unsupported transcript history replay for DeepSeek sessions.
  * Correctly reflects DeepSeek’s unsupported MCP and model-switching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->