### PR TITLE
Make the event stream resumable and hydration pageable

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -11,6 +11,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { openSse } from "./testing/sse.ts";
+
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
 const PORT = 18800 + Math.floor(Math.random() * 10_000);
@@ -281,5 +283,198 @@ describe("harness HTTP API", () => {
     const res = await api("GET", "/api/definitely-not-a-route");
     expect(res.status).toBe(404);
     expect(res.body.error).toContain("/api/definitely-not-a-route");
+  });
+});
+
+// Hydration is one call that returns every bot's entire transcript. Over
+// loopback that is right; over a phone network it is the whole problem.
+describe("message pages", () => {
+  /** A room whose default responder is mentions-only, posted to without any
+   * mention: the user message lands and nothing answers it. That makes the
+   * transcript exactly as long as we asked for — no bot turn racing the
+   * assertions. */
+  const seedRoom = async (count: number) => {
+    const { body } = await api("GET", "/api/bots");
+    const created = await api("POST", "/api/groups", { name: "Paging", memberIds: [body.bots[0].id] });
+    expect(created.status).toBe(201);
+    const groupId = created.body.group.id;
+    const quiet = await api("PATCH", `/api/groups/${groupId}`, { defaultResponder: { kind: "mentions" } });
+    expect(quiet.status).toBe(200);
+
+    for (let i = 0; i < count; i++) {
+      const posted = await api("POST", `/api/groups/${groupId}/messages`, { text: `page probe ${i}` });
+      expect(posted.status).toBe(202);
+    }
+    const after = await api("GET", "/api/bots");
+    return after.body.groups.find((g: { id: string }) => g.id === groupId);
+  };
+
+  it("returns the whole transcript when nothing is asked for", async () => {
+    const room = await seedRoom(6);
+    expect(room.messages).toHaveLength(6);
+    // the original shape carries no pagination fields at all
+    expect(room).not.toHaveProperty("hasMore");
+  });
+
+  it("returns only the newest n when asked", async () => {
+    const full = await seedRoom(6);
+    const { status, body } = await api("GET", "/api/bots?messages=2");
+    expect(status).toBe(200);
+    const slim = body.groups.find((g: { id: string }) => g.id === full.id);
+    expect(slim.messages).toHaveLength(2);
+    expect(slim.hasMore).toBe(true);
+    // the newest two, not the oldest two
+    expect(slim.messages.map((msg: { id: string }) => msg.id)).toEqual(
+      full.messages.slice(-2).map((msg: { id: string }) => msg.id),
+    );
+    // and every 1:1 thread is capped by the same parameter
+    expect(body.bots.every((b: { messages: unknown[] }) => b.messages.length <= 2)).toBe(true);
+  });
+
+  it("pages backwards from a message the client already holds", async () => {
+    const full = await seedRoom(6);
+    const fourth = full.messages[3];
+
+    const { status, body } = await api("GET", `/api/threads/${full.threadId}/messages?before=${fourth.id}&limit=2`);
+    expect(status).toBe(200);
+    expect(body.messages.map((msg: { id: string }) => msg.id)).toEqual(
+      full.messages.slice(1, 3).map((msg: { id: string }) => msg.id),
+    );
+    expect(body.hasMore).toBe(true);
+
+    // walking back far enough reaches the top and says so
+    const top = await api("GET", `/api/threads/${full.threadId}/messages?limit=200`);
+    expect(top.body.hasMore).toBe(false);
+    expect(top.body.messages).toHaveLength(6);
+  });
+
+  it("refuses a cursor or size it cannot page from", async () => {
+    const full = await seedRoom(1);
+    // silently answering with the newest page would paginate in a circle
+    expect((await api("GET", `/api/threads/${full.threadId}/messages?before=nope`)).status).toBe(404);
+    expect((await api("GET", "/api/threads/not-a-thread/messages")).status).toBe(404);
+    expect((await api("GET", "/api/bots?messages=-1")).status).toBe(400);
+    expect((await api("GET", "/api/bots?messages=lots")).status).toBe(400);
+    expect((await api("GET", `/api/threads/${full.threadId}/messages?limit=1.5`)).status).toBe(400);
+  });
+
+  it("404s an image on a message that has none", async () => {
+    const full = await seedRoom(1);
+    const res = await fetch(`${BASE}/api/threads/${full.threadId}/messages/${full.messages[0].id}/image`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// A phone reconnects every time it unlocks, so "what did I miss?" has to
+// be answerable without re-downloading every transcript.
+describe("resumable event stream", () => {
+  /** any request that makes the server broadcast exactly one frame */
+  const nudge = async (botId: string) => {
+    const res = await api("PATCH", `/api/bots/${botId}`, { unread: true });
+    expect(res.status).toBe(200);
+  };
+
+  it("hands out a cursor and numbers every frame", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      const hello = await stream.until((f) => f.kind === "hello");
+      expect(hello.cursor).toMatch(/^[0-9a-f]{8}:\d+$/);
+      // a cold connection offered no cursor, so there is nothing to resume
+      expect(hello.resumed).toBe(false);
+
+      await nudge(botId);
+      await nudge(botId);
+      // the PATCH response and the SSE frame travel on different sockets —
+      // wait for the frames themselves rather than assuming they landed
+      await stream.until(() => stream.frames.filter((f) => f.kind === "bot").length >= 2);
+      const bots = stream.frames.filter((f) => f.kind === "bot");
+      expect(bots[1].seq).toBeGreaterThan(bots[0].seq);
+    } finally {
+      stream.close();
+    }
+  });
+
+  it("replays exactly what a disconnected client missed", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+
+    const first = await openSse(`${BASE}/api/events`);
+    const hello = await first.until((f) => f.kind === "hello");
+    await nudge(botId);
+    const seen = await first.until((f) => f.kind === "bot");
+    first.close();
+    // a real client advances its cursor as frames arrive — resume from the
+    // last frame it actually saw, not from where it connected
+    const cursor = `${hello.cursor.split(":")[0]}:${seen.seq}`;
+
+    // ...three things happen while the phone is asleep...
+    await nudge(botId);
+    await nudge(botId);
+    await nudge(botId);
+
+    const resumed = await openSse(`${BASE}/api/events?since=${encodeURIComponent(cursor)}`);
+    try {
+      // ...and an old cursor still replays them, in order, without a hydrate
+      const back = await resumed.until((f) => f.kind === "hello");
+      expect(back.resumed).toBe(true);
+      await resumed.until((f) => f.kind === "bot" && f.seq === seen.seq + 3);
+      const replayed = resumed.frames.filter((f) => f.kind === "bot").map((f) => f.seq);
+      expect(replayed).toEqual([seen.seq + 1, seen.seq + 2, seen.seq + 3]);
+    } finally {
+      resumed.close();
+    }
+  });
+
+  it("resumes a browser EventSource through Last-Event-ID alone", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+
+    const first = await openSse(`${BASE}/api/events`);
+    const hello = await first.until((f) => f.kind === "hello");
+    first.close();
+    await nudge(botId);
+
+    // the id: field is what a browser echoes back on its own reconnect
+    const resumed = await openSse(`${BASE}/api/events`, { "last-event-id": hello.cursor });
+    try {
+      expect((await resumed.until((f) => f.kind === "hello")).resumed).toBe(true);
+      await resumed.until((f) => f.kind === "bot");
+    } finally {
+      resumed.close();
+    }
+  });
+
+  it("keeps delivering everything else when a client declines screen frames", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+
+    // a phone on cellular opts out of the live desktop captures; nothing
+    // else about its stream changes
+    const stream = await openSse(`${BASE}/api/events?screens=off`);
+    try {
+      expect((await stream.until((f) => f.kind === "hello")).resumed).toBe(false);
+      await nudge(botId);
+      await stream.until((f) => f.kind === "bot");
+      expect(stream.frames.some((f) => f.kind === "screen")).toBe(false);
+    } finally {
+      stream.close();
+    }
+  });
+
+  it("refuses a cursor it cannot honour instead of replaying the wrong run", async () => {
+    for (const cursor of ["deadbeef:1", "not-a-cursor", "12345678:999999"]) {
+      const stream = await openSse(`${BASE}/api/events?since=${encodeURIComponent(cursor)}`);
+      try {
+        const hello = await stream.until((f) => f.kind === "hello");
+        // false is the signal to hydrate — a partial replay would leave a
+        // permanent hole in the client's state
+        expect(hello.resumed).toBe(false);
+      } finally {
+        stream.close();
+      }
+    }
   });
 });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -363,6 +363,20 @@ describe("message pages", () => {
     const res = await fetch(`${BASE}/api/threads/${full.threadId}/messages/${full.messages[0].id}/image`);
     expect(res.status).toBe(404);
   });
