### PR TITLE
feat(acp): opt-in model selection through a session config option

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -40,6 +40,26 @@ const SELECT_MODEL_SUPPORT: AcpSupport = {
 };
 const SelectModelDriver = createAcpDriver(SELECT_MODEL_SUPPORT);
 
+/** Proves transformEnv can vary with the instance config, which is how the
+ *  opencode driver picks its permission policy from `fullAuto`. */
+const EnvPolicyDriver = createAcpDriver({
+  ...SELECT_MODEL_SUPPORT,
+  driverKind: "envPolicyTest",
+  selectModel: undefined,
+  transformEnv: (env, config) => {
+    env.TEST_POLICY = config.fullAuto ? "auto" : "ask";
+  },
+});
+
+/** Proves snapshot() awaits an async isAuthenticated, which is how the
+ *  opencode driver answers from a discovered catalog. */
+const AsyncAuthDriver = createAcpDriver({
+  ...SELECT_MODEL_SUPPORT,
+  driverKind: "asyncAuthTest",
+  selectModel: undefined,
+  isAuthenticated: async () => true,
+});
+
 describe("ACP decodeConfig", () => {
   it("grok defaults to the grok binary", () => {
     expect(GrokAgentDriver.decodeConfig({})).toEqual({ cli: "grok", fullAuto: false, workspace: undefined });
@@ -245,6 +265,24 @@ describe("ACP turns (fake CLI)", () => {
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: true });
   });
+
+  it("transformEnv sees the instance config", async () => {
+    const dump = join(scratch, "policy.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    instance = await EnvPolicyDriver.create({
+      instanceId: "policy-test",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    recorder = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "t-policy", text: "go" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(JSON.parse(readFileSync(dump, "utf8")).env.TEST_POLICY).toBe("auto");
+  });
 });
 
 describe("ACP snapshot", () => {
@@ -304,6 +342,22 @@ describe("ACP snapshot", () => {
     } finally {
       await instance.dispose();
       rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("awaits an async isAuthenticated", async () => {
+    const instance = await AsyncAuthDriver.create({
+      instanceId: "async-auth",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      // without the await this is a Promise: truthy, but not `true`
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
     }
   });
 });

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -15,11 +15,30 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../../config.ts";
 import type { ProviderInstance } from "../../contracts.ts";
 import { recordEvents, type EventRecorder } from "../../testing/events.ts";
+import { createAcpDriver, type AcpSupport } from "./core.ts";
 import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 import { KimiAgentDriver } from "./kimi.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
+
+/** A harness that exists only in tests: it exercises the opt-in session-config
+ *  model hook so PR 1 can prove the core capability without shipping a visible
+ *  engine. Real harnesses live in their own file. */
+const SELECT_MODEL_SUPPORT: AcpSupport = {
+  driverKind: "selectModelTest",
+  displayName: "Select Model Test",
+  models: { default: "m-one", options: [{ id: "m-one", label: "One" }, { id: "m-two", label: "Two" }] },
+  defaultCli: "fake-select-model",
+  nativeSource: "test.acp",
+  loginNote: "never reached",
+  selectModel: { configId: "model" },
+  spawnArgs: () => [],
+  pickAuthMethod: () => null,
+  authFailure: "continue",
+  isAuthenticated: () => true,
+};
+const SelectModelDriver = createAcpDriver(SELECT_MODEL_SUPPORT);
 
 describe("ACP decodeConfig", () => {
   it("grok defaults to the grok binary", () => {
@@ -70,6 +89,8 @@ describe("ACP turns (fake CLI)", () => {
     delete process.env.FAKE_ACP_MODE;
     delete process.env.FAKE_ACP_DUMP;
     delete process.env.XAI_API_KEY;
+    delete process.env.FAKE_ACP_MODELS;
+    delete process.env.FAKE_ACP_USAGE_ROOT;
     recorder?.stop();
     await instance?.dispose();
     rmSync(scratch, { recursive: true, force: true });
@@ -171,6 +192,17 @@ describe("ACP turns (fake CLI)", () => {
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: false });
     expect(recorder.events.some((e) => e.type === "runtime.error")).toBe(true);
+  });
+
+  it("selectModel confirms the requested model before prompting", async () => {
+    process.env.FAKE_ACP_MODELS = "m-one,m-two";
+    await create(SelectModelDriver);
+    await instance.adapter.sendTurn({ threadId: "t-model", text: "go", model: "m-two" });
+
+    const started = await recorder.until((e) => e.type === "session.started");
+    expect(started).toMatchObject({ model: "m-two" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true });
   });
 });
 

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -122,6 +122,16 @@ describe("ACP turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-happy")).toBe(false);
   });
 
+  it("reads token usage from the root of the prompt result", async () => {
+    process.env.FAKE_ACP_USAGE_ROOT = "1";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-usage-root", text: "go" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const usage = recorder.events.find((e) => e.type === "thread.token-usage.updated");
+    expect(usage).toMatchObject({ input: 10, output: 5 });
+  });
+
   it("passes ACP stdio flags and strips XAI_API_KEY from the child env", async () => {
     await create();
     const dump = join(scratch, "dump.json");

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -255,13 +255,16 @@ describe("ACP turns (fake CLI)", () => {
       threadId: "t-resume-model",
       text: "go",
       model: "m-two",
-      resumeCursor: "fake-acp-session",
+      // deliberately NOT "fake-acp-session", the id session/new returns: with
+      // that cursor a session/load that threw and fell back to session/new
+      // would emit the same sessionId and this test could not fail
+      resumeCursor: "resumed-thread-1",
     });
 
     // session/load feeds the same sessionResult as session/new, so the model
     // hook must fire on a resumed thread as well
     const started = await recorder.until((e) => e.type === "session.started");
-    expect(started).toMatchObject({ sessionId: "fake-acp-session", model: "m-two" });
+    expect(started).toMatchObject({ sessionId: "resumed-thread-1", model: "m-two" });
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: true });
   });

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -110,6 +110,7 @@ describe("ACP turns (fake CLI)", () => {
     delete process.env.FAKE_ACP_DUMP;
     delete process.env.XAI_API_KEY;
     delete process.env.FAKE_ACP_MODELS;
+    delete process.env.FAKE_ACP_MODEL_STICKS;
     delete process.env.FAKE_ACP_USAGE_ROOT;
     recorder?.stop();
     await instance?.dispose();
@@ -245,6 +246,24 @@ describe("ACP turns (fake CLI)", () => {
     const err = recorder.events.find((e) => e.type === "runtime.error")!;
     expect(err.message).toMatch(/model not found/);
     // nothing was generated: the prompt is never sent
+    expect(recorder.events.some((e) => e.type === "content.delta")).toBe(false);
+  });
+
+  // The unadvertised-model test above rides the fake's -32602, so it settles in
+  // `request()` and never reaches the guard. This one is the silent case the
+  // guard was written for: the agent acknowledges the switch and keeps its old
+  // model, which no error surfaces.
+  it("a model switch acknowledged but not applied fails the turn", async () => {
+    process.env.FAKE_ACP_MODELS = "m-one,m-two";
+    process.env.FAKE_ACP_MODEL_STICKS = "1";
+    await create(SelectModelDriver);
+    await instance.adapter.sendTurn({ threadId: "t-stuck-model", text: "go", model: "m-two" });
+
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: false });
+    const err = recorder.events.find((e) => e.type === "runtime.error")!;
+    expect(err.message).toMatch(/did not switch to m-two \(still m-one\)/);
+    // the whole point: no paid turn is spent on the wrong model
     expect(recorder.events.some((e) => e.type === "content.delta")).toBe(false);
   });
 

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -204,6 +204,37 @@ describe("ACP turns (fake CLI)", () => {
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: true });
   });
