### PR TITLE
Preserve browser sessions in computer sandboxes

### DIFF
--- a/server/box-lifecycle.test.ts
+++ b/server/box-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("cloud computer lifecycle", () => {
+  let api: Server;
+  let sleepBox: typeof import("./box.ts").sleepBox;
+  const requests: Array<{ method: string; path: string; command?: string }> = [];
+  const botId = "browser-session-test";
+
+  beforeAll(async () => {
+    const hash = createHash("sha256").update(botId).digest("hex").slice(0, 6);
+    const prefix = botId.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "");
+    const machineName = `ogb-${prefix}-${hash}`;
+    api = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://box.test");
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const parsed = body ? JSON.parse(body) : {};
+        requests.push({ method: req.method ?? "GET", path: url.pathname, command: parsed.command });
+        res.writeHead(200, { "content-type": "application/json" });
+        if (url.pathname === "/api/box/v1/boxes") {
+          res.end(JSON.stringify({ boxes: [{ id: "box-1", name: machineName, state: "ready" }] }));
+        } else if (url.pathname.endsWith("/commands")) {
+          res.end(JSON.stringify({ exitCode: 0, stdout: "", stderr: "" }));
+        } else {
+          res.end(JSON.stringify({ ok: true }));
+        }
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+    const port = (api.address() as any).port;
+    vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
+    vi.resetModules();
+    ({ sleepBox } = await import("./box.ts"));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve) => api.close(() => resolve()));
+  });
+
+  it("asks Chrome to exit before archiving the computer", async () => {
+    await sleepBox({ box: { token: "box_test" } } as any, botId);
+
+    const commandIndex = requests.findIndex((request) => request.path.endsWith("/commands"));
+    const stopIndex = requests.findIndex((request) => request.path.endsWith("/stop"));
+    expect(commandIndex).toBeGreaterThan(-1);
+    expect(stopIndex).toBeGreaterThan(commandIndex);
+    expect(requests[commandIndex]?.command).toContain("kill -TERM");
+    expect(requests[commandIndex]?.command).toContain("pgrep -o -x");
+  });
+});

