### PR TITLE
Harden peer delegation lifecycle

### DIFF
--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -36,6 +36,7 @@ export function mirrorExchange(
   target: BotRecord,
   message: string,
   channel: GroupRecord | undefined,
+  sourceThreadId = from.threadId,
 ): void {
   const note = (threadId: string, m: Omit<Message, "id" | "at">) => {
     const message = bus.store.appendMessage(threadId, m);
@@ -50,7 +51,7 @@ export function mirrorExchange(
       from: { botId: from.id, name: from.name, color: from.color },
     });
   }
-  note(from.threadId, {
+  note(sourceThreadId, {
     role: "bot",
     kind: "activity",
     tool: { name: `Messaged @${target.name}` },

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -393,7 +393,7 @@ describe("comms e2e (fake ACP fleet)", () => {
 
       // The card carries the allowKey the Always-allow flow mirrors back
       // into bot.alwaysAllow, and offers Allow / Deny / Always allow.
-      expect(card.card.allowKey).toBe("ask_bot:@Helper");
+      expect(card.card.allowKey).toBe(`ask_bot:${helper.id}`);
       expect(card.card.options).toEqual(["Allow", "Deny", "Always allow"]);
       expect(card.card.title).toContain("@Asker");
       expect(card.card.title).toContain("@Helper");
@@ -526,8 +526,9 @@ describe("comms e2e (fake ACP fleet)", () => {
   it("does not inject the agents integration into a depth-1 turn", async () => {
     const seeded = (await api("GET", "/api/bots")).body.bots[0];
     await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
-    // Both bots run ask-peer: A delegates to B (still in ask-peer mode),
-    // so the regression signal is observable when the guard is broken.
+    // A runs delegate-peer and hands off to B, which runs ask-peer. If the
+    // depth guard broke, B's depth-1 turn would call ask_bot and its reply
+    // would carry the "one hop" refusal — the regression signal.
     const selection = { instanceId: "grok", model: "fake-model" };
     const askerSelection = { instanceId: "askerDelegate", model: "fake-model" };
     const helper = (await api("POST", "/api/bots")).body.bot;

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -41,14 +41,14 @@ function setupBuses(store: Store): BusPair {
   return { commsBus, approvalBus, broadcasts, groupBroadcasts };
 }
 
-/** Poll until `predicate` returns a defined value or `timeout` elapses.
+/** Poll until `predicate` returns a truthy value or `timeout` elapses.
  * drainDelegations is fire-and-forget (processOne runs as a Promise) so
  * tests need to wait for its async steps to land. */
-async function waitFor<T>(predicate: () => T | undefined, timeout = 2_000): Promise<T> {
+async function waitFor<T>(predicate: () => T | undefined | false, timeout = 2_000): Promise<T> {
   const deadline = Date.now() + timeout;
   for (;;) {
     const v = predicate();
-    if (v !== undefined) return v;
+    if (v) return v as T;
     if (Date.now() > deadline) throw new Error("waitFor: timed out");
     await new Promise((r) => setTimeout(r, 25));
   }
@@ -128,6 +128,27 @@ describe("queueDelegation", () => {
     );
     expect(broadcast).toBeTruthy();
   });
+
+  it("keys detached routine delegations to their real source thread", async () => {
+    const routineTask = store.createTask(from.id, "Routine run", false)!;
+    const result = queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "routine follow-up", depth: 0 },
+      1,
+      routineTask.threadId,
+    );
+
+    expect(result).toBe("ok");
+    expect(_pendingCount(routineTask.threadId)).toBe(1);
+    expect(_pendingCount(from.threadId)).toBe(0);
+    expect(
+      store.messagesFor(routineTask.threadId).some((m) => m.tool?.name === "Delegated to @Helper"),
+    ).toBe(true);
+    expect(
+      store.messagesFor(from.threadId).some((m) => m.tool?.name === "Delegated to @Helper"),
+    ).toBe(false);
+  });
 });
 
 describe("drainDelegations", () => {
@@ -199,6 +220,45 @@ describe("drainDelegations", () => {
     expect(runTargetCalls[0]!.message).toContain("[Reason: next step]");
   });
 
+  it("drains and mirrors a detached routine delegation on its source thread", async () => {
+    const activeThreadId = from.threadId;
+    const routineTask = store.createTask(from.id, "Routine run", false)!;
+    queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "routine follow-up", depth: 0 },
+      1,
+      routineTask.threadId,
+    );
+
+    drainDelegations(commsBus, approvalBus, routineTask.threadId, (toBotId, message, commsDepth) => {
+      runTargetCalls.push({ toBotId, message, commsDepth });
+    });
+
+    await waitFor(() => runTargetCalls.length === 1);
+    expect(_pendingCount(routineTask.threadId)).toBe(0);
+    expect(
+      store.messagesFor(routineTask.threadId).some((m) => m.tool?.name === "Messaged @Helper"),
+    ).toBe(true);
+    expect(
+      store.messagesFor(activeThreadId).some((m) => m.tool?.name === "Messaged @Helper"),
+    ).toBe(false);
+  });
+
+  it("contains a rejected delegation worker and reports it on the source thread", async () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1);
+    drainDelegations(commsBus, approvalBus, from.threadId, () => {
+      throw new Error("target runner exploded");
+    });
+
+    const failure = await waitFor(() =>
+      store
+        .messagesFor(from.threadId)
+        .find((m) => m.tool?.ok === false && m.tool.name.includes("target runner exploded")),
+    );
+    expect(failure.tool?.name).toContain("delegation failed");
+  });
+
   it("skips runTarget and emits a 'no such bot' chip when the target was deleted", async () => {
     queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1);
     store.deleteBot(target.id);
@@ -243,7 +303,7 @@ describe("drainDelegations", () => {
     );
     expect(card.card?.title).toContain("delegate to @Helper");
     expect(card.card?.tool).toBe("delegate_bot");
-    expect(card.card?.allowKey).toBe(peerAllowKey("delegate_bot", "Helper"));
+    expect(card.card?.allowKey).toBe(peerAllowKey("delegate_bot", target.id));
     expect(card.card?.options).toEqual(["Allow", "Deny", "Always allow"]);
     expect(runTargetCalls).toEqual([]);
 
@@ -277,7 +337,7 @@ describe("drainDelegations", () => {
   it("auto-allows when alwaysAllow already covers the pair (no card pushed)", async () => {
     store.patchBot(from.id, {
       approvePeerComms: true,
-      alwaysAllow: [peerAllowKey("delegate_bot", "Helper")],
+      alwaysAllow: [peerAllowKey("delegate_bot", target.id)],
     });
     queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1);
     drainDelegations(commsBus, approvalBus, from.threadId, (toBotId, message, commsDepth) => {

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -157,7 +157,7 @@ describe("drainDelegations", () => {
   let target: BotRecord;
   let commsBus: CommsBus;
   let approvalBus: { store: Store; broadcast: (payload: unknown) => void };
-  let runTargetCalls: Array<{ toBotId: string; message: string; commsDepth: number }>;
+  let runTargetCalls: Array<{ toBotId: string; message: string; commsDepth: number; sourceThreadId?: string }>;
 
   beforeEach(() => {
     rmSync(DATA_DIR, { recursive: true, force: true });
@@ -231,12 +231,18 @@ describe("drainDelegations", () => {
       routineTask.threadId,
     );
 
-    drainDelegations(commsBus, approvalBus, routineTask.threadId, (toBotId, message, commsDepth) => {
-      runTargetCalls.push({ toBotId, message, commsDepth });
-    });
+    drainDelegations(
+      commsBus,
+      approvalBus,
+      routineTask.threadId,
+      (toBotId, message, commsDepth, sourceThreadId) => {
+        runTargetCalls.push({ toBotId, message, commsDepth, sourceThreadId });
+      },
+    );
 
     await waitFor(() => runTargetCalls.length === 1);
     expect(_pendingCount(routineTask.threadId)).toBe(0);
+    expect(runTargetCalls[0]?.sourceThreadId).toBe(routineTask.threadId);
     expect(
       store.messagesFor(routineTask.threadId).some((m) => m.tool?.name === "Messaged @Helper"),
     ).toBe(true);
@@ -257,6 +263,31 @@ describe("drainDelegations", () => {
         .find((m) => m.tool?.ok === false && m.tool.name.includes("target runner exploded")),
     );
     expect(failure.tool?.name).toContain("delegation failed");
+  });
+
+  it("reports an asynchronous target-start rejection on a detached source thread", async () => {
+    const activeThreadId = from.threadId;
+    const routineTask = store.createTask(from.id, "Routine run", false)!;
+    queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "do this", depth: 0 },
+      1,
+      routineTask.threadId,
+    );
+    drainDelegations(commsBus, approvalBus, routineTask.threadId, () =>
+      Promise.reject(new Error("provider disappeared")),
+    );
+
+    const failure = await waitFor(() =>
+      store
+        .messagesFor(routineTask.threadId)
+        .find((m) => m.tool?.ok === false && m.tool.name.includes("provider disappeared")),
+    );
+    expect(failure.tool?.name).toContain("delegation failed");
+    expect(
+      store.messagesFor(activeThreadId).some((m) => m.tool?.name.includes("provider disappeared")),
+    ).toBe(false);
   });
 
   it("skips runTarget and emits a 'no such bot' chip when the target was deleted", async () => {

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -77,7 +77,12 @@ export function drainDelegations(
   bus: CommsBus,
   approvalBus: ApprovalBus,
   threadId: string,
-  runTarget: (toBotId: string, message: string, commsDepth: number) => void,
+  runTarget: (
+    toBotId: string,
+    message: string,
+    commsDepth: number,
+    sourceThreadId: string,
+  ) => void | Promise<void>,
 ): void {
   const list = pendingDelegations.get(threadId);
   if (!list?.length) return;
@@ -123,7 +128,12 @@ async function processOne(
   from: BotRecord,
   sourceThreadId: string,
   item: DelegationItem,
-  runTarget: (toBotId: string, message: string, commsDepth: number) => void,
+  runTarget: (
+    toBotId: string,
+    message: string,
+    commsDepth: number,
+    sourceThreadId: string,
+  ) => void | Promise<void>,
 ): Promise<void> {
   let sender = from;
   let target = bus.store.bot(item.toBotId);
@@ -186,7 +196,7 @@ async function processOne(
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-  runTarget(item.toBotId, prefixed, item.depth + 1);
+  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId);
 }
 
 /** Test helper: how many items remain queued for a thread. */

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -44,25 +44,26 @@ export function queueDelegation(
   from: BotRecord,
   item: DelegationItem,
   maxDepth: number,
+  sourceThreadId = from.threadId,
 ): QueueResult {
   if (item.toBotId === from.id) return "self";
   if (item.depth >= maxDepth) return "too_deep";
   const target = bus.store.bot(item.toBotId);
   if (!target) return "no_target";
-  const list = pendingDelegations.get(from.threadId) ?? [];
+  const list = pendingDelegations.get(sourceThreadId) ?? [];
   // Async handoff removes the backpressure that ask_bot got for free by
   // making the caller wait. Without a cap, one turn can queue unboundedly
   // and fan out into as many real turns on the next settle.
   if (list.length >= MAX_QUEUED_PER_THREAD) return "too_many";
   list.push(item);
-  pendingDelegations.set(from.threadId, list);
+  pendingDelegations.set(sourceThreadId, list);
   const label = `Delegated to @${target.name}${item.reason ? `: ${item.reason}` : ""}`;
-  const note = bus.store.appendMessage(from.threadId, {
+  const note = bus.store.appendMessage(sourceThreadId, {
     role: "bot",
     kind: "activity",
     tool: { name: label },
   });
-  bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+  bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
   return "ok";
 }
 
@@ -84,7 +85,19 @@ export function drainDelegations(
   const from = bus.store.botByThread(threadId);
   if (!from) return;
   for (const item of list) {
-    void processOne(bus, approvalBus, from, item, runTarget);
+    void processOne(bus, approvalBus, from, threadId, item, runTarget).catch((error) => {
+      const why = error instanceof Error ? error.message : String(error);
+      try {
+        const note = bus.store.appendMessage(threadId, {
+          role: "bot",
+          kind: "activity",
+          tool: { name: `error: delegation failed — ${why.slice(0, 120)}`, ok: false },
+        });
+        bus.broadcast({ kind: "message", threadId, message: note });
+      } catch (reportError) {
+        console.error("delegation failed and could not be reported", reportError);
+      }
+    });
   }
 }
 
@@ -96,49 +109,58 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
   pendingDelegations.delete(threadId);
   const from = bus.store.botByThread(threadId);
   if (!from) return;
-  const note = bus.store.appendMessage(from.threadId, {
+  const note = bus.store.appendMessage(threadId, {
     role: "bot",
     kind: "activity",
     tool: { name: `${list.length} queued delegation${list.length > 1 ? "s" : ""} dropped — the turn did not finish`, ok: false },
   });
-  bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+  bus.broadcast({ kind: "message", threadId, message: note });
 }
 
 async function processOne(
   bus: CommsBus,
   approvalBus: ApprovalBus,
   from: BotRecord,
+  sourceThreadId: string,
   item: DelegationItem,
   runTarget: (toBotId: string, message: string, commsDepth: number) => void,
 ): Promise<void> {
-  const target = bus.store.bot(item.toBotId);
+  let sender = from;
+  let target = bus.store.bot(item.toBotId);
   if (!target) {
-    const note = bus.store.appendMessage(from.threadId, {
+    const note = bus.store.appendMessage(sourceThreadId, {
       role: "bot",
       kind: "activity",
       tool: { name: `error: delegation to ${item.toBotId} failed — no such bot`, ok: false },
     });
-    bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+    bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
     return;
   }
   if (target.busy) {
-    const note = bus.store.appendMessage(from.threadId, {
+    const note = bus.store.appendMessage(sourceThreadId, {
       role: "bot",
       kind: "activity",
       tool: { name: `Delegation to @${target.name} canceled — @${target.name} is busy`, ok: false },
     });
-    bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+    bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
     return;
   }
-  if (from.approvePeerComms) {
-    const verdict = await requestPeerApproval(approvalBus, from, target, item.message, "delegate_bot");
+  if (sender.approvePeerComms) {
+    const verdict = await requestPeerApproval(
+      approvalBus,
+      sender,
+      target,
+      item.message,
+      "delegate_bot",
+      sourceThreadId,
+    );
     if (verdict !== "allow") {
-      const note = bus.store.appendMessage(from.threadId, {
+      const note = bus.store.appendMessage(sourceThreadId, {
         role: "bot",
         kind: "activity",
         tool: { name: `Delegation to @${target.name} denied by user`, ok: false },
       });
-      bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+      bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
       return;
     }
     // The approval could have been sitting for up to 15 minutes. Everything
@@ -146,22 +168,24 @@ async function processOne(
     // busy, or an allow can start a second turn on a bot that is mid-turn —
     // and mirror a "Messaged @X" chip for an exchange that never happens.
     const current = bus.store.bot(item.toBotId);
-    const sender = bus.store.bot(from.id);
-    if (!current || !sender) return;
+    const currentSender = bus.store.bot(from.id);
+    if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return;
     if (current.busy) {
-      const note = bus.store.appendMessage(from.threadId, {
+      const note = bus.store.appendMessage(sourceThreadId, {
         role: "bot",
         kind: "activity",
         tool: { name: `Delegation to @${current.name} canceled — @${current.name} is busy`, ok: false },
       });
-      bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+      bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
       return;
     }
+    sender = currentSender;
+    target = current;
   }
-  const channel = getOrCreateChannel(bus.store, from, target);
-  mirrorExchange(bus, from, target, item.message, channel);
+  const channel = getOrCreateChannel(bus.store, sender, target);
+  mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
-  const prefixed = `[Delegated by @${from.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
+  const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
   runTarget(item.toBotId, prefixed, item.depth + 1);
 }
 

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -18,6 +18,8 @@ let stubPort = 0;
 let lastAuth: string | undefined;
 let lastAskBody: any = null;
 let askResponse: unknown = { botName: "Helper", text: "hi from helper" };
+let lastDelegateBody: any = null;
+let delegateResponse: unknown = { queued: true, message: "Delegation queued." };
 
 let child: ChildProcess;
 const pending = new Map<number, (msg: any) => void>();
@@ -60,6 +62,16 @@ beforeAll(async () => {
       });
       return;
     }
+    if (req.method === "POST" && req.url === "/api/internal/delegate-bot") {
+      let data = "";
+      req.on("data", (c) => (data += c));
+      req.on("end", () => {
+        lastDelegateBody = JSON.parse(data);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(delegateResponse));
+      });
+      return;
+    }
     res.writeHead(404, { "content-type": "application/json" });
     res.end(JSON.stringify({ error: "unknown" }));
   });
@@ -71,6 +83,7 @@ beforeAll(async () => {
       ...process.env,
       OMB_HARNESS_URL: `http://127.0.0.1:${stubPort}`,
       OMB_BOT_ID: "bot-asker",
+      OMB_THREAD_ID: "thread-asker-routine",
       OMB_COMMS_TOKEN: TOKEN,
       OMB_TURN_DEPTH: "0",
     },
@@ -117,7 +130,13 @@ describe("agents-proxy MCP surface", () => {
     const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
     expect(res.result.content[0].text).toContain("Helper replied:");
     expect(res.result.content[0].text).toContain("hi from helper");
-    expect(lastAskBody).toMatchObject({ fromBotId: "bot-asker", toBotId: "bot-helper", message: "ping", depth: 0 });
+    expect(lastAskBody).toMatchObject({
+      fromBotId: "bot-asker",
+      fromThreadId: "thread-asker-routine",
+      toBotId: "bot-helper",
+      message: "ping",
+      depth: 0,
+    });
   });
 
   it("renders a busy peer as a clean answer, not an error", async () => {
@@ -132,6 +151,31 @@ describe("agents-proxy MCP surface", () => {
     const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain("one hop");
+  });
+
+  it("forwards the source thread when queueing a delegation", async () => {
+    delegateResponse = { queued: true, message: "Delegation queued." };
+    const res = await callTool("delegate_bot", {
+      bot_id: "bot-helper",
+      message: "take this",
+      reason: "follow-up",
+    });
+    expect(res.result.content[0].text).toContain("Delegation queued");
+    expect(lastDelegateBody).toMatchObject({
+      fromBotId: "bot-asker",
+      fromThreadId: "thread-asker-routine",
+      toBotId: "bot-helper",
+      message: "take this",
+      reason: "follow-up",
+      depth: 0,
+    });
+  });
+
+  it("returns queue refusal guidance to the agent as a tool error", async () => {
+    delegateResponse = { error: "delegation chains are limited to one hop — do this one yourself" };
+    const res = await callTool("delegate_bot", { bot_id: "bot-helper", message: "take this" });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toContain("do this one yourself");
   });
 
   it("rejects unknown tools with -32602", async () => {

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -22,6 +22,7 @@ import readline from "node:readline";
 
 const HARNESS = process.env.OMB_HARNESS_URL ?? "http://127.0.0.1:8799";
 const BOT_ID = process.env.OMB_BOT_ID ?? "";
+const THREAD_ID = process.env.OMB_THREAD_ID ?? "";
 const TOKEN = process.env.OMB_COMMS_TOKEN ?? "";
 const DEPTH = Number(process.env.OMB_TURN_DEPTH ?? "0") || 0;
 
@@ -96,7 +97,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     if (!toBotId || !message) return { text: "ask_bot needs bot_id and message.", isError: true };
     const r = await api(`/api/internal/ask-bot`, {
       method: "POST",
-      body: JSON.stringify({ fromBotId: BOT_ID, toBotId, message, depth: DEPTH }),
+      body: JSON.stringify({ fromBotId: BOT_ID, fromThreadId: THREAD_ID, toBotId, message, depth: DEPTH }),
     });
     if (r.busy) return { text: `That bot is busy right now — try again after it finishes.` };
     if (r.error) return { text: `Couldn't reach that bot: ${r.error}`, isError: true };
@@ -107,7 +108,13 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     const message = String(args.message ?? "").trim();
     const reason = typeof args.reason === "string" ? args.reason.trim() : "";
     if (!toBotId || !message) return { text: "delegate_bot needs bot_id and message.", isError: true };
-    const body: Record<string, unknown> = { fromBotId: BOT_ID, toBotId, message, depth: DEPTH };
+    const body: Record<string, unknown> = {
+      fromBotId: BOT_ID,
+      fromThreadId: THREAD_ID,
+      toBotId,
+      message,
+      depth: DEPTH,
+    };
     if (reason) body.reason = reason;
     const r = await api(`/api/internal/delegate-bot`, { method: "POST", body: JSON.stringify(body) });
     if (r.error) return { text: `Couldn't queue the delegation: ${r.error}`, isError: true };

--- a/server/index.ts
+++ b/server/index.ts
@@ -473,22 +473,22 @@ bus.subscribe((event: RuntimeEvent) => {
   // firing it later: the user who hit Stop does not expect the delegations
   // that turn queued to run anyway, minutes later, on an unrelated turn.
   if (!event.ok) return void discardDelegations(commsBus, event.threadId);
-  drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth) => {
+  drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth, sourceThreadId) => {
     // startTurn REJECTS on an ordinary condition — busy target, deleted bot,
     // unavailable provider. Unhandled, that rejection is fatal to the
     // harness (Node's default), which in the packaged app kills the server
     // child. Every delegation failure has to land as a chip instead.
-    void startTurn(toBotId, text, { commsDepth }).catch((err) => {
+    return startTurn(toBotId, text, { commsDepth }).catch((err) => {
       const bot = store.bot(toBotId);
       const why = err instanceof Error ? err.message : String(err);
-      const source = store.botByThread(event.threadId);
+      const source = store.botByThread(sourceThreadId);
       if (!source) return;
-      const note = store.appendMessage(source.threadId, {
+      const note = store.appendMessage(sourceThreadId, {
         role: "bot",
         kind: "activity",
         tool: { name: `error: delegation to @${bot?.name ?? toBotId} could not start — ${why.slice(0, 120)}`, ok: false },
       });
-      broadcast({ kind: "message", threadId: source.threadId, message: note });
+      broadcast({ kind: "message", threadId: sourceThreadId, message: note });
     });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -74,7 +74,7 @@ const agentsProxyPath = (() => {
 // in the packaged app process.execPath is Electron — run the proxy as node
 const AGENTS_NODE_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
 
-function agentsIntegration(botId: string, depth: number) {
+function agentsIntegration(botId: string, threadId: string, depth: number) {
   return {
     command: process.execPath,
     args: [agentsProxyPath],
@@ -82,6 +82,7 @@ function agentsIntegration(botId: string, depth: number) {
       ...AGENTS_NODE_FLAG,
       OMB_HARNESS_URL: `http://127.0.0.1:${PORT}`,
       OMB_BOT_ID: botId,
+      OMB_THREAD_ID: threadId,
       OMB_COMMS_TOKEN: COMMS_TOKEN,
       OMB_TURN_DEPTH: String(depth),
     },
@@ -764,7 +765,7 @@ async function startTurn(
         instance.adapter.capabilities.agentsMcp === true &&
         store.bots.filter((b) => b.id !== bot.id && !b.hidden).length > 0
       ) {
-        integrations.agents = agentsIntegration(bot.id, commsDepth);
+        integrations.agents = agentsIntegration(bot.id, threadId, commsDepth);
       }
       // @mentions in the user's message (the composer's tagging UI) become
       // an explicit delegation nudge — the agent still does the ask_bot call
@@ -1203,7 +1204,12 @@ const server = createServer(async (req, res) => {
         // hard refusal — every peer turn has an accountable sender.
         const from = store.bot(fromBotId);
         if (!from) return json(res, 403, { error: "unknown sender" });
-        const fromName = from.name;
+        const fromThreadId = String(body.fromThreadId ?? from.threadId);
+        if (!store.taskByThread(from.id, fromThreadId)) {
+          return json(res, 403, { error: "source thread does not belong to sender" });
+        }
+        let currentFrom = from;
+        let currentTarget = target;
 
         // the exchange is mirrored into a bot⇄bot channel: it shows up in
         // the sidebar like any room, keeps the pair's full history, and the
@@ -1217,17 +1223,33 @@ const server = createServer(async (req, res) => {
         // and the chips are created only AFTER the verdict, so a denied
         // contact leaves no trace of an exchange that never happened.
         if (from.approvePeerComms) {
-          const verdict = await requestPeerApproval(approvalBus, from, target, message, "ask_bot");
+          const verdict = await requestPeerApproval(
+            approvalBus,
+            from,
+            target,
+            message,
+            "ask_bot",
+            fromThreadId,
+          );
           if (verdict !== "allow") return json(res, 200, { error: "denied by user" });
-          // the card may have been open for minutes — re-check the target
-          if (store.bot(toBotId)?.busy) return json(res, 200, { busy: true });
+          // The card may have been open for minutes. Re-read both records so
+          // deleted bots cannot recreate transcripts through stale objects.
+          const freshFrom = store.bot(fromBotId);
+          const freshTarget = store.bot(toBotId);
+          if (!freshFrom || !freshTarget) return json(res, 404, { error: "no such bot" });
+          if (!store.taskByThread(freshFrom.id, fromThreadId)) {
+            return json(res, 404, { error: "source task no longer exists" });
+          }
+          if (freshTarget.busy) return json(res, 200, { busy: true });
+          currentFrom = freshFrom;
+          currentTarget = freshTarget;
         }
-        const channel = getOrCreateChannel(store, from, target);
-        mirrorExchange(commsBus, from, target, message, channel);
-        const prefixed = `[Message from @${fromName}, another bot in this OpenMausBot workspace. Reply to them.]\n\n${message}`;
+        const channel = getOrCreateChannel(store, currentFrom, currentTarget);
+        mirrorExchange(commsBus, currentFrom, currentTarget, message, channel, fromThreadId);
+        const prefixed = `[Message from @${currentFrom.name}, another bot in this OpenMausBot workspace. Reply to them.]\n\n${message}`;
         const reply = await askBotAndWait(toBotId, prefixed, depth);
-        mirrorReply(commsBus, target, reply, channel);
-        return json(res, 200, { botName: target.name, text: reply });
+        mirrorReply(commsBus, currentTarget, reply, channel);
+        return json(res, 200, { botName: currentTarget.name, text: reply });
       }
       // Async handoff: the source bot queues a task for a peer and goes
       // back to the user; the peer turn runs after the source's
@@ -1242,7 +1264,17 @@ const server = createServer(async (req, res) => {
         if (!toBotId || !message) return json(res, 400, { error: "toBotId and message required" });
         const from = store.bot(fromBotId);
         if (!from) return json(res, 404, { error: "no such bot" });
-        const result = queueDelegation(commsBus, from, { toBotId, message, reason, depth }, MAX_COMMS_DEPTH);
+        const fromThreadId = String(body.fromThreadId ?? from.threadId);
+        if (!store.taskByThread(from.id, fromThreadId)) {
+          return json(res, 403, { error: "source thread does not belong to sender" });
+        }
+        const result = queueDelegation(
+          commsBus,
+          from,
+          { toBotId, message, reason, depth },
+          MAX_COMMS_DEPTH,
+          fromThreadId,
+        );
         if (result !== "ok") {
           // the agent reads this string — a bare enum ("too_deep") tells it
           // nothing about what to do instead
@@ -1252,7 +1284,7 @@ const server = createServer(async (req, res) => {
             no_target: "no such bot",
             too_many: "too many delegations queued on this turn — finish some first",
           };
-          return json(res, 400, { error: said[result] });
+          return json(res, 200, { error: said[result] });
         }
         const targetName = store.bot(toBotId)?.name ?? toBotId;
         return json(res, 200, {

--- a/server/peer-approval-key.ts
+++ b/server/peer-approval-key.ts
@@ -1,0 +1,6 @@
+export type PeerAction = "ask_bot" | "delegate_bot";
+
+/** Stable persisted grant for one peer action and one target bot. */
+export function peerAllowKey(action: PeerAction, targetId: string): string {
+  return `${action}:${targetId}`;
+}

--- a/server/peer-approval.test.ts
+++ b/server/peer-approval.test.ts
@@ -10,6 +10,7 @@ import type { ModelSelection } from "./contracts.ts";
 import {
   cancelPeerApprovalsFor,
   dismissStalePeerCards,
+  peerAllowKey,
   requestPeerApproval,
   resolvePeerComms,
   type ApprovalBus,
@@ -69,6 +70,22 @@ describe("peer approval card lifecycle", () => {
     expect(resolvePeerComms(bus, "not-a-peer-request", "allow")).toBe(false);
   });
 
+  it("keys persistent grants by target identity, not mutable or duplicate names", async () => {
+    const originalName = target.name;
+    store.patchBot(from.id, { alwaysAllow: [peerAllowKey("ask_bot", target.id)] });
+    store.patchBot(target.id, { name: "Renamed helper" });
+
+    await expect(requestPeerApproval(bus, from, target, "ping", "ask_bot")).resolves.toBe("allow");
+    expect(pendingCard(store, from)).toBeUndefined();
+
+    const impostor = store.patchBot(store.createBot().id, { name: originalName })!;
+    const verdict = requestPeerApproval(bus, from, impostor, "ping", "ask_bot");
+    const card = pendingCard(store, from);
+    expect(card).toBeTruthy();
+    cancelPeerApprovalsFor(impostor.id);
+    await expect(verdict).resolves.toBe("deny");
+  });
+
   it("denies and settles when the bot on either side is deleted", async () => {
     const verdict = requestPeerApproval(bus, from, target, "ping", "ask_bot");
     const card = pendingCard(store, from)!;
@@ -100,6 +117,26 @@ describe("peer approval card lifecycle", () => {
     expect(settled?.card?.dismissed).toBe(true);
     // and it is idempotent — a second boot must not re-dismiss or double count
     expect(dismissStalePeerCards(bus)).toBe(0);
+  });
+
+  it("dismisses stale cards in non-active task threads", () => {
+    const background = store.createTask(from.id, "Background", false)!;
+    const orphan = store.appendMessage(background.threadId, {
+      role: "bot",
+      kind: "options",
+      card: {
+        title: "@Asker wants to contact @Helper",
+        subtitle: "ping",
+        options: ["Allow", "Deny"],
+        requestId: "background-dead-process",
+        tool: "ask_bot",
+      },
+    });
+
+    expect(dismissStalePeerCards(bus)).toBe(1);
+    expect(
+      store.messagesFor(background.threadId).find((message) => message.id === orphan.id)?.card?.dismissed,
+    ).toBe(true);
   });
 
   it("leaves a live card alone at boot", async () => {

--- a/server/peer-approval.ts
+++ b/server/peer-approval.ts
@@ -15,7 +15,10 @@
 // `alwaysAllow`, so the two sides never disagree about what was granted.
 
 import { newId } from "./contracts.ts";
+import { peerAllowKey, type PeerAction } from "./peer-approval-key.ts";
 import type { BotRecord, Message, Store } from "./store.ts";
+
+export { peerAllowKey } from "./peer-approval-key.ts";
 
 /** What a peer-approval helper needs from the outside world: the store
  * for thread append + persist, and the SSE broadcaster so the chat
@@ -66,10 +69,6 @@ const APPROVAL_TIMEOUT_MS = 15 * 60_000;
 /** The narrow grant "always allow" remembers for a peer comm. Mirrored
  * back into `bot.alwaysAllow` when the user picks "Always allow" on the
  * card. */
-export function peerAllowKey(action: "ask_bot" | "delegate_bot", targetId: string): string {
-  return `${action}:${targetId}`;
-}
-
 function allowKeyAllowed(from: BotRecord, allowKey: string): boolean {
   return from.alwaysAllow?.includes(allowKey) ?? false;
 }
@@ -79,7 +78,7 @@ function pushApprovalCard(
   from: BotRecord,
   target: BotRecord,
   message: string,
-  action: "ask_bot" | "delegate_bot",
+  action: PeerAction,
   requestId: string,
   sourceThreadId: string,
 ): Message {
@@ -109,7 +108,7 @@ export function requestPeerApproval(
   from: BotRecord,
   target: BotRecord,
   message: string,
-  action: "ask_bot" | "delegate_bot",
+  action: PeerAction,
   sourceThreadId = from.threadId,
 ): Promise<"allow" | "deny"> {
   if (allowKeyAllowed(from, peerAllowKey(action, target.id))) {

--- a/server/peer-approval.ts
+++ b/server/peer-approval.ts
@@ -10,7 +10,7 @@
 // way nothing front-end has to learn about peer comms.
 //
 // "Always allow" rides on the existing per-bot `alwaysAllow` list. The
-// card carries an `allowKey` (`ask_bot:@Name` / `delegate_bot:@Name`) and
+// card carries an ID-based `allowKey` and
 // the user-facing Always-allow flow already mirrors that key back into
 // `alwaysAllow`, so the two sides never disagree about what was granted.
 
@@ -66,8 +66,8 @@ const APPROVAL_TIMEOUT_MS = 15 * 60_000;
 /** The narrow grant "always allow" remembers for a peer comm. Mirrored
  * back into `bot.alwaysAllow` when the user picks "Always allow" on the
  * card. */
-export function peerAllowKey(action: "ask_bot" | "delegate_bot", targetName: string): string {
-  return `${action}:@${targetName}`;
+export function peerAllowKey(action: "ask_bot" | "delegate_bot", targetId: string): string {
+  return `${action}:${targetId}`;
 }
 
 function allowKeyAllowed(from: BotRecord, allowKey: string): boolean {
@@ -81,9 +81,10 @@ function pushApprovalCard(
   message: string,
   action: "ask_bot" | "delegate_bot",
   requestId: string,
+  sourceThreadId: string,
 ): Message {
   const subtitle = message.length > 200 ? `${message.slice(0, 200)}…` : message;
-  const note = bus.store.appendMessage(from.threadId, {
+  const note = bus.store.appendMessage(sourceThreadId, {
     role: "bot",
     kind: "options",
     card: {
@@ -92,14 +93,14 @@ function pushApprovalCard(
       options: ["Allow", "Deny", "Always allow"],
       requestId,
       tool: action,
-      allowKey: peerAllowKey(action, target.name),
+      allowKey: peerAllowKey(action, target.id),
     },
   });
-  bus.broadcast({ kind: "message", threadId: from.threadId, message: note });
+  bus.broadcast({ kind: "message", threadId: sourceThreadId, message: note });
   return note;
 }
 
-/** Ask the user (in `from`'s thread) whether `from` may `action` `target`.
+/** Ask the user (in the source task thread) whether `from` may `action` `target`.
  * Resolves with `"allow"` or `"deny"`. If `from.alwaysAllow` already
  * covers the (action, target) pair, returns `"allow"` immediately
  * without a card. */
@@ -109,15 +110,16 @@ export function requestPeerApproval(
   target: BotRecord,
   message: string,
   action: "ask_bot" | "delegate_bot",
+  sourceThreadId = from.threadId,
 ): Promise<"allow" | "deny"> {
-  if (allowKeyAllowed(from, peerAllowKey(action, target.name))) {
+  if (allowKeyAllowed(from, peerAllowKey(action, target.id))) {
     return Promise.resolve("allow");
   }
   return new Promise((resolve) => {
     const requestId = newId();
     // the card has to exist before the entry, so a timeout or an answer can
     // always find it to settle
-    const card = pushApprovalCard(bus, from, target, message, action, requestId);
+    const card = pushApprovalCard(bus, from, target, message, action, requestId, sourceThreadId);
     const timer = setTimeout(() => {
       // 15 minutes without an answer → deny. Keeps an unattended bot from
       // stalling its own turn forever (matches the Claude broker timeout).
@@ -134,7 +136,7 @@ export function requestPeerApproval(
       fromBotId: from.id,
       toBotId: target.id,
       message,
-      threadId: from.threadId,
+      threadId: sourceThreadId,
       messageId: card.id,
       bus,
     });
@@ -178,17 +180,20 @@ export function cancelPeerApprovalsFor(botId: string): void {
 export function dismissStalePeerCards(bus: ApprovalBus): number {
   let dismissed = 0;
   for (const bot of bus.store.bots) {
-    for (const message of bus.store.messagesFor(bot.threadId)) {
-      const card = message.card;
-      if (!card?.requestId || card.answered || card.dismissed) continue;
-      if (card.tool !== "ask_bot" && card.tool !== "delegate_bot") continue;
-      if (pendingComms.has(card.requestId)) continue;
-      const patched = bus.store.patchMessage(bot.threadId, message.id, {
-        card: { ...card, answered: "deny", dismissed: true },
-      });
-      if (patched) {
-        bus.broadcast({ kind: "message.patch", threadId: bot.threadId, message: patched });
-        dismissed += 1;
+    const threadIds = new Set([bot.threadId, ...(bot.tasks ?? []).map((task) => task.threadId)]);
+    for (const threadId of threadIds) {
+      for (const message of bus.store.messagesFor(threadId)) {
+        const card = message.card;
+        if (!card?.requestId || card.answered || card.dismissed) continue;
+        if (card.tool !== "ask_bot" && card.tool !== "delegate_bot") continue;
+        if (pendingComms.has(card.requestId)) continue;
+        const patched = bus.store.patchMessage(threadId, message.id, {
+          card: { ...card, answered: "deny", dismissed: true },
+        });
+        if (patched) {
+          bus.broadcast({ kind: "message.patch", threadId, message: patched });
+          dismissed += 1;
+        }
       }
     }
   }

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
+import { peerAllowKey } from "./peer-approval-key.ts";
 import { Store, type BotRecord } from "./store.ts";
 
 const selection = (): ModelSelection => ({ instanceId: "claude", model: "claude-sonnet-5" });
@@ -75,6 +76,29 @@ describe("Store", () => {
     expect(back.busy).toBe(false);
     const messages = reloaded.messagesFor(bot.threadId);
     expect(messages.at(-1)).toMatchObject({ role: "user", text: "hi there" });
+  });
+
+  it("migrates unambiguous legacy peer grants without guessing duplicate names", () => {
+    const store = new Store(selection);
+    const requester = store.createBot();
+    const helper = store.patchBot(store.createBot().id, { name: "Helper" })!;
+    store.patchBot(store.createBot().id, { name: "Twin" });
+    store.patchBot(store.createBot().id, { name: "Twin" });
+    store.patchBot(requester.id, {
+      alwaysAllow: ["ask_bot:@Helper", "delegate_bot:@Twin", "Bash:git status"],
+    });
+
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(requester.id)?.alwaysAllow).toEqual([
+      peerAllowKey("ask_bot", helper.id),
+      "delegate_bot:@Twin",
+      "Bash:git status",
+    ]);
+
+    const persisted: BotRecord[] = JSON.parse(readFileSync(join(DATA_DIR, "bots.json"), "utf8"));
+    expect(persisted.find((bot) => bot.id === requester.id)?.alwaysAllow).toEqual(
+      reloaded.bot(requester.id)?.alwaysAllow,
+    );
   });
 
   it("keeps exactly one persisted Chief of Staff and supports handoff", () => {

--- a/server/store.ts
+++ b/server/store.ts
@@ -6,6 +6,7 @@ import { readFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 import { writeFileAtomic } from "./atomic.ts";
+import { peerAllowKey, type PeerAction } from "./peer-approval-key.ts";
 import { DATA_DIR } from "./config.ts";
 import { newId, type ModelSelection, type ThreadId } from "./contracts.ts";
 import { pickBotName } from "./names.ts";
@@ -312,6 +313,25 @@ export class Store {
       }
       b.chiefOfStaff = false;
       botsMigrated = true;
+    }
+    // Peer grants originally used mutable display names (ask_bot:@Helper).
+    // Convert only when exactly one bot has that name; ambiguous legacy
+    // entries remain inert rather than granting access to the wrong bot.
+    for (const b of this.bots) {
+      if (!b.alwaysAllow?.length) continue;
+      let changed = false;
+      const migrated = b.alwaysAllow.map((key) => {
+        const match = key.match(/^(ask_bot|delegate_bot):@(.+)$/);
+        if (!match) return key;
+        const candidates = this.bots.filter((candidate) => candidate.name === match[2]);
+        if (candidates.length !== 1) return key;
+        changed = true;
+        return peerAllowKey(match[1] as PeerAction, candidates[0]!.id);
+      });
+      if (changed) {
+        b.alwaysAllow = [...new Set(migrated)];
+        botsMigrated = true;
+      }
     }
     for (const g of this.groups) {
       g.busyBotId = null;


### PR DESCRIPTION
## What changed

- propagate the real source task thread through `ask_bot` and `delegate_bot`, including detached routine runs
- keep queue chips, approval cards, failure messages, and comms visibility on that source thread
- key persistent peer approvals by immutable bot ID instead of mutable names
- contain fire-and-forget delegation failures and surface them as activity errors
- revalidate bots and source tasks after delayed approvals
- clean stale peer-approval cards across every task thread
- return semantic queue refusals to the agent as tool guidance
- fix the delegation polling helper and the inaccurate depth-guard test comment

## Why

PR #129 added the approval gate and asynchronous delegation, but late review feedback identified lifecycle, identity, and detached-thread edge cases. Without these fixes, a routine delegation could be queued on the wrong task and run later from unrelated work, and a renamed or duplicate-named bot could inherit a stored approval.

Follow-up to #129.

## Validation

- `pnpm typecheck`
- `pnpm test` — 391 passed, 8 skipped
- updater node tests — 11 passed
- `pnpm build`
- compiled-server build to an isolated output directory
- `pnpm check:electron`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delegated actions and peer-agent requests now remain associated with their originating conversation thread.
  * Activity updates, approvals, failures, and discard notifications appear in the correct source thread.
  * Approval permissions remain tied to the intended bot, even after renames or duplicate names.

* **Bug Fixes**
  * Improved handling of delegation failures without interrupting other queued actions.
  * Stale approval cards are now removed from inactive task threads.
  * Added validation to prevent requests from accessing unauthorized threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->