### PR TITLE
Detect a signed-in Claude on macOS, where credentials live in the Key…

### DIFF
--- a/server/drivers/claude-auth.test.ts
+++ b/server/drivers/claude-auth.test.ts
@@ -1,0 +1,63 @@
+// Where "is Claude signed in?" is answered.
+//
+// The check used to be a single `existsSync` on
+// ~/.claude/.credentials.json, which is where Claude Code keeps credentials
+// on Linux and WSL. On macOS it uses the Keychain and writes no such file,
+// so every signed-in Mac reported as signed out and the engine was greyed
+// out in the model picker as "sign-in required".
+//
+// The platform and the keychain probe are injected here so the decision is
+// testable off a Mac, and without depending on whoever runs the suite being
+// signed into Claude.
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { claudeSignedIn } from "./claude.ts";
+
+const credentialsDir = join(homedir(), ".claude");
+const credentialsFile = join(credentialsDir, ".credentials.json");
+
+const writeCredentialsFile = () => {
+  mkdirSync(credentialsDir, { recursive: true });
+  writeFileSync(credentialsFile, "{}");
+};
+
+describe("claudeSignedIn", () => {
+  afterEach(() => {
+    rmSync(credentialsFile, { force: true });
+  });
+
+  it("takes the credentials file as proof, on any platform", async () => {
+    writeCredentialsFile();
+    let probed = false;
+    const keychain = async () => {
+      probed = true;
+      return false;
+    };
+
+    expect(await claudeSignedIn("linux", keychain)).toBe(true);
+    expect(await claudeSignedIn("darwin", keychain)).toBe(true);
+    // the file settles it — no need to touch the keychain
+    expect(probed).toBe(false);
+  });
+
+  it("does not consult a keychain that isn't there", async () => {
+    let probed = false;
+    const keychain = async () => {
+      probed = true;
+      return true;
+    };
+
+    expect(await claudeSignedIn("linux", keychain)).toBe(false);
+    expect(await claudeSignedIn("win32", keychain)).toBe(false);
+    expect(probed).toBe(false);
+  });
+
+  it("asks the keychain on macOS, where the file never exists", async () => {
+    // the case that was broken: no file, signed in
+    expect(await claudeSignedIn("darwin", async () => true)).toBe(true);
+    expect(await claudeSignedIn("darwin", async () => false)).toBe(false);
+  });
+});

--- a/server/drivers/claude-auth.test.ts
+++ b/server/drivers/claude-auth.test.ts
@@ -6,39 +6,30 @@
 // so every signed-in Mac reported as signed out and the engine was greyed
 // out in the model picker as "sign-in required".
 //
-// The platform and the keychain probe are injected here so the decision is
-// testable off a Mac, and without depending on whoever runs the suite being
-// signed into Claude.
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+// Every input is injected: the platform, the keychain probe, and whether
+// the credentials file is there. That last one matters most. The obvious
+// way to test "the file settles it" is to write the file — but the only
+// path involved is the real ~/.claude/.credentials.json, so writing it
+// clobbers the developer's actual credentials and the cleanup that follows
+// deletes them, signing them out of Claude Code. These tests touch no
+// filesystem at all.
+import { describe, expect, it } from "vitest";
 
 import { claudeSignedIn } from "./claude.ts";
 