--- a/server/box.ts
+++ b/server/box.ts
@@ -262,6 +262,14 @@ export async function joinBox(cfg: AppConfig, botId: string) {
 export async function sleepBox(cfg: AppConfig, botId: string) {
   const box = await findBox(cfg, botId);
   if (!box) throw new Error("no computer for this bot");
+  // Ask the browser's oldest (main) process to exit before the provider
+  // snapshots the disk. This gives Chrome a chance to flush cookies and
+  // session state instead of restoring a crash-marked profile next wake.
+  const quiesceBrowser = [
+    'for name in chrome google-chrome chromium chromium-browser; do pid=$(pgrep -o -x "$name" 2>/dev/null || true); [ -z "$pid" ] || kill -TERM "$pid" 2>/dev/null || true; done',
+    'for i in 1 2 3 4 5 6 7 8; do if ! pgrep -x chrome >/dev/null 2>&1 && ! pgrep -x google-chrome >/dev/null 2>&1 && ! pgrep -x chromium >/dev/null 2>&1 && ! pgrep -x chromium-browser >/dev/null 2>&1; then break; fi; sleep 0.25; done',
+  ].join("; ");
+  await runCommand(cfg, box.id, quiesceBrowser, { timeoutMs: 5_000 }).catch(() => null);
   await boxJson(cfg, `/boxes/${box.id}/stop`, { method: "POST" }).catch(() => {});
   return { ok: true };
 }

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -180,8 +180,20 @@ describe("computer proxy (fake box)", () => {
       params: { name: "type_text", arguments: { text: "hello" } },
     });
     const res = await waitFor(5);
-    expect(commands.at(-1)).toMatch(/xdotool type --delay 8 'hello'/);
+    expect(commands.at(-1)).toMatch(/xdotool type --clearmodifiers --delay 8 -- 'hello'/);
     expect(res.result.content[1]).toMatchObject({ type: "image" });
+  });
+
+  it("types leading hyphens as text after clearing stuck modifiers", async () => {
+    hash = "bbbb2223";
+    rpc({
+      jsonrpc: "2.0",
+      id: 51,
+      method: "tools/call",
+      params: { name: "type_text", arguments: { text: "--safe" } },
+    });
+    await waitFor(51);
+    expect(commands.at(-1)).toContain("xdotool type --clearmodifiers --delay 8 -- '--safe'");
   });
 
   it("runs a whole batch in one round trip with one frame at the end", async () => {
@@ -339,9 +351,16 @@ describe("computer proxy (fake box)", () => {
     const result = await waitFor(130);
     const issued = commands.slice(before);
     expect(issued).toHaveLength(2);
-    expect(issued[0]).toContain('mkdir -p "$HOME/.openmausbot/chrome-profile"');
-    expect(issued[0]).toContain('chmod 700 "$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('profile="$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('chmod 700 "$profile"');
+    expect(issued[0]).toContain('! cp -a -n "$browser_dir"/. "$profile"/');
+    expect(issued[0]).toContain('echo "failed to copy browser profile: $browser_dir" >&2');
+    expect(issued[0]).toContain('ln -s "$profile" "$browser_dir"');
+    expect(issued[0]).not.toContain("do;");
+    expect(issued[0]).not.toContain("then;");
     expect(issued[0]).toContain('--user-data-dir="$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain("--password-store=basic");
+    expect(issued[0]).toContain("--disable-session-crashed-bubble");
     expect(issued[0]).not.toContain("user:password@");
     expect(issued[0]).toContain("'https://example.com/requested?token=secret#fragment'");
     expect(result.result.content[0].text).toContain("https://example.com/landed");

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -51,9 +51,26 @@ const SETTLE_MS = 350;
 const ACTION_GAP_MS = 120;
 const CHROME_PROFILE = "$HOME/.openmausbot/chrome-profile";
 const CHROME_DEBUG_FLAGS =
-  `--user-data-dir="${CHROME_PROFILE}" --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
-const CHROME_PROFILE_SETUP =
-  `mkdir -p "${CHROME_PROFILE}" && chmod 700 "${CHROME_PROFILE}"`;
+  `--user-data-dir="${CHROME_PROFILE}" --password-store=basic --disable-session-crashed-bubble --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
+// Keep one durable browser identity regardless of which Chromium binary an
+// image supplies. Existing profiles are merged without overwriting files and
+// moved aside as backups before the conventional paths become symlinks.
+const CHROME_PROFILE_SETUP = [
+  `profile="${CHROME_PROFILE}"`,
+  'mkdir -p "$profile" "$HOME/.config"',
+  'chmod 700 "$profile"',
+  'for browser_dir in "$HOME/.config/google-chrome" "$HOME/.config/chromium"; do',
+  '  if [ -e "$browser_dir" ] && [ ! -L "$browser_dir" ]; then',
+  '    if [ -d "$browser_dir" ] && ! cp -a -n "$browser_dir"/. "$profile"/; then',
+  '      echo "failed to copy browser profile: $browser_dir" >&2',
+  "      exit 1",
+  "    fi",
+  '    mv "$browser_dir" "$browser_dir.pre-openmausbot-$(date +%s)-$$"',
+  "  fi",
+  '  if [ -L "$browser_dir" ]; then rm -f "$browser_dir"; fi',
+  '  ln -s "$profile" "$browser_dir"',
+  "done",
+].join("\n");
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -534,7 +551,7 @@ function actionShell(a: any): string | { error: string } {
   if (kind === "type_text") {
     const t = String(a.text ?? "");
     if (!t) return { error: "type_text needs text" };
-    return `xdotool type --delay 8 ${shellQuote(t)}`;
+    return `xdotool type --clearmodifiers --delay 8 -- ${shellQuote(t)}`;
   }
   if (kind === "press_key") {
     const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
@@ -743,7 +760,15 @@ async function handle(msg: any) {
     try {
       return await call(msg.id, msg.params?.name, msg.params?.arguments ?? {});
     } catch (e) {
-      return text(msg.id, `computer tool failed: ${(e as Error).message}`, true);
+      const error = e instanceof Error ? e : new Error(String(e));
+      const timedOut = error.name === "TimeoutError" || /timed?\s*out|timeout/i.test(error.message);
+      return text(
+        msg.id,
+        timedOut
+          ? "computer tool timed out. The action may or may not have completed; take a screenshot to inspect the current state before retrying it."
+          : `computer tool failed: ${error.message}`,
+        true,
+      );
     }
   }
   if (String(msg.method ?? "").startsWith("notifications/")) return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -899,6 +899,9 @@ async function startTurn(
               : computerKind === "local"
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
               : "") +
+          (computerKind
+            ? " At a sign-in, password, MFA, CAPTCHA, or other protected-input step, stop and ask the user to complete it on the visible computer. Never type their password or ask them to paste a password or one-time code into chat."
+            : "") +
           // gated on the integration, not the key: the hint only goes to a
           // bot whose driver actually mounted the tools
           (integrations.composio


### PR DESCRIPTION
## Summary

- keep one durable Chrome/Chromium profile and preserve any profile that already exists
- close the browser cleanly before a cloud computer is archived
- make text entry safe for leading hyphens and stuck keyboard modifiers
- give honest recovery instructions when a computer action times out
- stop at passwords, MFA, CAPTCHAs, and other protected-input steps so the user can take over on the visible computer

## Migration note

An existing cloud computer may ask the user to sign in once after this update because Chrome's Linux password-store mode changes. The durable profile keeps later sessions; no profile directory is discarded.

## Safety notes

- profile migration copies without overwriting and moves the old directory to a timestamped backup
- browser shutdown is best-effort and never prevents the computer from being archived
- DevTools remains bound to loopback only

## Verification

- `pnpm test` (450 passed, 8 skipped; updater tests 11 passed)
- `pnpm build`

## Merge order

This is stacked on #153. Merge #151, then #153, then this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved browser startup with more reliable profile handling and preservation of existing browser data.
  * Text entry now clears stuck modifier keys and handles leading hyphens safely.
  * Browser shutdown is more graceful, helping prevent incomplete sessions.
  * Error messages now distinguish timeouts and recommend taking a screenshot before retrying.
* **Security**
  * Protected steps such as sign-in, passwords, MFA, and CAPTCHA now prompt you to complete them directly on the visible computer instead of entering sensitive information in chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->