### PR TITLE
Pick a reasoning-effort level per bot

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -28,12 +28,18 @@ export class ProviderError extends Error {
   }
 }
 
+/** Reasoning-effort levels, ascending. A union of everything any engine
+ * accepts; each driver declares the subset its CLI will take. */
+export type EffortLevel = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+
 // ── model selection ────────────────────────────────────────────────────
 // "Which model" is a data value carried on the request, never a service
 // binding (upstream ModelSelectionWire). instanceId is the routing key.
 export interface ModelSelection {
   instanceId: InstanceId;
   model: string;
+  /** Optional: no effort means no flag, and the CLI keeps its own default. */
+  effort?: EffortLevel;
 }
 
 // ── instance configuration envelope ────────────────────────────────────
@@ -110,6 +116,7 @@ export interface SendTurnInput {
   threadId: ThreadId;
   text: string;
   model?: string;
+  effort?: EffortLevel;
   resumeCursor?: unknown;
   /** Prior turns for transcript-replay providers (API-backed drivers). */
   transcript?: Array<{ role: "user" | "assistant"; text: string }>;
@@ -154,6 +161,10 @@ export interface ProviderAdapter {
      * connected apps). Same rule again: a key in the config says the user
      * HAS those connections, not that this driver can reach them. */
     composioMcp?: boolean;
+    /** Effort levels this driver can pass to its CLI, ascending. Absent =
+     * the driver cannot set effort, so the app never offers the control —
+     * same rule as computerMcp: never show a knob the driver cannot turn. */
+    effortLevels?: readonly EffortLevel[];
   };
   sendTurn(input: SendTurnInput): Promise<TurnStartResult>;
   interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void>;

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -30,7 +30,13 @@ export class ProviderError extends Error {
 
 /** Reasoning-effort levels, ascending. A union of everything any engine
  * accepts; each driver declares the subset its CLI will take. */
-export type EffortLevel = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+export const EFFORT_LEVELS = ["none", "low", "medium", "high", "xhigh", "max"] as const;
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
+/** Narrow untrusted API/config input before it becomes a model selection. */
+export function isEffortLevel(value: unknown): value is EffortLevel {
+  return typeof value === "string" && (EFFORT_LEVELS as readonly string[]).includes(value);
+}
 
 // ── model selection ────────────────────────────────────────────────────
 // "Which model" is a data value carried on the request, never a service

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -455,6 +455,17 @@ describe("ACP turns (fake CLI)", () => {
 
     expect(JSON.parse(readFileSync(dump, "utf8")).env.TEST_POLICY).toBe("auto");
   });
+
+  it("declares effort levels for Grok only", async () => {
+    await create(GrokAgentDriver);
+    expect(instance.adapter.capabilities.effortLevels).toEqual(["low", "medium", "high", "xhigh"]);
+
+    await create(GeminiAgentDriver);
+    expect(instance.adapter.capabilities.effortLevels).toBeUndefined();
+
+    await create(KimiAgentDriver);
+    expect(instance.adapter.capabilities.effortLevels).toBeUndefined();
+  });
 });
 
 describe("ACP snapshot", () => {

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -458,7 +458,7 @@ describe("ACP turns (fake CLI)", () => {
 
   it("declares effort levels for Grok only", async () => {
     await create(GrokAgentDriver);
-    expect(instance.adapter.capabilities.effortLevels).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(instance.adapter.capabilities.effortLevels).toEqual(["low", "medium", "high"]);
 
     await create(GeminiAgentDriver);
     expect(instance.adapter.capabilities.effortLevels).toBeUndefined();

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -466,6 +466,26 @@ describe("ACP turns (fake CLI)", () => {
     await create(KimiAgentDriver);
     expect(instance.adapter.capabilities.effortLevels).toBeUndefined();
   });
+
+  it("passes effort to Grok, and omits the flag when unset", async () => {
+    const withEffort = join(scratch, "grok-effort.json");
+    await create(GrokAgentDriver);
+    process.env.FAKE_ACP_DUMP = withEffort;
+    await instance.adapter.sendTurn({ threadId: "t-effort", text: "hi", effort: "high" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(withEffort, "utf8"));
+    expect(seen.argv).toContain("--reasoning-effort");
+    expect(seen.argv[seen.argv.indexOf("--reasoning-effort") + 1]).toBe("high");
+
+    const without = join(scratch, "grok-no-effort.json");
+    await create(GrokAgentDriver);
+    process.env.FAKE_ACP_DUMP = without;
+    await instance.adapter.sendTurn({ threadId: "t-no-effort", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(JSON.parse(readFileSync(without, "utf8")).argv).not.toContain("--reasoning-effort");
+  });
 });
 
 describe("ACP snapshot", () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -22,6 +22,7 @@ import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../proc
 
 import type {
   DriverCreateInput,
+  EffortLevel,
   EngineInstall,
   ProviderDriver,
   ProviderInstance,
@@ -56,6 +57,11 @@ export interface AcpSupport {
   driverKind: string;
   displayName: string;
   models: { default: string; options: Array<{ id: string; label: string }> };
+  /** Effort levels this harness's CLI accepts, ascending. Omit when it has
+   * no reasoning-effort control. Static for the same reason `models` is:
+   * describe() runs before any session exists, so there is no _meta to read
+   * — eventually both should come from initialize's _meta.modelState. */
+  effortLevels?: readonly EffortLevel[];
   /** Default CLI binary name if the instance config doesn't override it. */
   defaultCli: string;
   /** Optional live model catalog. A failed lookup keeps the last usable catalog. */
@@ -639,7 +645,12 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         snapshot,
         adapter: {
           provider: DRIVER_KIND,
-          capabilities: { sessionModelSwitch: "unsupported", agentsMcp: true, computerMcp: true },
+          capabilities: {
+            sessionModelSwitch: "unsupported",
+            agentsMcp: true,
+            computerMcp: true,
+            effortLevels: support.effortLevels,
+          },
           sendTurn,
           interruptTurn: async (threadId) => active.get(threadId)?.interrupt(),
           respondToRequest: async (threadId, requestId, decision) => {

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -51,6 +51,9 @@ const support: AcpSupport = {
     "--permission-mode",
     config.fullAuto ? "bypassPermissions" : "default",
     ...(turn.model ? ["-m", turn.model] : []),
+    // long form on purpose: `--effort` is documented as an alias, and an
+    // alias is the part a CLI is free to rename
+    ...(turn.effort ? ["--reasoning-effort", turn.effort] : []),
     "agent",
     "stdio",
   ],

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -23,6 +23,11 @@ const support: AcpSupport = {
       { id: "grok-4.5", label: "Grok 4.5" },
     ],
   },
+  // Grok's accepted levels vary by model (grok-4.3 takes `none`,
+  // grok-4.20-multi-agent takes `xhigh`) and the CLI validates lazily — a
+  // rejected level logs and falls back. This is the subset its current
+  // models share.
+  effortLevels: ["low", "medium", "high", "xhigh"],
   defaultCli: "grok",
   nativeSource: "grok.acp",
   loginNote: "Grok CLI is not signed in — run `grok login` in a terminal",

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -23,11 +23,10 @@ const support: AcpSupport = {
       { id: "grok-4.5", label: "Grok 4.5" },
     ],
   },
-  // Grok's accepted levels vary by model (grok-4.3 takes `none`,
-  // grok-4.20-multi-agent takes `xhigh`) and the CLI validates lazily — a
-  // rejected level logs and falls back. This is the subset its current
-  // models share.
-  effortLevels: ["low", "medium", "high", "xhigh"],
+  // Grok's accepted levels vary by model and the CLI validates lazily — a
+  // rejected level only logs and falls back. Offer the intersection shared
+  // by every model in this driver's picker; notably, grok-4.5 rejects xhigh.
+  effortLevels: ["low", "medium", "high"],
   defaultCli: "grok",
   nativeSource: "grok.acp",
   loginNote: "Grok CLI is not signed in — run `grok login` in a terminal",

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -351,6 +351,32 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
   });
 
+  it("passes effort to the CLI, and omits the flag when unset", async () => {
+    await create();
+    const dump = join(scratch, "effort.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-effort", text: "hi", effort: "xhigh" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).toContain("--effort");
+    expect(seen.argv[seen.argv.indexOf("--effort") + 1]).toBe("xhigh");
+    expect(seen.argv.filter((a: string) => a === "--effort")).toHaveLength(1);
+  });
+
+  it("adds no effort flag when the turn has none", async () => {
+    await create();
+    const dump = join(scratch, "no-effort.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-no-effort", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).not.toContain("--effort");
+  });
+
   it("declares the effort levels the CLI accepts", async () => {
     await create();
     expect(instance.adapter.capabilities.effortLevels).toEqual([

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -350,6 +350,13 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.interruptTurn("t-perm-2");
     await recorder.until((e) => e.type === "turn.completed");
   });
+
+  it("declares the effort levels the CLI accepts", async () => {
+    await create();
+    expect(instance.adapter.capabilities.effortLevels).toEqual([
+      "low", "medium", "high", "xhigh", "max",
+    ]);
+  });
 });
 
 // Auth state must come from the CLI, not from probing its credential store:

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -560,7 +560,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       snapshot,
       adapter: {
         provider: DRIVER_KIND,
-        capabilities: { sessionModelSwitch: "in-session", agentsMcp: true, computerMcp: true, composioMcp: true },
+        capabilities: {
+          sessionModelSwitch: "in-session",
+          agentsMcp: true,
+          computerMcp: true,
+          composioMcp: true,
+          effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async (threadId, requestId, decision) => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -298,6 +298,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       if (sessionId) args.push("--resume", sessionId);
       else args.push("--session-id", newSessionId!);
       if (turn.model) args.push("--model", turn.model);
+      if (turn.effort) args.push("--effort", turn.effort);
       if (turn.system) args.push("--append-system-prompt", turn.system);
 
       // integrations → MCP servers; pre-allow their tools (a headless

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -204,4 +204,30 @@ describe("CodexDriver turns (fake app-server)", () => {
       "low", "medium", "high", "xhigh", "max",
     ]);
   });
+
+  it("sends effort on turn/start, and omits the key when unset", async () => {
+    await create();
+    const dump = join(scratch, "effort.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-effort", text: "hi", effort: "xhigh" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    const turnStart = seen.calls.find((c: any) => c.method === "turn/start");
+    expect(turnStart.params.effort).toBe("xhigh");
+  });
+
+  it("sends no effort key when the turn has none", async () => {
+    await create();
+    const dump = join(scratch, "no-effort.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-no-effort", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    const turnStart = seen.calls.find((c: any) => c.method === "turn/start");
+    expect(turnStart.params).not.toHaveProperty("effort");
+  });
 });

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -197,4 +197,11 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(done).toMatchObject({ ok: false });
     expect(await instance.snapshot()).toMatchObject({ state: "unavailable" });
   });
+
+  it("declares the effort levels the app-server accepts", async () => {
+    await create();
+    expect(instance.adapter.capabilities.effortLevels).toEqual([
+      "low", "medium", "high", "xhigh", "max",
+    ]);
+  });
 });

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -389,8 +389,15 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           await request("turn/start", {
             threadId: codexThreadId,
             input: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
-            // spread, not `effort: turn.effort ?? null` — an absent key leaves
-            // the thread's current effort alone, while null would clear it
+            // Spread, not `effort: turn.effort ?? null`. Probed against
+            // codex-cli 0.146.0: null is indistinguishable from an absent key
+            // — both leave the thread's current effort alone, emitting no
+            // thread/settings/updated, and thread/resume reads the old value
+            // back. The app-server offers no way to clear a level either:
+            // "" is rejected outright and thread/start takes no effort at
+            // all. So a thread keeps the last level it was sent until it is
+            // sent another, and choosing Default lands on the bot's next new
+            // thread rather than the current one.
             ...(turn.effort ? { effort: turn.effort } : {}),
           });
         } catch (e) {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -389,6 +389,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           await request("turn/start", {
             threadId: codexThreadId,
             input: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
+            // spread, not `effort: turn.effort ?? null` — an absent key leaves
+            // the thread's current effort alone, while null would clear it
+            ...(turn.effort ? { effort: turn.effort } : {}),
           });
         } catch (e) {
           if (!state.settled) {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -420,7 +420,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       snapshot,
       adapter: {
         provider: DRIVER_KIND,
-        capabilities: { sessionModelSwitch: "unsupported" },
+        capabilities: {
+          sessionModelSwitch: "unsupported",
+          effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async (threadId, requestId, decision) => {

--- a/server/harness/registry.test.ts
+++ b/server/harness/registry.test.ts
@@ -75,6 +75,24 @@ describe("ProviderRegistry", () => {
     expect(described.snapshot).toMatchObject({ state: "unavailable", reason: "provider probe exploded" });
   });
 
+  it("forwards a live instance's declared effort levels in describe()", async () => {
+    const fake = makeFakeDriver({ effortLevels: ["low", "high"] });
+    const registry = new ProviderRegistry([fake.driver]);
+    await registry.load({ a: { driver: "fake" } });
+
+    const [described] = await registry.describe();
+    expect(described.capabilities.effortLevels).toEqual(["low", "high"]);
+  });
+
+  it("omits effortLevels from describe() when the driver declares none", async () => {
+    const fake = makeFakeDriver();
+    const registry = new ProviderRegistry([fake.driver]);
+    await registry.load({ a: { driver: "fake" } });
+
+    const [described] = await registry.describe();
+    expect(described.capabilities.effortLevels).toBeUndefined();
+  });
+
   it("disposeAll disposes every live instance and empties the registry", async () => {
     const fake = makeFakeDriver();
     const registry = new ProviderRegistry([fake.driver]);

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -118,6 +118,7 @@ export class ProviderRegistry {
           capabilities: {
             computerMcp: inst.adapter.capabilities.computerMcp === true,
             agentsMcp: inst.adapter.capabilities.agentsMcp === true,
+            effortLevels: inst.adapter.capabilities.effortLevels,
           },
           install: this.driversByKind.get(inst.driverKind)?.install,
         };

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -315,6 +315,16 @@ describe("harness HTTP API", () => {
     });
   });
 
+  it("rejects an unknown effort value even while the engine is offline", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const patched = await api("PATCH", `/api/bots/${bot.id}`, {
+      modelSelection: { instanceId: "ghost", model: "ghost-1", effort: "turbo" },
+    });
+
+    expect(patched.status).toBe(400);
+    expect(patched.body.error).toContain("not recognized");
+  });
+
   it("leaves a bot with no effort level untouched", async () => {
     const bot = (await api("POST", "/api/bots")).body.bot;
     expect(bot.modelSelection.effort).toBeUndefined();

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -291,6 +291,28 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("rejects an effort level the bot's engine does not declare", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+
+    const bad = await api("PATCH", `/api/bots/${bot.id}`, {
+      modelSelection: { ...bot.modelSelection, effort: "banana" },
+    });
+    expect(bad.status).toBe(400);
+
+    const after = await api("GET", "/api/bots");
+    const reread = after.body.bots.find((b: { id: string }) => b.id === bot.id);
+    expect(reread.modelSelection.effort).toBeUndefined();
+  });
+
+  it("leaves a bot with no effort level untouched", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    expect(bot.modelSelection.effort).toBeUndefined();
+
+    const renamed = await api("PATCH", `/api/bots/${bot.id}`, { name: "Plain" });
+    expect(renamed.status).toBe(200);
+    expect(renamed.body.bot.modelSelection.effort).toBeUndefined();
+  });
+
   it("persists an answered onboarding card", async () => {
     const { body } = await api("GET", "/api/bots");
     const bot = body.bots[0];

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -324,6 +324,35 @@ describe("harness HTTP API", () => {
     expect(renamed.body.bot.modelSelection.effort).toBeUndefined();
   });
 
+  // This fixture pins a single unknown driver, so no instance here ever
+  // resolves: these cover the gate's pass-through and the store's replace
+  // semantics, NOT the comparison against a live engine's declared list.
+  // That branch has no coverage at this layer, and manufacturing a live
+  // instance in this fixture would cost it its no-probe determinism.
+  it("round-trips an effort level and clears it when the key is dropped", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const selection = { instanceId: "ghost", model: "ghost-1" };
+
+    const set = await api("PATCH", `/api/bots/${bot.id}`, {
+      modelSelection: { ...selection, effort: "high" },
+    });
+    expect(set.status).toBe(200);
+    expect(set.body.bot.modelSelection.effort).toBe("high");
+
+    const reread = (await api("GET", "/api/bots")).body.bots.find((b: { id: string }) => b.id === bot.id);
+    expect(reread.modelSelection.effort).toBe("high");
+
+    // The panel's "Default" button spreads the selection with effort:
+    // undefined, and JSON.stringify drops the key — so clearing reaches the
+    // server as a modelSelection carrying no effort at all.
+    const cleared = await api("PATCH", `/api/bots/${bot.id}`, { modelSelection: selection });
+    expect(cleared.status).toBe(200);
+
+    const after = (await api("GET", "/api/bots")).body.bots.find((b: { id: string }) => b.id === bot.id);
+    expect(after.modelSelection).toEqual(selection);
+    expect(after.modelSelection.effort).toBeUndefined();
+  });
+
   it("persists an answered onboarding card", async () => {
     const { body } = await api("GET", "/api/bots");
     const bot = body.bots[0];

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -291,17 +291,28 @@ describe("harness HTTP API", () => {
     }
   });
 
-  it("rejects an effort level the bot's engine does not declare", async () => {
-    const bot = (await api("POST", "/api/bots")).body.bot;
+  it("keeps the rest of a duplicate's fields when the source engine is offline", async () => {
+    // duplicateBot POSTs a blank bot, then PATCHes the source's whole
+    // modelSelection in one body beside its name, title and description.
+    // "ghost" is an unknown driver, so the registry resolves nothing and the
+    // level cannot be verified — which must not cost the copy everything
+    // else in the request.
+    const copy = (await api("POST", "/api/bots")).body.bot;
 
-    const bad = await api("PATCH", `/api/bots/${bot.id}`, {
-      modelSelection: { ...bot.modelSelection, effort: "banana" },
+    const patched = await api("PATCH", `/api/bots/${copy.id}`, {
+      name: "Reviewer copy",
+      title: "Reviewer",
+      description: "reads diffs",
+      modelSelection: { instanceId: "ghost", model: "ghost-1", effort: "xhigh" },
     });
-    expect(bad.status).toBe(400);
 
-    const after = await api("GET", "/api/bots");
-    const reread = after.body.bots.find((b: { id: string }) => b.id === bot.id);
-    expect(reread.modelSelection.effort).toBeUndefined();
+    expect(patched.status).toBe(200);
+    expect(patched.body.bot).toMatchObject({
+      name: "Reviewer copy",
+      title: "Reviewer",
+      description: "reads diffs",
+      modelSelection: { instanceId: "ghost", model: "ghost-1", effort: "xhigh" },
+    });
   });
 
   it("leaves a bot with no effort level untouched", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ import {
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
 import { resetPathCache } from "./env-path.ts";
 import { buildNotification, type Notification } from "./notify.ts";
-import type { RuntimeEvent } from "./contracts.ts";
+import { isEffortLevel, type RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
@@ -694,6 +694,14 @@ async function startTurn(
   // a cloud routine borrows the instance default model, so it borrows no
   // per-bot effort either
   const effort = opts?.runOn === "cloud" ? undefined : bot.modelSelection.effort;
+  // A selection can be persisted while its engine is offline. Re-check when
+  // the engine returns so an old or unsupported value never reaches a CLI.
+  if (effort && !instance.adapter.capabilities.effortLevels?.includes(effort)) {
+    throw Object.assign(
+      new Error(`effort "${effort}" is not offered by this bot's engine — choose another level in settings`),
+      { status: 409 },
+    );
+  }
 
   // an edit hands us its already-branched user message; a plain send appends
   let userMessage = opts?.userMessage;
@@ -1799,6 +1807,9 @@ const server = createServer(async (req, res) => {
         | { instanceId?: string; effort?: string }
         | undefined;
       if (nextSelection?.effort !== undefined) {
+        if (!isEffortLevel(nextSelection.effort)) {
+          return json(res, 400, { error: `effort "${String(nextSelection.effort)}" is not recognized` });
+        }
         const target = registry.get(nextSelection.instanceId ?? existing?.modelSelection.instanceId ?? "");
         // typed as strings, not levels: this is the boundary that decides
         // whether the value *is* a level, so it must not assert that it is

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ import {
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
 import { resetPathCache } from "./env-path.ts";
 import { buildNotification, type Notification } from "./notify.ts";
-import type { RuntimeEvent } from "./contracts.ts";
+import type { EffortLevel, RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
@@ -691,6 +691,9 @@ async function startTurn(
   }
   const instanceId = instance.instanceId;
   const model = opts?.runOn === "cloud" ? instance.models.default : bot.modelSelection.model;
+  // a cloud routine borrows the instance default model, so it borrows no
+  // per-bot effort either
+  const effort = opts?.runOn === "cloud" ? undefined : bot.modelSelection.effort;
 
   // an edit hands us its already-branched user message; a plain send appends
   let userMessage = opts?.userMessage;
@@ -865,6 +868,7 @@ async function startTurn(
         threadId,
         text: turnText,
         model,
+        effort,
         // a rewound thread never resumes the abandoned branch's session
         // the active task's own session — another task's cursor would
         // resume the wrong conversation and defeat the context bubble
@@ -1779,6 +1783,24 @@ const server = createServer(async (req, res) => {
     m = path.match(/^\/api\/bots\/([\w-]+)$/);
     if (m && method === "PATCH") {
       const body = await readBody(req);
+      const existing = store.bot(m[1]);
+      // Neither Codex (free-form string field) nor Grok (lazy, logs-only)
+      // rejects an unknown effort level at their own boundary — this is the
+      // only real gate. An unavailable target instance (registry.get finds
+      // nothing) offers an empty list, so any effort is rejected: an engine
+      // that isn't there cannot promise to honour a level.
+      const nextSelection = (body as Record<string, unknown>).modelSelection as
+        | { instanceId?: string; effort?: string }
+        | undefined;
+      if (nextSelection?.effort !== undefined) {
+        const target = registry.get(nextSelection.instanceId ?? existing?.modelSelection.instanceId ?? "");
+        const allowed = target?.adapter.capabilities.effortLevels ?? [];
+        if (!allowed.includes(nextSelection.effort as EffortLevel)) {
+          return json(res, 400, {
+            error: `effort "${nextSelection.effort}" is not offered by this bot's engine`,
+          });
+        }
+      }
       const patch: Record<string, unknown> = {};
       for (const key of ["name", "title", "description", "notifications", "modelSelection", "unread", "computer", "color", "mascotExpression", "pinned", "hidden", "speakReplies", "voice"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
@@ -1792,7 +1814,6 @@ const server = createServer(async (req, res) => {
       if (body.chiefOfStaff !== undefined && typeof body.chiefOfStaff !== "boolean") {
         return json(res, 400, { error: "chiefOfStaff must be true or false" });
       }
-      const existing = store.bot(m[1]);
       if (body.hidden === true && existing?.chiefOfStaff && body.chiefOfStaff !== false) {
         return json(res, 400, { error: "choose another Chief of Staff before hiding this bot" });
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ import {
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
 import { resetPathCache } from "./env-path.ts";
 import { buildNotification, type Notification } from "./notify.ts";
-import type { EffortLevel, RuntimeEvent } from "./contracts.ts";
+import type { RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
@@ -1786,16 +1786,24 @@ const server = createServer(async (req, res) => {
       const existing = store.bot(m[1]);
       // Neither Codex (free-form string field) nor Grok (lazy, logs-only)
       // rejects an unknown effort level at their own boundary — this is the
-      // only real gate. An unavailable target instance (registry.get finds
-      // nothing) offers an empty list, so any effort is rejected: an engine
-      // that isn't there cannot promise to honour a level.
+      // only real gate, so it stays. But it fires only when the target
+      // instance actually resolves. An instance that isn't there declares no
+      // levels, and rejecting against that empty list would 400 the *whole*
+      // request: this is the app's general-purpose bot endpoint, and
+      // duplicateBot re-sends the source bot's entire modelSelection beside
+      // its name, title and description, so a source engine that happens to
+      // be offline would cost the copy all of them. Letting it through is
+      // safe — startTurn refuses to run a turn on an unavailable instance
+      // anyway, so an unverifiable level never reaches a CLI.
       const nextSelection = (body as Record<string, unknown>).modelSelection as
         | { instanceId?: string; effort?: string }
         | undefined;
       if (nextSelection?.effort !== undefined) {
         const target = registry.get(nextSelection.instanceId ?? existing?.modelSelection.instanceId ?? "");
-        const allowed = target?.adapter.capabilities.effortLevels ?? [];
-        if (!allowed.includes(nextSelection.effort as EffortLevel)) {
+        // typed as strings, not levels: this is the boundary that decides
+        // whether the value *is* a level, so it must not assert that it is
+        const allowed: readonly string[] = target?.adapter.capabilities.effortLevels ?? [];
+        if (target && !allowed.includes(nextSelection.effort)) {
           return json(res, 400, {
             error: `effort "${nextSelection.effort}" is not offered by this bot's engine`,
           });

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -101,6 +101,17 @@ describe("Store", () => {
     );
   });
 
+  it("persists a bot's effort level across a restart, defaulting to none", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    expect(bot.modelSelection.effort).toBeUndefined();
+
+    store.patchBot(bot.id, { modelSelection: { ...bot.modelSelection, effort: "high" } });
+
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(bot.id)?.modelSelection.effort).toBe("high");
+  });
+
   it("keeps exactly one persisted Chief of Staff and supports handoff", () => {
     const store = new Store(selection);
     const first = store.createBot();

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -101,7 +101,7 @@ describe("Store", () => {
     );
   });
 
-  it("persists a bot's effort level across a restart, defaulting to none", () => {
+  it("persists a bot's effort level across a restart, defaulting to unset", () => {
     const store = new Store(selection);
     const bot = store.createBot();
     expect(bot.modelSelection.effort).toBeUndefined();

--- a/server/testing/fake-driver.ts
+++ b/server/testing/fake-driver.ts
@@ -3,6 +3,7 @@
 // canonical events as if the provider produced them.
 import type {
   DriverCreateInput,
+  EffortLevel,
   ProviderDriver,
   ProviderInstance,
   ProviderSnapshot,
@@ -16,6 +17,8 @@ export interface FakeDriverOptions {
   failCreate?: string;
   /** snapshot() rejects with this message (describe-downgrade path). */
   failSnapshot?: string;
+  /** effort levels this fake driver declares, forwarded onto capabilities. */
+  effortLevels?: readonly EffortLevel[];
 }
 
 export interface FakeDriverHandle {
@@ -62,7 +65,7 @@ export function makeFakeDriver(opts: FakeDriverOptions = {}): FakeDriverHandle {
           },
           adapter: {
             provider: kind,
-            capabilities: { sessionModelSwitch: "unsupported" },
+            capabilities: { sessionModelSwitch: "unsupported", effortLevels: opts.effortLevels },
             sendTurn: async () => ({ turnId: "fake-turn" }),
             interruptTurn: async () => {},
             respondToRequest: async () => {},

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -46,7 +46,21 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
   }, [open]);
 
   const pick = (instance: InstanceInfo, model: string) => {
-    dispatch({ type: "setModel", botId: bot.id, selection: { instanceId: instance.instanceId, model } });
+    // setModel replaces the whole selection, so a configured effort has to be
+    // carried across deliberately. Same engine, different model: keep it —
+    // silently resetting the level the user chose is not what "pick a model"
+    // means. Different engine: drop it, since effort vocabularies are
+    // per-driver and the old level may be one the new engine never declared.
+    const sameInstance = instance.instanceId === selection.instanceId;
+    dispatch({
+      type: "setModel",
+      botId: bot.id,
+      selection: {
+        instanceId: instance.instanceId,
+        model,
+        ...(sameInstance && selection.effort ? { effort: selection.effort } : {}),
+      },
+    });
     setOpen(false);
   };
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -50,6 +50,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "voice"
         | "chiefOfStaff"
         | "approvePeerComms"
+        | "modelSelection"
       >
     >,
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
@@ -274,6 +275,32 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             </div>
             <ModelPicker bot={bot} />
           </div>
+
+          {!!engine?.capabilities?.effortLevels?.length && (
+            <div className="rounded-xl bg-card p-4">
+              <div className="text-[15px] font-medium text-ink">Effort</div>
+              <div className="mt-0.5 text-[13px] text-ink-secondary">
+                How hard this bot thinks{bot.modelSelection.effort ? "" : " (currently: engine default)"}
+              </div>
+              <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
+                {([undefined, ...engine.capabilities.effortLevels] as const).map((level, i) => (
+                  <button
+                    key={level ?? "default"}
+                    onClick={() => patch({ modelSelection: { ...bot.modelSelection, effort: level } })}
+                    className={cn(
+                      "flex-1 py-1.5 text-[13px] capitalize",
+                      i > 0 && "border-l border-hairline/40",
+                      bot.modelSelection.effort === level
+                        ? "bg-raised text-ink"
+                        : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
+                    )}
+                  >
+                    {level ?? "Default"}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           <div className="rounded-xl bg-card p-4">
             <div className="text-[15px] font-medium text-ink">Computer</div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -291,6 +291,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                 {([undefined, ...engine.capabilities.effortLevels] as const).map((level, i) => (
                   <button
                     key={level ?? "default"}
+                    aria-pressed={bot.modelSelection.effort === level}
                     onClick={() => patch({ modelSelection: { ...bot.modelSelection, effort: level } })}
                     className={cn(
                       "flex-1 py-1.5 text-[13px] capitalize",
@@ -300,7 +301,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                         : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
                     )}
                   >
-                    {level ?? "Default"}
+                    {/* the others capitalize cleanly; "xhigh" would read "Xhigh" */}
+                    {level === "xhigh" ? "X-High" : (level ?? "Default")}
                   </button>
                 ))}
               </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -279,8 +279,13 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
           {!!engine?.capabilities?.effortLevels?.length && (
             <div className="rounded-xl bg-card p-4">
               <div className="text-[15px] font-medium text-ink">Effort</div>
+              {/* Says what the app does, not what the engine ends up at:
+                  Codex applies a level to the whole thread and has no way to
+                  take one back, so "currently: engine default" was a promise
+                  we could not keep for a thread that had already been sent
+                  one. Sending nothing is true on every engine. */}
               <div className="mt-0.5 text-[13px] text-ink-secondary">
-                How hard this bot thinks{bot.modelSelection.effort ? "" : " (currently: engine default)"}
+                How hard this bot thinks{bot.modelSelection.effort ? "" : " (Default: no level is sent)"}
               </div>
               <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
                 {([undefined, ...engine.capabilities.effortLevels] as const).map((level, i) => (

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -87,6 +87,7 @@ export interface Group {
 export interface ModelSelection {
   instanceId: string;
   model: string;
+  effort?: string;
 }
 
 /** One of a bot's separate contexts: its own thread, transcript and
@@ -196,7 +197,7 @@ export interface InstanceInfo {
     version?: string | null;
   };
   models: { default: string; options: Array<{ id: string; label: string }> };
-  capabilities?: { computerMcp?: boolean; agentsMcp?: boolean };
+  capabilities?: { computerMcp?: boolean; agentsMcp?: boolean; effortLevels?: readonly string[] };
   install?: EngineInstall;
 }
 
@@ -325,6 +326,7 @@ type Action =
           | "hidden"
           | "chiefOfStaff"
           | "approvePeerComms"
+          | "modelSelection"
         >
       >;
     };

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -13,6 +13,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import type { EffortLevel } from "../../server/contracts.ts";
 import type { MausColor, MausMotion } from "@/lib/mascot";
 import type { Routine, RoutineInput, RoutineRun } from "@/lib/routines";
 import type { WebhookAttempt, WebhookIngressStatus, WebhookTrigger } from "@/lib/webhooks";
@@ -87,7 +88,7 @@ export interface Group {
 export interface ModelSelection {
   instanceId: string;
   model: string;
-  effort?: string;
+  effort?: EffortLevel;
 }
 
 /** One of a bot's separate contexts: its own thread, transcript and
@@ -197,7 +198,7 @@ export interface InstanceInfo {
     version?: string | null;
   };
   models: { default: string; options: Array<{ id: string; label: string }> };
-  capabilities?: { computerMcp?: boolean; agentsMcp?: boolean; effortLevels?: readonly string[] };
+  capabilities?: { computerMcp?: boolean; agentsMcp?: boolean; effortLevels?: readonly EffortLevel[] };
   install?: EngineInstall;
 }
 


### PR DESCRIPTION
## The problem

A bot's engine binding is `{ instanceId, model }`. You can pick the model per bot;
you cannot pick how hard it thinks.

Every CLI the harness drives exposes a reasoning-effort control, and the reason to
want it per bot is the obvious one: a reviewer bot wants `xhigh`, a note-taking bot
wants `low`, and paying `max` prices for both is waste. Today the only route is to
hand-edit `~/.openmausbot/config.json` and point an instance at a wrapper script
that injects the flag — one instance per effort level.

## What this does

`ModelSelection` gains an optional `effort`, and a new per-driver
`capabilities.effortLevels` gates both the control and the validation. A bot with no
level behaves exactly as it does today: nothing is sent, and the CLI keeps its own
default.

The control appears beside Model, and only for engines that declare levels.

## Why the three engines carry it differently

Each driver forwards the level through whichever channel it already uses for the
model, rather than a new mechanism per engine:

| Engine | Model travels via | So effort travels via |
|---|---|---|
| Claude Code | `--model` argv | `--effort` argv |
| Codex | `model` on the app-server RPC | `effort` on `turn/start` |
| Grok | `-m` argv | `--reasoning-effort` argv |

Codex is the one worth a note. Its model never goes through argv, and the protocol
already models this: `codex app-server generate-json-schema` shows `TurnStartParams`
carrying an `effort` field beside `model`. Putting it there is also the only spot
that survives a resume — `thread/start` is skipped when a thread resumes, but
`turn/start` runs on every turn.

Gemini and Kimi declare no levels and are untouched.

## The gate

Neither Codex nor Grok rejects an unknown level at its boundary — Codex types the
field as a free-form string, and Grok validates lazily and logs. So the declared list
is the only real gate, and it is enforced at PATCH time, before anything persists.

It is enforced only when the target adapter actually resolves. An unavailable engine
cannot promise anything, and `startTurn` already refuses to run a turn on one, so
nothing unsafe gets through — while `duplicateBot`, which PATCHes a source bot's
whole `modelSelection`, keeps working when that bot's engine happens to be offline.

## Verification

`pnpm typecheck` clean; `pnpm test` 49 files, 428 passed, 8 skipped.

Levels were read off each CLI rather than assumed:

- **Codex** — `/model` picker and the app-server schema: `low, medium, high, xhigh, max`.
- **Claude** — `claude --help`: the same five.
- **Grok** — CLI 1.0.4's `initialize` `_meta.modelState` reports levels per model:
  `grok-4.6` takes `low, medium, high, xhigh` (default `high`), `grok-4.5` takes
  `low, medium, high`. The driver declares the four `grok-4.6` accepts.

Two behaviours were probed against the real binaries rather than reasoned about:

- **Codex `effort: null` does not clear an override.** With a thread set to `high`,
  sending `null` emitted no `thread/settings/updated` and `thread/resume` still read
  back `high` — identical to omitting the key. There is no clearing mechanism
  (`""` is rejected, `thread/start` has no effort field). So the driver omits the key,
  and the panel says what it does rather than promising a state it cannot reach.
- **Grok accepts the flag in that argv position.** `grok --permission-mode default
  -m grok-4.6 --reasoning-effort high agent stdio` parses and completes `initialize`;
  an unknown flag in the same position is rejected, so acceptance is meaningful.

## Known limits, deliberately not addressed here

- **Grok's flag is verified as parsed, not as applied.** Effort is applied when a
  model becomes active, which needs an authenticated session I do not have. The
  already-shipped `-m` rides the same argv path and carries the same caveat, so this
  is not a new risk introduced here.
- **On Codex, clearing a level takes effect on the next new thread**, since the
  running thread keeps its override. `model/list` exposes `defaultReasoningEffort`,
  which would make it immediately reversible — a later change, not this one.
- **Droid is not included.** Its CLI has `-r/--reasoning-effort`, but
  `server/drivers/acp/droid.ts` documents that droid validates argv flags and then
  ignores them for JSON-RPC sessions; its model and mode are set over the wire in
  `configureSession()`. Effort belongs there too, which is a different mechanism than
  the one this PR adds.
- **Group turns carry neither model nor effort**, unchanged by this PR.
- **The gate's accept branch has no API-level test.** `index.test.ts` deliberately
  configures a single unknown-driver instance so it needs no CLI probes; giving it a
  live instance would make `defaultSelection()` CLI-dependent for every other test in
  the file. The allow-when-unresolvable branch, persistence, and clearing are covered.

## Screenshots

**Before** — Model is followed directly by Computer.

![Before: no Effort row](https://raw.githubusercontent.com/NuCl34R/OpenMausBot/pr-assets/effort-level/b158094/before-no-effort-row.png)

**After** — the Effort row, with no level set.

![After: the Effort control](https://raw.githubusercontent.com/NuCl34R/OpenMausBot/pr-assets/effort-level/b158094/after-effort-control.png)

**After** — a level selected.

![After: High selected](https://raw.githubusercontent.com/NuCl34R/OpenMausBot/pr-assets/effort-level/b158094/after-effort-selected.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Effort setting for supported models, with levels from low through max.
  * Settings now display available effort levels and allow selections to be saved or cleared.
  * Model changes preserve effort settings when switching models on the same engine.
  * Supported engines now advertise their available effort levels.

* **Bug Fixes**
  * Cloud runs no longer inherit a bot’s configured effort level.
  * Invalid or unsupported effort selections are rejected when validation is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->