+
+  it("a model the session does not advertise fails the turn instead of running another", async () => {
+    process.env.FAKE_ACP_MODELS = "m-one,m-two";
+    await create(SelectModelDriver);
+    await instance.adapter.sendTurn({ threadId: "t-bad-model", text: "go", model: "m-nope" });
+
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: false });
+    const err = recorder.events.find((e) => e.type === "runtime.error")!;
+    expect(err.message).toMatch(/model not found/);
+    // nothing was generated: the prompt is never sent
+    expect(recorder.events.some((e) => e.type === "content.delta")).toBe(false);
+  });
+
+  it("selects the model on a resumed session too, not just a new one", async () => {
+    process.env.FAKE_ACP_MODELS = "m-one,m-two";
+    await create(SelectModelDriver);
+    await instance.adapter.sendTurn({
+      threadId: "t-resume-model",
+      text: "go",
+      model: "m-two",
+      resumeCursor: "fake-acp-session",
+    });
+
+    // session/load feeds the same sessionResult as session/new, so the model
+    // hook must fire on a resumed thread as well
+    const started = await recorder.until((e) => e.type === "session.started");
+    expect(started).toMatchObject({ sessionId: "fake-acp-session", model: "m-two" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true });
+  });
 });
 
 describe("ACP snapshot", () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -64,6 +64,11 @@ export interface AcpSupport {
   install?: EngineInstall;
   /** CLI argv AFTER the binary name to enter ACP stdio mode. */
   spawnArgs(config: AcpConfig, turn: SendTurnInput): string[];
+  /** Select the model through a session config option instead of argv, for
+   *  harnesses whose ACP subcommand takes no -m (opencode). The agent must
+   *  CONFIRM the requested model before we prompt: silently running a model
+   *  other than the one the picker shows is the failure this guards. */
+  selectModel?: { configId: string };
   /** Mutate the child env in place (e.g. strip a key). Optional. */
   transformEnv?(env: Record<string, string | undefined>): void;
   /** Pick the ACP authenticate methodId from initialize's advertised
@@ -439,24 +444,51 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             }
 
             const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
+            let sessionResult: any = null;
             if (cursor) {
               try {
-                await request("session/load", { sessionId: cursor, cwd, mcpServers }, LOAD_SESSION_TIMEOUT);
+                sessionResult = await request(
+                  "session/load",
+                  { sessionId: cursor, cwd, mcpServers },
+                  LOAD_SESSION_TIMEOUT,
+                );
                 sessionId = cursor;
               } catch {
                 /* session gone, load unsupported, or too slow — start fresh */
               }
             }
             if (!sessionId) {
-              const started = await request("session/new", { cwd, mcpServers }, NEW_SESSION_TIMEOUT);
-              sessionId = typeof started?.sessionId === "string" ? started.sessionId : null;
+              sessionResult = await request("session/new", { cwd, mcpServers }, NEW_SESSION_TIMEOUT);
+              sessionId = typeof sessionResult?.sessionId === "string" ? sessionResult.sessionId : null;
               if (!sessionId) throw new Error("session/new returned no sessionId");
             }
