### PR TITLE
Persist Local VM workspaces across recreation

### DIFF
--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -10,7 +10,12 @@ import {
   CUA_SOCKET,
   DRIVER_LABEL,
   IMAGE,
+  IMAGE_LAYER_LABEL,
+  IMAGE_LAYER_VERSION,
   MANAGED_LABEL,
+  VM_WORKSPACE_DIR,
+  VM_WORKSPACE_GUEST,
+  WORKSPACE_LABEL,
   computerProxyEnv,
   containerComputerAction,
   containerComputerMcp,
@@ -50,6 +55,7 @@ function preparedImageInspect() {
           [MANAGED_LABEL]: "1",
           [DRIVER_LABEL]: CUA_DRIVER_VERSION,
           [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+          [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
         },
       },
     },
@@ -65,6 +71,8 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
           [MANAGED_LABEL]: "1",
           [DRIVER_LABEL]: CUA_DRIVER_VERSION,
           [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+          [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+          [WORKSPACE_LABEL]: "1",
         },
         Env: ["VNC_PW=secret123"],
       },
@@ -78,6 +86,14 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
         CapAdd: ["CAP_SETUID", "CAP_SETGID"],
         PortBindings: { "6901/tcp": [{ HostIp: "127.0.0.1" }] },
       },
+      Mounts: [
+        {
+          Type: "bind",
+          Source: VM_WORKSPACE_DIR,
+          Destination: VM_WORKSPACE_GUEST,
+          RW: true,
+        },
+      ],
       ...overrides,
     },
   ]);
