### PR TITLE
Add shareable team manifests

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -202,6 +202,72 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
+  it("exports a room as a portable team and imports it with fresh IDs", async () => {
+    const first = (await api("POST", "/api/bots")).body.bot;
+    const second = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${first.id}`, {
+      name: "Mira",
+      title: "Project Lead",
+      description: "Coordinates the crew",
+      color: "purple",
+      mascotExpression: "focused",
+      autoApprove: true,
+      alwaysAllow: ["Bash:git"],
+    });
+    await api("PATCH", `/api/bots/${second.id}`, {
+      name: "Scout",
+      title: "Researcher",
+      description: "Finds evidence",
+      color: "cyan",
+    });
+    const createdRoom = await api("POST", "/api/groups", {
+      name: "Launch Crew",
+      memberIds: [first.id, second.id],
+    });
+    const roomId = createdRoom.body.group.id;
+    await api("PATCH", `/api/groups/${roomId}`, {
+      bulletin: "Prepare the launch together",
+      defaultResponder: { kind: "member", botId: second.id },
+    });
+
+    const exported = await api("GET", `/api/groups/${roomId}/team`);
+    expect(exported.status).toBe(200);
+    expect(exported.body).toMatchObject({
+      format: "openmaus.team",
+      version: 1,
+      team: {
+        name: "Launch Crew",
+        members: [
+          { key: "mira", name: "Mira", title: "Project Lead", appearance: { color: "purple" } },
+          { key: "scout", name: "Scout", title: "Researcher", appearance: { color: "cyan" } },
+        ],
+        room: {
+          name: "Launch Crew",
+          bulletin: "Prepare the launch together",
+          defaultResponder: { kind: "member", member: "scout" },
+        },
+      },
+    });
+    expect(JSON.stringify(exported.body)).not.toMatch(/autoApprove|alwaysAllow|modelSelection|threadId/);
+
+    const imported = await api("POST", "/api/teams/import", exported.body);
+    expect(imported.status).toBe(201);
+    expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(["Mira", "Scout"]);
+    expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
+    expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
+    expect(imported.body.group.memberIds).toEqual(imported.body.bots.map((bot: { id: string }) => bot.id));
+    expect(imported.body.group.defaultResponder).toEqual({ kind: "member", botId: imported.body.bots[1].id });
+
+    const invalid = await api("POST", "/api/teams/import", { ...exported.body, version: 2 });
+    expect(invalid.status).toBe(400);
+
+    expect((await api("DELETE", `/api/groups/${roomId}`)).status).toBe(200);
+    expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
+    for (const bot of [first, second, ...imported.body.bots]) {
+      expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
+    }
+  });
+
   it("persists an answered onboarding card", async () => {
     const { body } = await api("GET", "/api/bots");
     const bot = body.bots[0];

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -250,21 +250,36 @@ describe("harness HTTP API", () => {
     });
     expect(JSON.stringify(exported.body)).not.toMatch(/autoApprove|alwaysAllow|modelSelection|threadId/);
 
-    const imported = await api("POST", "/api/teams/import", exported.body);
-    expect(imported.status).toBe(201);
-    expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(["Mira", "Scout"]);
-    expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
-    expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
-    expect(imported.body.group.memberIds).toEqual(imported.body.bots.map((bot: { id: string }) => bot.id));
-    expect(imported.body.group.defaultResponder).toEqual({ kind: "member", botId: imported.body.bots[1].id });
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      await stream.until((frame) => frame.kind === "hello");
+      const imported = await api("POST", "/api/teams/import", exported.body);
+      expect(imported.status).toBe(201);
+      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(["Mira", "Scout"]);
+      expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
+      expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
+      expect(imported.body.group.memberIds).toEqual(imported.body.bots.map((bot: { id: string }) => bot.id));
+      expect(imported.body.group.defaultResponder).toEqual({ kind: "member", botId: imported.body.bots[1].id });
 
-    const invalid = await api("POST", "/api/teams/import", { ...exported.body, version: 2 });
-    expect(invalid.status).toBe(400);
+      await stream.until((frame) => frame.kind === "group" && frame.group?.id === imported.body.group.id);
+      const importedBotIds = new Set(imported.body.bots.map((bot: { id: string }) => bot.id));
+      const importFrames = stream.frames.filter(
+        (frame) =>
+          (frame.kind === "bot" && importedBotIds.has(frame.bot?.id)) ||
+          (frame.kind === "group" && frame.group?.id === imported.body.group.id),
+      );
+      expect(importFrames.map((frame) => frame.kind)).toEqual(["bot", "bot", "group"]);
 
-    expect((await api("DELETE", `/api/groups/${roomId}`)).status).toBe(200);
-    expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
-    for (const bot of [first, second, ...imported.body.bots]) {
-      expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
+      const invalid = await api("POST", "/api/teams/import", { ...exported.body, version: 2 });
+      expect(invalid.status).toBe(400);
+
+      expect((await api("DELETE", `/api/groups/${roomId}`)).status).toBe(200);
+      expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
+      for (const bot of [first, second, ...imported.body.bots]) {
+        expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
+      }
+    } finally {
+      stream.close();
     }
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1433,38 +1433,55 @@ const server = createServer(async (req, res) => {
         return json(res, 400, { error: error instanceof Error ? error.message : "Invalid team file" });
       }
 
-      const selection = await defaultSelection();
-      const importedBots = manifest.team.members.map((member) =>
-        store.createBot({
-          name: member.name,
-          title: member.title,
-          description: member.description,
-          color: member.appearance.color,
-          mascotExpression: member.appearance.mascotExpression,
-          modelSelection: selection,
-        }),
-      );
-      const idByKey = new Map(
-        manifest.team.members.map((member, index) => [member.key, importedBots[index]!.id]),
-      );
-      const group = store.createGroup(
-        manifest.team.room.name,
-        importedBots.map((bot) => bot.id),
-      );
-      const responder = manifest.team.room.defaultResponder;
-      const defaultResponder: GroupDefaultResponder =
-        responder.kind === "member"
-          ? { kind: "member", botId: idByKey.get(responder.member)! }
-          : { kind: responder.kind };
-      store.patchGroup(group.id, {
-        bulletin: manifest.team.room.bulletin,
-        defaultResponder,
-      });
-      broadcast({ kind: "group", group });
-      return json(res, 201, {
-        bots: importedBots.map(publicBot),
-        group: { ...group, messages: [] },
-      });
+      const importedBots: ReturnType<typeof store.createBot>[] = [];
+      let importedGroupId: string | null = null;
+      try {
+        const selection = await defaultSelection();
+        for (const member of manifest.team.members) {
+          importedBots.push(
+            store.createBot({
+              name: member.name,
+              title: member.title,
+              description: member.description,
+              color: member.appearance.color,
+              mascotExpression: member.appearance.mascotExpression,
+              modelSelection: selection,
+            }),
+          );
+        }
+        const idByKey = new Map(
+          manifest.team.members.map((member, index) => [member.key, importedBots[index]!.id]),
+        );
+        const group = store.createGroup(
+          manifest.team.room.name,
+          importedBots.map((bot) => bot.id),
+        );
+        importedGroupId = group.id;
+        const responder = manifest.team.room.defaultResponder;
+        const defaultResponder: GroupDefaultResponder =
+          responder.kind === "member"
+            ? { kind: "member", botId: idByKey.get(responder.member)! }
+            : { kind: responder.kind };
+        const configuredGroup = store.patchGroup(group.id, {
+          bulletin: manifest.team.room.bulletin,
+          defaultResponder,
+        });
+        if (!configuredGroup) throw new Error("The imported room could not be configured");
+
+        const publicBots = importedBots.map(publicBot);
+        // Other open windows need the new members before the room that
+        // references them. The importing window also folds the HTTP result.
+        for (const bot of publicBots) broadcast({ kind: "bot", bot });
+        broadcast({ kind: "group", group: configuredGroup });
+        return json(res, 201, {
+          bots: publicBots,
+          group: { ...configuredGroup, messages: [] },
+        });
+      } catch (error) {
+        if (importedGroupId) store.deleteGroup(importedGroupId);
+        for (const bot of importedBots) store.deleteBot(bot.id);
+        throw error;
+      }
     }
     m = path.match(/^\/api\/groups\/([\w-]+)$/);
     if (m && method === "PATCH") {

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
 import { RoutineManager, type RoutineRunOn } from "./routines.ts";
+import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
@@ -1416,6 +1417,54 @@ const server = createServer(async (req, res) => {
       const group = store.createGroup(name, memberIds);
       broadcast({ kind: "group", group });
       return json(res, 201, { group: { ...group, messages: [] } });
+    }
+    m = path.match(/^\/api\/groups\/([\w-]+)\/team$/);
+    if (m && method === "GET") {
+      const group = store.group(m[1]);
+      if (!group || group.dm) return json(res, 404, { error: "no such shareable room" });
+      return json(res, 200, createTeamManifest(group, store.bots));
+    }
+    if (method === "POST" && path === "/api/teams/import") {
+      const body = await readBody(req);
+      let manifest;
+      try {
+        manifest = parseTeamManifest(body);
+      } catch (error) {
+        return json(res, 400, { error: error instanceof Error ? error.message : "Invalid team file" });
+      }
+
+      const selection = await defaultSelection();
+      const importedBots = manifest.team.members.map((member) =>
+        store.createBot({
+          name: member.name,
+          title: member.title,
+          description: member.description,
+          color: member.appearance.color,
+          mascotExpression: member.appearance.mascotExpression,
+          modelSelection: selection,
+        }),
+      );
+      const idByKey = new Map(
+        manifest.team.members.map((member, index) => [member.key, importedBots[index]!.id]),
+      );
+      const group = store.createGroup(
+        manifest.team.room.name,
+        importedBots.map((bot) => bot.id),
+      );
+      const responder = manifest.team.room.defaultResponder;
+      const defaultResponder: GroupDefaultResponder =
+        responder.kind === "member"
+          ? { kind: "member", botId: idByKey.get(responder.member)! }
+          : { kind: responder.kind };
+      store.patchGroup(group.id, {
+        bulletin: manifest.team.room.bulletin,
+        defaultResponder,
+      });
+      broadcast({ kind: "group", group });
+      return json(res, 201, {
+        bots: importedBots.map(publicBot),
+        group: { ...group, messages: [] },
+      });
     }
     m = path.match(/^\/api\/groups\/([\w-]+)$/);
     if (m && method === "PATCH") {

--- a/server/store.ts
+++ b/server/store.ts
@@ -547,18 +547,23 @@ export class Store {
     return this.bots.find((b) => b.threadId === threadId || b.tasks?.some((t) => t.threadId === threadId)) ?? null;
   }
 
-  createBot(): BotRecord {
-    const name = pickBotName(this.bots.map((b) => b.name));
+  createBot(
+    profile: Partial<
+      Pick<BotRecord, "name" | "title" | "description" | "color" | "mascotExpression" | "modelSelection">
+    > = {},
+  ): BotRecord {
+    const name = profile.name?.trim() || pickBotName(this.bots.map((b) => b.name));
     const bot: BotRecord = {
       id: newId(),
       threadId: newId(),
       name,
-      title: "",
-      description: "",
+      title: profile.title ?? "",
+      description: profile.description ?? "",
       notifications: true,
-      color: COLORS[this.bots.length % COLORS.length],
+      color: profile.color ?? COLORS[this.bots.length % COLORS.length],
+      ...(profile.mascotExpression ? { mascotExpression: profile.mascotExpression } : {}),
       unread: false,
-      modelSelection: this.defaultSelection(),
+      modelSelection: profile.modelSelection ?? this.defaultSelection(),
       resumeCursors: {},
       createdAt: Date.now(),
     };

--- a/server/team-manifest.test.ts
+++ b/server/team-manifest.test.ts
@@ -110,4 +110,45 @@ describe("team manifests", () => {
       }),
     ).toThrow("Unknown default responder");
   });
+
+  it("refuses to export values that the importer would reject", () => {
+    expect(() =>
+      createTeamManifest(
+        {
+          name: "x".repeat(101),
+          memberIds: ["one"],
+          bulletin: "",
+          defaultResponder: { kind: "member", botId: "one" },
+        },
+        [
+          {
+            id: "one",
+            name: "One",
+            title: "",
+            description: "",
+            color: "blue",
+          },
+        ],
+      ),
+    ).toThrow("team.name is too long");
+
+    const bots = Array.from({ length: 51 }, (_, index) => ({
+      id: `bot-${index}`,
+      name: `Bot ${index}`,
+      title: "",
+      description: "",
+      color: "green" as const,
+    }));
+    expect(() =>
+      createTeamManifest(
+        {
+          name: "Too many",
+          memberIds: bots.map((bot) => bot.id),
+          bulletin: "",
+          defaultResponder: { kind: "everyone" },
+        },
+        bots,
+      ),
+    ).toThrow("at most 50 members");
+  });
 });

--- a/server/team-manifest.test.ts
+++ b/server/team-manifest.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
+
+describe("team manifests", () => {
+  it("exports portable member keys and room routing without runtime state", () => {
+    const manifest = createTeamManifest(
+      {
+        name: "Launch Crew",
+        memberIds: ["bot-a", "bot-b"],
+        bulletin: "Ship together",
+        defaultResponder: { kind: "member", botId: "bot-b" },
+      },
+      [
+        {
+          id: "bot-a",
+          name: "Mira",
+          title: "Lead",
+          description: "Coordinates the work",
+          color: "purple",
+          mascotExpression: "focused",
+        },
+        {
+          id: "bot-b",
+          name: "Mira",
+          title: "Researcher",
+          description: "Finds evidence",
+          color: "cyan",
+        },
+      ],
+    );
+
+    expect(manifest).toMatchObject({
+      format: "openmaus.team",
+      version: 1,
+      team: {
+        name: "Launch Crew",
+        members: [{ key: "mira" }, { key: "mira-2" }],
+        room: {
+          bulletin: "Ship together",
+          defaultResponder: { kind: "member", member: "mira-2" },
+        },
+      },
+    });
+    expect(JSON.stringify(manifest)).not.toMatch(/bot-a|bot-b|thread|model|permission|message/i);
+  });
+
+  it("parses the supported portable fields and drops unrelated settings", () => {
+    const manifest = parseTeamManifest({
+      format: "openmaus.team",
+      version: 1,
+      team: {
+        name: "  Research Lab  ",
+        members: [
+          {
+            key: "analyst",
+            name: " Ada ",
+            title: " Analyst ",
+            description: " Checks the evidence ",
+            appearance: { color: "green" },
+            modelSelection: { instanceId: "private-machine" },
+            alwaysAllow: ["everything"],
+          },
+        ],
+        room: {
+          name: " Research Room ",
+          bulletin: " Compare sources ",
+          defaultResponder: { kind: "member", member: "analyst" },
+          computer: "local",
+        },
+      },
+    });
+
+    expect(manifest.team.name).toBe("Research Lab");
+    expect(manifest.team.members[0]).toEqual({
+      key: "analyst",
+      name: "Ada",
+      title: "Analyst",
+      description: "Checks the evidence",
+      appearance: { color: "green" },
+    });
+    expect(manifest.team.room).toEqual({
+      name: "Research Room",
+      bulletin: "Compare sources",
+      defaultResponder: { kind: "member", member: "analyst" },
+    });
+  });
+
+  it("rejects unsupported versions and dangling member references", () => {
+    expect(() => parseTeamManifest({ format: "openmaus.team", version: 99 })).toThrow("not supported");
+    expect(() =>
+      parseTeamManifest({
+        format: "openmaus.team",
+        version: 1,
+        team: {
+          name: "Broken",
+          members: [
+            {
+              key: "one",
+              name: "One",
+              appearance: { color: "blue" },
+            },
+          ],
+          room: {
+            name: "Broken",
+            bulletin: "",
+            defaultResponder: { kind: "member", member: "missing" },
+          },
+        },
+      }),
+    ).toThrow("Unknown default responder");
+  });
+});

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -211,7 +211,7 @@ export function createTeamManifest(group: ExportableGroup, bots: ExportableBot[]
     defaultResponder = { kind: group.defaultResponder.kind };
   }
 
-  return {
+  const manifest: TeamManifestV1 = {
     format: TEAM_MANIFEST_FORMAT,
     version: TEAM_MANIFEST_VERSION,
     team: {
@@ -224,4 +224,7 @@ export function createTeamManifest(group: ExportableGroup, bots: ExportableBot[]
       },
     },
   };
+  // Keep export and import in lockstep: a file produced here must satisfy
+  // the exact same limits and normalization as an untrusted shared file.
+  return parseTeamManifest(manifest);
 }

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -1,0 +1,227 @@
+import type { GroupDefaultResponder, MausColor } from "./store.ts";
+
+export const TEAM_MANIFEST_FORMAT = "openmaus.team" as const;
+export const TEAM_MANIFEST_VERSION = 1 as const;
+
+const COLORS: readonly MausColor[] = [
+  "green",
+  "blue",
+  "red",
+  "orange",
+  "purple",
+  "cyan",
+  "pink",
+  "yellow",
+  "teal",
+  "coral",
+];
+
+export interface TeamManifestMember {
+  key: string;
+  name: string;
+  title: string;
+  description: string;
+  appearance: {
+    color: MausColor;
+    mascotExpression?: string;
+  };
+}
+
+export type TeamManifestResponder =
+  | { kind: "member"; member: string }
+  | { kind: "everyone" }
+  | { kind: "mentions" };
+
+export interface TeamManifestV1 {
+  format: typeof TEAM_MANIFEST_FORMAT;
+  version: typeof TEAM_MANIFEST_VERSION;
+  team: {
+    name: string;
+    description?: string;
+    members: TeamManifestMember[];
+    room: {
+      name: string;
+      bulletin: string;
+      defaultResponder: TeamManifestResponder;
+    };
+  };
+}
+
+interface ExportableBot {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  color: MausColor;
+  mascotExpression?: string | null;
+}
+
+interface ExportableGroup {
+  name: string;
+  memberIds: string[];
+  bulletin: string;
+  defaultResponder: GroupDefaultResponder;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+function requiredString(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} is required`);
+  const result = value.trim();
+  if (result.length > max) throw new Error(`${field} is too long`);
+  return result;
+}
+
+function optionalString(value: unknown, field: string, max: number): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") throw new Error(`${field} must be text`);
+  const result = value.trim();
+  if (result.length > max) throw new Error(`${field} is too long`);
+  return result || undefined;
+}
+
+/** Parse an untrusted shared file into the small, portable subset we support. */
+export function parseTeamManifest(value: unknown): TeamManifestV1 {
+  if (!isRecord(value)) throw new Error("This is not a team file");
+  if (value.format !== TEAM_MANIFEST_FORMAT) throw new Error("This is not an OpenMaus team file");
+  if (value.version !== TEAM_MANIFEST_VERSION) {
+    throw new Error(`Team file version ${String(value.version)} is not supported`);
+  }
+  if (!isRecord(value.team)) throw new Error("team is required");
+
+  const team = value.team;
+  const name = requiredString(team.name, "team.name", 100);
+  const description = optionalString(team.description, "team.description", 2_000);
+  if (!Array.isArray(team.members) || team.members.length === 0) {
+    throw new Error("A team needs at least one member");
+  }
+  if (team.members.length > 50) throw new Error("A team can have at most 50 members");
+
+  const seenKeys = new Set<string>();
+  const members = team.members.map((raw, index): TeamManifestMember => {
+    const field = `team.members[${index}]`;
+    if (!isRecord(raw)) throw new Error(`${field} must be an object`);
+    const key = requiredString(raw.key, `${field}.key`, 64);
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(key)) {
+      throw new Error(`${field}.key may only contain lowercase letters, numbers, - and _`);
+    }
+    if (seenKeys.has(key)) throw new Error(`Duplicate member key: ${key}`);
+    seenKeys.add(key);
+
+    const appearance = raw.appearance;
+    if (!isRecord(appearance)) throw new Error(`${field}.appearance is required`);
+    if (typeof appearance.color !== "string" || !COLORS.includes(appearance.color as MausColor)) {
+      throw new Error(`${field}.appearance.color is not supported`);
+    }
+    const mascotExpression = optionalString(
+      appearance.mascotExpression,
+      `${field}.appearance.mascotExpression`,
+      80,
+    );
+
+    return {
+      key,
+      name: requiredString(raw.name, `${field}.name`, 100),
+      title: optionalString(raw.title, `${field}.title`, 200) ?? "",
+      description: optionalString(raw.description, `${field}.description`, 4_000) ?? "",
+      appearance: {
+        color: appearance.color as MausColor,
+        ...(mascotExpression ? { mascotExpression } : {}),
+      },
+    };
+  });
+
+  if (!isRecord(team.room)) throw new Error("team.room is required");
+  const responder = team.room.defaultResponder;
+  if (!isRecord(responder) || typeof responder.kind !== "string") {
+    throw new Error("team.room.defaultResponder is required");
+  }
+  let defaultResponder: TeamManifestResponder;
+  if (responder.kind === "everyone" || responder.kind === "mentions") {
+    defaultResponder = { kind: responder.kind };
+  } else if (responder.kind === "member") {
+    const member = requiredString(responder.member, "team.room.defaultResponder.member", 64);
+    if (!seenKeys.has(member)) throw new Error(`Unknown default responder: ${member}`);
+    defaultResponder = { kind: "member", member };
+  } else {
+    throw new Error(`Unknown default responder kind: ${responder.kind}`);
+  }
+
+  return {
+    format: TEAM_MANIFEST_FORMAT,
+    version: TEAM_MANIFEST_VERSION,
+    team: {
+      name,
+      ...(description ? { description } : {}),
+      members,
+      room: {
+        name: requiredString(team.room.name, "team.room.name", 100),
+        bulletin: optionalString(team.room.bulletin, "team.room.bulletin", 12_000) ?? "",
+        defaultResponder,
+      },
+    },
+  };
+}
+
+function memberKey(name: string, index: number, used: Set<string>): string {
+  const stem =
+    name
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48) || `member-${index + 1}`;
+  let key = stem;
+  let suffix = 2;
+  while (used.has(key)) key = `${stem}-${suffix++}`;
+  used.add(key);
+  return key;
+}
+
+/** Build a shareable definition only: no IDs, transcripts, engines or permissions. */
+export function createTeamManifest(group: ExportableGroup, bots: ExportableBot[]): TeamManifestV1 {
+  const byId = new Map(bots.map((bot) => [bot.id, bot]));
+  const usedKeys = new Set<string>();
+  const keyById = new Map<string, string>();
+  const members = group.memberIds.map((id, index) => {
+    const bot = byId.get(id);
+    if (!bot) throw new Error(`Room member ${id} no longer exists`);
+    const key = memberKey(bot.name, index, usedKeys);
+    keyById.set(id, key);
+    return {
+      key,
+      name: bot.name,
+      title: bot.title,
+      description: bot.description,
+      appearance: {
+        color: bot.color,
+        ...(bot.mascotExpression ? { mascotExpression: bot.mascotExpression } : {}),
+      },
+    };
+  });
+
+  let defaultResponder: TeamManifestResponder;
+  if (group.defaultResponder.kind === "member") {
+    const member = keyById.get(group.defaultResponder.botId) ?? members[0]?.key;
+    if (!member) throw new Error("A team needs at least one member");
+    defaultResponder = { kind: "member", member };
+  } else {
+    defaultResponder = { kind: group.defaultResponder.kind };
+  }
+
+  return {
+    format: TEAM_MANIFEST_FORMAT,
+    version: TEAM_MANIFEST_VERSION,
+    team: {
+      name: group.name,
+      members,
+      room: {
+        name: group.name,
+        bulletin: group.bulletin,
+        defaultResponder,
+      },
+    },
+  };
+}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ChevronDown, Pin } from "lucide-react";
+import { ArrowDown, ArrowDownToLine, Check, ChevronDown, Loader2, Pin } from "lucide-react";
 import {
   useStore,
   useStreaming,
@@ -21,6 +21,8 @@ import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
+import { downloadTeamFile } from "@/lib/team-files";
+import { track } from "@/lib/analytics";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -187,6 +189,62 @@ function DefaultResponderSelect({ group, members }: { group: Group; members: Bot
   );
 }
 
+function ExportTeamButton({ groupId }: { groupId: string }) {
+  const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setStatus("idle");
+    setError("");
+  }, [groupId]);
+
+  useEffect(() => {
+    if (status !== "done") return;
+    const timer = window.setTimeout(() => setStatus("idle"), 2500);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const download = async () => {
+    setStatus("working");
+    setError("");
+    try {
+      const exported = await downloadTeamFile(groupId);
+      track("team_exported", { members: exported.members });
+      setStatus("done");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setStatus("error");
+    }
+  };
+
+  const title = status === "done" ? "Team exported" : error || "Export this team";
+  return (
+    <button
+      type="button"
+      onClick={() => void download()}
+      disabled={status === "working"}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "flex h-8 items-center gap-1.5 rounded-full bg-raised/60 px-2 sm:px-2.5 text-[12.5px] font-medium text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-60",
+        status === "error" && "text-danger",
+        status === "done" && "text-accent",
+      )}
+    >
+      {status === "working" ? (
+        <Loader2 size={13} className="animate-spin" />
+      ) : status === "done" ? (
+        <Check size={13} />
+      ) : (
+        <ArrowDownToLine size={13} />
+      )}
+      <span className="hidden sm:inline">
+        {status === "working" ? "Exporting…" : status === "done" ? "Exported" : "Export"}
+      </span>
+    </button>
+  );
+}
+
 export function GroupView({ group }: { group: Group }) {
   const { state, dispatch } = useStore();
   const stream = useStreaming();
@@ -240,6 +298,7 @@ export function GroupView({ group }: { group: Group }) {
       >
         <span className="text-[15px] font-semibold text-ink">{group.name}</span>
         <div className="flex items-center gap-1.5" style={noDrag}>
+          {!group.dm && <ExportTeamButton groupId={group.id} />}
           <GroupCallButton group={group} members={members} />
           {!group.dm && <DefaultResponderSelect group={group} members={members} />}
           {members.map((b) => (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -317,19 +317,56 @@ function ImportTeamPanel({
   pending,
   onClose,
   onImported,
+  returnFocusRef,
 }: {
   pending: PendingTeamImport;
   onClose: () => void;
   onImported: (name: string) => void;
+  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
 }) {
   const { dispatch } = useStore();
   const [working, setWorking] = useState(false);
   const [error, setError] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    const onKey = (event: KeyboardEvent) => event.key === "Escape" && !working && onClose();
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    confirmRef.current?.focus();
+    return () => returnFocusRef.current?.focus();
+  }, [returnFocusRef]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !working) {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable.at(-1)!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [onClose, working]);
 
   const importTeam = async () => {
@@ -357,8 +394,15 @@ function ImportTeamPanel({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/45"
       onMouseDown={(event) => event.target === event.currentTarget && !working && onClose()}
     >
-      <div className="w-[420px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl">
-        <div className="text-[17px] font-semibold text-ink">Import {pending.name}?</div>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="import-team-title"
+        tabIndex={-1}
+        className="w-[420px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl"
+      >
+        <div id="import-team-title" className="text-[17px] font-semibold text-ink">Import {pending.name}?</div>
         <div className="mt-1 text-[13px] text-ink-secondary">
           This creates {pending.members.length} new {pending.members.length === 1 ? "bot" : "bots"} and the room “{pending.roomName}”.
         </div>
@@ -375,7 +419,7 @@ function ImportTeamPanel({
         <div className="mt-3 text-[12.5px] leading-relaxed text-ink-secondary">
           The bots will use your default engine. Conversations, permissions, and computer access are never imported.
         </div>
-        {error && <div className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+        {error && <div role="alert" className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
         <div className="mt-5 flex justify-end gap-2">
           <button
             onClick={onClose}
@@ -385,6 +429,7 @@ function ImportTeamPanel({
             Cancel
           </button>
           <button
+            ref={confirmRef}
             onClick={() => void importTeam()}
             disabled={working}
             className="flex items-center gap-2 rounded-lg bg-accent px-3.5 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
@@ -648,6 +693,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const importInputRef = useRef<HTMLInputElement>(null);
+  const importReturnRef = useRef<HTMLButtonElement>(null);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [roomMenu, setRoomMenu] = useState<{ groupId: string; x: number; y: number } | null>(null);
   const [plusOpen, setPlusOpen] = useState(false);
@@ -760,6 +806,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           style={macInset ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined}
         >
           <button
+            ref={importReturnRef}
             onClick={() => setPlusOpen((o) => !o)}
             className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
             title="New bot or room"
@@ -906,6 +953,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       {pendingImport && (
         <ImportTeamPanel
           pending={pendingImport}
+          returnFocusRef={importReturnRef}
           onClose={() => setPendingImport(null)}
           onImported={(name) => {
             setPendingImport(null);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { track } from "@/lib/analytics";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   ArrowDownToLine,
   BellDot,
@@ -10,6 +11,7 @@ import {
   Copy,
   Crown,
   EyeOff,
+  FileUp,
   FolderPlus,
   Loader2,
   Pencil,
@@ -23,11 +25,12 @@ import {
   Trash2,
   Users,
 } from "lucide-react";
-import { useStore, formatTime, visibleMessages, type Bot, type Group } from "@/state/store";
+import { api, useStore, formatTime, visibleMessages, type Bot, type Group } from "@/state/store";
 import { MausAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
+import { downloadTeamFile } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
@@ -196,7 +199,15 @@ function GroupListItem({ group, onMenu }: { group: Group; onMenu: (menu: { group
   );
 }
 
-function RoomContextMenu({ menu, onClose }: { menu: { groupId: string; x: number; y: number }; onClose: () => void }) {
+function RoomContextMenu({
+  menu,
+  onClose,
+  onExport,
+}: {
+  menu: { groupId: string; x: number; y: number };
+  onClose: () => void;
+  onExport: (groupId: string) => void;
+}) {
   const { state, dispatch } = useStore();
   const group = state.groups.find((g) => g.id === menu.groupId);
 
@@ -216,9 +227,9 @@ function RoomContextMenu({ menu, onClose }: { menu: { groupId: string; x: number
   }, [onClose]);
 
   if (!group) return null;
-  const top = Math.min(menu.y, window.innerHeight - 120);
+  const top = Math.min(menu.y, window.innerHeight - 164);
   const left = Math.min(menu.x, window.innerWidth - 240);
-  return (
+  return createPortal(
     <div
       data-room-menu
       style={{ top, left }}
@@ -234,6 +245,18 @@ function RoomContextMenu({ menu, onClose }: { menu: { groupId: string; x: number
         <ClipboardCopy size={16} className="text-ink-secondary" />
         Copy conversation ID
       </button>
+      {!group.dm && (
+        <button
+          onClick={() => {
+            onExport(group.id);
+            onClose();
+          }}
+          className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+        >
+          <ArrowDownToLine size={16} className="text-ink-secondary" />
+          Export Team
+        </button>
+      )}
       <button
         onClick={() => {
           dispatch({ type: "deleteGroup", groupId: group.id });
@@ -244,7 +267,135 @@ function RoomContextMenu({ menu, onClose }: { menu: { groupId: string; x: number
         <Trash2 size={16} />
         Delete Room
       </button>
-    </div>
+    </div>,
+    document.body,
+  );
+}
+
+interface PendingTeamImport {
+  manifest: unknown;
+  name: string;
+  roomName: string;
+  members: Array<{ name: string; title: string }>;
+}
+
+function importPreview(manifest: unknown): PendingTeamImport {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("This file does not contain a team.");
+  }
+  const root = manifest as Record<string, unknown>;
+  if (root.format !== "openmaus.team") throw new Error("This is not an OpenMaus team file.");
+  if (root.version !== 1) throw new Error(`Team file version ${String(root.version)} is not supported.`);
+  if (!root.team || typeof root.team !== "object" || Array.isArray(root.team)) {
+    throw new Error("This team file is missing its team definition.");
+  }
+  const team = root.team as Record<string, unknown>;
+  if (typeof team.name !== "string" || !team.name.trim()) throw new Error("This team does not have a name.");
+  if (!Array.isArray(team.members) || team.members.length === 0) throw new Error("This team has no members.");
+  const members = team.members.map((member, index) => {
+    if (!member || typeof member !== "object" || Array.isArray(member)) {
+      throw new Error(`Team member ${index + 1} is invalid.`);
+    }
+    const value = member as Record<string, unknown>;
+    if (typeof value.name !== "string" || !value.name.trim()) {
+      throw new Error(`Team member ${index + 1} does not have a name.`);
+    }
+    return {
+      name: value.name.trim(),
+      title: typeof value.title === "string" ? value.title.trim() : "",
+    };
+  });
+  const room = team.room;
+  const roomName =
+    room && typeof room === "object" && !Array.isArray(room) && typeof (room as Record<string, unknown>).name === "string"
+      ? String((room as Record<string, unknown>).name).trim()
+      : team.name.trim();
+  return { manifest, name: team.name.trim(), roomName, members };
+}
+
+function ImportTeamPanel({
+  pending,
+  onClose,
+  onImported,
+}: {
+  pending: PendingTeamImport;
+  onClose: () => void;
+  onImported: (name: string) => void;
+}) {
+  const { dispatch } = useStore();
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => event.key === "Escape" && !working && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, working]);
+
+  const importTeam = async () => {
+    setWorking(true);
+    setError("");
+    try {
+      const response = (await api("/api/teams/import", {
+        method: "POST",
+        body: JSON.stringify(pending.manifest),
+      })) as { bots: Bot[]; group: Group };
+      for (const bot of response.bots) dispatch({ type: "botAdded", bot });
+      dispatch({ type: "groupPatched", group: response.group });
+      dispatch({ type: "select", id: response.group.id });
+      track("team_imported", { members: response.bots.length });
+      onImported(pending.name);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45"
+      onMouseDown={(event) => event.target === event.currentTarget && !working && onClose()}
+    >
+      <div className="w-[420px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl">
+        <div className="text-[17px] font-semibold text-ink">Import {pending.name}?</div>
+        <div className="mt-1 text-[13px] text-ink-secondary">
+          This creates {pending.members.length} new {pending.members.length === 1 ? "bot" : "bots"} and the room “{pending.roomName}”.
+        </div>
+        <div className="mt-4 max-h-64 space-y-1 overflow-y-auto rounded-xl bg-raised/50 p-2">
+          {pending.members.map((member, index) => (
+            <div key={`${member.name}-${index}`} className="flex items-baseline gap-2 rounded-lg px-2.5 py-2">
+              <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{member.name}</span>
+              <span className="max-w-[190px] truncate text-[12.5px] text-ink-secondary">
+                {member.title || "General assistant"}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 text-[12.5px] leading-relaxed text-ink-secondary">
+          The bots will use your default engine. Conversations, permissions, and computer access are never imported.
+        </div>
+        {error && <div className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={working}
+            className="rounded-lg px-3.5 py-2 text-[13.5px] text-ink-secondary hover:bg-raised disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void importTeam()}
+            disabled={working}
+            className="flex items-center gap-2 rounded-lg bg-accent px-3.5 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
+          >
+            {working ? <Loader2 size={15} className="animate-spin" /> : <FileUp size={15} />}
+            {working ? "Importing…" : "Import Team"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -496,10 +647,13 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
 export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
+  const importInputRef = useRef<HTMLInputElement>(null);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [roomMenu, setRoomMenu] = useState<{ groupId: string; x: number; y: number } | null>(null);
   const [plusOpen, setPlusOpen] = useState(false);
   const [newRoom, setNewRoom] = useState(false);
+  const [pendingImport, setPendingImport] = useState<PendingTeamImport | null>(null);
+  const [teamFeedback, setTeamFeedback] = useState<{ error: boolean; text: string } | null>(null);
   const [query, setQuery] = useState("");
 
   // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Bound only while the
@@ -514,6 +668,43 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     document.addEventListener("keydown", closeOnEscape);
     return () => document.removeEventListener("keydown", closeOnEscape);
   }, [open, onClose]);
+
+  useEffect(() => {
+    if (!teamFeedback) return;
+    const timer = window.setTimeout(() => setTeamFeedback(null), 5000);
+    return () => window.clearTimeout(timer);
+  }, [teamFeedback]);
+
+  const exportTeam = async (groupId: string) => {
+    setTeamFeedback(null);
+    try {
+      const exported = await downloadTeamFile(groupId);
+      track("team_exported", { members: exported.members });
+      setTeamFeedback({ error: false, text: `${exported.name} exported` });
+    } catch (cause) {
+      setTeamFeedback({ error: true, text: cause instanceof Error ? cause.message : String(cause) });
+    }
+  };
+
+  const chooseTeamFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = "";
+    if (!file) return;
+    if (file.size > 1_000_000) {
+      setTeamFeedback({ error: true, text: "That team file is too large." });
+      return;
+    }
+    try {
+      const manifest: unknown = JSON.parse(await file.text());
+      setPendingImport(importPreview(manifest));
+      setTeamFeedback(null);
+    } catch (cause) {
+      setTeamFeedback({
+        error: true,
+        text: cause instanceof SyntaxError ? "That team file is not valid JSON." : cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+  };
 
   const macInset = capabilities.windowChrome === "mac-inset";
   const browser = capabilities.host.label === "Browser";
@@ -600,11 +791,30 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                   <Users size={16} className="text-ink-secondary" />
                   New Room
                 </button>
+                <button
+                  onClick={() => {
+                    setPlusOpen(false);
+                    importInputRef.current?.click();
+                  }}
+                  className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+                >
+                  <FileUp size={16} className="text-ink-secondary" />
+                  Import Team
+                </button>
               </div>
             </>
           )}
         </div>
       </div>
+
+      <input
+        ref={importInputRef}
+        type="file"
+        accept=".json,.mausteam.json,application/json"
+        onChange={(event) => void chooseTeamFile(event)}
+        className="hidden"
+        aria-label="Choose an OpenMaus team file"
+      />
 
       {/* Search */}
       <div className="px-3 pt-2 pb-3">
@@ -685,8 +895,39 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       </div>
 
       {menu && <BotContextMenu menu={menu} onClose={() => setMenu(null)} />}
-      {roomMenu && <RoomContextMenu menu={roomMenu} onClose={() => setRoomMenu(null)} />}
+      {roomMenu && (
+        <RoomContextMenu
+          menu={roomMenu}
+          onClose={() => setRoomMenu(null)}
+          onExport={(groupId) => void exportTeam(groupId)}
+        />
+      )}
       {newRoom && <NewRoomPanel onClose={() => setNewRoom(false)} />}
+      {pendingImport && (
+        <ImportTeamPanel
+          pending={pendingImport}
+          onClose={() => setPendingImport(null)}
+          onImported={(name) => {
+            setPendingImport(null);
+            setTeamFeedback({ error: false, text: `${name} imported` });
+          }}
+        />
+      )}
+      {teamFeedback &&
+        createPortal(
+          <div
+            role="status"
+            className={cn(
+              "fixed bottom-4 left-4 z-[60] max-w-[300px] rounded-xl border px-3.5 py-2.5 text-[13px] shadow-xl",
+              teamFeedback.error
+                ? "border-danger/30 bg-card text-danger"
+                : "border-hairline/50 bg-card text-ink",
+            )}
+          >
+            {teamFeedback.text}
+          </div>,
+          document.body,
+        )}
     </aside>
   );
 }

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -24,6 +24,8 @@ export async function downloadTeamFile(groupId: string): Promise<{ name: string;
   document.body.appendChild(link);
   link.click();
   link.remove();
-  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  // There is no browser event for "download has consumed this URL". Keep it
+  // alive long enough for slower engines to start reading, then clean it up.
+  window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
   return { name: manifest.team.name, members: manifest.team.members.length };
 }

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -1,0 +1,29 @@
+import { api } from "@/state/store";
+
+interface ExportedTeam {
+  team: {
+    name: string;
+    members: unknown[];
+  };
+}
+
+/** Fetch a safe server-built manifest and hand it to the browser as a file. */
+export async function downloadTeamFile(groupId: string): Promise<{ name: string; members: number }> {
+  const manifest = (await api(`/api/groups/${groupId}/team`)) as ExportedTeam;
+  const slug =
+    manifest.team.name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "openmaus-team";
+  const blob = new Blob([`${JSON.stringify(manifest, null, 2)}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${slug}.mausteam.json`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  return { name: manifest.team.name, members: manifest.team.members.length };
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -444,6 +444,13 @@ function reducer(state: AppState, action: Action): AppState {
       return updateBot(withMascotMotion(state, action.botId, "surprise"), action.botId, (b) => ({ ...b, unread: true }));
     case "botPatched": {
       const before = state.bots.find((b) => b.id === action.bot.id);
+      // A bot event can announce a bot created by another app window (team
+      // import). Patch events for unknown partial records remain ignored.
+      if (!before) {
+        return Array.isArray(action.bot.messages)
+          ? { ...state, bots: [action.bot as Bot, ...state.bots] }
+          : state;
+      }
       const kind =
         action.bot.unread && !before?.unread
           ? "surprise"


### PR DESCRIPTION
## Summary

- add a versioned `.mausteam.json` format for portable bot teams
- add a visible room export control, context-menu export, and an import flow with member preview
- recreate imported members and their room with fresh IDs using the recipient's default engine
- validate untrusted manifests and exclude transcripts, runtime IDs, engine sessions, permissions, and computer access
- cover manifest validation and the complete export/import API round trip

## Why

Teams are currently local workspace state. A small portable manifest makes useful bot rosters, roles, personalities, room instructions, and routing reusable without sharing private runtime data.

## User impact

Users can export any normal room as a team file and import a shared file through the sidebar. Imports always create new bots and a new room, so existing bots are never overwritten.

## Validation

- `pnpm typecheck`
- `pnpm test` — 388 passed, 8 skipped, plus 11 updater tests passed
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export non-direct-message teams as portable JSON files.
  * Import team files through the sidebar with validation and a confirmation preview.
  * Recreate imported teams, including bots, room membership, and responder settings.
  * Show progress, success, and error notifications during export and import.
* **Bug Fixes**
  * Invalid, unsupported, or incomplete team files are rejected with clear errors.
  * Exported files omit internal identifiers and runtime-only information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->