+
+            let selectedModel: string | null = null;
+            if (support.selectModel) {
+              const { configId } = support.selectModel;
+              const currentOf = (r: any) =>
+                (Array.isArray(r?.configOptions) ? r.configOptions : []).find((o: any) => o?.id === configId)
+                  ?.currentValue ?? null;
+              selectedModel = currentOf(sessionResult);
+              if (turn.model && turn.model !== selectedModel) {
+                selectedModel = currentOf(
+                  await request("session/set_config_option", { sessionId, configId, value: turn.model }, INIT_TIMEOUT),
+                );
+                // an agent that answers OK but keeps its old model is worse than
+                // one that errors: it burns a paid turn on the wrong thing
+                if (selectedModel !== turn.model) {
+                  throw new Error(
+                    `${DRIVER_KIND} did not switch to ${turn.model} (still ${selectedModel ?? "unknown"})`,
+                  );
+                }
+              }
+            }
+
             emit({
               ...base(threadId, turnId),
               type: "session.started",
               sessionId,
-              model: init?._meta?.modelState?.currentModelId ?? turn.model ?? null,
+              model: selectedModel ?? init?._meta?.modelState?.currentModelId ?? turn.model ?? null,
             });
             state.promptSent = true;
             const text = support.buildPromptText

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -500,7 +500,9 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
               sessionId,
               prompt: [{ type: "text", text }],
             });