+
+  it("404s an image on a conversation that does not exist, without inventing one", async () => {
+    // `messagesFor` materialises and caches a ThreadState for any id it is
+    // given, so an unguarded route lets a client grow that map by asking
+    // for threads that were never real. The 404 is the visible half; not
+    // creating the thread is the half worth having.
+    const before = (await api("GET", "/api/bots")).body.bots.length;
+    const res = await fetch(`${BASE}/api/threads/not-a-thread/messages/not-a-message/image`);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toBe("no such conversation");
+    // and the phantom thread is not now answerable as an empty conversation
+    expect((await api("GET", "/api/threads/not-a-thread/messages")).status).toBe(404);
+    expect((await api("GET", "/api/bots")).body.bots.length).toBe(before);
+  });
 });
 
 // A phone reconnects every time it unlocks, so "what did I miss?" has to

--- a/server/index.ts
+++ b/server/index.ts
@@ -1258,6 +1258,14 @@ const server = createServer(async (req, res) => {
     // the pixels of one screen message, fetched only when something shows it
     m = path.match(/^\/api\/threads\/([\w-]+)\/messages\/([\w-]+)\/image$/);
     if (m && method === "GET") {
+      // Same guard as the page route above, and for the same reason twice
+      // over: an unknown id should 404 deliberately rather than by accident,
+      // and `messagesFor` materialises and caches a ThreadState for whatever
+      // it is handed. Without this, a client asking for images on ids that
+      // do not exist grows the thread map for as long as it keeps asking.
+      if (!store.botByThread(m[1]) && !store.groupByThread(m[1])) {
+        return json(res, 404, { error: "no such conversation" });
+      }
       const message = store.messagesFor(m[1]).find((msg) => msg.id === m![2]);
       if (!message?.png) return json(res, 404, { error: "no image on that message" });
       const bytes = Buffer.from(message.png, "base64");

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 // OpenMausBot server — the harness host. Clients hold no transports
 // (upstream rule): the React app dispatches typed commands over HTTP and
 // folds one SSE event stream; every provider process runs here.
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { dirname, extname, join } from "node:path";
@@ -21,6 +21,7 @@ import {
 } from "./container-computer.ts";
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
 import { resetPathCache } from "./env-path.ts";
+import { buildNotification, type Notification } from "./notify.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
@@ -139,15 +140,96 @@ const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
   tasks: store.tasks(bot.id).map(({ resumeCursors, ...task }) => task),
 });
 
+// ── message pages ──────────────────────────────────────────────────────
+// GET /api/bots hands back every bot with its entire transcript, which is
+// the right answer over loopback and the wrong one over a phone network:
+// a long-running bot's thread is megabytes, and a turn-end desktop capture
+// is a base64 PNG sitting inline in it.
+//
+// `?messages=n` opts into a slim shape — the last n messages, with screen
+// captures reduced to a flag and fetched one at a time from the image
+// endpoint. Omitting the parameter returns exactly what it always did.
+const MESSAGE_PAGE_MAX = 200;
+const DEFAULT_PAGE = 50;
+
+/** undefined = absent, null = present but unusable (the caller answers 400). */
+function pageSize(raw: string | null): number | null | undefined {
+  if (raw === null) return undefined;
+  const size = Number(raw);
+  if (!Number.isInteger(size) || size < 0) return null;
+  return Math.min(size, MESSAGE_PAGE_MAX);
+}
+
+/** A screen message without its pixels. The client fetches those from
+ * `/api/threads/:threadId/messages/:id/image` when it actually shows one. */
+function slimMessage(message: Message): Message | Record<string, unknown> {
+  if (message.kind !== "screen" || !message.png) return message;
+  const { png, mime, ...rest } = message;
+  return { ...rest, hasImage: true };
+}
+
+/** `limit === undefined` is the original, unpaginated shape. */
+function messagePage(threadId: string, limit: number | undefined, before?: string | null) {
+  const all = store.messagesFor(threadId);
+  if (limit === undefined) return { messages: all };
+  const end = before ? all.findIndex((msg) => msg.id === before) : -1;
+  const stop = end === -1 ? all.length : end;
+  const start = Math.max(0, stop - limit);
+  return { messages: all.slice(start, stop).map(slimMessage), hasMore: start > 0 };
+}
+
 // ── SSE fan-out to clients ─────────────────────────────────────────────
-const sseClients = new Set<ServerResponse>();
-function broadcast(payload: unknown) {
-  const frame = `data: ${JSON.stringify(payload)}\n\n`;
-  for (const res of [...sseClients]) {
+/** One connected client, and what it asked to be sent. */
+interface SseClient {
+  res: ServerResponse;
+  /** Live screen frames carry a base64 desktop capture every few seconds
+   * while a bot works. A client that isn't showing the computer panel —
+   * a phone on cellular, most of all — should not pay for them. */
+  screens: boolean;
+}
+const sseClients = new Set<SseClient>();
+
+/** Every frame is numbered, and the last few hundred are kept, so a client
+ * whose connection dropped can ask for what it missed instead of
+ * re-downloading every transcript. The desktop reconnects in milliseconds
+ * and barely needs this; a phone reconnects every time it unlocks.
+ *
+ * The stream id makes the cursor safe across restarts: sequence numbers
+ * begin again at 1 on boot, so a cursor from a previous run must be
+ * rejected rather than used to replay a different run's frames. It rides
+ * inside the SSE `id:` field, which means a browser EventSource resumes
+ * correctly through its own Last-Event-ID with no client code at all. */
+const STREAM_ID = randomUUID().slice(0, 8);
+const REPLAY_MAX = 500;
+let lastSeq = 0;
+const replayBuffer: Array<{ seq: number; kind: string; frame: string }> = [];
+
+/** Screen frames are the only kind a client can decline. */
+const wants = (client: SseClient, kind: string) => kind !== "screen" || client.screens;
+
+/** `<streamId>:<seq>` — opaque to clients, and the only thing they need to
+ * remember to resume. Returns null when it belongs to another run. */
+function cursorSeq(raw: string | string[] | undefined): number | null {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value) return null;
+  const [stream, seq] = value.split(":");
+  if (stream !== STREAM_ID) return null;
+  const parsed = Number(seq);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function broadcast(payload: Record<string, unknown>) {
+  const seq = ++lastSeq;
+  const kind = String(payload.kind ?? "");
+  const frame = `id: ${STREAM_ID}:${seq}\ndata: ${JSON.stringify({ ...payload, seq })}\n\n`;
+  replayBuffer.push({ seq, kind, frame });
+  if (replayBuffer.length > REPLAY_MAX) replayBuffer.shift();
+  for (const client of [...sseClients]) {
+    if (!wants(client, kind)) continue;
     try {
-      res.write(frame);
+      client.res.write(frame);
     } catch {
-      sseClients.delete(res);
+      sseClients.delete(client);
     }
   }
 }
@@ -160,6 +242,17 @@ function broadcast(payload: unknown) {
 // once can collide on a bare id and patch each other's messages.
 const toolMessageByItem = new Map<string, string>(); // threadId:itemId -> messageId
 const askMessageByRequest = new Map<string, string>(); // threadId:requestId -> messageId
+// the last settled assistant text per thread, so a "finished" notification
+// can carry what the bot actually said
+const lastReply = new Map<string, string>();
+
+/** Put a notification on the wire. Clients decide what to do with it — a
+ * desktop notification now, a push to a paired phone later. */
+function notify(notification: Notification | null) {
+  // nested rather than spread — the frame's own `kind` names the frame,
+  // exactly like {kind:"message", message} and {kind:"bot", bot}
+  if (notification) broadcast({ kind: "notify", notification });
+}
 
 // Group threads: the fold needs to know WHO is talking — the turn engine
 // records the active member here before dispatching its turn.
@@ -194,6 +287,9 @@ bus.subscribe((event: RuntimeEvent) => {
     case "item.completed":
       if (event.itemType === "assistant_text") {
         pushMessage({ role: "bot", kind: "text", text: event.text });
+        // kept so "finished" can say what it finished with, rather than
+        // just that something ended
+        lastReply.set(event.threadId, event.text);
       } else if (event.itemType === "tool" && event.itemId) {
         const itemKey = `${event.threadId}:${event.itemId}`;
         const messageId = toolMessageByItem.get(itemKey);
@@ -302,6 +398,12 @@ bus.subscribe((event: RuntimeEvent) => {
         },
       });
       if (event.requestId) askMessageByRequest.set(`${event.threadId}:${event.requestId}`, message.id);
+      // Notify from HERE, not from a separate subscriber on request.opened:
+      // this is the branch where a card actually reached a human. Anything
+      // auto mode answered took the early return above and never buzzes.
+      if (asker) {
+        notify(buildNotification(permission ? "approval" : "question", asker, event.threadId, event.summary));
+      }
       break;
     }
     case "request.resolved": {
@@ -327,9 +429,12 @@ bus.subscribe((event: RuntimeEvent) => {
       break;
     case "turn.completed": {
       if (activeVmThreadId === event.threadId) activeVmThreadId = null;
+      const reply = lastReply.get(event.threadId) ?? "";
+      lastReply.delete(event.threadId);
       if (bot) {
         store.patchBot(bot.id, { busy: false, unread: true });
         broadcast({ kind: "bot", bot: store.bot(bot.id) });
+        notify(buildNotification("done", bot, event.threadId, reply));
         if (screenPollers.has(bot.id)) {
           // the last live frame becomes a settled inline screen message —
           // the screenshot-in-chat moment. One fresh capture first, so the
@@ -938,6 +1043,8 @@ const server = createServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
   const path = url.pathname;
   const method = req.method ?? "GET";
+  /** scratch for route matches, shared by every `path.match` below */
+  let m: RegExpMatchArray | null = null;
   try {
     // ── internal peer-agent comms (localhost + shared token only) ──────
     // The agents-proxy (spawned inside a bot's agent process) calls these to
@@ -1073,13 +1180,41 @@ const server = createServer(async (req, res) => {
 
     // ── events stream ──
     if (method === "GET" && path === "/api/events") {
+      const client: SseClient = { res, screens: url.searchParams.get("screens") !== "off" };
       res.writeHead(200, {
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
         connection: "keep-alive",
       });
-      res.write(`data: ${JSON.stringify({ kind: "hello" })}\n\n`);
-      sseClients.add(res);
+
+      // Resume, if the client offered a cursor we can honour. `?since=` is
+      // for clients that read the stream by hand; Last-Event-ID is what a
+      // browser EventSource sends by itself.
+      const since = cursorSeq(url.searchParams.get("since") ?? req.headers["last-event-id"]);
+      // The buffer only reaches so far back. If the client's cursor fell off
+      // the end, saying so is the only honest answer — a partial replay
+      // would leave a permanent hole in its state.
+      const resumed =
+        since !== null &&
+        since <= lastSeq &&
+        (replayBuffer.length === 0 ? since === lastSeq : replayBuffer[0].seq <= since + 1);
+      res.write(
+        `data: ${JSON.stringify({
+          kind: "hello",
+          cursor: `${STREAM_ID}:${lastSeq}`,
+          // false means "I could not give you what you missed — hydrate".
+          // A client that offered no cursor gets false too, which is exactly
+          // what a cold start should do.
+          resumed,
+        })}\n\n`,
+      );
+      if (resumed) {
+        for (const buffered of replayBuffer) {
+          if (buffered.seq > since && wants(client, buffered.kind)) res.write(buffered.frame);
+        }
+      }
+
+      sseClients.add(client);
       const keepalive = setInterval(() => {
         try {
           res.write(": keepalive\n\n");
@@ -1087,21 +1222,55 @@ const server = createServer(async (req, res) => {
       }, 25_000);
       req.on("close", () => {
         clearInterval(keepalive);
-        sseClients.delete(res);
+        sseClients.delete(client);
       });
       return;
     }
 
     // ── bots ──
     if (method === "GET" && path === "/api/bots") {
+      const limit = pageSize(url.searchParams.get("messages"));
+      if (limit === null) return json(res, 400, { error: "messages must be a non-negative whole number" });
       return json(res, 200, {
-        bots: store.bots.map(publicBot),
-        groups: store.groups.map((g) => ({ ...g, messages: store.messagesFor(g.threadId) })),
+        bots: store.bots.map((bot) => ({ ...publicBot(bot), ...messagePage(bot.threadId, limit) })),
+        groups: store.groups.map((g) => ({ ...g, ...messagePage(g.threadId, limit) })),
       });
     }
 
+    // scrollback: the page before a message the client already holds
+    m = path.match(/^\/api\/threads\/([\w-]+)\/messages$/);
+    if (m && method === "GET") {
+      const threadId = m[1];
+      if (!store.botByThread(threadId) && !store.groupByThread(threadId)) {
+        return json(res, 404, { error: "no such conversation" });
+      }
+      const limit = pageSize(url.searchParams.get("limit"));
+      if (limit === null) return json(res, 400, { error: "limit must be a non-negative whole number" });
+      const before = url.searchParams.get("before");
+      // An unknown cursor must not silently answer with the newest page —
+      // the client would paginate in a circle and never reach the top.
+      if (before && !store.messagesFor(threadId).some((msg) => msg.id === before)) {
+        return json(res, 404, { error: "no such message" });
+      }
+      return json(res, 200, messagePage(threadId, limit ?? DEFAULT_PAGE, before));
+    }
+
+    // the pixels of one screen message, fetched only when something shows it
+    m = path.match(/^\/api\/threads\/([\w-]+)\/messages\/([\w-]+)\/image$/);
+    if (m && method === "GET") {
+      const message = store.messagesFor(m[1]).find((msg) => msg.id === m![2]);
+      if (!message?.png) return json(res, 404, { error: "no image on that message" });
+      const bytes = Buffer.from(message.png, "base64");
+      res.writeHead(200, {
+        "content-type": message.mime ?? "image/png",
+        "content-length": String(bytes.byteLength),
+        // a settled message's image never changes
+        "cache-control": "private, max-age=31536000, immutable",
+      });
+      return res.end(bytes);
+    }
+
     // ── rooms (group chats) ─────────────────────────────────────────────
-    let m: RegExpMatchArray | null = null;
     if (method === "POST" && path === "/api/groups") {
       const body = await readBody(req);
       const memberIds = (Array.isArray(body.memberIds) ? body.memberIds : []).filter(

--- a/server/index.ts
+++ b/server/index.ts
@@ -202,7 +202,7 @@ const sseClients = new Set<SseClient>();
 const STREAM_ID = randomUUID().slice(0, 8);
 const REPLAY_MAX = 500;
 let lastSeq = 0;
-const replayBuffer: Array<{ seq: number; kind: string; frame: string }> = [];
+const replayBuffer: Array<{ seq: number; kind: string; frame: string | null }> = [];
 
 /** Screen frames are the only kind a client can decline. */
 const wants = (client: SseClient, kind: string) => kind !== "screen" || client.screens;
@@ -222,7 +222,10 @@ function broadcast(payload: Record<string, unknown>) {
   const seq = ++lastSeq;
   const kind = String(payload.kind ?? "");
   const frame = `id: ${STREAM_ID}:${seq}\ndata: ${JSON.stringify({ ...payload, seq })}\n\n`;
-  replayBuffer.push({ seq, kind, frame });
+  // Live desktop captures can each be hundreds of kilobytes and become stale
+  // as soon as the next one arrives. Keep their sequence slots so resume-gap
+  // detection stays honest, but never retain their base64 payloads.
+  replayBuffer.push({ seq, kind, frame: kind === "screen" ? null : frame });
   if (replayBuffer.length > REPLAY_MAX) replayBuffer.shift();
   for (const client of [...sseClients]) {
     if (!wants(client, kind)) continue;
@@ -1210,7 +1213,7 @@ const server = createServer(async (req, res) => {
       );
       if (resumed) {
         for (const buffered of replayBuffer) {
-          if (buffered.seq > since && wants(client, buffered.kind)) res.write(buffered.frame);
+          if (buffered.seq > since && buffered.frame && wants(client, buffered.kind)) res.write(buffered.frame);
         }
       }
 
@@ -1327,6 +1330,7 @@ const server = createServer(async (req, res) => {
     if (m && method === "DELETE") {
       const group = store.group(m[1]);
       if (!group) return json(res, 404, { error: "no such room" });
+      lastReply.delete(group.threadId);
       store.deleteGroup(group.id);
       for (const dir of [EVENTS_DIR, NATIVE_DIR]) {
         try {
@@ -1431,6 +1435,7 @@ const server = createServer(async (req, res) => {
       await registry.get(bot.modelSelection.instanceId)?.adapter.interruptTurn(bot.threadId).catch(() => {});
       stopScreenPoller(bot.id);
       routines!.disableForBot(bot.id);
+      lastReply.delete(bot.threadId);
       store.deleteBot(bot.id);
       for (const dir of [EVENTS_DIR, NATIVE_DIR]) {
         try {

--- a/server/notify.test.ts
+++ b/server/notify.test.ts
@@ -1,0 +1,60 @@
+// What is worth interrupting someone for. The policy is small, so the
+// tests are mostly about the cases where the answer is "stay quiet".
+import { describe, expect, it } from "vitest";
+
+import { buildNotification, summarize } from "./notify.ts";
+
+const bot = { id: "bot-1", name: "Scout", threadId: "thread-1" };
+
+describe("buildNotification", () => {
+  it("names the bot and carries the detail, per kind", () => {
+    expect(buildNotification("approval", bot, "thread-1", "rm -rf ./build")).toMatchObject({
+      kind: "approval",
+      botId: "bot-1",
+      threadId: "thread-1",
+      title: "Scout needs approval",
+      body: "rm -rf ./build",
+    });
+    expect(buildNotification("question", bot, "thread-1", "which branch?")?.title).toBe("Scout has a question");
+    expect(buildNotification("done", bot, "thread-1", "pushed the branch")?.title).toBe("Scout finished");
+    expect(buildNotification("routine-failed", bot, "thread-1", "boom")?.title).toBe("Scout's routine failed");
+  });
+
+  it("stays silent for a bot whose notifications are off", () => {
+    const quiet = { ...bot, notifications: false };
+    for (const kind of ["approval", "question", "done", "routine-failed"] as const) {
+      expect(buildNotification(kind, quiet, "thread-1", "anything")).toBeNull();
+    }
+    // absent means "not turned off" — older bot records predate the flag
+    expect(buildNotification("approval", { ...bot, notifications: undefined }, "thread-1", "x")).not.toBeNull();
+    expect(buildNotification("approval", { ...bot, notifications: true }, "thread-1", "x")).not.toBeNull();
+  });
+
+  it("does not buzz for a finish with nothing to say", () => {
+    expect(buildNotification("done", bot, "thread-1", "   ")).toBeNull();
+    expect(buildNotification("done", bot, "thread-1", "")).toBeNull();
+    // ...but a blocked bot is worth knowing about even with a thin summary
+    expect(buildNotification("approval", bot, "thread-1", "")).not.toBeNull();
+  });
+
+  it("uses the thread it was raised on, not the bot's current one", () => {
+    // a routine runs a bot in a detached task; the notification has to open
+    // that conversation, not whatever the bot happens to be showing
+    expect(buildNotification("done", bot, "other-thread", "done")?.threadId).toBe("other-thread");
+  });
+});
+
+describe("summarize", () => {
+  it("flattens a model's answer into one lock-screen line", () => {
+    expect(summarize("line one\n\nline two")).toBe("line one line two");
+    expect(summarize("before\n```js\nconst x = 1;\n```\nafter")).toBe("before after");
+    expect(summarize("   padded   ")).toBe("padded");
+  });
+
+  it("clamps long text with an ellipsis", () => {
+    const long = summarize("x".repeat(400));
+    expect(long).toHaveLength(140);
+    expect(long.endsWith("…")).toBe(true);
+    expect(summarize("short")).toBe("short");
+  });
+});

--- a/server/notify.ts
+++ b/server/notify.ts
@@ -1,0 +1,68 @@
+// Notifications — what is worth interrupting someone for.
+//
+// `BotRecord.notifications` has been a switch in the settings panel that
+// nothing read. This is the thing that reads it. The rule it encodes is
+// small and deliberate: a bot that is *blocked on you* is worth a buzz, and
+// a bot that *finished* is worth one if you asked for it; everything else a
+// bot does while it works is not.
+//
+// Delivery is a separate concern. The harness emits a frame; whoever is
+// listening decides what to do with it — a desktop notification today, an
+// APNs push to a paired phone once that exists.
+
+export type NotifyKind = "approval" | "question" | "done" | "routine-failed";
+
+export interface Notification {
+  kind: NotifyKind;
+  botId: string;
+  botName: string;
+  threadId: string;
+  title: string;
+  body: string;
+}
+
+/** One line, short enough for a lock screen, with the newlines and code
+ * fences of a model's answer flattened out of it. */
+export function summarize(text: string, max = 140): string {
+  const line = text.replace(/```[\s\S]*?```/g, " ").replace(/\s+/g, " ").trim();
+  return line.length > max ? `${line.slice(0, max - 1).trimEnd()}…` : line;
+}
+
+export interface NotifyBot {
+  id: string;
+  name: string;
+  threadId: string;
+  notifications?: boolean;
+}
+
+/** Build the frame for one event, or null when it should stay quiet.
+ *
+ * Kept pure and separate from the event fold so the policy — which is the
+ * part people will argue about — can be read and tested on its own. */
+export function buildNotification(
+  kind: NotifyKind,
+  bot: NotifyBot,
+  threadId: string,
+  detail: string,
+): Notification | null {
+  // The toggle means what it says: off is off, including for approvals.
+  // A bot whose notifications you turned off can still block waiting for
+  // you — that is the choice you made, and the chat still shows the card.
+  if (bot.notifications === false) return null;
+
+  const body = summarize(detail);
+  const title =
+    kind === "approval"
+      ? `${bot.name} needs approval`
+      : kind === "question"
+        ? `${bot.name} has a question`
+        : kind === "routine-failed"
+          ? `${bot.name}'s routine failed`
+          : `${bot.name} finished`;
+
+  // A "finished" with nothing to say is not worth a notification — the
+  // badge in the sidebar already carries that much.
+  if (kind === "done" && !body) return null;
+
+  return { kind, botId: bot.id, botName: bot.name, threadId, title, body };
+}

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -79,7 +79,9 @@ interface RoutineFile {
 export interface RoutineManagerOptions {
   file?: string;
   now?: () => number;
-  emit?: (payload: unknown) => void;
+  /** Keyed frames only: every payload on this bus is `{ kind, … }`, which
+   * is what lets the server number and replay them. */
+  emit?: (payload: Record<string, unknown>) => void;
   botState: (botId: string) => "ready" | "busy" | "missing";
   createTask: (botId: string, title: string) => { threadId: string } | null;
   startTurn: (

--- a/server/testing/sse.test.ts
+++ b/server/testing/sse.test.ts
@@ -1,0 +1,24 @@
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+
+import { openSse } from "./sse.ts";
+
+describe("SSE recorder", () => {
+  it("rejects pending waits as soon as the remote stream ends", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(": connected\n\n");
+      setTimeout(() => res.end(), 10);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port");
+
+    try {
+      const recorder = await openSse(`http://127.0.0.1:${address.port}`);
+      await expect(recorder.until(() => false, 5_000)).rejects.toThrow(/stream closed/);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/server/testing/sse.ts
+++ b/server/testing/sse.ts
@@ -27,13 +27,24 @@ export async function openSse(url: string, headers: Record<string, string> = {})
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let closed = false;
+  const finish = (error: Error) => {
+    if (closed) return;
+    closed = true;
+    for (const waiter of waiters.splice(0)) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  };
 
   void (async () => {
     let buffer = "";
     try {
       for (;;) {
         const { done, value } = await reader.read();
-        if (done) break;
+        if (done) {
+          finish(new Error("SSE stream closed before a matching frame arrived"));
+          break;
+        }
         buffer += decoder.decode(value, { stream: true });
         let split: number;
         // frames are separated by a blank line; keepalives are comments
@@ -57,8 +68,8 @@ export async function openSse(url: string, headers: Record<string, string> = {})
           }
         }
       }
-    } catch {
-      /* aborted by close(), or the server went away */
+    } catch (error) {
+      if (!closed) finish(error instanceof Error ? error : new Error("SSE stream read failed"));
     }
   })();
 
@@ -85,12 +96,8 @@ export async function openSse(url: string, headers: Record<string, string> = {})
     },
     close: () => {
       if (closed) return;
-      closed = true;
+      finish(new Error("SSE stream closed before a matching frame arrived"));
       controller.abort();
-      for (const waiter of waiters.splice(0)) {
-        clearTimeout(waiter.timer);
-        waiter.reject(new Error("SSE stream closed before a matching frame arrived"));
-      }
     },
   };
 }

--- a/server/testing/sse.ts
+++ b/server/testing/sse.ts
@@ -1,0 +1,75 @@
+// SSE reader for API tests: connect to /api/events, collect frames, and
+// await predicates instead of sleeping — same rule as recordEvents, one
+// layer up (HTTP frames rather than adapter events).
+export interface SseRecorder {
+  frames: any[];
+  /** Resolves with the first frame matching `pred`, already-seen ones
+   * included. Rejects after `timeoutMs` with what did arrive. */
+  until(pred: (frame: any) => boolean, timeoutMs?: number): Promise<any>;
+  close(): void;
+}
+
+export async function openSse(url: string, headers: Record<string, string> = {}): Promise<SseRecorder> {
+  const controller = new AbortController();
+  const res = await fetch(url, { headers: { accept: "text/event-stream", ...headers }, signal: controller.signal });
+  if (!res.ok || !res.body) throw new Error(`SSE connect failed: ${res.status}`);
+
+  const frames: any[] = [];
+  const waiters: Array<{ pred: (frame: any) => boolean; resolve: (frame: any) => void }> = [];
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+
+  void (async () => {
+    let buffer = "";
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let split: number;
+        // frames are separated by a blank line; keepalives are comments
+        while ((split = buffer.indexOf("\n\n")) !== -1) {
+          const chunk = buffer.slice(0, split);
+          buffer = buffer.slice(split + 2);
+          const data = chunk.split("\n").find((line) => line.startsWith("data: "));
+          if (!data) continue;
+          let frame: unknown;
+          try {
+            frame = JSON.parse(data.slice(6));
+          } catch {
+            continue;
+          }
+          frames.push(frame);
+          for (let i = waiters.length - 1; i >= 0; i--) {
+            if (waiters[i].pred(frame)) waiters.splice(i, 1)[0].resolve(frame);
+          }
+        }
+      }
+    } catch {
+      /* aborted by close(), or the server went away */
+    }
+  })();
+
+  return {
+    frames,
+    until(pred, timeoutMs = 10_000) {
+      const seen = frames.find(pred);
+      if (seen) return Promise.resolve(seen);
+      return new Promise((resolve, reject) => {
+        const waiter = { pred, resolve: (frame: any) => (clearTimeout(timer), resolve(frame)) };
+        const timer = setTimeout(() => {
+          const index = waiters.indexOf(waiter);
+          if (index !== -1) waiters.splice(index, 1);
+          reject(
+            new Error(
+              `no matching frame within ${timeoutMs}ms; saw: ${frames.map((f) => f?.kind).join(", ") || "(none)"}`,
+            ),
+          );
+        }, timeoutMs);
+        timer.unref?.();
+        waiters.push(waiter);
+      });
+    },
+    close: () => controller.abort(),
+  };
+}

--- a/server/testing/sse.ts
+++ b/server/testing/sse.ts
@@ -12,12 +12,21 @@ export interface SseRecorder {
 export async function openSse(url: string, headers: Record<string, string> = {}): Promise<SseRecorder> {
   const controller = new AbortController();
   const res = await fetch(url, { headers: { accept: "text/event-stream", ...headers }, signal: controller.signal });
-  if (!res.ok || !res.body) throw new Error(`SSE connect failed: ${res.status}`);
+  if (!res.ok || !res.body) {
+    controller.abort();
+    throw new Error(`SSE connect failed: ${res.status}`);
+  }
 
   const frames: any[] = [];
-  const waiters: Array<{ pred: (frame: any) => boolean; resolve: (frame: any) => void }> = [];
+  const waiters: Array<{
+    pred: (frame: any) => boolean;
+    resolve: (frame: any) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
+  let closed = false;
 
   void (async () => {
     let buffer = "";
@@ -41,7 +50,10 @@ export async function openSse(url: string, headers: Record<string, string> = {})
           }
           frames.push(frame);
           for (let i = waiters.length - 1; i >= 0; i--) {
-            if (waiters[i].pred(frame)) waiters.splice(i, 1)[0].resolve(frame);
+            if (!waiters[i].pred(frame)) continue;
+            const waiter = waiters.splice(i, 1)[0];
+            clearTimeout(waiter.timer);
+            waiter.resolve(frame);
           }
         }
       }
@@ -55,8 +67,8 @@ export async function openSse(url: string, headers: Record<string, string> = {})
     until(pred, timeoutMs = 10_000) {
       const seen = frames.find(pred);
       if (seen) return Promise.resolve(seen);
+      if (closed) return Promise.reject(new Error("SSE stream closed before a matching frame arrived"));
       return new Promise((resolve, reject) => {
-        const waiter = { pred, resolve: (frame: any) => (clearTimeout(timer), resolve(frame)) };
         const timer = setTimeout(() => {
           const index = waiters.indexOf(waiter);
           if (index !== -1) waiters.splice(index, 1);
@@ -67,9 +79,18 @@ export async function openSse(url: string, headers: Record<string, string> = {})
           );
         }, timeoutMs);
         timer.unref?.();
+        const waiter = { pred, resolve, reject, timer };
         waiters.push(waiter);
       });
     },
-    close: () => controller.abort(),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      controller.abort();
+      for (const waiter of waiters.splice(0)) {
+        clearTimeout(waiter.timer);
+        waiter.reject(new Error("SSE stream closed before a matching frame arrived"));
+      }
+    },
   };
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/mascot";
 import { ModelPicker } from "./ModelPicker";
 import { cn } from "@/lib/cn";
+import { requestNotificationPermission } from "@/lib/notify";
 
 function Field({
   label,
@@ -357,7 +358,11 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             <button
               role="switch"
               aria-checked={bot.notifications}
-              onClick={() => patch({ notifications: !bot.notifications })}
+              onClick={() => {
+                const enabled = !bot.notifications;
+                if (enabled) void requestNotificationPermission();
+                patch({ notifications: enabled });
+              }}
               className={cn(
                 "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors",
                 bot.notifications ? "bg-accent" : "bg-raised",

--- a/src/lib/notify.test.ts
+++ b/src/lib/notify.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { requestNotificationPermission, showNotification, type NotifyFrame } from "./notify";
+
+const frame: NotifyFrame = {
+  kind: "done",
+  botId: "bot-1",
+  botName: "Maus",
+  threadId: "thread-1",
+  title: "Maus finished",
+  body: "All done",
+};
+
+function installNotification(permission: NotificationPermission) {
+  const notices: Array<{ title: string; options?: NotificationOptions; onclick: (() => void) | null }> = [];
+  const requestPermission = vi.fn(async () => "granted" as NotificationPermission);
+  class FakeNotification {
+    static permission = permission;
+    static requestPermission = requestPermission;
+    onclick: (() => void) | null = null;
+    constructor(public title: string, public options?: NotificationOptions) {
+      notices.push(this);
+    }
+  }
+  vi.stubGlobal("Notification", FakeNotification);
+  vi.stubGlobal("document", { hasFocus: () => false });
+  vi.stubGlobal("window", { focus: vi.fn() });
+  return { notices, requestPermission };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("desktop notifications", () => {
+  it("does not request permission from a background notification frame", () => {
+    const { notices, requestPermission } = installNotification("default");
+    showNotification(frame, vi.fn());
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(notices).toHaveLength(0);
+  });
+
+  it("requests permission through the explicit settings action", async () => {
+    const { requestPermission } = installNotification("default");
+    await requestNotificationPermission();
+    expect(requestPermission).toHaveBeenCalledOnce();
+  });
+
+  it("shows a notification after permission is granted", () => {
+    const { notices } = installNotification("granted");
+    showNotification(frame, vi.fn());
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({ title: frame.title, options: { body: frame.body, tag: frame.threadId } });
+  });
+});

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -5,6 +5,13 @@ import type { Notification } from "../../server/notify.ts";
 
 export type NotifyFrame = Notification;
 
+/** Ask while handling the settings click. Browsers may reject permission
+ * requests that are triggered later by an incoming SSE frame. */
+export function requestNotificationPermission(): Promise<NotificationPermission> | null {
+  if (typeof Notification === "undefined" || Notification.permission !== "default") return null;
+  return Notification.requestPermission();
+}
+
 /** Show one, unless the app is already in front of the user — a banner over
  * the window you are looking at is noise, and the chat itself already shows
  * the card. */
@@ -19,14 +26,5 @@ export function showNotification(frame: NotifyFrame, onOpen: (botId: string) => 
 
   if (Notification.permission === "granted") {
     new Notification(frame.title, { body: frame.body, tag: frame.threadId }).onclick = open;
-    return;
-  }
-  // Ask only when there is something real to show — a permission prompt on
-  // launch, before the user has any bots doing anything, gets denied.
-  if (Notification.permission === "default") {
-    void Notification.requestPermission().then((permission) => {
-      if (permission !== "granted" || document.hasFocus()) return;
-      new Notification(frame.title, { body: frame.body, tag: frame.threadId }).onclick = open;
-    });
   }
 }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,37 @@
+// Desktop notifications, driven by the harness's {kind:"notify"} frames.
+// The server decides *whether* something is worth an interruption (it owns
+// the per-bot toggle); this only decides how to show it here.
+export interface NotifyFrame {
+  kind: "approval" | "question" | "done" | "routine-failed";
+  botId: string;
+  botName: string;
+  threadId: string;
+  title: string;
+  body: string;
+}
+
+/** Show one, unless the app is already in front of the user — a banner over
+ * the window you are looking at is noise, and the chat itself already shows
+ * the card. */
+export function showNotification(frame: NotifyFrame, onOpen: (botId: string) => void) {
+  if (typeof Notification === "undefined") return;
+  if (document.hasFocus()) return;
+
+  const open = () => {
+    window.focus();
+    onOpen(frame.botId);
+  };
+
+  if (Notification.permission === "granted") {
+    new Notification(frame.title, { body: frame.body, tag: frame.threadId }).onclick = open;
+    return;
+  }
+  // Ask only when there is something real to show — a permission prompt on
+  // launch, before the user has any bots doing anything, gets denied.
+  if (Notification.permission === "default") {
+    void Notification.requestPermission().then((permission) => {
+      if (permission !== "granted" || document.hasFocus()) return;
+      new Notification(frame.title, { body: frame.body, tag: frame.threadId }).onclick = open;
+    });
+  }
+}

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,14 +1,9 @@
 // Desktop notifications, driven by the harness's {kind:"notify"} frames.
 // The server decides *whether* something is worth an interruption (it owns
 // the per-bot toggle); this only decides how to show it here.
-export interface NotifyFrame {
-  kind: "approval" | "question" | "done" | "routine-failed";
-  botId: string;
-  botName: string;
-  threadId: string;
-  title: string;
-  body: string;
-}
+import type { Notification } from "../../server/notify.ts";
+
+export type NotifyFrame = Notification;
 
 /** Show one, unless the app is already in front of the user — a banner over
  * the window you are looking at is noise, and the chat itself already shows

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -16,6 +16,7 @@ import {
 import type { MausColor, MausMotion } from "@/lib/mascot";
 import type { Routine, RoutineInput, RoutineRun } from "@/lib/routines";
 import { currentCall } from "@/lib/call";
+import { showNotification } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 
 export type { MausColor } from "@/lib/mascot";
@@ -1056,10 +1057,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     loadAll();
 
     const es = new EventSource("/api/events");
-    es.onopen = () => {
-      rawDispatch({ type: "connected", value: true });
-      loadAll(); // resync anything missed while disconnected
-    };
+    // The hydrate decision belongs to the hello frame, not to onopen: the
+    // server replays what we missed when it can, and re-downloading every
+    // transcript on a reconnect it already covered is pure waste.
+    es.onopen = () => rawDispatch({ type: "connected", value: true });
     es.onerror = () => rawDispatch({ type: "connected", value: false });
     es.onmessage = (raw) => {
       let frame: any;
@@ -1069,6 +1070,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         return;
       }
       switch (frame.kind) {
+        // First frame on every connection. `resumed` is the server saying
+        // whether it could replay the gap — the browser resends its cursor
+        // as Last-Event-ID by itself, so there is nothing to track here.
+        case "hello":
+          if (!frame.resumed) loadAll();
+          break;
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
           // a settled assistant bubble replaces the in-flight stream
@@ -1126,6 +1133,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           rawDispatch({ type: "groupPatched", group });
           break;
         }
+        // the harness decided this was worth interrupting for; the toggle
+        // in each bot's settings is what gates it, server-side
+        case "notify":
+          showNotification(frame.notification, (botId) => rawDispatch({ type: "select", id: botId }));
+          break;
         case "group.deleted":
           rawDispatch({ type: "groupDeleted", groupId: frame.groupId });
           break;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1055,6 +1055,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         .catch(() => {});
     };
     loadAll();
+    // The eager call above is the cold start. `hello` below decides whether
+    // a *reconnect* needs another one, and this first connection never does.
+    let firstHello = true;
 
     const es = new EventSource("/api/events");
     // The hydrate decision belongs to the hello frame, not to onopen: the
@@ -1074,7 +1077,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         // whether it could replay the gap — the browser resends its cursor
         // as Last-Event-ID by itself, so there is nothing to track here.
         case "hello":
-          if (!frame.resumed) loadAll();
+          // The eager load already covered the cold start, so the first
+          // hello is never a reason to repeat it — treating it as one cost
+          // eight API calls and two full transcript downloads on every page
+          // load. Only a reconnect the server could not replay needs fresh
+          // state.
+          if (!firstHello && !frame.resumed) loadAll();
+          firstHello = false;
           break;
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
@@ -1136,7 +1145,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         // the harness decided this was worth interrupting for; the toggle
         // in each bot's settings is what gates it, server-side
         case "notify":
-          showNotification(frame.notification, (botId) => rawDispatch({ type: "select", id: botId }));
+          // the wrapped dispatch, not rawDispatch: `select` clears the badge
+          // in local state either way, but only the wrapper PATCHes
+          // unread:false back. Opening a bot from its own notification and
+          // watching the badge return on the next hydration is exactly the
+          // bug that makes notifications feel broken.
+          showNotification(frame.notification, (botId) => dispatch({ type: "select", id: botId }));
           break;
         case "group.deleted":
           rawDispatch({ type: "groupDeleted", groupId: frame.groupId });

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1040,24 +1040,57 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // ── initial load + SSE fold ──────────────────────────────────────────
   useEffect(() => {
     let alive = true;
-    const loadAll = () => {
-      api("/api/bots")
-        .then(({ bots, groups }) => alive && rawDispatch({ type: "hydrate", bots, groups: groups ?? [] }))
-        .catch(() => {});
-      api("/api/instances")
-        .then(({ instances }) => alive && rawDispatch({ type: "instances", instances }))
-        .catch(() => {});
-      api("/api/config")
-        .then((config) => alive && rawDispatch({ type: "configStatus", config }))
-        .catch(() => {});
-      api("/api/routines")
-        .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs }))
-        .catch(() => {});
+    const loadAll = () =>
+      Promise.all([
+        api("/api/bots")
+          .then(({ bots, groups }) => alive && rawDispatch({ type: "hydrate", bots, groups: groups ?? [] }))
+          .catch(() => {}),
+        api("/api/instances")
+          .then(({ instances }) => alive && rawDispatch({ type: "instances", instances }))
+          .catch(() => {}),
+        api("/api/config")
+          .then((config) => alive && rawDispatch({ type: "configStatus", config }))
+          .catch(() => {}),
+        api("/api/routines")
+          .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs }))
+          .catch(() => {}),
+      ]);
+
+    // A snapshot and the live fold have to meet at a defined boundary. Start
+    // hydration only after the stream says hello, queue frames that arrive
+    // while the REST snapshot is in flight, then apply them on top. Otherwise
+    // a late hydrate can overwrite a newer event, or an event can land between
+    // an eager request and the stream opening and disappear entirely.
+    let hydrated = false;
+    let hydrating = false;
+    let rehydrateRequested = false;
+    const pendingFrames: any[] = [];
+    let handleFrame: (frame: any) => void;
+    const hydrate = () => {
+      if (hydrating) {
+        // A second non-resumable hello means this snapshot may have started
+        // before another connection gap. Run one more after it settles.
+        rehydrateRequested = true;
+        return;
+      }
+      hydrating = true;
+      hydrated = false;
+      void loadAll().finally(() => {
+        if (!alive) return;
+        hydrating = false;
+        if (rehydrateRequested) {
+          rehydrateRequested = false;
+          hydrate();
+          return;
+        }
+        hydrated = true;
+        for (const frame of pendingFrames.splice(0)) handleFrame(frame);
+      });
     };
-    loadAll();
-    // The eager call above is the cold start. `hello` below decides whether
-    // a *reconnect* needs another one, and this first connection never does.
-    let firstHello = true;
+    // If SSE is unavailable, the app should still show its saved state. A
+    // later first hello hydrates again because it cannot prove there was no
+    // gap before that connection opened.
+    const hydrationFallback = setTimeout(hydrate, 1_000);
 
     const es = new EventSource("/api/events");
     // The hydrate decision belongs to the hello frame, not to onopen: the
@@ -1065,26 +1098,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // transcript on a reconnect it already covered is pure waste.
     es.onopen = () => rawDispatch({ type: "connected", value: true });
     es.onerror = () => rawDispatch({ type: "connected", value: false });
-    es.onmessage = (raw) => {
-      let frame: any;
-      try {
-        frame = JSON.parse(raw.data);
-      } catch {
-        return;
-      }
+    handleFrame = (frame) => {
       switch (frame.kind) {
-        // First frame on every connection. `resumed` is the server saying
-        // whether it could replay the gap — the browser resends its cursor
-        // as Last-Event-ID by itself, so there is nothing to track here.
-        case "hello":
-          // The eager load already covered the cold start, so the first
-          // hello is never a reason to repeat it — treating it as one cost
-          // eight API calls and two full transcript downloads on every page
-          // load. Only a reconnect the server could not replay needs fresh
-          // state.
-          if (!firstHello && !frame.resumed) loadAll();
-          firstHello = false;
-          break;
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
           // a settled assistant bubble replaces the in-flight stream
@@ -1216,8 +1231,26 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
       }
     };
+    es.onmessage = (raw) => {
+      let frame: any;
+      try {
+        frame = JSON.parse(raw.data);
+      } catch {
+        return;
+      }
+      // `hello` is the snapshot boundary. A false `resumed` means the server
+      // could not fill the gap, so queue subsequent frames behind a hydrate.
+      if (frame.kind === "hello") {
+        clearTimeout(hydrationFallback);
+        if (!frame.resumed) hydrate();
+        return;
+      }
+      if (hydrated) handleFrame(frame);
+      else pendingFrames.push(frame);
+    };
     return () => {
       alive = false;
+      clearTimeout(hydrationFallback);
       es.close();
     };
   }, []);


### PR DESCRIPTION
## What changed

Three changes to the event stream and hydration, all of which any client benefits from — the desktop app included.

**The SSE stream is resumable.** Every broadcast frame now carries a monotonic `seq`, stamped at broadcast and emitted as the SSE `id:` field. `GET /api/events?since=<cursor>` — or a `Last-Event-ID` header, which is what `EventSource` sends by itself — replays from that point instead of starting cold.

**Hydration is pageable.** `GET /api/bots?messages=n` returns the newest *n* messages per thread with a `hasMore` flag instead of every message ever. `GET /api/threads/:threadId/messages?before=<id>&limit=n` walks backwards from there. In the paged shape, screen captures are reduced to a flag and fetched individually from `GET /api/threads/:threadId/messages/:messageId/image`.

**`BotRecord.notifications` is finally read.** `buildNotification` consults it and returns `null` when the toggle is off; the resulting `notify` frame is what a client acts on.

`server/testing/sse.ts` is a small test helper for driving a real event stream, so the frames are asserted on the wire rather than on an internal bus.

## Why

**Reconnect refetches the world.** Frames carry no sequence number and `/api/events` honours no cursor, so a client that loses its connection for two seconds has no way to ask what it missed. Its only recovery is full re-hydration. That is invisible on a fast machine with three bots and expensive on a long-running fleet — and it happens on every laptop sleep.

**Hydration is all-or-nothing.** `GET /api/bots` returns every bot's entire transcript. That is a perfectly good shape over loopback, where it is a memcpy. It is a poor one anywhere else, and it is also the reason a cold start gets slower every week you use the app. Inlining base64 screen captures into that same payload compounds it.

**The per-bot notifications toggle already ships in the UI and nothing reads it.** Turning it off does nothing today.

None of this changes the default behaviour: `?messages=` and `?since=` are opt-in, and a client that passes neither gets exactly what it got before.

## How it was verified

- `pnpm typecheck` and `pnpm test` — green (304 tests).
- `pnpm check:electron` — green.
- Both new thread routes 404 an unknown conversation rather than answering for it. That matters more than it reads: `store.messagesFor()` materialises **and caches** a `ThreadState` for any id it is handed, so an unguarded route lets a client grow that map by asking about threads that were never real.
- New tests in `server/index.test.ts` cover the paging boundaries (`hasMore` at and past the end, `before=` walking to the start of a thread, the image endpoint), and the replay path: a client that disconnects, misses frames, and reconnects with a cursor receives exactly the frames it missed and no others.
- `server/notify.test.ts` covers the toggle being respected and the summary stripping code fences — a notification whose body is a diff is not a notification.
- The replay tests drive a real SSE connection through `server/testing/sse.ts` and assert on the emitted frames, not on the bus, so the `id:` field and the cursor are checked as a client would see them. No sleeps — every wait is on the event that proves the behaviour.

## Screenshots (UI changes)

No visible UI change. The one user-facing difference is that the existing per-bot notifications toggle now has an effect.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added desktop notifications for questions, approvals, completed responses, and routine failures.
  - Notifications summarize activity and open the associated bot and conversation when selected.
  - Added paginated transcript loading with cursor support and on-demand screen-image retrieval.
  - Added screen filtering and reliable event-stream reconnection with replay support.

- **Bug Fixes**
  - Improved synchronization during initial loading and reconnects, reducing unnecessary data reloads.
  - Prevented notifications for disabled bots and empty completed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->