### PR TITLE
Mirror delegated turn terminal state into the bot⇄bot channel

### DIFF
--- a/dist-server/comms-visibility.js
+++ b/dist-server/comms-visibility.js
@@ -64,3 +64,21 @@ export function mirrorReply(bus, target, reply, channel) {
     bus.store.patchGroup(channel.id, { unread: true });
     bus.broadcastGroup(channel.id);
 }
+/** Mirror a terminal activity note into the channel — for async handoffs
+ * whose terminal state is not a reply (turn failed, was stopped, or never
+ * started). Prior art (A2A, MCP Tasks) is unanimous that every terminal
+ * state of an async handoff should be visible where the human is looking,
+ * and the channel is that place. */
+export function mirrorActivity(bus, from, channel, name, ok) {
+    if (!channel)
+        return;
+    const message = bus.store.appendMessage(channel.threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name, ok },
+        from: { botId: from.id, name: from.name, color: from.color },
+    });
+    bus.broadcast({ kind: "message", threadId: channel.threadId, message });
+    bus.store.patchGroup(channel.id, { unread: true });
+    bus.broadcastGroup(channel.id);
+}

--- a/dist-server/delegations.js
+++ b/dist-server/delegations.js
@@ -150,7 +150,7 @@ async function processOne(bus, approvalBus, from, sourceThreadId, item, runTarge
     mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
     const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
     const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-    await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId);