-            const usage = result?._meta ?? {};
+            // opencode 1.18.18 reports usage at the result root; grok and
+            // gemini put it under _meta. Read both rather than lose the count.
+            const usage = result?.usage ?? result?._meta ?? {};
             if (typeof usage.inputTokens === "number" || typeof usage.outputTokens === "number") {
               emit({
                 ...base(threadId, turnId),

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -69,16 +69,18 @@ export interface AcpSupport {
    *  CONFIRM the requested model before we prompt: silently running a model
    *  other than the one the picker shows is the failure this guards. */
   selectModel?: { configId: string };
-  /** Mutate the child env in place (e.g. strip a key). Optional. */
-  transformEnv?(env: Record<string, string | undefined>): void;
+  /** Mutate the child env in place: strip a key, inject a policy. Receives the
+   *  instance config so a support can vary with fullAuto. */
+  transformEnv?(env: Record<string, string | undefined>, config: AcpConfig): void;
   /** Pick the ACP authenticate methodId from initialize's advertised
    * authMethods; return null to skip the authenticate step. */
   pickAuthMethod(authMethods: Array<{ id?: string }>): string | null;
   /** "fail": abort the turn if auth is missing/errors (subscription CLIs).
    *  "continue": proceed anyway (CLIs that work off an ambient login). */
   authFailure: "fail" | "continue";
-  /** snapshot(): is the CLI signed in? (env already carries the merged config) */
-  isAuthenticated(env: Record<string, string | undefined>): boolean;
+  /** snapshot(): can this harness actually run a turn? (env already carries the
+   *  merged config). May be async for harnesses that have to ask the CLI. */
+  isAuthenticated(env: Record<string, string | undefined>, config: AcpConfig): boolean | Promise<boolean>;
   /** Compose the session/prompt text. Default prepends the persona. */
   buildPromptText?(turn: SendTurnInput): string;
 }
@@ -141,7 +143,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           ...input.environment,
           PATH: augmentedPath(),
         };
-        support.transformEnv?.(env);
+        support.transformEnv?.(env, config);
         return env;
       };
 
@@ -544,7 +546,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           );
         });
         if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
-        return { state: "available", version, authenticated: support.isAuthenticated(env) };
+        return { state: "available", version, authenticated: await support.isAuthenticated(env, config) };
       };
 
       return {

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -15,6 +15,9 @@
 //                        surface: session/new and session/load return
 //                        configOptions, and session/set_config_option switches
 //                        the model (rejecting an unadvertised one with -32602).
+//   FAKE_ACP_MODEL_STICKS  session/set_config_option succeeds but leaves the
+//                        model where it was, so the confirmation guard in
+//                        core.ts has something to catch
 //   FAKE_ACP_USAGE_ROOT  put the prompt result's usage at the root instead of
 //                        under _meta (what opencode 1.18.18 actually does)
 //
@@ -180,7 +183,10 @@ function handle(msg: any) {
         });
         break;
       }
-      currentModel = value;
+      // FAKE_ACP_MODEL_STICKS: answer OK and keep the old model anyway. Nothing
+      // in the protocol forbids it, and it is the shape core.ts's confirmation
+      // guard exists for — an error is loud, this is silent.
+      if (!process.env.FAKE_ACP_MODEL_STICKS) currentModel = value;
       result(msg.id, { configOptions: configOptions() });
       break;
     }

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -191,7 +191,14 @@ function handle(msg: any) {
         return;
       }
       const complete = () =>
