### PR TITLE
Suspend idle Local VMs safely

### DIFF
--- a/server/box-lifecycle.test.ts
+++ b/server/box-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("cloud computer lifecycle", () => {
+  let api: Server;
+  let sleepBox: typeof import("./box.ts").sleepBox;
+  const requests: Array<{ method: string; path: string; command?: string }> = [];
+  const botId = "browser-session-test";
+
+  beforeAll(async () => {
+    const hash = createHash("sha256").update(botId).digest("hex").slice(0, 6);
+    const prefix = botId.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "");
+    const machineName = `ogb-${prefix}-${hash}`;
+    api = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://box.test");
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const parsed = body ? JSON.parse(body) : {};
+        requests.push({ method: req.method ?? "GET", path: url.pathname, command: parsed.command });
+        res.writeHead(200, { "content-type": "application/json" });
+        if (url.pathname === "/api/box/v1/boxes") {
+          res.end(JSON.stringify({ boxes: [{ id: "box-1", name: machineName, state: "ready" }] }));
+        } else if (url.pathname.endsWith("/commands")) {
+          res.end(JSON.stringify({ exitCode: 0, stdout: "", stderr: "" }));
+        } else {
+          res.end(JSON.stringify({ ok: true }));
+        }
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+    const port = (api.address() as any).port;
+    vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
+    vi.resetModules();
+    ({ sleepBox } = await import("./box.ts"));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve) => api.close(() => resolve()));
+  });
+
+  it("asks Chrome to exit before archiving the computer", async () => {
+    await sleepBox({ box: { token: "box_test" } } as any, botId);
+
+    const commandIndex = requests.findIndex((request) => request.path.endsWith("/commands"));
+    const stopIndex = requests.findIndex((request) => request.path.endsWith("/stop"));
+    expect(commandIndex).toBeGreaterThan(-1);
+    expect(stopIndex).toBeGreaterThan(commandIndex);
+    expect(requests[commandIndex]?.command).toContain("kill -TERM");
+    expect(requests[commandIndex]?.command).toContain("pgrep -o -x");
+  });
+});

--- a/server/box-provision.test.ts
+++ b/server/box-provision.test.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+type RequestRecord = { method: string; path: string; headers: IncomingMessage["headers"] };
+
+describe("cloud computer provisioning cleanup", () => {
+  let api: Server;
+  let provisionBox: typeof import("./box.ts").provisionBox;
+  let scenario: "rename-failure" | "existing-desktop-failure" = "rename-failure";
+  const requests: RequestRecord[] = [];
+
+  const nameFor = (botId: string) => {
+    const prefix = botId.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "");
+    const hash = createHash("sha256").update(botId).digest("hex").slice(0, 6);
+    return `ogb-${prefix}-${hash}`;
+  };
+
+  beforeAll(async () => {
+    api = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://box.test");
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        requests.push({ method: req.method ?? "GET", path: url.pathname, headers: req.headers });
+        res.setHeader("content-type", "application/json");
+
+        if (url.pathname === "/api/box/v1/boxes" && req.method === "GET") {
+          const boxes =
+            scenario === "existing-desktop-failure"
+              ? [{ id: "existing-box", name: nameFor("existing-bot"), state: "ready" }]
+              : [];
+          res.writeHead(200).end(JSON.stringify({ ok: true, boxes }));
+        } else if (url.pathname === "/api/box/v1/boxes" && req.method === "POST") {
+          res.writeHead(201).end(JSON.stringify({ ok: true, box: { id: "new-box", state: "provisioning" } }));
+        } else if (url.pathname === "/api/box/v1/boxes/new-box" && req.method === "PATCH") {
+          res.writeHead(500).end(JSON.stringify({ ok: false, message: "rename rejected" }));
+        } else if (url.pathname === "/api/box/v1/boxes/new-box" && req.method === "DELETE") {
+          res.writeHead(202).end(JSON.stringify({ ok: true, operationId: "delete-1" }));
+        } else if (url.pathname === "/api/box/v1/boxes/existing-box" && req.method === "GET") {
+          res.writeHead(200).end(
+            JSON.stringify({ ok: true, box: { id: "existing-box", name: nameFor("existing-bot"), state: "ready" } }),
+          );
+        } else if (url.pathname.endsWith("/commands")) {
+          res.writeHead(200).end(JSON.stringify({ ok: true, exitCode: 0, stdout: "bootstrapped", stderr: "" }));
+        } else if (url.pathname.endsWith("/desktop")) {
+          res.writeHead(500).end(JSON.stringify({ ok: false, message: "desktop unavailable" }));
+        } else {
+          res.writeHead(404).end(JSON.stringify({ ok: false, message: `unexpected ${req.method} ${url.pathname}` }));
+        }
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+    const port = (api.address() as any).port;
+    vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
+    vi.resetModules();
+    ({ provisionBox } = await import("./box.ts"));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve) => api.close(() => resolve()));
+  });
+
+  it("permanently deletes a newly created box when naming fails", async () => {
+    scenario = "rename-failure";
+    requests.length = 0;
+
+    await expect(provisionBox({ box: { token: "box_test" } } as any, "new-bot", "New Bot")).rejects.toThrow(
+      /box naming failed: rename rejected/,
+    );
+
+    const removal = requests.find((request) => request.method === "DELETE");
+    expect(removal?.path).toBe("/api/box/v1/boxes/new-box");
+    expect(removal?.headers["x-ascii-confirm-delete"]).toBe("new-box");
+  });
+
+  it("never deletes a pre-existing box when a later step fails", async () => {
+    scenario = "existing-desktop-failure";
+    requests.length = 0;
+
+    await expect(
+      provisionBox({ box: { token: "box_test" } } as any, "existing-bot", "Existing Bot"),
+    ).rejects.toThrow(/desktop link could not be created/);
+
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false);
+  });
+});