@@ -122,6 +138,14 @@ describe("containerComputerStatus", () => {
             image: IMAGE,
             resources: { cpus: 2, memoryInBytes: 4 * 1024 * 1024 * 1024 },
             publishedPorts: [{ hostAddress: "127.0.0.1", containerPort: 6901 }],
+            labels: {
+              [MANAGED_LABEL]: "1",
+              [DRIVER_LABEL]: CUA_DRIVER_VERSION,
+              [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+              [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+              [WORKSPACE_LABEL]: "1",
+            },
+            mounts: [{ source: VM_WORKSPACE_DIR, destination: VM_WORKSPACE_GUEST, options: [] }],
           },
           status: { state: "running" },
         },
@@ -162,6 +186,27 @@ describe("containerComputerStatus", () => {
     expect(status.ready).toBe(false);
   });
 
+  it("rejects missing or unexpected host mounts instead of exposing them to the bot", async () => {
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect({
+        Mounts: [
+          { Type: "bind", Source: VM_WORKSPACE_DIR, Destination: VM_WORKSPACE_GUEST, RW: true },
+          { Type: "bind", Source: "/tmp/unexpected", Destination: "/host", RW: true },
+        ],
+      }),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.persistence).toBe("unsafe");
+    expect(status.ready).toBe(false);
+    expect(status.problem).toContain("durable workspace");
+  });
+
   it("does not mistake an unrelated container executable for Apple container off macOS", async () => {
     const fake = runner({
       "where.exe docker": new Error("missing"),
@@ -192,6 +237,7 @@ describe("containerComputerStatus", () => {
       managed: true,
       network: "loopback",
       security: "hardened",
+      persistence: "durable",
       desktopReady: true,
       ready: true,
       problem: null,
@@ -266,6 +312,11 @@ describe("Cua integration", () => {
     expect(dockerfile).toContain(`install -D -m 0755 \"$driver_bin\" ${CUA_EXECUTABLE}`);
     expect(dockerfile).toContain(`cua-driver ${CUA_DRIVER_VERSION}`);
     expect(dockerfile).toContain(`serve --socket ${CUA_SOCKET} --permission-mode standard`);
+    expect(dockerfile).toContain("prepare-openmausbot-workspace.sh");
+    expect(dockerfile).toContain("migrate_profile google-chrome");
+    expect(dockerfile).toContain("migrate_profile chromium");
+    expect(dockerfile).toContain("SingletonLock");
+    expect(dockerfile).toContain(`${IMAGE_LAYER_LABEL}=\"${IMAGE_LAYER_VERSION}\"`);
   });
 
   it("captures the preview through Cua Driver rather than xdotool or VNC", async () => {
@@ -359,6 +410,18 @@ describe("setupCommands", () => {
     expect(command).toContain("--cap-drop ALL --cap-add SETUID --cap-add SETGID");
     expect(command).toContain(`--label ${MANAGED_LABEL}=1`);
     expect(command).toContain(`--label ${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`);
+    expect(command).toContain(`--label ${WORKSPACE_LABEL}=1`);
+    expect(command).toContain(`--hostname ${CONTAINER}`);
+    expect(command).toContain(
+      `--mount type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST}`,
+    );
+  });
+
+  it("asks rootless Podman to map and privately relabel the durable workspace", () => {
+    const command = setupCommands("podman", "linux").run!;
+    expect(command).toContain(
+      `--mount type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private,U=true`,
+    );
   });
 
   it("shows the pinned base pull while creating the managed derivative through the API", () => {

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -8,13 +8,14 @@
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { augmentedPath } from "./env-path.ts";
+import { DATA_DIR } from "./config.ts";
 
 const run = promisify(execFile);
 
@@ -32,11 +33,16 @@ export const BASE_IMAGE = `${BASE_IMAGE_REPOSITORY}@${BASE_IMAGE_DIGEST}`;
 // This tag is built locally from the pinned Cua base. Image and container
 // labels below are the authoritative compatibility check, not the mutable tag.
 export const IMAGE_REPOSITORY = "openmausbot/cua-local-vm";
-export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}`;
+export const IMAGE_LAYER_VERSION = "2";
+export const IMAGE_LAYER_LABEL = "com.openmausbot.image-layer";
+export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}-v${IMAGE_LAYER_VERSION}`;
 export const CONTAINER = "openmausbot-computer";
 export const MANAGED_LABEL = "com.openmausbot.local-vm";
 export const DRIVER_LABEL = "com.openmausbot.cua-driver";
 export const BASE_IMAGE_LABEL = "com.openmausbot.cua-base";
+export const WORKSPACE_LABEL = "com.openmausbot.workspace";
+export const VM_WORKSPACE_DIR = join(DATA_DIR, "vm-home");
+export const VM_WORKSPACE_GUEST = "/home/cua/workspace";
 export const DISPLAY = ":1";
 export const CUA_SOCKET = "/run/user/1000/openmausbot-cua.sock";
 export const CUA_EXECUTABLE = "/usr/local/libexec/openmausbot/cua-driver";
@@ -82,9 +88,33 @@ RUN set -eux; \\
     driver_bin="$(find /opt/venv/lib -path '*/cua_driver/bin/cua-driver' -type f -print -quit)"; \\
     test -n "$driver_bin"; \\
     install -D -m 0755 "$driver_bin" ${CUA_EXECUTABLE}; \\
+    install -d -o cua -g cua -m 0700 ${VM_WORKSPACE_GUEST}; \\
     test "$(${CUA_EXECUTABLE} --version)" = "cua-driver ${CUA_DRIVER_VERSION}"
 RUN printf '%s\\n' \\
       '#!/bin/sh' \\
+      'set -eu' \\
+      'workspace=${VM_WORKSPACE_GUEST}' \\
+      'profiles="$workspace/.browser-profiles"' \\
+      'mkdir -p "$profiles/google-chrome" "$profiles/chromium" "$HOME/.config"' \\
+      'chmod 0700 "$workspace" "$profiles" "$profiles/google-chrome" "$profiles/chromium"' \\
+      'migrate_profile() {' \\
+      '  name="$1"' \\
+      '  source="$HOME/.config/$name"' \\
+      '  target="$profiles/$name"' \\
+      '  if [ -d "$source" ] && [ ! -L "$source" ] && [ -z "$(find "$target" -mindepth 1 -print -quit)" ]; then' \\
+      '    cp -a "$source"/. "$target"/' \\
+      '  fi' \\
+      '  rm -rf "$source"' \\
+      '  ln -s "$target" "$source"' \\
+      '}' \\
+      'migrate_profile google-chrome' \\
+      'migrate_profile chromium' \\
+      'find "$profiles" \\( -name SingletonLock -o -name SingletonSocket -o -name SingletonCookie -o -name .parentlock \\) -delete' \\
+      > /usr/local/bin/prepare-openmausbot-workspace.sh \\
+    && chmod 0755 /usr/local/bin/prepare-openmausbot-workspace.sh
+RUN printf '%s\\n' \\
+      '#!/bin/sh' \\
+      '/usr/local/bin/prepare-openmausbot-workspace.sh' \\
       'while ! DISPLAY=:1 xset q >/dev/null 2>&1; do sleep 1; done' \\
       'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
@@ -103,7 +133,8 @@ RUN printf '%s\\n' \\
       >> /etc/supervisor/supervisord.conf
 LABEL ${MANAGED_LABEL}="1" \\
       ${DRIVER_LABEL}="${CUA_DRIVER_VERSION}" \\
-      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}"
+      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}" \\
+      ${IMAGE_LAYER_LABEL}="${IMAGE_LAYER_VERSION}"
 `;
 }
 
@@ -141,6 +172,7 @@ export interface ContainerComputerStatus {
   container: "running" | "stopped" | "missing";
   network: "loopback" | "unsafe" | "unknown";
   security: "hardened" | "unsafe" | "unknown";
+  persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
   ready: boolean;
   problem: string | null;
@@ -148,6 +180,8 @@ export interface ContainerComputerStatus {
   base_image_ref: string;
   driver_version: string;
   container_name: string;
+  workspace_path: string;
+  workspace_guest_path: string;
   viewer_url: string;
 }
 
@@ -163,6 +197,7 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     container: "missing",
     network: "unknown",
     security: "unknown",
+    persistence: "unknown",
     desktopReady: false,
     ready: false,
     problem: "Install a supported container runtime first",
@@ -170,6 +205,8 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     base_image_ref: BASE_IMAGE,
     driver_version: CUA_DRIVER_VERSION,
     container_name: CONTAINER,
+    workspace_path: VM_WORKSPACE_DIR,
+    workspace_guest_path: VM_WORKSPACE_GUEST,
     viewer_url: `http://127.0.0.1:${HOST_VIEWER_PORT}/vnc.html`,
   };
 }
@@ -183,17 +220,23 @@ function statusProblem(status: ContainerComputerStatus): string | null {
   if (!status.managed) return "The existing container was not created by OpenMausBot; recreate it";
   if (status.network === "unsafe") return "The existing Local VM exposes its viewer publicly; recreate it";
   if (status.security === "unsafe") return "The existing Local VM is missing safety limits; recreate it";
+  if (status.persistence === "unsafe") return "The existing Local VM is missing its durable workspace; recreate it";
   if (status.container === "stopped") return "Start the Local VM";
   if (!status.desktopReady) return "The Local VM started, but Cua Driver is not ready yet";
   return null;
 }
 
-function labelsMatch(labels: Record<string, string> | undefined): boolean {
+function imageLabelsMatch(labels: Record<string, string> | undefined): boolean {
   return (
     labels?.[MANAGED_LABEL] === "1" &&
     labels?.[DRIVER_LABEL] === CUA_DRIVER_VERSION &&
-    labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST
+    labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST &&
+    labels?.[IMAGE_LAYER_LABEL] === IMAGE_LAYER_VERSION
   );
+}
+
+function containerLabelsMatch(labels: Record<string, string> | undefined): boolean {
+  return imageLabelsMatch(labels) && labels?.[WORKSPACE_LABEL] === "1";
 }
 
 function inspectedImageLabels(stdout: string): Record<string, string> | undefined {
@@ -273,7 +316,7 @@ export async function containerComputerStatus(
 
   try {
     const { stdout } = await runner(status.runtime, ["image", "inspect", IMAGE]);
-    status.image = labelsMatch(inspectedImageLabels(stdout));
+    status.image = imageLabelsMatch(inspectedImageLabels(stdout));
   } catch {
     // The prepared OpenMausBot derivative has not been built yet.
   }
@@ -288,6 +331,8 @@ export async function containerComputerStatus(
           resources?: { cpus?: number; memoryInBytes?: number };
           publishedPorts?: Array<{ hostAddress?: string; containerPort?: number }>;
           environment?: string[] | Record<string, string>;
+          labels?: Record<string, string>;
+          mounts?: Array<{ source?: string; destination?: string; options?: string[] }>;
         };
         status?: { state?: string };
       }>;
@@ -299,7 +344,10 @@ export async function containerComputerStatus(
           ? detail.configuration.image
           : detail?.configuration?.image?.reference ?? detail?.configuration?.imageReference;
       status.imageMatches = appleImage === IMAGE;
-      status.managed = status.imageMatches;
+      status.managed = containerLabelsMatch(detail?.configuration?.labels);
+      status.persistence = appleWorkspaceMountIsSafe(detail?.configuration?.mounts, platform)
+        ? "durable"
+        : "unsafe";
       const resources = detail?.configuration?.resources;
       status.security =
         (resources?.memoryInBytes ?? 0) >= MEMORY_BYTES && resources?.cpus === 2 ? "hardened" : "unsafe";
@@ -316,13 +364,20 @@ export async function containerComputerStatus(
           CapDrop?: string[] | null;
           CapAdd?: string[] | null;
         };
+        Mounts?: Array<{
+          Type?: string;
+          Source?: string;
+          Destination?: string;
+          RW?: boolean;
+        }>;
         State?: { Running?: boolean };
       }>;
       const detail = inspected[0];
       status.container = detail?.State?.Running ? "running" : "stopped";
       status.network = dockerPortsAreLocal(detail?.HostConfig?.PortBindings) ? "loopback" : "unsafe";
-      status.imageMatches = detail?.Config?.Image === IMAGE && labelsMatch(detail?.Config?.Labels);
-      status.managed = detail?.Config?.Labels?.[MANAGED_LABEL] === "1";
+      status.imageMatches = detail?.Config?.Image === IMAGE && imageLabelsMatch(detail?.Config?.Labels);
+      status.managed = containerLabelsMatch(detail?.Config?.Labels);
+      status.persistence = dockerWorkspaceMountIsSafe(detail?.Mounts, platform) ? "durable" : "unsafe";
       status.security = dockerSecurityIsHardened(detail?.HostConfig) ? "hardened" : "unsafe";
       status.viewer_url = viewerUrl(viewerPassword(detail?.Config?.Env));
     }
@@ -335,7 +390,8 @@ export async function containerComputerStatus(
     status.imageMatches &&
     status.managed &&
     status.network === "loopback" &&
-    status.security === "hardened";
+    status.security === "hardened" &&
+    status.persistence === "durable";
   if (canProbe) {
     try {
       const expected = `cua-driver ${CUA_DRIVER_VERSION}`;
@@ -375,6 +431,41 @@ function applePortsAreLocal(
   );
 }
 
+function sameWorkspaceSource(source: string | undefined, platform: NodeJS.Platform): boolean {
+  if (!source) return false;
+  const actual = resolve(source);
+  const expected = resolve(VM_WORKSPACE_DIR);
+  return platform === "win32" ? actual.toLowerCase() === expected.toLowerCase() : actual === expected;
+}
+
+function dockerWorkspaceMountIsSafe(
+  mounts:
+    | Array<{ Type?: string; Source?: string; Destination?: string; RW?: boolean }>
+    | undefined,
+  platform: NodeJS.Platform,
+): boolean {
+  return Boolean(
+    mounts?.length === 1 &&
+      mounts[0]?.Type === "bind" &&
+      sameWorkspaceSource(mounts[0]?.Source, platform) &&
+      mounts[0]?.Destination === VM_WORKSPACE_GUEST &&
+      mounts[0]?.RW !== false,
+  );
+}
+
+function appleWorkspaceMountIsSafe(
+  mounts: Array<{ source?: string; destination?: string; options?: string[] }> | undefined,
+  platform: NodeJS.Platform,
+): boolean {
+  const options = mounts?.[0]?.options ?? [];
+  return Boolean(
+    mounts?.length === 1 &&
+      sameWorkspaceSource(mounts[0]?.source, platform) &&
+      mounts[0]?.destination === VM_WORKSPACE_GUEST &&
+      !options.some((option) => option === "ro" || option === "readonly"),
+  );
+}
+
 function dockerSecurityIsHardened(
   config:
     | {
@@ -405,6 +496,18 @@ function dockerSecurityIsHardened(
 
 export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): string[] {
   const common = ["run", "-d", "--name", CONTAINER];
+  common.push(
+    "--label",
+    `${MANAGED_LABEL}=1`,
+    "--label",
+    `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`,
+    "--label",
+    `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`,
+    "--label",
+    `${IMAGE_LAYER_LABEL}=${IMAGE_LAYER_VERSION}`,
+    "--label",
+    `${WORKSPACE_LABEL}=1`,
+  );
   if (runtime === "container") {
     // Apple container already places each Linux container in a lightweight VM.
     common.push(
@@ -423,12 +526,8 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     );
   } else {
     common.push(
-      "--label",
-      `${MANAGED_LABEL}=1`,
-      "--label",
-      `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`,
-      "--label",
-      `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`,
+      "--hostname",
+      CONTAINER,
       "--memory",
       "4g",
       "--memory-swap",
@@ -448,6 +547,10 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     );
   }
   common.push(
+    "--mount",
+    runtime === "podman"
+      ? `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private,U=true`
+      : `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST}`,
     "-e",
     `VNC_PW=${password}`,
     "-p",
@@ -455,6 +558,11 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     IMAGE,
   );
   return common;
+}
+
+async function ensureVmWorkspace(platform: NodeJS.Platform): Promise<void> {
+  await mkdir(VM_WORKSPACE_DIR, { recursive: true, mode: 0o700 });
+  if (platform !== "win32") await chmod(VM_WORKSPACE_DIR, 0o700);
 }
 
 async function prepareManagedImage(runtime: Runtime, runner: CommandRunner): Promise<void> {
@@ -506,6 +614,7 @@ export async function containerComputerAction(
   if (action === "pull") {
     await prepareManagedImage(runtime, runner);
   } else {
+    if (action === "run") await ensureVmWorkspace(platform);
     const args =
       action === "run"
         ? containerRunArgs(runtime, randomBytes(6).toString("base64url"))

--- a/server/index.ts
+++ b/server/index.ts
@@ -885,7 +885,7 @@ async function startTurn(
         system:
           persona +
           (computerKind === "vm"
-            ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine with no host folders mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
+            ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine. Only /home/cua/workspace is durable; save downloads, repositories, working files, and browser profiles there because everything else inside the VM is disposable. No other host folder is mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
             : computerKind === "box" && instance.driverKind !== "boxAgent"
               ? " You have your own cloud computer — use screenshot, click, type_text, open_url and computer_exec whenever a desktop helps. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable sequences with computer_batch."
               : computerKind === "local"

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -27,6 +27,7 @@ interface Status {
   container: "running" | "stopped" | "missing";
   network: "loopback" | "unsafe" | "unknown";
   security: "hardened" | "unsafe" | "unknown";
+  persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
   ready: boolean;
   problem: string | null;
@@ -34,6 +35,8 @@ interface Status {
   base_image_ref: string;
   driver_version: string;
   container_name: string;
+  workspace_path: string;
+  workspace_guest_path: string;
   viewer_url: string;
   commands: {
     install: string | null;
@@ -149,10 +152,13 @@ export function LocalComputerSection() {
   };
 
   const act = async (action: Action) => {
-    if (action === "remove" && !window.confirm("Delete the Local VM and everything stored inside it?")) return;
+    if (
+      action === "remove" &&
+      !window.confirm("Delete the Local VM? Files and browser sign-ins in its durable workspace will remain.")
+    ) return;
     if (
       action === "recreate" &&
-      !window.confirm("Delete the existing Local VM and recreate it with the pinned image and safety limits? Anything stored inside it will be lost.")
+      !window.confirm("Replace the existing Local VM with the pinned image and safety limits? Files and browser sign-ins in its durable workspace will remain.")
     ) return;
     setPending(action);
     setError(null);
@@ -178,7 +184,11 @@ export function LocalComputerSection() {
   const existing = status?.container !== "missing";
   const needsRecreate = Boolean(
     existing &&
-      (!status?.imageMatches || !status?.managed || status?.network === "unsafe" || status?.security === "unsafe"),
+      (!status?.imageMatches ||
+        !status?.managed ||
+        status?.network === "unsafe" ||
+        status?.security === "unsafe" ||
+        status?.persistence === "unsafe"),
   );
   const unavailable = !loading && !status;
   const host = status?.platform === "darwin" ? "Mac" : "computer";
@@ -187,7 +197,7 @@ export function LocalComputerSection() {
     <>
       <Card
         title="Local VM"
-        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, disposable, and separate from your own screen and files.`}
+        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, isolated, and backed by one durable workspace.`}
       >
         <div className="flex flex-wrap items-center gap-2">
           <span
@@ -295,7 +305,7 @@ export function LocalComputerSection() {
 
       <Card
         title="Safety and storage"
-        subtitle="Cua Driver operates only the VM's desktop. No host folders are mounted, and the password-protected viewer is available only on this machine. Docker and Podman runs are limited to 4 GB memory, 2 CPUs and 512 processes; all Linux capabilities are dropped except the two the desktop supervisor needs to switch to its unprivileged user. The VM can still reach the internet, and bots share it one at a time."
+        subtitle={`Cua Driver operates only the VM's desktop. Exactly one private host folder is mounted at ${status?.workspace_guest_path ?? "/home/cua/workspace"}; files and browser profiles there survive VM replacement, while everything elsewhere in the VM remains disposable. The password-protected viewer is available only on this machine. Docker and Podman runs are limited to 4 GB memory, 2 CPUs and 512 processes; all Linux capabilities are dropped except the two the desktop supervisor needs to switch to its unprivileged user. The VM can still reach the internet, and bots share it one at a time.`}
       >
         {existing && (
           <div className="flex flex-wrap gap-2">
@@ -310,6 +320,7 @@ export function LocalComputerSection() {
           </div>
         )}
         <div className="mt-3 break-all text-[11px] text-ink-secondary">
+          Durable workspace: {status?.workspace_path ?? "not created"} ·{" "}
           Cua Driver: {status?.driver_version ?? "0.19.3"} · Local image: {status?.image_ref ?? "not prepared"}
           {status?.base_image_ref ? <> · Base: {status.base_image_ref}</> : null}
         </div>


### PR DESCRIPTION
## What changed

- mounts a single private OpenMausBot-owned directory at `/home/cua/workspace`
- treats that exact mount as part of the Local VM safety and compatibility contract
- preserves Chrome and Chromium profiles inside the durable workspace
- migrates an existing default profile on first boot and removes stale browser singleton locks
- pins the VM hostname and versions the managed image layer
- explains clearly which files survive VM replacement in the UI and agent instructions

## Why

The Local VM previously stored every file and browser profile only in the container's writable layer. Recreating the container for an image or driver update therefore removed downloads, repositories, installed work, and authenticated browser sessions.

The VM is now disposable while one narrow workspace remains durable. Unexpected additional mounts are rejected instead of being exposed to a bot.

## User impact

Users can recreate an outdated or unhealthy Local VM without losing files or browser sign-ins saved in the durable workspace. Existing VMs are intentionally marked for recreation once so they adopt the new storage boundary.

## Validation

- `pnpm test` — 440 passed, 8 skipped
- `pnpm build`
- focused post-rebase tests — 57 passed
- live Docker Desktop image build and boot
- verified the unprivileged `cua` user can write the workspace
- verified files survive container removal and recreation
- verified Chrome/Chromium profile links and stale-lock cleanup after recreation