+    await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel);
 }
 /** Test helper: how many items remain queued for a thread. */
 export function _pendingCount(threadId) {

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -534,23 +534,7 @@ bus.subscribe((event) => {
             // the request was mirrored there when the delegation drained, and a
             // channel that only ever shows requests is half a record. Mirror the
             // reply on success; mirror a failed/stopped terminal chip otherwise.
-            const watched = delegationWatch.get(event.threadId);
-            if (watched) {
-                delegationWatch.delete(event.threadId);
-                const target = store.bot(watched.toBotId);
-                const channel = watched.channelId ? store.group(watched.channelId) : undefined;
-                if (target && channel) {
-                    if (event.ok && reply.trim()) {
-                        mirrorReply(commsBus, target, reply, channel);
-                    }
-                    else if (event.ok) {
-                        mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
-                    }
-                    else {
-                        mirrorActivity(commsBus, target, channel, "Delegated turn did not finish", false);
-                    }
-                }
-            }
+            finalizeDelegationWatch(event.threadId, event.ok, reply);
             // group busy/unread settle in the group turn engine, which knows
             // whether more member turns are queued behind this one
             break;
@@ -563,6 +547,26 @@ bus.subscribe((event) => {
 // turn's TERMINAL state into the A⇄B channel when it completes — the
 // channel stays the full record of the handoff, not just its request.
 const delegationWatch = new Map();
+/** Consume one delegated-turn watch and mirror exactly one terminal state.
+ * Some harness paths settle a busy bot without a provider turn.completed
+ * event, so they call this same finalizer explicitly. */
+function finalizeDelegationWatch(threadId, ok, reply = "", failureName = "Delegated turn did not finish") {
+    const watched = delegationWatch.get(threadId);
+    if (!watched)
+        return false;
+    delegationWatch.delete(threadId);
+    const target = store.bot(watched.toBotId);
+    const channel = watched.channelId ? store.group(watched.channelId) : undefined;
+    if (!target || !channel)
+        return true;
+    if (ok && reply.trim())
+        mirrorReply(commsBus, target, reply, channel);
+    else if (ok)
+        mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
+    else
+        mirrorActivity(commsBus, target, channel, failureName, false);
+    return true;
+}
 // Drain queued delegations for a source thread after its turn settles.
 // Run as a separate subscriber so the drain logic stays out of the main
 // fold (which has its own switch/case noise) and its approval + startTurn
@@ -588,10 +592,11 @@ bus.subscribe((event) => {
             if (failureReported)
                 return;
             failureReported = true;
-            if (targetThreadId)
-                delegationWatch.delete(targetThreadId);
             const bot = store.bot(toBotId);
             const why = error instanceof Error ? error.message : String(error);
+            if (targetThreadId) {
+                finalizeDelegationWatch(targetThreadId, false, "", `Delegated turn could not start — ${why.slice(0, 120)}`);
+            }
             const source = store.botByThread(sourceThreadId);
             if (!source)
                 return;
@@ -601,11 +606,6 @@ bus.subscribe((event) => {
                 tool: { name: `error: delegation to @${bot?.name ?? toBotId} could not start — ${why.slice(0, 120)}`, ok: false },
             });
             broadcast({ kind: "message", threadId: sourceThreadId, message: note });
-            // The channel promised an exchange; a turn that never starts is a
-            // terminal state too, and it belongs where the request is visible.
-            if (bot && channel) {
-                mirrorActivity(commsBus, bot, channel, `Delegated turn could not start — ${why.slice(0, 120)}`, false);
-            }
         };
         return startTurn(toBotId, text, {
             commsDepth,
@@ -1201,6 +1201,7 @@ async function reloadProviders() {
     // forever. Settle anything still marked busy.
     for (const b of store.bots.filter((b) => b.busy)) {
         stopScreenPoller(b.id);
+        finalizeDelegationWatch(b.threadId, false, "", "Delegated turn did not finish — provider settings changed");
         const note = store.appendMessage(b.threadId, {
             role: "bot",
             kind: "activity",

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -17,7 +17,7 @@ import { resetPathCache } from "./env-path.js";
 import { buildNotification } from "./notify.js";
 import { isEffortLevel } from "./contracts.js";
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.js";
-import { getOrCreateChannel, mirrorExchange, mirrorReply } from "./comms-visibility.js";
+import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply } from "./comms-visibility.js";
 import { discardDelegations, drainDelegations, queueDelegation } from "./delegations.js";
 import { EventBus } from "./harness/bus.js";
 import { ProviderRegistry } from "./harness/registry.js";
@@ -530,12 +530,39 @@ bus.subscribe((event) => {
                     });
                 }
             }
+            // A delegated turn's terminal state belongs in the A⇄B channel:
+            // the request was mirrored there when the delegation drained, and a
+            // channel that only ever shows requests is half a record. Mirror the
+            // reply on success; mirror a failed/stopped terminal chip otherwise.
+            const watched = delegationWatch.get(event.threadId);
+            if (watched) {
+                delegationWatch.delete(event.threadId);
+                const target = store.bot(watched.toBotId);
+                const channel = watched.channelId ? store.group(watched.channelId) : undefined;
+                if (target && channel) {
+                    if (event.ok && reply.trim()) {
+                        mirrorReply(commsBus, target, reply, channel);
+                    }
+                    else if (event.ok) {
+                        mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
+                    }
+                    else {
+                        mirrorActivity(commsBus, target, channel, "Delegated turn did not finish", false);
+                    }
+                }
+            }
             // group busy/unread settle in the group turn engine, which knows
             // whether more member turns are queued behind this one
             break;
         }
     }
 });
+// Delegated turns are fire-and-forget, so the drain cannot hand the
+// peer's reply back to the caller the way ask_bot does. This watch map
+// (target threadId → channel) lets the main fold mirror the delegated
+// turn's TERMINAL state into the A⇄B channel when it completes — the
+// channel stays the full record of the handoff, not just its request.
+const delegationWatch = new Map();
 // Drain queued delegations for a source thread after its turn settles.
 // Run as a separate subscriber so the drain logic stays out of the main
 // fold (which has its own switch/case noise) and its approval + startTurn
@@ -548,17 +575,23 @@ bus.subscribe((event) => {
     // that turn queued to run anyway, minutes later, on an unrelated turn.
     if (!event.ok)
         return void discardDelegations(commsBus, event.threadId);
-    drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth, sourceThreadId) => {
+    drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth, sourceThreadId, channel) => {
         // startTurn REJECTS on an ordinary condition — busy target, deleted bot,
         // unavailable provider. Unhandled, that rejection is fatal to the
         // harness (Node's default), which in the packaged app kills the server
         // child. Every delegation failure has to land as a chip instead.
-        return startTurn(toBotId, text, {
-            commsDepth,
-            unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
-        }).catch((err) => {
+        const targetThreadId = store.bot(toBotId)?.threadId;
+        if (targetThreadId)
+            delegationWatch.set(targetThreadId, { channelId: channel?.id, toBotId });
+        let failureReported = false;
+        const reportStartFailure = (error) => {
+            if (failureReported)
+                return;
+            failureReported = true;
+            if (targetThreadId)
+                delegationWatch.delete(targetThreadId);
             const bot = store.bot(toBotId);
-            const why = err instanceof Error ? err.message : String(err);
+            const why = error instanceof Error ? error.message : String(error);
             const source = store.botByThread(sourceThreadId);
             if (!source)
                 return;
@@ -568,6 +601,21 @@ bus.subscribe((event) => {
                 tool: { name: `error: delegation to @${bot?.name ?? toBotId} could not start — ${why.slice(0, 120)}`, ok: false },
             });
             broadcast({ kind: "message", threadId: sourceThreadId, message: note });
+            // The channel promised an exchange; a turn that never starts is a
+            // terminal state too, and it belongs where the request is visible.
+            if (bot && channel) {
+                mirrorActivity(commsBus, bot, channel, `Delegated turn could not start — ${why.slice(0, 120)}`, false);
+            }
+        };
+        return startTurn(toBotId, text, {
+            commsDepth,
+            unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
+            // startTurn schedules provider/integration setup after marking the bot
+            // busy. Those asynchronous setup failures do not emit turn.completed,
+            // so clear the watch and report them through this callback too.
+            onDispatchError: reportStartFailure,
+        }).catch((err) => {
+            reportStartFailure(err);
         });
     });
 });

--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -93,3 +93,27 @@ export function mirrorReply(
   bus.store.patchGroup(channel.id, { unread: true });
   bus.broadcastGroup(channel.id);
 }
+
+/** Mirror a terminal activity note into the channel — for async handoffs
+ * whose terminal state is not a reply (turn failed, was stopped, or never
+ * started). Prior art (A2A, MCP Tasks) is unanimous that every terminal
+ * state of an async handoff should be visible where the human is looking,
+ * and the channel is that place. */
+export function mirrorActivity(
+  bus: CommsBus,
+  from: BotRecord,
+  channel: GroupRecord | undefined,
+  name: string,
+  ok: boolean,
+): void {
+  if (!channel) return;
+  const message = bus.store.appendMessage(channel.threadId, {
+    role: "bot",
+    kind: "activity",
+    tool: { name, ok },
+    from: { botId: from.id, name: from.name, color: from.color },
+  });
+  bus.broadcast({ kind: "message", threadId: channel.threadId, message });
+  bus.store.patchGroup(channel.id, { unread: true });
+  bus.broadcastGroup(channel.id);
+}

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -131,6 +131,12 @@ describe("comms e2e (fake ACP fleet)", () => {
             environment: { FAKE_ACP_MODE: "empty-reply" },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
+          // a turn that remains busy until provider reload disposes it.
+          helperHang: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "hang" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
         },
       }),
     );
@@ -407,6 +413,70 @@ describe("comms e2e (fake ACP fleet)", () => {
       }
     },
     45_000,
+  );
+
+  it(
+    "finalizes a delegated turn interrupted by provider reload",
+    async () => {
+      const seeded = (await api("GET", "/api/bots")).body.bots[0];
+      await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "Helper",
+        modelSelection: { instanceId: "helperHang", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "Asker",
+        modelSelection: { instanceId: "askerDelegate", model: "fake-model" },
+      });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, { text: "hey @Helper please pick this up" });
+      expect(send.status).toBe(202);
+
+      let channelId: string | undefined;
+      const busyDeadline = Date.now() + 30_000;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        const askerBot = state.bots.find((b: any) => b.id === asker.id);
+        const helperBot = state.bots.find((b: any) => b.id === helper.id);
+        channelId = askerBot.messages.find(
+          (m: any) => m.kind === "activity" && m.tool?.name === "Messaged @Helper",
+        )?.comm?.groupId;
+        if (channelId && helperBot.busy) break;
+        if (Date.now() > busyDeadline) {
+          throw new Error(`delegated hanging turn never started. stderr: ${stderr.slice(-2000)}`);
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      // Any provider credential change rebuilds the fleet and settles busy
+      // turns without relying on a provider turn.completed event.
+      const reload = await api("PUT", "/api/config", { xai: { key: "xai_reload_test" } });
+      expect(reload.status).toBe(200);
+
+      const terminalDeadline = Date.now() + 30_000;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        const channel = state.groups.find((g: any) => g.id === channelId);
+        const terminal = channel?.messages.filter(
+          (m: any) =>
+            m.from?.botId === helper.id
+            && m.kind === "activity"
+            && m.tool?.ok === false
+            && m.tool?.name === "Delegated turn did not finish — provider settings changed",
+        );
+        if (terminal?.length === 1) break;
+        if (Date.now() > terminalDeadline) {
+          throw new Error(
+            `provider reload did not finalize delegation. channel tail: ${JSON.stringify(channel?.messages?.slice(-6))}\n` +
+              `stderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    },
+    60_000,
   );
 
   it(

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -124,6 +124,13 @@ describe("comms e2e (fake ACP fleet)", () => {
             environment: { FAKE_ACP_MODE: "exit-early" },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
+          // a successful peer turn that deliberately emits no assistant
+          // text — the channel still needs a positive terminal record.
+          helperEmpty: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "empty-reply" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
         },
       }),
     );
@@ -350,8 +357,58 @@ describe("comms e2e (fake ACP fleet)", () => {
   // ── delegation terminal-state mirroring ─────────────────────────────
   // A delegated turn is fire-and-forget: nobody waits for B, so the ONLY
   // place a human would ever see how it ended is the A⇄B channel. These
-  // two tests pin the non-happy terminal states: the delegated turn
-  // crashed, and the delegated turn never started.
+  // tests pin a successful empty reply plus both non-happy terminal states:
+  // the delegated turn crashed, and the delegated turn never started.
+  it(
+    "mirrors a successful delegated turn with no reply as a completed terminal chip",
+    async () => {
+      const seeded = (await api("GET", "/api/bots")).body.bots[0];
+      await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "Helper",
+        modelSelection: { instanceId: "helperEmpty", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "Asker",
+        modelSelection: { instanceId: "askerDelegate", model: "fake-model" },
+      });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, { text: "hey @Helper please pick this up" });
+      expect(send.status).toBe(202);
+
+      const deadline = Date.now() + 30_000;
+      let channel: any;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        const askerBot = state.bots.find((b: any) => b.id === asker.id);
+        const note = askerBot.messages.find(
+          (m: any) => m.kind === "activity" && m.tool?.name === "Messaged @Helper",
+        );
+        channel = note?.comm?.groupId
+          ? state.groups.find((g: any) => g.id === note.comm.groupId)
+          : undefined;
+        const terminal = channel?.messages.some(
+          (m: any) =>
+            m.from?.botId === helper.id
+            && m.kind === "activity"
+            && m.tool?.ok === true
+            && m.tool?.name === "Delegated turn completed",
+        );
+        if (terminal) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `no completed terminal chip in channel. channel tail: ${JSON.stringify(channel?.messages?.slice(-6))}\n` +
+              `stderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    },
+    45_000,
+  );
+
   it(
     "mirrors a crashed delegated turn into the channel as a failed terminal chip",
     async () => {

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -116,6 +116,14 @@ describe("comms e2e (fake ACP fleet)", () => {
             environment: { FAKE_ACP_MODE: "delegate-peer" },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
+          // a peer whose agent crashes at initialize — the delegated turn
+          // ends with ok=false, so the channel must show a failed terminal
+          // chip, not silence.
+          helperCrash: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "exit-early" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
         },
       }),
     );
@@ -318,10 +326,14 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(channel.memberIds).toContain(asker.id);
       expect(channel.memberIds).toContain(helper.id);
       // A's outgoing task is mirrored into the channel attributed to A.
-      // The peer's reply is intentionally NOT mirrored (delegate_bot is
-      // fire-and-forget — the user opens B's thread to see what B did).
       expect(
         channel.messages.some((m: any) => m.from?.botId === asker.id && m.text?.includes("delegated task")),
+      ).toBe(true);
+      // B's reply IS mirrored too: the channel is the full record of the
+      // handoff — every terminal state of an async delegation is visible
+      // where the human is looking, not just the request.
+      expect(
+        channel.messages.some((m: any) => m.from?.botId === helper.id && m.text?.includes("hello from fake acp")),
       ).toBe(true);
 
       // B's receive-side chip points at the same channel
@@ -331,6 +343,116 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(helperNote?.comm?.groupId).toBe(note.comm.groupId);
       expect(helperBot.busy).toBeFalsy();
       expect(askerBot.busy).toBeFalsy();
+    },
+    45_000,
+  );
+
+  // ── delegation terminal-state mirroring ─────────────────────────────
+  // A delegated turn is fire-and-forget: nobody waits for B, so the ONLY
+  // place a human would ever see how it ended is the A⇄B channel. These
+  // two tests pin the non-happy terminal states: the delegated turn
+  // crashed, and the delegated turn never started.
+  it(
+    "mirrors a crashed delegated turn into the channel as a failed terminal chip",
+    async () => {
+      const seeded = (await api("GET", "/api/bots")).body.bots[0];
+      await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "Helper",
+        modelSelection: { instanceId: "helperCrash", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "Asker",
+        modelSelection: { instanceId: "askerDelegate", model: "fake-model" },
+      });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, { text: "hey @Helper please pick this up" });
+      expect(send.status).toBe(202);
+
+      // settle = the channel exists (request mirrored) and carries the
+      // failed terminal chip (B's turn started and crashed at initialize)
+      const deadline = Date.now() + 30_000;
+      let channel: any;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        const askerBot = state.bots.find((b: any) => b.id === asker.id);
+        const note = askerBot.messages.find(
+          (m: any) => m.kind === "activity" && m.tool?.name === "Messaged @Helper",
+        );
+        channel = note?.comm?.groupId
+          ? state.groups.find((g: any) => g.id === note.comm.groupId)
+          : undefined;
+        const terminal = channel?.messages.some(
+          (m: any) => m.kind === "activity" && m.tool?.ok === false && m.tool?.name?.includes("did not finish"),
+        );
+        if (terminal) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `no failed terminal chip in channel. channel tail: ${JSON.stringify(channel?.messages?.slice(-6))}\n` +
+              `stderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      // the request side of the exchange is still there, attributed to A —
+      // the channel reads as a complete (if unsuccessful) handoff
+      expect(
+        channel.messages.some((m: any) => m.from?.botId === asker.id && m.text?.includes("delegated task")),
+      ).toBe(true);
+    },
+    45_000,
+  );
+
+  it(
+    "mirrors a delegation that could not start into the channel",
+    async () => {
+      const seeded = (await api("GET", "/api/bots")).body.bots[0];
+      await api("PATCH", `/api/bots/${seeded.id}`, { hidden: true });
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      // no such instance — startTurn rejects, so B's turn never starts
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "Helper",
+        modelSelection: { instanceId: "missing-instance", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "Asker",
+        modelSelection: { instanceId: "askerDelegate", model: "fake-model" },
+      });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, { text: "hey @Helper please pick this up" });
+      expect(send.status).toBe(202);
+
+      const deadline = Date.now() + 30_000;
+      let channel: any;
+      let sourceChip: any;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        const askerBot = state.bots.find((b: any) => b.id === asker.id);
+        const note = askerBot.messages.find(
+          (m: any) => m.kind === "activity" && m.tool?.name === "Messaged @Helper",
+        );
+        sourceChip = askerBot.messages.find(
+          (m: any) => m.kind === "activity" && m.tool?.ok === false && m.tool?.name?.includes("could not start"),
+        );
+        channel = note?.comm?.groupId
+          ? state.groups.find((g: any) => g.id === note.comm.groupId)
+          : undefined;
+        const terminal = channel?.messages.some(
+          (m: any) => m.kind === "activity" && m.tool?.ok === false && m.tool?.name?.includes("could not start"),
+        );
+        if (sourceChip && terminal) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `could-not-start not mirrored. sourceChip=${JSON.stringify(sourceChip)}\n` +
+              `channel tail: ${JSON.stringify(channel?.messages?.slice(-6))}\nstderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
     },
     45_000,
   );

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -13,7 +13,7 @@
 
 import { getOrCreateChannel, mirrorExchange, type CommsBus } from "./comms-visibility.ts";
 import { requestPeerApproval, type ApprovalBus } from "./peer-approval.ts";
