### PR TITLE
Name the Composio tools that actually exist

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -764,7 +764,7 @@ async function startTurn(
           // gated on the integration, not the key: the hint only goes to a
           // bot whose driver actually mounted the tools
           (integrations.composio
-            ? " The user's connected apps (Gmail, Calendar, Slack, Notion, and the rest) are reachable through the composio tools — find the right one with COMPOSIO_SEARCH_TOOLS and run it with COMPOSIO_EXECUTE_TOOL. Reach for them before telling the user you have no access to a service."
+            ? " The user's connected apps (Gmail, Calendar, Slack, Notion, and the rest) are reachable through the composio tools — find the right one with COMPOSIO_SEARCH_TOOLS, read its arguments with COMPOSIO_GET_TOOL_SCHEMAS, then run it with COMPOSIO_MULTI_EXECUTE_TOOL. Reach for them before telling the user you have no access to a service."
             : "") +
           (coordinationPrompt ? ` ${coordinationPrompt}` : "") +
           (tagged.length


### PR DESCRIPTION
The system-prompt hint from #36 tells every Composio-enabled bot to *"run it with `COMPOSIO_EXECUTE_TOOL`"*. **That tool does not exist.**

I queried the live endpoint the driver actually mounts (`connect.composio.dev/mcp`, using the repo's own configured key, through the same URL/header path as `server/composio.ts`). `tools/list` returns exactly seven tools:

```
COMPOSIO_GET_TOOL_SCHEMAS   COMPOSIO_MANAGE_CONNECTIONS   COMPOSIO_MULTI_EXECUTE_TOOL
COMPOSIO_REMOTE_BASH_TOOL   COMPOSIO_REMOTE_WORKBENCH     COMPOSIO_SEARCH_TOOLS
COMPOSIO_WAIT_FOR_CONNECTIONS
```

`COMPOSIO_EXECUTE_TOOL` is not among them and is not an alias — calling it returns `MCP error -32602: Tool COMPOSIO_EXECUTE_TOOL not found`.

**Why it matters:** a bot that trusts the hint burns its turn on a `-32602` and then tells the user it has no access to the service — precisely the failure #36 was written to prevent. The hint also skipped a step: a tool's arguments come from `COMPOSIO_GET_TOOL_SCHEMAS`, so search → execute alone can't construct a valid call.

The prompt now names the real flow: `COMPOSIO_SEARCH_TOOLS` → `COMPOSIO_GET_TOOL_SCHEMAS` → `COMPOSIO_MULTI_EXECUTE_TOOL`.

One line. `pnpm typecheck` clean, 327 passed / 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)