### PR TITLE
Harden Local VM lifecycle and readiness

### DIFF
--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -50,6 +50,7 @@ const statusProbe =
 function preparedImageInspect() {
   return JSON.stringify([
     {
+      Id: "sha256:managed-image-id",
       Config: {
         Labels: {
           [MANAGED_LABEL]: "1",
@@ -77,6 +78,7 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
         Env: ["VNC_PW=secret123"],
       },
       State: { Running: true },
+      Image: "sha256:managed-image-id",
       HostConfig: {
         Memory: 4 * 1024 * 1024 * 1024,
         MemorySwap: 4 * 1024 * 1024 * 1024,
@@ -135,7 +137,7 @@ describe("containerComputerStatus", () => {
       [`container inspect ${CONTAINER}`]: JSON.stringify([
         {
           configuration: {
-            image: IMAGE,
+            image: { reference: IMAGE, descriptor: { digest: "sha256:managed-image-id" } },
             resources: { cpus: 2, memoryInBytes: 4 * 1024 * 1024 * 1024 },
             publishedPorts: [{ hostAddress: "127.0.0.1", containerPort: 6901 }],
             labels: {
@@ -239,11 +241,32 @@ describe("containerComputerStatus", () => {
       security: "hardened",
       persistence: "durable",
       desktopReady: true,
+      desktop_error: null,
       ready: true,
       problem: null,
       driver_version: "0.19.3",
     });
     expect(status.viewer_url).toContain("#autoconnect=true&resize=scale&password=secret123");
+  });
+
+  it("reports the bounded desktop startup error instead of waiting forever", async () => {
+    const errorProbe =
+      `docker exec ${CONTAINER} tail -n 4 /var/log/supervisor/cua-driver.error.log`;
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect(),
+      [versionProbe]: new Error("driver unavailable"),
+      [errorProbe]: "X display :1 did not become ready within 45 seconds\n",
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.desktopReady).toBe(false);
+    expect(status.desktop_error).toContain("did not become ready");
+    expect(status.problem).toContain("desktop failed to start");
   });
 
   it("rejects a lookalike container with a different driver or base-image label", async () => {
@@ -266,6 +289,23 @@ describe("containerComputerStatus", () => {
     expect(status.ready).toBe(false);
     expect(status.problem).toContain("older desktop or Cua Driver");
     expect(fake.calls).not.toContain(versionProbe);
+  });
+
+  it("rejects a container created from a stale build under the same mutable tag", async () => {
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect({ Image: "sha256:previous-build-id" }),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.image_id).toBe("managed-image-id");
+    expect(status.imageMatches).toBe(false);
+    expect(status.ready).toBe(false);
+    expect(status.problem).toContain("older desktop or Cua Driver");
   });
 
   it("does not treat an unlabelled image under the local tag as prepared", async () => {
@@ -317,6 +357,8 @@ describe("Cua integration", () => {
     expect(dockerfile).toContain("migrate_profile chromium");
     expect(dockerfile).toContain("SingletonLock");
     expect(dockerfile).toContain(`${IMAGE_LAYER_LABEL}=\"${IMAGE_LAYER_VERSION}\"`);
+    expect(dockerfile).toContain("did not become ready within 45 seconds");
+    expect(dockerfile).not.toContain("while ! DISPLAY=:1 xset q");
   });
 
   it("captures the preview through Cua Driver rather than xdotool or VNC", async () => {

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -18,6 +18,7 @@ import { augmentedPath } from "./env-path.ts";
 import { DATA_DIR } from "./config.ts";
 
 const run = promisify(execFile);
+const SCREENSHOT_STATUS_TTL_MS = 10_000;
 
 export type CommandRunner = (
   command: string,
@@ -115,7 +116,12 @@ RUN printf '%s\\n' \\
 RUN printf '%s\\n' \\
       '#!/bin/sh' \\
       '/usr/local/bin/prepare-openmausbot-workspace.sh' \\
-      'while ! DISPLAY=:1 xset q >/dev/null 2>&1; do sleep 1; done' \\
+      'attempt=0' \\
+      'until DISPLAY=:1 xset q >/dev/null 2>&1; do' \\
+      '  attempt=$((attempt + 1))' \\
+      '  if [ "$attempt" -ge 45 ]; then echo "X display :1 did not become ready within 45 seconds" >&2; exit 1; fi' \\
+      '  sleep 1' \\
+      'done' \\
       'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
     && chmod 0755 /usr/local/bin/start-openmausbot-cua-driver.sh
@@ -174,9 +180,11 @@ export interface ContainerComputerStatus {
   security: "hardened" | "unsafe" | "unknown";
   persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
+  desktop_error: string | null;
   ready: boolean;
   problem: string | null;
   image_ref: string;
+  image_id: string | null;
   base_image_ref: string;
   driver_version: string;
   container_name: string;
@@ -199,9 +207,11 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     security: "unknown",
     persistence: "unknown",
     desktopReady: false,
+    desktop_error: null,
     ready: false,
     problem: "Install a supported container runtime first",
     image_ref: IMAGE,
+    image_id: null,
     base_image_ref: BASE_IMAGE,
     driver_version: CUA_DRIVER_VERSION,
     container_name: CONTAINER,
@@ -222,6 +232,7 @@ function statusProblem(status: ContainerComputerStatus): string | null {
   if (status.security === "unsafe") return "The existing Local VM is missing safety limits; recreate it";
   if (status.persistence === "unsafe") return "The existing Local VM is missing its durable workspace; recreate it";
   if (status.container === "stopped") return "Start the Local VM";
+  if (status.desktop_error) return `The Local VM desktop failed to start: ${status.desktop_error}`;
   if (!status.desktopReady) return "The Local VM started, but Cua Driver is not ready yet";
   return null;
 }
@@ -239,14 +250,27 @@ function containerLabelsMatch(labels: Record<string, string> | undefined): boole
   return imageLabelsMatch(labels) && labels?.[WORKSPACE_LABEL] === "1";
 }
 
-function inspectedImageLabels(stdout: string): Record<string, string> | undefined {
+function normalizeImageId(id: string | undefined): string | null {
+  return id?.trim().replace(/^sha256:/, "") || null;
+}
+
+function inspectedImage(stdout: string): {
+  labels: Record<string, string> | undefined;
+  id: string | null;
+} {
   const parsed = JSON.parse(stdout) as Array<{
+    Id?: string;
+    id?: string;
     Config?: { Labels?: Record<string, string> };
     config?: { Labels?: Record<string, string>; labels?: Record<string, string> };
-    configuration?: { labels?: Record<string, string> };
+    configuration?: { labels?: Record<string, string>; descriptor?: { digest?: string } };
   }>;
   const image = parsed[0];
-  return image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels;
+  return {
+    labels:
+      image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels,
+    id: normalizeImageId(image?.Id ?? image?.id ?? image?.configuration?.descriptor?.digest),
+  };
 }
 
 function viewerPassword(env: string[] | Record<string, string> | undefined): string | null {
@@ -316,7 +340,9 @@ export async function containerComputerStatus(
 
   try {
     const { stdout } = await runner(status.runtime, ["image", "inspect", IMAGE]);
-    status.image = imageLabelsMatch(inspectedImageLabels(stdout));
+    const image = inspectedImage(stdout);
+    status.image = imageLabelsMatch(image.labels);
+    status.image_id = image.id;
   } catch {
     // The prepared OpenMausBot derivative has not been built yet.
   }
@@ -326,7 +352,7 @@ export async function containerComputerStatus(
     if (status.runtime === "container") {
       const inspected = JSON.parse(stdout) as Array<{
         configuration?: {
-          image?: string | { reference?: string };
+          image?: string | { reference?: string; descriptor?: { digest?: string } };
           imageReference?: string;
           resources?: { cpus?: number; memoryInBytes?: number };
           publishedPorts?: Array<{ hostAddress?: string; containerPort?: number }>;
@@ -343,7 +369,12 @@ export async function containerComputerStatus(
         typeof detail?.configuration?.image === "string"
           ? detail.configuration.image
           : detail?.configuration?.image?.reference ?? detail?.configuration?.imageReference;
-      status.imageMatches = appleImage === IMAGE;
+      const appleImageId =
+        typeof detail?.configuration?.image === "object"
+          ? normalizeImageId(detail.configuration.image.descriptor?.digest)
+          : null;
+      status.imageMatches =
+        appleImage === IMAGE && status.image_id !== null && appleImageId === status.image_id;
       status.managed = containerLabelsMatch(detail?.configuration?.labels);
       status.persistence = appleWorkspaceMountIsSafe(detail?.configuration?.mounts, platform)
         ? "durable"
@@ -371,11 +402,16 @@ export async function containerComputerStatus(
           RW?: boolean;
         }>;
         State?: { Running?: boolean };
+        Image?: string;
       }>;
       const detail = inspected[0];
       status.container = detail?.State?.Running ? "running" : "stopped";
       status.network = dockerPortsAreLocal(detail?.HostConfig?.PortBindings) ? "loopback" : "unsafe";
-      status.imageMatches = detail?.Config?.Image === IMAGE && imageLabelsMatch(detail?.Config?.Labels);
+      status.imageMatches =
+        detail?.Config?.Image === IMAGE &&
+        imageLabelsMatch(detail?.Config?.Labels) &&
+        status.image_id !== null &&
+        normalizeImageId(detail?.Image) === status.image_id;
       status.managed = containerLabelsMatch(detail?.Config?.Labels);
       status.persistence = dockerWorkspaceMountIsSafe(detail?.Mounts, platform) ? "durable" : "unsafe";
       status.security = dockerSecurityIsHardened(detail?.HostConfig) ? "hardened" : "unsafe";
@@ -400,7 +436,19 @@ export async function containerComputerStatus(
       await runner(status.runtime, cuaExecArgs(["status", "--socket", CUA_SOCKET]), 8000);
       status.desktopReady = true;
     } catch {
-      // XFCE and the supervisor-owned Cua daemon need a few seconds to start.
+      // An empty log means XFCE and the supervisor-owned Cua daemon are
+      // probably still starting. A real startup failure should be actionable
+      // in the panel instead of looking like an endless readiness wait.
+      try {
+        const errorLog = await runner(
+          status.runtime,
+          ["exec", CONTAINER, "tail", "-n", "4", "/var/log/supervisor/cua-driver.error.log"],
+          4000,
+        );
+        status.desktop_error = errorLog.stdout.replace(/\s+/g, " ").trim().slice(0, 320) || null;
+      } catch {
+        // The log may not exist during the first seconds of container boot.
+      }
     }
   }
 
@@ -581,6 +629,7 @@ export async function containerComputerAction(
   runner: CommandRunner = sh,
   platform: NodeJS.Platform = process.platform,
 ): Promise<ContainerComputerStatus> {
+  if (runner === sh && platform === process.platform) screenshotStatusCache = null;
   const before = await containerComputerStatus(runner, platform);
   const runtime = before.runtime;
   if (!runtime) throw Object.assign(new Error(before.problem ?? "No container runtime is installed"), { status: 409 });
@@ -646,32 +695,46 @@ export async function containerComputerScreenshot(
   runner: CommandRunner = sh,
   platform: NodeJS.Platform = process.platform,
 ): Promise<string> {
-  const status = await containerComputerStatus(runner, platform);
+  const cacheable = runner === sh && platform === process.platform;
+  const now = Date.now();
+  const status =
+    cacheable && screenshotStatusCache && screenshotStatusCache.expiresAt > now
+      ? screenshotStatusCache.status
+      : await containerComputerStatus(runner, platform);
   if (!status.ready || !status.runtime) {
+    if (cacheable) screenshotStatusCache = null;
     throw Object.assign(new Error(status.problem ?? "The Local VM is not ready"), { status: 409 });
   }
-  const screenshot = "/tmp/openmausbot-preview.png";
-  await runner(
-    status.runtime,
-    cuaExecArgs([
-      "call",
-      "get_desktop_state",
-      "{}",
-      "--socket",
-      CUA_SOCKET,
-      "--screenshot-out-file",
-      screenshot,
-    ]),
-    30_000,
-  );
-  const { stdout } = await runner(status.runtime, ["exec", CONTAINER, "base64", "-w0", screenshot], 30_000);
-  const data = stdout.trim();
-  const checked = wholeScreenshot(Buffer.from(data, "base64"));
-  if (!checked.ok) {
-    throw Object.assign(new Error("Cua Driver returned an incomplete screenshot"), { status: 502 });
+  if (cacheable) screenshotStatusCache = { status, expiresAt: now + SCREENSHOT_STATUS_TTL_MS };
+  try {
+    const screenshot = "/tmp/openmausbot-preview.png";
+    await runner(
+      status.runtime,
+      cuaExecArgs([
+        "call",
+        "get_desktop_state",
+        "{}",
+        "--socket",
+        CUA_SOCKET,
+        "--screenshot-out-file",
+        screenshot,
+      ]),
+      30_000,
+    );
+    const { stdout } = await runner(status.runtime, ["exec", CONTAINER, "base64", "-w0", screenshot], 30_000);
+    const data = stdout.trim();
+    const checked = wholeScreenshot(Buffer.from(data, "base64"));
+    if (!checked.ok) {
+      throw Object.assign(new Error("Cua Driver returned an incomplete screenshot"), { status: 502 });
+    }
+    return `data:${checked.mime};base64,${data}`;
+  } catch (error) {
+    if (cacheable) screenshotStatusCache = null;
+    throw error;
   }
-  return `data:${checked.mime};base64,${data}`;
 }
+
+let screenshotStatusCache: { status: ContainerComputerStatus; expiresAt: number } | null = null;
 
 const containerMcpPath = (() => {
   const ts = join(dirname(fileURLToPath(import.meta.url)), "container-mcp.ts");

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { LocalVmLease } from "./local-vm-lease.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
 import { listenWebhookIngress, webhookCredential, type WebhookIngress } from "./webhook-ingress.ts";
@@ -334,10 +335,13 @@ let routines: RoutineManager | null = null;
 // The Local VM is intentionally one shared, visible desktop. Two agents
 // driving it simultaneously would mix clicks, keystrokes and screenshots,
 // so only one thread may lease it at a time.
-let activeVmThreadId: string | null = null;
+const localVmLease = new LocalVmLease(30 * 60_000);
+const localVmOwnerBusy = (botId: string) => store.bot(botId)?.busy === true;
 let localVmLifecycleBusy = false;
 
 bus.subscribe((event: RuntimeEvent) => {
+  localVmLease.touch(event.threadId);
+  if (event.type === "turn.completed") localVmLease.release(event.threadId);
   broadcast({ kind: "runtime", event });
   routines?.handleRuntimeEvent(event);
   const bot = store.botByThread(event.threadId);
@@ -503,7 +507,6 @@ bus.subscribe((event: RuntimeEvent) => {
       });
       break;
     case "turn.completed": {
-      if (activeVmThreadId === event.threadId) activeVmThreadId = null;
       const reply = lastReply.get(event.threadId) ?? "";
       lastReply.delete(event.threadId);
       if (bot) {
@@ -777,14 +780,19 @@ async function startTurn(
         if (!mountsComputerMcp || instance.driverKind === "boxAgent") {
           throw new Error("this model engine cannot use the Local VM — choose Claude or an ACP engine, or select another computer destination");
         }
+        if (localVmLifecycleBusy) {
+          throw new Error("the Local VM is being started, stopped, or replaced — wait for setup to finish");
+        }
+        // Claim before the first await. The lifecycle route performs its
+        // matching check synchronously, so neither side can enter while the
+        // other is between inspection and mutation.
+        if (!localVmLease.claim(threadId, bot.id, localVmOwnerBusy)) {
+          throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
+        }
         const localVm = await containerComputerStatus();
         if (!localVm.ready || !localVm.runtime) {
           throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
         }
-        if (activeVmThreadId && activeVmThreadId !== threadId) {
-          throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
-        }
-        activeVmThreadId = threadId;
         integrations.localComputer = containerComputerMcp(localVm.runtime);
         computerKind = "vm";
       } else if (wants === "local") {
@@ -911,7 +919,7 @@ async function startTurn(
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
       if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
-      if (activeVmThreadId === threadId) activeVmThreadId = null;
+      localVmLease.release(threadId);
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(threadId, {
         role: "bot",
@@ -2093,7 +2101,8 @@ const server = createServer(async (req, res) => {
       if (localVmLifecycleBusy) {
         return json(res, 409, { error: "another Local VM setup action is still running" });
       }
-      if (activeVmThreadId && (action === "stop" || action === "remove" || action === "run")) {
+      const vmOwner = localVmLease.current(localVmOwnerBusy);
+      if (vmOwner && (action === "stop" || action === "remove" || action === "run")) {
         return json(res, 409, { error: "the Local VM is being used by a bot — stop that turn first" });
       }
       localVmLifecycleBusy = true;

--- a/server/local-vm-lease.test.ts
+++ b/server/local-vm-lease.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { LocalVmLease } from "./local-vm-lease.ts";
+
+describe("LocalVmLease", () => {
+  it("serializes different threads while letting the owner renew", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+
+    expect(lease.claim("thread-a", "bot-a", busy, 1_000)).toBe(true);
+    expect(lease.claim("thread-b", "bot-b", busy, 1_001)).toBe(false);
+    expect(lease.claim("thread-a", "bot-a", busy, 1_002)).toBe(true);
+    expect(lease.current(busy, 1_050)).toMatchObject({ threadId: "thread-a", botId: "bot-a" });
+  });
+
+  it("expires a wedged owner and allows recovery", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+
+    expect(lease.current(busy, 1_100)).toBeNull();
+    expect(lease.claim("thread-b", "bot-b", busy, 1_100)).toBe(true);
+  });
+
+  it("refreshes on owner activity and releases when its bot settles", () => {
+    const lease = new LocalVmLease(100);
+    let ownerBusy = true;
+    const busy = () => ownerBusy;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+    lease.touch("thread-a", 1_090);
+    expect(lease.current(busy, 1_150)).not.toBeNull();
+
+    ownerBusy = false;
+    expect(lease.current(busy, 1_151)).toBeNull();
+  });
+
+  it("does not revive an expired owner from a delayed event", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+    lease.touch("thread-a", 1_100);
+
+    expect(lease.current(busy, 1_100)).toBeNull();
+    expect(lease.claim("thread-b", "bot-b", busy, 1_100)).toBe(true);
+  });
+
+  it("only lets the owning thread release the lease", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+
+    lease.release("thread-b");
+    expect(lease.current(busy, 1_001)).not.toBeNull();
+    lease.release("thread-a");
+    expect(lease.current(busy, 1_002)).toBeNull();
+  });
+});

--- a/server/local-vm-lease.ts
+++ b/server/local-vm-lease.ts
@@ -1,0 +1,48 @@
+export interface LocalVmLeaseRecord {
+  threadId: string;
+  botId: string;
+  expiresAt: number;
+}
+
+/** A short, renewable ownership fence for the one shared Local VM desktop.
+ * Runtime events keep an active turn's lease alive; a dead provider cannot
+ * pin the VM forever. All methods are synchronous so lifecycle routes and
+ * turn dispatch can claim their side of the race before either awaits. */
+export class LocalVmLease {
+  private record: LocalVmLeaseRecord | null = null;
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number) {
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) throw new Error("Local VM lease TTL must be positive");
+    this.ttlMs = ttlMs;
+  }
+
+  current(isBotBusy: (botId: string) => boolean, now = Date.now()): LocalVmLeaseRecord | null {
+    if (this.record && (this.record.expiresAt <= now || !isBotBusy(this.record.botId))) this.record = null;
+    return this.record ? { ...this.record } : null;
+  }
+
+  claim(
+    threadId: string,
+    botId: string,
+    isBotBusy: (ownerBotId: string) => boolean,
+    now = Date.now(),
+  ): boolean {
+    const current = this.current(isBotBusy, now);
+    if (current && current.threadId !== threadId) return false;
+    this.record = { threadId, botId, expiresAt: now + this.ttlMs };
+    return true;
+  }
+
+  touch(threadId: string, now = Date.now()): void {
+    if (this.record && this.record.expiresAt <= now) {
+      this.record = null;
+      return;
+    }
+    if (this.record?.threadId === threadId) this.record.expiresAt = now + this.ttlMs;
+  }
+
+  release(threadId: string): void {
+    if (this.record?.threadId === threadId) this.record = null;
+  }
+}


### PR DESCRIPTION
## What changed

- replaces the unbounded Local VM owner flag with a renewable, expiring lease
- claims VM ownership before asynchronous status inspection, closing the setup/turn lifecycle race
- releases ownership on every terminal turn event and dispatch failure
- compares the container's resolved image ID with the currently prepared image, not only its mutable tag and labels
- bounds the X display startup wait and reports the supervisor error in Settings
- caches a recently verified Ready status for preview frames to avoid a full runtime inspection on every screenshot

## Why

A wedged turn could previously reserve the shared VM until the app restarted. A setup action could also begin between a turn's status check and lease claim. Separately, rebuilding a managed image under the same tag left existing containers looking current, and a failed X server looked like an endless startup.

These changes make ownership recoverable, lifecycle decisions atomic before awaits, image drift detectable, and readiness failures actionable.

## User impact

- another bot can recover the VM after an abandoned lease expires
- Stop/Remove/Create cannot race a new VM turn
- stale containers reliably request recreation
- desktop startup failures explain themselves
- an open screen viewer performs substantially fewer host runtime inspections

## Validation

- `pnpm test` — 448 passed, 8 skipped
- `pnpm build`
- live Docker test: rebuilt the same image tag while a VM was running and verified it changed from Ready to the expected recreate warning

## Merge order

Stacked on #151; merge #151 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exclusive coordination for shared Local VM desktop access.
  * Added desktop startup error reporting, including recent supervisor logs when available.
  * Added bounded desktop readiness checks with a 45-second timeout.
  * Added short-term caching for repeated screenshot status checks.

* **Bug Fixes**
  * Prevented stale containers from being reused after image updates.
  * Improved image compatibility checks across supported container runtimes.
  * Improved handling of conflicting lifecycle actions and bot activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->