### PR TITLE
Replace Composio Connect with project sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ already have:
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch
-  live, or your own Mac — plus 500+ apps through Composio Connect.
+  live, or your own Mac — plus 500+ apps through Composio.
 
 ## Features
 
@@ -93,7 +93,7 @@ permission broker turns every risky action into a decision you make, for cloud a
 
 ### 🔌 Connected apps
 
-A one-click marketplace over Composio Connect: Gmail, Slack, GitHub, Notion, Linear and hundreds more.
+A one-click marketplace over Composio Sessions: Gmail, Slack, GitHub, Notion, Linear and hundreds more.
 OAuth once, and every bot can use them as tools.
 
 <img src="docs/screenshots/marketplace.png" alt="Connected apps marketplace" width="100%">
@@ -162,7 +162,7 @@ flowchart LR
     REG --> CL & CX & GR
     CL & CX & GR -- "permission requests" --> BROKER
     server -- "Box API" --> BOX[("Cloud computer<br/>box.ascii.dev")]
-    server -- "Composio Connect" --> APPS[("Gmail · Slack · GitHub · …")]
+    server -- "Composio Session" --> APPS[("Gmail · Slack · GitHub · …")]
 ```
 
 | Layer | Where | What it does |
@@ -228,8 +228,7 @@ in the sidebar footer) when you want to enable its integration:
 
 | Credential | What it enables | Where to get it |
 |---|---|---|
-| Composio Connect key (`ck_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [Composio Connect setup guide](https://docs.composio.dev/docs/composio-connect) |
-| Composio API key (`ak_…`) | Browse the full app catalog with official names and logos | [Composio project API key guide](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
+| Composio project key (`ak_…`) | Connect Gmail, GitHub, Slack, Notion, and other apps to your bots | [OpenMausBot Composio setup](docs/composio.md) |
 | Box API key | Give bots an isolated remote Linux computer with a desktop and terminal | [Box API key guide](https://docs.ascii.dev/box/api-keys) |
 | ElevenLabs key | Read replies aloud, and call your bots | [ElevenLabs API keys](https://elevenlabs.io/app/settings/api-keys) |
 

--- a/dist-server/composio.js
+++ b/dist-server/composio.js
@@ -1,83 +1,152 @@
-const CONNECT_URL = "https://connect.composio.dev/mcp";
-const BACKEND_URL = "https://backend.composio.dev/api/v3";
-function parseMcpResponse(text) {
-    // Streamable-HTTP servers answer JSON or SSE (`data: {...}` lines).
-    const line = text.startsWith("{")
-        ? text
-        : text.split("\n").find((l) => l.startsWith("data: "))?.slice(6);
-    if (!line)
-        throw new Error("empty MCP response");
-    const msg = JSON.parse(line);
-    if (msg.error)
-        throw new Error(msg.error.message || "MCP error");
-    const content = msg.result?.content?.find((c) => c.type === "text")?.text;
-    if (!content)
-        return msg.result ?? null;
+// A project API key (ak_…) creates/reuses one Composio Session. That
+// Session owns connection state, auth links and the MCP endpoint.
+import { saveConfig } from "./config.js";
+import { randomUUID } from "node:crypto";
+const DEFAULT_BACKEND_ORIGIN = "https://backend.composio.dev";
+function apiBase() {
+    return (process.env.OMB_COMPOSIO_API ?? `${DEFAULT_BACKEND_ORIGIN}/api/v3.1`).replace(/\/$/, "");
+}
+function toolkitBase() {
+    return (process.env.OMB_COMPOSIO_TOOLKITS_API ?? `${DEFAULT_BACKEND_ORIGIN}/api/v3`).replace(/\/$/, "");
+}
+function projectHeaders(apiKey, json = false) {
+    return {
+        "x-api-key": apiKey,
+        ...(json ? { "content-type": "application/json" } : {}),
+    };
+}
+async function responseError(res, fallback) {
+    const raw = await res.text().catch(() => "");
     try {
-        return JSON.parse(content);
+        const body = JSON.parse(raw);
+        return String(body?.message ?? body?.error?.message ?? body?.error ?? fallback);
     }
     catch {
-        return { text: content };
+        return raw.trim().slice(0, 300) || fallback;
     }
 }
-export async function composioTool(cfg, name, args) {
-    if (!cfg.composio?.key) {
-        throw new Error('no Composio key configured — add {"composio":{"key":"ck_…"}} to ~/.openmausbot/config.json');
+async function getProjectSession(apiKey, sessionId) {
+    const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(sessionId)}`, {
+        headers: projectHeaders(apiKey),
+        signal: AbortSignal.timeout(15_000),
+    });
+    if (res.status === 404)
+        return null;
+    if (!res.ok)
+        throw new Error(await responseError(res, `Composio session: HTTP ${res.status}`));
+    return (await res.json());
+}
+/** Validate a project key and return one reusable Session for this install. */
+export async function prepareProjectSession(apiKey, current) {
+    const trimmed = apiKey.trim();
+    if (!trimmed)
+        throw new Error("Enter a Composio project API key");
+    if (!trimmed.startsWith("ak_"))
+        throw new Error("Composio project API keys start with ak_");
+    if (trimmed === current?.apiKey && current.sessionId) {
+        const existing = await getProjectSession(trimmed, current.sessionId);
+        if (existing) {
+            return {
+                apiKey: trimmed,
+                userId: existing.config?.user_id ?? current.userId ?? `openmausbot_${randomUUID()}`,
+                sessionId: existing.session_id,
+            };
+        }
     }
-    const res = await fetch(cfg.composio.url || CONNECT_URL, {
+    const userId = current?.userId ?? `openmausbot_${randomUUID()}`;
+    const res = await fetch(`${apiBase()}/tool_router/session`, {
         method: "POST",
-        headers: {
-            "content-type": "application/json",
-            accept: "application/json, text/event-stream",
-            "x-consumer-api-key": cfg.composio.key,
-        },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } }),
+        headers: projectHeaders(trimmed, true),
+        body: JSON.stringify({ user_id: userId }),
         signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok)
-        throw new Error(`Composio MCP: HTTP ${res.status}`);
-    return parseMcpResponse(await res.text());
+        throw new Error(await responseError(res, `Composio rejected this key (HTTP ${res.status})`));
+    const session = (await res.json());
+    if (!session.session_id || !session.mcp?.url)
+        throw new Error("Composio created an incomplete Session");
+    return { apiKey: trimmed, userId, sessionId: session.session_id };
+}
+async function ensureProjectSession(cfg) {
+    const composio = cfg.composio;
+    if (!composio?.apiKey)
+        throw new Error("No Composio project key configured");
+    if (composio.sessionId) {
+        const existing = await getProjectSession(composio.apiKey, composio.sessionId);
+        if (existing)
+            return existing;
+    }
+    // A missing/deleted session is recreated and its non-secret identifiers are
+    // persisted so an edited config/env setup does not recreate it every launch.
+    const prepared = await prepareProjectSession(composio.apiKey, composio);
+    composio.userId = prepared.userId;
+    composio.sessionId = prepared.sessionId;
+    saveConfig({ composio: { userId: prepared.userId, sessionId: prepared.sessionId } });
+    const created = await getProjectSession(composio.apiKey, prepared.sessionId);
+    if (!created)
+        throw new Error("Composio Session disappeared after creation");
+    return created;
+}
+export async function mcpIntegration(cfg) {
+    if (!cfg.composio?.apiKey)
+        return null;
+    const session = await ensureProjectSession(cfg);
+    return { url: session.mcp.url, headers: { "x-api-key": cfg.composio.apiKey } };
 }
 /** Connection status per service slug: { slack: { connected, status } }. */
 export async function connectionStatus(cfg, slugs) {
-    const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-        toolkits: slugs.map((name) => ({ name, action: "list" })),
-    });
-    const results = out?.data?.results ?? {};
-    const status = {};
-    for (const slug of slugs) {
-        const r = results[slug];
-        const active = (r?.accounts ?? []).some((a) => /active/i.test(a.status ?? "")) || /^active$/i.test(r?.status ?? "");
-        status[slug] = { connected: active, status: r?.status ?? "unknown" };
-    }
-    return status;
+    if (!cfg.composio?.apiKey)
+        throw new Error("No Composio project key configured");
+    const session = await ensureProjectSession(cfg);
+    const params = new URLSearchParams({ limit: "50" });
+    if (slugs.length)
+        params.set("toolkits", slugs.join(","));
+    const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`, { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) });
+    if (!res.ok)
+        throw new Error(await responseError(res, `Composio toolkits: HTTP ${res.status}`));
+    const body = (await res.json());
+    const bySlug = new Map((body.items ?? []).map((item) => [item.slug?.toLowerCase(), item]));
+    return Object.fromEntries(slugs.map((slug) => {
+        const item = bySlug.get(slug.toLowerCase());
+        const state = item?.connected_account?.status ?? (item?.is_no_auth ? "ACTIVE" : "not_connected");
+        return [slug, { connected: item?.is_no_auth === true || /^active$/i.test(state), status: state }];
+    }));
 }
 /** Disconnect a service: remove every connected account for the slug. */
 export async function removeService(cfg, slug) {
-    const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-        toolkits: [{ name: slug, action: "list" }],
-    });
-    const accounts = out?.data?.results?.[slug]?.accounts ?? [];
-    const ids = accounts.map((a) => a.id ?? a.account_id ?? a.nanoid).filter(Boolean);
-    for (const id of ids) {
-        await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-            toolkits: [{ name: slug, action: "remove", account_id: id }],
-        });
-    }
-    return { removed: ids.length };
+    if (!cfg.composio?.apiKey)
+        throw new Error("No Composio project key configured");
+    const session = await ensureProjectSession(cfg);
+    const params = new URLSearchParams({ limit: "50", toolkits: slug });
+    const list = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`, { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) });
+    if (!list.ok)
+        throw new Error(await responseError(list, `Composio toolkits: HTTP ${list.status}`));
+    const body = (await list.json());
+    const id = body.items?.find((item) => item.slug?.toLowerCase() === slug.toLowerCase())?.connected_account?.id;
+    if (!id)
+        return { removed: 0 };
+    const removed = await fetch(`${apiBase()}/connected_accounts/${encodeURIComponent(id)}?revoke_on_delete=true`, { method: "DELETE", headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(30_000) });
+    if (!removed.ok)
+        throw new Error(await responseError(removed, `Composio disconnect: HTTP ${removed.status}`));
+    return { removed: 1 };
 }
 /** Mint a browser auth link for one service. Returns { url } or throws. */
 export async function authorizeService(cfg, slug) {
-    const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-        toolkits: [{ name: slug, action: "add" }],
+    if (!cfg.composio?.apiKey)
+        throw new Error("No Composio project key configured");
+    const session = await ensureProjectSession(cfg);
+    const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/link`, {
+        method: "POST",
+        headers: projectHeaders(cfg.composio.apiKey, true),
+        body: JSON.stringify({ toolkit: slug }),
+        signal: AbortSignal.timeout(30_000),
     });
