### PR TITLE
Clean up failed cloud computer provisioning

### DIFF
--- a/server/box-provision.test.ts
+++ b/server/box-provision.test.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+type RequestRecord = { method: string; path: string; headers: IncomingMessage["headers"] };
+
+describe("cloud computer provisioning cleanup", () => {
+  let api: Server;
+  let provisionBox: typeof import("./box.ts").provisionBox;
+  let scenario: "rename-failure" | "existing-desktop-failure" = "rename-failure";
+  const requests: RequestRecord[] = [];
+
+  const nameFor = (botId: string) => {
+    const prefix = botId.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "");
+    const hash = createHash("sha256").update(botId).digest("hex").slice(0, 6);
+    return `ogb-${prefix}-${hash}`;
+  };
+
+  beforeAll(async () => {
+    api = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://box.test");
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        requests.push({ method: req.method ?? "GET", path: url.pathname, headers: req.headers });
+        res.setHeader("content-type", "application/json");
+
+        if (url.pathname === "/api/box/v1/boxes" && req.method === "GET") {
+          const boxes =
+            scenario === "existing-desktop-failure"
+              ? [{ id: "existing-box", name: nameFor("existing-bot"), state: "ready" }]
+              : [];
+          res.writeHead(200).end(JSON.stringify({ ok: true, boxes }));
+        } else if (url.pathname === "/api/box/v1/boxes" && req.method === "POST") {
+          res.writeHead(201).end(JSON.stringify({ ok: true, box: { id: "new-box", state: "provisioning" } }));
+        } else if (url.pathname === "/api/box/v1/boxes/new-box" && req.method === "PATCH") {
+          res.writeHead(500).end(JSON.stringify({ ok: false, message: "rename rejected" }));
+        } else if (url.pathname === "/api/box/v1/boxes/new-box" && req.method === "DELETE") {
+          res.writeHead(202).end(JSON.stringify({ ok: true, operationId: "delete-1" }));
+        } else if (url.pathname === "/api/box/v1/boxes/existing-box" && req.method === "GET") {
+          res.writeHead(200).end(
+            JSON.stringify({ ok: true, box: { id: "existing-box", name: nameFor("existing-bot"), state: "ready" } }),
+          );
+        } else if (url.pathname.endsWith("/commands")) {
+          res.writeHead(200).end(JSON.stringify({ ok: true, exitCode: 0, stdout: "bootstrapped", stderr: "" }));
+        } else if (url.pathname.endsWith("/desktop")) {
+          res.writeHead(500).end(JSON.stringify({ ok: false, message: "desktop unavailable" }));
+        } else {
+          res.writeHead(404).end(JSON.stringify({ ok: false, message: `unexpected ${req.method} ${url.pathname}` }));
+        }
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+    const port = (api.address() as any).port;
+    vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
+    vi.resetModules();
+    ({ provisionBox } = await import("./box.ts"));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve) => api.close(() => resolve()));
+  });
+
+  it("permanently deletes a newly created box when naming fails", async () => {
+    scenario = "rename-failure";
+    requests.length = 0;
+
+    await expect(provisionBox({ box: { token: "box_test" } } as any, "new-bot", "New Bot")).rejects.toThrow(
+      /box naming failed: rename rejected/,
+    );
+
+    const removal = requests.find((request) => request.method === "DELETE");
+    expect(removal?.path).toBe("/api/box/v1/boxes/new-box");
+    expect(removal?.headers["x-ascii-confirm-delete"]).toBe("new-box");
+  });
+
+  it("never deletes a pre-existing box when a later step fails", async () => {
+    scenario = "existing-desktop-failure";
+    requests.length = 0;
+
+    await expect(
+      provisionBox({ box: { token: "box_test" } } as any, "existing-bot", "Existing Bot"),
+    ).rejects.toThrow(/desktop link could not be created/);
+
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false);
+  });
+});