-import type { BotRecord } from "./store.ts";
+import type { BotRecord, GroupRecord } from "./store.ts";
 
 export interface DelegationItem {
   toBotId: string;
@@ -82,6 +82,7 @@ export function drainDelegations(
     message: string,
     commsDepth: number,
     sourceThreadId: string,
+    channel?: GroupRecord,
   ) => void | Promise<void>,
 ): void {
   const list = pendingDelegations.get(threadId);
@@ -133,6 +134,7 @@ async function processOne(
     message: string,
     commsDepth: number,
     sourceThreadId: string,
+    channel?: GroupRecord,
   ) => void | Promise<void>,
 ): Promise<void> {
   let sender = from;
@@ -196,7 +198,7 @@ async function processOne(
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId);
+  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel);
 }
 
 /** Test helper: how many items remain queued for a thread. */

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,7 +26,7 @@ import { buildNotification, type Notification } from "./notify.ts";
 import { isEffortLevel, type RuntimeEvent } from "./contracts.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
-import { getOrCreateChannel, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
+import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { discardDelegations, drainDelegations, queueDelegation, type QueueResult } from "./delegations.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
@@ -558,12 +558,36 @@ bus.subscribe((event: RuntimeEvent) => {
           });
         }
       }
+      // A delegated turn's terminal state belongs in the A⇄B channel:
+      // the request was mirrored there when the delegation drained, and a
+      // channel that only ever shows requests is half a record. Mirror the
+      // reply on success; mirror a failed/stopped terminal chip otherwise.
+      const watched = delegationWatch.get(event.threadId);
+      if (watched) {
+        delegationWatch.delete(event.threadId);
+        const target = store.bot(watched.toBotId);
+        const channel = watched.channelId ? store.group(watched.channelId) : undefined;
+        if (target && channel) {
+          if (event.ok) {
+            mirrorReply(commsBus, target, reply, channel);
+          } else {
+            mirrorActivity(commsBus, target, channel, "Delegated turn did not finish", false);
+          }
+        }
+      }
       // group busy/unread settle in the group turn engine, which knows
       // whether more member turns are queued behind this one
       break;
     }
   }
 });
