### PR TITLE
docs: make the README clearer and easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-> ⚠️ **No affiliation with any cryptocurrency.** OpenMausBot has no token. Any coin using the OpenMausBot, Maus, or SupaMaus name is not created, endorsed, or affiliated with this project or its maintainer. I have received no tokens, payment, or allocation from anyone, and I will not be endorsing any token.
+> [!WARNING]
+> **OpenMausBot has no cryptocurrency or token.** Coins using the OpenMausBot, Maus, or SupaMaus name are not created, endorsed, or affiliated with this project or its maintainer. The maintainer has received no tokens, payment, or allocation and will not endorse any token.
 
 <div align="center">
 
 # OpenMausBot
 
-**Your own team of AI bots, in a chat app.**
+**A local-first chat app for running a team of AI agents.**
 
-<sub>An open-source version of **Grok Bot** — bring-your-own-agent, local-first, on the models you already have.</sub>
+Give each bot its own role, model, computer, and connected apps. Talk to it like a contact, watch it work, and approve sensitive actions before they run.
 
-Every bot in the sidebar is a real agent — Claude or Codex running locally under the hood — with its own
-personality, its own model, its own cloud computer, and its own connected apps.
-Talk to them like contacts. Watch them work. Approve what matters.
+[Website](https://openmausbot.vercel.app/) · [Documentation](#how-it-works) · [Contributing](CONTRIBUTING.md) · [Releases](https://github.com/milind-soni/openmausbot-releases/releases)
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
 ![Electron](https://img.shields.io/badge/Electron-macOS%20%C2%B7%20Windows%20%C2%B7%20Ubuntu-2B2E3A?logo=electron&logoColor=9FEAF9)
-![Agents](https://img.shields.io/badge/agents-Claude%20·%20Codex-d97757)
-![PRs](https://img.shields.io/badge/PRs-welcome-38d591)
+![Agents](https://img.shields.io/badge/agents-Claude%20%C2%B7%20Codex%20%C2%B7%20Grok-d97757)
+![License](https://img.shields.io/badge/license-MIT-38d591)
 
 <br>
 
@@ -28,30 +27,56 @@ Talk to them like contacts. Watch them work. Approve what matters.
   <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Windows&labelColor=070707&color=4cc2ff&cacheSeconds=300" alt="Download the latest OpenMausBot for Windows (.exe)" height="40">
 </a>
 
-<sub>macOS: Apple silicon · signed & notarized · one-click .dmg &nbsp;·&nbsp; Windows: 64-bit · one-click installer, no admin rights &nbsp;·&nbsp; both always the latest · [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
+<sub>macOS: Apple silicon, signed and notarized · Windows: x64, per-user installer · [View all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
 
-<br>
-<br>
+<br><br>
 
-<img src="docs/screenshots/hero.png" alt="OpenMausBot — a Telegram-style chat app where every chat is a real AI agent" width="900">
+<img src="docs/screenshots/hero.png" alt="OpenMausBot chat app with a roster of AI agents" width="900">
 
 </div>
 
----
+## What is OpenMausBot?
 
-## Why
+OpenMausBot is an open-source take on the idea behind Grok Bot: AI agents presented as a messaging app instead of a single assistant in a single box.
 
-One assistant in one box is the wrong shape for agents. OpenMausBot is an open-source take on **Grok Bot** —
-it keeps the idea (AI as a *messaging app*: a roster of bots you chat with, each with its own personality,
-memory of its thread, model, computer, and apps) and rebuilds it open, local-first, and on the agents you
-already have:
+Each bot is a real agent process powered by a CLI already installed on your computer. It keeps its own conversation, can use a local or cloud computer, and can connect to tools such as Gmail, Slack, GitHub, Notion, and Linear.
 
-- **Bring your own agents.** Bots run on the `claude`, `codex`, and `grok` CLIs installed on your own machine
-  — your existing logins and subscriptions, no new accounts, no proxy in the middle.
-- **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
-  events live in `~/.openmausbot`, not a cloud.
-- **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch
-  live, or your own Mac — plus 500+ apps through Composio Connect.
+- **Bring your own agents.** Use the `claude`, `codex`, or `grok` CLI with your existing login or subscription. Local CLI bots use those existing provider sessions; OpenMausBot does not sell model access.
+- **Local-first by default.** The harness listens on `127.0.0.1`; transcripts, credentials, and events are stored under `~/.openmausbot`.
+- **Review permission requests in chat.** Supported provider permission requests and agent questions appear as inline approval cards.
+- **Add computers and apps when you need them.** Bots can use a supported Mac, an optional remote Linux desktop, and services from the Composio catalog.
+
+## Install
+
+Released desktop builds include the harness server, so there is no separate server to configure. You still need at least one supported agent CLI installed and signed in.
+
+| Platform | Download | Notes |
+|---|---|---|
+| **macOS** | [OpenMausBot.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Apple silicon. Drag to Applications and open. Signed and notarized. |
+| **Windows** | [OpenMausBot-setup.exe](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Windows x64. Per-user install; no admin rights required. The installer is not code-signed yet, so SmartScreen may show **Unknown publisher**. Choose **More info → Run anyway**. |
+| **Ubuntu Desktop** | Build from source | Ubuntu 24.04 x64 is in beta. See the [Ubuntu Desktop guide](docs/linux-desktop.md). |
+
+You also need at least one supported agent CLI installed and logged in:
+
+- [Claude Code](https://claude.com/claude-code)
+- [OpenAI Codex](https://github.com/openai/codex)
+- [Grok CLI](https://x.ai/cli)
+
+Available CLIs appear in the model picker automatically.
+
+### Run from source
+
+Requirements: **Node.js 24+**, **pnpm**, and macOS, Windows, or Ubuntu 24.04 x64.
+
+```sh
+git clone https://github.com/milind-soni/OpenMausBot.git
+cd OpenMausBot
+pnpm install
+
+pnpm dev:server    # harness server → 127.0.0.1:8799
+pnpm dev           # web app → 127.0.0.1:5199
+pnpm dev:desktop   # Electron shell; keep the two commands above running
+```
 
 ## Features
 
@@ -59,42 +84,38 @@ already have:
 <tr>
 <td width="50%" valign="top">
 
-### 🧠 Pick a brain per bot
+### 🧠 Choose a model per bot
 
-A model picker with a provider rail — Claude and Codex models side by side, defaults marked, unavailable
-providers dimmed with the reason. Switch a bot's model mid-conversation.
+Use Claude, Codex, and Grok models side by side. Switch a bot's model without starting a new conversation.
 
-<img src="docs/screenshots/model-picker.png" alt="Model picker with provider rail" width="100%">
+<img src="docs/screenshots/model-picker.png" alt="Model picker with Claude and Codex providers" width="100%">
 
 </td>
 <td width="50%" valign="top">
 
-### 🖥️ Every bot gets a computer
+### 🖥️ Give a bot a computer
 
-Open the Computer panel and the bot's cloud desktop spins up on its own — live screen preview while it
-works, "Open desktop" to take over in your browser, or point the bot at *this Mac* instead.
+Watch a cloud desktop live, take over in your browser, or let a supported bot work on your Mac.
 
-<img src="docs/screenshots/computer-panel.png" alt="Computer panel with live screen preview" width="100%">
+<img src="docs/screenshots/computer-panel.png" alt="Computer panel with a live cloud desktop preview" width="100%">
 
 </td>
 </tr>
 <tr>
 <td width="50%" valign="top">
 
-### 🙋 Bots ask before they act
+### 🙋 Review permission requests
 
-Shell commands, file edits, and questions surface as inline cards — Allow / Deny / answer in chat. A
-permission broker turns every risky action into a decision you make, for cloud and local computers alike.
+Allow or deny permission requests surfaced by supported provider integrations, and answer agent questions without leaving the conversation. Approvals are a consent layer, not a sandbox; local agents run with your user account's privileges.
 
 <img src="docs/screenshots/approval-card.png" alt="Approval and question cards in chat" width="100%">
 
 </td>
 <td width="50%" valign="top">
 
-### 🔌 Connected apps
+### 🔌 Connect the apps you use
 
-A one-click marketplace over Composio Connect: Gmail, Slack, GitHub, Notion, Linear and hundreds more.
-OAuth once, and every bot can use them as tools.
+Expose services such as Gmail, Slack, GitHub, Notion, and Linear to bots through the optional Composio Connect integration.
 
 <img src="docs/screenshots/marketplace.png" alt="Connected apps marketplace" width="100%">
 
@@ -103,178 +124,126 @@ OAuth once, and every bot can use them as tools.
 <tr>
 <td width="50%" valign="top">
 
-### 🗂 Manage bots like chats
+### 🗂 Manage agents like contacts
 
-Right-click any bot: pin, mark unread, edit profile, duplicate, copy conversation ID, hide, delete. It's a
-messaging app — your agents behave like contacts.
+Pin, duplicate, hide, or delete bots. Each bot keeps its own profile and conversation.
 
 <img src="docs/screenshots/context-menu.png" alt="Bot context menu" width="100%">
 
 </td>
 <td width="50%" valign="top">
 
-### 🔑 Keys once, everything lights up
+### 🔑 Configure credentials once
 
-Paste credentials in App Settings — they persist locally and the provider fleet hot-reloads instantly.
-Secrets are write-only: the UI only ever sees "configured" flags.
+Credentials are stored unencrypted in the local OpenMausBot configuration and hot-reloaded. The API returns configuration status, not saved secret values.
 
-<img src="docs/screenshots/app-settings.png" alt="App-level settings with API keys" width="100%">
+<img src="docs/screenshots/app-settings.png" alt="App settings with configured API keys" width="100%">
 
 </td>
 </tr>
 </table>
 
-### 🎧 Bots that talk back
+### Voice, calls, routines, and webhooks
 
-Press the speaker on any reply, or switch a bot to read its answers out as they land — so you can listen
-to what ran overnight while you make breakfast. Hit **call** and it's a conversation: it hears you, tells
-you what it's doing while it works, and asks for approvals out loud.
+Use ElevenLabs to read replies aloud or give each bot a voice. On macOS, call mode combines ElevenLabs with on-device Apple speech recognition so a bot can narrate its work and ask for approval out loud. See [Voice mode](docs/voice-mode.md) for current limitations.
 
-Bring your own ElevenLabs key — paste it once in App Settings, pick a voice, and every bot can talk.
-Give a bot its own voice and a room stops sounding like one person.
-
-**Also in the box:** streaming replies with tool-run activity chips · native macOS dictation from the
-composer mic (on-device Apple speech recognition — desktop app) · SupaMaus cursor mascots with role-aware
-expressions · screenshots of the bot's work folded into the transcript.
+Routines run once or on selected weekdays using a bot's configured model and computer. Webhook triggers use the same queued task runner and can start work from another service. The local webhook receiver listens on `127.0.0.1:8800` by default and exposes only `/health` plus secret hook URLs. OpenMausBot must remain running to receive deliveries.
 
 ## How it works
 
-Two processes. The app holds no transports of its own — it sends typed commands over HTTP and folds one SSE
-event stream into state. The harness server owns every agent process and normalizes each provider's native
-protocol into one canonical runtime event stream (logged per-thread as NDJSON).
+The React app sends commands over HTTP and folds one SSE event stream into local state. A harness server owns every agent process, normalizes each provider's native protocol, brokers approvals, and records thread events as NDJSON.
 
 ```mermaid
 flowchart LR
-    subgraph app ["App — React + Tailwind (5199)"]
+    subgraph app ["App — React + Tailwind"]
         UI[Chat UI · model picker · computer panel]
     end
-    subgraph server ["Harness server (127.0.0.1:8799)"]
+    subgraph server ["Local harness — 127.0.0.1:8799"]
         REG[Driver registry] --> BUS[Event bus → SSE]
         BROKER[Permission broker]
     end
-    subgraph agents ["Agents on your computer"]
-        CL[claude CLI]
-        CX[codex CLI]
-        GR[grok CLI]
+    subgraph agents ["Agent CLIs on your computer"]
+        CL[claude]
+        CX[codex]
+        GR[grok]
     end
     UI -- "HTTP commands" --> server
     BUS -- "one SSE stream" --> UI
     REG --> CL & CX & GR
     CL & CX & GR -- "permission requests" --> BROKER
-    server -- "Box API" --> BOX[("Cloud computer<br/>box.ascii.dev")]
-    server -- "Composio Connect" --> APPS[("Gmail · Slack · GitHub · …")]
+    server -- "optional Box API" --> BOX[("Cloud computer")]
+    server -- "optional Composio Connect" --> APPS[("Connected apps")]
 ```
 
-| Layer | Where | What it does |
+| Layer | Location | Responsibility |
 |---|---|---|
-| Drivers | `server/drivers/` | One per provider: Claude, Codex, and Grok Build over their local CLIs (stream-JSON / JSON-RPC / ACP), plus a cloud-computer agent. Unknown drivers degrade to "unavailable", never crash the fleet. |
-| Harness | `server/harness/` | Registry (configs → live instances) and the fan-in event bus every client folds. |
-| API | `server/index.ts` | Bots, turns, approvals, model catalog, computer lifecycle, connectors, config — HTTP + SSE. |
-| Voice | `server/tts/` | ElevenLabs, bring your own key. Runs on the harness so the key never reaches the UI; markdown is rewritten into something worth hearing before it is spoken. |
-| App | `src/` | The chat shell. Server-backed store, one reducer, zero client-side transports. |
-| Desktop | `electron/` | macOS, Windows, and Ubuntu shells with an embedded harness and explicit platform capabilities; Apple speech, local screen capture, and the current CUA bridge remain macOS-only. |
+| Drivers | `server/drivers/` | Adapt provider CLIs and ACP/JSON-RPC protocols to one runtime contract. Unknown drivers become unavailable instead of crashing the fleet. |
+| Harness | `server/harness/` | Own live agent instances and fan events into one bus. |
+| API | `server/index.ts` | Expose bots, turns, approvals, models, computers, connectors, and config over HTTP + SSE. |
+| Voice | `server/tts/` | Call ElevenLabs without exposing its key to the UI, and rewrite markdown for speech. |
+| App | `src/` | Render the chat shell and fold server events through one reducer. |
+| Desktop | `electron/` | Package the app with platform capabilities and an embedded harness. |
 
-## Quick start
+## Data, security, and third-party services
 
-**Released builds:** the harness server is embedded, so macOS and Windows need no separate server setup.
+Local-first describes where OpenMausBot stores its application data, not wholly offline operation:
 
-| | Download | Install |
+- **Local harness.** The main API binds to `127.0.0.1` and has no application-level authentication. It trusts the local user and must not be exposed to a network.
+- **Local files.** Bot state, transcripts, runtime events, and configuration are stored under `~/.openmausbot`.
+- **Credentials.** Saved integration keys are stored unencrypted in `~/.openmausbot/config.json`. On POSIX systems, OpenMausBot writes the file with owner-only permissions. The API returns only `configured` flags, not stored values.
+- **Agent privileges.** Local CLIs run with your operating-system user's privileges. The permission broker is a consent boundary, not process isolation.
+- **External services.** Prompts and tool activity may be sent to the provider behind your selected CLI. Box, Composio, and ElevenLabs receive data when their optional features are used.
+- **Usage analytics.** OpenMausBot sends named product-usage events to PostHog. Automatic element and page-view capture are disabled. If you submit an email during onboarding, it identifies the PostHog record; skipping the email does not disable anonymous usage events.
+- **Security reports.** Do not open a public issue for a vulnerability. Follow the private reporting instructions in [SECURITY.md](SECURITY.md).
+
+Optional services have their own data handling, accounts, terms, and pricing:
+
+| Service | Purpose | Required? |
 |---|---|---|
-| **macOS** (Apple silicon) | [OpenMausBot.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Drag it to Applications, open it. Signed & notarized. |
-| **Windows** (x64) | [OpenMausBot-setup.exe](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Run it — one-click, per-user, no admin rights. The installer isn't code-signed yet, so SmartScreen shows "unknown publisher": **More info → Run anyway**. |
+| Agent CLI provider | Generates model responses using your existing CLI login or subscription | At least one is required |
+| [Composio Connect](https://docs.composio.dev/docs/composio-connect) | Connects external apps such as Gmail, GitHub, and Slack | Optional |
+| [Box](https://docs.ascii.dev/box/api-keys) | Provides a remote Linux computer | Optional; paid after its trial |
+| [ElevenLabs](https://elevenlabs.io/app/settings/api-keys) | Reads replies aloud and powers bot voices | Optional |
 
-**Ubuntu Desktop beta:** build the `.deb` or AppImage from source using the commands below. Release downloads
-will be linked here once Linux publishing is enabled. See [the Ubuntu Desktop guide](docs/linux-desktop.md) for
-installation, capabilities, and troubleshooting.
+Credentials can be added in **App Settings**. Local chat works without Composio, Box, or ElevenLabs.
 
-**From source:**
+## Platform capabilities
+
+| Capability | macOS | Windows x64 | Ubuntu 24.04 x64 |
+|---|---|---|---|
+| Packaged app with embedded harness | Supported | Supported | Beta |
+| Local agent CLIs | Supported | Supported | Beta |
+| Composio and cloud computers | Supported | Supported | Beta |
+| Local screen preview and computer control | Supported on current macOS builds | Unavailable | Unavailable |
+| Native dictation and call input | Apple Speech; on-device where supported | Unavailable | Unavailable |
+
+Unavailable native features fail closed without blocking chat or cloud features. Linux local computer control, Wayland capture and automation, dictation, and ARM64 are tracked in [#29](https://github.com/milind-soni/OpenMausBot/issues/29).
+
+## Development
 
 ```sh
-git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot
-pnpm install
-
-pnpm dev:server    # harness server → 127.0.0.1:8799
-pnpm dev           # app → http://127.0.0.1:5199
-pnpm dev:desktop   # Electron shell; keep the two commands above running
+pnpm typecheck       # app + server TypeScript
+pnpm test            # unit, driver, API, and updater tests
+pnpm build           # typecheck + production build
+pnpm check:electron  # syntax-check Electron main/preload files
 ```
 
-Requirements: **macOS, Windows, or Ubuntu 24.04 x64**, **Node 24+**, **pnpm**, and at least one agent CLI — [`claude`](https://claude.com/claude-code),
-[`codex`](https://github.com/openai/codex), or [`grok`](https://x.ai/cli) — installed and logged in. They appear
-in the model picker automatically.
-
-Package the desktop application:
+Package desktop builds:
 
 ```sh
 pnpm package:mac      # macOS: DMG + ZIP; requires Swift/Xcode tools
 pnpm package:win      # Windows: installer + ZIP
-pnpm package:linux    # Ubuntu x64: .deb + AppImage; no Swift required
+pnpm package:linux    # Ubuntu x64: .deb + AppImage
 ```
 
-### Desktop capability status
+See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. The provider SPI in [`server/contracts.ts`](server/contracts.ts) is intentionally small; a new provider is usually one driver plus one registration.
 
-| Capability | macOS | Ubuntu 24.04 Xorg | Ubuntu 24.04 Wayland |
-|---|---|---|---|
-| Packaged app, embedded harness, local agent CLIs | Supported | Beta | Beta |
-| Composio and Box/cloud computers | Supported | Beta | Beta |
-| Local screen preview and computer control | Supported | Planned | Planned after compositor validation |
-| Native on-device dictation | Supported | Planned | Planned |
+## Project status
 
-Unavailable native features fail closed on Ubuntu without blocking chat or cloud features. Linux local computer
-control, Wayland capture/automation, dictation, and ARM64 are tracked in
-[#29](https://github.com/milind-soni/OpenMausBot/issues/29) and are not claimed by the baseline package.
+OpenMausBot is early but functional: messages stream from real agent processes, tools request approval, and bots can use connected apps and computers. Expect rough edges. Hosted and mobile connectivity are still being developed, Linux desktop support is in beta, and webhooks currently require the local app to remain online.
 
-These credentials are optional — local chat works without them. Paste a key once in **App Settings** (gear
-in the sidebar footer) when you want to enable its integration:
-
-| Credential | What it enables | Where to get it |
-|---|---|---|
-| Composio Connect key (`ck_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [Composio Connect setup guide](https://docs.composio.dev/docs/composio-connect) |
-| Composio API key (`ak_…`) | Browse the full app catalog with official names and logos | [Composio project API key guide](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
-| Box API key | Give bots an isolated remote Linux computer with a desktop and terminal | [Box API key guide](https://docs.ascii.dev/box/api-keys) |
-| ElevenLabs key | Read replies aloud, and call your bots | [ElevenLabs API keys](https://elevenlabs.io/app/settings/api-keys) |
-
-Composio and Box are third-party services with their own accounts and terms. Box is a paid service after
-its trial, and using a cloud computer may incur charges.
-
-```sh
-pnpm typecheck     # app + server
-pnpm test          # unit, driver, API, and desktop capability tests
-pnpm build         # typecheck + production build
-pnpm check:electron # syntax-check Electron main/preload files
-pnpm package:win   # Windows installer + zip → release/
-pnpm package:linux # Ubuntu x64 .deb + AppImage → release/
-```
-
-### Routines and webhook triggers
-
-Routines can run once or on selected weekdays, using either a MAUS's configured model/computer or the
-Cloud VM runner. Webhook triggers are independent from schedules but reuse the same queued task executor
-and calendar receipts.
-
-OpenMausBot starts a webhook-only receiver on `127.0.0.1:8800` by default (or one port above `OMB_PORT`).
-Set `OMB_WEBHOOK_PORT` to choose another port. A webhook secret is shown once when the trigger is created
-or rotated. Bearer authentication is recommended so the secret stays out of request URLs and most access
-logs; a single capability URL remains available for senders that cannot configure headers. The receiver
-exposes only `/health` and secret `/hooks/...` endpoints; it never exposes the app's broader API.
-OpenMausBot must remain running to accept a delivery. For public internet delivery, proxy only this
-dedicated receiver through a hosted relay or a tool such as Tailscale Funnel.
-
-## Status
-
-Early but real — the loop works end to end: message → agent → streamed reply → tools → approvals →
-computer use. macOS and Windows have released builds; Ubuntu 24.04 x64 packages are in beta with the
-capability limits above. Rough edges to expect: hosted/mobile connectivity is still being built, and webhook
-triggers currently use the local receiver rather than an always-on hosted relay.
-Voice needs an ElevenLabs key, and calls are macOS-only for now (they ride the same on-device dictation as
-the composer mic) — see [`docs/voice-mode.md`](docs/voice-mode.md) for the design and the known gaps.
-
-Contributions welcome — the driver SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately
-small; adding a provider is one file in [`server/drivers/`](server/drivers/) plus a one-line registration.
-
-## License
+## License and attribution
 
 [MIT](LICENSE) © 2026 Milind Soni and contributors.
 
-OpenMausBot is an independent, open-source project inspired by Grok Bot. It is
-not affiliated with, endorsed by, or associated with xAI; "Grok" is a trademark
-of its respective owner.
+OpenMausBot is an independent, open-source project inspired by Grok Bot. It is not affiliated with, endorsed by, or associated with xAI. “Grok” is a trademark of its respective owner.


### PR DESCRIPTION
## Summary
- move installation and prerequisites directly below the product overview
- reduce repeated marketing copy and make the feature section easier to scan
- clarify local-first behavior, approvals, optional third-party services, and platform limits
- consolidate architecture, development, status, license, and trademark guidance
- add the live website and contribution links to the hero

## Verification
- `git diff --check`
- local README links and image paths verified
- README rendered through GitHub's GFM API (1 H1, 9 H2 sections, 5 tables, 14 images)
- markdownlint passed with the existing README's intentional HTML, long-link, and pre-heading conventions excluded

## Notes
Documentation-only change; application code and dependencies are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized and substantially expanded the project documentation.
  - Added updated installation, development, architecture, platform, service, and licensing guidance.
  - Documented supported command-line tools, credential handling, webhook behavior, API responsibilities, and current limitations.
  - Updated links, badges, release details, feature descriptions, headings, and introductory content.
  - Added a cryptocurrency disclaimer and project hero image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->