### PR TITLE
Simplify webhook terminal testing

### DIFF
--- a/src/components/WebhooksPanel.tsx
+++ b/src/components/WebhooksPanel.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Check,
-  ChevronRight,
-  CircleAlert,
   Cloud,
   Copy,
   ExternalLink,
-  KeyRound,
   Laptop,
   Loader2,
   MoreHorizontal,
@@ -15,7 +12,6 @@ import {
   Plus,
   RotateCw,
   Send,
-  ShieldCheck,
   Trash2,
   Webhook,
   X,
@@ -72,75 +68,8 @@ function outcomeLabel(outcome: WebhookAttempt["outcome"], run?: RoutineRun) {
   return "Accepted";
 }
 
-function SetupModal({ credential, webhookId, available, onClose }: { credential: WebhookCredential; webhookId: string; available: boolean; onClose: () => void }) {
-  const { state, dispatch } = useStore();
-  const webhook = state.webhooks.find((candidate) => candidate.id === webhookId);
-  const [copied, setCopied] = useState<"url" | "endpoint" | "secret" | "command" | null>(null);
-  const [working, setWorking] = useState(false);
-  const [error, setError] = useState("");
-  const command = `curl -sS '${credential.url}' --json '{"task":"Summarize this event and recommend the next step"}'`;
-  const headerCommand = `curl -sS '${credential.endpointUrl}' -H 'Authorization: Bearer ${credential.secret}' --json '{"task":"Summarize this event and recommend the next step"}'`;
-
-  const copy = async (kind: typeof copied, value: string) => {
-    await navigator.clipboard?.writeText(value);
-    setCopied(kind);
-    setTimeout(() => setCopied(null), 1_800);
-  };
-
-  const enable = async () => {
-    if (!webhook) return;
-    setWorking(true);
-    setError("");
-    try {
-      const response = await api(`/api/webhooks/${webhook.id}`, { method: "PATCH", body: JSON.stringify({ enabled: true, verificationPending: false }) });
-      dispatch({ type: "webhookPatched", webhook: response.webhook });
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setWorking(false);
-    }
-  };
-
-  return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 p-5 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
-      <div className="max-h-[90vh] w-full max-w-[620px] overflow-y-auto rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
-        <div className="flex items-start justify-between border-b border-hairline/40 px-5 py-4">
-          <div><div className="flex items-center gap-2 text-[17px] font-semibold text-ink"><Webhook size={18} className="text-accent" />Local webhook setup</div><div className="mt-1 text-[12px] text-ink-secondary">Copy one URL, send a real event, then turn it on.</div></div>
-          <button onClick={onClose} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button>
-        </div>
-        <div className="space-y-4 p-5">
-          <div className={cn("rounded-xl border p-3.5", available ? "border-warning/25 bg-warning/5" : "border-danger/30 bg-danger/10")}>
-            <div className={cn("flex items-center gap-2 text-[12px] font-medium", available ? "text-warning" : "text-danger")}>{available ? <Laptop size={14} /> : <CircleAlert size={14} />}{available ? "Local receiver running" : "Local receiver unavailable"}</div>
-            <p className="mt-1.5 text-[11.5px] leading-relaxed text-ink-secondary">{available ? "This address only works on this Mac. OpenMausBot must stay open." : "Restart OpenMausBot or change its webhook port before testing."}</p>
-          </div>
-          <div>
-            <div className="mb-1.5 text-[12px] font-medium text-ink">Webhook URL</div>
-            <button onClick={() => void copy("url", credential.url)} className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 text-[13px] font-medium text-white hover:brightness-110">{copied === "url" ? <Check size={15} /> : <Copy size={15} />}{copied === "url" ? "Copied" : "Copy local webhook URL"}</button>
-            <p className="mt-2 text-[11px] leading-relaxed text-ink-secondary">The URL contains a one-time secret. Treat it like a password.</p>
-          </div>
-          <div className="rounded-xl border border-hairline/45 bg-inset/55 p-4">
-            {webhook?.enabled ? (
-              <div className="flex items-start gap-3"><ShieldCheck size={18} className="mt-0.5 text-success" /><div><div className="text-[13px] font-medium text-ink">Webhook is active</div><p className="mt-1 text-[11.5px] text-ink-secondary">New requests will start a background task for this MAUS.</p></div></div>
-            ) : webhook?.verifiedAt ? (
-              <div><div className="flex items-start gap-3"><Check size={18} className="mt-0.5 text-success" /><div className="min-w-0"><div className="text-[13px] font-medium text-ink">Test event received</div><p className="mt-1 break-words font-mono text-[11px] leading-relaxed text-ink-secondary">{webhook.verificationSample?.preview || "Empty payload"}</p></div></div><button disabled={working} onClick={() => void enable()} className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-50">{working ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}Turn on webhook</button></div>
-            ) : (
-              <div><div className="flex items-start gap-3"><Loader2 size={18} className="mt-0.5 animate-spin text-accent" /><div><div className="text-[13px] font-medium text-ink">Waiting for a real event</div><p className="mt-1 text-[11.5px] leading-relaxed text-ink-secondary">The first authenticated request is captured for preview and will not start the MAUS.</p></div></div><div className="relative mt-3 rounded-lg border border-hairline/40 bg-[#101010] p-3 pr-11"><code className="block overflow-x-auto whitespace-nowrap text-[10.5px] text-ink-secondary">{command}</code><button onClick={() => void copy("command", command)} className="absolute right-1.5 top-1.5 rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink" title="Copy test command">{copied === "command" ? <Check size={13} className="text-success" /> : <Copy size={13} />}</button></div></div>
-            )}
-          </div>
-          {error && <div className="rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[12px] text-danger">{error}</div>}
-          <details className="rounded-xl border border-hairline/40 bg-inset px-3.5 py-3">
-            <summary className="cursor-pointer text-[12px] font-medium text-ink">Advanced authentication</summary>
-            <div className="mt-3 space-y-2">
-              <div className="flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel p-2"><div className="min-w-0 flex-1"><div className="px-2 text-[9px] uppercase tracking-wider text-ink-secondary">Endpoint</div><code className="block overflow-x-auto px-2 pt-0.5 text-[11px] text-ink">{credential.endpointUrl}</code></div><button onClick={() => void copy("endpoint", credential.endpointUrl)} className="rounded-lg bg-raised p-2.5 text-ink-secondary hover:text-ink">{copied === "endpoint" ? <Check size={13} /> : <Copy size={13} />}</button></div>
-              <div className="flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel p-2"><div className="min-w-0 flex-1"><div className="px-2 text-[9px] uppercase tracking-wider text-ink-secondary">Bearer secret</div><code className="block overflow-x-auto px-2 pt-0.5 text-[11px] text-ink">{credential.secret}</code></div><button onClick={() => void copy("secret", credential.secret)} className="rounded-lg bg-raised p-2.5 text-ink-secondary hover:text-ink">{copied === "secret" ? <Check size={13} /> : <KeyRound size={13} />}</button></div>
-              <div className="relative rounded-lg border border-hairline/40 bg-[#101010] p-3 pr-11"><code className="block overflow-x-auto whitespace-nowrap text-[10.5px] text-ink-secondary">{headerCommand}</code></div>
-            </div>
-          </details>
-        </div>
-        <div className="flex justify-end border-t border-hairline/40 px-5 py-4"><button onClick={onClose} className="rounded-xl bg-raised px-4 py-2 text-[13px] text-ink hover:bg-raised-hover">Done</button></div>
-      </div>
-    </div>
-  );
+function terminalCommand(credential: WebhookCredential) {
+  return `curl -sS '${credential.url}' --json '{"task":"A production deploy failed. Summarize what happened and tell me the first thing to check."}'`;
 }
 
 function WebhookEditor({ webhook, bots, onClose, onCredential }: { webhook?: WebhookTrigger; bots: Bot[]; onClose: () => void; onCredential: (credential: WebhookCredential, webhookId: string) => void }) {
@@ -201,9 +130,10 @@ interface ActivityItem { id: string; at: number; outcome: WebhookAttempt["outcom
 export function WebhooksPanel({ bots }: { bots: Bot[] }) {
   const { state, dispatch } = useStore();
   const [editor, setEditor] = useState<WebhookTrigger | "new" | null>(null);
-  const [setup, setSetup] = useState<{ credential: WebhookCredential; webhookId: string } | null>(null);
+  const [credentials, setCredentials] = useState<Record<string, WebhookCredential>>({});
   const [selectedId, setSelectedId] = useState<string | null>(state.webhooks[0]?.id ?? null);
   const [working, setWorking] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   const [error, setError] = useState("");
   const runById = useMemo(() => new Map(state.routineRuns.map((run) => [run.id, run])), [state.routineRuns]);
 
@@ -222,7 +152,7 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
     return [...attempts, ...legacy].sort((a, b) => b.at - a.at).slice(0, 30);
   }, [attemptsByRun, runById, selected, state.routineRuns, state.webhookAttempts]);
 
-  const invoke = async (webhook: WebhookTrigger, action: "sample" | "rotate" | "toggle" | "delete") => {
+  const invoke = async (webhook: WebhookTrigger, action: "toggle" | "delete") => {
     setWorking(`${webhook.id}:${action}`);
     setError("");
     try {
@@ -235,14 +165,6 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
         if (enabling && webhook.verificationPending) throw new Error("Send a test event before turning this webhook on");
         const response = await api(`/api/webhooks/${webhook.id}`, { method: "PATCH", body: JSON.stringify({ enabled: enabling, verificationPending: false }) });
         dispatch({ type: "webhookPatched", webhook: response.webhook });
-      } else if (action === "rotate") {
-        if (!window.confirm("Generate a new setup URL? The previous secret will stop working immediately.")) return;
-        const response = await api(`/api/webhooks/${webhook.id}/rotate`, { method: "POST" });
-        dispatch({ type: "webhookPatched", webhook: response.webhook });
-        setSetup({ credential: response.credential, webhookId: webhook.id });
-      } else {
-        if (!window.confirm(`Run a sample task with ${bots.find((bot) => bot.id === webhook.botId)?.name ?? "this MAUS"}? This can use tokens and allowed tools.`)) return;
-        await api(`/api/webhooks/${webhook.id}/test`, { method: "POST", body: JSON.stringify({ task: "Summarize this sample event and recommend the next step." }) });
       }
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -251,29 +173,95 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
     }
   };
 
+  const createAndCopyCommand = async (webhook: WebhookTrigger, replace = false) => {
+    setWorking(`${webhook.id}:command`);
+    setError("");
+    try {
+      let credential = replace ? undefined : credentials[webhook.id];
+      if (!credential) {
+        const response = await api(`/api/webhooks/${webhook.id}/rotate`, { method: "POST" });
+        credential = response.credential;
+        dispatch({ type: "webhookPatched", webhook: response.webhook });
+        setCredentials((current) => ({ ...current, [webhook.id]: credential! }));
+      }
+      if (!credential) throw new Error("Could not create a terminal command");
+      await navigator.clipboard.writeText(terminalCommand(credential));
+      setCopiedId(webhook.id);
+      setTimeout(() => setCopiedId((current) => current === webhook.id ? null : current), 1_800);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setWorking(null);
+    }
+  };
+
   const ingress = state.webhookIngress;
+  const credential = selected ? credentials[selected.id] : undefined;
+  const command = credential ? terminalCommand(credential) : "";
+
   return (
     <div className="min-h-0 flex-1 overflow-y-auto border-t border-hairline/40 p-5 md:p-6">
-      <div className="mx-auto max-w-[1100px] space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="text-[16px] font-semibold text-ink">Webhooks <span className="ml-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-accent">Local beta</span></h2><p className="mt-1 text-[12px] text-ink-secondary">Send a task to a MAUS the moment an event happens.</p></div><button onClick={() => setEditor("new")} disabled={bots.length === 0} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />New webhook</button></div>
-        <div className={cn("flex items-center gap-2 rounded-xl border px-3.5 py-2.5 text-[11.5px]", ingress?.available ? "border-warning/20 bg-warning/5 text-ink-secondary" : "border-danger/25 bg-danger/10 text-danger")}>{ingress?.available ? <Laptop size={14} className="text-warning" /> : <CircleAlert size={14} />}<span><span className="font-medium text-ink">{ingress?.available ? "Local receiver running" : "Local receiver unavailable"}</span>{ingress?.available ? " · Only this Mac can receive events right now." : ` · ${ingress?.error ?? "Restart OpenMausBot to try again."}`}</span></div>
+      <div className="mx-auto max-w-[980px] space-y-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-[16px] font-semibold text-ink">Webhooks <span className="ml-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-accent">Local beta</span></h2>
+            <p className="mt-1 text-[12px] text-ink-secondary">Send a task to a MAUS from Terminal or another app.</p>
+            <div className={cn("mt-2 flex items-center gap-1.5 text-[10.5px]", ingress?.available ? "text-success" : "text-danger")}>
+              <span className={cn("size-1.5 rounded-full", ingress?.available ? "bg-success" : "bg-danger")} />
+              {ingress?.available ? "Listening on this Mac" : ingress?.error ?? "Receiver unavailable"}
+            </div>
+          </div>
+          <button onClick={() => setEditor("new")} disabled={bots.length === 0} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />New webhook</button>
+        </div>
         {error && <div className="rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[12px] text-danger">{error}</div>}
         {state.webhooks.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-hairline/60 bg-panel/50 px-6 py-12 text-center"><div className="mx-auto mb-4 flex size-14 items-center justify-center rounded-2xl bg-accent/10 text-accent"><Send size={26} /></div><h3 className="text-[16px] font-semibold text-ink">Send a task from anywhere on this Mac</h3><p className="mx-auto mt-2 max-w-[450px] text-[12.5px] leading-relaxed text-ink-secondary">Create a URL for a MAUS, then send <code className="text-ink">{`{"task":"…"}`}</code> from Terminal or another local app.</p><button onClick={() => setEditor("new")} disabled={bots.length === 0} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />Create local webhook</button>{bots.length === 0 && <p className="mt-3 text-[12px] text-warning">Create a MAUS first, then come back here.</p>}</div>
         ) : (
-          <div className="grid min-h-[480px] overflow-hidden rounded-2xl border border-hairline/45 bg-panel md:grid-cols-[310px_minmax(0,1fr)]">
-            <div className="border-b border-hairline/35 bg-inset/25 md:border-b-0 md:border-r">{state.webhooks.map((webhook) => { const bot = bots.find((candidate) => candidate.id === webhook.botId); const status = statusFor(webhook); const last = state.webhookAttempts.filter((attempt) => attempt.webhookId === webhook.id).at(-1); return <button key={webhook.id} onClick={() => setSelectedId(webhook.id)} className={cn("flex w-full items-center gap-3 border-b border-hairline/25 px-3.5 py-3 text-left last:border-b-0", selectedId === webhook.id ? "bg-raised/75" : "hover:bg-raised/35")}>{bot ? <MausAvatar color={bot.color} state={webhook.enabled ? "idle" : "sleeping"} size={42} animated={false} label={bot.name} /> : <div className="flex size-[42px] items-center justify-center rounded-xl bg-raised text-ink-secondary"><Webhook size={18} /></div>}<div className="min-w-0 flex-1"><div className="truncate text-[13px] font-medium text-ink">{webhook.name}</div><div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-ink-secondary"><span className={cn("size-1.5 rounded-full", status.dot)} /><span className={status.tone}>{status.label}</span>{last && <><span>·</span><span>{relativeTime(last.receivedAt)}</span></>}</div></div><ChevronRight size={14} className="shrink-0 text-ink-secondary" /></button>; })}</div>
-            {selected && <div className="min-w-0 p-5">
-              <div className="flex flex-wrap items-start justify-between gap-3"><div className="flex min-w-0 items-center gap-3">{selectedBot ? <MausAvatar color={selectedBot.color} state={selected.enabled ? "idle" : "sleeping"} size={52} animated={false} label={selectedBot.name} /> : <div className="flex size-[52px] items-center justify-center rounded-xl bg-raised text-ink-secondary"><Webhook size={22} /></div>}<div className="min-w-0"><h3 className="truncate text-[17px] font-semibold text-ink">{selected.name}</h3><div className="mt-1 flex items-center gap-1.5 text-[11px] text-ink-secondary"><span>{selectedBot?.name ?? "Deleted MAUS"}</span><span>·</span><span>{selected.runOn === "cloud" ? "Cloud VM" : "This computer"}</span><span>·</span><span className={statusFor(selected).tone}>{statusFor(selected).label}</span></div></div></div><div className="flex items-center gap-1.5">{selected.enabled && <button disabled={Boolean(working)} onClick={() => void invoke(selected, "sample")} className="flex items-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[11.5px] text-ink hover:bg-raised-hover disabled:opacity-40"><Play size={12} />Run sample</button>}<details className="relative"><summary className="list-none rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><MoreHorizontal size={17} /></summary><div className="absolute right-0 top-full z-20 mt-1 w-[190px] rounded-xl border border-hairline/50 bg-card p-1.5 shadow-2xl"><button onClick={() => setEditor(selected)} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-ink hover:bg-raised">Edit</button><button onClick={() => void invoke(selected, "rotate")} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-ink hover:bg-raised"><RotateCw size={13} />New setup URL</button>{!selected.verificationPending && <button onClick={() => void invoke(selected, "toggle")} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-ink hover:bg-raised">{selected.enabled ? <Pause size={13} /> : <Play size={13} />}{selected.enabled ? "Pause" : "Enable"}</button>}<button onClick={() => void invoke(selected, "delete")} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-danger hover:bg-danger/10"><Trash2 size={13} />Delete</button></div></details></div></div>
-              <div className="mt-5 grid gap-3 sm:grid-cols-2"><div className="rounded-xl border border-hairline/40 bg-inset/40 p-3.5"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">When an event arrives</div><div className="mt-2 text-[12px] leading-relaxed text-ink">{selected.prompt || "Use the task or message sent in each request."}</div>{selected.eventTypes?.length ? <div className="mt-2 text-[10.5px] text-ink-secondary">Only: {selected.eventTypes.join(", ")}</div> : null}</div><div className="rounded-xl border border-hairline/40 bg-inset/40 p-3.5"><div className="flex items-center justify-between"><div className="text-[10px] uppercase tracking-wider text-ink-secondary">Connection</div><span className="rounded-full bg-warning/10 px-2 py-0.5 text-[9.5px] text-warning">Local only</span></div><div className="mt-2 flex items-center gap-2 text-[12px] text-ink"><Laptop size={13} />{ingress?.available ? "Receiver running" : "Receiver unavailable"}</div><p className="mt-1.5 text-[10.5px] leading-relaxed text-ink-secondary">OpenMausBot must stay open. Public connectivity is not configured.</p><button onClick={() => void invoke(selected, "rotate")} className="mt-3 flex items-center gap-1.5 text-[11px] font-medium text-accent hover:brightness-125"><KeyRound size={12} />Generate setup URL</button></div></div>
+          <div>
+            {state.webhooks.length > 1 && (
+              <label className="mb-5 block max-w-[360px]">
+                <span className="mb-1.5 block text-[10.5px] font-medium uppercase tracking-wider text-ink-secondary">Webhook</span>
+                <select value={selectedId ?? ""} onChange={(event) => setSelectedId(event.target.value)} className="w-full rounded-xl border border-hairline/50 bg-panel px-3.5 py-2.5 text-[12.5px] text-ink outline-none focus:border-accent/70">
+                  {state.webhooks.map((webhook) => <option key={webhook.id} value={webhook.id}>{webhook.name} · {statusFor(webhook).label}</option>)}
+                </select>
+              </label>
+            )}
+            {selected && <div className="min-w-0">
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-hairline/35 pb-5">
+                <div className="flex min-w-0 items-center gap-3">
+                  {selectedBot ? <MausAvatar color={selectedBot.color} state={selected.enabled ? "idle" : "sleeping"} size={48} animated={false} label={selectedBot.name} /> : <div className="flex size-12 items-center justify-center rounded-xl bg-raised text-ink-secondary"><Webhook size={20} /></div>}
+                  <div className="min-w-0">
+                    <h3 className="truncate text-[17px] font-semibold text-ink">{selected.name}</h3>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-ink-secondary"><span>{selectedBot?.name ?? "Deleted MAUS"}</span><span>·</span><span>{selected.runOn === "cloud" ? "Cloud VM" : "This Mac"}</span><span>·</span><span className={statusFor(selected).tone}>{statusFor(selected).label}</span></div>
+                  </div>
+                </div>
+                <details className="relative"><summary className="list-none rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><MoreHorizontal size={17} /></summary><div className="absolute right-0 top-full z-20 mt-1 w-[180px] rounded-xl border border-hairline/50 bg-card p-1.5 shadow-2xl"><button onClick={() => setEditor(selected)} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-ink hover:bg-raised">Edit</button>{!selected.verificationPending && <button onClick={() => void invoke(selected, "toggle")} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-ink hover:bg-raised">{selected.enabled ? <Pause size={13} /> : <Play size={13} />}{selected.enabled ? "Pause" : "Enable"}</button>}<button onClick={() => void invoke(selected, "delete")} className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[12px] text-danger hover:bg-danger/10"><Trash2 size={13} />Delete</button></div></details>
+              </div>
+
+              <section className="py-5">
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                  <div><h4 className="text-[13px] font-medium text-ink">Test from Terminal</h4><p className="mt-1 text-[11.5px] text-ink-secondary">Copy, paste, and press Return. The task is already included.</p></div>
+                  {!credential && <button disabled={Boolean(working) || !ingress?.available} onClick={() => void createAndCopyCommand(selected)} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2.5 text-[12.5px] font-medium text-white hover:brightness-110 disabled:opacity-40">{working === `${selected.id}:command` ? <Loader2 size={14} className="animate-spin" /> : <Copy size={14} />}Create & copy command</button>}
+                </div>
+                {credential ? (
+                  <div className="mt-3 flex items-center gap-2 rounded-xl border border-hairline/45 bg-[#101010] p-2 pl-3">
+                    <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-ink-secondary">{command}</code>
+                    <button onClick={() => void createAndCopyCommand(selected)} className="flex shrink-0 items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[11.5px] font-medium text-white hover:brightness-110">{copiedId === selected.id ? <Check size={13} /> : <Copy size={13} />}{copiedId === selected.id ? "Copied" : "Copy"}</button>
+                    <button onClick={() => void createAndCopyCommand(selected, true)} className="shrink-0 rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink" title="Create a different private URL"><RotateCw size={14} /></button>
+                  </div>
+                ) : <p className="mt-2 text-[10.5px] text-ink-secondary">Creates a private local URL. Any previous URL for this webhook will stop working.</p>}
+                <p className="mt-2 text-[10.5px] text-ink-secondary">OpenMausBot must stay open. This local URL cannot be called from GitHub, Stripe, or another internet service yet.</p>
+                {selected.prompt && <p className="mt-2 text-[10.5px] text-ink-secondary">Default instruction: <span className="text-ink">{selected.prompt}</span></p>}
+                {selected.eventTypes?.length ? <p className="mt-1 text-[10.5px] text-ink-secondary">Accepted events: <span className="text-ink">{selected.eventTypes.join(", ")}</span></p> : null}
+              </section>
+
               {selected.verificationSample && !selected.enabled && <div className="mt-3 rounded-xl border border-success/20 bg-success/5 p-3.5"><div className="flex items-center gap-2 text-[12px] font-medium text-success"><Check size={13} />Test event received</div><p className="mt-2 break-words font-mono text-[10.5px] leading-relaxed text-ink-secondary">{selected.verificationSample.preview || "Empty payload"}</p><button disabled={Boolean(working)} onClick={() => void invoke(selected, "toggle")} className="mt-3 flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[11.5px] font-medium text-white hover:brightness-110"><Play size={12} />Turn on webhook</button></div>}
-              <div className="mt-5"><div className="mb-2 flex items-center justify-between"><h4 className="text-[12.5px] font-medium text-ink">Activity</h4><span className="text-[10.5px] text-ink-secondary">Updates automatically</span></div><div className="overflow-hidden rounded-xl border border-hairline/35 bg-inset/35">{activity.length === 0 ? <div className="px-4 py-8 text-center text-[11.5px] text-ink-secondary">No requests yet. Generate a setup URL and send a test event.</div> : activity.map((item, index) => <div key={item.id} className={cn("flex items-center gap-2.5 px-3.5 py-3", index > 0 && "border-t border-hairline/25")}><span className={cn("size-2 shrink-0 rounded-full", item.outcome === "rejected" || item.run?.status === "failed" ? "bg-danger" : item.run && ["queued", "running", "waiting"].includes(item.run.status) ? "animate-pulse bg-accent" : item.outcome === "ignored" || item.outcome === "duplicate" ? "bg-ink-secondary/50" : "bg-success")} /><div className="min-w-0 flex-1"><div className="flex items-center gap-1.5 text-[11.5px]"><span className="truncate font-medium text-ink">{item.eventName}</span><span className="shrink-0 text-ink-secondary">· {relativeTime(item.at)}</span></div><div className="mt-0.5 truncate font-mono text-[10.5px] text-ink-secondary/85">{item.reason || item.preview || "Empty payload"}</div></div><span className={cn("shrink-0 text-[10.5px] font-medium", outcomeTone(item.outcome, item.run))}>{outcomeLabel(item.outcome, item.run)}</span>{item.run?.threadId && selectedBot && <button onClick={() => { dispatch({ type: "select", id: selectedBot.id }); dispatch({ type: "switchTask", botId: selectedBot.id, threadId: item.run!.threadId! }); }} className="flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-[10.5px] text-ink-secondary hover:bg-raised hover:text-ink" title="Open this execution in the MAUS chat"><ExternalLink size={11} />Open chat</button>}</div>)}</div></div>
+              <div className="border-t border-hairline/35 pt-5"><div className="mb-2 flex items-center justify-between"><h4 className="text-[12.5px] font-medium text-ink">Activity</h4><span className="text-[10.5px] text-ink-secondary">Updates automatically</span></div><div className="overflow-hidden rounded-xl border border-hairline/35">{activity.length === 0 ? <div className="px-4 py-8 text-center text-[11.5px] text-ink-secondary">No requests yet. Copy the terminal command above to send one.</div> : activity.map((item, index) => <div key={item.id} className={cn("flex items-center gap-2.5 px-3.5 py-3", index > 0 && "border-t border-hairline/25")}><span className={cn("size-2 shrink-0 rounded-full", item.outcome === "rejected" || item.run?.status === "failed" ? "bg-danger" : item.run && ["queued", "running", "waiting"].includes(item.run.status) ? "animate-pulse bg-accent" : item.outcome === "ignored" || item.outcome === "duplicate" ? "bg-ink-secondary/50" : "bg-success")} /><div className="min-w-0 flex-1"><div className="flex items-center gap-1.5 text-[11.5px]"><span className="truncate font-medium text-ink">{item.eventName}</span><span className="shrink-0 text-ink-secondary">· {relativeTime(item.at)}</span></div><div className="mt-0.5 truncate font-mono text-[10.5px] text-ink-secondary/85">{item.reason || item.preview || "Empty payload"}</div></div><span className={cn("shrink-0 text-[10.5px] font-medium", outcomeTone(item.outcome, item.run))}>{outcomeLabel(item.outcome, item.run)}</span>{item.run?.threadId && selectedBot && <button onClick={() => { dispatch({ type: "select", id: selectedBot.id }); dispatch({ type: "switchTask", botId: selectedBot.id, threadId: item.run!.threadId! }); }} className="flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-[10.5px] text-ink-secondary hover:bg-raised hover:text-ink" title="Open this execution in the MAUS chat"><ExternalLink size={11} />Open chat</button>}</div>)}</div></div>
             </div>}
           </div>
         )}
       </div>
-      {editor && <WebhookEditor webhook={editor === "new" ? undefined : editor} bots={bots} onClose={() => setEditor(null)} onCredential={(credential, webhookId) => setSetup({ credential, webhookId })} />}
-      {setup && <SetupModal credential={setup.credential} webhookId={setup.webhookId} available={Boolean(ingress?.available)} onClose={() => setSetup(null)} />}
+      {editor && <WebhookEditor webhook={editor === "new" ? undefined : editor} bots={bots} onClose={() => setEditor(null)} onCredential={(newCredential, webhookId) => { setCredentials((current) => ({ ...current, [webhookId]: newCredential })); setSelectedId(webhookId); }} />}
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- Removed the large webhook detail and connection cards
- Removed the in-app sample action that bypassed the real receiver
- Added one obvious **Test from Terminal** section
- Added a ready-to-paste `curl` command with a direct Copy button
- Shows the command inline after creation and keeps URL replacement behind a small refresh action
- Replaced the large receiver banner and multi-column webhook list with compact status and selection controls

## Why

The previous screen made users hunt for **Generate setup URL**, then opened another modal before they could test the webhook. The primary job on this page is sending a real request, so the real terminal command now sits directly above Activity.

## User impact

Users can click once, paste into Terminal, and watch the delivery appear in Activity. Existing URLs remain secret-at-rest; creating a command for an older webhook replaces its previous private URL and shows the new one only in the current app session.

## Validation

- `pnpm typecheck`
- `pnpm test` — 414 passed, 8 skipped; 11 updater tests passed
- `pnpm build`
- Manual app verification of the simplified layout, copy feedback, and live delivery appearing in Activity
