### PR TITLE
Show webhook runs live in MAUS chat

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -935,8 +935,8 @@ routines = new RoutineManager({
     const bot = store.bot(botId);
     return !bot ? "missing" : bot.busy ? "busy" : "ready";
   },
-  createTask: (botId, title) => {
-    const task = store.createTask(botId, title, false);
+  createTask: (botId, title, activate = false) => {
+    const task = store.createTask(botId, title, activate);
     const bot = store.bot(botId);
     if (task && bot) broadcast({ kind: "bot", bot: publicBot(bot) });
     return task;

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -20,13 +20,17 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
   const started: Array<{ botId: string; threadId: string; prompt: string }> = [];
   const runOns: string[] = [];
   const triggerSources: string[] = [];
+  const taskActivations: boolean[] = [];
   const emitted: any[] = [];
   const options: RoutineManagerOptions = {
     file: tempFile(),
     now: () => now,
     emit: (payload) => emitted.push(payload),
     botState: () => bot,
-    createTask: () => ({ threadId: `thread-${++task}` }),
+    createTask: (_botId, _title, activate = false) => {
+      taskActivations.push(activate);
+      return { threadId: `thread-${++task}` };
+    },
     startTurn: async (botId, threadId, prompt, runOn, triggerSource) => {
       started.push({ botId, threadId, prompt });
       runOns.push(runOn);
@@ -41,6 +45,7 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
     started,
     runOns,
     triggerSources,
+    taskActivations,
     setNow: (value: number) => (now = value),
     setBot: (value: typeof bot) => (bot = value),
   };
@@ -108,6 +113,7 @@ describe("RoutineManager", () => {
     expect(h.manager.listRuns()[0]).toMatchObject({ status: "running", threadId: "thread-1" });
     expect(h.manager.activeRunForBot("maus-2")?.threadId).toBe("thread-1");
     expect(h.manager.isActiveThread("thread-1")).toBe(true);
+    expect(h.taskActivations).toEqual([false]);
   });
 
   it("cancels queued work when a routine is paused", async () => {
@@ -175,7 +181,7 @@ describe("RoutineManager", () => {
     expect(h.manager.listRoutines()[0]).toMatchObject({ runOn: "maus" });
   });
 
-  it("queues webhook jobs through the same detached-task executor", async () => {
+  it("opens webhook jobs in the assigned bot's live chat", async () => {
     const h = harness();
     const receivedAt = new Date(2026, 7, 17, 8, 2).getTime();
     const queued = h.manager.enqueueWebhook({
@@ -200,6 +206,7 @@ describe("RoutineManager", () => {
     expect(h.started).toEqual([{ botId: "maus-webhook", threadId: "thread-1", prompt: "Handle ticket 42" }]);
     expect(h.runOns).toEqual(["cloud"]);
     expect(h.triggerSources).toEqual(["webhook"]);
+    expect(h.taskActivations).toEqual([true]);
   });
 
   it("folds provider lifecycle events into the calendar receipt", async () => {

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -89,7 +89,7 @@ export interface RoutineManagerOptions {
    * is what lets the server number and replay them. */
   emit?: (payload: Record<string, unknown>) => void;
   botState: (botId: string) => "ready" | "busy" | "missing";
-  createTask: (botId: string, title: string) => { threadId: string } | null;
+  createTask: (botId: string, title: string, activate?: boolean) => { threadId: string } | null;
   startTurn: (
     botId: string,
     threadId: string,
@@ -451,7 +451,9 @@ export class RoutineManager {
           this.emitRun(run);
           continue;
         }
-        const task = this.options.createTask(run.botId, run.routineName);
+        // A webhook is an incoming message, so make its task the bot's live
+        // chat immediately. Scheduled work remains detached and unobtrusive.
+        const task = this.options.createTask(run.botId, run.routineName, run.triggerSource === "webhook");
         if (!task) {
           run.status = "failed";
           run.error = "Could not create a task for this run";

--- a/src/components/WebhooksPanel.tsx
+++ b/src/components/WebhooksPanel.tsx
@@ -21,6 +21,12 @@ import {
 import { MausAvatar } from "@/components/Avatar";
 import { cn } from "@/lib/cn";
 import type { RoutineRun, RoutineRunOn } from "@/lib/routines";
+import {
+  loadWebhookCredentials,
+  removeWebhookCredential,
+  saveWebhookCredential,
+  webhookCredentialStore,
+} from "@/lib/webhook-credentials";
 import type { WebhookAttempt, WebhookCredential, WebhookTrigger, WebhookTriggerInput } from "@/lib/webhooks";
 import { api, useStore, type Bot } from "@/state/store";
 
@@ -70,7 +76,7 @@ function outcomeLabel(outcome: WebhookAttempt["outcome"], run?: RoutineRun) {
 }
 
 function terminalCommand(credential: WebhookCredential) {
-  return `curl -sS '${credential.url}' --json '{"task":"A production deploy failed. Summarize what happened and tell me the first thing to check."}'`;
+  return `curl -sS '${credential.url}' --json '{"task":"A customer wrote: This app saved me hours. Write a short thank-you reply."}'`;
 }
 
 function WebhookEditor({ webhook, bots, onClose, onCredential }: { webhook?: WebhookTrigger; bots: Bot[]; onClose: () => void; onCredential: (credential: WebhookCredential, webhookId: string) => void }) {
@@ -133,7 +139,9 @@ interface ActivityItem { id: string; at: number; outcome: WebhookAttempt["outcom
 export function WebhooksPanel({ bots }: { bots: Bot[] }) {
   const { state, dispatch } = useStore();
   const [editor, setEditor] = useState<WebhookTrigger | "new" | null>(null);
-  const [credentials, setCredentials] = useState<Record<string, WebhookCredential>>({});
+  const [credentials, setCredentials] = useState<Record<string, WebhookCredential>>(() =>
+    loadWebhookCredentials(webhookCredentialStore()),
+  );
   const [selectedId, setSelectedId] = useState<string | null>(state.webhooks[0]?.id ?? null);
   const [tab, setTab] = useState<"setup" | "activity">("setup");
   const [working, setWorking] = useState<string | null>(null);
@@ -179,6 +187,12 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
         if (!window.confirm(`Delete “${webhook.name}”? Existing task history will stay available.`)) return;
         await api(`/api/webhooks/${webhook.id}`, { method: "DELETE" });
         dispatch({ type: "webhookDeleted", webhookId: webhook.id });
+        removeWebhookCredential(webhookCredentialStore(), webhook.id);
+        setCredentials((current) => {
+          const next = { ...current };
+          delete next[webhook.id];
+          return next;
+        });
       } else {
         const enabling = !webhook.enabled;
         if (enabling && webhook.verificationPending) throw new Error("Send a test event before turning this webhook on");
@@ -193,6 +207,7 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
   };
 
   const createAndCopyCommand = async (webhook: WebhookTrigger, replace = false) => {
+    if (replace && !window.confirm("Replace this private URL? Every previously copied command will stop working.")) return;
     setWorking(`${webhook.id}:command`);
     setError("");
     try {
@@ -202,6 +217,7 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
         credential = response.credential;
         dispatch({ type: "webhookPatched", webhook: response.webhook });
         setCredentials((current) => ({ ...current, [webhook.id]: credential! }));
+        saveWebhookCredential(webhookCredentialStore(), webhook.id, credential!);
       }
       if (!credential) throw new Error("Could not create a terminal command");
       await navigator.clipboard.writeText(terminalCommand(credential));
@@ -305,7 +321,10 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
                         <pre className="overflow-x-auto p-4 font-mono text-[11px] leading-relaxed whitespace-pre-wrap break-all text-ink-secondary">{command}</pre>
                       </div>
                     ) : (
-                      <button disabled={Boolean(working) || !ingress?.available} onClick={() => void createAndCopyCommand(selected)} className="mt-4 flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2.5 text-[12px] font-medium text-white hover:brightness-110 disabled:opacity-40">{working === `${selected.id}:command` ? <Loader2 size={14} className="animate-spin" /> : <Copy size={14} />}Create & copy test command</button>
+                      <div className="mt-4">
+                        <p className="max-w-[560px] text-[10.5px] leading-relaxed text-ink-secondary">The private URL is shown once. Generate a replacement to copy a test command; any older command for this webhook will stop working.</p>
+                        <button disabled={Boolean(working) || !ingress?.available} onClick={() => void createAndCopyCommand(selected)} className="mt-3 flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2.5 text-[12px] font-medium text-white hover:brightness-110 disabled:opacity-40">{working === `${selected.id}:command` ? <Loader2 size={14} className="animate-spin" /> : <RotateCw size={14} />}Generate new private URL</button>
+                      </div>
                     )}
                     <div className="mt-3 flex items-start gap-2 text-[10.5px] leading-relaxed text-ink-secondary"><Laptop size={12} className="mt-0.5 shrink-0" /><span>Local only for now. Keep OpenMausBot open while sending the request.</span></div>
 
@@ -337,7 +356,7 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
           </div>
         )}
       </div>
-      {editor && <WebhookEditor webhook={editor === "new" ? undefined : editor} bots={bots} onClose={() => setEditor(null)} onCredential={(newCredential, webhookId) => { setCredentials((current) => ({ ...current, [webhookId]: newCredential })); setSelectedId(webhookId); setTab("setup"); }} />}
+      {editor && <WebhookEditor webhook={editor === "new" ? undefined : editor} bots={bots} onClose={() => setEditor(null)} onCredential={(newCredential, webhookId) => { saveWebhookCredential(webhookCredentialStore(), webhookId, newCredential); setCredentials((current) => ({ ...current, [webhookId]: newCredential })); setSelectedId(webhookId); setTab("setup"); }} />}
     </div>
   );
 }

--- a/src/lib/webhook-credentials.test.ts
+++ b/src/lib/webhook-credentials.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  loadWebhookCredentials,
+  removeWebhookCredential,
+  saveWebhookCredential,
+} from "./webhook-credentials.js";
+
+function memoryStore() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => void values.set(key, value),
+  };
+}
+
+const credential = {
+  endpointUrl: "http://127.0.0.1:8800/hooks/wh_demo",
+  secret: "whsec_demo",
+  url: "http://127.0.0.1:8800/hooks/wh_demo/whsec_demo",
+};
+
+describe("webhook credential storage", () => {
+  it("keeps a one-time private URL available after the panel remounts", () => {
+    const store = memoryStore();
+    saveWebhookCredential(store, "hook-1", credential);
+    expect(loadWebhookCredentials(store)).toEqual({ "hook-1": credential });
+  });
+
+  it("ignores malformed entries and removes deleted webhooks", () => {
+    const store = memoryStore();
+    store.setItem("omb-webhook-credentials", JSON.stringify({ broken: { url: 3 }, "hook-1": credential }));
+    expect(loadWebhookCredentials(store)).toEqual({ "hook-1": credential });
+    removeWebhookCredential(store, "hook-1");
+    expect(loadWebhookCredentials(store)).toEqual({});
+  });
+});

--- a/src/lib/webhook-credentials.ts
+++ b/src/lib/webhook-credentials.ts
@@ -1,0 +1,57 @@
+import type { WebhookCredential } from "./webhooks.js";
+
+const KEY = "omb-webhook-credentials";
+
+type Store = Pick<Storage, "getItem" | "setItem"> | undefined;
+
+function isCredential(value: unknown): value is WebhookCredential {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return [candidate.endpointUrl, candidate.secret, candidate.url].every(
+    (part) => typeof part === "string" && part.length > 0,
+  );
+}
+
+/** Private webhook URLs are returned only when created or rotated. Keep that
+ * one-time value in this app's local browser storage so changing tabs or
+ * relaunching the desktop app does not force a surprise secret rotation. */
+export function loadWebhookCredentials(store: Store): Record<string, WebhookCredential> {
+  try {
+    const raw = store?.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter((entry): entry is [string, WebhookCredential] => isCredential(entry[1])),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function saveWebhookCredential(store: Store, webhookId: string, credential: WebhookCredential): void {
+  const credentials = loadWebhookCredentials(store);
+  credentials[webhookId] = credential;
+  try {
+    store?.setItem(KEY, JSON.stringify(credentials));
+  } catch {
+    // Storage is best-effort. The URL remains usable for this mount.
+  }
+}
+
+export function removeWebhookCredential(store: Store, webhookId: string): void {
+  const credentials = loadWebhookCredentials(store);
+  delete credentials[webhookId];
+  try {
+    store?.setItem(KEY, JSON.stringify(credentials));
+  } catch {
+    // A failed cleanup must not block deleting the webhook itself.
+  }
+}
+
+export function webhookCredentialStore(): Store {
+  try {
+    return typeof localStorage === "undefined" ? undefined : localStorage;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -503,7 +503,20 @@ function reducer(state: AppState, action: Action): AppState {
             ),
           }
         : animated;
-      return updateBot(next, action.bot.id, (b) => ({ ...b, ...action.bot, messages: b.messages }));
+      const switchedThread =
+        typeof action.bot.threadId === "string" && action.bot.threadId !== before.threadId;
+      return updateBot(next, action.bot.id, (b) => ({
+        ...b,
+        ...action.bot,
+        // Ordinary bot patches omit messages and must preserve the current
+        // transcript. A task switch is different: its full bot event carries
+        // the new transcript, which must replace the previous task before the
+        // webhook's streamed messages begin arriving.
+        messages:
+          switchedThread && Array.isArray(action.bot.messages)
+            ? action.bot.messages
+            : b.messages,
+      }));
     }
     case "messageAdded": {
       const bot = state.bots.find((b) => b.threadId === action.threadId);


### PR DESCRIPTION
## What changed

- Open each authenticated webhook execution directly in the assigned MAUS active chat so the incoming task and streamed reply appear immediately.
- Reconcile full transcripts when the server switches a bot to another task thread.
- Keep one-time private webhook URLs in local app storage across tab changes and desktop relaunches.
- Make URL replacement explicit and warn that rotating invalidates older commands.
- Replace the technical deployment demo with a short customer-review example.

## Root cause

Webhook runs were created as detached tasks. The client also preserved the old thread messages when a bot event announced a task switch, then discarded subsequent events because their thread did not match the visible bot thread. Separately, reopening Setup lost the one-time private URL and the copy action silently rotated the secret, invalidating previously copied commands.

## Validation

- `pnpm test` — 440 passed, 8 skipped
- updater tests — 11 passed
- `pnpm build`
- `pnpm typecheck`
- targeted routine and credential tests — 13 passed
- real desktop flow: local webhook returned HTTP 202, the task appeared immediately in Ember chat, the MAUS response streamed and completed, and the same private URL/sample command remained visible after a renderer reload
