### PR TITLE
Clean up webhook chat card

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -311,7 +311,7 @@ function Bubble({
           className={cn(
             "max-w-[70%] rounded-2xl text-[15px] leading-relaxed",
             user && webhookView
-              ? "overflow-hidden border border-accent/20 bg-bubble-user text-ink"
+              ? "overflow-hidden border border-accent/25 bg-card text-ink shadow-[0_10px_30px_rgba(0,0,0,0.18)]"
               : user
                 ? "bg-bubble-user px-4 py-2.5 whitespace-pre-wrap text-ink"
                 : "bg-card px-4 py-2.5 text-ink",
@@ -320,21 +320,15 @@ function Bubble({
         >
           {user && webhookView ? (
             <div className="min-w-[300px] max-w-[520px]">
-              <div className="flex items-center gap-2 border-b border-hairline/30 px-4 py-2.5 text-[11.5px] font-medium text-accent">
+              <div className="flex items-center gap-2 border-b border-accent/15 bg-accent/[0.055] px-4 py-2.5 text-[11.5px] font-medium text-accent">
                 <Webhook size={13} />
                 <span>Webhook task</span>
-                {webhookView.eventName && <><span className="text-ink-secondary/60">·</span><span className="truncate text-ink-secondary">{webhookView.eventName}</span></>}
               </div>
               <div className="px-4 py-3 whitespace-pre-wrap">{webhookView.task}</div>
-              {(webhookView.eventName || webhookView.details.length > 0) && (
-                <div className="flex flex-wrap items-center gap-1.5 px-4 pb-3 text-[10.5px] text-ink-secondary">
-                  {webhookView.details.map((detail) => <span key={detail} className="rounded-md bg-raised/70 px-2 py-1">{detail}</span>)}
-                </div>
-              )}
               {webhookView.payload && (
-                <details className="border-t border-hairline/25 px-4 py-2.5 text-[11.5px] text-ink-secondary">
+                <details className="border-t border-hairline/30 bg-inset/25 px-4 py-2.5 text-[11.5px] text-ink-secondary">
                   <summary className="cursor-pointer select-none hover:text-ink">View event payload</summary>
-                  <pre className="mt-2 max-h-48 overflow-auto rounded-lg bg-black/20 p-3 font-mono text-[10.5px] leading-relaxed whitespace-pre-wrap text-ink-secondary">{webhookView.payload}</pre>
+                  <pre className="mt-2 max-h-48 overflow-auto rounded-lg border border-hairline/25 bg-black/25 p-3 font-mono text-[10.5px] leading-relaxed whitespace-pre-wrap text-ink-secondary">{webhookView.payload}</pre>
                 </details>
               )}
             </div>

--- a/src/lib/webhook-message.test.ts
+++ b/src/lib/webhook-message.test.ts
@@ -20,15 +20,13 @@ describe("webhookMessageView", () => {
 
     expect(webhookMessageView(text)).toEqual({
       task: "Summarize the failed deploy and suggest the first check.",
-      eventName: "deployment.failed",
       payload: JSON.stringify({ task: "Summarize the failed deploy and suggest the first check.", service: "checkout-api", environment: "production" }, null, 2),
-      details: ["checkout-api", "production"],
     });
   });
 
   it("supports configured instructions and leaves normal chat messages alone", () => {
     const webhook = "[USER-CONFIGURED WEBHOOK INSTRUCTIONS]\nTriage every build failure.\n[/USER-CONFIGURED WEBHOOK INSTRUCTIONS]\n\n[UNTRUSTED WEBHOOK EVENT DATA]\nEvent: build.failed\n\nraw payload\n[/UNTRUSTED WEBHOOK EVENT DATA]";
-    expect(webhookMessageView(webhook)).toMatchObject({ task: "Triage every build failure.", eventName: "build.failed", payload: "raw payload" });
+    expect(webhookMessageView(webhook)).toMatchObject({ task: "Triage every build failure.", payload: "raw payload" });
     expect(webhookMessageView("hello from a person")).toBeNull();
   });
 });

--- a/src/lib/webhook-message.ts
+++ b/src/lib/webhook-message.ts
@@ -1,8 +1,6 @@
 export interface WebhookMessageView {
   task: string;
-  eventName?: string;
   payload?: string;
-  details: string[];
 }
 
 /** Convert the model-safe webhook prompt into the smaller view shown in chat.
@@ -27,23 +25,6 @@ export function webhookMessageView(text: string): WebhookMessageView | null {
   if (!task || !eventData) return null;
 
   const splitAt = eventData.indexOf("\n\n");
-  const metadata = splitAt >= 0 ? eventData.slice(0, splitAt) : eventData;
   const payload = (splitAt >= 0 ? eventData.slice(splitAt + 2) : "").trim();
-  const eventName = metadata.match(/^Event:\s*(.+)$/m)?.[1]?.trim();
-  const details: string[] = [];
-
-  if (payload) {
-    try {
-      const parsed = JSON.parse(payload) as Record<string, unknown>;
-      for (const key of ["service", "environment", "repository", "branch"]) {
-        const value = parsed?.[key];
-        if (typeof value === "string" && value.trim() && value.trim() !== task && !details.includes(value.trim())) details.push(value.trim());
-        if (details.length === 2) break;
-      }
-    } catch {
-      // Plain text and truncated payloads are still available behind View payload.
-    }
-  }
-
-  return { task, eventName, payload: payload || undefined, details };
+  return { task, payload: payload || undefined };
 }


### PR DESCRIPTION
## What changed

- gives webhook task messages a dark neutral card with a subtle accent header
- removes payload-derived context chips from the chat card
- removes the webhook event-type label from the chat card
- keeps the raw event payload available behind the disclosure control

## Why

The webhook card inherited the much brighter normal user-message color and displayed transport metadata that duplicated the task or belonged in webhook Activity. This made webhook executions feel noisy and visually disconnected from the rest of the conversation.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/lib/webhook-message.test.ts`
- `pnpm build`
- live desktop verification against an existing webhook execution