-        result(msg.id, { stopReason: "end_turn", _meta: { inputTokens: 10, outputTokens: 5 } });
+        result(
+          msg.id,
+          // FAKE_ACP_USAGE_ROOT reproduces opencode 1.18.18's shape: usage at
+          // the result root with an empty _meta, instead of usage under _meta.
+          process.env.FAKE_ACP_USAGE_ROOT
+            ? { stopReason: "end_turn", usage: { inputTokens: 10, outputTokens: 5 }, _meta: {} }
+            : { stopReason: "end_turn", _meta: { inputTokens: 10, outputTokens: 5 } },
+        );
       if (mode === "ask-peer" && agentsMcp) {
         // the comms e2e: reach a peer bot through the injected agents proxy
         // and reply with whatever it said (the peer's fake runs plain happy

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -11,12 +11,37 @@
 //                     peer, and reply with what the peer said — the comms e2e)
 //   FAKE_ACP_DUMP   path to write {argv, env} as JSON, so a test can assert
 //                   argv shape (agent/stdio flags) and env hygiene
+//   FAKE_ACP_MODELS      comma-separated model ids. Enables the opencode-shaped
+//                        surface: session/new and session/load return
+//                        configOptions, and session/set_config_option switches
+//                        the model (rejecting an unadvertised one with -32602).
+//   FAKE_ACP_USAGE_ROOT  put the prompt result's usage at the root instead of
+//                        under _meta (what opencode 1.18.18 actually does)
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
 import { spawn } from "node:child_process";
 import { writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "happy";
+// opencode-shaped surface: the session carries its own model catalog and the
+// model is chosen with session/set_config_option, because `opencode acp` takes
+// no -m. Off unless FAKE_ACP_MODELS is set, so every existing mode is byte-
+// identical to before.
+const models = (process.env.FAKE_ACP_MODELS ?? "").split(",").filter(Boolean);
+let currentModel: string | null = models[0] ?? null;
+const configOptions = () =>
+  models.length
+    ? [
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: currentModel,
+          options: models.map((value) => ({ value, name: value })),
+        },
+      ]
+    : null;
 const argv = process.argv.slice(2);
 if (argv.includes("--version")) {
   console.log("fake-acp 1.0.0");
@@ -136,12 +161,29 @@ function handle(msg: any) {
     case "session/new": {
       const servers: McpEntry[] = Array.isArray(msg.params?.mcpServers) ? msg.params.mcpServers : [];
       agentsMcp = servers.find((s: any) => s?.name === "agents") ?? null;
-      result(msg.id, { sessionId: "fake-acp-session" });
+      const opts = configOptions();
+      result(msg.id, opts ? { sessionId: "fake-acp-session", configOptions: opts } : { sessionId: "fake-acp-session" });
       break;
     }
-    case "session/load":
-      result(msg.id, {});
+    case "session/load": {
+      const opts = configOptions();
+      result(msg.id, opts ? { configOptions: opts } : {});
       break;
+    }
+    case "session/set_config_option": {
+      const { configId, value } = msg.params ?? {};
+      if (configId !== "model" || !models.includes(value)) {
+        out({
+          jsonrpc: "2.0",
+          id: msg.id,
+          error: { code: -32602, message: `Invalid params: model not found: ${value}`, data: { modelId: value } },
+        });
+        break;
+      }
+      currentModel = value;
+      result(msg.id, { configOptions: configOptions() });
+      break;
+    }
     case "session/prompt": {
       if (mode === "hang") {
         // never resolve the prompt — lets tests exercise interrupt


### PR DESCRIPTION
## What

Three capabilities on the generic ACP runtime in `server/drivers/acp/core.ts`,
all of them opt-in, plus one bug fix. No new engine, nothing visible in the UI,
and no existing driver file is touched.

This is step 1 of the plan in #102. The measurements behind each item are in
[my comment there](https://github.com/milind-soni/OpenMausBot/pull/102#issuecomment-5304800457),
taken against `opencode` 1.18.18.

## Why

`opencode acp` cannot be driven by the current core: it takes no `-m`, and it
reports token usage somewhere the core does not read. Rather than fold those
quirks into a driver, they belong in the runtime the same way `pickAuthMethod`
and `authFailure` already do. Each capability below is inert unless a support
object asks for it, so this lands safely on its own, ahead of any engine.

## The three capabilities

**`selectModel?: { configId: string }`.** For harnesses whose ACP subcommand
takes no `-m`, the model is set through `session/set_config_option` after the
session exists. The hook fires on `session/load` as well as `session/new`, so a
resumed thread selects its model too.

It verifies rather than trusts. The agent has to *confirm* the new value in the
returned `configOptions`, and the turn aborts if it does not:

```ts
if (selectedModel !== turn.model) {
  throw new Error(`… did not switch to ${turn.model} (still ${selectedModel ?? "unknown"})`);
}
```

An agent that answers OK and keeps its old model is worse than one that errors,
because it silently burns a paid turn on something other than what the picker
shows.

**`transformEnv(env, config)`** now receives the instance config, so a support
can vary the child env with `fullAuto` instead of only stripping fixed keys.

**`isAuthenticated(env, config)`** may now return a promise. Some harnesses
cannot answer "can this actually run a turn" without asking the CLI.

## The bug fix

`session/prompt` usage was read from `result._meta` only. opencode reports it at
the result root, so the count was dropped:

```ts
const usage = result?.usage ?? result?._meta ?? {};
```

The order matters and is not arbitrary. opencode sends `_meta: {}` alongside the
real numbers, and an empty object is truthy, so reading `_meta` first would
return zero counts for the engine this is meant to fix. Grok and Gemini put
usage under `_meta` and have no root `usage`, so both shapes resolve correctly.

## What does not change

The two signature changes are widenings: an existing `transformEnv(env)` still
type-checks when called with a second argument, and a synchronous
`isAuthenticated` still satisfies `boolean | Promise<boolean>`. That is why no
driver file appears in this diff. Any engine that does not declare `selectModel`
runs exactly the code path it ran before.

## Verified

On this branch alone, against `upstream/main` at `13a1bb7`, under node 24:

| | main @ 13a1bb7 | this branch |
|---|---|---|
| `pnpm test` | 287 passed / 8 skipped, 35 files | **294 passed / 8 skipped, 35 files** |
| `pnpm typecheck` | 0 | 0 |
| `pnpm check:electron` | 0 | 0 |
| `vite build` | 0 | 0 |

The seven new tests, one per behaviour:

```
reads token usage from the root of the prompt result
selectModel confirms the requested model before prompting
a model the session does not advertise fails the turn instead of running another
a model switch acknowledged but not applied fails the turn
selects the model on a resumed session too, not just a new one
transformEnv sees the instance config
awaits an async isAuthenticated
```

The fourth one arrived from CodeRabbit's review of this PR and was worth having.
The unadvertised-model test rides the fake CLI's `-32602`, so it settles inside
`request()` and never reaches the confirmation guard; the guard's own case had
no coverage. It was checked both ways: with the guard neutered the new test does
not merely fail, it reports `ok: true` on a turn that ran `m-one` while `m-two`
was requested, which is precisely the silent wrong-model turn the guard exists
to stop.

The `_meta` shape keeps its existing coverage untouched, which is what proves
the `??` order did not regress the engines already using it. The fake ACP CLI in
`server/testing/fake-acp-cli.ts` grew the switches needed to produce the new
shapes.

One of those tests is a fix to a test I wrote earlier in this branch: it passed
`resumeCursor: "fake-acp-session"`, which is the same id `session/new` returns,
so a `session/load` that threw and fell back would have emitted a
byte-identical `sessionId` and the assertion would still have passed. Proved
rather than argued: making the fake's `session/load` return an error left the
old test green, and turns it red with a distinct cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model selection when starting or resuming sessions.
  * Sessions now validate requested models and report the selected model.
  * Added support for configuration-aware environment settings and authentication checks.
  * Improved compatibility with token usage information returned in multiple formats.
* **Bug Fixes**
  * Improved session loading and model switching behavior.
  * Authentication checks now complete reliably before session snapshots are created.
  * Expanded handling for invalid model selections and alternate usage responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->