--- a/server/box.ts
+++ b/server/box.ts
@@ -262,6 +262,14 @@ export async function joinBox(cfg: AppConfig, botId: string) {
 export async function sleepBox(cfg: AppConfig, botId: string) {
   const box = await findBox(cfg, botId);
   if (!box) throw new Error("no computer for this bot");
+  // Ask the browser's oldest (main) process to exit before the provider
+  // snapshots the disk. This gives Chrome a chance to flush cookies and
+  // session state instead of restoring a crash-marked profile next wake.
+  const quiesceBrowser = [
+    'for name in chrome google-chrome chromium chromium-browser; do pid=$(pgrep -o -x "$name" 2>/dev/null || true); [ -z "$pid" ] || kill -TERM "$pid" 2>/dev/null || true; done',
+    'for i in 1 2 3 4 5 6 7 8; do if ! pgrep -x chrome >/dev/null 2>&1 && ! pgrep -x google-chrome >/dev/null 2>&1 && ! pgrep -x chromium >/dev/null 2>&1 && ! pgrep -x chromium-browser >/dev/null 2>&1; then break; fi; sleep 0.25; done',
+  ].join("; ");
+  await runCommand(cfg, box.id, quiesceBrowser, { timeoutMs: 5_000 }).catch(() => null);
   await boxJson(cfg, `/boxes/${box.id}/stop`, { method: "POST" }).catch(() => {});
   return { ok: true };
 }

--- a/server/box.ts
+++ b/server/box.ts
@@ -192,61 +192,82 @@ export async function provisionBox(cfg: AppConfig, botId: string, botName: strin
   const vmName = await boxNameFor(botId);
   let box = await findBox(cfg, botId);
   let created = false;
-  if (!box) {
-    const createRes = await boxJson(cfg, "/boxes", {
-      method: "POST",
-      // substrate-side backstop: archives itself (billing pauses, disk
-      // survives) if every stop path dies
-      body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
-    });
-    if (!createRes.ok || !createRes.body?.box?.id) {
-      throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+  try {
+    if (!box) {
+      const createRes = await boxJson(cfg, "/boxes", {
+        method: "POST",
+        // substrate-side backstop: archives itself (billing pauses, disk
+        // survives) if every stop path dies
+        body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
+      });
+      if (!createRes.ok || !createRes.body?.box?.id) {
+        throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+      }
+      box = createRes.body.box;
+      created = true;
+      const rename = await boxJson(cfg, `/boxes/${box.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ name: vmName }),
+      });
+      if (!rename.ok) throw new Error(boxErrorMessage(rename.status, "box naming", rename.body));
     }
-    box = createRes.body.box;
-    created = true;
-    await boxJson(cfg, `/boxes/${box.id}`, { method: "PATCH", body: JSON.stringify({ name: vmName }) });
-  }
-  const ready = await waitReady(cfg, box.id);
-  if (!ready) throw new Error("box did not become ready within 90s — retry in a minute");
+    const ready = await waitReady(cfg, box.id);
+    if (!ready) throw new Error("box did not become ready within 90s — retry in a minute");
 
-  // Idempotent bootstrap. Three layers:
-  //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
-  //      always-works fallback for the computer tools.
-  //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
-  //      the BACKGROUND (first install takes minutes; nohup'd children
-  //      survive the commands endpoint returning — probed by agentcal).
-  //   3. computer-server started loopback-only on :8000 when installed —
-  //      driven from outside via the box's run-command endpoint, so no
-  //      inbound port and no tunnel is ever needed.
-  const cuaInstall = [
-    "sudo apt-get update -qq || true",
-    "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
-    'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
-    'export PATH="$HOME/.local/bin:$PATH"',
-    'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
-    "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
-    "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
-    "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
-  ].join("; ");
-  const bootstrap = [
-    "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
-    `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
-    // start CUA computer-server (loopback only) once installed; pidfile-free
-    // guard on the module name is safe here — the pattern cannot match this
-    // bootstrap's own shell (agentcal's pgrep self-match trap)
-    'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
-    `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
-    "echo bootstrapped",
-  ].join("\n");
-  let boot;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    boot = await runCommand(cfg, box.id, bootstrap);
-    if (boot.ok || boot.exitCode !== null) break;
-    await new Promise((r) => setTimeout(r, 3000));
-  }
+    // Idempotent bootstrap. Three layers:
+    //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
+    //      always-works fallback for the computer tools.
+    //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
+    //      the BACKGROUND (first install takes minutes; nohup'd children
+    //      survive the commands endpoint returning — probed by agentcal).
+    //   3. computer-server started loopback-only on :8000 when installed —
+    //      driven from outside via the box's run-command endpoint, so no
+    //      inbound port and no tunnel is ever needed.
+    const cuaInstall = [
+      "sudo apt-get update -qq || true",
+      "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
+      'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
+      'export PATH="$HOME/.local/bin:$PATH"',
+      'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
+      "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
+      "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
+      "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
+    ].join("; ");
+    const bootstrap = [
+      "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
+      `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
+      // start CUA computer-server (loopback only) once installed; pidfile-free
+      // guard on the module name is safe here — the pattern cannot match this
+      // bootstrap's own shell (agentcal's pgrep self-match trap)
+      'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
+      `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
+      "echo bootstrapped",
+    ].join("\n");
+    let boot;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      boot = await runCommand(cfg, box.id, bootstrap);
+      if (boot.ok || boot.exitCode !== null) break;
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+    if (!boot?.ok) {
+      const detail = boot?.stderr?.slice(0, 200) || (boot?.exitCode != null ? `exit ${boot.exitCode}` : "no response");
+      throw new Error(`box setup failed: ${detail}`);
+    }
 
-  const joinUrl = await mintDesktopUrl(cfg, box.id);
-  return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
+    const joinUrl = await mintDesktopUrl(cfg, box.id);
+    if (!joinUrl) throw new Error("box desktop link could not be created");
+    return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
+  } catch (error) {
+    if (!created || !box?.id) throw error;
+    const cleanup = await boxJson(cfg, `/boxes/${box.id}`, {
+      method: "DELETE",
+      headers: { "X-Ascii-Confirm-Delete": box.id },
+    }).catch(() => null);
+    boxIdCache.delete(botId);
+    if (cleanup?.ok) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}. The new computer could not be removed automatically; delete box ${box.id} in ascii.dev.`);
+  }
 }
 
 /** Wake the bot's box and return a FRESH desktop URL. */

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -180,8 +180,20 @@ describe("computer proxy (fake box)", () => {
       params: { name: "type_text", arguments: { text: "hello" } },
     });
     const res = await waitFor(5);
-    expect(commands.at(-1)).toMatch(/xdotool type --delay 8 'hello'/);
+    expect(commands.at(-1)).toMatch(/xdotool type --clearmodifiers --delay 8 -- 'hello'/);
     expect(res.result.content[1]).toMatchObject({ type: "image" });
+  });
+
+  it("types leading hyphens as text after clearing stuck modifiers", async () => {
+    hash = "bbbb2223";
+    rpc({
+      jsonrpc: "2.0",
+      id: 51,
+      method: "tools/call",
+      params: { name: "type_text", arguments: { text: "--safe" } },
+    });
+    await waitFor(51);
+    expect(commands.at(-1)).toContain("xdotool type --clearmodifiers --delay 8 -- '--safe'");
   });
 
   it("runs a whole batch in one round trip with one frame at the end", async () => {
@@ -339,9 +351,13 @@ describe("computer proxy (fake box)", () => {
     const result = await waitFor(130);
     const issued = commands.slice(before);
     expect(issued).toHaveLength(2);
-    expect(issued[0]).toContain('mkdir -p "$HOME/.openmausbot/chrome-profile"');
-    expect(issued[0]).toContain('chmod 700 "$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('profile="$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain('chmod 700 "$profile"');
+    expect(issued[0]).toContain('cp -a -n "$browser_dir"/. "$profile"/');
+    expect(issued[0]).toContain('ln -s "$profile" "$browser_dir"');
     expect(issued[0]).toContain('--user-data-dir="$HOME/.openmausbot/chrome-profile"');
+    expect(issued[0]).toContain("--password-store=basic");
+    expect(issued[0]).toContain("--disable-session-crashed-bubble");
     expect(issued[0]).not.toContain("user:password@");
     expect(issued[0]).toContain("'https://example.com/requested?token=secret#fragment'");
     expect(result.result.content[0].text).toContain("https://example.com/landed");

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -51,9 +51,23 @@ const SETTLE_MS = 350;
 const ACTION_GAP_MS = 120;
 const CHROME_PROFILE = "$HOME/.openmausbot/chrome-profile";
 const CHROME_DEBUG_FLAGS =
-  `--user-data-dir="${CHROME_PROFILE}" --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
-const CHROME_PROFILE_SETUP =
-  `mkdir -p "${CHROME_PROFILE}" && chmod 700 "${CHROME_PROFILE}"`;
+  `--user-data-dir="${CHROME_PROFILE}" --password-store=basic --disable-session-crashed-bubble --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
+// Keep one durable browser identity regardless of which Chromium binary an
+// image supplies. Existing profiles are merged without overwriting files and
+// moved aside as backups before the conventional paths become symlinks.
+const CHROME_PROFILE_SETUP = [
+  `profile="${CHROME_PROFILE}"`,
+  'mkdir -p "$profile" "$HOME/.config"',
+  'chmod 700 "$profile"',
+  'for browser_dir in "$HOME/.config/google-chrome" "$HOME/.config/chromium"; do',
+  '  if [ -e "$browser_dir" ] && [ ! -L "$browser_dir" ]; then',
+  '    if [ -d "$browser_dir" ]; then cp -a -n "$browser_dir"/. "$profile"/ 2>/dev/null || true; fi',
+  '    mv "$browser_dir" "$browser_dir.pre-openmausbot-$(date +%s)-$$"',
+  "  fi",
+  '  if [ -L "$browser_dir" ]; then rm -f "$browser_dir"; fi',
+  '  ln -s "$profile" "$browser_dir"',
+  "done",
+].join("; ");
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -534,7 +548,7 @@ function actionShell(a: any): string | { error: string } {
   if (kind === "type_text") {
     const t = String(a.text ?? "");
     if (!t) return { error: "type_text needs text" };
-    return `xdotool type --delay 8 ${shellQuote(t)}`;
+    return `xdotool type --clearmodifiers --delay 8 -- ${shellQuote(t)}`;
   }
   if (kind === "press_key") {
     const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
@@ -743,7 +757,15 @@ async function handle(msg: any) {
     try {
       return await call(msg.id, msg.params?.name, msg.params?.arguments ?? {});
     } catch (e) {
-      return text(msg.id, `computer tool failed: ${(e as Error).message}`, true);
+      const error = e as Error;
+      const timedOut = error?.name === "TimeoutError" || /timed?\s*out|timeout/i.test(error?.message ?? "");
+      return text(
+        msg.id,
+        timedOut
+          ? "computer tool timed out. The action may or may not have completed; take a screenshot to inspect the current state before retrying it."
+          : `computer tool failed: ${error.message}`,
+        true,
+      );
     }
   }
   if (String(msg.method ?? "").startsWith("notifications/")) return;

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -10,7 +10,12 @@ import {
   CUA_SOCKET,
   DRIVER_LABEL,
   IMAGE,
+  IMAGE_LAYER_LABEL,
+  IMAGE_LAYER_VERSION,
   MANAGED_LABEL,
+  VM_WORKSPACE_DIR,
+  VM_WORKSPACE_GUEST,
+  WORKSPACE_LABEL,
   computerProxyEnv,
   containerComputerAction,
   containerComputerMcp,
@@ -50,6 +55,7 @@ function preparedImageInspect() {
           [MANAGED_LABEL]: "1",
           [DRIVER_LABEL]: CUA_DRIVER_VERSION,
           [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+          [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
         },
       },
     },
@@ -65,6 +71,8 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
           [MANAGED_LABEL]: "1",
           [DRIVER_LABEL]: CUA_DRIVER_VERSION,
           [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+          [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+          [WORKSPACE_LABEL]: "1",
         },
         Env: ["VNC_PW=secret123"],
       },
@@ -78,6 +86,14 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
         CapAdd: ["CAP_SETUID", "CAP_SETGID"],
         PortBindings: { "6901/tcp": [{ HostIp: "127.0.0.1" }] },
       },
+      Mounts: [
+        {
+          Type: "bind",
+          Source: VM_WORKSPACE_DIR,
+          Destination: VM_WORKSPACE_GUEST,
+          RW: true,
+        },
+      ],
       ...overrides,
     },
   ]);
@@ -122,6 +138,14 @@ describe("containerComputerStatus", () => {
             image: IMAGE,
             resources: { cpus: 2, memoryInBytes: 4 * 1024 * 1024 * 1024 },
             publishedPorts: [{ hostAddress: "127.0.0.1", containerPort: 6901 }],
+            labels: {
+              [MANAGED_LABEL]: "1",
+              [DRIVER_LABEL]: CUA_DRIVER_VERSION,
+              [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
+              [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+              [WORKSPACE_LABEL]: "1",
+            },
+            mounts: [{ source: VM_WORKSPACE_DIR, destination: VM_WORKSPACE_GUEST, options: [] }],
           },
           status: { state: "running" },
         },
@@ -162,6 +186,27 @@ describe("containerComputerStatus", () => {
     expect(status.ready).toBe(false);
   });
 
+  it("rejects missing or unexpected host mounts instead of exposing them to the bot", async () => {
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect({
+        Mounts: [
+          { Type: "bind", Source: VM_WORKSPACE_DIR, Destination: VM_WORKSPACE_GUEST, RW: true },
+          { Type: "bind", Source: "/tmp/unexpected", Destination: "/host", RW: true },
+        ],
+      }),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.persistence).toBe("unsafe");
+    expect(status.ready).toBe(false);
+    expect(status.problem).toContain("durable workspace");
+  });
+
   it("does not mistake an unrelated container executable for Apple container off macOS", async () => {
     const fake = runner({
       "where.exe docker": new Error("missing"),
@@ -192,6 +237,7 @@ describe("containerComputerStatus", () => {
       managed: true,
       network: "loopback",
       security: "hardened",
+      persistence: "durable",
       desktopReady: true,
       ready: true,
       problem: null,
@@ -266,6 +312,11 @@ describe("Cua integration", () => {
     expect(dockerfile).toContain(`install -D -m 0755 \"$driver_bin\" ${CUA_EXECUTABLE}`);
     expect(dockerfile).toContain(`cua-driver ${CUA_DRIVER_VERSION}`);
     expect(dockerfile).toContain(`serve --socket ${CUA_SOCKET} --permission-mode standard`);
+    expect(dockerfile).toContain("prepare-openmausbot-workspace.sh");
+    expect(dockerfile).toContain("migrate_profile google-chrome");
+    expect(dockerfile).toContain("migrate_profile chromium");
+    expect(dockerfile).toContain("SingletonLock");
+    expect(dockerfile).toContain(`${IMAGE_LAYER_LABEL}=\"${IMAGE_LAYER_VERSION}\"`);
   });
 
   it("captures the preview through Cua Driver rather than xdotool or VNC", async () => {
@@ -359,6 +410,18 @@ describe("setupCommands", () => {
     expect(command).toContain("--cap-drop ALL --cap-add SETUID --cap-add SETGID");
     expect(command).toContain(`--label ${MANAGED_LABEL}=1`);
     expect(command).toContain(`--label ${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`);
+    expect(command).toContain(`--label ${WORKSPACE_LABEL}=1`);
+    expect(command).toContain(`--hostname ${CONTAINER}`);
+    expect(command).toContain(
+      `--mount type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST}`,
+    );
+  });
+
+  it("asks rootless Podman to map and privately relabel the durable workspace", () => {
+    const command = setupCommands("podman", "linux").run!;
+    expect(command).toContain(
+      `--mount type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private,U=true`,
+    );
   });
 
   it("shows the pinned base pull while creating the managed derivative through the API", () => {

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -50,6 +50,7 @@ const statusProbe =
 function preparedImageInspect() {
   return JSON.stringify([
     {
+      Id: "sha256:managed-image-id",
       Config: {
         Labels: {
           [MANAGED_LABEL]: "1",
@@ -77,6 +78,7 @@ function readyInspect(overrides: Record<string, unknown> = {}) {
         Env: ["VNC_PW=secret123"],
       },
       State: { Running: true },
+      Image: "sha256:managed-image-id",
       HostConfig: {
         Memory: 4 * 1024 * 1024 * 1024,
         MemorySwap: 4 * 1024 * 1024 * 1024,
@@ -135,7 +137,7 @@ describe("containerComputerStatus", () => {
       [`container inspect ${CONTAINER}`]: JSON.stringify([
         {
           configuration: {
-            image: IMAGE,
+            image: { reference: IMAGE, descriptor: { digest: "sha256:managed-image-id" } },
             resources: { cpus: 2, memoryInBytes: 4 * 1024 * 1024 * 1024 },
             publishedPorts: [{ hostAddress: "127.0.0.1", containerPort: 6901 }],
             labels: {
@@ -239,11 +241,32 @@ describe("containerComputerStatus", () => {
       security: "hardened",
       persistence: "durable",
       desktopReady: true,
+      desktop_error: null,
       ready: true,
       problem: null,
       driver_version: "0.19.3",
     });
     expect(status.viewer_url).toContain("#autoconnect=true&resize=scale&password=secret123");
+  });
+
+  it("reports the bounded desktop startup error instead of waiting forever", async () => {
+    const errorProbe =
+      `docker exec ${CONTAINER} tail -n 4 /var/log/supervisor/cua-driver.error.log`;
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect(),
+      [versionProbe]: new Error("driver unavailable"),
+      [errorProbe]: "X display :1 did not become ready within 45 seconds\n",
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.desktopReady).toBe(false);
+    expect(status.desktop_error).toContain("did not become ready");
+    expect(status.problem).toContain("desktop failed to start");
   });
 
   it("rejects a lookalike container with a different driver or base-image label", async () => {
@@ -266,6 +289,23 @@ describe("containerComputerStatus", () => {
     expect(status.ready).toBe(false);
     expect(status.problem).toContain("older desktop or Cua Driver");
     expect(fake.calls).not.toContain(versionProbe);
+  });
+
+  it("rejects a container created from a stale build under the same mutable tag", async () => {
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect({ Image: "sha256:previous-build-id" }),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.image_id).toBe("managed-image-id");
+    expect(status.imageMatches).toBe(false);
+    expect(status.ready).toBe(false);
+    expect(status.problem).toContain("older desktop or Cua Driver");
   });
 
   it("does not treat an unlabelled image under the local tag as prepared", async () => {
@@ -317,6 +357,8 @@ describe("Cua integration", () => {
     expect(dockerfile).toContain("migrate_profile chromium");
     expect(dockerfile).toContain("SingletonLock");
     expect(dockerfile).toContain(`${IMAGE_LAYER_LABEL}=\"${IMAGE_LAYER_VERSION}\"`);
+    expect(dockerfile).toContain("did not become ready within 45 seconds");
+    expect(dockerfile).not.toContain("while ! DISPLAY=:1 xset q");
   });
 
   it("captures the preview through Cua Driver rather than xdotool or VNC", async () => {

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -8,13 +8,14 @@
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { augmentedPath } from "./env-path.ts";
+import { DATA_DIR } from "./config.ts";
 
 const run = promisify(execFile);
 
@@ -32,11 +33,16 @@ export const BASE_IMAGE = `${BASE_IMAGE_REPOSITORY}@${BASE_IMAGE_DIGEST}`;
 // This tag is built locally from the pinned Cua base. Image and container
 // labels below are the authoritative compatibility check, not the mutable tag.
 export const IMAGE_REPOSITORY = "openmausbot/cua-local-vm";
-export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}`;
+export const IMAGE_LAYER_VERSION = "2";
+export const IMAGE_LAYER_LABEL = "com.openmausbot.image-layer";
+export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}-v${IMAGE_LAYER_VERSION}`;
 export const CONTAINER = "openmausbot-computer";
 export const MANAGED_LABEL = "com.openmausbot.local-vm";
 export const DRIVER_LABEL = "com.openmausbot.cua-driver";
 export const BASE_IMAGE_LABEL = "com.openmausbot.cua-base";
+export const WORKSPACE_LABEL = "com.openmausbot.workspace";
+export const VM_WORKSPACE_DIR = join(DATA_DIR, "vm-home");
+export const VM_WORKSPACE_GUEST = "/home/cua/workspace";
 export const DISPLAY = ":1";
 export const CUA_SOCKET = "/run/user/1000/openmausbot-cua.sock";
 export const CUA_EXECUTABLE = "/usr/local/libexec/openmausbot/cua-driver";
@@ -82,9 +88,33 @@ RUN set -eux; \\
     driver_bin="$(find /opt/venv/lib -path '*/cua_driver/bin/cua-driver' -type f -print -quit)"; \\
     test -n "$driver_bin"; \\
     install -D -m 0755 "$driver_bin" ${CUA_EXECUTABLE}; \\
+    install -d -o cua -g cua -m 0700 ${VM_WORKSPACE_GUEST}; \\
     test "$(${CUA_EXECUTABLE} --version)" = "cua-driver ${CUA_DRIVER_VERSION}"
 RUN printf '%s\\n' \\
       '#!/bin/sh' \\
+      'set -eu' \\
+      'workspace=${VM_WORKSPACE_GUEST}' \\
+      'profiles="$workspace/.browser-profiles"' \\
+      'mkdir -p "$profiles/google-chrome" "$profiles/chromium" "$HOME/.config"' \\
+      'chmod 0700 "$workspace" "$profiles" "$profiles/google-chrome" "$profiles/chromium"' \\
+      'migrate_profile() {' \\
+      '  name="$1"' \\
+      '  source="$HOME/.config/$name"' \\
+      '  target="$profiles/$name"' \\
+      '  if [ -d "$source" ] && [ ! -L "$source" ] && [ -z "$(find "$target" -mindepth 1 -print -quit)" ]; then' \\
+      '    cp -a "$source"/. "$target"/' \\
+      '  fi' \\
+      '  rm -rf "$source"' \\
+      '  ln -s "$target" "$source"' \\
+      '}' \\
+      'migrate_profile google-chrome' \\
+      'migrate_profile chromium' \\
+      'find "$profiles" \\( -name SingletonLock -o -name SingletonSocket -o -name SingletonCookie -o -name .parentlock \\) -delete' \\
+      > /usr/local/bin/prepare-openmausbot-workspace.sh \\
+    && chmod 0755 /usr/local/bin/prepare-openmausbot-workspace.sh
+RUN printf '%s\\n' \\
+      '#!/bin/sh' \\
+      '/usr/local/bin/prepare-openmausbot-workspace.sh' \\
       'while ! DISPLAY=:1 xset q >/dev/null 2>&1; do sleep 1; done' \\
       'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
@@ -103,7 +133,8 @@ RUN printf '%s\\n' \\
       >> /etc/supervisor/supervisord.conf
 LABEL ${MANAGED_LABEL}="1" \\
       ${DRIVER_LABEL}="${CUA_DRIVER_VERSION}" \\
-      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}"
+      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}" \\
+      ${IMAGE_LAYER_LABEL}="${IMAGE_LAYER_VERSION}"
 `;
 }
 
@@ -141,6 +172,7 @@ export interface ContainerComputerStatus {
   container: "running" | "stopped" | "missing";
   network: "loopback" | "unsafe" | "unknown";
   security: "hardened" | "unsafe" | "unknown";
+  persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
   ready: boolean;
   problem: string | null;
@@ -148,6 +180,8 @@ export interface ContainerComputerStatus {
   base_image_ref: string;
   driver_version: string;
   container_name: string;
+  workspace_path: string;
+  workspace_guest_path: string;
   viewer_url: string;
 }
 
@@ -163,6 +197,7 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     container: "missing",
     network: "unknown",
     security: "unknown",
+    persistence: "unknown",
     desktopReady: false,
     ready: false,
     problem: "Install a supported container runtime first",
@@ -170,6 +205,8 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     base_image_ref: BASE_IMAGE,
     driver_version: CUA_DRIVER_VERSION,
     container_name: CONTAINER,
+    workspace_path: VM_WORKSPACE_DIR,
+    workspace_guest_path: VM_WORKSPACE_GUEST,
     viewer_url: `http://127.0.0.1:${HOST_VIEWER_PORT}/vnc.html`,
   };
 }
@@ -183,17 +220,23 @@ function statusProblem(status: ContainerComputerStatus): string | null {
   if (!status.managed) return "The existing container was not created by OpenMausBot; recreate it";
   if (status.network === "unsafe") return "The existing Local VM exposes its viewer publicly; recreate it";
   if (status.security === "unsafe") return "The existing Local VM is missing safety limits; recreate it";
+  if (status.persistence === "unsafe") return "The existing Local VM is missing its durable workspace; recreate it";
   if (status.container === "stopped") return "Start the Local VM";
   if (!status.desktopReady) return "The Local VM started, but Cua Driver is not ready yet";
   return null;
 }
 
-function labelsMatch(labels: Record<string, string> | undefined): boolean {
+function imageLabelsMatch(labels: Record<string, string> | undefined): boolean {
   return (
     labels?.[MANAGED_LABEL] === "1" &&
     labels?.[DRIVER_LABEL] === CUA_DRIVER_VERSION &&
-    labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST
+    labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST &&
+    labels?.[IMAGE_LAYER_LABEL] === IMAGE_LAYER_VERSION
   );
+}
+
+function containerLabelsMatch(labels: Record<string, string> | undefined): boolean {
+  return imageLabelsMatch(labels) && labels?.[WORKSPACE_LABEL] === "1";
 }
 
 function inspectedImageLabels(stdout: string): Record<string, string> | undefined {
@@ -273,7 +316,7 @@ export async function containerComputerStatus(
 
   try {
     const { stdout } = await runner(status.runtime, ["image", "inspect", IMAGE]);
-    status.image = labelsMatch(inspectedImageLabels(stdout));
+    status.image = imageLabelsMatch(inspectedImageLabels(stdout));
   } catch {
     // The prepared OpenMausBot derivative has not been built yet.
   }
@@ -288,6 +331,8 @@ export async function containerComputerStatus(
           resources?: { cpus?: number; memoryInBytes?: number };
           publishedPorts?: Array<{ hostAddress?: string; containerPort?: number }>;
           environment?: string[] | Record<string, string>;
+          labels?: Record<string, string>;
+          mounts?: Array<{ source?: string; destination?: string; options?: string[] }>;
         };
         status?: { state?: string };
       }>;
@@ -299,7 +344,10 @@ export async function containerComputerStatus(
           ? detail.configuration.image
           : detail?.configuration?.image?.reference ?? detail?.configuration?.imageReference;
       status.imageMatches = appleImage === IMAGE;
-      status.managed = status.imageMatches;
+      status.managed = containerLabelsMatch(detail?.configuration?.labels);
+      status.persistence = appleWorkspaceMountIsSafe(detail?.configuration?.mounts, platform)
+        ? "durable"
+        : "unsafe";
       const resources = detail?.configuration?.resources;
       status.security =
         (resources?.memoryInBytes ?? 0) >= MEMORY_BYTES && resources?.cpus === 2 ? "hardened" : "unsafe";
@@ -316,13 +364,20 @@ export async function containerComputerStatus(
           CapDrop?: string[] | null;
           CapAdd?: string[] | null;
         };
+        Mounts?: Array<{
+          Type?: string;
+          Source?: string;
+          Destination?: string;
+          RW?: boolean;
+        }>;
         State?: { Running?: boolean };
       }>;
       const detail = inspected[0];
       status.container = detail?.State?.Running ? "running" : "stopped";
       status.network = dockerPortsAreLocal(detail?.HostConfig?.PortBindings) ? "loopback" : "unsafe";
-      status.imageMatches = detail?.Config?.Image === IMAGE && labelsMatch(detail?.Config?.Labels);
-      status.managed = detail?.Config?.Labels?.[MANAGED_LABEL] === "1";
+      status.imageMatches = detail?.Config?.Image === IMAGE && imageLabelsMatch(detail?.Config?.Labels);
+      status.managed = containerLabelsMatch(detail?.Config?.Labels);
+      status.persistence = dockerWorkspaceMountIsSafe(detail?.Mounts, platform) ? "durable" : "unsafe";
       status.security = dockerSecurityIsHardened(detail?.HostConfig) ? "hardened" : "unsafe";
       status.viewer_url = viewerUrl(viewerPassword(detail?.Config?.Env));
     }
@@ -335,7 +390,8 @@ export async function containerComputerStatus(
     status.imageMatches &&
     status.managed &&
     status.network === "loopback" &&
-    status.security === "hardened";
+    status.security === "hardened" &&
+    status.persistence === "durable";
   if (canProbe) {
     try {
       const expected = `cua-driver ${CUA_DRIVER_VERSION}`;
@@ -375,6 +431,41 @@ function applePortsAreLocal(
   );
 }
 
+function sameWorkspaceSource(source: string | undefined, platform: NodeJS.Platform): boolean {
+  if (!source) return false;
+  const actual = resolve(source);
+  const expected = resolve(VM_WORKSPACE_DIR);
+  return platform === "win32" ? actual.toLowerCase() === expected.toLowerCase() : actual === expected;
+}
+
+function dockerWorkspaceMountIsSafe(
+  mounts:
+    | Array<{ Type?: string; Source?: string; Destination?: string; RW?: boolean }>
+    | undefined,
+  platform: NodeJS.Platform,
+): boolean {
+  return Boolean(
+    mounts?.length === 1 &&
+      mounts[0]?.Type === "bind" &&
+      sameWorkspaceSource(mounts[0]?.Source, platform) &&
+      mounts[0]?.Destination === VM_WORKSPACE_GUEST &&
+      mounts[0]?.RW !== false,
+  );
+}
+
+function appleWorkspaceMountIsSafe(
+  mounts: Array<{ source?: string; destination?: string; options?: string[] }> | undefined,
+  platform: NodeJS.Platform,
+): boolean {
+  const options = mounts?.[0]?.options ?? [];
+  return Boolean(
+    mounts?.length === 1 &&
+      sameWorkspaceSource(mounts[0]?.source, platform) &&
+      mounts[0]?.destination === VM_WORKSPACE_GUEST &&
+      !options.some((option) => option === "ro" || option === "readonly"),
+  );
+}
+
 function dockerSecurityIsHardened(
   config:
     | {
@@ -405,6 +496,18 @@ function dockerSecurityIsHardened(
 
 export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): string[] {
   const common = ["run", "-d", "--name", CONTAINER];
+  common.push(
+    "--label",
+    `${MANAGED_LABEL}=1`,
+    "--label",
+    `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`,
+    "--label",
+    `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`,
+    "--label",
+    `${IMAGE_LAYER_LABEL}=${IMAGE_LAYER_VERSION}`,
+    "--label",
+    `${WORKSPACE_LABEL}=1`,
+  );
   if (runtime === "container") {
     // Apple container already places each Linux container in a lightweight VM.
     common.push(
@@ -423,12 +526,8 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     );
   } else {
     common.push(
-      "--label",
-      `${MANAGED_LABEL}=1`,
-      "--label",
-      `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`,
-      "--label",
-      `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`,
+      "--hostname",
+      CONTAINER,
       "--memory",
       "4g",
       "--memory-swap",
@@ -448,6 +547,10 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     );
   }
   common.push(
+    "--mount",
+    runtime === "podman"
+      ? `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private,U=true`
+      : `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST}`,
     "-e",
     `VNC_PW=${password}`,
     "-p",
@@ -455,6 +558,11 @@ export function containerRunArgs(runtime: Runtime, password = "CHANGE_ME"): stri
     IMAGE,
   );
   return common;
+}
+
+async function ensureVmWorkspace(platform: NodeJS.Platform): Promise<void> {
+  await mkdir(VM_WORKSPACE_DIR, { recursive: true, mode: 0o700 });
+  if (platform !== "win32") await chmod(VM_WORKSPACE_DIR, 0o700);
 }
 
 async function prepareManagedImage(runtime: Runtime, runner: CommandRunner): Promise<void> {
@@ -506,6 +614,7 @@ export async function containerComputerAction(
   if (action === "pull") {
     await prepareManagedImage(runtime, runner);
   } else {
+    if (action === "run") await ensureVmWorkspace(platform);
     const args =
       action === "run"
         ? containerRunArgs(runtime, randomBytes(6).toString("base64url"))

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -18,6 +18,7 @@ import { augmentedPath } from "./env-path.ts";
 import { DATA_DIR } from "./config.ts";
 
 const run = promisify(execFile);
+const SCREENSHOT_STATUS_TTL_MS = 10_000;
 
 export type CommandRunner = (
   command: string,
@@ -115,7 +116,12 @@ RUN printf '%s\\n' \\
 RUN printf '%s\\n' \\
       '#!/bin/sh' \\
       '/usr/local/bin/prepare-openmausbot-workspace.sh' \\
-      'while ! DISPLAY=:1 xset q >/dev/null 2>&1; do sleep 1; done' \\
+      'attempt=0' \\
+      'until DISPLAY=:1 xset q >/dev/null 2>&1; do' \\
+      '  attempt=$((attempt + 1))' \\
+      '  if [ "$attempt" -ge 45 ]; then echo "X display :1 did not become ready within 45 seconds" >&2; exit 1; fi' \\
+      '  sleep 1' \\
+      'done' \\
       'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
     && chmod 0755 /usr/local/bin/start-openmausbot-cua-driver.sh
@@ -174,9 +180,11 @@ export interface ContainerComputerStatus {
   security: "hardened" | "unsafe" | "unknown";
   persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
+  desktop_error: string | null;
   ready: boolean;
   problem: string | null;
   image_ref: string;
+  image_id: string | null;
   base_image_ref: string;
   driver_version: string;
   container_name: string;
@@ -199,9 +207,11 @@ function emptyStatus(platform: NodeJS.Platform): ContainerComputerStatus {
     security: "unknown",
     persistence: "unknown",
     desktopReady: false,
+    desktop_error: null,
     ready: false,
     problem: "Install a supported container runtime first",
     image_ref: IMAGE,
+    image_id: null,
     base_image_ref: BASE_IMAGE,
     driver_version: CUA_DRIVER_VERSION,
     container_name: CONTAINER,
@@ -222,6 +232,7 @@ function statusProblem(status: ContainerComputerStatus): string | null {
   if (status.security === "unsafe") return "The existing Local VM is missing safety limits; recreate it";
   if (status.persistence === "unsafe") return "The existing Local VM is missing its durable workspace; recreate it";
   if (status.container === "stopped") return "Start the Local VM";
+  if (status.desktop_error) return `The Local VM desktop failed to start: ${status.desktop_error}`;
   if (!status.desktopReady) return "The Local VM started, but Cua Driver is not ready yet";
   return null;
 }
@@ -239,14 +250,27 @@ function containerLabelsMatch(labels: Record<string, string> | undefined): boole
   return imageLabelsMatch(labels) && labels?.[WORKSPACE_LABEL] === "1";
 }
 
-function inspectedImageLabels(stdout: string): Record<string, string> | undefined {
+function normalizeImageId(id: string | undefined): string | null {
+  return id?.trim().replace(/^sha256:/, "") || null;
+}
+
+function inspectedImage(stdout: string): {
+  labels: Record<string, string> | undefined;
+  id: string | null;
+} {
   const parsed = JSON.parse(stdout) as Array<{
+    Id?: string;
+    id?: string;
     Config?: { Labels?: Record<string, string> };
     config?: { Labels?: Record<string, string>; labels?: Record<string, string> };
-    configuration?: { labels?: Record<string, string> };
+    configuration?: { labels?: Record<string, string>; descriptor?: { digest?: string } };
   }>;
   const image = parsed[0];
-  return image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels;
+  return {
+    labels:
+      image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels,
+    id: normalizeImageId(image?.Id ?? image?.id ?? image?.configuration?.descriptor?.digest),
+  };
 }
 
 function viewerPassword(env: string[] | Record<string, string> | undefined): string | null {
@@ -316,7 +340,9 @@ export async function containerComputerStatus(
 
   try {
     const { stdout } = await runner(status.runtime, ["image", "inspect", IMAGE]);
-    status.image = imageLabelsMatch(inspectedImageLabels(stdout));
+    const image = inspectedImage(stdout);
+    status.image = imageLabelsMatch(image.labels);
+    status.image_id = image.id;
   } catch {
     // The prepared OpenMausBot derivative has not been built yet.
   }
@@ -326,7 +352,7 @@ export async function containerComputerStatus(
     if (status.runtime === "container") {
       const inspected = JSON.parse(stdout) as Array<{
         configuration?: {
-          image?: string | { reference?: string };
+          image?: string | { reference?: string; descriptor?: { digest?: string } };
           imageReference?: string;
           resources?: { cpus?: number; memoryInBytes?: number };
           publishedPorts?: Array<{ hostAddress?: string; containerPort?: number }>;
@@ -343,7 +369,12 @@ export async function containerComputerStatus(
         typeof detail?.configuration?.image === "string"
           ? detail.configuration.image
           : detail?.configuration?.image?.reference ?? detail?.configuration?.imageReference;
-      status.imageMatches = appleImage === IMAGE;
+      const appleImageId =
+        typeof detail?.configuration?.image === "object"
+          ? normalizeImageId(detail.configuration.image.descriptor?.digest)
+          : null;
+      status.imageMatches =
+        appleImage === IMAGE && status.image_id !== null && appleImageId === status.image_id;
       status.managed = containerLabelsMatch(detail?.configuration?.labels);
       status.persistence = appleWorkspaceMountIsSafe(detail?.configuration?.mounts, platform)
         ? "durable"
@@ -371,11 +402,16 @@ export async function containerComputerStatus(
           RW?: boolean;
         }>;
         State?: { Running?: boolean };
+        Image?: string;
       }>;
       const detail = inspected[0];
       status.container = detail?.State?.Running ? "running" : "stopped";
       status.network = dockerPortsAreLocal(detail?.HostConfig?.PortBindings) ? "loopback" : "unsafe";
-      status.imageMatches = detail?.Config?.Image === IMAGE && imageLabelsMatch(detail?.Config?.Labels);
+      status.imageMatches =
+        detail?.Config?.Image === IMAGE &&
+        imageLabelsMatch(detail?.Config?.Labels) &&
+        status.image_id !== null &&
+        normalizeImageId(detail?.Image) === status.image_id;
       status.managed = containerLabelsMatch(detail?.Config?.Labels);
       status.persistence = dockerWorkspaceMountIsSafe(detail?.Mounts, platform) ? "durable" : "unsafe";
       status.security = dockerSecurityIsHardened(detail?.HostConfig) ? "hardened" : "unsafe";
@@ -400,7 +436,19 @@ export async function containerComputerStatus(
       await runner(status.runtime, cuaExecArgs(["status", "--socket", CUA_SOCKET]), 8000);
       status.desktopReady = true;
     } catch {
-      // XFCE and the supervisor-owned Cua daemon need a few seconds to start.
+      // An empty log means XFCE and the supervisor-owned Cua daemon are
+      // probably still starting. A real startup failure should be actionable
+      // in the panel instead of looking like an endless readiness wait.
+      try {
+        const errorLog = await runner(
+          status.runtime,
+          ["exec", CONTAINER, "tail", "-n", "4", "/var/log/supervisor/cua-driver.error.log"],
+          4000,
+        );
+        status.desktop_error = errorLog.stdout.replace(/\s+/g, " ").trim().slice(0, 320) || null;
+      } catch {
+        // The log may not exist during the first seconds of container boot.
+      }
     }
   }
 
@@ -581,6 +629,7 @@ export async function containerComputerAction(
   runner: CommandRunner = sh,
   platform: NodeJS.Platform = process.platform,
 ): Promise<ContainerComputerStatus> {
+  if (runner === sh && platform === process.platform) screenshotStatusCache = null;
   const before = await containerComputerStatus(runner, platform);
   const runtime = before.runtime;
   if (!runtime) throw Object.assign(new Error(before.problem ?? "No container runtime is installed"), { status: 409 });
@@ -646,10 +695,17 @@ export async function containerComputerScreenshot(
   runner: CommandRunner = sh,
   platform: NodeJS.Platform = process.platform,
 ): Promise<string> {
-  const status = await containerComputerStatus(runner, platform);
+  const cacheable = runner === sh && platform === process.platform;
+  const now = Date.now();
+  const status =
+    cacheable && screenshotStatusCache && screenshotStatusCache.expiresAt > now
+      ? screenshotStatusCache.status
+      : await containerComputerStatus(runner, platform);
   if (!status.ready || !status.runtime) {
+    if (cacheable) screenshotStatusCache = null;
     throw Object.assign(new Error(status.problem ?? "The Local VM is not ready"), { status: 409 });
   }
+  if (cacheable) screenshotStatusCache = { status, expiresAt: now + SCREENSHOT_STATUS_TTL_MS };
   const screenshot = "/tmp/openmausbot-preview.png";
   await runner(
     status.runtime,
@@ -672,6 +728,8 @@ export async function containerComputerScreenshot(
   }
   return `data:${checked.mime};base64,${data}`;
 }
+
+let screenshotStatusCache: { status: ContainerComputerStatus; expiresAt: number } | null = null;
 
 const containerMcpPath = (() => {
   const ts = join(dirname(fileURLToPath(import.meta.url)), "container-mcp.ts");

--- a/server/index.ts
+++ b/server/index.ts
@@ -885,7 +885,7 @@ async function startTurn(
         system:
           persona +
           (computerKind === "vm"
-            ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine with no host folders mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
+            ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine. Only /home/cua/workspace is durable; save downloads, repositories, working files, and browser profiles there because everything else inside the VM is disposable. No other host folder is mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
             : computerKind === "box" && instance.driverKind !== "boxAgent"
               ? " You have your own cloud computer — use screenshot, click, type_text, open_url and computer_exec whenever a desktop helps. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable sequences with computer_batch."
               : computerKind === "local"

--- a/server/index.ts
+++ b/server/index.ts
@@ -899,6 +899,9 @@ async function startTurn(
               : computerKind === "local"
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
               : "") +
+          (computerKind
+            ? " At a sign-in, password, MFA, CAPTCHA, or other protected-input step, stop and ask the user to complete it on the visible computer. Never type their password or ask them to paste a password or one-time code into chat."
+            : "") +
           // gated on the integration, not the key: the hint only goes to a
           // bot whose driver actually mounted the tools
           (integrations.composio

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { LocalVmLease } from "./local-vm-lease.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
 import { listenWebhookIngress, webhookCredential, type WebhookIngress } from "./webhook-ingress.ts";
@@ -334,10 +335,13 @@ let routines: RoutineManager | null = null;
 // The Local VM is intentionally one shared, visible desktop. Two agents
 // driving it simultaneously would mix clicks, keystrokes and screenshots,
 // so only one thread may lease it at a time.
-let activeVmThreadId: string | null = null;
+const localVmLease = new LocalVmLease(30 * 60_000);
+const localVmOwnerBusy = (botId: string) => store.bot(botId)?.busy === true;
 let localVmLifecycleBusy = false;
 
 bus.subscribe((event: RuntimeEvent) => {
+  localVmLease.touch(event.threadId);
+  if (event.type === "turn.completed") localVmLease.release(event.threadId);
   broadcast({ kind: "runtime", event });
   routines?.handleRuntimeEvent(event);
   const bot = store.botByThread(event.threadId);
@@ -503,7 +507,6 @@ bus.subscribe((event: RuntimeEvent) => {
       });
       break;
     case "turn.completed": {
-      if (activeVmThreadId === event.threadId) activeVmThreadId = null;
       const reply = lastReply.get(event.threadId) ?? "";
       lastReply.delete(event.threadId);
       if (bot) {
@@ -777,14 +780,19 @@ async function startTurn(
         if (!mountsComputerMcp || instance.driverKind === "boxAgent") {
           throw new Error("this model engine cannot use the Local VM — choose Claude or an ACP engine, or select another computer destination");
         }
+        if (localVmLifecycleBusy) {
+          throw new Error("the Local VM is being started, stopped, or replaced — wait for setup to finish");
+        }
+        // Claim before the first await. The lifecycle route performs its
+        // matching check synchronously, so neither side can enter while the
+        // other is between inspection and mutation.
+        if (!localVmLease.claim(threadId, bot.id, localVmOwnerBusy)) {
+          throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
+        }
         const localVm = await containerComputerStatus();
         if (!localVm.ready || !localVm.runtime) {
           throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
         }
-        if (activeVmThreadId && activeVmThreadId !== threadId) {
-          throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
-        }
-        activeVmThreadId = threadId;
         integrations.localComputer = containerComputerMcp(localVm.runtime);
         computerKind = "vm";
       } else if (wants === "local") {
@@ -911,7 +919,7 @@ async function startTurn(
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
       if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
-      if (activeVmThreadId === threadId) activeVmThreadId = null;
+      localVmLease.release(threadId);
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(threadId, {
         role: "bot",
@@ -2093,7 +2101,8 @@ const server = createServer(async (req, res) => {
       if (localVmLifecycleBusy) {
         return json(res, 409, { error: "another Local VM setup action is still running" });
       }
-      if (activeVmThreadId && (action === "stop" || action === "remove" || action === "run")) {
+      const vmOwner = localVmLease.current(localVmOwnerBusy);
+      if (vmOwner && (action === "stop" || action === "remove" || action === "run")) {
         return json(res, 409, { error: "the Local VM is being used by a bot — stop that turn first" });
       }
       localVmLifecycleBusy = true;

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { LocalVmIdleTimer } from "./local-vm-idle.ts";
 import { LocalVmLease } from "./local-vm-lease.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
@@ -338,10 +339,38 @@ let routines: RoutineManager | null = null;
 const localVmLease = new LocalVmLease(30 * 60_000);
 const localVmOwnerBusy = (botId: string) => store.bot(botId)?.busy === true;
 let localVmLifecycleBusy = false;
+let localVmActiveThread: string | null = null;
+const LOCAL_VM_IDLE_MS = 8 * 60 * 60_000;
+const localVmIdle = new LocalVmIdleTimer(
+  LOCAL_VM_IDLE_MS,
+  () => localVmLifecycleBusy || localVmActiveThread !== null,
+  async () => {
+    // Fence lifecycle and turn dispatch before the first runtime inspection.
+    localVmLifecycleBusy = true;
+    try {
+      const status = await containerComputerStatus();
+      if (status.container === "running") await containerComputerAction("stop");
+    } finally {
+      localVmLifecycleBusy = false;
+    }
+  },
+);
+
+// A running VM may have survived an app/server restart. Start its idle
+// backstop even if nobody opens Settings or begins a turn this session.
+void containerComputerStatus()
+  .then((status) => {
+    if (status.container === "running") localVmIdle.touch();
+  })
+  .catch(() => null);
 
 bus.subscribe((event: RuntimeEvent) => {
   localVmLease.touch(event.threadId);
-  if (event.type === "turn.completed") localVmLease.release(event.threadId);
+  if (localVmActiveThread === event.threadId) localVmIdle.touch();
+  if (event.type === "turn.completed") {
+    localVmLease.release(event.threadId);
+    if (localVmActiveThread === event.threadId) localVmActiveThread = null;
+  }
   broadcast({ kind: "runtime", event });
   routines?.handleRuntimeEvent(event);
   const bot = store.botByThread(event.threadId);
@@ -789,6 +818,8 @@ async function startTurn(
         if (!localVmLease.claim(threadId, bot.id, localVmOwnerBusy)) {
           throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
         }
+        localVmActiveThread = threadId;
+        localVmIdle.touch();
         const localVm = await containerComputerStatus();
         if (!localVm.ready || !localVm.runtime) {
           throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
@@ -923,6 +954,7 @@ async function startTurn(
       if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
       localVmLease.release(threadId);
+      if (localVmActiveThread === threadId) localVmActiveThread = null;
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(threadId, {
         role: "bot",
@@ -2089,7 +2121,7 @@ const server = createServer(async (req, res) => {
     // its daemon is up, and whether the desktop image and container exist
     if (method === "GET" && path === "/api/local-computer") {
       const status = await containerComputerStatus();
-      return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+      return json(res, 200, { ...status, commands: setupCommands(status.runtime), idle_timeout_ms: LOCAL_VM_IDLE_MS });
     }
     m = path.match(/^\/api\/local-computer\/(pull|run|start|stop|remove)$/);
     if (m && method === "POST") {
@@ -2111,12 +2143,19 @@ const server = createServer(async (req, res) => {
       localVmLifecycleBusy = true;
       try {
         const status = await containerComputerAction(action);
-        return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+        if (action === "run" || action === "start") localVmIdle.touch();
+        if (action === "stop" || action === "remove") localVmIdle.cancel();
+        return json(res, 200, {
+          ...status,
+          commands: setupCommands(status.runtime),
+          idle_timeout_ms: LOCAL_VM_IDLE_MS,
+        });
       } finally {
         localVmLifecycleBusy = false;
       }
     }
     if (method === "POST" && path === "/api/local-computer/screenshot") {
+      localVmIdle.touch();
       return json(res, 200, { image: await containerComputerScreenshot() });
     }
 
@@ -2306,6 +2345,7 @@ server.listen(PORT, "127.0.0.1", () => {
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
+    localVmIdle.cancel();
     routines?.stop();
     webhookIngress?.server.close();
     void registry.disposeAll().finally(() => process.exit(0));

--- a/server/local-vm-idle.test.ts
+++ b/server/local-vm-idle.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocalVmIdleTimer } from "./local-vm-idle.ts";
+
+describe("LocalVmIdleTimer", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("suspends only after a complete idle window", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("renews the deadline on activity", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(700);
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(700);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("never suspends active work and retries after another full window", async () => {
+    let busy = true;
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => busy, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).not.toHaveBeenCalled();
+    busy = false;
+    await vi.advanceTimersByTimeAsync(999);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("can be cancelled after a manual stop", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+    idle.touch();
+    idle.cancel();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+
+  it("re-arms after a transient suspension failure", async () => {
+    const suspend = vi.fn().mockRejectedValueOnce(new Error("runtime unavailable")).mockResolvedValue(undefined);
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/local-vm-idle.ts
+++ b/server/local-vm-idle.ts
@@ -1,0 +1,45 @@
+/** Renewable idle deadline for the shared Local VM.
+ *
+ * Activity resets the full window. Expiry is reversible (the caller stops,
+ * never removes, the VM), and an active turn or lifecycle operation defers
+ * suspension for another full window instead of racing current work.
+ */
+export class LocalVmIdleTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly idleMs: number;
+  private readonly isBusy: () => boolean;
+  private readonly suspend: () => Promise<void>;
+
+  constructor(idleMs: number, isBusy: () => boolean, suspend: () => Promise<void>) {
+    if (!Number.isFinite(idleMs) || idleMs <= 0) throw new Error("Local VM idle timeout must be positive");
+    this.idleMs = idleMs;
+    this.isBusy = isBusy;
+    this.suspend = suspend;
+  }
+
+  touch(): void {
+    this.cancel();
+    this.timer = setTimeout(() => void this.expire(), this.idleMs);
+    this.timer.unref?.();
+  }
+
+  cancel(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private async expire(): Promise<void> {
+    this.timer = null;
+    if (this.isBusy()) {
+      this.touch();
+      return;
+    }
+    try {
+      await this.suspend();
+    } catch {
+      // A transient runtime failure must not disable the cost/resource
+      // backstop forever. Retry after a fresh full idle window.
+      this.touch();
+    }
+  }
+}

--- a/server/local-vm-lease.test.ts
+++ b/server/local-vm-lease.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { LocalVmLease } from "./local-vm-lease.ts";
+
+describe("LocalVmLease", () => {
+  it("serializes different threads while letting the owner renew", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+
+    expect(lease.claim("thread-a", "bot-a", busy, 1_000)).toBe(true);
+    expect(lease.claim("thread-b", "bot-b", busy, 1_001)).toBe(false);
+    expect(lease.claim("thread-a", "bot-a", busy, 1_002)).toBe(true);
+    expect(lease.current(busy, 1_050)).toMatchObject({ threadId: "thread-a", botId: "bot-a" });
+  });
+
+  it("expires a wedged owner and allows recovery", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+
+    expect(lease.current(busy, 1_100)).toBeNull();
+    expect(lease.claim("thread-b", "bot-b", busy, 1_100)).toBe(true);
+  });
+
+  it("refreshes on owner activity and releases when its bot settles", () => {
+    const lease = new LocalVmLease(100);
+    let ownerBusy = true;
+    const busy = () => ownerBusy;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+    lease.touch("thread-a", 1_090);
+    expect(lease.current(busy, 1_150)).not.toBeNull();
+
+    ownerBusy = false;
+    expect(lease.current(busy, 1_151)).toBeNull();
+  });
+
+  it("only lets the owning thread release the lease", () => {
+    const lease = new LocalVmLease(100);
+    const busy = () => true;
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+
+    lease.release("thread-b");
+    expect(lease.current(busy, 1_001)).not.toBeNull();
+    lease.release("thread-a");
+    expect(lease.current(busy, 1_002)).toBeNull();
+  });
+});

--- a/server/local-vm-lease.ts
+++ b/server/local-vm-lease.ts
@@ -1,0 +1,44 @@
+export interface LocalVmLeaseRecord {
+  threadId: string;
+  botId: string;
+  expiresAt: number;
+}
+
+/** A short, renewable ownership fence for the one shared Local VM desktop.
+ * Runtime events keep an active turn's lease alive; a dead provider cannot
+ * pin the VM forever. All methods are synchronous so lifecycle routes and
+ * turn dispatch can claim their side of the race before either awaits. */
+export class LocalVmLease {
+  private record: LocalVmLeaseRecord | null = null;
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number) {
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) throw new Error("Local VM lease TTL must be positive");
+    this.ttlMs = ttlMs;
+  }
+
+  current(isBotBusy: (botId: string) => boolean, now = Date.now()): LocalVmLeaseRecord | null {
+    if (this.record && (this.record.expiresAt <= now || !isBotBusy(this.record.botId))) this.record = null;
+    return this.record ? { ...this.record } : null;
+  }
+
+  claim(
+    threadId: string,
+    botId: string,
+    isBotBusy: (ownerBotId: string) => boolean,
+    now = Date.now(),
+  ): boolean {
+    const current = this.current(isBotBusy, now);
+    if (current && current.threadId !== threadId) return false;
+    this.record = { threadId, botId, expiresAt: now + this.ttlMs };
+    return true;
+  }
+
+  touch(threadId: string, now = Date.now()): void {
+    if (this.record?.threadId === threadId) this.record.expiresAt = now + this.ttlMs;
+  }
+
+  release(threadId: string): void {
+    if (this.record?.threadId === threadId) this.record = null;
+  }
+}

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -27,6 +27,7 @@ interface Status {
   container: "running" | "stopped" | "missing";
   network: "loopback" | "unsafe" | "unknown";
   security: "hardened" | "unsafe" | "unknown";
+  persistence: "durable" | "unsafe" | "unknown";
   desktopReady: boolean;
   ready: boolean;
   problem: string | null;
@@ -34,6 +35,8 @@ interface Status {
   base_image_ref: string;
   driver_version: string;
   container_name: string;
+  workspace_path: string;
+  workspace_guest_path: string;
   viewer_url: string;
   commands: {
     install: string | null;
@@ -149,10 +152,13 @@ export function LocalComputerSection() {
   };
 
   const act = async (action: Action) => {
-    if (action === "remove" && !window.confirm("Delete the Local VM and everything stored inside it?")) return;
+    if (
+      action === "remove" &&
+      !window.confirm("Delete the Local VM? Files and browser sign-ins in its durable workspace will remain.")
+    ) return;
     if (
       action === "recreate" &&
-      !window.confirm("Delete the existing Local VM and recreate it with the pinned image and safety limits? Anything stored inside it will be lost.")
+      !window.confirm("Replace the existing Local VM with the pinned image and safety limits? Files and browser sign-ins in its durable workspace will remain.")
     ) return;
     setPending(action);
     setError(null);
@@ -178,7 +184,11 @@ export function LocalComputerSection() {
   const existing = status?.container !== "missing";
   const needsRecreate = Boolean(
     existing &&
-      (!status?.imageMatches || !status?.managed || status?.network === "unsafe" || status?.security === "unsafe"),
+      (!status?.imageMatches ||
+        !status?.managed ||
+        status?.network === "unsafe" ||
+        status?.security === "unsafe" ||
+        status?.persistence === "unsafe"),
   );
   const unavailable = !loading && !status;
   const host = status?.platform === "darwin" ? "Mac" : "computer";
@@ -187,7 +197,7 @@ export function LocalComputerSection() {
     <>
       <Card
         title="Local VM"
-        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, disposable, and separate from your own screen and files.`}
+        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, isolated, and backed by one durable workspace.`}
       >
         <div className="flex flex-wrap items-center gap-2">
           <span
@@ -295,7 +305,7 @@ export function LocalComputerSection() {
 
       <Card
         title="Safety and storage"
-        subtitle="Cua Driver operates only the VM's desktop. No host folders are mounted, and the password-protected viewer is available only on this machine. Docker and Podman runs are limited to 4 GB memory, 2 CPUs and 512 processes; all Linux capabilities are dropped except the two the desktop supervisor needs to switch to its unprivileged user. The VM can still reach the internet, and bots share it one at a time."
+        subtitle={`Cua Driver operates only the VM's desktop. Exactly one private host folder is mounted at ${status?.workspace_guest_path ?? "/home/cua/workspace"}; files and browser profiles there survive VM replacement, while everything elsewhere in the VM remains disposable. The password-protected viewer is available only on this machine. Docker and Podman runs are limited to 4 GB memory, 2 CPUs and 512 processes; all Linux capabilities are dropped except the two the desktop supervisor needs to switch to its unprivileged user. The VM can still reach the internet, and bots share it one at a time.`}
       >
         {existing && (
           <div className="flex flex-wrap gap-2">
@@ -310,6 +320,7 @@ export function LocalComputerSection() {
           </div>
         )}
         <div className="mt-3 break-all text-[11px] text-ink-secondary">
+          Durable workspace: {status?.workspace_path ?? "not created"} ·{" "}
           Cua Driver: {status?.driver_version ?? "0.19.3"} · Local image: {status?.image_ref ?? "not prepared"}
           {status?.base_image_ref ? <> · Base: {status.base_image_ref}</> : null}
         </div>

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -38,6 +38,7 @@ interface Status {
   workspace_path: string;
   workspace_guest_path: string;
   viewer_url: string;
+  idle_timeout_ms: number;
   commands: {
     install: string | null;
     runtimeStart: string | null;
@@ -197,7 +198,7 @@ export function LocalComputerSection() {
     <>
       <Card
         title="Local VM"
-        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, isolated, and backed by one durable workspace.`}
+        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — isolated, backed by one durable workspace, and automatically stopped after 8 hours without activity.`}
       >
         <div className="flex flex-wrap items-center gap-2">
           <span


### PR DESCRIPTION
## Summary

- automatically stop a running Local VM after 8 hours without activity
- renew the idle window for bot runtime events, VM starts, and preview screenshots
- restore the timer for a VM that survived an app restart
- defer suspension while a bot turn or lifecycle operation is active
- cancel the timer after an explicit stop or removal
- explain the behavior in Local VM settings

The backstop only stops the container. It never removes the VM, image, or durable workspace, so starting again is reversible.

## Verification

- `pnpm test` (457 passed, 8 skipped; updater tests 11 passed)
- `pnpm build`
- deterministic timer tests cover renewal, active-work deferral, cancellation, and retry after transient failure

## Merge order

This is stacked on #155. Merge #151, #153, #154, #155, then this PR.
