### PR TITLE
Stop handing clients the provider session cursors

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -414,25 +414,35 @@ describe("harness HTTP API", () => {
     }
 
     const created = await api("POST", "/api/bots");
-    expect(created.body.bot).not.toHaveProperty("resumeCursors");
-    const patched = await api("PATCH", `/api/bots/${created.body.bot.id}`, { name: "Cursorless" });
-    expect(patched.body.bot).not.toHaveProperty("resumeCursors");
-
-    const task = await api("POST", `/api/bots/${created.body.bot.id}/tasks`, {});
-    expect(task.body.bot).not.toHaveProperty("resumeCursors");
-    for (const t of task.body.bot.tasks ?? []) expect(t).not.toHaveProperty("resumeCursors");
-
-    // and the same on the wire, not just in the HTTP responses
-    const stream = await openSse(`${BASE}/api/events`);
+    const botId = created.body.bot.id;
     try {
-      await api("PATCH", `/api/bots/${created.body.bot.id}`, { unread: true });
-      const frame = await stream.until((f) => f.kind === "bot");
-      expect(frame.bot).not.toHaveProperty("resumeCursors");
-      expect(JSON.stringify(frame)).not.toContain("resumeCursors");
+      expect(created.body.bot).not.toHaveProperty("resumeCursors");
+      const patched = await api("PATCH", `/api/bots/${botId}`, { name: "Cursorless" });
+      expect(patched.body.bot).not.toHaveProperty("resumeCursors");
+
+      const task = await api("POST", `/api/bots/${botId}/tasks`, {});
+      expect(task.body.bot).not.toHaveProperty("resumeCursors");
+      for (const t of task.body.bot.tasks ?? []) expect(t).not.toHaveProperty("resumeCursors");
+      // the task alone, not just the bot it came attached to
+      expect(task.body.task).not.toHaveProperty("resumeCursors");
+      const renamed = await api("PATCH", `/api/bots/${botId}/tasks/${task.body.task.threadId}`, {
+        title: "Cursorless task",
+      });
+      expect(renamed.body.task).not.toHaveProperty("resumeCursors");
+
+      // and the same on the wire, not just in the HTTP responses
+      const stream = await openSse(`${BASE}/api/events`);
+      try {
+        await api("PATCH", `/api/bots/${botId}`, { unread: true });
+        const frame = await stream.until((f) => f.kind === "bot");
+        expect(frame.bot).not.toHaveProperty("resumeCursors");
+        expect(JSON.stringify(frame)).not.toContain("resumeCursors");
+      } finally {
+        stream.close();
+      }
     } finally {
-      stream.close();
+      await api("DELETE", `/api/bots/${botId}`);
     }
-    await api("DELETE", `/api/bots/${created.body.bot.id}`);
   });
 
   it("404s unknown routes with the route in the error", async () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -403,6 +403,38 @@ describe("harness HTTP API", () => {
     expect(array.body.error).toContain("opencodeGo");
   });
 
+  it("never hands a client the provider session cursors", async () => {
+    // resumeCursors is the harness's own bookkeeping. It reached clients for
+    // a long time as harmless noise; once a phone is a client it is provider
+    // session state leaving the machine, so nothing carrying a bot may have it.
+    const listed = await api("GET", "/api/bots");
+    for (const bot of listed.body.bots) {
+      expect(bot).not.toHaveProperty("resumeCursors");
+      for (const task of bot.tasks ?? []) expect(task).not.toHaveProperty("resumeCursors");
+    }
+
+    const created = await api("POST", "/api/bots");
+    expect(created.body.bot).not.toHaveProperty("resumeCursors");
+    const patched = await api("PATCH", `/api/bots/${created.body.bot.id}`, { name: "Cursorless" });
+    expect(patched.body.bot).not.toHaveProperty("resumeCursors");
+
+    const task = await api("POST", `/api/bots/${created.body.bot.id}/tasks`, {});
+    expect(task.body.bot).not.toHaveProperty("resumeCursors");
+    for (const t of task.body.bot.tasks ?? []) expect(t).not.toHaveProperty("resumeCursors");
+
+    // and the same on the wire, not just in the HTTP responses
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      await api("PATCH", `/api/bots/${created.body.bot.id}`, { unread: true });
+      const frame = await stream.until((f) => f.kind === "bot");
+      expect(frame.bot).not.toHaveProperty("resumeCursors");
+      expect(JSON.stringify(frame)).not.toContain("resumeCursors");
+    } finally {
+      stream.close();
+    }
+    await api("DELETE", `/api/bots/${created.body.bot.id}`);
+  });
+
   it("404s unknown routes with the route in the error", async () => {
     const res = await api("GET", "/api/definitely-not-a-route");
     expect(res.status).toBe(404);

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,14 @@ import { discardDelegations, drainDelegations, queueDelegation, type QueueResult
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { cancelPeerApprovalsFor, dismissStalePeerCards, requestPeerApproval, resolvePeerComms, type ApprovalBus } from "./peer-approval.ts";
-import { mentionedBots, roomResponders, Store, type GroupDefaultResponder, type Message } from "./store.ts";
+import {
+  mentionedBots,
+  roomResponders,
+  Store,
+  type GroupDefaultResponder,
+  type Message,
+  type TaskRecord,
+} from "./store.ts";
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
@@ -146,16 +153,18 @@ store.seedIfEmpty();
  * paired phone has even less business holding provider session identifiers
  * than the desktop window did. Stripped here rather than at each call site
  * so a new broadcast cannot forget. */
+const wireTask = ({ resumeCursors, ...task }: TaskRecord) => task;
+
 const wireBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => {
   const { resumeCursors, tasks, ...rest } = bot;
-  return { ...rest, ...(tasks ? { tasks: tasks.map(({ resumeCursors: _, ...task }) => task) } : {}) };
+  return { ...rest, ...(tasks ? { tasks: tasks.map(wireTask) } : {}) };
 };
 
 const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
   ...wireBot(bot),
   messages: store.messagesFor(bot.threadId),
   activeLeafId: store.activeLeaf(bot.threadId),
-  tasks: store.tasks(bot.id).map(({ resumeCursors, ...task }) => task),
+  tasks: store.tasks(bot.id).map(wireTask),
 });
 
 // ── message pages ──────────────────────────────────────────────────────
@@ -1825,7 +1834,7 @@ const server = createServer(async (req, res) => {
       ...wireBot(bot),
       messages: store.messagesFor(bot.threadId),
       activeLeafId: store.activeLeaf(bot.threadId),
-      tasks: store.tasks(bot.id).map(({ resumeCursors, ...t }) => t),
+      tasks: store.tasks(bot.id).map(wireTask),
     });
 
     m = path.match(/^\/api\/bots\/([\w-]+)\/tasks$/);
@@ -1838,7 +1847,7 @@ const server = createServer(async (req, res) => {
       if (!task) return json(res, 500, { error: "couldn't create that task" });
       const fresh = botWithThread(store.bot(bot.id)!);
       broadcast({ kind: "bot", bot: fresh });
-      return json(res, 201, { bot: fresh, task });
+      return json(res, 201, { bot: fresh, task: wireTask(task) });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)\/tasks\/([\w-]+)$/);
     if (m && method === "POST") {
@@ -1854,7 +1863,7 @@ const server = createServer(async (req, res) => {
       if (!task) return json(res, 404, { error: "no such task" });
       const fresh = botWithThread(store.bot(m[1])!);
       broadcast({ kind: "bot", bot: fresh });
-      return json(res, 200, { task });
+      return json(res, 200, { task: wireTask(task) });
     }
     if (m && method === "DELETE") {
       const bot = store.bot(m[1]);

--- a/server/index.ts
+++ b/server/index.ts
@@ -139,8 +139,20 @@ const store = new Store(() => bootSelection);
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
 
+/** A bot as a client may see it: no provider session cursors.
+ *
+ * `resumeCursors` is the harness's own bookkeeping — the native session id
+ * to resume, per instance, per task. No client has ever used it, and a
+ * paired phone has even less business holding provider session identifiers
+ * than the desktop window did. Stripped here rather than at each call site
+ * so a new broadcast cannot forget. */
+const wireBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => {
+  const { resumeCursors, tasks, ...rest } = bot;
+  return { ...rest, ...(tasks ? { tasks: tasks.map(({ resumeCursors: _, ...task }) => task) } : {}) };
+};
+
 const publicBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
-  ...bot,
+  ...wireBot(bot),
   messages: store.messagesFor(bot.threadId),
   activeLeafId: store.activeLeaf(bot.threadId),
   tasks: store.tasks(bot.id).map(({ resumeCursors, ...task }) => task),
@@ -442,7 +454,7 @@ bus.subscribe((event: RuntimeEvent) => {
       lastReply.delete(event.threadId);
       if (bot) {
         store.patchBot(bot.id, { busy: false, unread: true });
-        broadcast({ kind: "bot", bot: store.bot(bot.id) });
+        broadcast({ kind: "bot", bot: wireBot(store.bot(bot.id)!) });
         notify(buildNotification("done", bot, event.threadId, reply));
         if (screenPollers.has(bot.id)) {
           // the last live frame becomes a settled inline screen message —
@@ -661,7 +673,7 @@ async function startTurn(
   // in the background — box provisioning can take ~90s and must never
   // hang the HTTP request
   store.patchBot(bot.id, { busy: true, unread: false });
-  broadcast({ kind: "bot", bot: store.bot(bot.id) });
+  broadcast({ kind: "bot", bot: wireBot(store.bot(bot.id)!) });
 
   void (async () => {
     try {
@@ -827,7 +839,7 @@ async function startTurn(
       });
       broadcast({ kind: "message", threadId, message: failure });
       store.patchBot(bot.id, { busy: false });
-      broadcast({ kind: "bot", bot: store.bot(bot.id) });
+      broadcast({ kind: "bot", bot: wireBot(store.bot(bot.id)!) });
       opts?.onDispatchError?.(message);
     }
   })();
@@ -1063,7 +1075,7 @@ async function reloadProviders() {
     });
     broadcast({ kind: "message", threadId: b.threadId, message: note });
     store.patchBot(b.id, { busy: false });
-    broadcast({ kind: "bot", bot: store.bot(b.id) });
+    broadcast({ kind: "bot", bot: wireBot(store.bot(b.id)!) });
   }
 }
 
@@ -1593,7 +1605,7 @@ const server = createServer(async (req, res) => {
       store.patchBot(bot.id, { modelSelection: await defaultSelection() });
       return json(res, 201, {
         bot: {
-          ...store.bot(bot.id)!,
+          ...wireBot(store.bot(bot.id)!),
           messages: store.messagesFor(bot.threadId),
           activeLeafId: store.activeLeaf(bot.threadId),
         },
@@ -1649,8 +1661,8 @@ const server = createServer(async (req, res) => {
       if (chiefChanges === null) return json(res, 404, { error: "no such bot" });
       const changed = new Map([[bot.id, store.bot(bot.id)!]]);
       for (const changedBot of chiefChanges) changed.set(changedBot.id, changedBot);
-      for (const changedBot of changed.values()) broadcast({ kind: "bot", bot: changedBot });
-      return json(res, 200, { bot });
+      for (const changedBot of changed.values()) broadcast({ kind: "bot", bot: wireBot(changedBot) });
+      return json(res, 200, { bot: wireBot(bot) });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)$/);
     if (m && method === "DELETE") {
@@ -1810,7 +1822,7 @@ const server = createServer(async (req, res) => {
     // changes which transcript is live, and a partial patch would leave
     // the client showing the previous task's conversation.
     const botWithThread = (bot: NonNullable<ReturnType<typeof store.bot>>) => ({
-      ...bot,
+      ...wireBot(bot),
       messages: store.messagesFor(bot.threadId),
       activeLeafId: store.activeLeaf(bot.threadId),
       tasks: store.tasks(bot.id).map(({ resumeCursors, ...t }) => t),


### PR DESCRIPTION
`resumeCursors` is the harness's own bookkeeping — the native session id to resume, per instance, per task. It goes out on every bot payload and every `bot` SSE frame, and no client has ever read it.

It is harmless noise only for as long as every client is this machine. It is still worth not sending: it is internal provider state on the wire, it makes `GET /api/bots` bigger for no reason, and anything that ever consumes this API from somewhere else inherits it by default.

Stripped at one chokepoint rather than at each call site, because there are nine of them and a new broadcast should not have to remember.

The test asserts on the SSE bytes as well as the HTTP bodies. That is deliberate: this was found by capturing real wire output rather than by reading the code, and the wire is where it has to stay fixed.

<!--
Please read CONTRIBUTING.md first — it's short. One concern per PR;
big changes should have an issue agreeing on the approach before code.
-->

## What changed

Two serializers in `server/index.ts` are now the only place a record reaches a client:

- `wireBot(bot)` — drops `resumeCursors` from the bot and from its nested tasks. Every `broadcast({ kind: "bot" })`, the create/patch/chief responses, `publicBot`, and `botWithThread` go through it.
- `wireTask(task)` — drops `resumeCursors` from a task. Used for the nested task lists and for the two responses that answer with a task on its own: `POST /api/bots/:id/tasks` and `PATCH /api/bots/:id/tasks/:threadId`.

The task lists previously repeated the same `({ resumeCursors, ...t }) => t` filter inline in three places; those now call `wireTask`.

No `dist-server/` changes — build output is regenerated, not hand-edited.

## Why

Covered above: it is provider session state, no client reads it, and a paired phone is a client now. The reason it is one chokepoint per shape rather than a filter at each call site is that the call sites keep multiplying and a new one silently ships the cursors again — which is exactly what happened to the standalone task responses in the first pass of this PR.

## How it was verified

- `pnpm typecheck` — clean
- `pnpm test` — 47 files, 399 passed, 8 skipped
- New test `never hands a client the provider session cursors` covers `GET /api/bots`, create, patch, task create, task rename, and the `bot` SSE frame. It asserts on the serialized frame (`JSON.stringify(frame)`) as well as on the parsed objects, so a nested leak cannot pass.
- The new assertions were checked against a deliberately reverted fix: with `PATCH .../tasks/:threadId` answering with the raw store record, the test fails with `expected { …(4) } to not have property "resumeCursors"`. It is not a vacuous assertion.
- macOS (Darwin 25.6), pnpm/vitest. No UI changes to click through.

<!-- commands run, platforms tested on, what you clicked through -->

## Screenshots (UI changes)

None — server-side only, no visible change.

<!-- before/after images; video for anything animated -->

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed internal provider resume cursor data from bot and task responses.
  * Ensured cursor data is excluded from bot updates, creation and task operations, and real-time event notifications.
  * Preserved normal bot and task behavior while preventing internal state from being exposed to clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