-    // be liberal: any https URL mentioning composio/auth wins, else the first
-    const raw = JSON.stringify(out);
-    const urls = raw.match(/https:\/\/[^"\\\s]+/g) ?? [];
-    const url = urls.find((u) => /composio|connect|auth/i.test(u)) ?? urls[0];
-    if (!url)
+    if (!res.ok)
+        throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
+    const body = (await res.json());
+    if (!body.redirect_url)
         throw new Error(`Composio returned no auth link for ${slug}`);
-    return { url };
+    return { url: body.redirect_url };
 }
 // Curated fallback — the services agentcal's connectors page ships plus the
 // long marketplace tail. Logos resolve client-side:
@@ -117,10 +186,10 @@ export async function listToolkits(cfg) {
     if (toolkitCache && Date.now() - toolkitCache.at < 10 * 60_000) {
         return { cards: toolkitCache.cards, source: "api" };
     }
-    const backendKey = cfg.composio?.apiKey ?? cfg.composio?.key;
+    const backendKey = cfg.composio?.apiKey;
     if (backendKey) {
         try {
-            const res = await fetch(`${BACKEND_URL}/toolkits?limit=500&sort_by=usage`, {
+            const res = await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
                 headers: { "x-api-key": backendKey },
                 signal: AbortSignal.timeout(15_000),
             });

--- a/dist-server/config.js
+++ b/dist-server/config.js
@@ -1,5 +1,5 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
-//   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
+//   { "xai": {"key":"xai-…"}, "composio": {"apiKey":"ak_…"}, "box": {"token":"…"},
 //     "instances": { "<instanceId>": {"driver":"grok", …} } }
 import { readFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
@@ -33,7 +33,10 @@ export function loadConfig() {
         /* first run — env fallbacks below */
     }
     cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
-    cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
+    cfg.composio = {
+        ...cfg.composio,
+        ...(process.env.COMPOSIO_API_KEY !== undefined ? { apiKey: process.env.COMPOSIO_API_KEY } : {}),
+    };
     cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
     cfg.opencodeGo = { apiKey: process.env.OPENCODE_API_KEY, ...cfg.opencodeGo };
     cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };

--- a/dist-server/drivers/claude.js
+++ b/dist-server/drivers/claude.js
@@ -5,7 +5,7 @@
 // continues across turns via --resume <sessionId> (the resumeCursor).
 //
 // Integrations become MCP servers on the CLI:
-//   - Composio Connect (connected apps → tools) over streamable HTTP
+//   - Composio Sessions (connected apps → tools) over streamable HTTP
 //   - the bot's cloud computer (box.ascii.dev) via server/computer-proxy.ts
 //     — screenshot/exec/open_url, the CUA-on-the-box bridge
 import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
@@ -264,11 +264,11 @@ export const ClaudeDriver = {
             // acceptEdits run silently denies anything unlisted)
             const mcpServers = {};
             const allowed = [];
-            if (turn.integrations?.composio?.key) {
+            if (turn.integrations?.composio) {
                 mcpServers.composio = {
                     type: "http",
-                    url: turn.integrations.composio.url || "https://connect.composio.dev/mcp",
-                    headers: { "x-consumer-api-key": turn.integrations.composio.key },
+                    url: turn.integrations.composio.url,
+                    headers: turn.integrations.composio.headers,
                 };
                 allowed.push("mcp__composio");
             }

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -733,8 +733,10 @@ async function startTurn(botId, text, opts) {
             // the user's connected apps, but only to a driver that can mount
             // them — a key in the config says the connections exist, not that
             // this engine can reach them
-            if (cfg.composio?.key && instance.adapter.capabilities.composioMcp === true) {
-                integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
+            if (cfg.composio?.apiKey && instance.adapter.capabilities.composioMcp === true) {
+                const connection = await composio.mcpIntegration(cfg);
+                if (connection)
+                    integrations.composio = connection;
             }
             // dweb is opt-in: without an explicit daemon URL, do not advertise
             // tools that would fail on every call or spawn an unnecessary proxy.
@@ -1127,7 +1129,9 @@ function startGroupTurn(groupId, text) {
 function configStatus() {
     return {
         xai: { configured: Boolean(cfg.xai?.key) },
-        composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
+        composio: {
+            configured: Boolean(cfg.composio?.apiKey),
+        },
         box: { configured: Boolean(cfg.box?.token) },
         opencodeGo: { configured: Boolean(cfg.opencodeGo?.apiKey) },
         // the chosen voice is a setting, not a secret; the key is reported the
@@ -2124,6 +2128,19 @@ const server = createServer(async (req, res) => {
         }
         if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
             const body = await readBody(req);
+            const rawComposio = body.composio;
+            if (rawComposio !== undefined
+                && (rawComposio === null || typeof rawComposio !== "object" || Array.isArray(rawComposio))) {
+                return json(res, 400, { error: "composio must be an object" });
+            }
+            if (rawComposio) {
+                for (const field of ["apiKey"]) {
+                    if (Object.prototype.hasOwnProperty.call(rawComposio, field)
+                        && typeof rawComposio[field] !== "string") {
+                        return json(res, 400, { error: `composio.${field} must be a string` });
+                    }
+                }
+            }
             const rawOpenCode = body.opencodeGo;
             if (rawOpenCode !== undefined
                 && (rawOpenCode === null || typeof rawOpenCode !== "object" || Array.isArray(rawOpenCode))) {
@@ -2141,6 +2158,24 @@ const server = createServer(async (req, res) => {
             }
             if (!Object.keys(patch).length)
                 return json(res, 400, { error: "nothing to save" });
+            // A project key is useful only if it can create/reuse the Session that
+            // powers both the connections UI and the agent MCP. Validate it before
+            // persisting, and save the non-secret ids needed to reuse that Session.
+            const requestedComposioKey = patch.composio?.apiKey;
+            if (typeof requestedComposioKey === "string") {
+                if (requestedComposioKey.trim()) {
+                    try {
+                        const prepared = await composio.prepareProjectSession(requestedComposioKey, cfg.composio);
+                        patch.composio = { ...(patch.composio ?? {}), ...prepared };
+                    }
+                    catch (error) {
+                        return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+                    }
+                }
+                else {
+                    patch.composio = { ...(patch.composio ?? {}), apiKey: "", sessionId: "" };
+                }
+            }
             // check a box token against the provider before storing it: a
             // rejected token used to save happily and only surface as a 401 in
             // another panel later, with nothing the user could act on
@@ -2159,8 +2194,22 @@ const server = createServer(async (req, res) => {
                 if (!check.ok)
                     return json(res, 400, { error: check.message });
             }
-            saveConfig(patch);
-            Object.assign(cfg, loadConfig());
+            const externalSecretStorage = url.searchParams.get("secretStorage") === "external";
+            if (externalSecretStorage && patch.composio) {
+                // Electron stores the project key with OS-backed encryption. Persist
+                // only the non-secret Session ids here, while keeping the supplied
+                // key live in this process until the next launch injects it by env.
+                const composioPatch = patch.composio;
+                const { apiKey: _secret, ...metadata } = composioPatch;
+                saveConfig({ composio: { ...metadata, apiKey: "" } });
+                cfg.composio = { ...cfg.composio, ...composioPatch };
+                if (typeof composioPatch.apiKey === "string")
+                    process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
+            }
+            else {
+                saveConfig(patch);
+                Object.assign(cfg, loadConfig());
+            }
             // provider keys change the fleet; a profile or voice edit must not
             // kill in-flight turns with a pointless reload — no driver reads
             // either, and picking a voice mid-turn should be free
@@ -2220,12 +2269,13 @@ const server = createServer(async (req, res) => {
         // ── connectors (Composio) ──
         if (method === "GET" && path === "/api/connectors/catalog") {
             const { cards, source } = await composio.listToolkits(cfg);
-            return json(res, 200, { configured: Boolean(cfg.composio?.key), source, cards });
+            return json(res, 200, { configured: Boolean(cfg.composio?.apiKey), source, cards });
         }
         if (method === "GET" && path === "/api/connectors") {
             const services = (url.searchParams.get("services") ?? "").split(",").filter(Boolean);
-            if (!cfg.composio?.key)
+            if (!cfg.composio?.apiKey) {
                 return json(res, 200, { configured: false, services: {} });
+            }
             const status = await composio.connectionStatus(cfg, services.length ? services : composio.CURATED_SLUGS);
             return json(res, 200, { configured: true, services: status });
         }

--- a/dist-server/redact.js
+++ b/dist-server/redact.js
@@ -11,7 +11,7 @@
 // tells you a token was passed, under which name, and how long it was —
 // enough to debug "the proxy got no token" without the token being there.
 /** Key names whose value is a credential. Matched case-insensitively as a
- * substring, so KEY catches ANTHROPIC_API_KEY and x-consumer-api-key. */
+ * substring, so KEY catches ANTHROPIC_API_KEY and x-api-key. */
 const SECRET_KEY_PARTS = ["token", "secret", "password", "passwd", "apikey", "api_key", "authorization", "auth_token"];
 /** `key` alone is too broad — it matches `keyboard`, `keys`, `hotkey`. Only
  * treat it as a credential when it stands alone or is a suffix, which is how

--- a/docs/composio.md
+++ b/docs/composio.md
@@ -1,0 +1,35 @@
+# Connect apps through Composio
+
+OpenMausBot uses one Composio project API key and one reusable Composio Session. That project key is the only Composio credential users need to provide.
+
+## Packaged desktop app
+
+1. Open the [Composio Dashboard](https://dashboard.composio.dev).
+2. Select **Platform**, select or create a project, then open **Settings → API Keys**.
+3. Copy a project key beginning with `ak_`.
+4. In OpenMausBot, open **App Settings → Connections** and save it under **Composio project key**.
+5. Open **Connected apps** and choose Gmail, GitHub, Slack, or another service. Authentication happens in your normal browser.
+
+The desktop app validates the key before saving it. The key is encrypted using Electron's operating-system-backed `safeStorage`; the local JSON configuration stores only the non-secret Composio user and Session identifiers.
+
+## Scoped key permissions
+
+A default project API key works without additional configuration. For a least-privilege scoped key, grant:
+
+- **Sessions:** read and write
+- **Toolkits:** read
+- **Connected accounts:** read and write
+
+Connected-account write access is required so **Disconnect** can revoke the upstream provider grant before removing the connection.
+
+## Running from source
+
+Set the key in the server environment:
+
+```sh
+COMPOSIO_API_KEY=ak_your_project_key pnpm dev:server
+```
+
+The browser-only development UI can also save a key to the owner-only `~/.openmausbot/config.json` file. Using the environment variable is preferred for headless and shared development machines.
+
+OpenMausBot creates a stable random user identifier for the installation, stores the returned Session identifier, and reuses that Session across launches. No Gmail, GitHub, Slack, or other provider tokens are stored by OpenMausBot; Composio owns their connection lifecycle.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, desktopCapturer, ipcMain, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, ipcMain, safeStorage, session, shell, systemPreferences, utilityProcess } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,68 @@ if (process.platform === "linux") app.setDesktopName("com.openmausbot.app.deskto
 // our API shape, not just a 200).
 let serverProc = null;
 let serverReady = true;
+let secureCredentials = {};
+
+const CREDENTIALS_FILE = path.join(app.getPath("userData"), "credentials.bin");
+
+async function loadSecureCredentials() {
+  try {
+    if (!fs.existsSync(CREDENTIALS_FILE) || !(await safeStorage.isAsyncEncryptionAvailable())) return {};
+    const decrypted = await safeStorage.decryptStringAsync(fs.readFileSync(CREDENTIALS_FILE));
+    return JSON.parse(decrypted.result);
+  } catch (error) {
+    slog(`credential load failed: ${error?.message ?? error}`);
+    return {};
+  }
+}
+
+async function saveSecureCredentials(credentials) {
+  if (!(await safeStorage.isAsyncEncryptionAvailable())) {
+    throw new Error("The operating-system credential store is unavailable");
+  }
+  fs.mkdirSync(path.dirname(CREDENTIALS_FILE), { recursive: true });
+  const encrypted = await safeStorage.encryptStringAsync(JSON.stringify(credentials));
+  const temporary = `${CREDENTIALS_FILE}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, encrypted, { mode: 0o600 });
+  fs.renameSync(temporary, CREDENTIALS_FILE);
+}
+
+async function secureComposioConfig() {
+  const dataDir = process.env.OMB_DATA_DIR || path.join(app.getPath("home"), ".openmausbot");
+  const configPath = path.join(dataDir, "config.json");
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    if (!config?.composio || typeof config.composio !== "object") return;
+    let changed = false;
+    const apiKey = config?.composio?.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim().startsWith("ak_")) {
+      if (!secureCredentials.composioApiKey) {
+        secureCredentials.composioApiKey = apiKey.trim();
+        await saveSecureCredentials(secureCredentials);
+      }
+      config.composio.apiKey = "";
+      changed = true;
+    } else if (typeof apiKey === "string" && apiKey.trim()) {
+      config.composio.apiKey = "";
+      changed = true;
+    }
+    // These were the old Connect credential and endpoint. They are no longer
+    // read; remove them during the upgrade so an unused secret is not left in
+    // plaintext indefinitely.
+    for (const field of ["key", "url"]) {
+      if (Object.hasOwn(config.composio, field)) {
+        delete config.composio[field];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    const temporary = `${configPath}.${process.pid}.tmp`;
+    fs.writeFileSync(temporary, JSON.stringify(config, null, 2), { mode: 0o600 });
+    fs.renameSync(temporary, configPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") slog(`credential migration failed: ${error?.message ?? error}`);
+  }
+}
 
 // The packaged app has no terminal: everything about the server child's life
 // goes to server.log in the OS log dir (~/Library/Logs/OpenMausBot on macOS,
@@ -58,6 +120,9 @@ async function startServerOn(port) {
       OMB_STATIC_DIR: path.join(process.resourcesPath, "ui"),
       OMB_PORT: String(port),
       OMB_USER_DATA: app.getPath("userData"),
+      ...(secureCredentials.composioApiKey
+        ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
+        : {}),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -285,8 +350,38 @@ ipcMain.handle("desktop:capabilities", async () =>
   }),
 );
 
+ipcMain.handle("credential:set", async (_event, name, value) => {
+  if (name !== "composioApiKey" || typeof value !== "string") {
+    throw new Error("Unsupported credential");
+  }
+  if (app.isPackaged && !(await safeStorage.isAsyncEncryptionAvailable())) {
+    throw new Error("The operating-system credential store is unavailable");
+  }
+  // In development the server is a separately launched process, so it cannot
+  // receive credentials from Electron at boot. Keep its established local
+  // config path there; production always uses the encrypted external store.
+  const secretStorage = app.isPackaged ? "?secretStorage=external" : "";
+  const response = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config${secretStorage}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ composio: { apiKey: value.trim() } }),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(body?.error || `Could not save credential (HTTP ${response.status})`);
+  if (app.isPackaged) {
+    if (value.trim()) secureCredentials.composioApiKey = value.trim();
+    else delete secureCredentials.composioApiKey;
+    await saveSecureCredentials(secureCredentials);
+  }
+  return body;
+});
+
 app.whenReady().then(async () => {
   if (process.platform === "darwin") app.dock.setIcon(APP_ICON);
+  if (app.isPackaged) {
+    secureCredentials = await loadSecureCredentials();
+    await secureComposioConfig();
+  }
   // getDisplayMedia in the renderer → this handler → ScreenCaptureKit, all
   // inside the app's own processes — the one capture path macOS reliably
   // attributes to the app (registers it in the Screen Recording pane and

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -42,6 +42,8 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Copies an engine install command and opens a blank terminal. Resolves
    * false if no terminal could be launched; the clipboard still has it. */
   openInstallTerminal: (command) => ipcRenderer.invoke("engine:open-terminal", command),
+  /** Store a provider credential with OS-backed encryption. */
+  setCredential: (name, value) => ipcRenderer.invoke("credential:set", name, value),
 
   /** In-app auto-update. State object:
    *  { status: "idle"|"checking"|"available"|"downloading"|"downloaded"|"error",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -1,0 +1,132 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { AppConfig } from "./config.ts";
+import {
+  authorizeService,
+  connectionStatus,
+  mcpIntegration,
+  prepareProjectSession,
+  removeService,
+} from "./composio.ts";
+
+let api: Server;
+let base = "";
+const calls: Array<{ method: string; path: string; query: string; body: any }> = [];
+
+beforeAll(async () => {
+  api = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://stub");
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    const body = raw ? JSON.parse(raw) : null;
+    calls.push({ method: req.method ?? "GET", path: url.pathname, query: url.search, body });
+
+    if (req.headers["x-api-key"] !== "ak_test") {
+      res.writeHead(401, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ error: { message: "invalid project key" } }));
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/v3.1/tool_router/session") {
+      res.writeHead(201, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        session_id: "trs_test",
+        mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_test/mcp" },
+        config: { user_id: body.user_id },
+      }));
+    }
+    if (req.method === "GET" && url.pathname === "/api/v3.1/tool_router/session/trs_test") {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        session_id: "trs_test",
+        mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_test/mcp" },
+        config: { user_id: "openmausbot_existing" },
+      }));
+    }
+    if (req.method === "GET" && url.pathname.endsWith("/toolkits")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        items: [
+          { slug: "github", connected_account: { id: "ca_github", status: "ACTIVE" } },
+          { slug: "gmail", is_no_auth: true },
+          { slug: "slack" },
+        ],
+      }));
+    }
+    if (req.method === "POST" && url.pathname.endsWith("/link")) {
+      res.writeHead(201, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ redirect_url: `https://connect.composio.dev/link/${body.toolkit}` }));
+    }
+    if (req.method === "DELETE" && url.pathname === "/api/v3.1/connected_accounts/ca_github") {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ success: true }));
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+  });
+  await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${(api.address() as { port: number }).port}/api/v3.1`;
+  process.env.OMB_COMPOSIO_API = base;
+});
+
+afterAll(async () => {
+  delete process.env.OMB_COMPOSIO_API;
+  await new Promise<void>((resolve) => api.close(() => resolve()));
+});
+
+describe.sequential("Composio Sessions", () => {
+  it("accepts only project API keys", async () => {
+    await expect(prepareProjectSession("old_key")).rejects.toThrow(/start with ak_/i);
+    await expect(prepareProjectSession("ak_wrong")).rejects.toThrow(/invalid project key/i);
+  });
+
+  it("creates one stable per-installation session and reuses it", async () => {
+    const created = await prepareProjectSession("ak_test", { userId: "openmausbot_existing" });
+    expect(created).toEqual({
+      apiKey: "ak_test",
+      userId: "openmausbot_existing",
+      sessionId: "trs_test",
+    });
+    expect(calls.filter((call) => call.method === "POST" && call.path.endsWith("/session")).at(-1)?.body).toEqual({
+      user_id: "openmausbot_existing",
+    });
+
+    const reused = await prepareProjectSession("ak_test", created);
+    expect(reused).toEqual({
+      apiKey: "ak_test",
+      userId: "openmausbot_existing",
+      sessionId: "trs_test",
+    });
+  });
+
+  it("mounts the Session MCP endpoint with the project key header", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    await expect(mcpIntegration(cfg)).resolves.toEqual({
+      url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+      headers: { "x-api-key": "ak_test" },
+    });
+  });
+
+  it("reports connection state, creates auth links and revokes disconnects", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    await expect(connectionStatus(cfg, ["github", "gmail", "slack", "notion"])).resolves.toEqual({
+      github: { connected: true, status: "ACTIVE" },
+      gmail: { connected: true, status: "ACTIVE" },
+      slack: { connected: false, status: "not_connected" },
+      notion: { connected: false, status: "not_connected" },
+    });
+    await expect(authorizeService(cfg, "github")).resolves.toEqual({
+      url: "https://connect.composio.dev/link/github",
+    });
+    await expect(removeService(cfg, "github")).resolves.toEqual({ removed: 1 });
+    expect(calls.some(
+      (call) => call.method === "DELETE"
+        && call.path.endsWith("/connected_accounts/ca_github")
+        && call.query === "?revoke_on_delete=true",
+    )).toBe(true);
+  });
+});

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -1,92 +1,170 @@
-// Composio — two clients in one file:
-//  1) the Connect meta-MCP (connect.composio.dev) for connection state +
-//     auth links, ported from agentcal src/composio.js
-//  2) the v3 toolkits catalog (backend.composio.dev) for the plugin
-//     marketplace — names, descriptions, logos. Works when the key is a
-//     project API key; when it isn't, the caller falls back to the curated
-//     catalog below (logos then resolve via favicon fallback client-side).
-import type { AppConfig } from "./config.ts";
+// A project API key (ak_…) creates/reuses one Composio Session. That
+// Session owns connection state, auth links and the MCP endpoint.
+import { saveConfig, type AppConfig } from "./config.ts";
+import { randomUUID } from "node:crypto";
 
-const CONNECT_URL = "https://connect.composio.dev/mcp";
-const BACKEND_URL = "https://backend.composio.dev/api/v3";
+const DEFAULT_BACKEND_ORIGIN = "https://backend.composio.dev";
 
-function parseMcpResponse(text: string) {
-  // Streamable-HTTP servers answer JSON or SSE (`data: {...}` lines).
-  const line = text.startsWith("{")
-    ? text
-    : text.split("\n").find((l) => l.startsWith("data: "))?.slice(6);
-  if (!line) throw new Error("empty MCP response");
-  const msg = JSON.parse(line);
-  if (msg.error) throw new Error(msg.error.message || "MCP error");
-  const content = msg.result?.content?.find((c: any) => c.type === "text")?.text;
-  if (!content) return msg.result ?? null;
+function apiBase() {
+  return (process.env.OMB_COMPOSIO_API ?? `${DEFAULT_BACKEND_ORIGIN}/api/v3.1`).replace(/\/$/, "");
+}
+
+function toolkitBase() {
+  return (process.env.OMB_COMPOSIO_TOOLKITS_API ?? `${DEFAULT_BACKEND_ORIGIN}/api/v3`).replace(/\/$/, "");
+}
+
+interface SessionResponse {
+  session_id: string;
+  mcp: { type: "http" | "sse"; url: string };
+  config?: { user_id?: string };
+}
+
+export interface ComposioMcpIntegration {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function projectHeaders(apiKey: string, json = false) {
+  return {
+    "x-api-key": apiKey,
+    ...(json ? { "content-type": "application/json" } : {}),
+  };
+}
+
+async function responseError(res: Response, fallback: string) {
+  const raw = await res.text().catch(() => "");
   try {
-    return JSON.parse(content);
+    const body = JSON.parse(raw);
+    return String(body?.message ?? body?.error?.message ?? body?.error ?? fallback);
   } catch {
-    return { text: content };
+    return raw.trim().slice(0, 300) || fallback;
   }
 }
 
-export async function composioTool(cfg: AppConfig, name: string, args: unknown) {
-  if (!cfg.composio?.key) {
-    throw new Error('no Composio key configured — add {"composio":{"key":"ck_…"}} to ~/.openmausbot/config.json');
+async function getProjectSession(apiKey: string, sessionId: string): Promise<SessionResponse | null> {
+  const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(sessionId)}`, {
+    headers: projectHeaders(apiKey),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(await responseError(res, `Composio session: HTTP ${res.status}`));
+  return (await res.json()) as SessionResponse;
+}
+
+/** Validate a project key and return one reusable Session for this install. */
+export async function prepareProjectSession(
+  apiKey: string,
+  current?: { apiKey?: string; userId?: string; sessionId?: string },
+): Promise<{ apiKey: string; userId: string; sessionId: string }> {
+  const trimmed = apiKey.trim();
+  if (!trimmed) throw new Error("Enter a Composio project API key");
+  if (!trimmed.startsWith("ak_")) throw new Error("Composio project API keys start with ak_");
+
+  if (trimmed === current?.apiKey && current.sessionId) {
+    const existing = await getProjectSession(trimmed, current.sessionId);
+    if (existing) {
+      return {
+        apiKey: trimmed,
+        userId: existing.config?.user_id ?? current.userId ?? `openmausbot_${randomUUID()}`,
+        sessionId: existing.session_id,
+      };
+    }
   }
-  const res = await fetch(cfg.composio.url || CONNECT_URL, {
+
+  const userId = current?.userId ?? `openmausbot_${randomUUID()}`;
+  const res = await fetch(`${apiBase()}/tool_router/session`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json, text/event-stream",
-      "x-consumer-api-key": cfg.composio.key,
-    },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } }),
+    headers: projectHeaders(trimmed, true),
+    body: JSON.stringify({ user_id: userId }),
     signal: AbortSignal.timeout(30_000),
   });
-  if (!res.ok) throw new Error(`Composio MCP: HTTP ${res.status}`);
-  return parseMcpResponse(await res.text());
+  if (!res.ok) throw new Error(await responseError(res, `Composio rejected this key (HTTP ${res.status})`));
+  const session = (await res.json()) as SessionResponse;
+  if (!session.session_id || !session.mcp?.url) throw new Error("Composio created an incomplete Session");
+  return { apiKey: trimmed, userId, sessionId: session.session_id };
+}
+
+async function ensureProjectSession(cfg: AppConfig): Promise<SessionResponse> {
+  const composio = cfg.composio;
+  if (!composio?.apiKey) throw new Error("No Composio project key configured");
+  if (composio.sessionId) {
+    const existing = await getProjectSession(composio.apiKey, composio.sessionId);
+    if (existing) return existing;
+  }
+  // A missing/deleted session is recreated and its non-secret identifiers are
+  // persisted so an edited config/env setup does not recreate it every launch.
+  const prepared = await prepareProjectSession(composio.apiKey, composio);
+  composio.userId = prepared.userId;
+  composio.sessionId = prepared.sessionId;
+  saveConfig({ composio: { userId: prepared.userId, sessionId: prepared.sessionId } });
+  const created = await getProjectSession(composio.apiKey, prepared.sessionId);
+  if (!created) throw new Error("Composio Session disappeared after creation");
+  return created;
+}
+
+export async function mcpIntegration(cfg: AppConfig): Promise<ComposioMcpIntegration | null> {
+  if (!cfg.composio?.apiKey) return null;
+  const session = await ensureProjectSession(cfg);
+  return { url: session.mcp.url, headers: { "x-api-key": cfg.composio.apiKey } };
 }
 
 /** Connection status per service slug: { slack: { connected, status } }. */
 export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
-  const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-    toolkits: slugs.map((name) => ({ name, action: "list" })),
-  });
-  const results = out?.data?.results ?? {};
-  const status: Record<string, { connected: boolean; status: string }> = {};
-  for (const slug of slugs) {
-    const r = results[slug];
-    const active =
-      (r?.accounts ?? []).some((a: any) => /active/i.test(a.status ?? "")) || /^active$/i.test(r?.status ?? "");
-    status[slug] = { connected: active, status: r?.status ?? "unknown" };
-  }
-  return status;
+  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  const session = await ensureProjectSession(cfg);
+  const params = new URLSearchParams({ limit: "50" });
+  if (slugs.length) params.set("toolkits", slugs.join(","));
+  const res = await fetch(
+    `${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`,
+    { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) },
+  );
+  if (!res.ok) throw new Error(await responseError(res, `Composio toolkits: HTTP ${res.status}`));
+  const body = (await res.json()) as { items?: Array<{ slug?: string; is_no_auth?: boolean; connected_account?: { status?: string } }> };
+  const bySlug = new Map((body.items ?? []).map((item) => [item.slug?.toLowerCase(), item]));
+  return Object.fromEntries(
+    slugs.map((slug) => {
+      const item = bySlug.get(slug.toLowerCase());
+      const state = item?.connected_account?.status ?? (item?.is_no_auth ? "ACTIVE" : "not_connected");
+      return [slug, { connected: item?.is_no_auth === true || /^active$/i.test(state), status: state }];
+    }),
+  );
 }
 
 /** Disconnect a service: remove every connected account for the slug. */
 export async function removeService(cfg: AppConfig, slug: string) {
-  const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-    toolkits: [{ name: slug, action: "list" }],
-  });
-  const accounts = out?.data?.results?.[slug]?.accounts ?? [];
-  const ids = accounts.map((a: any) => a.id ?? a.account_id ?? a.nanoid).filter(Boolean);
-  for (const id of ids) {
-    await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-      toolkits: [{ name: slug, action: "remove", account_id: id }],
-    });
-  }
-  return { removed: ids.length };
+  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  const session = await ensureProjectSession(cfg);
+  const params = new URLSearchParams({ limit: "50", toolkits: slug });
+  const list = await fetch(
+    `${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`,
+    { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) },
+  );
+  if (!list.ok) throw new Error(await responseError(list, `Composio toolkits: HTTP ${list.status}`));
+  const body = (await list.json()) as { items?: Array<{ slug?: string; connected_account?: { id?: string } }> };
+  const id = body.items?.find((item) => item.slug?.toLowerCase() === slug.toLowerCase())?.connected_account?.id;
+  if (!id) return { removed: 0 };
+  const removed = await fetch(
+    `${apiBase()}/connected_accounts/${encodeURIComponent(id)}?revoke_on_delete=true`,
+    { method: "DELETE", headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(30_000) },
+  );
+  if (!removed.ok) throw new Error(await responseError(removed, `Composio disconnect: HTTP ${removed.status}`));
+  return { removed: 1 };
 }
 
 /** Mint a browser auth link for one service. Returns { url } or throws. */
 export async function authorizeService(cfg: AppConfig, slug: string) {
-  const out = await composioTool(cfg, "COMPOSIO_MANAGE_CONNECTIONS", {
-    toolkits: [{ name: slug, action: "add" }],
+  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  const session = await ensureProjectSession(cfg);
+  const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/link`, {
+    method: "POST",
+    headers: projectHeaders(cfg.composio.apiKey, true),
+    body: JSON.stringify({ toolkit: slug }),
+    signal: AbortSignal.timeout(30_000),
   });
-  // be liberal: any https URL mentioning composio/auth wins, else the first
-  const raw = JSON.stringify(out);
-  const urls = raw.match(/https:\/\/[^"\\\s]+/g) ?? [];
-  const url = urls.find((u) => /composio|connect|auth/i.test(u)) ?? urls[0];
-  if (!url) throw new Error(`Composio returned no auth link for ${slug}`);
-  return { url };
+  if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
+  const body = (await res.json()) as { redirect_url?: string };
+  if (!body.redirect_url) throw new Error(`Composio returned no auth link for ${slug}`);
+  return { url: body.redirect_url };
 }
 
 // ── marketplace catalog ────────────────────────────────────────────────
@@ -139,10 +217,10 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
   if (toolkitCache && Date.now() - toolkitCache.at < 10 * 60_000) {
     return { cards: toolkitCache.cards, source: "api" };
   }
-  const backendKey = cfg.composio?.apiKey ?? cfg.composio?.key;
+  const backendKey = cfg.composio?.apiKey;
   if (backendKey) {
     try {
-      const res = await fetch(`${BACKEND_URL}/toolkits?limit=500&sort_by=usage`, {
+      const res = await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
         headers: { "x-api-key": backendKey },
         signal: AbortSignal.timeout(15_000),
       });

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,5 @@
 // Config + data dirs. One file, ~/.openmausbot/config.json, env fallbacks:
-//   { "xai": {"key":"xai-…"}, "composio": {"key":"ck_…"}, "box": {"token":"…"},
+//   { "xai": {"key":"xai-…"}, "composio": {"apiKey":"ak_…"}, "box": {"token":"…"},
 //     "instances": { "<instanceId>": {"driver":"grok", …} } }
 import { readFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
@@ -10,10 +10,13 @@ import type { InstanceConfigMap } from "./contracts.ts";
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
-  /** key = ck_… Connect consumer key (connections + agent tools);
-   * apiKey = ak_… project API key — optional, unlocks the full toolkit
-   * catalog with official logos in the plugins marketplace. */
-  composio?: { key?: string; apiKey?: string; url?: string };
+  /** Project key used for Sessions, catalog and agent tools. userId/sessionId
+   * are non-secret local identifiers used to reuse one Composio Session. */
+  composio?: {
+    apiKey?: string;
+    userId?: string;
+    sessionId?: string;
+  };
   box?: { token?: string };
   /** OpenCode Go key; persisted write-only and passed only to its child. */
   opencodeGo?: { apiKey?: string };
@@ -53,7 +56,10 @@ export function loadConfig(): AppConfig {
     /* first run — env fallbacks below */
   }
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
-  cfg.composio = { key: process.env.COMPOSIO_KEY, ...cfg.composio };
+  cfg.composio = {
+    ...cfg.composio,
+    ...(process.env.COMPOSIO_API_KEY !== undefined ? { apiKey: process.env.COMPOSIO_API_KEY } : {}),
+  };
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
   cfg.opencodeGo = { apiKey: process.env.OPENCODE_API_KEY, ...cfg.opencodeGo };
   cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -130,7 +130,7 @@ export interface SendTurnInput {
   system?: string;
   /** Per-bot integrations the driver may hand to the agent as tools. */
   integrations?: {
-    composio?: { url?: string; key: string };
+    composio?: { url: string; headers: Record<string, string> };
     /** Cloud computer, reached through OpenMausBot's REST-to-MCP adapter. */
     computer?: { kind?: "box"; boxId: string; token: string };
     /** Direct stdio connection to a Cua Driver MCP server (host or sandbox). */

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -196,18 +196,23 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({
       threadId: "t-composio",
       text: "hi",
-      integrations: { composio: { key: "ck_test" } },
+      integrations: {
+        composio: {
+          url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+          headers: { "x-api-key": "ak_test" },
+        },
+      },
     });
     await recorder.until((e) => e.type === "turn.completed");
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.mcpConfig.mcpServers.composio).toMatchObject({
       type: "http",
-      url: "https://connect.composio.dev/mcp",
-      headers: { "x-consumer-api-key": "ck_test" },
+      url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+      headers: { "x-api-key": "ak_test" },
     });
     // the user's Composio key must not be readable via `ps`
-    expect(JSON.stringify(seen.argv)).not.toContain("ck_test");
+    expect(JSON.stringify(seen.argv)).not.toContain("ak_test");
     expect(seen.argv[seen.argv.indexOf("--allowedTools") + 1]).toContain("mcp__composio");
   });
 
@@ -222,7 +227,16 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const dump = join(scratch, "dump.json");
     process.env.FAKE_CLAUDE_DUMP = dump;
 
-    await instance.adapter.sendTurn({ threadId: "t-cleanup", text: "hi", integrations: { composio: { key: "ck_x" } } });
+    await instance.adapter.sendTurn({
+      threadId: "t-cleanup",
+      text: "hi",
+      integrations: {
+        composio: {
+          url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+          headers: { "x-api-key": "ak_test" },
+        },
+      },
+    });
     await recorder.until((e) => e.type === "turn.completed");
 
     const configPath = (() => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -5,7 +5,7 @@
 // continues across turns via --resume <sessionId> (the resumeCursor).
 //
 // Integrations become MCP servers on the CLI:
-//   - Composio Connect (connected apps → tools) over streamable HTTP
+//   - Composio Sessions (connected apps → tools) over streamable HTTP
 //   - the bot's cloud computer (box.ascii.dev) via server/computer-proxy.ts
 //     — screenshot/exec/open_url, the CUA-on-the-box bridge
 import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
@@ -305,11 +305,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // acceptEdits run silently denies anything unlisted)
       const mcpServers: Record<string, unknown> = {};
       const allowed: string[] = [];
-      if (turn.integrations?.composio?.key) {
+      if (turn.integrations?.composio) {
         mcpServers.composio = {
           type: "http",
-          url: turn.integrations.composio.url || "https://connect.composio.dev/mcp",
-          headers: { "x-consumer-api-key": turn.integrations.composio.key },
+          url: turn.integrations.composio.url,
+          headers: turn.integrations.composio.headers,
         };
         allowed.push("mcp__composio");
       }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -5,7 +5,7 @@
 // the shadow-instance behavior end to end while it's at it.
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, request, type Server } from "node:http";
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -60,7 +60,22 @@ beforeAll(async () => {
     JSON.stringify({ instances: { ghost: { driver: "not-a-real-driver", displayName: "Ghost" } } }),
   );
 
-  boxStub = createServer((req, res) => {
+  boxStub = createServer(async (req, res) => {
+    if (req.url?.startsWith("/api/v3.1/tool_router/session")) {
+      if (req.headers["x-api-key"] !== "ak_good") {
+        res.writeHead(401, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ error: { message: "invalid project key" } }));
+      }
+      let raw = "";
+      for await (const chunk of req) raw += chunk;
+      const body = raw ? JSON.parse(raw) : {};
+      res.writeHead(201, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        session_id: "trs_config_test",
+        mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_config_test/mcp" },
+        config: { user_id: body.user_id },
+      }));
+    }
     const ok = req.headers.authorization === "Bearer box_good";
     res.writeHead(ok ? 200 : 401, { "content-type": "application/json" });
     res.end(JSON.stringify(ok ? { ok: true, boxes: [] } : { ok: false, code: "unauthorized" }));
@@ -78,6 +93,7 @@ beforeAll(async () => {
       OMB_PORT: String(PORT),
       OMB_WEBHOOK_PORT: String(WEBHOOK_PORT),
       OMB_BOX_API: `http://127.0.0.1:${boxStubPort}`,
+      OMB_COMPOSIO_API: `http://127.0.0.1:${boxStubPort}/api/v3.1`,
       OMB_STATIC_DIR: staticDir,
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -447,6 +463,30 @@ describe("harness HTTP API", () => {
 
     const nothing = await api("PUT", "/api/config", {});
     expect(nothing.status).toBe(400);
+  });
+
+  it("validates a Composio project key, creates a Session, and keeps externally stored secrets off disk", async () => {
+    const oldKey = await api("PUT", "/api/config", { composio: { apiKey: "old_key" } });
+    expect(oldKey.status).toBe(400);
+    expect(oldKey.body.error).toMatch(/start with ak_/i);
+
+    const rejected = await api("PUT", "/api/config", { composio: { apiKey: "ak_wrong" } });
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toMatch(/invalid project key/i);
+
+    const saved = await api("PUT", "/api/config?secretStorage=external", { composio: { apiKey: "ak_good" } });
+    expect(saved.status).toBe(200);
+    expect(saved.body.composio).toEqual({ configured: true });
+    expect(JSON.stringify(saved.body)).not.toContain("ak_good");
+
+    const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
+    expect(disk.composio).toMatchObject({ apiKey: "", sessionId: "trs_config_test" });
+    expect(JSON.stringify(disk)).not.toContain("ak_good");
+
+    // A later ordinary setting save reloads config; the in-process secure-env
+    // override must keep Composio configured until the next app launch.
+    expect((await api("PUT", "/api/config", { profile: { name: "Grace" } })).status).toBe(200);
+    expect((await api("GET", "/api/config")).body.composio).toEqual({ configured: true });
   });
 
   it.skipIf(process.platform === "win32")("stores the credentials file with owner-only permissions", () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,7 @@ import {
   setupCommands,
   type LifecycleAction,
 } from "./container-computer.ts";
-import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR } from "./config.ts";
+import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR, type AppConfig } from "./config.ts";
 import { resetPathCache } from "./env-path.ts";
 import { buildNotification, type Notification } from "./notify.ts";
 import { isEffortLevel, type RuntimeEvent } from "./contracts.ts";
@@ -793,8 +793,9 @@ async function startTurn(
       // the user's connected apps, but only to a driver that can mount
       // them — a key in the config says the connections exist, not that
       // this engine can reach them
-      if (cfg.composio?.key && instance.adapter.capabilities.composioMcp === true) {
-        integrations.composio = { key: cfg.composio.key, url: cfg.composio.url };
+      if (cfg.composio?.apiKey && instance.adapter.capabilities.composioMcp === true) {
+        const connection = await composio.mcpIntegration(cfg);
+        if (connection) integrations.composio = connection;
       }
       // dweb is opt-in: without an explicit daemon URL, do not advertise
       // tools that would fail on every call or spawn an unnecessary proxy.
@@ -1202,7 +1203,9 @@ function startGroupTurn(groupId: string, text: string) {
 function configStatus() {
   return {
     xai: { configured: Boolean(cfg.xai?.key) },
-    composio: { configured: Boolean(cfg.composio?.key), apiKeyConfigured: Boolean(cfg.composio?.apiKey) },
+    composio: {
+      configured: Boolean(cfg.composio?.apiKey),
+    },
     box: { configured: Boolean(cfg.box?.token) },
     opencodeGo: { configured: Boolean(cfg.opencodeGo?.apiKey) },
     // the chosen voice is a setting, not a secret; the key is reported the
@@ -2185,6 +2188,23 @@ const server = createServer(async (req, res) => {
     }
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
+      const rawComposio = body.composio;
+      if (
+        rawComposio !== undefined
+        && (rawComposio === null || typeof rawComposio !== "object" || Array.isArray(rawComposio))
+      ) {
+        return json(res, 400, { error: "composio must be an object" });
+      }
+      if (rawComposio) {
+        for (const field of ["apiKey"] as const) {
+          if (
+            Object.prototype.hasOwnProperty.call(rawComposio, field)
+            && typeof (rawComposio as Record<string, unknown>)[field] !== "string"
+          ) {
+            return json(res, 400, { error: `composio.${field} must be a string` });
+          }
+        }
+      }
       const rawOpenCode = body.opencodeGo;
       if (
         rawOpenCode !== undefined
@@ -2204,6 +2224,22 @@ const server = createServer(async (req, res) => {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });
+      // A project key is useful only if it can create/reuse the Session that
+      // powers both the connections UI and the agent MCP. Validate it before
+      // persisting, and save the non-secret ids needed to reuse that Session.
+      const requestedComposioKey = (patch.composio as { apiKey?: unknown } | undefined)?.apiKey;
+      if (typeof requestedComposioKey === "string") {
+        if (requestedComposioKey.trim()) {
+          try {
+            const prepared = await composio.prepareProjectSession(requestedComposioKey, cfg.composio);
+            patch.composio = { ...(patch.composio ?? {}), ...prepared };
+          } catch (error) {
+            return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
+        } else {
+          patch.composio = { ...(patch.composio ?? {}), apiKey: "", sessionId: "" };
+        }
+      }
       // check a box token against the provider before storing it: a
       // rejected token used to save happily and only surface as a 401 in
       // another panel later, with nothing the user could act on
@@ -2220,8 +2256,20 @@ const server = createServer(async (req, res) => {
         const check = await tts.verifyKey(newTts.key.trim());
         if (!check.ok) return json(res, 400, { error: check.message });
       }
-      saveConfig(patch);
-      Object.assign(cfg, loadConfig());
+      const externalSecretStorage = url.searchParams.get("secretStorage") === "external";
+      if (externalSecretStorage && patch.composio) {
+        // Electron stores the project key with OS-backed encryption. Persist
+        // only the non-secret Session ids here, while keeping the supplied
+        // key live in this process until the next launch injects it by env.
+        const composioPatch = patch.composio as NonNullable<AppConfig["composio"]>;
+        const { apiKey: _secret, ...metadata } = composioPatch;
+        saveConfig({ composio: { ...metadata, apiKey: "" } });
+        cfg.composio = { ...cfg.composio, ...composioPatch };
+        if (typeof composioPatch.apiKey === "string") process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
+      } else {
+        saveConfig(patch);
+        Object.assign(cfg, loadConfig());
+      }
       // provider keys change the fleet; a profile or voice edit must not
       // kill in-flight turns with a pointless reload — no driver reads
       // either, and picking a voice mid-turn should be free
@@ -2277,11 +2325,13 @@ const server = createServer(async (req, res) => {
     // ── connectors (Composio) ──
     if (method === "GET" && path === "/api/connectors/catalog") {
       const { cards, source } = await composio.listToolkits(cfg);
-      return json(res, 200, { configured: Boolean(cfg.composio?.key), source, cards });
+      return json(res, 200, { configured: Boolean(cfg.composio?.apiKey), source, cards });
     }
     if (method === "GET" && path === "/api/connectors") {
       const services = (url.searchParams.get("services") ?? "").split(",").filter(Boolean);
-      if (!cfg.composio?.key) return json(res, 200, { configured: false, services: {} });
+      if (!cfg.composio?.apiKey) {
+        return json(res, 200, { configured: false, services: {} });
+      }
       const status = await composio.connectionStatus(cfg, services.length ? services : composio.CURATED_SLUGS);
       return json(res, 200, { configured: true, services: status });
     }

--- a/server/redact.test.ts
+++ b/server/redact.test.ts
@@ -59,17 +59,17 @@ describe("redactSecrets", () => {
       mcpServers: {
         composio: {
           type: "http",
-          url: "https://connect.composio.dev/mcp",
-          headers: { "x-consumer-api-key": "ck_live_supersecret" },
+          url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+          headers: { "x-api-key": "ak_live_supersecret" },
         },
         computer: { env: { ELECTRON_RUN_AS_NODE: "1", OGB_BOX_TOKEN: "box_live_zzz" } },
       },
     };
 
     const out = flat(redactSecrets(config));
-    expect(out).not.toContain("ck_live_supersecret");
+    expect(out).not.toContain("ak_live_supersecret");
     expect(out).not.toContain("box_live_zzz");
-    expect(out).toContain("connect.composio.dev");
+    expect(out).toContain("app.composio.dev");
     expect(out).toContain("ELECTRON_RUN_AS_NODE");
     expect(out).toContain('"1"'); // a non-secret value is untouched
   });

--- a/server/redact.ts
+++ b/server/redact.ts
@@ -12,7 +12,7 @@
 // enough to debug "the proxy got no token" without the token being there.
 
 /** Key names whose value is a credential. Matched case-insensitively as a
- * substring, so KEY catches ANTHROPIC_API_KEY and x-consumer-api-key. */
+ * substring, so KEY catches ANTHROPIC_API_KEY and x-api-key. */
 const SECRET_KEY_PARTS = ["token", "secret", "password", "passwd", "apikey", "api_key", "authorization", "auth_token"];
 
 /** `key` alone is too broad — it matches `keyboard`, `keys`, `hotkey`. Only

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,16 +6,15 @@ import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "composioApi" | "box" | "opencodeGo";
+export type ConfigSection = "composio" | "box" | "opencodeGo";
 
 const SECTIONS: Record<
   ConfigSection,
   { body: (value: string) => unknown; flag: (config: ConfigStatus) => boolean }
 > = {
-  composio: { body: (v) => ({ composio: { key: v } }), flag: (c) => c.composio.configured },
-  composioApi: {
+  composio: {
     body: (v) => ({ composio: { apiKey: v } }),
-    flag: (c) => c.composio.apiKeyConfigured ?? false,
+    flag: (c) => c.composio.configured,
   },
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
   opencodeGo: { body: (v) => ({ opencodeGo: { apiKey: v } }), flag: (c) => c.opencodeGo?.configured ?? false },
@@ -34,19 +33,11 @@ const CREDENTIALS: Record<
   }
 > = {
   composio: {
-    label: "Composio Connect key",
-    placeholder: "ck_…",
-    description: "Connect Gmail, GitHub, Slack, Notion, and other apps to your bots.",
-    href: "https://docs.composio.dev/docs/composio-connect",
-    linkLabel: "Open Composio setup guide",
-    optional: true,
-  },
-  composioApi: {
-    label: "Composio API key",
+    label: "Composio project key",
     placeholder: "ak_…",
-    description: "Unlock the full app catalog with official names and logos.",
-    href: "https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions",
-    linkLabel: "Open Composio API key guide",
+    description: "Connect Gmail, GitHub, Slack, Notion, and other apps through your own Composio project.",
+    href: "https://dashboard.composio.dev",
+    linkLabel: "Create or copy a project key",
     optional: true,
   },
   box: {
@@ -159,10 +150,13 @@ export function ApiKeyRow({
     if (saving || (!value.trim() && !configured)) return;
     setSaving(true);
     setError(null);
-    api("/api/config", {
-      method: "PUT",
-      body: JSON.stringify(SECTIONS[section].body(value.trim())),
-    })
+    const request = section === "composio" && window.ogb?.setCredential
+      ? window.ogb.setCredential("composioApiKey", value.trim())
+      : api("/api/config", {
+          method: "PUT",
+          body: JSON.stringify(SECTIONS[section].body(value.trim())),
+        });
+    request
       .then((status: ConfigStatus) => {
         dispatch({ type: "configStatus", config: status });
         setValue("");

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -1,4 +1,4 @@
-// Connected apps marketplace, backed by Composio Connect. Catalog comes
+// Connected apps marketplace, backed by Composio Sessions. Catalog comes
 // from /api/connectors/catalog — the full toolkit list with logos when a
 // Composio API key is configured, a curated set otherwise. Icons resolve
 // logo → favicon → monogram.
@@ -187,12 +187,12 @@ export function PluginsPanel() {
           </div>
         </div>
         <div className="mt-1 text-[13px] text-ink-secondary">
-          Apps your bots can use through Composio Connect.
+          Apps your bots can use through Composio.
         </div>
 
         {!configured && (
           <div className="mt-3 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[13px] text-warning">
-            No Composio Connect key yet —{" "}
+            Connect your own Composio project first —{" "}
             <button
               className="underline"
               onClick={() => {
@@ -200,7 +200,7 @@ export function PluginsPanel() {
                 dispatch({ type: "toggleAppSettings", open: true });
               }}
             >
-              add one in App Settings
+              add a project key in App Settings
             </button>{" "}
             to connect apps.
           </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -207,7 +207,6 @@ export function SettingsModal() {
               >
                 <div className="flex flex-col gap-4">
                   <ApiKeyRow section="composio" />
-                  <ApiKeyRow section="composioApi" />
                   <ApiKeyRow section="box" />
                   <ApiKeyRow section="opencodeGo" />
                 </div>

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -165,7 +165,7 @@ export function messageVersions(bot: Bot, message: Message): Message[] {
 /** GET /api/config — configured flags only; secrets are never echoed. */
 export interface ConfigStatus {
   xai?: { configured: boolean };
-  composio: { configured: boolean; apiKeyConfigured?: boolean };
+  composio: { configured: boolean };
   box: { configured: boolean };
   opencodeGo?: { configured: boolean };
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -57,6 +57,8 @@ declare global {
       /** Copies an engine install command and opens a blank terminal. False
        * when no terminal could be launched; the clipboard still has it. */
       openInstallTerminal?(command: string): Promise<boolean>;
+      /** Save a provider credential through Electron's OS-backed store. */
+      setCredential?(name: "composioApiKey", value: string): Promise<ConfigStatus>;
       /** In-app auto-update (packaged app only; dormant in dev). onState
        * fires immediately with the current state, then on transitions. */
       updater?: {


### PR DESCRIPTION
## What changed

- replace the legacy Composio Connect consumer-key flow with one Composio project key and a reusable Composio Session
- use the current Sessions APIs for toolkit status, browser auth links, disconnect/revoke, and the agent MCP endpoint
- validate the project key before saving and automatically recover a deleted Session
- keep the project key out of the packaged app's JSON config by encrypting it with Electron safeStorage
- remove stale legacy Connect fields during packaged-app upgrade
- simplify Settings to one Composio credential and add a self-host setup guide
- bump the release version to 0.1.22 and rebuild the packaged server output

## Why

Fresh installs could not use connected apps because the UI still asked for the old Connect key, while current Composio projects use project API keys and Sessions. The old split-key setup also made onboarding needlessly confusing.

## User impact

A self-hosting user now creates or copies one `ak_…` project key, pastes it once, and connects providers from the Connected apps screen. Provider OAuth tokens remain in Composio; OpenMausBot stores only its project key and non-secret Session identifiers.

The packaged desktop app encrypts the project key with the operating system credential store. Source/headless installs can use `COMPOSIO_API_KEY`.

## Validation

- `pnpm test`: 471 passed, 8 skipped
- updater tests: 11 passed
- focused Composio/server tests: 71 passed, 1 skipped
- `pnpm typecheck`
- `pnpm check:electron`
- `pnpm build`
- `pnpm package:prepare`
- `git diff --check`

## Remaining live check

One real provider authorization should be completed with a real Composio project key before marking this ready for merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Composio now uses reusable Sessions for connected-app access, authorization, status checks, and account removal.
  * Added project API key configuration through App Settings.
  * Added secure OS-backed storage for Composio credentials in packaged desktop builds.
  * Added session reuse and recovery for more reliable connections.

* **Bug Fixes**
  * Improved handling of connection status, authentication links, and session errors.

* **Documentation**
  * Updated setup guidance, terminology, permissions, credential storage, and session management instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->