### PR TITLE
Export teams without creating rooms

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -205,7 +205,7 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
-  it("exports a room as a portable team and imports it with fresh IDs", async () => {
+  it("exports selected bots without a room and imports the team with fresh IDs", async () => {
     const first = (await api("POST", "/api/bots")).body.bot;
     const second = (await api("POST", "/api/bots")).body.bot;
     await api("PATCH", `/api/bots/${first.id}`, {
@@ -223,40 +223,46 @@ describe("harness HTTP API", () => {
       description: "Finds evidence",
       color: "cyan",
     });
-    const createdRoom = await api("POST", "/api/groups", {
-      name: "Launch Crew",
+
+    const roomsBeforeSelectionExport = (await api("GET", "/api/bots")).body.groups.length;
+    const selectedExport = await api("POST", "/api/teams/export", {
+      name: "Field Team",
       memberIds: [first.id, second.id],
     });
-    const roomId = createdRoom.body.group.id;
-    await api("PATCH", `/api/groups/${roomId}`, {
-      bulletin: "Prepare the launch together",
-      defaultResponder: { kind: "member", botId: second.id },
-    });
-
-    const exported = await api("GET", `/api/groups/${roomId}/team`);
-    expect(exported.status).toBe(200);
-    expect(exported.body).toMatchObject({
+    expect(selectedExport.status).toBe(200);
+    expect(selectedExport.body).toMatchObject({
       format: "openmaus.team",
       version: 1,
       team: {
-        name: "Launch Crew",
+        name: "Field Team",
         members: [
           { key: "mira", name: "Mira", title: "Project Lead", appearance: { color: "purple" } },
           { key: "scout", name: "Scout", title: "Researcher", appearance: { color: "cyan" } },
         ],
         room: {
-          name: "Launch Crew",
-          bulletin: "Prepare the launch together",
-          defaultResponder: { kind: "member", member: "scout" },
+          name: "Field Team",
+          bulletin: "",
+          defaultResponder: { kind: "everyone" },
         },
       },
     });
-    expect(JSON.stringify(exported.body)).not.toMatch(/autoApprove|alwaysAllow|modelSelection|threadId/);
+    expect(JSON.stringify(selectedExport.body)).not.toMatch(/autoApprove|alwaysAllow|modelSelection|threadId/);
+    expect((await api("GET", "/api/bots")).body.groups).toHaveLength(roomsBeforeSelectionExport);
+    expect((await api("POST", "/api/teams/export", { name: "", memberIds: [first.id] })).status).toBe(400);
+    expect((await api("POST", "/api/teams/export", { name: "Empty", memberIds: [] })).status).toBe(400);
+    expect((await api("POST", "/api/teams/export", { name: "Missing", memberIds: ["no-such-bot"] })).status).toBe(400);
+
+    const importManifest = structuredClone(selectedExport.body);
+    importManifest.team.room = {
+      name: "Launch Crew",
+      bulletin: "Prepare the launch together",
+      defaultResponder: { kind: "member", member: "scout" },
+    };
 
     const stream = await openSse(`${BASE}/api/events`);
     try {
       await stream.until((frame) => frame.kind === "hello");
-      const imported = await api("POST", "/api/teams/import", exported.body);
+      const imported = await api("POST", "/api/teams/import", importManifest);
       expect(imported.status).toBe(201);
       expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(["Mira", "Scout"]);
       expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
@@ -273,10 +279,9 @@ describe("harness HTTP API", () => {
       );
       expect(importFrames.map((frame) => frame.kind)).toEqual(["bot", "bot", "group"]);
 
-      const invalid = await api("POST", "/api/teams/import", { ...exported.body, version: 2 });
+      const invalid = await api("POST", "/api/teams/import", { ...importManifest, version: 2 });
       expect(invalid.status).toBe(400);
 
-      expect((await api("DELETE", `/api/groups/${roomId}`)).status).toBe(200);
       expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
       for (const bot of [first, second, ...imported.body.bots]) {
         expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1530,11 +1530,35 @@ const server = createServer(async (req, res) => {
       broadcast({ kind: "group", group });
       return json(res, 201, { group: { ...group, messages: [] } });
     }
-    m = path.match(/^\/api\/groups\/([\w-]+)\/team$/);
-    if (m && method === "GET") {
-      const group = store.group(m[1]);
-      if (!group || group.dm) return json(res, 404, { error: "no such shareable room" });
-      return json(res, 200, createTeamManifest(group, store.bots));
+    if (method === "POST" && path === "/api/teams/export") {
+      const body = await readBody(req);
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      const rawMemberIds = Array.isArray(body.memberIds) ? body.memberIds : [];
+      if (!name) return json(res, 400, { error: "team name is required" });
+      if (rawMemberIds.length === 0) return json(res, 400, { error: "a team needs at least one bot" });
+      if (
+        rawMemberIds.some((id: unknown) => typeof id !== "string" || !store.bot(id)) ||
+        new Set(rawMemberIds).size !== rawMemberIds.length
+      ) {
+        return json(res, 400, { error: "team members are invalid" });
+      }
+      try {
+        return json(
+          res,
+          200,
+          createTeamManifest(
+            {
+              name,
+              memberIds: rawMemberIds as string[],
+              bulletin: "",
+              defaultResponder: { kind: "everyone" },
+            },
+            store.bots,
+          ),
+        );
+      } catch (error) {
+        return json(res, 400, { error: error instanceof Error ? error.message : "Team could not be exported" });
+      }
     }
     if (method === "POST" && path === "/api/teams/import") {
       const body = await readBody(req);

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -56,7 +56,7 @@ interface ExportableBot {
   mascotExpression?: string | null;
 }
 
-interface ExportableGroup {
+interface ExportableTeam {
   name: string;
   memberIds: string[];
   bulletin: string;
@@ -181,13 +181,13 @@ function memberKey(name: string, index: number, used: Set<string>): string {
 }
 
 /** Build a shareable definition only: no IDs, transcripts, engines or permissions. */
-export function createTeamManifest(group: ExportableGroup, bots: ExportableBot[]): TeamManifestV1 {
+export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]): TeamManifestV1 {
   const byId = new Map(bots.map((bot) => [bot.id, bot]));
   const usedKeys = new Set<string>();
   const keyById = new Map<string, string>();
-  const members = group.memberIds.map((id, index) => {
+  const members = team.memberIds.map((id, index) => {
     const bot = byId.get(id);
-    if (!bot) throw new Error(`Room member ${id} no longer exists`);
+    if (!bot) throw new Error(`Team member ${id} no longer exists`);
     const key = memberKey(bot.name, index, usedKeys);
     keyById.set(id, key);
     return {
@@ -203,23 +203,23 @@ export function createTeamManifest(group: ExportableGroup, bots: ExportableBot[]
   });
 
   let defaultResponder: TeamManifestResponder;
-  if (group.defaultResponder.kind === "member") {
-    const member = keyById.get(group.defaultResponder.botId) ?? members[0]?.key;
+  if (team.defaultResponder.kind === "member") {
+    const member = keyById.get(team.defaultResponder.botId) ?? members[0]?.key;
     if (!member) throw new Error("A team needs at least one member");
     defaultResponder = { kind: "member", member };
   } else {
-    defaultResponder = { kind: group.defaultResponder.kind };
+    defaultResponder = { kind: team.defaultResponder.kind };
   }
 
   const manifest: TeamManifestV1 = {
     format: TEAM_MANIFEST_FORMAT,
     version: TEAM_MANIFEST_VERSION,
     team: {
-      name: group.name,
+      name: team.name,
       members,
       room: {
-        name: group.name,
-        bulletin: group.bulletin,
+        name: team.name,
+        bulletin: team.bulletin,
         defaultResponder,
       },
     },

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowDownToLine, Check, ChevronDown, Loader2, Pin } from "lucide-react";
+import { ArrowDown, ChevronDown, Pin } from "lucide-react";
 import {
   useStore,
   useStreaming,
@@ -21,8 +21,6 @@ import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
-import { downloadTeamFile } from "@/lib/team-files";
-import { track } from "@/lib/analytics";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -189,62 +187,6 @@ function DefaultResponderSelect({ group, members }: { group: Group; members: Bot
   );
 }
 
-function ExportTeamButton({ groupId }: { groupId: string }) {
-  const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    setStatus("idle");
-    setError("");
-  }, [groupId]);
-
-  useEffect(() => {
-    if (status !== "done") return;
-    const timer = window.setTimeout(() => setStatus("idle"), 2500);
-    return () => window.clearTimeout(timer);
-  }, [status]);
-
-  const download = async () => {
-    setStatus("working");
-    setError("");
-    try {
-      const exported = await downloadTeamFile(groupId);
-      track("team_exported", { members: exported.members });
-      setStatus("done");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-      setStatus("error");
-    }
-  };
-
-  const title = status === "done" ? "Team exported" : error || "Export this team";
-  return (
-    <button
-      type="button"
-      onClick={() => void download()}
-      disabled={status === "working"}
-      title={title}
-      aria-label={title}
-      className={cn(
-        "flex h-8 items-center gap-1.5 rounded-full bg-raised/60 px-2 sm:px-2.5 text-[12.5px] font-medium text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-60",
-        status === "error" && "text-danger",
-        status === "done" && "text-accent",
-      )}
-    >
-      {status === "working" ? (
-        <Loader2 size={13} className="animate-spin" />
-      ) : status === "done" ? (
-        <Check size={13} />
-      ) : (
-        <ArrowDownToLine size={13} />
-      )}
-      <span className="hidden sm:inline">
-        {status === "working" ? "Exporting…" : status === "done" ? "Exported" : "Export"}
-      </span>
-    </button>
-  );
-}
-
 export function GroupView({ group }: { group: Group }) {
   const { state, dispatch } = useStore();
   const stream = useStreaming();
@@ -298,7 +240,6 @@ export function GroupView({ group }: { group: Group }) {
       >
         <span className="text-[15px] font-semibold text-ink">{group.name}</span>
         <div className="flex items-center gap-1.5" style={noDrag}>
-          {!group.dm && <ExportTeamButton groupId={group.id} />}
           <GroupCallButton group={group} members={members} />
           {!group.dm && <DefaultResponderSelect group={group} members={members} />}
           {members.map((b) => (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ import { MausAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
-import { downloadTeamFile } from "@/lib/team-files";
+import { downloadSelectedTeam } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
@@ -202,11 +202,9 @@ function GroupListItem({ group, onMenu }: { group: Group; onMenu: (menu: { group
 function RoomContextMenu({
   menu,
   onClose,
-  onExport,
 }: {
   menu: { groupId: string; x: number; y: number };
   onClose: () => void;
-  onExport: (groupId: string) => void;
 }) {
   const { state, dispatch } = useStore();
   const group = state.groups.find((g) => g.id === menu.groupId);
@@ -245,18 +243,6 @@ function RoomContextMenu({
         <ClipboardCopy size={16} className="text-ink-secondary" />
         Copy conversation ID
       </button>
-      {!group.dm && (
-        <button
-          onClick={() => {
-            onExport(group.id);
-            onClose();
-          }}
-          className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
-        >
-          <ArrowDownToLine size={16} className="text-ink-secondary" />
-          Export Team
-        </button>
-      )}
       <button
         onClick={() => {
           dispatch({ type: "deleteGroup", groupId: group.id });
@@ -437,6 +423,191 @@ function ImportTeamPanel({
             {working ? <Loader2 size={15} className="animate-spin" /> : <FileUp size={15} />}
             {working ? "Importing…" : "Import Team"}
           </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function ExportTeamPanel({
+  onClose,
+  onExported,
+  returnFocusRef,
+}: {
+  onClose: () => void;
+  onExported: (name: string) => void;
+  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
+}) {
+  const { state } = useStore();
+  const [name, setName] = useState("");
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+  const bots = state.bots.filter((bot) => !bot.hidden);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    nameRef.current?.focus();
+    return () => returnFocusRef.current?.focus();
+  }, [returnFocusRef]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !working) {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable.at(-1)!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose, working]);
+
+  const toggle = (id: string) => {
+    setPicked((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else if (next.size < 50) next.add(id);
+      return next;
+    });
+  };
+
+  const exportTeam = async () => {
+    const teamName = name.trim();
+    if (!teamName || picked.size === 0) return;
+    setWorking(true);
+    setError("");
+    try {
+      const exported = await downloadSelectedTeam(teamName, [...picked]);
+      track("team_exported", { members: exported.members });
+      onExported(exported.name);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45"
+      onMouseDown={(event) => event.target === event.currentTarget && !working && onClose()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="export-team-title"
+        tabIndex={-1}
+        className="w-[380px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl"
+      >
+        <div id="export-team-title" className="text-[17px] font-semibold text-ink">Export Team</div>
+        <div className="mt-1 text-[13px] text-ink-secondary">
+          Choose any bots to share. You do not need to create a room first.
+        </div>
+        <input
+          ref={nameRef}
+          value={name}
+          maxLength={100}
+          disabled={working}
+          onChange={(event) => setName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") void exportTeam();
+          }}
+          placeholder="Team name"
+          aria-label="Team name"
+          className="mt-4 w-full rounded-lg bg-raised/70 px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none disabled:opacity-60"
+        />
+        <div className="mt-3 flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-xl bg-raised/30 p-1.5">
+          {bots.length === 0 && (
+            <div className="px-2 py-5 text-center text-[13px] text-ink-secondary">
+              Create a bot first, then it can be shared as part of a team.
+            </div>
+          )}
+          {bots.map((bot) => {
+            const selected = picked.has(bot.id);
+            const capped = !selected && picked.size >= 50;
+            return (
+              <button
+                key={bot.id}
+                type="button"
+                aria-pressed={selected}
+                disabled={working || capped}
+                onClick={() => toggle(bot.id)}
+                className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left hover:bg-raised/70 disabled:opacity-40"
+              >
+                <MausAvatar color={bot.color} state="happy" size={28} />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[14px] text-ink">{bot.name}</span>
+                  {bot.title && <span className="block truncate text-[11.5px] text-ink-secondary">{bot.title}</span>}
+                </span>
+                <span
+                  className={cn(
+                    "flex size-[18px] shrink-0 items-center justify-center rounded-full border",
+                    selected ? "border-accent bg-accent text-white" : "border-hairline/60",
+                  )}
+                >
+                  {selected && <Check size={12} />}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-3 text-[12.5px] leading-relaxed text-ink-secondary">
+          Messages, permissions, credentials, engines, and computer access are never included.
+        </div>
+        {error && (
+          <div role="alert" className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">
+            {error}
+          </div>
+        )}
+        <div className="mt-5 flex items-center justify-between gap-3">
+          <span className="text-[12.5px] text-ink-secondary">
+            {picked.size} {picked.size === 1 ? "bot" : "bots"} selected
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={working}
+              className="rounded-lg px-3.5 py-2 text-[13.5px] text-ink-secondary hover:bg-raised disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void exportTeam()}
+              disabled={working || !name.trim() || picked.size === 0}
+              className="flex items-center gap-2 rounded-lg bg-accent px-3.5 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-40"
+            >
+              {working ? <Loader2 size={15} className="animate-spin" /> : <ArrowDownToLine size={15} />}
+              {working ? "Exporting…" : "Export"}
+            </button>
+          </div>
         </div>
       </div>
     </div>,
@@ -698,6 +869,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   const [roomMenu, setRoomMenu] = useState<{ groupId: string; x: number; y: number } | null>(null);
   const [plusOpen, setPlusOpen] = useState(false);
   const [newRoom, setNewRoom] = useState(false);
+  const [exportTeamOpen, setExportTeamOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingTeamImport | null>(null);
   const [teamFeedback, setTeamFeedback] = useState<{ error: boolean; text: string } | null>(null);
   const [query, setQuery] = useState("");
@@ -720,17 +892,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     const timer = window.setTimeout(() => setTeamFeedback(null), 5000);
     return () => window.clearTimeout(timer);
   }, [teamFeedback]);
-
-  const exportTeam = async (groupId: string) => {
-    setTeamFeedback(null);
-    try {
-      const exported = await downloadTeamFile(groupId);
-      track("team_exported", { members: exported.members });
-      setTeamFeedback({ error: false, text: `${exported.name} exported` });
-    } catch (cause) {
-      setTeamFeedback({ error: true, text: cause instanceof Error ? cause.message : String(cause) });
-    }
-  };
 
   const chooseTeamFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];
@@ -809,7 +970,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             ref={importReturnRef}
             onClick={() => setPlusOpen((o) => !o)}
             className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
-            title="New bot or room"
+            title="New or share"
           >
             <Plus size={20} strokeWidth={2} />
           </button>
@@ -837,6 +998,16 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                 >
                   <Users size={16} className="text-ink-secondary" />
                   New Room
+                </button>
+                <button
+                  onClick={() => {
+                    setPlusOpen(false);
+                    setExportTeamOpen(true);
+                  }}
+                  className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+                >
+                  <ArrowDownToLine size={16} className="text-ink-secondary" />
+                  Export Team
                 </button>
                 <button
                   onClick={() => {
@@ -946,10 +1117,19 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         <RoomContextMenu
           menu={roomMenu}
           onClose={() => setRoomMenu(null)}
-          onExport={(groupId) => void exportTeam(groupId)}
         />
       )}
       {newRoom && <NewRoomPanel onClose={() => setNewRoom(false)} />}
+      {exportTeamOpen && (
+        <ExportTeamPanel
+          returnFocusRef={importReturnRef}
+          onClose={() => setExportTeamOpen(false)}
+          onExported={(name) => {
+            setExportTeamOpen(false);
+            setTeamFeedback({ error: false, text: `${name} exported` });
+          }}
+        />
+      )}
       {pendingImport && (
         <ImportTeamPanel
           pending={pendingImport}

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -7,9 +7,7 @@ interface ExportedTeam {
   };
 }
 
-/** Fetch a safe server-built manifest and hand it to the browser as a file. */
-export async function downloadTeamFile(groupId: string): Promise<{ name: string; members: number }> {
-  const manifest = (await api(`/api/groups/${groupId}/team`)) as ExportedTeam;
+function downloadManifest(manifest: ExportedTeam): { name: string; members: number } {
   const slug =
     manifest.team.name
       .trim()
@@ -28,4 +26,16 @@ export async function downloadTeamFile(groupId: string): Promise<{ name: string;
   // alive long enough for slower engines to start reading, then clean it up.
   window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
   return { name: manifest.team.name, members: manifest.team.members.length };
+}
+
+/** Export an ad-hoc selection of bots without creating a room first. */
+export async function downloadSelectedTeam(
+  name: string,
+  memberIds: string[],
+): Promise<{ name: string; members: number }> {
+  const manifest = (await api("/api/teams/export", {
+    method: "POST",
+    body: JSON.stringify({ name, memberIds }),
+  })) as ExportedTeam;
+  return downloadManifest(manifest);
 }


### PR DESCRIPTION
## What changed

- moves team export to the top-level **+** menu
- adds a picker for naming a team and selecting any existing bots
- removes export controls from room headers and room context menus
- replaces the room-specific export endpoint with a selection-based team export endpoint
- preserves the safe manifest: no messages, credentials, engines, permissions, or computer access

## Why

Teams are portable bot configurations and should not require a group conversation to exist first. Rooms remain conversations; team sharing now sits above them.

## User impact

Users can choose **+ → Export Team**, select bots, name the team, and download a `.mausteam.json` file without creating or changing any room.

## Verification

- visually exercised the picker and export flow in the local app
- `pnpm typecheck`
- `pnpm test` — 409 passed, 8 skipped
- `pnpm build`
- focused API/manifest tests — 35 passed
