### PR TITLE
Harden local and remote CUA computer use

### DIFF
--- a/dist-server/box.js
+++ b/dist-server/box.js
@@ -1,3 +1,4 @@
+import { ensureRemoteCuaCommand, remoteComputerBootstrapCommand } from "./remote-computer.js";
 // overridable so tests can point at a stub instead of the live provider
 const BOX_API = process.env.OMB_BOX_API || "https://ascii.dev/api/box/v1";
 const READY = new Set(["idle", "ready", "running"]);
@@ -176,61 +177,64 @@ export async function provisionBox(cfg, botId, botName) {
     const vmName = await boxNameFor(botId);
     let box = await findBox(cfg, botId);
     let created = false;
-    if (!box) {
-        const createRes = await boxJson(cfg, "/boxes", {
-            method: "POST",
-            // substrate-side backstop: archives itself (billing pauses, disk
-            // survives) if every stop path dies
-            body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
-        });
-        if (!createRes.ok || !createRes.body?.box?.id) {
-            throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+    try {
+        if (!box) {
+            const createRes = await boxJson(cfg, "/boxes", {
+                method: "POST",
+                // substrate-side backstop: archives itself (billing pauses, disk
+                // survives) if every stop path dies
+                // The computer needs the user's desktop session, not the account
+                // owner's host credentials. Keep provider-side env injection off so
+                // API keys cannot silently appear inside the guest.
+                body: JSON.stringify({ ttlSeconds: 8 * 60 * 60, noEnv: true }),
+            });
+            if (!createRes.ok || !createRes.body?.box?.id) {
+                throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
+            }
+            box = createRes.body.box;
+            created = true;
+            const rename = await boxJson(cfg, `/boxes/${box.id}`, {
+                method: "PATCH",
+                body: JSON.stringify({ name: vmName }),
+            });
+            if (!rename.ok)
+                throw new Error(boxErrorMessage(rename.status, "box naming", rename.body));
         }
-        box = createRes.body.box;
-        created = true;
-        await boxJson(cfg, `/boxes/${box.id}`, { method: "PATCH", body: JSON.stringify({ name: vmName }) });
+        const ready = await waitReady(cfg, box.id);
+        if (!ready)
+            throw new Error("box did not become ready within 90s — retry in a minute");
+        // Install the exact Cua Driver executable in the background, keep its
+        // daemon private to the VM, and retain X11 tooling as a degraded fallback.
+        const bootstrap = remoteComputerBootstrapCommand(botName);
+        let boot;
+        for (let attempt = 0; attempt < 5; attempt++) {
+            boot = await runCommand(cfg, box.id, bootstrap);
+            if (boot.ok || boot.exitCode !== null)
+                break;
+            await new Promise((r) => setTimeout(r, 3000));
+        }
+        if (!boot?.ok) {
+            const detail = boot?.stderr?.slice(0, 200) || (boot?.exitCode != null ? `exit ${boot.exitCode}` : "no response");
+            throw new Error(`box setup failed: ${detail}`);
+        }
+        const joinUrl = await mintDesktopUrl(cfg, box.id);
+        if (!joinUrl)
+            throw new Error("box desktop link could not be created");
+        return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
     }
-    const ready = await waitReady(cfg, box.id);
-    if (!ready)
-        throw new Error("box did not become ready within 90s — retry in a minute");
-    // Idempotent bootstrap. Three layers:
-    //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
-    //      always-works fallback for the computer tools.
-    //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
-    //      the BACKGROUND (first install takes minutes; nohup'd children
-    //      survive the commands endpoint returning — probed by agentcal).
-    //   3. computer-server started loopback-only on :8000 when installed —
-    //      driven from outside via the box's run-command endpoint, so no
-    //      inbound port and no tunnel is ever needed.
-    const cuaInstall = [
-        "sudo apt-get update -qq || true",
-        "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
-        'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
-        'export PATH="$HOME/.local/bin:$PATH"',
-        'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
-        "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
-        "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
-        "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
-    ].join("; ");
-    const bootstrap = [
-        "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
-        `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
-        // start CUA computer-server (loopback only) once installed; pidfile-free
-        // guard on the module name is safe here — the pattern cannot match this
-        // bootstrap's own shell (agentcal's pgrep self-match trap)
-        'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
-        `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
-        "echo bootstrapped",
-    ].join("\n");
-    let boot;
-    for (let attempt = 0; attempt < 5; attempt++) {
-        boot = await runCommand(cfg, box.id, bootstrap);
-        if (boot.ok || boot.exitCode !== null)
-            break;
-        await new Promise((r) => setTimeout(r, 3000));
+    catch (error) {
+        if (!created || !box?.id)
+            throw error;
+        const cleanup = await boxJson(cfg, `/boxes/${box.id}`, {
+            method: "DELETE",
+            headers: { "X-Ascii-Confirm-Delete": box.id },
+        }).catch(() => null);
+        boxIdCache.delete(botId);
+        if (cleanup?.ok)
+            throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`${message}. The new computer could not be removed automatically; delete box ${box.id} in ascii.dev.`);
     }
-    const joinUrl = await mintDesktopUrl(cfg, box.id);
-    return { boxId: box.id, machineName: vmName, reused: !created, state: ready.state, joinUrl };
 }
 /** Wake the bot's box and return a FRESH desktop URL. */
 export async function joinBox(cfg, botId) {
@@ -240,6 +244,9 @@ export async function joinBox(cfg, botId) {
     const ready = await waitReady(cfg, box.id);
     if (!ready)
         throw new Error("the box did not wake in time — try again");
+    // Provider archive/resume preserves disk but not processes. Reattach the
+    // driver daemon before handing the desktop back to the user.
+    await runCommand(cfg, box.id, ensureRemoteCuaCommand(), { timeoutMs: 15_000 }).catch(() => null);
     return { joinUrl: await mintDesktopUrl(cfg, box.id), state: ready.state ?? null };
 }
 /** Archive the bot's box now (billing pauses, disk survives). */
@@ -247,6 +254,14 @@ export async function sleepBox(cfg, botId) {
     const box = await findBox(cfg, botId);
     if (!box)
         throw new Error("no computer for this bot");
+    // Ask the browser's oldest (main) process to exit before the provider
+    // snapshots the disk. This gives Chrome a chance to flush cookies and
+    // session state instead of restoring a crash-marked profile next wake.
+    const quiesceBrowser = [
+        'for name in chrome google-chrome chromium chromium-browser; do pid=$(pgrep -o -x "$name" 2>/dev/null || true); [ -z "$pid" ] || kill -TERM "$pid" 2>/dev/null || true; done',
+        'for i in 1 2 3 4 5 6 7 8; do if ! pgrep -x chrome >/dev/null 2>&1 && ! pgrep -x google-chrome >/dev/null 2>&1 && ! pgrep -x chromium >/dev/null 2>&1 && ! pgrep -x chromium-browser >/dev/null 2>&1; then break; fi; sleep 0.25; done',
+    ].join("; ");
+    await runCommand(cfg, box.id, quiesceBrowser, { timeoutMs: 5_000 }).catch(() => null);
     await boxJson(cfg, `/boxes/${box.id}/stop`, { method: "POST" }).catch(() => { });
     return { ok: true };
 }

--- a/dist-server/computer-proxy.js
+++ b/dist-server/computer-proxy.js
@@ -51,13 +51,16 @@ const CHROME_PROFILE_SETUP = [
     'chmod 700 "$profile"',
     'for browser_dir in "$HOME/.config/google-chrome" "$HOME/.config/chromium"; do',
     '  if [ -e "$browser_dir" ] && [ ! -L "$browser_dir" ]; then',
-    '    if [ -d "$browser_dir" ]; then cp -a -n "$browser_dir"/. "$profile"/ 2>/dev/null || true; fi',
+    '    if [ -d "$browser_dir" ] && ! cp -a -n "$browser_dir"/. "$profile"/; then',
+    '      echo "failed to copy browser profile: $browser_dir" >&2',
+    "      exit 1",
+    "    fi",
     '    mv "$browser_dir" "$browser_dir.pre-openmausbot-$(date +%s)-$$"',
     "  fi",
     '  if [ -L "$browser_dir" ]; then rm -f "$browser_dir"; fi',
     '  ln -s "$profile" "$browser_dir"',
     "done",
-].join("; ");
+].join("\n");
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -882,8 +885,8 @@ async function handle(msg) {
             return await call(msg.id, msg.params?.name, msg.params?.arguments ?? {});
         }
         catch (e) {
-            const error = e;
-            const timedOut = error?.name === "TimeoutError" || /timed?\s*out|timeout/i.test(error?.message ?? "");
+            const error = e instanceof Error ? e : new Error(String(e));
+            const timedOut = error.name === "TimeoutError" || /timed?\s*out|timeout/i.test(error.message);
             return text(msg.id, timedOut
                 ? "computer tool timed out. The action may or may not have completed; take a screenshot to inspect the current state before retrying it."
                 : `computer tool failed: ${error.message}`, true);

--- a/dist-server/computer-proxy.js
+++ b/dist-server/computer-proxy.js
@@ -27,6 +27,7 @@
 //
 // stdout is the MCP channel — never console.log here.
 import { normalizeBrowserUrl, normalizeCrop, ObservationCoordinator, parseBrowserTargets, safeBrowserUrl, } from "./computer-observation.js";
+import { ensureRemoteCuaCommand, REMOTE_CUA_EXECUTABLE, REMOTE_CUA_SESSION, REMOTE_CUA_SOCKET, REMOTE_CUA_VERSION, semanticBrowserCommand, } from "./remote-computer.js";
 const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
 const token = process.env.OGB_BOX_TOKEN ?? "";
@@ -40,8 +41,23 @@ const SETTLE_MS = 350;
 /** Gap between batched actions so focus changes land before typing. */
 const ACTION_GAP_MS = 120;
 const CHROME_PROFILE = "$HOME/.openmausbot/chrome-profile";
-const CHROME_DEBUG_FLAGS = `--user-data-dir="${CHROME_PROFILE}" --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
-const CHROME_PROFILE_SETUP = `mkdir -p "${CHROME_PROFILE}" && chmod 700 "${CHROME_PROFILE}"`;
+const CHROME_DEBUG_FLAGS = `--user-data-dir="${CHROME_PROFILE}" --password-store=basic --disable-session-crashed-bubble --no-first-run --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222`;
+// Keep one durable browser identity regardless of which Chromium binary an
+// image supplies. Existing profiles are merged without overwriting files and
+// moved aside as backups before the conventional paths become symlinks.
+const CHROME_PROFILE_SETUP = [
+    `profile="${CHROME_PROFILE}"`,
+    'mkdir -p "$profile" "$HOME/.config"',
+    'chmod 700 "$profile"',
+    'for browser_dir in "$HOME/.config/google-chrome" "$HOME/.config/chromium"; do',
+    '  if [ -e "$browser_dir" ] && [ ! -L "$browser_dir" ]; then',
+    '    if [ -d "$browser_dir" ]; then cp -a -n "$browser_dir"/. "$profile"/ 2>/dev/null || true; fi',
+    '    mv "$browser_dir" "$browser_dir.pre-openmausbot-$(date +%s)-$$"',
+    "  fi",
+    '  if [ -L "$browser_dir" ]; then rm -f "$browser_dir"; fi',
+    '  ln -s "$profile" "$browser_dir"',
+    "done",
+].join("; ");
 /** Frames larger than this come back over the files API instead of
  * inline stdout (keeps us clear of the command endpoint's stdout cap). */
 const INLINE_MAX_BYTES = 400_000;
@@ -66,10 +82,26 @@ async function resumeBox() {
     return false;
 }
 async function runOnBox(command, timeoutMs = 60_000, allowWake = true) {
+    // Old boxes may predate noEnv:true. Run every agent-issued command with an
+    // explicit desktop-only environment so provider/account credentials cannot
+    // leak through `computer_exec` or a child GUI process.
+    const isolatedCommand = [
+        "exec env -i",
+        'HOME="$HOME"',
+        'USER="${USER:-$(id -un)}"',
+        'LOGNAME="${LOGNAME:-${USER:-$(id -un)}}"',
+        'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
+        'DISPLAY="${DISPLAY:-:0}"',
+        'XAUTHORITY="${XAUTHORITY:-$HOME/.Xauthority}"',
+        'XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"',
+        'DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}"',
+        "/bin/bash -c",
+        shellQuote(command),
+    ].join(" ");
     const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
         method: "POST",
         headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-        body: JSON.stringify({ command }),
+        body: JSON.stringify({ command: isolatedCommand }),
         signal: AbortSignal.timeout(timeoutMs),
     });
     const body = await res.json().catch(() => null);
@@ -124,6 +156,7 @@ async function waitForNavigation(value, attempts = 3) {
     return { ok: false, targets };
 }
 const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+const CUA_ENV = "CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0";
 /** Resolve the real display size into $W/$H for box-side click scaling. */
 const GEOMETRY = [
     "g=$(xdotool getdisplaygeometry 2>/dev/null)",
@@ -139,6 +172,17 @@ const GEOMETRY = [
 function scaled(varName, value) {
     const v = Math.round(value);
     return `if [ "$W" -gt ${SHOT_WIDTH} ] 2>/dev/null; then ${varName}=$(( ${v} * W / ${SHOT_WIDTH} )); else ${varName}=${v}; fi`;
+}
+/** Prefer the official driver but keep the proven X11 command as a degraded
+ * path while a first install is finishing or if the daemon needs repair. */
+function cuaOrX11(tool, argumentsShell, fallback) {
+    return [
+        `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1;`,
+        `then if CUA_OUT=$(env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call ${tool} ${argumentsShell} --socket ${REMOTE_CUA_SOCKET} 2>/tmp/ogb-cua-call.error);`,
+        `then echo "BACKEND CUA"; echo "CUA_RESULT $(printf %s "$CUA_OUT" | base64 -w0 2>/dev/null || printf %s "$CUA_OUT" | base64 | tr -d '\\n')"`,
+        `else ${fallback}; X11_RC=$?; echo "BACKEND X11"; [ "$X11_RC" -eq 0 ]; fi`,
+        `else ${fallback}; X11_RC=$?; echo "BACKEND X11"; [ "$X11_RC" -eq 0 ]; fi`,
+    ].join(" ");
 }
 /** act → settle → capture → canonical hash → optional crop → inline bytes.
  * The hash is taken before cropping, so change detection always describes
@@ -156,8 +200,10 @@ function captureBlock(settleMs = SETTLE_MS, crop = null) {
     return [
         settleMs > 0 ? `sleep ${(settleMs / 1000).toFixed(2)}` : "true",
         `f=${SHOT_PATH}`,
+        'raw=/tmp/ogb-shot.png',
         `rm -f "$f" 2>/dev/null || true`,
-        `scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1`,
+        `rm -f "$raw" 2>/dev/null || true`,
+        `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1 && env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call get_desktop_state ${shellQuote(JSON.stringify({ scope: "desktop", session: REMOTE_CUA_SESSION }))} --socket ${REMOTE_CUA_SOCKET} --screenshot-out-file "$raw" >/dev/null 2>&1 && command -v convert >/dev/null 2>&1 && convert "$raw" -quality ${JPEG_QUALITY} "$f" 2>/dev/null; then echo "CAPTURE CUA"; else scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1; echo "CAPTURE X11"; fi`,
         // only re-encode when the display is bigger than the model's space —
         // ImageMagick startup is the most expensive step in the old pipeline
         downscale,
@@ -227,6 +273,8 @@ async function fetchFrame(expectedBytes) {
 }
 let inlineWorks = true; // flipped off for the proxy's life on first garbage
 let lastDisplayGeometry = null;
+let semanticBrowserUrl = null;
+let semanticBrowserRefs = new Set();
 function geometryFrom(stdout) {
     const match = stdout.match(/^GEOM\s+(\d+)\s+(\d+)$/m);
     if (!match)
@@ -234,6 +282,24 @@ function geometryFrom(stdout) {
     const width = Number(match[1]);
     const height = Number(match[2]);
     return width > 0 && height > 0 ? { width, height } : null;
+}
+function automationSummary(stdout) {
+    if (/^BACKEND CUA$/m.test(stdout)) {
+        const encoded = stdout.match(/^CUA_RESULT\s+([^\s]+)$/m)?.[1];
+        if (!encoded)
+            return `Cua Driver ${REMOTE_CUA_VERSION}`;
+        try {
+            const result = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+            const details = [result.effect, result.route, result.escalation]
+                .filter((value) => typeof value === "string" && Boolean(value))
+                .slice(0, 3);
+            return [`Cua Driver ${REMOTE_CUA_VERSION}`, ...details].join(" · ");
+        }
+        catch {
+            return `Cua Driver ${REMOTE_CUA_VERSION}`;
+        }
+    }
+    return /^BACKEND X11$/m.test(stdout) ? "X11 fallback" : "automation backend unavailable";
 }
 async function observationBounds() {
     let geometry = lastDisplayGeometry;
@@ -352,6 +418,29 @@ const TOOLS = [
         inputSchema: { type: "object", properties: {} },
     },
     {
+        name: "browser_snapshot",
+        description: "Read Chrome's semantic accessibility tree and return fresh element refs. Prefer this over screenshots for links, buttons, and form fields.",
+        inputSchema: { type: "object", properties: {} },
+    },
+    {
+        name: "browser_click",
+        description: "Click one element ref from the most recent browser_snapshot and return the resulting screen.",
+        inputSchema: {
+            type: "object",
+            properties: { ref: { type: "string" }, ...OBSERVE_PROPS },
+            required: ["ref"],
+        },
+    },
+    {
+        name: "browser_fill",
+        description: "Replace the text in one field ref from the most recent browser_snapshot and return the resulting screen.",
+        inputSchema: {
+            type: "object",
+            properties: { ref: { type: "string" }, text: { type: "string" }, ...OBSERVE_PROPS },
+            required: ["ref", "text"],
+        },
+    },
+    {
         name: "wait_for_navigation",
         description: "Verify that Chrome reached one exact http(s) URL, including its query and fragment, with at most three bounded checks.",
         inputSchema: {
@@ -363,6 +452,11 @@ const TOOLS = [
     {
         name: "observation_metrics",
         description: "Return this turn's observation, action, retry, and verification counters.",
+        inputSchema: { type: "object", properties: {} },
+    },
+    {
+        name: "computer_status",
+        description: "Report whether the cloud computer is using Cua Driver or the degraded X11 fallback.",
         inputSchema: { type: "object", properties: {} },
     },
     {
@@ -480,24 +574,37 @@ function actionShell(a) {
             return { error: "click needs numeric x,y" };
         const btn = a.button === "right" ? 3 : 1;
         const rep = a.double ? "--repeat 2 --delay 60 " : "";
-        return `${scaled("CX", x)}; ${scaled("CY", y)}; xdotool mousemove $CX $CY click ${rep}${btn}`;
+        const button = a.button === "right" ? "right" : "left";
+        const count = a.double ? 2 : 1;
+        const fallback = `xdotool mousemove $CX $CY click ${rep}${btn}`;
+        const args = `$(printf '{"x":%s,"y":%s,"button":"${button}","count":${count},"scope":"desktop","session":"${REMOTE_CUA_SESSION}"}' "$CX" "$CY")`;
+        return `${scaled("CX", x)}; ${scaled("CY", y)}; CUA_ARGS=${args}; ${cuaOrX11("click", '"$CUA_ARGS"', fallback)}`;
     }
     if (kind === "type_text") {
         const t = String(a.text ?? "");
         if (!t)
             return { error: "type_text needs text" };
-        return `xdotool type --delay 8 ${shellQuote(t)}`;
+        const cuaArgs = shellQuote(JSON.stringify({ text: t, scope: "desktop", session: REMOTE_CUA_SESSION }));
+        return cuaOrX11("type_text", cuaArgs, `xdotool type --clearmodifiers --delay 8 -- ${shellQuote(t)}`);
     }
     if (kind === "press_key") {
         const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
         if (!keys)
             return { error: "press_key needs keys" };
-        return `xdotool key ${keys}`;
+        const parts = keys.split("+").filter(Boolean);
+        const tool = parts.length > 1 ? "hotkey" : "press_key";
+        const cuaArgs = shellQuote(JSON.stringify(parts.length > 1
+            ? { keys: parts, scope: "desktop", session: REMOTE_CUA_SESSION }
+            : { key: parts[0]?.toLowerCase(), scope: "desktop", session: REMOTE_CUA_SESSION }));
+        return cuaOrX11(tool, cuaArgs, `xdotool key ${keys}`);
     }
     if (kind === "scroll") {
         const clicks = Math.min(Math.max(Math.round(Number(a.clicks) || 3), 1), 20);
         const btn = a.direction === "up" ? 4 : 5;
-        return `xdotool click --repeat ${clicks} ${btn}`;
+        const direction = a.direction === "up" ? "up" : "down";
+        const fallback = `xdotool click --repeat ${clicks} ${btn}`;
+        const args = `$(printf '{"x":%s,"y":%s,"direction":"${direction}","amount":${clicks},"by":"line","scope":"desktop","session":"${REMOTE_CUA_SESSION}"}' "$((W / 2))" "$((H / 2))")`;
+        return `CUA_ARGS=${args}; ${cuaOrX11("scroll", '"$CUA_ARGS"', fallback)}`;
     }
     if (kind === "wait") {
         const ms = Math.min(Math.max(Number(a.ms) || 500, 0), 5000);
@@ -527,16 +634,60 @@ async function actAndObserve(id, actions, note, args, timeoutMs = 60_000) {
     // ended up in. Joining with ";" alone made a failed action look
     // identical to one that did nothing.
     const guarded = `if { ${parts.join("; ")}; }; then ACT=ok; else ACT=failed; fi`;
-    const command = [ENV, GEOMETRY, guarded, observe ? captureBlock(settleOf(args)) : "true", 'echo "ACT $ACT"'].join("; ");
+    const command = [
+        ENV,
+        GEOMETRY,
+        ensureRemoteCuaCommand(),
+        guarded,
+        observe ? captureBlock(settleOf(args)) : "true",
+        'echo "ACT $ACT"',
+    ].join("; ");
     const out = await runOnBox(command, timeoutMs);
     const acted = /^ACT ok$/m.test(out.stdout);
     if (!acted && !out.stdout.includes("GEOM")) {
         return text(id, `${note.replace(/^./, (c) => c.toLowerCase())} failed: ${out.stderr.slice(0, 200) || `exit ${out.exitCode}`}`, true);
     }
-    const full = acted ? note : `${note}\n(the action reported an error: ${out.stderr.slice(0, 160) || "no detail"})`;
+    const backend = automationSummary(out.stdout);
+    const full = acted
+        ? `${note}\n(${backend})`
+        : `${note}\n(the action reported an error: ${out.stderr.slice(0, 160) || "no detail"}; ${backend})`;
     if (!observe)
         return text(id, full, !acted);
     return observed(id, full, await frameFrom(out));
+}
+async function semanticActAndObserve(id, action, ref, value, args) {
+    if (!semanticBrowserUrl || !semanticBrowserRefs.has(ref)) {
+        return text(id, "that browser ref is stale or unknown — take a new browser_snapshot", true);
+    }
+    const observe = wantsFrame(args);
+    const semantic = semanticBrowserCommand(action, {
+        ref,
+        ...(action === "fill" ? { text: value ?? "" } : {}),
+        url: semanticBrowserUrl,
+    });
+    const guarded = `if ${semantic}; then SEM=ok; else SEM=failed; fi`;
+    const command = [
+        ENV,
+        GEOMETRY,
+        guarded,
+        ensureRemoteCuaCommand(),
+        observe ? captureBlock(settleOf(args)) : "true",
+        'echo "SEM $SEM"',
+    ].join("; ");
+    observations.noteAction();
+    const out = await runOnBox(command, action === "fill" ? 120_000 : 60_000);
+    const acted = /^SEM ok$/m.test(out.stdout);
+    // DOM mutations can invalidate backend node IDs; force a fresh snapshot
+    // after every semantic action instead of risking a click on an old target.
+    semanticBrowserRefs.clear();
+    const note = acted
+        ? action === "fill"
+            ? `filled ${ref} with ${value?.length ?? 0} chars (trusted Chrome DevTools input)`
+            : `clicked ${ref} (trusted Chrome DevTools input)`
+        : `${action} ${ref} failed: ${out.stderr.slice(0, 200) || "the page changed; take a new browser_snapshot"}`;
+    if (!observe)
+        return text(id, note, !acted);
+    return observed(id, note, await frameFrom(out));
 }
 async function call(id, name, args) {
     if (name === "screenshot") {
@@ -550,7 +701,7 @@ async function call(id, name, args) {
                 return text(id, `region must be at least 32×32 and stay within the ${bounds.width}×${bounds.height} screenshot`, true);
             }
         }
-        const out = await runOnBox([ENV, GEOMETRY, captureBlock(0, crop)].join("; "), 60_000);
+        const out = await runOnBox([ENV, GEOMETRY, ensureRemoteCuaCommand(), captureBlock(0, crop)].join("; "), 60_000);
         if (/CROP_FAILED/.test(out.stdout)) {
             return text(id, `crop failed: ${out.stderr.slice(0, 200) || "ImageMagick could not create the requested region"}`, true);
         }
@@ -566,6 +717,38 @@ async function call(id, name, args) {
             ? `Structured browser state:\n${targets.map((target) => `- ${target.title || "Untitled"}: ${target.url}`).join("\n")}`
             : "Structured browser state unavailable. Use screenshot only if visual state is necessary.");
     }
+    if (name === "browser_snapshot") {
+        const out = await runOnBox(semanticBrowserCommand("snapshot", {}), 20_000);
+        if (!out.ok) {
+            semanticBrowserUrl = null;
+            semanticBrowserRefs.clear();
+            return text(id, "Semantic browser state is unavailable. Open Chrome with open_url, or use screenshot.", true);
+        }
+        try {
+            const snapshot = JSON.parse(out.stdout);
+            if (!Array.isArray(snapshot.elements) || typeof snapshot.url !== "string")
+                throw new Error("invalid snapshot");
+            semanticBrowserUrl = snapshot.url;
+            semanticBrowserRefs = new Set(snapshot.elements.map((element) => element.ref));
+            observations.noteStructuredObservation();
+            const publicUrl = safeBrowserUrl(snapshot.url) ?? "URL unavailable";
+            const lines = snapshot.elements.map((element) => `- [${element.ref}] ${element.role}${element.disabled ? " disabled" : ""}: ${element.name.replace(/\s+/g, " ").slice(0, 180)}`);
+            return text(id, `Semantic browser snapshot — ${snapshot.title || "Untitled"}: ${publicUrl}\n${lines.join("\n") || "No interactive elements found."}`);
+        }
+        catch {
+            semanticBrowserUrl = null;
+            semanticBrowserRefs.clear();
+            return text(id, "Chrome returned an invalid semantic snapshot; use screenshot.", true);
+        }
+    }
+    if (name === "browser_click") {
+        const ref = String(args.ref ?? "");
+        return semanticActAndObserve(id, "click", ref, undefined, args);
+    }
+    if (name === "browser_fill") {
+        const ref = String(args.ref ?? "");
+        return semanticActAndObserve(id, "fill", ref, String(args.text ?? ""), args);
+    }
     if (name === "wait_for_navigation") {
         const url = String(args.url ?? "");
         const publicUrl = safeBrowserUrl(url);
@@ -580,6 +763,22 @@ async function call(id, name, args) {
     }
     if (name === "observation_metrics")
         return text(id, metricsText());
+    if (name === "computer_status") {
+        const command = [
+            ENV,
+            ensureRemoteCuaCommand(),
+            `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1; then`,
+            `  echo "CUA $(${REMOTE_CUA_EXECUTABLE} --version)"`,
+            `  env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call health_report '{}' --socket ${REMOTE_CUA_SOCKET} 2>/dev/null || true`,
+            "else echo 'X11 fallback'; fi",
+        ].join("\n");
+        const out = await runOnBox(command, 20_000);
+        if (!/^CUA /m.test(out.stdout)) {
+            return text(id, "Cloud computer automation: X11 fallback (Cua Driver is still installing or needs repair).", true);
+        }
+        const overall = out.stdout.match(/"overall"\s*:\s*"(ok|degraded|failed)"/)?.[1] ?? "unknown";
+        return text(id, `Cloud computer automation: Cua Driver ${REMOTE_CUA_VERSION} (${overall}).`);
+    }
     if (name === "click") {
         const x = Math.round(Number(args.x));
         const y = Math.round(Number(args.y));
@@ -629,7 +828,7 @@ async function call(id, name, args) {
         const note = `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`;
         if (args.observe !== true)
             return text(id, note);
-        const shot = await runOnBox([ENV, GEOMETRY, captureBlock()].join("; "), 60_000);
+        const shot = await runOnBox([ENV, GEOMETRY, ensureRemoteCuaCommand(), captureBlock()].join("; "), 60_000);
         return observed(id, note, await frameFrom(shot));
     }
     if (name === "open_url") {
@@ -648,6 +847,7 @@ async function call(id, name, args) {
             CHROME_PROFILE_SETUP,
             `(google-chrome ${CHROME_DEBUG_FLAGS} ${q} || chromium ${CHROME_DEBUG_FLAGS} ${q} || chromium-browser ${CHROME_DEBUG_FLAGS} ${q} || xdg-open ${q}) >/dev/null 2>&1 &`,
             'for i in 1 2 3 4 5 6 7 8 9 10 11 12; do xdotool search --onlyvisible --class "chrom" >/dev/null 2>&1 && break; sleep 0.25; done',
+            ensureRemoteCuaCommand(),
             observe ? captureBlock(600) : "true",
         ].join("; ");
         observations.noteAction();
@@ -682,7 +882,11 @@ async function handle(msg) {
             return await call(msg.id, msg.params?.name, msg.params?.arguments ?? {});
         }
         catch (e) {
-            return text(msg.id, `computer tool failed: ${e.message}`, true);
+            const error = e;
+            const timedOut = error?.name === "TimeoutError" || /timed?\s*out|timeout/i.test(error?.message ?? "");
+            return text(msg.id, timedOut
+                ? "computer tool timed out. The action may or may not have completed; take a screenshot to inspect the current state before retrying it."
+                : `computer tool failed: ${error.message}`, true);
         }
     }
     if (String(msg.method ?? "").startsWith("notifications/"))

--- a/dist-server/container-computer.js
+++ b/dist-server/container-computer.js
@@ -8,14 +8,16 @@
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { augmentedPath } from "./env-path.js";
+import { DATA_DIR } from "./config.js";
 const run = promisify(execFile);
-export const CUA_DRIVER_VERSION = "0.19.3";
+const SCREENSHOT_STATUS_TTL_MS = 10_000;
+export const CUA_DRIVER_VERSION = "0.20.0";
 export const BASE_IMAGE_REPOSITORY = "docker.io/trycua/xfce-cua";
 // Official multi-architecture Cua XFCE 0.1.0 manifest (amd64 + arm64).
 export const BASE_IMAGE_DIGEST = "sha256:274eb636f5cf3fc58f705916ee72b7a701270b3877369d08533a385c5325be9b";
@@ -23,11 +25,16 @@ export const BASE_IMAGE = `${BASE_IMAGE_REPOSITORY}@${BASE_IMAGE_DIGEST}`;
 // This tag is built locally from the pinned Cua base. Image and container
 // labels below are the authoritative compatibility check, not the mutable tag.
 export const IMAGE_REPOSITORY = "openmausbot/cua-local-vm";
-export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}`;
+export const IMAGE_LAYER_VERSION = "3";
+export const IMAGE_LAYER_LABEL = "com.openmausbot.image-layer";
+export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}-v${IMAGE_LAYER_VERSION}`;
 export const CONTAINER = "openmausbot-computer";
 export const MANAGED_LABEL = "com.openmausbot.local-vm";
 export const DRIVER_LABEL = "com.openmausbot.cua-driver";
 export const BASE_IMAGE_LABEL = "com.openmausbot.cua-base";
+export const WORKSPACE_LABEL = "com.openmausbot.workspace";
+export const VM_WORKSPACE_DIR = join(DATA_DIR, "vm-home");
+export const VM_WORKSPACE_GUEST = "/home/cua/workspace";
 export const DISPLAY = ":1";
 export const CUA_SOCKET = "/run/user/1000/openmausbot-cua.sock";
 export const CUA_EXECUTABLE = "/usr/local/libexec/openmausbot/cua-driver";
@@ -39,12 +46,12 @@ const NANO_CPUS = 2_000_000_000;
 const PIDS_LIMIT = 512;
 const LINUX_WHEELS = {
     x86_64: {
-        url: "https://files.pythonhosted.org/packages/88/26/1b372765b192a2f4f7ee7e1474d1e39be9ab3bd637765f632e30e7ee6e18/cua_driver-0.19.3-py3-none-manylinux_2_31_x86_64.whl",
-        sha256: "3f327a444f5b666037dee5e7c15c98990abbfb4fe83669ef708cb34c2cafef14",
+        url: "https://files.pythonhosted.org/packages/fa/d7/a43008a328a40c85e7bc706fc20235b9abedc75e28b413817655153157ff/cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl",
+        sha256: "f60c35696a37f37ac954935e478ae4754f220856d022036625c9400d72185961",
     },
     aarch64: {
-        url: "https://files.pythonhosted.org/packages/8f/ca/9b1b9e2fba756b5a6db710db4789d63682d6bdf8dc92280c10bdffeb9e77/cua_driver-0.19.3-py3-none-manylinux_2_31_aarch64.whl",
-        sha256: "99cdaaaaf78def68236558b645c799034ac0b6fe5bb37abdf5fc7abc3afeff67",
+        url: "https://files.pythonhosted.org/packages/94/9d/1c1838b69067e83266c3d2aae02d74eef353a43dc8644884ccf03fe7f933/cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl",
+        sha256: "48833bc5e4c60e701fc9eefb57dbac36ec77ef3990f816fbbe85b4e954af2c77",
     },
 };
 /** Reproducible, multi-architecture derivative of Cua's sandbox desktop.
@@ -67,11 +74,40 @@ RUN set -eux; \\
     driver_bin="$(find /opt/venv/lib -path '*/cua_driver/bin/cua-driver' -type f -print -quit)"; \\
     test -n "$driver_bin"; \\
     install -D -m 0755 "$driver_bin" ${CUA_EXECUTABLE}; \\
+    install -d -o cua -g cua -m 0700 ${VM_WORKSPACE_GUEST}; \\
     test "$(${CUA_EXECUTABLE} --version)" = "cua-driver ${CUA_DRIVER_VERSION}"
 RUN printf '%s\\n' \\
       '#!/bin/sh' \\
-      'while ! DISPLAY=:1 xset q >/dev/null 2>&1; do sleep 1; done' \\
-      'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
+      'set -eu' \\
+      'workspace=${VM_WORKSPACE_GUEST}' \\
+      'profiles="$workspace/.browser-profiles"' \\
+      'mkdir -p "$profiles/google-chrome" "$profiles/chromium" "$HOME/.config"' \\
+      'chmod 0700 "$workspace" "$profiles" "$profiles/google-chrome" "$profiles/chromium"' \\
+      'migrate_profile() {' \\
+      '  name="$1"' \\
+      '  source="$HOME/.config/$name"' \\
+      '  target="$profiles/$name"' \\
+      '  if [ -d "$source" ] && [ ! -L "$source" ] && [ -z "$(find "$target" -mindepth 1 -print -quit)" ]; then' \\
+      '    cp -a "$source"/. "$target"/' \\
+      '  fi' \\
+      '  rm -rf "$source"' \\
+      '  ln -s "$target" "$source"' \\
+      '}' \\
+      'migrate_profile google-chrome' \\
+      'migrate_profile chromium' \\
+      'find "$profiles" \\( -name SingletonLock -o -name SingletonSocket -o -name SingletonCookie -o -name .parentlock \\) -delete' \\
+      > /usr/local/bin/prepare-openmausbot-workspace.sh \\
+    && chmod 0755 /usr/local/bin/prepare-openmausbot-workspace.sh
+RUN printf '%s\\n' \\
+      '#!/bin/sh' \\
+      '/usr/local/bin/prepare-openmausbot-workspace.sh' \\
+      'attempt=0' \\
+      'until DISPLAY=:1 xset q >/dev/null 2>&1; do' \\
+      '  attempt=$((attempt + 1))' \\
+      '  if [ "$attempt" -ge 45 ]; then echo "X display :1 did not become ready within 45 seconds" >&2; exit 1; fi' \\
+      '  sleep 1' \\
+      'done' \\
+      'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
     && chmod 0755 /usr/local/bin/start-openmausbot-cua-driver.sh
 RUN printf '%s\\n' \\
@@ -88,7 +124,8 @@ RUN printf '%s\\n' \\
       >> /etc/supervisor/supervisord.conf
 LABEL ${MANAGED_LABEL}="1" \\
       ${DRIVER_LABEL}="${CUA_DRIVER_VERSION}" \\
-      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}"
+      ${BASE_IMAGE_LABEL}="${BASE_IMAGE_DIGEST}" \\
+      ${IMAGE_LAYER_LABEL}="${IMAGE_LAYER_VERSION}"
 `;
 }
 async function sh(cmd, args, timeout = 8000) {
@@ -121,13 +158,18 @@ function emptyStatus(platform) {
         container: "missing",
         network: "unknown",
         security: "unknown",
+        persistence: "unknown",
         desktopReady: false,
+        desktop_error: null,
         ready: false,
         problem: "Install a supported container runtime first",
         image_ref: IMAGE,
+        image_id: null,
         base_image_ref: BASE_IMAGE,
         driver_version: CUA_DRIVER_VERSION,
         container_name: CONTAINER,
+        workspace_path: VM_WORKSPACE_DIR,
+        workspace_guest_path: VM_WORKSPACE_GUEST,
         viewer_url: `http://127.0.0.1:${HOST_VIEWER_PORT}/vnc.html`,
     };
 }
@@ -148,21 +190,35 @@ function statusProblem(status) {
         return "The existing Local VM exposes its viewer publicly; recreate it";
     if (status.security === "unsafe")
         return "The existing Local VM is missing safety limits; recreate it";
+    if (status.persistence === "unsafe")
+        return "The existing Local VM is missing its durable workspace; recreate it";
     if (status.container === "stopped")
-        return "Start the Local VM";
+        return "This desktop image cannot safely resume; recreate the Local VM";
+    if (status.desktop_error)
+        return `The Local VM desktop failed to start: ${status.desktop_error}`;
     if (!status.desktopReady)
         return "The Local VM started, but Cua Driver is not ready yet";
     return null;
 }
-function labelsMatch(labels) {
+function imageLabelsMatch(labels) {
     return (labels?.[MANAGED_LABEL] === "1" &&
         labels?.[DRIVER_LABEL] === CUA_DRIVER_VERSION &&
-        labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST);
+        labels?.[BASE_IMAGE_LABEL] === BASE_IMAGE_DIGEST &&
+        labels?.[IMAGE_LAYER_LABEL] === IMAGE_LAYER_VERSION);
 }
-function inspectedImageLabels(stdout) {
+function containerLabelsMatch(labels) {
+    return imageLabelsMatch(labels) && labels?.[WORKSPACE_LABEL] === "1";
+}
+function normalizeImageId(id) {
+    return id?.trim().replace(/^sha256:/, "") || null;
+}
+function inspectedImage(stdout) {
     const parsed = JSON.parse(stdout);
     const image = parsed[0];
-    return image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels;
+    return {
+        labels: image?.Config?.Labels ?? image?.config?.Labels ?? image?.config?.labels ?? image?.configuration?.labels,
+        id: normalizeImageId(image?.Id ?? image?.id ?? image?.configuration?.descriptor?.digest),
+    };
 }
 function viewerPassword(env) {
     if (Array.isArray(env)) {
@@ -189,6 +245,8 @@ function cuaExecArgs(args, interactive = false) {
         `DISPLAY=${DISPLAY}`,
         "-e",
         "CUA_DRIVER_INSTALL_CHANNEL=python_package",
+        "-e",
+        "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
         CONTAINER,
         CUA_EXECUTABLE,
         ...args,
@@ -219,7 +277,9 @@ export async function containerComputerStatus(runner = sh, platform = process.pl
     }
     try {
         const { stdout } = await runner(status.runtime, ["image", "inspect", IMAGE]);
-        status.image = labelsMatch(inspectedImageLabels(stdout));
+        const image = inspectedImage(stdout);
+        status.image = imageLabelsMatch(image.labels);
+        status.image_id = image.id;
     }
     catch {
         // The prepared OpenMausBot derivative has not been built yet.
@@ -234,8 +294,15 @@ export async function containerComputerStatus(runner = sh, platform = process.pl
             const appleImage = typeof detail?.configuration?.image === "string"
                 ? detail.configuration.image
                 : detail?.configuration?.image?.reference ?? detail?.configuration?.imageReference;
-            status.imageMatches = appleImage === IMAGE;
-            status.managed = status.imageMatches;
+            const appleImageId = typeof detail?.configuration?.image === "object"
+                ? normalizeImageId(detail.configuration.image.descriptor?.digest)
+                : null;
+            status.imageMatches =
+                appleImage === IMAGE && status.image_id !== null && appleImageId === status.image_id;
+            status.managed = containerLabelsMatch(detail?.configuration?.labels);
+            status.persistence = appleWorkspaceMountIsSafe(detail?.configuration?.mounts, platform)
+                ? "durable"
+                : "unsafe";
             const resources = detail?.configuration?.resources;
             status.security =
                 (resources?.memoryInBytes ?? 0) >= MEMORY_BYTES && resources?.cpus === 2 ? "hardened" : "unsafe";
@@ -246,8 +313,13 @@ export async function containerComputerStatus(runner = sh, platform = process.pl
             const detail = inspected[0];
             status.container = detail?.State?.Running ? "running" : "stopped";
             status.network = dockerPortsAreLocal(detail?.HostConfig?.PortBindings) ? "loopback" : "unsafe";
-            status.imageMatches = detail?.Config?.Image === IMAGE && labelsMatch(detail?.Config?.Labels);
-            status.managed = detail?.Config?.Labels?.[MANAGED_LABEL] === "1";
+            status.imageMatches =
+                detail?.Config?.Image === IMAGE &&
+                    imageLabelsMatch(detail?.Config?.Labels) &&
+                    status.image_id !== null &&
+                    normalizeImageId(detail?.Image) === status.image_id;
+            status.managed = containerLabelsMatch(detail?.Config?.Labels);
+            status.persistence = dockerWorkspaceMountIsSafe(detail?.Mounts, platform) ? "durable" : "unsafe";
             status.security = dockerSecurityIsHardened(detail?.HostConfig) ? "hardened" : "unsafe";
             status.viewer_url = viewerUrl(viewerPassword(detail?.Config?.Env));
         }
@@ -259,7 +331,8 @@ export async function containerComputerStatus(runner = sh, platform = process.pl
         status.imageMatches &&
         status.managed &&
         status.network === "loopback" &&
-        status.security === "hardened";
+        status.security === "hardened" &&
+        status.persistence === "durable";
     if (canProbe) {
         try {
             const expected = `cua-driver ${CUA_DRIVER_VERSION}`;
@@ -267,10 +340,43 @@ export async function containerComputerStatus(runner = sh, platform = process.pl
             if (version.stdout.trim() !== expected)
                 throw new Error(`expected ${expected}`);
             await runner(status.runtime, cuaExecArgs(["status", "--socket", CUA_SOCKET]), 8000);
+            const health = await runner(status.runtime, cuaExecArgs(["call", "health_report", "{}", "--socket", CUA_SOCKET]), 15_000);
+            const report = JSON.parse(health.stdout);
+            if (report.schema_version !== "1" ||
+                !Array.isArray(report.checks) ||
+                (report.overall !== "ok" && report.overall !== "degraded")) {
+                throw new Error(`Cua health report is ${report.overall ?? "invalid"}`);
+            }
+            const readinessShot = "/tmp/openmausbot-readiness.png";
+            await runner(status.runtime, cuaExecArgs([
+                "call",
+                "get_desktop_state",
+                "{}",
+                "--socket",
+                CUA_SOCKET,
+                "--screenshot-out-file",
+                readinessShot,
+            ]), 20_000);
+            const captured = await runner(status.runtime, ["exec", CONTAINER, "base64", "-w0", readinessShot], 20_000);
+            if (!wholeScreenshot(Buffer.from(captured.stdout.trim(), "base64")).ok) {
+                throw new Error("Cua Driver returned an incomplete readiness screenshot");
+            }
             status.desktopReady = true;
         }
-        catch {
-            // XFCE and the supervisor-owned Cua daemon need a few seconds to start.
+        catch (error) {
+            // An empty log means XFCE and the supervisor-owned Cua daemon are
+            // probably still starting. A real startup failure should be actionable
+            // in the panel instead of looking like an endless readiness wait.
+            status.desktop_error = error instanceof Error ? error.message.slice(0, 320) : null;
+            try {
+                const errorLog = await runner(status.runtime, ["exec", CONTAINER, "tail", "-n", "4", "/var/log/supervisor/cua-driver.error.log"], 4000);
+                status.desktop_error =
+                    errorLog.stdout.replace(/\s+/g, " ").trim().slice(0, 320) ||
+                        status.desktop_error;
+            }
+            catch {
+                // The log may not exist during the first seconds of container boot.
+            }
         }
     }
     status.problem = statusProblem(status);
@@ -290,6 +396,27 @@ function applePortsAreLocal(bindings) {
         bindings[0]?.containerPort === INTERNAL_VIEWER_PORT &&
         loopback(bindings[0]?.hostAddress));
 }
+function sameWorkspaceSource(source, platform) {
+    if (!source)
+        return false;
+    const actual = resolve(source);
+    const expected = resolve(VM_WORKSPACE_DIR);
+    return platform === "win32" ? actual.toLowerCase() === expected.toLowerCase() : actual === expected;
+}
+function dockerWorkspaceMountIsSafe(mounts, platform) {
+    return Boolean(mounts?.length === 1 &&
+        mounts[0]?.Type === "bind" &&
+        sameWorkspaceSource(mounts[0]?.Source, platform) &&
+        mounts[0]?.Destination === VM_WORKSPACE_GUEST &&
+        mounts[0]?.RW !== false);
+}
+function appleWorkspaceMountIsSafe(mounts, platform) {
+    const options = mounts?.[0]?.options ?? [];
+    return Boolean(mounts?.length === 1 &&
+        sameWorkspaceSource(mounts[0]?.source, platform) &&
+        mounts[0]?.destination === VM_WORKSPACE_GUEST &&
+        !options.some((option) => option === "ro" || option === "readonly"));
+}
 function dockerSecurityIsHardened(config) {
     if (!config)
         return false;
@@ -307,15 +434,23 @@ function dockerSecurityIsHardened(config) {
 }
 export function containerRunArgs(runtime, password = "CHANGE_ME") {
     const common = ["run", "-d", "--name", CONTAINER];
+    common.push("--label", `${MANAGED_LABEL}=1`, "--label", `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`, "--label", `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`, "--label", `${IMAGE_LAYER_LABEL}=${IMAGE_LAYER_VERSION}`, "--label", `${WORKSPACE_LABEL}=1`);
     if (runtime === "container") {
         // Apple container already places each Linux container in a lightweight VM.
         common.push("--memory", "4g", "--cpus", "2", "--cap-drop", "ALL", "--cap-add", "SETUID", "--cap-add", "SETGID", "--shm-size", "512m");
     }
     else {
-        common.push("--label", `${MANAGED_LABEL}=1`, "--label", `${DRIVER_LABEL}=${CUA_DRIVER_VERSION}`, "--label", `${BASE_IMAGE_LABEL}=${BASE_IMAGE_DIGEST}`, "--memory", "4g", "--memory-swap", "4g", "--cpus", "2", "--pids-limit", String(PIDS_LIMIT), "--cap-drop", "ALL", "--cap-add", "SETUID", "--cap-add", "SETGID", "--shm-size", "512m");
+        common.push("--hostname", CONTAINER, "--memory", "4g", "--memory-swap", "4g", "--cpus", "2", "--pids-limit", String(PIDS_LIMIT), "--cap-drop", "ALL", "--cap-add", "SETUID", "--cap-add", "SETGID", "--shm-size", "512m");
     }
-    common.push("-e", `VNC_PW=${password}`, "-p", `127.0.0.1:${HOST_VIEWER_PORT}:${INTERNAL_VIEWER_PORT}`, IMAGE);
+    common.push("--mount", runtime === "podman"
+        ? `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private,U=true`
+        : `type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST}`, "-e", `VNC_PW=${password}`, "-p", `127.0.0.1:${HOST_VIEWER_PORT}:${INTERNAL_VIEWER_PORT}`, IMAGE);
     return common;
+}
+async function ensureVmWorkspace(platform) {
+    await mkdir(VM_WORKSPACE_DIR, { recursive: true, mode: 0o700 });
+    if (platform !== "win32")
+        await chmod(VM_WORKSPACE_DIR, 0o700);
 }
 async function prepareManagedImage(runtime, runner) {
     await runner(runtime, ["pull", BASE_IMAGE], 10 * 60_000);
@@ -329,6 +464,8 @@ async function prepareManagedImage(runtime, runner) {
     }
 }
 export async function containerComputerAction(action, runner = sh, platform = process.platform) {
+    if (runner === sh && platform === process.platform)
+        screenshotStatusCache = null;
     const before = await containerComputerStatus(runner, platform);
     const runtime = before.runtime;
     if (!runtime)
@@ -341,12 +478,8 @@ export async function containerComputerAction(action, runner = sh, platform = pr
     if (action === "run" && !before.image) {
         throw Object.assign(new Error("Prepare the Cua desktop image before creating the Local VM"), { status: 409 });
     }
-    if (action === "start" && before.container !== "stopped") {
-        throw Object.assign(new Error(before.container === "running" ? "The Local VM is already running" : "Create the Local VM first"), { status: 409 });
-    }
-    if (action === "start" &&
-        (!before.imageMatches || !before.managed || before.network !== "loopback" || before.security !== "hardened")) {
-        throw Object.assign(new Error("The existing Local VM is incompatible or unsafe; remove and recreate it"), {
+    if (action === "start") {
+        throw Object.assign(new Error("This desktop image cannot safely resume; remove and recreate the Local VM"), {
             status: 409,
         });
     }
@@ -359,6 +492,8 @@ export async function containerComputerAction(action, runner = sh, platform = pr
         await prepareManagedImage(runtime, runner);
     }
     else {
+        if (action === "run")
+            await ensureVmWorkspace(platform);
         const args = action === "run"
             ? containerRunArgs(runtime, randomBytes(6).toString("base64url"))
             : action === "remove"
@@ -385,10 +520,18 @@ function wholeScreenshot(bytes) {
     };
 }
 export async function containerComputerScreenshot(runner = sh, platform = process.platform) {
-    const status = await containerComputerStatus(runner, platform);
+    const cacheable = runner === sh && platform === process.platform;
+    const now = Date.now();
+    const status = cacheable && screenshotStatusCache && screenshotStatusCache.expiresAt > now
+        ? screenshotStatusCache.status
+        : await containerComputerStatus(runner, platform);
     if (!status.ready || !status.runtime) {
+        if (cacheable)
+            screenshotStatusCache = null;
         throw Object.assign(new Error(status.problem ?? "The Local VM is not ready"), { status: 409 });
     }
+    if (cacheable)
+        screenshotStatusCache = { status, expiresAt: now + SCREENSHOT_STATUS_TTL_MS };
     const screenshot = "/tmp/openmausbot-preview.png";
     await runner(status.runtime, cuaExecArgs([
         "call",
@@ -407,6 +550,7 @@ export async function containerComputerScreenshot(runner = sh, platform = proces
     }
     return `data:${checked.mime};base64,${data}`;
 }
+let screenshotStatusCache = null;
 const containerMcpPath = (() => {
     const ts = join(dirname(fileURLToPath(import.meta.url)), "container-mcp.ts");
     return existsSync(ts) ? ts : ts.replace(/\.ts$/, ".js");
@@ -455,10 +599,10 @@ export function setupCommands(runtime, platform = process.platform) {
         install,
         runtimeStart,
         // This is the inspectable base download. The normal Prepare button also
-        // builds the checksum-pinned 0.19.3 derivative automatically.
+        // builds the checksum-pinned 0.20.0 derivative automatically.
         pull: command(["pull", BASE_IMAGE]),
         run: command(containerRunArgs(runtime)),
-        start: command(["start", CONTAINER]),
+        start: null,
         stop: command(["stop", CONTAINER]),
         remove: command(["rm", runtime === "container" ? "--force" : "-f", CONTAINER]),
         view: `http://127.0.0.1:${HOST_VIEWER_PORT}/vnc.html`,

--- a/dist-server/container-computer.js
+++ b/dist-server/container-computer.js
@@ -532,23 +532,30 @@ export async function containerComputerScreenshot(runner = sh, platform = proces
     }
     if (cacheable)
         screenshotStatusCache = { status, expiresAt: now + SCREENSHOT_STATUS_TTL_MS };
-    const screenshot = "/tmp/openmausbot-preview.png";
-    await runner(status.runtime, cuaExecArgs([
-        "call",
-        "get_desktop_state",
-        "{}",
-        "--socket",
-        CUA_SOCKET,
-        "--screenshot-out-file",
-        screenshot,
-    ]), 30_000);
-    const { stdout } = await runner(status.runtime, ["exec", CONTAINER, "base64", "-w0", screenshot], 30_000);
-    const data = stdout.trim();
-    const checked = wholeScreenshot(Buffer.from(data, "base64"));
-    if (!checked.ok) {
-        throw Object.assign(new Error("Cua Driver returned an incomplete screenshot"), { status: 502 });
+    try {
+        const screenshot = "/tmp/openmausbot-preview.png";
+        await runner(status.runtime, cuaExecArgs([
+            "call",
+            "get_desktop_state",
+            "{}",
+            "--socket",
+            CUA_SOCKET,
+            "--screenshot-out-file",
+            screenshot,
+        ]), 30_000);
+        const { stdout } = await runner(status.runtime, ["exec", CONTAINER, "base64", "-w0", screenshot], 30_000);
+        const data = stdout.trim();
+        const checked = wholeScreenshot(Buffer.from(data, "base64"));
+        if (!checked.ok) {
+            throw Object.assign(new Error("Cua Driver returned an incomplete screenshot"), { status: 502 });
+        }
+        return `data:${checked.mime};base64,${data}`;
     }
-    return `data:${checked.mime};base64,${data}`;
+    catch (error) {
+        if (cacheable)
+            screenshotStatusCache = null;
+        throw error;
+    }
 }
 let screenshotStatusCache = null;
 const containerMcpPath = (() => {

--- a/dist-server/container-mcp.js
+++ b/dist-server/container-mcp.js
@@ -22,6 +22,8 @@ const child = spawn(runtime, [
     "DISPLAY=:1",
     "-e",
     "CUA_DRIVER_INSTALL_CHANNEL=python_package",
+    "-e",
+    "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
     container,
     "/usr/local/libexec/openmausbot/cua-driver",
     "mcp",

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -26,6 +26,8 @@ import { mentionedBots, roomResponders, Store, } from "./store.js";
 import * as tts from "./tts/index.js";
 import { narrateTool, toUtterances } from "./tts/speech-text.js";
 import { readCuaConnection } from "./local-computer.js";
+import { LocalVmIdleTimer } from "./local-vm-idle.js";
+import { LocalVmLease } from "./local-vm-lease.js";
 import { RoutineManager } from "./routines.js";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.js";
 import { listenWebhookIngress, webhookCredential } from "./webhook-ingress.js";
@@ -299,9 +301,43 @@ let routines = null;
 // The Local VM is intentionally one shared, visible desktop. Two agents
 // driving it simultaneously would mix clicks, keystrokes and screenshots,
 // so only one thread may lease it at a time.
-let activeVmThreadId = null;
+const localVmLease = new LocalVmLease(30 * 60_000);
+const localVmOwnerBusy = (botId) => store.bot(botId)?.busy === true;
 let localVmLifecycleBusy = false;
+let localVmActiveThread = null;
+const LOCAL_VM_IDLE_MS = 8 * 60 * 60_000;
+const localVmIdle = new LocalVmIdleTimer(LOCAL_VM_IDLE_MS, () => localVmLifecycleBusy || localVmActiveThread !== null, async () => {
+    // Fence lifecycle and turn dispatch before the first runtime inspection.
+    localVmLifecycleBusy = true;
+    try {
+        const status = await containerComputerStatus();
+        // The upstream desktop leaves a stale X lock after a stop, so it cannot
+        // safely resume. Remove only the disposable container; the mounted
+        // workspace and prepared image remain for a fast, clean recreation.
+        if (status.container === "running")
+            await containerComputerAction("remove");
+    }
+    finally {
+        localVmLifecycleBusy = false;
+    }
+});
+// A running VM may have survived an app/server restart. Start its idle
+// backstop even if nobody opens Settings or begins a turn this session.
+void containerComputerStatus()
+    .then((status) => {
+    if (status.container === "running")
+        localVmIdle.touch();
+})
+    .catch(() => null);
 bus.subscribe((event) => {
+    localVmLease.touch(event.threadId);
+    if (localVmActiveThread === event.threadId)
+        localVmIdle.touch();
+    if (event.type === "turn.completed") {
+        localVmLease.release(event.threadId);
+        if (localVmActiveThread === event.threadId)
+            localVmActiveThread = null;
+    }
     broadcast({ kind: "runtime", event });
     routines?.handleRuntimeEvent(event);
     const bot = store.botByThread(event.threadId);
@@ -475,8 +511,6 @@ bus.subscribe((event) => {
             });
             break;
         case "turn.completed": {
-            if (activeVmThreadId === event.threadId)
-                activeVmThreadId = null;
             const reply = lastReply.get(event.threadId) ?? "";
             lastReply.delete(event.threadId);
             if (bot) {
@@ -718,14 +752,21 @@ async function startTurn(botId, text, opts) {
                 if (!mountsComputerMcp || instance.driverKind === "boxAgent") {
                     throw new Error("this model engine cannot use the Local VM — choose Claude or an ACP engine, or select another computer destination");
                 }
+                if (localVmLifecycleBusy) {
+                    throw new Error("the Local VM is being started, stopped, or replaced — wait for setup to finish");
+                }
+                // Claim before the first await. The lifecycle route performs its
+                // matching check synchronously, so neither side can enter while the
+                // other is between inspection and mutation.
+                if (!localVmLease.claim(threadId, bot.id, localVmOwnerBusy)) {
+                    throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
+                }
+                localVmActiveThread = threadId;
+                localVmIdle.touch();
                 const localVm = await containerComputerStatus();
                 if (!localVm.ready || !localVm.runtime) {
                     throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
                 }
-                if (activeVmThreadId && activeVmThreadId !== threadId) {
-                    throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
-                }
-                activeVmThreadId = threadId;
                 integrations.localComputer = containerComputerMcp(localVm.runtime);
                 computerKind = "vm";
             }
@@ -819,12 +860,15 @@ async function startTurn(botId, text, opts) {
                 transcript,
                 system: persona +
                     (computerKind === "vm"
-                        ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine with no host folders mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
+                        ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine. Only /home/cua/workspace is durable; save downloads, repositories, working files, and browser profiles there because everything else inside the VM is disposable. No other host folder is mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
                         : computerKind === "box" && instance.driverKind !== "boxAgent"
-                            ? " You have your own cloud computer — use screenshot, click, type_text, open_url and computer_exec whenever a desktop helps. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable sequences with computer_batch."
+                            ? " You have your own cloud computer. In Chrome, prefer browser_snapshot with browser_click/browser_fill for semantic, trusted actions; use screenshot/click/type_text for visual or non-browser UI, open_url for navigation, and computer_exec for Linux tasks. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable pixel actions with computer_batch."
                             : computerKind === "local"
                                 ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
                                 : "") +
+                    (computerKind
+                        ? " At a sign-in, password, MFA, CAPTCHA, or other protected-input step, stop and ask the user to complete it on the visible computer. Never type their password or ask them to paste a password or one-time code into chat."
+                        : "") +
                     // gated on the integration, not the key: the hint only goes to a
                     // bot whose driver actually mounted the tools
                     (integrations.composio
@@ -848,8 +892,9 @@ async function startTurn(botId, text, opts) {
                 startScreenPoller(bot.id, previewBoxId);
         }
         catch (e) {
-            if (activeVmThreadId === threadId)
-                activeVmThreadId = null;
+            localVmLease.release(threadId);
+            if (localVmActiveThread === threadId)
+                localVmActiveThread = null;
             const message = e instanceof Error ? e.message : String(e);
             const failure = store.appendMessage(threadId, {
                 role: "bot",
@@ -2018,7 +2063,7 @@ const server = createServer(async (req, res) => {
         // its daemon is up, and whether the desktop image and container exist
         if (method === "GET" && path === "/api/local-computer") {
             const status = await containerComputerStatus();
-            return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+            return json(res, 200, { ...status, commands: setupCommands(status.runtime), idle_timeout_ms: LOCAL_VM_IDLE_MS });
         }
         m = path.match(/^\/api\/local-computer\/(pull|run|start|stop|remove)$/);
         if (m && method === "POST") {
@@ -2033,19 +2078,29 @@ const server = createServer(async (req, res) => {
             if (localVmLifecycleBusy) {
                 return json(res, 409, { error: "another Local VM setup action is still running" });
             }
-            if (activeVmThreadId && (action === "stop" || action === "remove" || action === "run")) {
+            const vmOwner = localVmLease.current(localVmOwnerBusy);
+            if (vmOwner && (action === "stop" || action === "remove" || action === "run")) {
                 return json(res, 409, { error: "the Local VM is being used by a bot — stop that turn first" });
             }
             localVmLifecycleBusy = true;
             try {
                 const status = await containerComputerAction(action);
-                return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+                if (action === "run" || action === "start")
+                    localVmIdle.touch();
+                if (action === "stop" || action === "remove")
+                    localVmIdle.cancel();
+                return json(res, 200, {
+                    ...status,
+                    commands: setupCommands(status.runtime),
+                    idle_timeout_ms: LOCAL_VM_IDLE_MS,
+                });
             }
             finally {
                 localVmLifecycleBusy = false;
             }
         }
         if (method === "POST" && path === "/api/local-computer/screenshot") {
+            localVmIdle.touch();
             return json(res, 200, { image: await containerComputerScreenshot() });
         }
         // identity handshake for the packaged app's port fallback: the forked
@@ -2239,6 +2294,7 @@ server.listen(PORT, "127.0.0.1", () => {
 });
 for (const signal of ["SIGINT", "SIGTERM"]) {
     process.on(signal, () => {
+        localVmIdle.cancel();
         routines?.stop();
         webhookIngress?.server.close();
         void registry.disposeAll().finally(() => process.exit(0));

--- a/dist-server/local-vm-idle.js
+++ b/dist-server/local-vm-idle.js
@@ -1,0 +1,44 @@
+/** Renewable idle deadline for the shared Local VM.
+ *
+ * Activity resets the full window. The caller decides how to suspend or
+ * recycle the disposable VM, and an active turn or lifecycle operation defers
+ * that work for another full window instead of racing current work.
+ */
+export class LocalVmIdleTimer {
+    timer = null;
+    idleMs;
+    isBusy;
+    suspend;
+    constructor(idleMs, isBusy, suspend) {
+        if (!Number.isFinite(idleMs) || idleMs <= 0)
+            throw new Error("Local VM idle timeout must be positive");
+        this.idleMs = idleMs;
+        this.isBusy = isBusy;
+        this.suspend = suspend;
+    }
+    touch() {
+        this.cancel();
+        this.timer = setTimeout(() => void this.expire(), this.idleMs);
+        this.timer.unref?.();
+    }
+    cancel() {
+        if (this.timer)
+            clearTimeout(this.timer);
+        this.timer = null;
+    }
+    async expire() {
+        this.timer = null;
+        if (this.isBusy()) {
+            this.touch();
+            return;
+        }
+        try {
+            await this.suspend();
+        }
+        catch {
+            // A transient runtime failure must not disable the cost/resource
+            // backstop forever. Retry after a fresh full idle window.
+            this.touch();
+        }
+    }
+}

--- a/dist-server/local-vm-lease.js
+++ b/dist-server/local-vm-lease.js
@@ -1,0 +1,33 @@
+/** A short, renewable ownership fence for the one shared Local VM desktop.
+ * Runtime events keep an active turn's lease alive; a dead provider cannot
+ * pin the VM forever. All methods are synchronous so lifecycle routes and
+ * turn dispatch can claim their side of the race before either awaits. */
+export class LocalVmLease {
+    record = null;
+    ttlMs;
+    constructor(ttlMs) {
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0)
+            throw new Error("Local VM lease TTL must be positive");
+        this.ttlMs = ttlMs;
+    }
+    current(isBotBusy, now = Date.now()) {
+        if (this.record && (this.record.expiresAt <= now || !isBotBusy(this.record.botId)))
+            this.record = null;
+        return this.record ? { ...this.record } : null;
+    }
+    claim(threadId, botId, isBotBusy, now = Date.now()) {
+        const current = this.current(isBotBusy, now);
+        if (current && current.threadId !== threadId)
+            return false;
+        this.record = { threadId, botId, expiresAt: now + this.ttlMs };
+        return true;
+    }
+    touch(threadId, now = Date.now()) {
+        if (this.record?.threadId === threadId)
+            this.record.expiresAt = now + this.ttlMs;
+    }
+    release(threadId) {
+        if (this.record?.threadId === threadId)
+            this.record = null;
+    }
+}

--- a/dist-server/local-vm-lease.js
+++ b/dist-server/local-vm-lease.js
@@ -23,6 +23,10 @@ export class LocalVmLease {
         return true;
     }
     touch(threadId, now = Date.now()) {
+        if (this.record && this.record.expiresAt <= now) {
+            this.record = null;
+            return;
+        }
         if (this.record?.threadId === threadId)
             this.record.expiresAt = now + this.ttlMs;
     }

--- a/dist-server/remote-computer.js
+++ b/dist-server/remote-computer.js
@@ -1,0 +1,142 @@
+// Shared provisioning and shell contract for the cloud computer's Cua Driver.
+// The box command API is the transport boundary: the daemon stays loopback-only
+// inside the VM and OpenMausBot never exposes another inbound port.
+export const REMOTE_CUA_VERSION = "0.20.0";
+export const REMOTE_CUA_EXECUTABLE = "/opt/ogb/cua-driver";
+export const REMOTE_CUA_SOCKET = "/opt/ogb/run/cua.sock";
+export const REMOTE_CUA_SESSION = "openmausbot";
+export const REMOTE_CDP_HELPER = "/opt/ogb/openmausbot-cdp.mjs";
+const REMOTE_CUA_WHEELS = {
+    x86_64: {
+        url: "https://files.pythonhosted.org/packages/fa/d7/a43008a328a40c85e7bc706fc20235b9abedc75e28b413817655153157ff/cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl",
+        sha256: "f60c35696a37f37ac954935e478ae4754f220856d022036625c9400d72185961",
+    },
+    aarch64: {
+        url: "https://files.pythonhosted.org/packages/94/9d/1c1838b69067e83266c3d2aae02d74eef353a43dc8644884ccf03fe7f933/cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl",
+        sha256: "48833bc5e4c60e701fc9eefb57dbac36ec77ef3990f816fbbe85b4e954af2c77",
+    },
+};
+const CDP_HELPER_SOURCE = String.raw `const [action, encoded = ""] = process.argv.slice(2);
+const input = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8") || "{}");
+const pages = await fetch("http://127.0.0.1:9222/json/list").then((r) => r.json());
+const page = pages.find((item) => item.type === "page" && item.webSocketDebuggerUrl);
+if (!page) throw new Error("no debuggable browser page");
+if (input.url && page.url !== input.url) throw new Error("page changed; take a new browser snapshot");
+const socket = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true });
+  socket.addEventListener("error", () => reject(new Error("DevTools connection failed")), { once: true });
+});
+let nextId = 0;
+const pending = new Map();
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(String(event.data));
+  if (!message.id) return;
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+  pending.delete(message.id);
+  if (message.error) waiter.reject(new Error(message.error.message));
+  else waiter.resolve(message.result ?? {});
+});
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+  const id = ++nextId;
+  pending.set(id, { resolve, reject });
+  socket.send(JSON.stringify({ id, method, params }));
+});
+const refId = (value) => {
+  const match = /^b(\d+)$/.exec(String(value ?? ""));
+  if (!match) throw new Error("invalid or stale browser ref; take a new snapshot");
+  return Number(match[1]);
+};
+if (action === "snapshot") {
+  await send("Accessibility.enable");
+  const { nodes = [] } = await send("Accessibility.getFullAXTree", { depth: 14 });
+  const useful = new Set(["button", "checkbox", "combobox", "heading", "link", "menuitem", "radio", "searchbox", "slider", "spinbutton", "switch", "tab", "textbox"]);
+  const elements = [];
+  for (const node of nodes) {
+    const role = String(node.role?.value ?? "").toLowerCase();
+    const name = String(node.name?.value ?? "").replace(/\s+/g, " ").trim().slice(0, 180);
+    const backend = Number(node.backendDOMNodeId ?? 0);
+    if (!backend || !useful.has(role) || (!name && role !== "textbox" && role !== "searchbox")) continue;
+    const disabled = node.properties?.some((property) => property.name === "disabled" && property.value?.value === true) ?? false;
+    elements.push({ ref: "b" + backend, role, name: name || "unnamed", disabled });
+    if (elements.length >= 250) break;
+  }
+  process.stdout.write(JSON.stringify({ title: String(page.title ?? "").slice(0, 200), url: page.url, elements }));
+} else if (action === "click") {
+  const backendNodeId = refId(input.ref);
+  const { model } = await send("DOM.getBoxModel", { backendNodeId });
+  const quad = model?.border ?? model?.content;
+  if (!Array.isArray(quad) || quad.length < 8) throw new Error("element is not visible; take a new snapshot");
+  const x = (quad[0] + quad[2] + quad[4] + quad[6]) / 4;
+  const y = (quad[1] + quad[3] + quad[5] + quad[7]) / 4;
+  await send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1 });
+  await send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+  process.stdout.write(JSON.stringify({ ok: true, ref: input.ref }));
+} else if (action === "fill") {
+  const backendNodeId = refId(input.ref);
+  await send("DOM.focus", { backendNodeId });
+  await send("Input.dispatchKeyEvent", { type: "keyDown", key: "a", code: "KeyA", modifiers: 2 });
+  await send("Input.dispatchKeyEvent", { type: "keyUp", key: "a", code: "KeyA", modifiers: 2 });
+  await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Backspace", code: "Backspace" });
+  await send("Input.dispatchKeyEvent", { type: "keyUp", key: "Backspace", code: "Backspace" });
+  await send("Input.insertText", { text: String(input.text ?? "") });
+  process.stdout.write(JSON.stringify({ ok: true, ref: input.ref }));
+} else {
+  throw new Error("unknown browser action");
+}
+socket.close();`;
+const shellQuote = (value) => `'${value.replace(/'/g, "'\\''")}'`;
+/** Start the already-installed daemon after a box resume. This is cheap when
+ * it is healthy and intentionally does not install anything on the hot path. */
+export function ensureRemoteCuaCommand() {
+    return [
+        `if [ -x ${REMOTE_CUA_EXECUTABLE} ]; then`,
+        `  mkdir -p ${REMOTE_CUA_SOCKET.slice(0, REMOTE_CUA_SOCKET.lastIndexOf("/"))}`,
+        `  if ! ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1; then`,
+        `    rm -f ${REMOTE_CUA_SOCKET}`,
+        '    display=${DISPLAY:-$(find /tmp/.X11-unix -maxdepth 1 -name "X*" -printf ":%f\\n" 2>/dev/null | sed "s/:X/:/" | head -1)}',
+        '    display=${display:-:0}',
+        `    nohup env HOME="$HOME" DISPLAY="$display" CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${REMOTE_CUA_EXECUTABLE} serve --socket ${REMOTE_CUA_SOCKET} --permission-mode standard > /tmp/ogb-cua-driver.log 2>&1 &`,
+        `    for i in 1 2 3 4 5 6 7 8 9 10; do ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1 && break; sleep 0.2; done`,
+        "  fi",
+        "fi",
+    ].join("\n");
+}
+/** Idempotent setup. The exact wheel is verified before its bundled native
+ * executable is installed; installation remains asynchronous so first-time
+ * provisioning does not block the desktop for several minutes. */
+export function remoteComputerBootstrapCommand(botName) {
+    const helper = Buffer.from(CDP_HELPER_SOURCE).toString("base64");
+    const installer = [
+        "set -eu",
+        "trap 'rm -f /tmp/ogb-cua-installing' EXIT",
+        "sudo mkdir -p /opt/ogb/run",
+        'sudo chown -R "$(id -u):$(id -g)" /opt/ogb',
+        'arch="$(uname -m)"',
+        `case "$arch" in x86_64) url=${shellQuote(REMOTE_CUA_WHEELS.x86_64.url)}; sha=${REMOTE_CUA_WHEELS.x86_64.sha256} ;; aarch64|arm64) url=${shellQuote(REMOTE_CUA_WHEELS.aarch64.url)}; sha=${REMOTE_CUA_WHEELS.aarch64.sha256} ;; *) echo "unsupported architecture: $arch" >&2; exit 1 ;; esac`,
+        'wheel="/tmp/cua-driver-${sha}.whl"',
+        'curl -fsSL "$url" -o "$wheel"',
+        'echo "$sha  $wheel" | sha256sum -c -',
+        'python3 - "$wheel" <<\'PY\'\nimport os, sys, zipfile\nwheel = sys.argv[1]\nwith zipfile.ZipFile(wheel) as archive:\n    names = [name for name in archive.namelist() if name == "cua_driver/bin/cua-driver" or name.endswith("/cua_driver/bin/cua-driver")]\n    if len(names) != 1:\n        raise SystemExit("cua-driver executable missing from wheel")\n    with archive.open(names[0]) as source, open("/opt/ogb/cua-driver", "wb") as target:\n        target.write(source.read())\nos.chmod("/opt/ogb/cua-driver", 0o755)\nPY',
+        `test "$(${REMOTE_CUA_EXECUTABLE} --version)" = "cua-driver ${REMOTE_CUA_VERSION}"`,
+        `touch /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready`,
+        'rm -f "$wheel"',
+    ].join("\n");
+    const safeName = botName.replace(/["'\\]/g, "");
+    return [
+        "if ! command -v xdotool >/dev/null || ! command -v convert >/dev/null || ! command -v curl >/dev/null || ! command -v python3 >/dev/null; then sudo apt-get update -qq || true; sudo apt-get install -y -qq ca-certificates curl python3 gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true; fi",
+        "sudo mkdir -p /opt/ogb/run",
+        `printf %s ${shellQuote(helper)} | base64 -d | sudo tee ${REMOTE_CDP_HELPER} >/dev/null`,
+        `sudo chmod 0755 ${REMOTE_CDP_HELPER}`,
+        'pkill -f "^/opt/ogb/venv/bin/python -m computer_server( |$)" >/dev/null 2>&1 || true',
+        `[ -f /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c ${shellQuote(installer)} > /tmp/ogb-cua-install.log 2>&1 & }`,
+        ensureRemoteCuaCommand(),
+        `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${safeName}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
+        "echo bootstrapped",
+    ].join("\n");
+}
+export function semanticBrowserCommand(action, input) {
+    const encoded = Buffer.from(JSON.stringify(input ?? {})).toString("base64url");
+    return `node ${REMOTE_CDP_HELPER} ${action} ${shellQuote(encoded)}`;
+}

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -31,6 +31,8 @@ const STANDALONE_SOCKET = path.join(
   "Library/Caches/cua-driver/cua-driver.sock",
 );
 const HOST_BUNDLE_ID = "com.openmausbot.app";
+const CUA_ENV = { CUA_DRIVER_RS_TELEMETRY_ENABLED: "0" };
+process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED ??= "0";
 
 let embeddedHost = null; // EmbeddedCuaDriverHost | null
 const connectionStore = createCuaConnectionStore({
@@ -100,7 +102,7 @@ async function startEmbedded(binary) {
     socketPath: conn.socketPath,
     mcpCommand: binary,
     mcpArgs: ["mcp", "--embedded", "--socket", conn.socketPath],
-    mcpEnv: { CUA_DRIVER_EMBEDDED: "1", CUA_DRIVER_HOST_BUNDLE_ID: HOST_BUNDLE_ID },
+    mcpEnv: { ...CUA_ENV, CUA_DRIVER_EMBEDDED: "1", CUA_DRIVER_HOST_BUNDLE_ID: HOST_BUNDLE_ID },
   };
 }
 
@@ -133,7 +135,7 @@ export async function startCua() {
       socketPath: STANDALONE_SOCKET,
       mcpCommand: binary,
       mcpArgs: ["mcp"],
-      mcpEnv: {},
+      mcpEnv: { ...CUA_ENV },
     };
   } else {
     nextConnection = {
@@ -152,6 +154,7 @@ export function cuaPermissionsStatus() {
   const out = spawnSync(binary, ["permissions", "status", "--json"], {
     encoding: "utf8",
     timeout: 5000,
+    env: { ...process.env, ...CUA_ENV },
   });
   try {
     return { available: true, ...JSON.parse(out.stdout) };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "package": "pnpm package:mac"
   },
   "dependencies": {
-    "@trycua/cua-driver": "0.19.3",
+    "@trycua/cua-driver": "0.20.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
     "posthog-js": "^1.415.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@trycua/cua-driver':
-        specifier: 0.19.3
-        version: 0.19.3
+        specifier: 0.20.0
+        version: 0.20.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -707,40 +707,40 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@trycua/cua-driver-darwin-arm64@0.19.3':
-    resolution: {integrity: sha512-zd37WTn8JP3ixXiMN4BjhYsN5o/+TsF/UTD4YTEtapYqTiw1DcQxuwZhXQDtvrmQYfaPjOgwlDib1vZ584UBIA==}
+  '@trycua/cua-driver-darwin-arm64@0.20.0':
+    resolution: {integrity: sha512-LiEZ3Mku2BI83UJD7MWNoGw+PYIyo6hfmqA5T3zWle7Rti3Jhvic+Tnu+KZ9i+HXBZEQ84GUR91S+zUTdchh+Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@trycua/cua-driver-darwin-x64@0.19.3':
-    resolution: {integrity: sha512-Z1jTJ9IImfR6njGu79DHe5JCuvximAUbqlpi+RmcXHVmkW8R6Ht7lhnAvOT58pa3FEiyY6zIDouZyxePxX950A==}
+  '@trycua/cua-driver-darwin-x64@0.20.0':
+    resolution: {integrity: sha512-4T2+qPYvW8ZUi6XYJM9r6mjfllw3zyEZUUdYvy9Q1WQA6HjcY4mXhXFlEfLjWE0wOeXYrNEXJ8JyYEL0jlzmtw==}
     cpu: [x64]
     os: [darwin]
 
-  '@trycua/cua-driver-linux-arm64-gnu@0.19.3':
-    resolution: {integrity: sha512-Q0pDIpg0TNbLQmi8mIdgeBrfcvSq0vJYLQu20E0DBTiAQz+hhx2uvPjNbOadQXJgEnnEs7RUgO5g+mJ5SZpQ3A==}
+  '@trycua/cua-driver-linux-arm64-gnu@0.20.0':
+    resolution: {integrity: sha512-ya4Cc3ZO1x3HvCIAcouvVnhWDP5f7ZDWczeG1ym3qWST02AP5EtWXrqoPxRKbTV7y/yqovPO/Bk3mG+3F92AoA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@trycua/cua-driver-linux-x64-gnu@0.19.3':
-    resolution: {integrity: sha512-knUIsm9k5DlUOx8cTDOTwN2GQHyDvAsNqETdVpKOpTakut5FO4OHgabjlPw+q37TkZxPaKntaY6OBjCNlezgvA==}
+  '@trycua/cua-driver-linux-x64-gnu@0.20.0':
+    resolution: {integrity: sha512-NjCt19AoCTqe148FdNAK6DmYEuFz9oW+/zh0OzCpfrGNvOvqnOkBT5wVFl7NFQIaNIlERV9f3+SG0Z6eL2QBkA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@trycua/cua-driver-win32-arm64-msvc@0.19.3':
-    resolution: {integrity: sha512-SEyYNfDXsgbOzH9z0mEqgMrrSkfEveB8C8SRemfujXvhnvtx8CfzGz+BPYKqLGo9tA9JxJwX4jfM8J41XOR8/g==}
+  '@trycua/cua-driver-win32-arm64-msvc@0.20.0':
+    resolution: {integrity: sha512-16a1berZU8BdIA5NDg7ZWM+6r+LTTrOUcS3inUfPeWTxYiqlYhLthDVKR4PZCJhkx+w07ySSviS5O47XQx/M9A==}
     cpu: [arm64]
     os: [win32]
 
-  '@trycua/cua-driver-win32-x64-msvc@0.19.3':
-    resolution: {integrity: sha512-an3KaK/6HxB6LnHJ1uYv3ZBpZl3v0jukEOHPXzWifk3Zml14pKtTMbTuEnkr4I07c6BJumzXJ7gOTOZYcuMX7g==}
+  '@trycua/cua-driver-win32-x64-msvc@0.20.0':
+    resolution: {integrity: sha512-COOfQZJIcbhWSrfvcT98F7TFbdmwMqqP9AUQIzvPo82VxzXb/nG2KrZohinelR5dAdJ6YBGRw8hIMW/QsgTp9g==}
     cpu: [x64]
     os: [win32]
 
-  '@trycua/cua-driver@0.19.3':
-    resolution: {integrity: sha512-Oc/FsGP56kpKn4TcADELcEUkLDCby+Wglt+5dX6r4QJbESWvRPdPJ09wvFPmIQeJ7dAUEnrIjuQt4Kz/LIQN3Q==}
+  '@trycua/cua-driver@0.20.0':
+    resolution: {integrity: sha512-PYNA9zbZX46LLObcPSNUm37tIlP0/klphRaSyuJPA3NdaaLiglfw3HcWM/C0wB2KTb8nIS17hb2qCxB8F1VC4Q==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3044,35 +3044,35 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
-  '@trycua/cua-driver-darwin-arm64@0.19.3':
+  '@trycua/cua-driver-darwin-arm64@0.20.0':
     optional: true
 
-  '@trycua/cua-driver-darwin-x64@0.19.3':
+  '@trycua/cua-driver-darwin-x64@0.20.0':
     optional: true
 
-  '@trycua/cua-driver-linux-arm64-gnu@0.19.3':
+  '@trycua/cua-driver-linux-arm64-gnu@0.20.0':
     optional: true
 
-  '@trycua/cua-driver-linux-x64-gnu@0.19.3':
+  '@trycua/cua-driver-linux-x64-gnu@0.20.0':
     optional: true
 
-  '@trycua/cua-driver-win32-arm64-msvc@0.19.3':
+  '@trycua/cua-driver-win32-arm64-msvc@0.20.0':
     optional: true
 
-  '@trycua/cua-driver-win32-x64-msvc@0.19.3':
+  '@trycua/cua-driver-win32-x64-msvc@0.20.0':
     optional: true
 
-  '@trycua/cua-driver@0.19.3':
+  '@trycua/cua-driver@0.20.0':
     dependencies:
       '@ubjs/core': 0.31.0-3
       '@ubjs/node': 0.31.0-3
     optionalDependencies:
-      '@trycua/cua-driver-darwin-arm64': 0.19.3
-      '@trycua/cua-driver-darwin-x64': 0.19.3
-      '@trycua/cua-driver-linux-arm64-gnu': 0.19.3
-      '@trycua/cua-driver-linux-x64-gnu': 0.19.3
-      '@trycua/cua-driver-win32-arm64-msvc': 0.19.3
-      '@trycua/cua-driver-win32-x64-msvc': 0.19.3
+      '@trycua/cua-driver-darwin-arm64': 0.20.0
+      '@trycua/cua-driver-darwin-x64': 0.20.0
+      '@trycua/cua-driver-linux-arm64-gnu': 0.20.0
+      '@trycua/cua-driver-linux-x64-gnu': 0.20.0
+      '@trycua/cua-driver-win32-arm64-msvc': 0.20.0
+      '@trycua/cua-driver-win32-x64-msvc': 0.20.0
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/scripts/prepare-cua.mjs
+++ b/scripts/prepare-cua.mjs
@@ -23,9 +23,9 @@ const dependencyRoot = join(sdkRoot, "..", "..");
 const sdkPackage = JSON.parse(await readFile(join(sdkRoot, "package.json"), "utf8"));
 const expectedVersion = String(sdkPackage.version);
 const release = {
-  version: "0.19.3",
-  file: "cua-driver-rs-0.19.3-darwin-universal-binary.tar.gz",
-  sha256: "733e28a3782ac8d325f8fce8b5d97486c1054af755b40dfd086151b34c79377e",
+  version: "0.20.0",
+  file: "cua-driver-rs-0.20.0-darwin-universal-binary.tar.gz",
+  sha256: "07a88ea2c28a9ead66b2d9f6f93fab4b1189a1f7c704d2cd7b6d12c30eee9984",
 };
 if (expectedVersion !== release.version) {
   throw new Error(

--- a/scripts/smoke-cua-container.mjs
+++ b/scripts/smoke-cua-container.mjs
@@ -23,6 +23,8 @@ const child = spawn(
     "DISPLAY=:1",
     "-e",
     "CUA_DRIVER_INSTALL_CHANNEL=python_package",
+    "-e",
+    "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
     container,
     "/usr/local/libexec/openmausbot/cua-driver",
     "mcp",

--- a/scripts/smoke-cua.mjs
+++ b/scripts/smoke-cua.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const resources = process.env.OMB_CUA_RESOURCES ?? join(root, "dist-native");
 process.env.OPENMAUSBOT_CUA_SDK_LIBRARY = join(resources, "cua-sdk/native/libcua_driver_sdk.dylib");
+process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED = "0";
 const sdk = pathToFileURL(join(resources, "cua-sdk/cua-sdk.mjs")).href;
 const binary = join(resources, "cua-driver");
 const { EmbeddedCuaDriverHost } = await import(sdk);
@@ -21,6 +22,7 @@ try {
       ...Object.fromEntries(connection.mcp.environment.map(({ name, value }) => [name, value])),
       CUA_DRIVER_EMBEDDED: "1",
       CUA_DRIVER_HOST_BUNDLE_ID: "com.openmausbot.app",
+      CUA_DRIVER_RS_TELEMETRY_ENABLED: "0",
     },
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/server/box-provision.test.ts
+++ b/server/box-provision.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-type RequestRecord = { method: string; path: string; headers: IncomingMessage["headers"] };
+type RequestRecord = { method: string; path: string; headers: IncomingMessage["headers"]; body: string };
 
 describe("cloud computer provisioning cleanup", () => {
   let api: Server;
@@ -22,7 +22,7 @@ describe("cloud computer provisioning cleanup", () => {
       let body = "";
       req.on("data", (chunk) => (body += chunk));
       req.on("end", () => {
-        requests.push({ method: req.method ?? "GET", path: url.pathname, headers: req.headers });
+        requests.push({ method: req.method ?? "GET", path: url.pathname, headers: req.headers, body });
         res.setHeader("content-type", "application/json");
 
         if (url.pathname === "/api/box/v1/boxes" && req.method === "GET") {
@@ -71,6 +71,8 @@ describe("cloud computer provisioning cleanup", () => {
     );
 
     const removal = requests.find((request) => request.method === "DELETE");
+    const creation = requests.find((request) => request.method === "POST" && request.path.endsWith("/boxes"));
+    expect(JSON.parse(creation?.body ?? "{}")).toMatchObject({ noEnv: true });
     expect(removal?.path).toBe("/api/box/v1/boxes/new-box");
     expect(removal?.headers["x-ascii-confirm-delete"]).toBe("new-box");
   });

--- a/server/box.ts
+++ b/server/box.ts
@@ -11,6 +11,7 @@
 //   - X11 desktop with Chrome + Ghostty; passwordless sudo; node 24.
 //   - the dedicated IP rotates across archive/resume — never persist it.
 import type { AppConfig } from "./config.ts";
+import { ensureRemoteCuaCommand, remoteComputerBootstrapCommand } from "./remote-computer.ts";
 
 // overridable so tests can point at a stub instead of the live provider
 const BOX_API = process.env.OMB_BOX_API || "https://ascii.dev/api/box/v1";
@@ -198,7 +199,10 @@ export async function provisionBox(cfg: AppConfig, botId: string, botName: strin
         method: "POST",
         // substrate-side backstop: archives itself (billing pauses, disk
         // survives) if every stop path dies
-        body: JSON.stringify({ ttlSeconds: 8 * 60 * 60 }),
+        // The computer needs the user's desktop session, not the account
+        // owner's host credentials. Keep provider-side env injection off so
+        // API keys cannot silently appear inside the guest.
+        body: JSON.stringify({ ttlSeconds: 8 * 60 * 60, noEnv: true }),
       });
       if (!createRes.ok || !createRes.body?.box?.id) {
         throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
@@ -214,35 +218,9 @@ export async function provisionBox(cfg: AppConfig, botId: string, botName: strin
     const ready = await waitReady(cfg, box.id);
     if (!ready) throw new Error("box did not become ready within 90s — retry in a minute");
 
-    // Idempotent bootstrap. Three layers:
-    //   1. X11 action + capture tools (xdotool/scrot/imagemagick) — the
-    //      always-works fallback for the computer tools.
-    //   2. CUA (cua-computer-server, trycua) installed into /opt/ogb/venv in
-    //      the BACKGROUND (first install takes minutes; nohup'd children
-    //      survive the commands endpoint returning — probed by agentcal).
-    //   3. computer-server started loopback-only on :8000 when installed —
-    //      driven from outside via the box's run-command endpoint, so no
-    //      inbound port and no tunnel is ever needed.
-    const cuaInstall = [
-      "sudo apt-get update -qq || true",
-      "sudo apt-get install -y -qq gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true",
-      'curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true',
-      'export PATH="$HOME/.local/bin:$PATH"',
-      'sudo mkdir -p /opt/ogb && sudo chown "$(whoami)" /opt/ogb',
-      "uv venv /opt/ogb/venv --python 3.13 >/dev/null 2>&1 || uv venv /opt/ogb/venv >/dev/null 2>&1 || true",
-      "[ -x /opt/ogb/venv/bin/python ] && uv pip install --python /opt/ogb/venv/bin/python cua-computer-server >/dev/null 2>&1 || true",
-      "[ -x /opt/ogb/venv/bin/python ] && /opt/ogb/venv/bin/python -c 'import computer_server' 2>/dev/null && touch /opt/ogb/cua-ready || true",
-    ].join("; ");
-    const bootstrap = [
-      "command -v xdotool >/dev/null || sudo apt-get install -y -qq xdotool scrot imagemagick >/dev/null 2>&1 || true",
-      `[ -f /opt/ogb/cua-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c '${cuaInstall.replace(/'/g, "'\\''")}; rm -f /tmp/ogb-cua-installing' > /tmp/ogb-cua-install.log 2>&1 & }`,
-      // start CUA computer-server (loopback only) once installed; pidfile-free
-      // guard on the module name is safe here — the pattern cannot match this
-      // bootstrap's own shell (agentcal's pgrep self-match trap)
-      'if [ -f /opt/ogb/cua-ready ] && ! pgrep -f "computer_server" >/dev/null 2>&1; then DISPLAY=${DISPLAY:-:0} nohup /opt/ogb/venv/bin/python -m computer_server --host 127.0.0.1 --port 8000 --width 1280 --height 800 > /tmp/ogb-cua-server.log 2>&1 & fi',
-      `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${botName.replace(/["'\\\\]/g, "")}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
-      "echo bootstrapped",
-    ].join("\n");
+    // Install the exact Cua Driver executable in the background, keep its
+    // daemon private to the VM, and retain X11 tooling as a degraded fallback.
+    const bootstrap = remoteComputerBootstrapCommand(botName);
     let boot;
     for (let attempt = 0; attempt < 5; attempt++) {
       boot = await runCommand(cfg, box.id, bootstrap);
@@ -276,6 +254,9 @@ export async function joinBox(cfg: AppConfig, botId: string) {
   if (!box) throw new Error("no computer yet — provision it first");
   const ready = await waitReady(cfg, box.id);
   if (!ready) throw new Error("the box did not wake in time — try again");
+  // Provider archive/resume preserves disk but not processes. Reattach the
+  // driver daemon before handing the desktop back to the user.
+  await runCommand(cfg, box.id, ensureRemoteCuaCommand(), { timeoutMs: 15_000 }).catch(() => null);
   return { joinUrl: await mintDesktopUrl(cfg, box.id), state: ready.state ?? null };
 }
 

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -10,7 +10,7 @@
 //   4. computer_batch runs a whole sequence in one round trip,
 //   5. an unchanged screen is reported as text instead of resending the
 //      same pixels.
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -63,6 +63,17 @@ describe("computer proxy (fake box)", () => {
             ? JSON.stringify([
                 { id: "page-1", type: "page", title: " Example ", url: browserUrl },
               ])
+            : command.includes("openmausbot-cdp.mjs snapshot")
+              ? JSON.stringify({
+                  title: "Account",
+                  url: "https://user:password@example.com/form?token=secret#private",
+                  elements: [
+                    { ref: "b41", role: "textbox", name: "Email" },
+                    { ref: "b42", role: "button", name: "Continue" },
+                  ],
+                })
+              : command.includes("openmausbot-cdp.mjs click") || command.includes("openmausbot-cdp.mjs fill")
+                ? `GEOM 1920 1080\nHASH ${hash}\nSIZE ${size}\nB64 ${JPEG}\nSEM ok\n`
             : cropFails && /convert "\$f" -crop/.test(command)
               ? `GEOM 1920 1080\nHASH ${hash}\nCROP_FAILED\n`
               : /GEOM/.test(command)
@@ -123,7 +134,17 @@ describe("computer proxy (fake box)", () => {
     const res = await waitFor(2);
     const names = res.result.tools.map((t: any) => t.name);
     expect(names).toContain("computer_batch");
-    expect(names).toEqual(expect.arrayContaining(["browser_state", "wait_for_navigation", "observation_metrics"]));
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "browser_state",
+        "browser_snapshot",
+        "browser_click",
+        "browser_fill",
+        "computer_status",
+        "wait_for_navigation",
+        "observation_metrics",
+      ]),
+    );
     const click = res.result.tools.find((t: any) => t.name === "click");
     expect(click.description).toMatch(/return the resulting screen/i);
     const screenshot = res.result.tools.find((t: any) => t.name === "screenshot");
@@ -142,12 +163,17 @@ describe("computer proxy (fake box)", () => {
     // one command carried the click, the settle and the capture
     expect(commands.length - before).toBe(1);
     const command = commands.at(-1)!;
+    expect(command).toContain('exec env -i HOME="$HOME"');
+    if (process.platform !== "win32") expect(spawnSync("/bin/bash", ["-n", "-c", command]).status).toBe(0);
     expect(command).toMatch(/xdotool mousemove \$CX \$CY click 1/);
+    expect(command).toContain("/opt/ogb/cua-driver call click");
+    expect(command).toContain("CUA_DRIVER_RS_TELEMETRY_ENABLED=0");
     expect(command).toMatch(/getdisplaygeometry/); // scaling resolved box-side
     // scaling is conditional: a display narrower than the model's space is
     // captured at native size, so the coordinates must pass through as-is
     expect(command).toMatch(/if \[ "\$W" -gt 1280 \].*CX=\$\(\( 100 \* W \/ 1280 \)\).*else CX=100/);
     expect(command).toMatch(/scrot -o -q 75/); // JPEG, no unconditional convert
+    expect(command).toContain("call get_desktop_state");
     // ...and the model got pixels back with it, no second tool call
     const content = res.result.content;
     expect(content[0].type).toBe("text");
@@ -180,7 +206,7 @@ describe("computer proxy (fake box)", () => {
       params: { name: "type_text", arguments: { text: "hello" } },
     });
     const res = await waitFor(5);
-    expect(commands.at(-1)).toMatch(/xdotool type --clearmodifiers --delay 8 -- 'hello'/);
+    expect(commands.at(-1)).toMatch(/xdotool type --clearmodifiers --delay 8 -- .*hello/);
     expect(res.result.content[1]).toMatchObject({ type: "image" });
   });
 
@@ -193,7 +219,7 @@ describe("computer proxy (fake box)", () => {
       params: { name: "type_text", arguments: { text: "--safe" } },
     });
     await waitFor(51);
-    expect(commands.at(-1)).toContain("xdotool type --clearmodifiers --delay 8 -- '--safe'");
+    expect(commands.at(-1)).toMatch(/xdotool type --clearmodifiers --delay 8 -- .*--safe/);
   });
 
   it("runs a whole batch in one round trip with one frame at the end", async () => {
@@ -243,6 +269,41 @@ describe("computer proxy (fake box)", () => {
     const output = res.result.content[0].text;
     expect(output).toContain("https://example.com/path");
     expect(output).not.toMatch(/user|password|token|secret|private/);
+  });
+
+  it("uses fresh semantic browser refs without exposing URL secrets", async () => {
+    rpc({ jsonrpc: "2.0", id: 81, method: "tools/call", params: { name: "browser_snapshot", arguments: {} } });
+    const snapshot = await waitFor(81);
+    const snapshotText = snapshot.result.content[0].text;
+    expect(snapshotText).toContain("[b41] textbox: Email");
+    expect(snapshotText).toContain("https://example.com/form");
+    expect(snapshotText).not.toMatch(/user|password|token|secret|private/);
+
+    hash = "semantic-1";
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 82,
+      method: "tools/call",
+      params: { name: "browser_fill", arguments: { ref: "b41", text: "person@example.com" } },
+    });
+    const filled = await waitFor(82);
+    expect(commands.length - before).toBe(1);
+    expect(commands.at(-1)).toContain("openmausbot-cdp.mjs fill");
+    expect(commands.at(-1)).not.toContain("person@example.com");
+    expect(filled.result.content[0].text).toMatch(/trusted Chrome DevTools input/);
+
+    const staleBefore = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 83,
+      method: "tools/call",
+      params: { name: "browser_click", arguments: { ref: "b42" } },
+    });
+    const stale = await waitFor(83);
+    expect(stale.result.isError).toBe(true);
+    expect(stale.result.content[0].text).toMatch(/stale/i);
+    expect(commands.length).toBe(staleBefore);
   });
 
   it("does not verify a different query or an invalid expected URL", async () => {

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -35,6 +35,14 @@ import {
   type BrowserTarget,
   type CropRegion,
 } from "./computer-observation.ts";
+import {
+  ensureRemoteCuaCommand,
+  REMOTE_CUA_EXECUTABLE,
+  REMOTE_CUA_SESSION,
+  REMOTE_CUA_SOCKET,
+  REMOTE_CUA_VERSION,
+  semanticBrowserCommand,
+} from "./remote-computer.ts";
 
 const BOX_API = process.env.OGB_BOX_API ?? "https://ascii.dev/api/box/v1";
 const boxId = process.env.OGB_BOX_ID ?? "";
@@ -102,10 +110,26 @@ async function resumeBox(): Promise<boolean> {
 }
 
 async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): Promise<RunOut> {
+  // Old boxes may predate noEnv:true. Run every agent-issued command with an
+  // explicit desktop-only environment so provider/account credentials cannot
+  // leak through `computer_exec` or a child GUI process.
+  const isolatedCommand = [
+    "exec env -i",
+    'HOME="$HOME"',
+    'USER="${USER:-$(id -un)}"',
+    'LOGNAME="${LOGNAME:-${USER:-$(id -un)}}"',
+    'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
+    'DISPLAY="${DISPLAY:-:0}"',
+    'XAUTHORITY="${XAUTHORITY:-$HOME/.Xauthority}"',
+    'XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"',
+    'DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}"',
+    "/bin/bash -c",
+    shellQuote(command),
+  ].join(" ");
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-    body: JSON.stringify({ command }),
+    body: JSON.stringify({ command: isolatedCommand }),
     signal: AbortSignal.timeout(timeoutMs),
   });
   const body: any = await res.json().catch(() => null);
@@ -166,6 +190,7 @@ async function waitForNavigation(
 }
 
 const ENV = 'export DISPLAY=${DISPLAY:-:0}';
+const CUA_ENV = "CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0";
 /** Resolve the real display size into $W/$H for box-side click scaling. */
 const GEOMETRY = [
   "g=$(xdotool getdisplaygeometry 2>/dev/null)",
@@ -184,6 +209,18 @@ function scaled(varName: string, value: number): string {
   return `if [ "$W" -gt ${SHOT_WIDTH} ] 2>/dev/null; then ${varName}=$(( ${v} * W / ${SHOT_WIDTH} )); else ${varName}=${v}; fi`;
 }
 
+/** Prefer the official driver but keep the proven X11 command as a degraded
+ * path while a first install is finishing or if the daemon needs repair. */
+function cuaOrX11(tool: string, argumentsShell: string, fallback: string): string {
+  return [
+    `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1;`,
+    `then if CUA_OUT=$(env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call ${tool} ${argumentsShell} --socket ${REMOTE_CUA_SOCKET} 2>/tmp/ogb-cua-call.error);`,
+    `then echo "BACKEND CUA"; echo "CUA_RESULT $(printf %s "$CUA_OUT" | base64 -w0 2>/dev/null || printf %s "$CUA_OUT" | base64 | tr -d '\\n')"`,
+    `else ${fallback}; X11_RC=$?; echo "BACKEND X11"; [ "$X11_RC" -eq 0 ]; fi`,
+    `else ${fallback}; X11_RC=$?; echo "BACKEND X11"; [ "$X11_RC" -eq 0 ]; fi`,
+  ].join(" ");
+}
+
 /** act → settle → capture → canonical hash → optional crop → inline bytes.
  * The hash is taken before cropping, so change detection always describes
  * the full screen. A requested crop fails closed when conversion fails. */
@@ -200,8 +237,10 @@ function captureBlock(settleMs = SETTLE_MS, crop: CropRegion | null = null): str
   return [
     settleMs > 0 ? `sleep ${(settleMs / 1000).toFixed(2)}` : "true",
     `f=${SHOT_PATH}`,
+    'raw=/tmp/ogb-shot.png',
     `rm -f "$f" 2>/dev/null || true`,
-    `scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1`,
+    `rm -f "$raw" 2>/dev/null || true`,
+    `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1 && env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call get_desktop_state ${shellQuote(JSON.stringify({ scope: "desktop", session: REMOTE_CUA_SESSION }))} --socket ${REMOTE_CUA_SOCKET} --screenshot-out-file "$raw" >/dev/null 2>&1 && command -v convert >/dev/null 2>&1 && convert "$raw" -quality ${JPEG_QUALITY} "$f" 2>/dev/null; then echo "CAPTURE CUA"; else scrot -o -q ${JPEG_QUALITY} "$f" 2>/dev/null || import -window root -quality ${JPEG_QUALITY} "$f" 2>/dev/null || ffmpeg -y -f x11grab -i "$DISPLAY" -frames:v 1 -q:v 6 "$f" >/dev/null 2>&1; echo "CAPTURE X11"; fi`,
     // only re-encode when the display is bigger than the model's space —
     // ImageMagick startup is the most expensive step in the old pipeline
     downscale,
@@ -281,6 +320,14 @@ interface Frame {
 
 let inlineWorks = true; // flipped off for the proxy's life on first garbage
 let lastDisplayGeometry: Frame["geometry"] = null;
+let semanticBrowserUrl: string | null = null;
+let semanticBrowserRefs = new Set<string>();
+
+interface SemanticBrowserSnapshot {
+  title: string;
+  url: string;
+  elements: Array<{ ref: string; role: string; name: string; disabled?: boolean }>;
+}
 
 function geometryFrom(stdout: string): Frame["geometry"] {
   const match = stdout.match(/^GEOM\s+(\d+)\s+(\d+)$/m);
@@ -288,6 +335,23 @@ function geometryFrom(stdout: string): Frame["geometry"] {
   const width = Number(match[1]);
   const height = Number(match[2]);
   return width > 0 && height > 0 ? { width, height } : null;
+}
+
+function automationSummary(stdout: string): string {
+  if (/^BACKEND CUA$/m.test(stdout)) {
+    const encoded = stdout.match(/^CUA_RESULT\s+([^\s]+)$/m)?.[1];
+    if (!encoded) return `Cua Driver ${REMOTE_CUA_VERSION}`;
+    try {
+      const result = JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as Record<string, unknown>;
+      const details = [result.effect, result.route, result.escalation]
+        .filter((value): value is string => typeof value === "string" && Boolean(value))
+        .slice(0, 3);
+      return [`Cua Driver ${REMOTE_CUA_VERSION}`, ...details].join(" · ");
+    } catch {
+      return `Cua Driver ${REMOTE_CUA_VERSION}`;
+    }
+  }
+  return /^BACKEND X11$/m.test(stdout) ? "X11 fallback" : "automation backend unavailable";
 }
 
 async function observationBounds(): Promise<{ width: number; height: number } | null> {
@@ -411,6 +475,30 @@ const TOOLS = [
     inputSchema: { type: "object", properties: {} },
   },
   {
+    name: "browser_snapshot",
+    description:
+      "Read Chrome's semantic accessibility tree and return fresh element refs. Prefer this over screenshots for links, buttons, and form fields.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "browser_click",
+    description: "Click one element ref from the most recent browser_snapshot and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: { ref: { type: "string" }, ...OBSERVE_PROPS },
+      required: ["ref"],
+    },
+  },
+  {
+    name: "browser_fill",
+    description: "Replace the text in one field ref from the most recent browser_snapshot and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: { ref: { type: "string" }, text: { type: "string" }, ...OBSERVE_PROPS },
+      required: ["ref", "text"],
+    },
+  },
+  {
     name: "wait_for_navigation",
     description:
       "Verify that Chrome reached one exact http(s) URL, including its query and fragment, with at most three bounded checks.",
@@ -423,6 +511,11 @@ const TOOLS = [
   {
     name: "observation_metrics",
     description: "Return this turn's observation, action, retry, and verification counters.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "computer_status",
+    description: "Report whether the cloud computer is using Cua Driver or the degraded X11 fallback.",
     inputSchema: { type: "object", properties: {} },
   },
   {
@@ -546,22 +639,39 @@ function actionShell(a: any): string | { error: string } {
     if (!Number.isFinite(x) || !Number.isFinite(y)) return { error: "click needs numeric x,y" };
     const btn = a.button === "right" ? 3 : 1;
     const rep = a.double ? "--repeat 2 --delay 60 " : "";
-    return `${scaled("CX", x)}; ${scaled("CY", y)}; xdotool mousemove $CX $CY click ${rep}${btn}`;
+    const button = a.button === "right" ? "right" : "left";
+    const count = a.double ? 2 : 1;
+    const fallback = `xdotool mousemove $CX $CY click ${rep}${btn}`;
+    const args = `$(printf '{"x":%s,"y":%s,"button":"${button}","count":${count},"scope":"desktop","session":"${REMOTE_CUA_SESSION}"}' "$CX" "$CY")`;
+    return `${scaled("CX", x)}; ${scaled("CY", y)}; CUA_ARGS=${args}; ${cuaOrX11("click", '"$CUA_ARGS"', fallback)}`;
   }
   if (kind === "type_text") {
     const t = String(a.text ?? "");
     if (!t) return { error: "type_text needs text" };
-    return `xdotool type --clearmodifiers --delay 8 -- ${shellQuote(t)}`;
+    const cuaArgs = shellQuote(JSON.stringify({ text: t, scope: "desktop", session: REMOTE_CUA_SESSION }));
+    return cuaOrX11("type_text", cuaArgs, `xdotool type --clearmodifiers --delay 8 -- ${shellQuote(t)}`);
   }
   if (kind === "press_key") {
     const keys = String(a.keys ?? "").replace(/[^\w+]/g, "");
     if (!keys) return { error: "press_key needs keys" };
-    return `xdotool key ${keys}`;
+    const parts = keys.split("+").filter(Boolean);
+    const tool = parts.length > 1 ? "hotkey" : "press_key";
+    const cuaArgs = shellQuote(
+      JSON.stringify(
+        parts.length > 1
+          ? { keys: parts, scope: "desktop", session: REMOTE_CUA_SESSION }
+          : { key: parts[0]?.toLowerCase(), scope: "desktop", session: REMOTE_CUA_SESSION },
+      ),
+    );
+    return cuaOrX11(tool, cuaArgs, `xdotool key ${keys}`);
   }
   if (kind === "scroll") {
     const clicks = Math.min(Math.max(Math.round(Number(a.clicks) || 3), 1), 20);
     const btn = a.direction === "up" ? 4 : 5;
-    return `xdotool click --repeat ${clicks} ${btn}`;
+    const direction = a.direction === "up" ? "up" : "down";
+    const fallback = `xdotool click --repeat ${clicks} ${btn}`;
+    const args = `$(printf '{"x":%s,"y":%s,"direction":"${direction}","amount":${clicks},"by":"line","scope":"desktop","session":"${REMOTE_CUA_SESSION}"}' "$((W / 2))" "$((H / 2))")`;
+    return `CUA_ARGS=${args}; ${cuaOrX11("scroll", '"$CUA_ARGS"', fallback)}`;
   }
   if (kind === "wait") {
     const ms = Math.min(Math.max(Number(a.ms) || 500, 0), 5000);
@@ -596,9 +706,14 @@ async function actAndObserve(
   // ended up in. Joining with ";" alone made a failed action look
   // identical to one that did nothing.
   const guarded = `if { ${parts.join("; ")}; }; then ACT=ok; else ACT=failed; fi`;
-  const command = [ENV, GEOMETRY, guarded, observe ? captureBlock(settleOf(args)) : "true", 'echo "ACT $ACT"'].join(
-    "; ",
-  );
+  const command = [
+    ENV,
+    GEOMETRY,
+    ensureRemoteCuaCommand(),
+    guarded,
+    observe ? captureBlock(settleOf(args)) : "true",
+    'echo "ACT $ACT"',
+  ].join("; ");
   const out = await runOnBox(command, timeoutMs);
   const acted = /^ACT ok$/m.test(out.stdout);
   if (!acted && !out.stdout.includes("GEOM")) {
@@ -608,9 +723,52 @@ async function actAndObserve(
       true,
     );
   }
-  const full = acted ? note : `${note}\n(the action reported an error: ${out.stderr.slice(0, 160) || "no detail"})`;
+  const backend = automationSummary(out.stdout);
+  const full = acted
+    ? `${note}\n(${backend})`
+    : `${note}\n(the action reported an error: ${out.stderr.slice(0, 160) || "no detail"}; ${backend})`;
   if (!observe) return text(id, full, !acted);
   return observed(id, full, await frameFrom(out));
+}
+
+async function semanticActAndObserve(
+  id: unknown,
+  action: "click" | "fill",
+  ref: string,
+  value: string | undefined,
+  args: any,
+): Promise<void> {
+  if (!semanticBrowserUrl || !semanticBrowserRefs.has(ref)) {
+    return text(id, "that browser ref is stale or unknown — take a new browser_snapshot", true);
+  }
+  const observe = wantsFrame(args);
+  const semantic = semanticBrowserCommand(action, {
+    ref,
+    ...(action === "fill" ? { text: value ?? "" } : {}),
+    url: semanticBrowserUrl,
+  });
+  const guarded = `if ${semantic}; then SEM=ok; else SEM=failed; fi`;
+  const command = [
+    ENV,
+    GEOMETRY,
+    guarded,
+    ensureRemoteCuaCommand(),
+    observe ? captureBlock(settleOf(args)) : "true",
+    'echo "SEM $SEM"',
+  ].join("; ");
+  observations.noteAction();
+  const out = await runOnBox(command, action === "fill" ? 120_000 : 60_000);
+  const acted = /^SEM ok$/m.test(out.stdout);
+  // DOM mutations can invalidate backend node IDs; force a fresh snapshot
+  // after every semantic action instead of risking a click on an old target.
+  semanticBrowserRefs.clear();
+  const note = acted
+    ? action === "fill"
+      ? `filled ${ref} with ${value?.length ?? 0} chars (trusted Chrome DevTools input)`
+      : `clicked ${ref} (trusted Chrome DevTools input)`
+    : `${action} ${ref} failed: ${out.stderr.slice(0, 200) || "the page changed; take a new browser_snapshot"}`;
+  if (!observe) return text(id, note, !acted);
+  return observed(id, note, await frameFrom(out));
 }
 
 async function call(id: unknown, name: string, args: any) {
@@ -628,7 +786,7 @@ async function call(id: unknown, name: string, args: any) {
         );
       }
     }
-    const out = await runOnBox([ENV, GEOMETRY, captureBlock(0, crop)].join("; "), 60_000);
+    const out = await runOnBox([ENV, GEOMETRY, ensureRemoteCuaCommand(), captureBlock(0, crop)].join("; "), 60_000);
     if (/CROP_FAILED/.test(out.stdout)) {
       return text(id, `crop failed: ${out.stderr.slice(0, 200) || "ImageMagick could not create the requested region"}`, true);
     }
@@ -647,6 +805,42 @@ async function call(id: unknown, name: string, args: any) {
         : "Structured browser state unavailable. Use screenshot only if visual state is necessary.",
     );
   }
+  if (name === "browser_snapshot") {
+    const out = await runOnBox(semanticBrowserCommand("snapshot", {}), 20_000);
+    if (!out.ok) {
+      semanticBrowserUrl = null;
+      semanticBrowserRefs.clear();
+      return text(id, "Semantic browser state is unavailable. Open Chrome with open_url, or use screenshot.", true);
+    }
+    try {
+      const snapshot = JSON.parse(out.stdout) as SemanticBrowserSnapshot;
+      if (!Array.isArray(snapshot.elements) || typeof snapshot.url !== "string") throw new Error("invalid snapshot");
+      semanticBrowserUrl = snapshot.url;
+      semanticBrowserRefs = new Set(snapshot.elements.map((element) => element.ref));
+      observations.noteStructuredObservation();
+      const publicUrl = safeBrowserUrl(snapshot.url) ?? "URL unavailable";
+      const lines = snapshot.elements.map(
+        (element) =>
+          `- [${element.ref}] ${element.role}${element.disabled ? " disabled" : ""}: ${element.name.replace(/\s+/g, " ").slice(0, 180)}`,
+      );
+      return text(
+        id,
+        `Semantic browser snapshot — ${snapshot.title || "Untitled"}: ${publicUrl}\n${lines.join("\n") || "No interactive elements found."}`,
+      );
+    } catch {
+      semanticBrowserUrl = null;
+      semanticBrowserRefs.clear();
+      return text(id, "Chrome returned an invalid semantic snapshot; use screenshot.", true);
+    }
+  }
+  if (name === "browser_click") {
+    const ref = String(args.ref ?? "");
+    return semanticActAndObserve(id, "click", ref, undefined, args);
+  }
+  if (name === "browser_fill") {
+    const ref = String(args.ref ?? "");
+    return semanticActAndObserve(id, "fill", ref, String(args.text ?? ""), args);
+  }
   if (name === "wait_for_navigation") {
     const url = String(args.url ?? "");
     const publicUrl = safeBrowserUrl(url);
@@ -664,6 +858,22 @@ async function call(id: unknown, name: string, args: any) {
     );
   }
   if (name === "observation_metrics") return text(id, metricsText());
+  if (name === "computer_status") {
+    const command = [
+      ENV,
+      ensureRemoteCuaCommand(),
+      `if [ -x ${REMOTE_CUA_EXECUTABLE} ] && ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1; then`,
+      `  echo "CUA $(${REMOTE_CUA_EXECUTABLE} --version)"`,
+      `  env ${CUA_ENV} ${REMOTE_CUA_EXECUTABLE} call health_report '{}' --socket ${REMOTE_CUA_SOCKET} 2>/dev/null || true`,
+      "else echo 'X11 fallback'; fi",
+    ].join("\n");
+    const out = await runOnBox(command, 20_000);
+    if (!/^CUA /m.test(out.stdout)) {
+      return text(id, "Cloud computer automation: X11 fallback (Cua Driver is still installing or needs repair).", true);
+    }
+    const overall = out.stdout.match(/"overall"\s*:\s*"(ok|degraded|failed)"/)?.[1] ?? "unknown";
+    return text(id, `Cloud computer automation: Cua Driver ${REMOTE_CUA_VERSION} (${overall}).`);
+  }
   if (name === "click") {
     const x = Math.round(Number(args.x));
     const y = Math.round(Number(args.y));
@@ -710,7 +920,7 @@ async function call(id: unknown, name: string, args: any) {
     const out = await runOnBox(command, 120_000);
     const note = `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`;
     if (args.observe !== true) return text(id, note);
-    const shot = await runOnBox([ENV, GEOMETRY, captureBlock()].join("; "), 60_000);
+    const shot = await runOnBox([ENV, GEOMETRY, ensureRemoteCuaCommand(), captureBlock()].join("; "), 60_000);
     return observed(id, note, await frameFrom(shot));
   }
   if (name === "open_url") {
@@ -728,6 +938,7 @@ async function call(id: unknown, name: string, args: any) {
       CHROME_PROFILE_SETUP,
       `(google-chrome ${CHROME_DEBUG_FLAGS} ${q} || chromium ${CHROME_DEBUG_FLAGS} ${q} || chromium-browser ${CHROME_DEBUG_FLAGS} ${q} || xdg-open ${q}) >/dev/null 2>&1 &`,
       'for i in 1 2 3 4 5 6 7 8 9 10 11 12; do xdotool search --onlyvisible --class "chrom" >/dev/null 2>&1 && break; sleep 0.25; done',
+      ensureRemoteCuaCommand(),
       observe ? captureBlock(600) : "true",
     ].join("; ");
     observations.noteAction();

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -40,12 +40,21 @@ function runner(responses: Record<string, string | Error>) {
   return { calls, run };
 }
 
-const versionProbe =
-  `docker exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ${CONTAINER} ` +
-  `${CUA_EXECUTABLE} --version`;
-const statusProbe =
-  `docker exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ${CONTAINER} ` +
-  `${CUA_EXECUTABLE} status --socket ${CUA_SOCKET}`;
+const driverExec =
+  `docker exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ` +
+  `-e CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${CONTAINER} ${CUA_EXECUTABLE}`;
+const versionProbe = `${driverExec} --version`;
+const statusProbe = `${driverExec} status --socket ${CUA_SOCKET}`;
+const healthProbe = `${driverExec} call health_report {} --socket ${CUA_SOCKET}`;
+const readinessProbe =
+  `${driverExec} call get_desktop_state {} --socket ${CUA_SOCKET} ` +
+  "--screenshot-out-file /tmp/openmausbot-readiness.png";
+const readinessRead = `docker exec ${CONTAINER} base64 -w0 /tmp/openmausbot-readiness.png`;
+const validPng = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.alloc(600),
+  Buffer.from("IEND", "ascii"),
+]);
 
 function preparedImageInspect() {
   return JSON.stringify([
@@ -230,6 +239,9 @@ describe("containerComputerStatus", () => {
       [`docker inspect ${CONTAINER}`]: readyInspect(),
       [versionProbe]: `cua-driver ${CUA_DRIVER_VERSION}\n`,
       [statusProbe]: "running\n",
+      [healthProbe]: JSON.stringify({ schema_version: "1", overall: "ok", checks: [] }),
+      [readinessProbe]: "{}\n",
+      [readinessRead]: validPng.toString("base64"),
     });
 
     const status = await containerComputerStatus(fake.run, "linux");
@@ -244,7 +256,7 @@ describe("containerComputerStatus", () => {
       desktop_error: null,
       ready: true,
       problem: null,
-      driver_version: "0.19.3",
+      driver_version: "0.20.0",
     });
     expect(status.viewer_url).toContain("#autoconnect=true&resize=scale&password=secret123");
   });
@@ -267,6 +279,27 @@ describe("containerComputerStatus", () => {
     expect(status.desktopReady).toBe(false);
     expect(status.desktop_error).toContain("did not become ready");
     expect(status.problem).toContain("desktop failed to start");
+  });
+
+  it("does not report ready when the driver's health contract fails", async () => {
+    const errorProbe = `docker exec ${CONTAINER} tail -n 4 /var/log/supervisor/cua-driver.error.log`;
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect(),
+      [versionProbe]: `cua-driver ${CUA_DRIVER_VERSION}\n`,
+      [statusProbe]: "running\n",
+      [healthProbe]: JSON.stringify({ schema_version: "1", overall: "failed", checks: [] }),
+      [errorProbe]: "",
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux");
+
+    expect(status.desktopReady).toBe(false);
+    expect(status.desktop_error).toContain("health report is failed");
+    expect(fake.calls).not.toContain(readinessProbe);
   });
 
   it("rejects a lookalike container with a different driver or base-image label", async () => {
@@ -325,7 +358,7 @@ describe("containerComputerStatus", () => {
 });
 
 describe("Cua integration", () => {
-  it("hands cloud credentials only to the legacy cloud adapter", () => {
+  it("hands cloud credentials only to the isolated remote adapter", () => {
     expect(computerProxyEnv({ boxId: "bx_1", token: "t" })).toEqual({
       OGB_BOX_ID: "bx_1",
       OGB_BOX_TOKEN: "t",
@@ -341,17 +374,18 @@ describe("Cua integration", () => {
     expect(connection.env).toEqual({ ELECTRON_RUN_AS_NODE: "1" });
   });
 
-  it("builds an exact, checksum-verified Cua Driver 0.19.3 image", () => {
+  it("builds an exact, checksum-verified Cua Driver 0.20.0 image", () => {
     const dockerfile = managedImageDockerfile();
     expect(BASE_IMAGE).toMatch(/@sha256:[a-f0-9]{64}$/);
     expect(dockerfile).toContain(`FROM ${BASE_IMAGE}`);
-    expect(dockerfile).toContain("cua_driver-0.19.3-py3-none-manylinux_2_31_x86_64.whl");
-    expect(dockerfile).toContain("cua_driver-0.19.3-py3-none-manylinux_2_31_aarch64.whl");
+    expect(dockerfile).toContain("cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl");
+    expect(dockerfile).toContain("cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl");
     expect(dockerfile).not.toContain("/tmp/cua-driver.whl");
     expect(dockerfile).toContain("sha256sum -c -");
     expect(dockerfile).toContain(`install -D -m 0755 \"$driver_bin\" ${CUA_EXECUTABLE}`);
     expect(dockerfile).toContain(`cua-driver ${CUA_DRIVER_VERSION}`);
     expect(dockerfile).toContain(`serve --socket ${CUA_SOCKET} --permission-mode standard`);
+    expect(dockerfile).toContain("CUA_DRIVER_RS_TELEMETRY_ENABLED=0");
     expect(dockerfile).toContain("prepare-openmausbot-workspace.sh");
     expect(dockerfile).toContain("migrate_profile google-chrome");
     expect(dockerfile).toContain("migrate_profile chromium");
@@ -363,14 +397,9 @@ describe("Cua integration", () => {
 
   it("captures the preview through Cua Driver rather than xdotool or VNC", async () => {
     const screenshotCall =
-      `docker exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ${CONTAINER} ` +
-      `${CUA_EXECUTABLE} call get_desktop_state {} --socket ${CUA_SOCKET} ` +
+      `${driverExec} call get_desktop_state {} --socket ${CUA_SOCKET} ` +
       "--screenshot-out-file /tmp/openmausbot-preview.png";
-    const png = Buffer.concat([
-      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      Buffer.alloc(600),
-      Buffer.from("IEND", "ascii"),
-    ]);
+    const png = validPng;
     const fake = runner({
       "/usr/bin/which docker": "docker\n",
       "/usr/bin/which podman": new Error("missing"),
@@ -379,6 +408,9 @@ describe("Cua integration", () => {
       [`docker inspect ${CONTAINER}`]: readyInspect(),
       [versionProbe]: `cua-driver ${CUA_DRIVER_VERSION}\n`,
       [statusProbe]: "running\n",
+      [healthProbe]: JSON.stringify({ schema_version: "1", overall: "degraded", checks: [] }),
+      [readinessProbe]: "{}\n",
+      [readinessRead]: png.toString("base64"),
       [screenshotCall]: "{}\n",
       [`docker exec ${CONTAINER} base64 -w0 /tmp/openmausbot-preview.png`]: png.toString("base64"),
     });
@@ -407,22 +439,16 @@ describe("containerComputerAction", () => {
     expect(fake.calls.some((call) => call.startsWith("docker run "))).toBe(false);
   });
 
-  it("never starts an older stopped VM that must be recreated", async () => {
+  it("never starts a stopped desktop because its stale X lock makes resume unsafe", async () => {
     const fake = runner({
       "/usr/bin/which docker": "docker\n",
       "/usr/bin/which podman": new Error("missing"),
       "docker info --format {{.ServerVersion}}": "29\n",
       [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
-      [`docker inspect ${CONTAINER}`]: JSON.stringify([
-        {
-          Config: { Image: "old-desktop:latest", Labels: {} },
-          State: { Running: false },
-          HostConfig: { PortBindings: { "6080/tcp": [{ HostIp: "127.0.0.1" }] } },
-        },
-      ]),
+      [`docker inspect ${CONTAINER}`]: readyInspect({ State: { Running: false } }),
     });
 
-    await expect(containerComputerAction("start", fake.run, "linux")).rejects.toThrow("remove and recreate");
+    await expect(containerComputerAction("start", fake.run, "linux")).rejects.toThrow("cannot safely resume");
     expect(fake.calls).not.toContain(`docker start ${CONTAINER}`);
   });
 });
@@ -443,6 +469,10 @@ describe("setupCommands", () => {
     expect(command).not.toContain(" -p 6080:6901");
     expect(command).not.toContain("5900");
     expect(command).toContain("VNC_PW=CHANGE_ME");
+  });
+
+  it("does not suggest docker start for an image that must be recreated", () => {
+    expect(setupCommands("docker", "linux").start).toBeNull();
   });
 
   it("limits resources and retains only the sandbox supervisor's identity-switch caps", () => {

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -26,7 +26,7 @@ export type CommandRunner = (
   timeout?: number,
 ) => Promise<{ stdout: string }>;
 
-export const CUA_DRIVER_VERSION = "0.19.3";
+export const CUA_DRIVER_VERSION = "0.20.0";
 export const BASE_IMAGE_REPOSITORY = "docker.io/trycua/xfce-cua";
 // Official multi-architecture Cua XFCE 0.1.0 manifest (amd64 + arm64).
 export const BASE_IMAGE_DIGEST = "sha256:274eb636f5cf3fc58f705916ee72b7a701270b3877369d08533a385c5325be9b";
@@ -34,7 +34,7 @@ export const BASE_IMAGE = `${BASE_IMAGE_REPOSITORY}@${BASE_IMAGE_DIGEST}`;
 // This tag is built locally from the pinned Cua base. Image and container
 // labels below are the authoritative compatibility check, not the mutable tag.
 export const IMAGE_REPOSITORY = "openmausbot/cua-local-vm";
-export const IMAGE_LAYER_VERSION = "2";
+export const IMAGE_LAYER_VERSION = "3";
 export const IMAGE_LAYER_LABEL = "com.openmausbot.image-layer";
 export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}-v${IMAGE_LAYER_VERSION}`;
 export const CONTAINER = "openmausbot-computer";
@@ -60,12 +60,12 @@ const PIDS_LIMIT = 512;
 
 const LINUX_WHEELS = {
   x86_64: {
-    url: "https://files.pythonhosted.org/packages/88/26/1b372765b192a2f4f7ee7e1474d1e39be9ab3bd637765f632e30e7ee6e18/cua_driver-0.19.3-py3-none-manylinux_2_31_x86_64.whl",
-    sha256: "3f327a444f5b666037dee5e7c15c98990abbfb4fe83669ef708cb34c2cafef14",
+    url: "https://files.pythonhosted.org/packages/fa/d7/a43008a328a40c85e7bc706fc20235b9abedc75e28b413817655153157ff/cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl",
+    sha256: "f60c35696a37f37ac954935e478ae4754f220856d022036625c9400d72185961",
   },
   aarch64: {
-    url: "https://files.pythonhosted.org/packages/8f/ca/9b1b9e2fba756b5a6db710db4789d63682d6bdf8dc92280c10bdffeb9e77/cua_driver-0.19.3-py3-none-manylinux_2_31_aarch64.whl",
-    sha256: "99cdaaaaf78def68236558b645c799034ac0b6fe5bb37abdf5fc7abc3afeff67",
+    url: "https://files.pythonhosted.org/packages/94/9d/1c1838b69067e83266c3d2aae02d74eef353a43dc8644884ccf03fe7f933/cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl",
+    sha256: "48833bc5e4c60e701fc9eefb57dbac36ec77ef3990f816fbbe85b4e954af2c77",
   },
 } as const;
 
@@ -122,7 +122,7 @@ RUN printf '%s\\n' \\
       '  if [ "$attempt" -ge 45 ]; then echo "X display :1 did not become ready within 45 seconds" >&2; exit 1; fi' \\
       '  sleep 1' \\
       'done' \\
-      'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
+      'exec env CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${CUA_EXECUTABLE} serve --socket ${CUA_SOCKET} --permission-mode standard' \\
       > /usr/local/bin/start-openmausbot-cua-driver.sh \\
     && chmod 0755 /usr/local/bin/start-openmausbot-cua-driver.sh
 RUN printf '%s\\n' \\
@@ -231,7 +231,7 @@ function statusProblem(status: ContainerComputerStatus): string | null {
   if (status.network === "unsafe") return "The existing Local VM exposes its viewer publicly; recreate it";
   if (status.security === "unsafe") return "The existing Local VM is missing safety limits; recreate it";
   if (status.persistence === "unsafe") return "The existing Local VM is missing its durable workspace; recreate it";
-  if (status.container === "stopped") return "Start the Local VM";
+  if (status.container === "stopped") return "This desktop image cannot safely resume; recreate the Local VM";
   if (status.desktop_error) return `The Local VM desktop failed to start: ${status.desktop_error}`;
   if (!status.desktopReady) return "The Local VM started, but Cua Driver is not ready yet";
   return null;
@@ -299,6 +299,8 @@ function cuaExecArgs(args: string[], interactive = false): string[] {
     `DISPLAY=${DISPLAY}`,
     "-e",
     "CUA_DRIVER_INSTALL_CHANNEL=python_package",
+    "-e",
+    "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
     CONTAINER,
     CUA_EXECUTABLE,
     ...args,
@@ -434,18 +436,56 @@ export async function containerComputerStatus(
       const version = await runner(status.runtime, cuaExecArgs(["--version"]), 8000);
       if (version.stdout.trim() !== expected) throw new Error(`expected ${expected}`);
       await runner(status.runtime, cuaExecArgs(["status", "--socket", CUA_SOCKET]), 8000);
+      const health = await runner(
+        status.runtime,
+        cuaExecArgs(["call", "health_report", "{}", "--socket", CUA_SOCKET]),
+        15_000,
+      );
+      const report = JSON.parse(health.stdout) as { schema_version?: string; overall?: string; checks?: unknown[] };
+      if (
+        report.schema_version !== "1" ||
+        !Array.isArray(report.checks) ||
+        (report.overall !== "ok" && report.overall !== "degraded")
+      ) {
+        throw new Error(`Cua health report is ${report.overall ?? "invalid"}`);
+      }
+      const readinessShot = "/tmp/openmausbot-readiness.png";
+      await runner(
+        status.runtime,
+        cuaExecArgs([
+          "call",
+          "get_desktop_state",
+          "{}",
+          "--socket",
+          CUA_SOCKET,
+          "--screenshot-out-file",
+          readinessShot,
+        ]),
+        20_000,
+      );
+      const captured = await runner(
+        status.runtime,
+        ["exec", CONTAINER, "base64", "-w0", readinessShot],
+        20_000,
+      );
+      if (!wholeScreenshot(Buffer.from(captured.stdout.trim(), "base64")).ok) {
+        throw new Error("Cua Driver returned an incomplete readiness screenshot");
+      }
       status.desktopReady = true;
-    } catch {
+    } catch (error) {
       // An empty log means XFCE and the supervisor-owned Cua daemon are
       // probably still starting. A real startup failure should be actionable
       // in the panel instead of looking like an endless readiness wait.
+      status.desktop_error = error instanceof Error ? error.message.slice(0, 320) : null;
       try {
         const errorLog = await runner(
           status.runtime,
           ["exec", CONTAINER, "tail", "-n", "4", "/var/log/supervisor/cua-driver.error.log"],
           4000,
         );
-        status.desktop_error = errorLog.stdout.replace(/\s+/g, " ").trim().slice(0, 320) || null;
+        status.desktop_error =
+          errorLog.stdout.replace(/\s+/g, " ").trim().slice(0, 320) ||
+          status.desktop_error;
       } catch {
         // The log may not exist during the first seconds of container boot.
       }
@@ -641,17 +681,8 @@ export async function containerComputerAction(
   if (action === "run" && !before.image) {
     throw Object.assign(new Error("Prepare the Cua desktop image before creating the Local VM"), { status: 409 });
   }
-  if (action === "start" && before.container !== "stopped") {
-    throw Object.assign(
-      new Error(before.container === "running" ? "The Local VM is already running" : "Create the Local VM first"),
-      { status: 409 },
-    );
-  }
-  if (
-    action === "start" &&
-    (!before.imageMatches || !before.managed || before.network !== "loopback" || before.security !== "hardened")
-  ) {
-    throw Object.assign(new Error("The existing Local VM is incompatible or unsafe; remove and recreate it"), {
+  if (action === "start") {
+    throw Object.assign(new Error("This desktop image cannot safely resume; remove and recreate the Local VM"), {
       status: 409,
     });
   }
@@ -796,10 +827,10 @@ export function setupCommands(
     install,
     runtimeStart,
     // This is the inspectable base download. The normal Prepare button also
-    // builds the checksum-pinned 0.19.3 derivative automatically.
+    // builds the checksum-pinned 0.20.0 derivative automatically.
     pull: command(["pull", BASE_IMAGE]),
     run: command(containerRunArgs(runtime)),
-    start: command(["start", CONTAINER]),
+    start: null,
     stop: command(["stop", CONTAINER]),
     remove: command(["rm", runtime === "container" ? "--force" : "-f", CONTAINER]),
     view: `http://127.0.0.1:${HOST_VIEWER_PORT}/vnc.html`,

--- a/server/container-mcp.test.ts
+++ b/server/container-mcp.test.ts
@@ -51,7 +51,8 @@ posixOnly("Local VM Cua MCP bridge", () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toBe(input);
     expect(result.stderr).toContain(
-      `ARGS:exec -i -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ${CONTAINER} ` +
+      `ARGS:exec -i -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ` +
+        `-e CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${CONTAINER} ` +
         `${CUA_EXECUTABLE} mcp --socket ${CUA_SOCKET}`,
     );
   });

--- a/server/container-mcp.ts
+++ b/server/container-mcp.ts
@@ -27,6 +27,8 @@ const child = spawn(
     "DISPLAY=:1",
     "-e",
     "CUA_DRIVER_INSTALL_CHANNEL=python_package",
+    "-e",
+    "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
     container,
     "/usr/local/libexec/openmausbot/cua-driver",
     "mcp",

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import { LocalVmIdleTimer } from "./local-vm-idle.ts";
 import { LocalVmLease } from "./local-vm-lease.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
@@ -338,10 +339,38 @@ let routines: RoutineManager | null = null;
 const localVmLease = new LocalVmLease(30 * 60_000);
 const localVmOwnerBusy = (botId: string) => store.bot(botId)?.busy === true;
 let localVmLifecycleBusy = false;
+let localVmActiveThread: string | null = null;
+const LOCAL_VM_IDLE_MS = 8 * 60 * 60_000;
+const localVmIdle = new LocalVmIdleTimer(
+  LOCAL_VM_IDLE_MS,
+  () => localVmLifecycleBusy || localVmActiveThread !== null,
+  async () => {
+    // Fence lifecycle and turn dispatch before the first runtime inspection.
+    localVmLifecycleBusy = true;
+    try {
+      const status = await containerComputerStatus();
+      if (status.container === "running") await containerComputerAction("stop");
+    } finally {
+      localVmLifecycleBusy = false;
+    }
+  },
+);
+
+// A running VM may have survived an app/server restart. Start its idle
+// backstop even if nobody opens Settings or begins a turn this session.
+void containerComputerStatus()
+  .then((status) => {
+    if (status.container === "running") localVmIdle.touch();
+  })
+  .catch(() => null);
 
 bus.subscribe((event: RuntimeEvent) => {
   localVmLease.touch(event.threadId);
-  if (event.type === "turn.completed") localVmLease.release(event.threadId);
+  if (localVmActiveThread === event.threadId) localVmIdle.touch();
+  if (event.type === "turn.completed") {
+    localVmLease.release(event.threadId);
+    if (localVmActiveThread === event.threadId) localVmActiveThread = null;
+  }
   broadcast({ kind: "runtime", event });
   routines?.handleRuntimeEvent(event);
   const bot = store.botByThread(event.threadId);
@@ -789,6 +818,8 @@ async function startTurn(
         if (!localVmLease.claim(threadId, bot.id, localVmOwnerBusy)) {
           throw new Error("the shared Local VM is already being used by another bot — wait for that turn to finish");
         }
+        localVmActiveThread = threadId;
+        localVmIdle.touch();
         const localVm = await containerComputerStatus();
         if (!localVm.ready || !localVm.runtime) {
           throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
@@ -923,6 +954,7 @@ async function startTurn(
       if (previewBoxId) startScreenPoller(bot.id, previewBoxId);
     } catch (e) {
       localVmLease.release(threadId);
+      if (localVmActiveThread === threadId) localVmActiveThread = null;
       const message = e instanceof Error ? e.message : String(e);
       const failure = store.appendMessage(threadId, {
         role: "bot",
@@ -2089,7 +2121,7 @@ const server = createServer(async (req, res) => {
     // its daemon is up, and whether the desktop image and container exist
     if (method === "GET" && path === "/api/local-computer") {
       const status = await containerComputerStatus();
-      return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+      return json(res, 200, { ...status, commands: setupCommands(status.runtime), idle_timeout_ms: LOCAL_VM_IDLE_MS });
     }
     m = path.match(/^\/api\/local-computer\/(pull|run|start|stop|remove)$/);
     if (m && method === "POST") {
@@ -2111,12 +2143,19 @@ const server = createServer(async (req, res) => {
       localVmLifecycleBusy = true;
       try {
         const status = await containerComputerAction(action);
-        return json(res, 200, { ...status, commands: setupCommands(status.runtime) });
+        if (action === "run" || action === "start") localVmIdle.touch();
+        if (action === "stop" || action === "remove") localVmIdle.cancel();
+        return json(res, 200, {
+          ...status,
+          commands: setupCommands(status.runtime),
+          idle_timeout_ms: LOCAL_VM_IDLE_MS,
+        });
       } finally {
         localVmLifecycleBusy = false;
       }
     }
     if (method === "POST" && path === "/api/local-computer/screenshot") {
+      localVmIdle.touch();
       return json(res, 200, { image: await containerComputerScreenshot() });
     }
 
@@ -2306,6 +2345,7 @@ server.listen(PORT, "127.0.0.1", () => {
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
+    localVmIdle.cancel();
     routines?.stop();
     webhookIngress?.server.close();
     void registry.disposeAll().finally(() => process.exit(0));

--- a/server/index.ts
+++ b/server/index.ts
@@ -349,7 +349,10 @@ const localVmIdle = new LocalVmIdleTimer(
     localVmLifecycleBusy = true;
     try {
       const status = await containerComputerStatus();
-      if (status.container === "running") await containerComputerAction("stop");
+      // The upstream desktop leaves a stale X lock after a stop, so it cannot
+      // safely resume. Remove only the disposable container; the mounted
+      // workspace and prepared image remain for a fast, clean recreation.
+      if (status.container === "running") await containerComputerAction("remove");
     } finally {
       localVmLifecycleBusy = false;
     }
@@ -926,7 +929,7 @@ async function startTurn(
           (computerKind === "vm"
             ? " You have a shared, isolated Cua sandbox: a Linux desktop in a container on this machine. Only /home/cua/workspace is durable; save downloads, repositories, working files, and browser profiles there because everything else inside the VM is disposable. No other host folder is mounted. Use the computer tools for desktop, accessibility, window, and shell work. Inspect the desktop state before acting, prefer accessibility targets over raw coordinates, and work carefully."
             : computerKind === "box" && instance.driverKind !== "boxAgent"
-              ? " You have your own cloud computer — use screenshot, click, type_text, open_url and computer_exec whenever a desktop helps. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable sequences with computer_batch."
+            ? " You have your own cloud computer. In Chrome, prefer browser_snapshot with browser_click/browser_fill for semantic, trusted actions; use screenshot/click/type_text for visual or non-browser UI, open_url for navigation, and computer_exec for Linux tasks. Every action already returns the resulting screen, so don't follow it with screenshot; batch predictable pixel actions with computer_batch."
               : computerKind === "local"
               ? " You can act on the user's computer through the computer tools — take a screenshot or read the desktop state first, prefer accessibility actions over raw coordinates, and act carefully."
               : "") +

--- a/server/local-vm-idle.test.ts
+++ b/server/local-vm-idle.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocalVmIdleTimer } from "./local-vm-idle.ts";
+
+describe("LocalVmIdleTimer", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("suspends only after a complete idle window", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("renews the deadline on activity", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(700);
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(700);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("never suspends active work and retries after another full window", async () => {
+    let busy = true;
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => busy, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).not.toHaveBeenCalled();
+    busy = false;
+    await vi.advanceTimersByTimeAsync(999);
+    expect(suspend).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(suspend).toHaveBeenCalledOnce();
+  });
+
+  it("can be cancelled after a manual stop", async () => {
+    const suspend = vi.fn(async () => {});
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+    idle.touch();
+    idle.cancel();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+
+  it("re-arms after a transient suspension failure", async () => {
+    const suspend = vi.fn().mockRejectedValueOnce(new Error("runtime unavailable")).mockResolvedValue(undefined);
+    const idle = new LocalVmIdleTimer(1_000, () => false, suspend);
+
+    idle.touch();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(suspend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/local-vm-idle.ts
+++ b/server/local-vm-idle.ts
@@ -1,8 +1,8 @@
 /** Renewable idle deadline for the shared Local VM.
  *
- * Activity resets the full window. Expiry is reversible (the caller stops,
- * never removes, the VM), and an active turn or lifecycle operation defers
- * suspension for another full window instead of racing current work.
+ * Activity resets the full window. The caller decides how to suspend or
+ * recycle the disposable VM, and an active turn or lifecycle operation defers
+ * that work for another full window instead of racing current work.
  */
 export class LocalVmIdleTimer {
   private timer: ReturnType<typeof setTimeout> | null = null;

--- a/server/local-vm-idle.ts
+++ b/server/local-vm-idle.ts
@@ -1,0 +1,45 @@
+/** Renewable idle deadline for the shared Local VM.
+ *
+ * Activity resets the full window. Expiry is reversible (the caller stops,
+ * never removes, the VM), and an active turn or lifecycle operation defers
+ * suspension for another full window instead of racing current work.
+ */
+export class LocalVmIdleTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly idleMs: number;
+  private readonly isBusy: () => boolean;
+  private readonly suspend: () => Promise<void>;
+
+  constructor(idleMs: number, isBusy: () => boolean, suspend: () => Promise<void>) {
+    if (!Number.isFinite(idleMs) || idleMs <= 0) throw new Error("Local VM idle timeout must be positive");
+    this.idleMs = idleMs;
+    this.isBusy = isBusy;
+    this.suspend = suspend;
+  }
+
+  touch(): void {
+    this.cancel();
+    this.timer = setTimeout(() => void this.expire(), this.idleMs);
+    this.timer.unref?.();
+  }
+
+  cancel(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private async expire(): Promise<void> {
+    this.timer = null;
+    if (this.isBusy()) {
+      this.touch();
+      return;
+    }
+    try {
+      await this.suspend();
+    } catch {
+      // A transient runtime failure must not disable the cost/resource
+      // backstop forever. Retry after a fresh full idle window.
+      this.touch();
+    }
+  }
+}

--- a/server/remote-computer.test.ts
+++ b/server/remote-computer.test.ts
@@ -24,7 +24,9 @@ describe("remote Cua computer setup", () => {
     expect(command).not.toContain("uv pip install");
     expect(command).not.toContain("cua-computer-server");
     expect(command).not.toContain("--port 8000");
-    expect(spawnSync("/bin/bash", ["-n"], { input: command }).status).toBe(0);
+    if (process.platform !== "win32") {
+      expect(spawnSync("/bin/bash", ["-n"], { input: command }).status).toBe(0);
+    }
   });
 
   it("reattaches the private daemon after resume without opening a port", () => {

--- a/server/remote-computer.test.ts
+++ b/server/remote-computer.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureRemoteCuaCommand,
+  REMOTE_CUA_EXECUTABLE,
+  REMOTE_CUA_SOCKET,
+  REMOTE_CUA_VERSION,
+  remoteComputerBootstrapCommand,
+  semanticBrowserCommand,
+} from "./remote-computer.ts";
+
+describe("remote Cua computer setup", () => {
+  it("installs one exact checksummed 0.20.0 driver and disables telemetry", () => {
+    const command = remoteComputerBootstrapCommand("Test Bot");
+    expect(REMOTE_CUA_VERSION).toBe("0.20.0");
+    expect(command).toContain("cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl");
+    expect(command).toContain("cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl");
+    expect(command).toContain("f60c35696a37f37ac954935e478ae4754f220856d022036625c9400d72185961");
+    expect(command).toContain("48833bc5e4c60e701fc9eefb57dbac36ec77ef3990f816fbbe85b4e954af2c77");
+    expect(command).toContain(`test \"$(${REMOTE_CUA_EXECUTABLE} --version)\" = \"cua-driver 0.20.0\"`);
+    expect(command).toContain("sha256sum -c -");
+    expect(command).toContain("CUA_DRIVER_RS_TELEMETRY_ENABLED=0");
+    expect(command).not.toContain("uv pip install");
+    expect(command).not.toContain("cua-computer-server");
+    expect(command).not.toContain("--port 8000");
+    expect(spawnSync("/bin/bash", ["-n"], { input: command }).status).toBe(0);
+  });
+
+  it("reattaches the private daemon after resume without opening a port", () => {
+    const command = ensureRemoteCuaCommand();
+    expect(command).toContain(`status --socket ${REMOTE_CUA_SOCKET}`);
+    expect(command).toContain(`serve --socket ${REMOTE_CUA_SOCKET} --permission-mode standard`);
+    expect(command).toContain("CUA_DRIVER_RS_TELEMETRY_ENABLED=0");
+    expect(command).not.toMatch(/--host|--port/);
+  });
+
+  it("encodes semantic browser input instead of interpolating it into shell", () => {
+    const command = semanticBrowserCommand("fill", { ref: "b7", text: "don't expand $HOME" });
+    expect(command).toContain("openmausbot-cdp.mjs fill");
+    expect(command).not.toContain("don't expand");
+    expect(command).not.toContain("$HOME");
+  });
+});

--- a/server/remote-computer.ts
+++ b/server/remote-computer.ts
@@ -1,0 +1,149 @@
+// Shared provisioning and shell contract for the cloud computer's Cua Driver.
+// The box command API is the transport boundary: the daemon stays loopback-only
+// inside the VM and OpenMausBot never exposes another inbound port.
+
+export const REMOTE_CUA_VERSION = "0.20.0";
+export const REMOTE_CUA_EXECUTABLE = "/opt/ogb/cua-driver";
+export const REMOTE_CUA_SOCKET = "/opt/ogb/run/cua.sock";
+export const REMOTE_CUA_SESSION = "openmausbot";
+export const REMOTE_CDP_HELPER = "/opt/ogb/openmausbot-cdp.mjs";
+
+const REMOTE_CUA_WHEELS = {
+  x86_64: {
+    url: "https://files.pythonhosted.org/packages/fa/d7/a43008a328a40c85e7bc706fc20235b9abedc75e28b413817655153157ff/cua_driver-0.20.0-py3-none-manylinux_2_31_x86_64.whl",
+    sha256: "f60c35696a37f37ac954935e478ae4754f220856d022036625c9400d72185961",
+  },
+  aarch64: {
+    url: "https://files.pythonhosted.org/packages/94/9d/1c1838b69067e83266c3d2aae02d74eef353a43dc8644884ccf03fe7f933/cua_driver-0.20.0-py3-none-manylinux_2_31_aarch64.whl",
+    sha256: "48833bc5e4c60e701fc9eefb57dbac36ec77ef3990f816fbbe85b4e954af2c77",
+  },
+} as const;
+
+const CDP_HELPER_SOURCE = String.raw`const [action, encoded = ""] = process.argv.slice(2);
+const input = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8") || "{}");
+const pages = await fetch("http://127.0.0.1:9222/json/list").then((r) => r.json());
+const page = pages.find((item) => item.type === "page" && item.webSocketDebuggerUrl);
+if (!page) throw new Error("no debuggable browser page");
+if (input.url && page.url !== input.url) throw new Error("page changed; take a new browser snapshot");
+const socket = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true });
+  socket.addEventListener("error", () => reject(new Error("DevTools connection failed")), { once: true });
+});
+let nextId = 0;
+const pending = new Map();
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(String(event.data));
+  if (!message.id) return;
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+  pending.delete(message.id);
+  if (message.error) waiter.reject(new Error(message.error.message));
+  else waiter.resolve(message.result ?? {});
+});
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+  const id = ++nextId;
+  pending.set(id, { resolve, reject });
+  socket.send(JSON.stringify({ id, method, params }));
+});
+const refId = (value) => {
+  const match = /^b(\d+)$/.exec(String(value ?? ""));
+  if (!match) throw new Error("invalid or stale browser ref; take a new snapshot");
+  return Number(match[1]);
+};
+if (action === "snapshot") {
+  await send("Accessibility.enable");
+  const { nodes = [] } = await send("Accessibility.getFullAXTree", { depth: 14 });
+  const useful = new Set(["button", "checkbox", "combobox", "heading", "link", "menuitem", "radio", "searchbox", "slider", "spinbutton", "switch", "tab", "textbox"]);
+  const elements = [];
+  for (const node of nodes) {
+    const role = String(node.role?.value ?? "").toLowerCase();
+    const name = String(node.name?.value ?? "").replace(/\s+/g, " ").trim().slice(0, 180);
+    const backend = Number(node.backendDOMNodeId ?? 0);
+    if (!backend || !useful.has(role) || (!name && role !== "textbox" && role !== "searchbox")) continue;
+    const disabled = node.properties?.some((property) => property.name === "disabled" && property.value?.value === true) ?? false;
+    elements.push({ ref: "b" + backend, role, name: name || "unnamed", disabled });
+    if (elements.length >= 250) break;
+  }
+  process.stdout.write(JSON.stringify({ title: String(page.title ?? "").slice(0, 200), url: page.url, elements }));
+} else if (action === "click") {
+  const backendNodeId = refId(input.ref);
+  const { model } = await send("DOM.getBoxModel", { backendNodeId });
+  const quad = model?.border ?? model?.content;
+  if (!Array.isArray(quad) || quad.length < 8) throw new Error("element is not visible; take a new snapshot");
+  const x = (quad[0] + quad[2] + quad[4] + quad[6]) / 4;
+  const y = (quad[1] + quad[3] + quad[5] + quad[7]) / 4;
+  await send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1 });
+  await send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+  process.stdout.write(JSON.stringify({ ok: true, ref: input.ref }));
+} else if (action === "fill") {
+  const backendNodeId = refId(input.ref);
+  await send("DOM.focus", { backendNodeId });
+  await send("Input.dispatchKeyEvent", { type: "keyDown", key: "a", code: "KeyA", modifiers: 2 });
+  await send("Input.dispatchKeyEvent", { type: "keyUp", key: "a", code: "KeyA", modifiers: 2 });
+  await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Backspace", code: "Backspace" });
+  await send("Input.dispatchKeyEvent", { type: "keyUp", key: "Backspace", code: "Backspace" });
+  await send("Input.insertText", { text: String(input.text ?? "") });
+  process.stdout.write(JSON.stringify({ ok: true, ref: input.ref }));
+} else {
+  throw new Error("unknown browser action");
+}
+socket.close();`;
+
+const shellQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
+
+/** Start the already-installed daemon after a box resume. This is cheap when
+ * it is healthy and intentionally does not install anything on the hot path. */
+export function ensureRemoteCuaCommand(): string {
+  return [
+    `if [ -x ${REMOTE_CUA_EXECUTABLE} ]; then`,
+    `  mkdir -p ${REMOTE_CUA_SOCKET.slice(0, REMOTE_CUA_SOCKET.lastIndexOf("/"))}`,
+    `  if ! ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1; then`,
+    `    rm -f ${REMOTE_CUA_SOCKET}`,
+    '    display=${DISPLAY:-$(find /tmp/.X11-unix -maxdepth 1 -name "X*" -printf ":%f\\n" 2>/dev/null | sed "s/:X/:/" | head -1)}',
+    '    display=${display:-:0}',
+    `    nohup env HOME="$HOME" DISPLAY="$display" CUA_DRIVER_INSTALL_CHANNEL=python_package CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${REMOTE_CUA_EXECUTABLE} serve --socket ${REMOTE_CUA_SOCKET} --permission-mode standard > /tmp/ogb-cua-driver.log 2>&1 &`,
+    `    for i in 1 2 3 4 5 6 7 8 9 10; do ${REMOTE_CUA_EXECUTABLE} status --socket ${REMOTE_CUA_SOCKET} >/dev/null 2>&1 && break; sleep 0.2; done`,
+    "  fi",
+    "fi",
+  ].join("\n");
+}
+
+/** Idempotent setup. The exact wheel is verified before its bundled native
+ * executable is installed; installation remains asynchronous so first-time
+ * provisioning does not block the desktop for several minutes. */
+export function remoteComputerBootstrapCommand(botName: string): string {
+  const helper = Buffer.from(CDP_HELPER_SOURCE).toString("base64");
+  const installer = [
+    "set -eu",
+    "trap 'rm -f /tmp/ogb-cua-installing' EXIT",
+    "sudo mkdir -p /opt/ogb/run",
+    'sudo chown -R "$(id -u):$(id -g)" /opt/ogb',
+    'arch="$(uname -m)"',
+    `case "$arch" in x86_64) url=${shellQuote(REMOTE_CUA_WHEELS.x86_64.url)}; sha=${REMOTE_CUA_WHEELS.x86_64.sha256} ;; aarch64|arm64) url=${shellQuote(REMOTE_CUA_WHEELS.aarch64.url)}; sha=${REMOTE_CUA_WHEELS.aarch64.sha256} ;; *) echo "unsupported architecture: $arch" >&2; exit 1 ;; esac`,
+    'wheel="/tmp/cua-driver-${sha}.whl"',
+    'curl -fsSL "$url" -o "$wheel"',
+    'echo "$sha  $wheel" | sha256sum -c -',
+    'python3 - "$wheel" <<\'PY\'\nimport os, sys, zipfile\nwheel = sys.argv[1]\nwith zipfile.ZipFile(wheel) as archive:\n    names = [name for name in archive.namelist() if name == "cua_driver/bin/cua-driver" or name.endswith("/cua_driver/bin/cua-driver")]\n    if len(names) != 1:\n        raise SystemExit("cua-driver executable missing from wheel")\n    with archive.open(names[0]) as source, open("/opt/ogb/cua-driver", "wb") as target:\n        target.write(source.read())\nos.chmod("/opt/ogb/cua-driver", 0o755)\nPY',
+    `test "$(${REMOTE_CUA_EXECUTABLE} --version)" = "cua-driver ${REMOTE_CUA_VERSION}"`,
+    `touch /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready`,
+    'rm -f "$wheel"',
+  ].join("\n");
+  const safeName = botName.replace(/["'\\]/g, "");
+  return [
+    "if ! command -v xdotool >/dev/null || ! command -v convert >/dev/null || ! command -v curl >/dev/null || ! command -v python3 >/dev/null; then sudo apt-get update -qq || true; sudo apt-get install -y -qq ca-certificates curl python3 gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true; fi",
+    "sudo mkdir -p /opt/ogb/run",
+    `printf %s ${shellQuote(helper)} | base64 -d | sudo tee ${REMOTE_CDP_HELPER} >/dev/null`,
+    `sudo chmod 0755 ${REMOTE_CDP_HELPER}`,
+    'pkill -f "^/opt/ogb/venv/bin/python -m computer_server( |$)" >/dev/null 2>&1 || true',
+    `[ -f /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c ${shellQuote(installer)} > /tmp/ogb-cua-install.log 2>&1 & }`,
+    ensureRemoteCuaCommand(),
+    `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${safeName}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
+    "echo bootstrapped",
+  ].join("\n");
+}
+
+export function semanticBrowserCommand(action: "snapshot" | "click" | "fill", input: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(input ?? {})).toString("base64url");
+  return `node ${REMOTE_CDP_HELPER} ${action} ${shellQuote(encoded)}`;
+}

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -38,6 +38,7 @@ interface Status {
   workspace_path: string;
   workspace_guest_path: string;
   viewer_url: string;
+  idle_timeout_ms: number;
   commands: {
     install: string | null;
     runtimeStart: string | null;
@@ -197,7 +198,7 @@ export function LocalComputerSection() {
     <>
       <Card
         title="Local VM"
-        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — free, isolated, and backed by one durable workspace.`}
+        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — isolated, backed by one durable workspace, and automatically stopped after 8 hours without activity.`}
       >
         <div className="flex flex-wrap items-center gap-2">
           <span

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -185,7 +185,8 @@ export function LocalComputerSection() {
   const existing = status?.container !== "missing";
   const needsRecreate = Boolean(
     existing &&
-      (!status?.imageMatches ||
+      (status?.container === "stopped" ||
+        !status?.imageMatches ||
         !status?.managed ||
         status?.network === "unsafe" ||
         status?.security === "unsafe" ||
@@ -198,7 +199,7 @@ export function LocalComputerSection() {
     <>
       <Card
         title="Local VM"
-        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — isolated, backed by one durable workspace, and automatically stopped after 8 hours without activity.`}
+        subtitle={`A shared Cua Linux sandbox on this ${host} for bots to browse and work in — isolated, backed by one durable workspace, and automatically recycled after 8 hours without activity.`}
       >
         <div className="flex flex-wrap items-center gap-2">
           <span
@@ -322,7 +323,7 @@ export function LocalComputerSection() {
         )}
         <div className="mt-3 break-all text-[11px] text-ink-secondary">
           Durable workspace: {status?.workspace_path ?? "not created"} ·{" "}
-          Cua Driver: {status?.driver_version ?? "0.19.3"} · Local image: {status?.image_ref ?? "not prepared"}
+          Cua Driver: {status?.driver_version ?? "0.20.0"} · Local image: {status?.image_ref ?? "not prepared"}
           {status?.base_image_ref ? <> · Base: {status.base_image_ref}</> : null}
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- make stopped Local VM desktops recreate safely instead of attempting a broken Docker resume, with idle recycling that preserves user workspace and browser data
- upgrade the bundled CUA SDK and executables to 0.20.0, disable telemetry, and verify daemon health plus real screenshot capture before reporting readiness
- route hosted computer actions and screenshots through a private CUA daemon with automatic reattachment after wake and an X11 fallback
- add safer semantic Chromium controls, isolate hosted command environments, and improve computer status reporting

## Validation
- `pnpm typecheck`
- `pnpm check:electron`
- `pnpm test` (466 passed, 8 skipped; updater 11 passed)
- `pnpm build`
- `pnpm build:server`
- `pnpm build:cua`
- `node scripts/smoke-cua.mjs` (56 tools, PNG screenshot)

Supersedes #156 and #157 with a clean branch based directly on the updated `main` after #155.