--- a/server/box.ts
+++ b/server/box.ts
@@ -192,61 +192,82 @@ export async function provisionBox(cfg: AppConfig, botId: string, botName: strin
   const vmName = await boxNameFor(botId);
   let box = await findBox(cfg, botId);
   let created = false;
-  if (!box) {
-    const createRes = await boxJson(cfg, "/boxes", {
-      method: "POST",
-      // substrate-side backstop: archives itself (billing pauses, disk
-      // survives) if every stop path dies
-      body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
-    });
-    if (!createRes.ok || !createRes.body?.box?.id) {
-      throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+  try {
+    if (!box) {
+      const createRes = await boxJson(cfg, "/boxes", {
+        method: "POST",
+        // substrate-side backstop: archives itself (billing pauses, disk
+        // survives) if every stop path dies
+        body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
+      });
+      if (!createRes.ok || !createRes.body?.box?.id) {
+        throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+      }
+      box = createRes.body.box;
+      created = true;
+      const rename = await boxJson(cfg, `/boxes/${box.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ name: vmName }),
+      });
+      if (!rename.ok) throw new Error(boxErrorMessage(rename.status, "box naming", rename.body));
     }
-    box = createRes.body.box;
-    created = true;
-    await boxJson(cfg, `/boxes/${box.id}`, { method: "PATCH", body: JSON.stringify({ name: vmName }) });
-  }
-  const ready = await waitReady(cfg, box.id);
-  if (!ready) throw new Error("box did not become ready within 90s — retry in a minute");
+    const ready = await waitReady(cfg, box.id);
+    if (!ready) throw new Error("box did not become ready within 90s — retry in a minute");
 
-  // Idempotent bootstrap. Three layers:
-  //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
-  //      always-works fallback for the computer tools.
-  //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
-  //      the BACKGROUND (first install takes minutes; nohup'd children
-  //      survive the commands endpoint returning — probed by agentcal).
-  //   3. computer-server started loopback-only on :8000 when installed —
-  //      driven from outside via the box's run-command endpoint, so no
-  //      inbound port and no tunnel is ever needed.
-  const cuaInstall = [
-    "sudo apt-get update -qq || true",
-    "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
-    'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
-    'export PATH="$HOME/.local/bin:$PATH"',
-    'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
-    "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
-    "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
-    "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
-  ].join("; ");
-  const bootstrap = [
-    "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
-    `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
-    // start CUA computer-server (loopback only) once installed; pidfile-free
-    // guard on the module name is safe here — the pattern cannot match this
-    // bootstrap's own shell (agentcal's pgrep self-match trap)
-    'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
-    `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
-    "echo bootstrapped",
-  ].join("\n");
-  let boot;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    boot = await runCommand(cfg, box.id, bootstrap);
-    if (boot.ok || boot.exitCode !== null) break;
-    await new Promise((r) => setTimeout(r, 3000));
-  }
+    // Idempotent bootstrap. Three layers:
+    //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
+    //      always-works fallback for the computer tools.
+    //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
+    //      the BACKGROUND (first install takes minutes; nohup'd children
+    //      survive the commands endpoint returning — probed by agentcal).
+    //   3. computer-server started loopback-only on :8000 when installed —
+    //      driven from outside via the box's run-command endpoint, so no
+    //      inbound port and no tunnel is ever needed.
+    const cuaInstall = [
+      "sudo apt-get update -qq || true",
+      "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
+      'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
+      'export PATH="$HOME/.local/bin:$PATH"',
+      'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
+      "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
+      "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
+      "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
+    ].join("; ");
+    const bootstrap = [
+      "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
+      `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
+      // start CUA computer-server (loopback only) once installed; pidfile-free
+      // guard on the module name is safe here — the pattern cannot match this
+      // bootstrap's own shell (agentcal's pgrep self-match trap)
+      'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
+      `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
+      "echo bootstrapped",
+    ].join("\n");
+    let boot;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      boot = await runCommand(cfg, box.id, bootstrap);
+      if (boot.ok || boot.exitCode !== null) break;
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+    if (!boot?.ok) {
+      const detail = boot?.stderr?.slice(0, 200) || (boot?.exitCode != null ? `exit ${boot.exitCode}` : "no response");
+      throw new Error(`box setup failed: ${detail}`);
+    }
 
-  const joinUrl = await mintDesktopUrl(cfg, box.id);
-  return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
+    const joinUrl = await mintDesktopUrl(cfg, box.id);
+    if (!joinUrl) throw new Error("box desktop link could not be created");
+    return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
+  } catch (error) {
+    if (!created || !box?.id) throw error;
+    const cleanup = await boxJson(cfg, `/boxes/${box.id}`, {
+      method: "DELETE",
+      headers: { "X-Ascii-Confirm-Delete": box.id },
+    }).catch(() => null);
+    boxIdCache.delete(botId);
+    if (cleanup?.ok) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}. The new computer could not be removed automatically; delete box ${box.id} in ascii.dev.`);
+  }
 }
 
 /** Wake the bot's box and return a FRESH desktop URL. */


### PR DESCRIPTION
## Summary

- fail immediately when a new cloud computer cannot be named
- treat readiness, bootstrap, and desktop-link failures as provisioning failures
- permanently remove only the machine created by the failing attempt
- preserve pre-existing machines on every later failure path
- surface a manual cleanup warning and exact box ID if automatic deletion itself fails

The cleanup request follows the provider's current permanent-delete contract, including the exact-ID confirmation header.

## Verification

- `pnpm test` (452 passed, 8 skipped; updater tests 11 passed)
- `pnpm build`
- provider-contract tests cover cleanup after a failed rename and non-cleanup of an existing machine

## Merge order

This is stacked on #154. Merge #151, #153, #154, then this PR.