-const credentialsDir = join(homedir(), ".claude");
-const credentialsFile = join(credentialsDir, ".credentials.json");
-
-const writeCredentialsFile = () => {
-  mkdirSync(credentialsDir, { recursive: true });
-  writeFileSync(credentialsFile, "{}");
-};
+const present = () => true;
+const absent = () => false;
 
 describe("claudeSignedIn", () => {
-  afterEach(() => {
-    rmSync(credentialsFile, { force: true });
-  });
-
   it("takes the credentials file as proof, on any platform", async () => {
-    writeCredentialsFile();
     let probed = false;
     const keychain = async () => {
       probed = true;
       return false;
     };
 
-    expect(await claudeSignedIn("linux", keychain)).toBe(true);
-    expect(await claudeSignedIn("darwin", keychain)).toBe(true);
+    expect(await claudeSignedIn("linux", keychain, present)).toBe(true);
+    expect(await claudeSignedIn("darwin", keychain, present)).toBe(true);
     // the file settles it — no need to touch the keychain
     expect(probed).toBe(false);
   });
@@ -50,14 +41,14 @@ describe("claudeSignedIn", () => {
       return true;
     };
 
-    expect(await claudeSignedIn("linux", keychain)).toBe(false);
-    expect(await claudeSignedIn("win32", keychain)).toBe(false);
+    expect(await claudeSignedIn("linux", keychain, absent)).toBe(false);
+    expect(await claudeSignedIn("win32", keychain, absent)).toBe(false);
     expect(probed).toBe(false);
   });
 
   it("asks the keychain on macOS, where the file never exists", async () => {
     // the case that was broken: no file, signed in
-    expect(await claudeSignedIn("darwin", async () => true)).toBe(true);
-    expect(await claudeSignedIn("darwin", async () => false)).toBe(false);
+    expect(await claudeSignedIn("darwin", async () => true, absent)).toBe(true);
+    expect(await claudeSignedIn("darwin", async () => false, absent)).toBe(false);
   });
 });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -58,15 +58,21 @@ function keychainHasCredentials(): Promise<boolean> {
  * signed out — which is not cosmetic: `authenticated: false` greys the engine
  * out in the model picker as "sign-in required".
  *
- * The platform and the probe are injectable so the decision can be tested off
- * a Mac, and without depending on whoever is running the suite being signed
- * into Claude.
+ * All three inputs — platform, keychain, credentials file — are injectable so
+ * the decision can be tested off a Mac, without depending on whoever is
+ * running the suite being signed into Claude, and above all without the test
+ * going anywhere near the real `~/.claude/.credentials.json`. A test that
+ * writes that file to set up a case has to delete it to tear the case down,
+ * and deleting it signs the developer out.
  */
+export const credentialsFilePath = (): string => join(homedir(), ".claude", ".credentials.json");
+
 export async function claudeSignedIn(
   platform: NodeJS.Platform = process.platform,
   keychain: () => Promise<boolean> = keychainHasCredentials,
+  hasCredentialsFile: () => boolean = () => existsSync(credentialsFilePath()),
 ): Promise<boolean> {
-  if (existsSync(join(homedir(), ".claude", ".credentials.json"))) return true;
+  if (hasCredentialsFile()) return true;
   if (platform !== "darwin") return false;
   return keychain();
 }

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -8,6 +8,7 @@
 //   - Composio Connect (connected apps → tools) over streamable HTTP
 //   - the bot's cloud computer (box.ascii.dev) via server/computer-proxy.ts
 //     — screenshot/exec/open_url, the CUA-on-the-box bridge
+import { execFile } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { homedir } from "node:os";
@@ -30,6 +31,45 @@ import type {
 import { computerProxyEnv } from "../container-computer.ts";
 import { newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
+
+/** Does the macOS Keychain hold Claude Code's credentials?
+ *
+ * Deliberately `find-generic-password` WITHOUT `-w`: that returns the item's
+ * attributes only. Asking for the secret would both be unnecessary — we only
+ * want to know whether sign-in happened — and would trigger a keychain
+ * authorization prompt the user has no reason to expect from a version probe.
+ */
+function keychainHasCredentials(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      "/usr/bin/security",
+      ["find-generic-password", "-s", "Claude Code-credentials"],
+      { timeout: 5000 },
+      (error) => resolve(!error),
+    );
+  });
+}
+
+/** Whether `claude` has been signed in.
+ *
+ * Claude Code writes `~/.claude/.credentials.json` on Linux and WSL, but on
+ * macOS it keeps its OAuth credentials in the Keychain and writes no such
+ * file. Checking only the file therefore reported every signed-in Mac as
+ * signed out — which is not cosmetic: `authenticated: false` greys the engine
+ * out in the model picker as "sign-in required".
+ *
+ * The platform and the probe are injectable so the decision can be tested off
+ * a Mac, and without depending on whoever is running the suite being signed
+ * into Claude.
+ */
+export async function claudeSignedIn(
+  platform: NodeJS.Platform = process.platform,
+  keychain: () => Promise<boolean> = keychainHasCredentials,
+): Promise<boolean> {
+  if (existsSync(join(homedir(), ".claude", ".credentials.json"))) return true;
+  if (platform !== "darwin") return false;
+  return keychain();
+}
 
 const DRIVER_KIND = "claudeAgent";
 
@@ -481,7 +521,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         );
       });
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
-      const authenticated = existsSync(join(homedir(), ".claude", ".credentials.json"));
+      const authenticated = await claudeSignedIn();
       return { state: "available", version, authenticated };
     };
 


### PR DESCRIPTION
## What changed

`claudeSignedIn` now falls back to the macOS Keychain when `~/.claude/.credentials.json` is absent.

The check is factored so the platform and the keychain probe are injected, which is what makes it testable off a Mac.

## Why

`~/.claude/.credentials.json` is where Claude Code keeps credentials on Linux and WSL. On macOS it uses the Keychain and writes no such file.

So on every Mac, `claudeSignedIn()` returned `false` no matter what — a signed-in user saw the Claude engine greyed out in the model picker as "sign-in required", and signing in again changed nothing, because there was nothing the check could ever find.

## How it was verified

- `pnpm typecheck` and `pnpm test` — green.
- `pnpm check:electron` — green (nothing here touches the desktop shell).
- Three new unit tests in `server/drivers/claude-auth.test.ts` cover the three cases: file present (settles it on any platform, keychain never consulted), file absent on non-darwin (false, keychain never consulted), file absent on darwin (defers to the keychain, both answers).
- Confirmed on a Mac against a real signed-in Claude Code install: before the change the engine reported "sign-in required"; after it, available and authenticated.

### Two things worth reviewing specifically

**The probe reads no secret.** It is `security find-generic-password -s "Claude Code-credentials"` **without `-w`**. That asks only whether the keychain item exists; it never reads the password, so it neither needs nor triggers an authorisation prompt, and nothing sensitive can reach a log or a response. Adding `-w` would change both of those, which is why the flag's absence is deliberate rather than incidental.

**On the platform rule:** `CONTRIBUTING.md` asks that macOS-only code live in `electron/` behind a `darwin` gate, and this is in `server/`. I think it belongs here, but it is a fair thing to push back on. The reasoning: this *is* portable Node — no Swift helper, no TCC, no `~/Library` path — and it is gated on `platform !== "darwin"` before the probe runs. Moving it to `electron/` would mean the harness could not answer "is Claude signed in?" without the desktop shell running, which would break the check for anyone using `pnpm dev:server` alone. Happy to move it if you'd rather the rule be absolute.

## Screenshots (UI changes)

No new UI. The visible effect is an existing control changing state: the Claude engine in the model picker stops being greyed out as "sign-in required" on a Mac that is signed in.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