+
+// Delegated turns are fire-and-forget, so the drain cannot hand the
+// peer's reply back to the caller the way ask_bot does. This watch map
+// (target threadId → channel) lets the main fold mirror the delegated
+// turn's TERMINAL state into the A⇄B channel when it completes — the
+// channel stays the full record of the handoff, not just its request.
+const delegationWatch = new Map<string, { channelId?: string; toBotId: string }>();
 
 // Drain queued delegations for a source thread after its turn settles.
 // Run as a separate subscriber so the drain logic stays out of the main
@@ -575,15 +599,18 @@ bus.subscribe((event: RuntimeEvent) => {
   // firing it later: the user who hit Stop does not expect the delegations
   // that turn queued to run anyway, minutes later, on an unrelated turn.
   if (!event.ok) return void discardDelegations(commsBus, event.threadId);
-  drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth, sourceThreadId) => {
+  drainDelegations(commsBus, approvalBus, event.threadId, (toBotId, text, commsDepth, sourceThreadId, channel) => {
     // startTurn REJECTS on an ordinary condition — busy target, deleted bot,
     // unavailable provider. Unhandled, that rejection is fatal to the
     // harness (Node's default), which in the packaged app kills the server
     // child. Every delegation failure has to land as a chip instead.
+    const targetThreadId = store.bot(toBotId)?.threadId;
+    if (targetThreadId) delegationWatch.set(targetThreadId, { channelId: channel?.id, toBotId });
     return startTurn(toBotId, text, {
       commsDepth,
       unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
     }).catch((err) => {
+      if (targetThreadId) delegationWatch.delete(targetThreadId);
       const bot = store.bot(toBotId);
       const why = err instanceof Error ? err.message : String(err);
       const source = store.botByThread(sourceThreadId);
@@ -594,6 +621,11 @@ bus.subscribe((event: RuntimeEvent) => {
         tool: { name: `error: delegation to @${bot?.name ?? toBotId} could not start — ${why.slice(0, 120)}`, ok: false },
       });
       broadcast({ kind: "message", threadId: sourceThreadId, message: note });
+      // The channel promised an exchange; a turn that never starts is a
+      // terminal state too, and it belongs where the request is visible.
+      if (bot && channel) {
+        mirrorActivity(commsBus, bot, channel, `Delegated turn could not start — ${why.slice(0, 120)}`, false);
+      }
     });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -568,8 +568,10 @@ bus.subscribe((event: RuntimeEvent) => {
         const target = store.bot(watched.toBotId);
         const channel = watched.channelId ? store.group(watched.channelId) : undefined;
         if (target && channel) {
-          if (event.ok) {
+          if (event.ok && reply.trim()) {
             mirrorReply(commsBus, target, reply, channel);
+          } else if (event.ok) {
+            mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
           } else {
             mirrorActivity(commsBus, target, channel, "Delegated turn did not finish", false);
           }
@@ -606,13 +608,13 @@ bus.subscribe((event: RuntimeEvent) => {
     // child. Every delegation failure has to land as a chip instead.
     const targetThreadId = store.bot(toBotId)?.threadId;
     if (targetThreadId) delegationWatch.set(targetThreadId, { channelId: channel?.id, toBotId });
-    return startTurn(toBotId, text, {
-      commsDepth,
-      unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
-    }).catch((err) => {
+    let failureReported = false;
+    const reportStartFailure = (error: unknown) => {
+      if (failureReported) return;
+      failureReported = true;
       if (targetThreadId) delegationWatch.delete(targetThreadId);
       const bot = store.bot(toBotId);
-      const why = err instanceof Error ? err.message : String(err);
+      const why = error instanceof Error ? error.message : String(error);
       const source = store.botByThread(sourceThreadId);
       if (!source) return;
       const note = store.appendMessage(sourceThreadId, {
@@ -626,6 +628,16 @@ bus.subscribe((event: RuntimeEvent) => {
       if (bot && channel) {
         mirrorActivity(commsBus, bot, channel, `Delegated turn could not start — ${why.slice(0, 120)}`, false);
       }
+    };
+    return startTurn(toBotId, text, {
+      commsDepth,
+      unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
+      // startTurn schedules provider/integration setup after marking the bot
+      // busy. Those asynchronous setup failures do not emit turn.completed,
+      // so clear the watch and report them through this callback too.
+      onDispatchError: reportStartFailure,
+    }).catch((err) => {
+      reportStartFailure(err);
     });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -562,21 +562,7 @@ bus.subscribe((event: RuntimeEvent) => {
       // the request was mirrored there when the delegation drained, and a
       // channel that only ever shows requests is half a record. Mirror the
       // reply on success; mirror a failed/stopped terminal chip otherwise.
-      const watched = delegationWatch.get(event.threadId);
-      if (watched) {
-        delegationWatch.delete(event.threadId);
-        const target = store.bot(watched.toBotId);
-        const channel = watched.channelId ? store.group(watched.channelId) : undefined;
-        if (target && channel) {
-          if (event.ok && reply.trim()) {
-            mirrorReply(commsBus, target, reply, channel);
-          } else if (event.ok) {
-            mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
-          } else {
-            mirrorActivity(commsBus, target, channel, "Delegated turn did not finish", false);
-          }
-        }
-      }
+      finalizeDelegationWatch(event.threadId, event.ok, reply);
       // group busy/unread settle in the group turn engine, which knows
       // whether more member turns are queued behind this one
       break;
@@ -590,6 +576,27 @@ bus.subscribe((event: RuntimeEvent) => {
 // turn's TERMINAL state into the A⇄B channel when it completes — the
 // channel stays the full record of the handoff, not just its request.
 const delegationWatch = new Map<string, { channelId?: string; toBotId: string }>();
+
+/** Consume one delegated-turn watch and mirror exactly one terminal state.
+ * Some harness paths settle a busy bot without a provider turn.completed
+ * event, so they call this same finalizer explicitly. */
+function finalizeDelegationWatch(
+  threadId: string,
+  ok: boolean,
+  reply = "",
+  failureName = "Delegated turn did not finish",
+): boolean {
+  const watched = delegationWatch.get(threadId);
+  if (!watched) return false;
+  delegationWatch.delete(threadId);
+  const target = store.bot(watched.toBotId);
+  const channel = watched.channelId ? store.group(watched.channelId) : undefined;
+  if (!target || !channel) return true;
+  if (ok && reply.trim()) mirrorReply(commsBus, target, reply, channel);
+  else if (ok) mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
+  else mirrorActivity(commsBus, target, channel, failureName, false);
+  return true;
+}
 
 // Drain queued delegations for a source thread after its turn settles.
 // Run as a separate subscriber so the drain logic stays out of the main
@@ -612,9 +619,16 @@ bus.subscribe((event: RuntimeEvent) => {
     const reportStartFailure = (error: unknown) => {
       if (failureReported) return;
       failureReported = true;
-      if (targetThreadId) delegationWatch.delete(targetThreadId);
       const bot = store.bot(toBotId);
       const why = error instanceof Error ? error.message : String(error);
+      if (targetThreadId) {
+        finalizeDelegationWatch(
+          targetThreadId,
+          false,
+          "",
+          `Delegated turn could not start — ${why.slice(0, 120)}`,
+        );
+      }
       const source = store.botByThread(sourceThreadId);
       if (!source) return;
       const note = store.appendMessage(sourceThreadId, {
@@ -623,11 +637,6 @@ bus.subscribe((event: RuntimeEvent) => {
         tool: { name: `error: delegation to @${bot?.name ?? toBotId} could not start — ${why.slice(0, 120)}`, ok: false },
       });
       broadcast({ kind: "message", threadId: sourceThreadId, message: note });
-      // The channel promised an exchange; a turn that never starts is a
-      // terminal state too, and it belongs where the request is visible.
-      if (bot && channel) {
-        mirrorActivity(commsBus, bot, channel, `Delegated turn could not start — ${why.slice(0, 120)}`, false);
-      }
     };
     return startTurn(toBotId, text, {
       commsDepth,
@@ -1272,6 +1281,12 @@ async function reloadProviders() {
   // forever. Settle anything still marked busy.
   for (const b of store.bots.filter((b) => b.busy)) {
     stopScreenPoller(b.id);
+    finalizeDelegationWatch(
+      b.threadId,
+      false,
+      "",
+      "Delegated turn did not finish — provider settings changed",
+    );
     const note = store.appendMessage(b.threadId, {
       role: "bot",
       kind: "activity",

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -5,7 +5,7 @@
 // session/prompt, and streams session/update notifications for a scripted
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
-//   FAKE_ACP_MODE   happy (default) | exit-early | hang | no-auth | auth-required | permission
+//   FAKE_ACP_MODE   happy (default) | empty-reply | exit-early | hang | no-auth | auth-required | permission
 //                   | no-session-config (reject session/set_mode + set_model
 //                     with -32601, i.e. an agent predating those methods)
 //                   | ask-peer (spawn the injected "agents" MCP server from
@@ -316,7 +316,7 @@ function handle(msg: any) {
           });
         return;
       }
-      playTurn();
+      if (mode !== "empty-reply") playTurn();
       if (mode === "permission") {
         // ask the client to approve a tool, then complete once answered
         pendingPermissionId = 9001;


### PR DESCRIPTION
Follow-up to the note in #129:

> The delegated turn's **reply** isn't mirrored back into the `A ⇄ B` channel — `mirrorReply` is only called on the `ask_bot` path — so the channel is complete for asks but request-only for delegations. Worth a follow-up: prior art (A2A, MCP Tasks, buzz) is unanimous that every terminal state of an async handoff should be visible where the human is looking.

This PR makes the channel the full record of a delegation. Every terminal state lands there:

- **Reply on success** — a `delegationWatch` map (target threadId → channel) is registered when the drain starts the peer turn; the main fold's `turn.completed` (where the reply text is already in scope) mirrors it via the existing `mirrorReply`.
- **Failed / stopped turn** — mirrored as an `ok:false` activity chip (`Delegated turn did not finish`), covering errors and user interrupts.
- **Turn never started** — `startTurn` rejects (busy target, deleted bot, unavailable provider); the existing source-thread chip is unchanged, and the same failure is now mirrored into the channel too, so a request never sits there looking unanswered.

## Changes

- `server/delegations.ts` — passes the channel through to `runTarget` (pure plumbing, no behavior change)
- `server/comms-visibility.ts` — new `mirrorActivity` helper for non-reply terminal notes; `mirrorReply` untouched
- `server/index.ts` — `delegationWatch` + terminal-state mirroring in the fold and in the drain's start-failure catch
- `server/comms.test.ts` — the existing delegate e2e's "intentionally NOT mirrored" assertion is flipped (channel now carries B's reply, attributed to B); two new e2e tests pin the failure paths: a peer whose agent crashes at initialize (`exit-early`), and a peer on a missing provider instance (`startTurn` rejects)

## Test plan

- `pnpm typecheck` clean
- `pnpm test`: **58 files, 468 passed / 8 skipped** — including the flipped delegate e2e and both new terminal-state tests
- The depth-cap and approval-gate semantics from #129 are untouched: the watch is keyed by the target's 1:1 thread, consumed on its first `turn.completed`, and deleted bots/channels are re-read from the store before mirroring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegated bot activity is now mirrored in shared communication channels.
  * Completed replies display success status and sender details.
  * Failed starts, interruptions, and unsuccessful delegated turns now show clear status information.
  * Shared channels are marked unread when new delegated activity is posted.

* **Bug Fixes**
  * Improved visibility into delegated tasks that fail to initialize, start, or return a response.
  * Prevented duplicate failure notifications during delegated task errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->