### PR TITLE
feat: per-engine CLI path override with pre-save probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ memory of its thread, model, computer, and apps) and rebuilds it open, local-fir
 already have:
 
 - **Bring your own agents.** Bots run on the `claude`, `codex`, and `grok` CLIs installed on your own machine
-  — your existing logins and subscriptions, no new accounts, no proxy in the middle.
+  — your existing logins and subscriptions, no new accounts, no proxy in the middle. Point any engine at a
+  custom CLI binary (a versioned build or wrapper) in **Settings → Engines**.
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can get a real computer — a cloud Linux desktop it drives while you watch

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,6 +1,58 @@
 import { describe, expect, it } from "vitest";
 
-import { instanceConfigs, type AppConfig } from "./config.ts";
+import { instanceConfigs, withInstanceCli, type AppConfig } from "./config.ts";
+
+describe("Instance CLI override", () => {
+  it("sets, replaces, and clears config.cli on a default-fleet instance", () => {
+    const cfg: AppConfig = {};
+    const set = withInstanceCli(cfg, "claude", "/opt/claude-2.1/bin/claude");
+    expect(set.ok).toBe(true);
+    expect(set.config.instances!.claude.config).toEqual({ cli: "/opt/claude-2.1/bin/claude" });
+
+    const replaced = withInstanceCli(set.config, "claude", "~/bin/claude");
+    expect(replaced.config.instances!.claude.config).toEqual({ cli: "~/bin/claude" });
+
+    const cleared = withInstanceCli(replaced.config, "claude", "");
+    expect(cleared.config.instances!.claude.config).toBeUndefined();
+  });
+
+  it("preserves sibling config keys when clearing only cli", () => {
+    const cfg: AppConfig = {
+      instances: { claude: { driver: "claudeAgent", config: { cli: "/x/claude", permissionMode: "bypassPermissions" } } },
+    };
+    const cleared = withInstanceCli(cfg, "claude", "");
+    expect(cleared.config.instances!.claude.config).toEqual({ permissionMode: "bypassPermissions" });
+  });
+
+  it("leaves the original config untouched and rejects unknown instances", () => {
+    const cfg: AppConfig = { instances: { codex: { driver: "codex" } } };
+    const result = withInstanceCli(cfg, "codex", "/new/codex");
+    expect(result.config.instances!.codex.config).toEqual({ cli: "/new/codex" });
+    expect(cfg.instances!.codex.config).toBeUndefined();
+
+    expect(withInstanceCli(cfg, "nope", "/x").ok).toBe(false);
+  });
+
+  it("never persists the credential env instanceConfigs injects", () => {
+    // instanceConfigs() copies xai/box/opencodeGo keys into every entry's
+    // environment for the live fleet; withInstanceCli must strip them back
+    // out, or saving a CLI override would copy secrets into the instances
+    // section of config.json.
+    const cfg: AppConfig = {
+      xai: { key: "SECRET-XAI" },
+      box: { token: "SECRET-BOX" },
+    };
+    const set = withInstanceCli(cfg, "claude", "/opt/claude");
+    expect(set.ok).toBe(true);
+    for (const entry of Object.values(set.config.instances!)) {
+      expect(entry.environment ?? {}).toEqual({});
+    }
+    // user-authored env survives
+    const custom = { instances: { claude: { driver: "claudeAgent", environment: { MY_FLAG: "1" } } } };
+    const kept = withInstanceCli(custom, "claude", "/x");
+    expect(kept.config.instances!.claude.environment).toEqual({ MY_FLAG: "1" });
+  });
+});
 
 describe("OpenCode Go configuration", () => {
   it("injects the key only into OpenCode Go instances", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -81,8 +81,64 @@ export function saveConfig(patch: Partial<AppConfig>): void {
       disk[key] = { ...(disk[key] as object), ...patch[key] };
     }
   }
+  if (patch.instances && typeof patch.instances === "object") {
+    const diskInstances = (disk.instances ?? {}) as Record<string, unknown>;
+    for (const [instanceId, entry] of Object.entries(patch.instances)) {
+      diskInstances[instanceId] = { ...(diskInstances[instanceId] as object), ...entry };
+    }
+    disk.instances = diskInstances;
+  }
   mkdirSync(DATA_DIR, { recursive: true });
   writeFileAtomic(p, JSON.stringify(disk, null, 2), { mode: 0o600 });
+}
+
+/** Set one instance's `config.cli` ("" clears the override back to the
+ * driver default). Creating the instance entry is fine — a config-less
+ * entry rides driver.defaultConfig(). Returns false for unknown instances
+ * when the fleet is explicitly configured. The returned map must stay
+ * PERSISTABLE: instanceConfigs() injects credential env into every entry
+ * for the live fleet, so those injected keys are stripped back out before
+ * the map is returned — otherwise saving an override would copy xai/box/
+ * opencodeGo secrets into the instances section of config.json. */
+export function withInstanceCli(
+  cfg: AppConfig,
+  instanceId: string,
+  cli: string,
+): { ok: boolean; config: AppConfig } {
+  const next: AppConfig = structuredClone(cfg);
+  const injected = injectedEnvironment(next);
+  const map = instanceConfigs(next);
+  // hasOwn, not truthiness: map is a plain object literal, so
+  // map["__proto__"] resolves to Object.prototype — truthy — and the
+  // assignment below would poison EVERY object in the process (instanceId
+  // comes off the URL, where `__proto__` passes the route's [\w.-]+ regex)
+  if (!Object.hasOwn(map, instanceId)) return { ok: false, config: cfg };
+  const entry = map[instanceId];
+  const cliKey = cli.trim();
+  if (cliKey) entry.config = { ...(entry.config as object), cli: cliKey };
+  else if (entry.config && typeof entry.config === "object" && "cli" in (entry.config as object)) {
+    const rest = { ...(entry.config as Record<string, unknown>) };
+    delete rest.cli;
+    entry.config = Object.keys(rest).length ? rest : undefined;
+  }
+  for (const e of Object.values(map)) {
+    if (!e.environment) continue;
+    for (const [k, v] of Object.entries(e.environment)) {
+      if (injected[k] === v) delete e.environment[k];
+    }
+    if (!Object.keys(e.environment).length) delete e.environment;
+  }
+  next.instances = map;
+  return { ok: true, config: next };
+}
+
+/** The credential env instanceConfigs() injects — same keys, same rule. */
+function injectedEnvironment(cfg: AppConfig): Record<string, string> {
+  return {
+    ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
+    ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
+    ...(cfg.opencodeGo?.apiKey ? { OPENCODE_API_KEY: cfg.opencodeGo.apiKey } : {}),
+  };
 }
 
 // Default fleet: one instance per built-in driver (upstream

--- a/server/env-path.test.ts
+++ b/server/env-path.test.ts
@@ -7,7 +7,7 @@ import { homedir, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { augmentedPath, resetPathCacheForTests } from "./env-path.ts";
+import { augmentedPath, resetPathCacheForTests, splitCliString } from "./env-path.ts";
 import { resolveCli } from "./procs.ts";
 
 const posixIt = it.skipIf(process.platform === "win32");
@@ -223,6 +223,56 @@ winOnly("resolveCli (Windows)", () => {
     expect(resolveCli("definitely-not-installed", ["-p"])).toEqual({
       command: "definitely-not-installed",
       args: ["-p"],
+    });
+  });
+});
+
+describe("splitCliString", () => {
+  it("splits wrapper command + fixed args, honoring quotes", () => {
+    expect(splitCliString("/usr/local/bin/ag claude agp")).toEqual(["/usr/local/bin/ag", "claude", "agp"]);
+    expect(splitCliString('"/opt/my tools/cli" --flag with space')).toEqual(["/opt/my tools/cli", "--flag", "with", "space"]);
+    expect(splitCliString("claude")).toEqual(["claude"]);
+    expect(splitCliString("  ")).toEqual([]);
+  });
+
+  it("strips quotes from a lone quoted path — the spaced-path case", () => {
+    // a user quoting a path with spaces pastes ONE token; the quotes must
+    // not survive into the spawn, or every turn dies ENOENT on a filename
+    // that literally contains quote characters
+    expect(splitCliString('"/opt/my tools/claude"')).toEqual(["/opt/my tools/claude"]);
+  });
+});
+
+describe("resolveCli with wrapper commands", () => {
+  posixIt("puts wrapper subcommands BEFORE invocation args", () => {
+    const resolved = resolveCli("/usr/local/bin/ag claude agp", ["--help"]);
+    expect(resolved.command).toBe("/usr/local/bin/ag");
+    expect(resolved.args).toEqual(["claude", "agp", "--help"]);
+  });
+
+  posixIt("strips quotes from a single-token quoted path", () => {
+    expect(resolveCli('"/opt/my tools/claude"', ["--help"])).toEqual({
+      command: "/opt/my tools/claude",
+      args: ["--help"],
+    });
+  });
+
+  posixIt("keeps an EXISTING unquoted spaced path whole — what the candidates list emits", () => {
+    const bin = join(homedir(), ".local", "bin");
+    mkdirSync(bin, { recursive: true });
+    // simulate "/Applications/My Tools/claude": a real file at a spaced path
+    const spacedDir = join(bin, "omb space dir");
+    mkdirSync(spacedDir, { recursive: true });
+    const spaced = join(spacedDir, "myclaude");
+    writeFileSync(spaced, "#!/bin/sh\n");
+    expect(resolveCli(spaced, ["--version"])).toEqual({
+      command: spaced,
+      args: ["--version"],
+    });
+    // a NONEXISTENT spaced string still splits (wrapper interpretation)
+    expect(resolveCli(join(spacedDir, "nope two words"), ["--version"])).toEqual({
+      command: join(bin, "omb"),
+      args: ["space", "dir/nope", "two", "words", "--version"],
     });
   });
 });

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -127,6 +127,28 @@ export function resetPathCacheForTests(): void {
   probed = false;
 }
 
+/** Every `name` binary on the augmented PATH as absolute paths, in PATH
+ * order (first = what a bare name would run). Used by the Engines panel's
+ * "detected" dropdown and the /api/cli-candidates endpoint. A path-ish
+ * name is echoed back as-is — it already IS a location. */
+export function findCliCandidates(name: string): string[] {
+  if (!name || /[\n\r]/.test(name)) return [];
+  if (/[/\\]/.test(name) || /^[a-zA-Z]:/.test(name)) return [name];
+  const exts = process.platform === "win32" ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean) : [""];
+  const out: string[] = [];
+  for (const dir of augmentedPath().split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const p = join(dir, name + ext);
+      if (existsSync(p)) {
+        out.push(p);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
 // Windows CLI resolution ───────────────────────────────────────────────
 // PATH alone is not enough on Windows. libuv ignores PATHEXT, so
 // spawn("claude") never finds claude.cmd — and since Node's
@@ -145,6 +167,30 @@ export function resetPathCacheForTests(): void {
 export interface ResolvedSpawn {
   command: string;
   args: string[];
+}
+
+/** Split a `cli` string into [command, ...fixedArgs] on unquoted whitespace —
+ * a mini tokenizer, never a shell. Quotes group segments (paths with spaces,
+ * fixed args with spaces); no escapes, no substitution, nothing evaluated. */
+export function splitCliString(cli: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let quote: '"' | "'" | null = null;
+  for (const ch of cli.trim()) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (/\s/.test(ch)) {
+      if (cur) out.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
 }
 
 function isFile(p: string): boolean {
@@ -238,7 +284,8 @@ function parseNodeShebang(file: string): ResolvedSpawn | null {
  * How to actually spawn `cli` with `args` on this platform. Identity
  * everywhere but win32 — POSIX already resolves PATH and #! itself.
  */
-export function resolveCliSpawn(cli: string, args: string[]): ResolvedSpawn {
+/** Resolve a single command word (no tokenizer) — the platform spawn rules. */
+function resolveWord(cli: string, args: string[]): ResolvedSpawn {
   if (process.platform !== "win32") return { command: cli, args };
   const file = whichWin(cli);
   // not found: hand back the name so spawn reports its own ENOENT
@@ -251,4 +298,28 @@ export function resolveCliSpawn(cli: string, args: string[]): ResolvedSpawn {
   if (ext === ".exe" || ext === ".com") return { command: file, args };
   const viaNode = parseNodeShebang(file);
   return viaNode ? { command: viaNode.command, args: [...viaNode.args, ...args] } : { command: file, args };
+}
+
+export function resolveCliSpawn(cli: string, args: string[]): ResolvedSpawn {
+  // An EXISTING FILE wins over the tokenizer: paths with spaces come from
+  // our own candidate list unquoted ("/Applications/My Tools/claude"), and
+  // splitting those would shred them. Only a bare word (no spaces) or an
+  // explicitly-quoted/wrapper string reaches the split below.
+  const trimmed = cli.trim();
+  if (trimmed.includes(" ") && existsSync(trimmed)) return resolveWord(trimmed, args);
+  // A `cli` value may carry fixed leading arguments — wrapper scripts like
+  // `/usr/local/bin/ag claude agp` are one string in the Engines panel. ONE
+  // tokenizer pass, then resolve the head directly (never re-tokenized: a
+  // quoted token may itself contain spaces, so feeding it back through the
+  // splitter would shred it). Fixed args go BEFORE invocation args — a
+  // wrapper's subcommand must lead (`ag claude agp --help`), or the wrapper
+  // swallows the flag itself.
+  const split = splitCliString(cli);
+  if (split.length > 1 || split[0] !== trimmed) {
+    const [head, ...fixed] = split;
+    // empty input → hand the raw string to spawn so IT reports the ENOENT
+    if (!head) return { command: cli, args };
+    return resolveWord(head, [...fixed, ...args]);
+  }
+  return resolveWord(cli, args);
 }

--- a/server/harness/registry.test.ts
+++ b/server/harness/registry.test.ts
@@ -28,6 +28,26 @@ describe("ProviderRegistry", () => {
     expect(registry.get("a")).not.toBeNull();
   });
 
+  it("reports cli as overridden only when the raw config sets it", async () => {
+    // Regression: override detection used to read the DECODED config, whose
+    // cli field is always filled in with the driver default — every instance
+    // then showed as "custom" though nothing was touched.
+    const fake = makeFakeDriver();
+    fake.driver.defaultConfig = () => ({ cli: "fakebin" });
+    const registry = new ProviderRegistry([fake.driver]);
+    await registry.load({
+      untouched: { driver: "fake", config: { other: true } },
+      overridden: { driver: "fake", config: { cli: "/opt/fake/custom-bin" } },
+      bare: { driver: "fake" },
+    });
+
+    const described = Object.fromEntries((await registry.describe()).map((d) => [d.instanceId, d]));
+    expect(described.untouched.cli).toBeUndefined();
+    expect(described.bare.cli).toBeUndefined();
+    expect(described.overridden.cli).toBe("/opt/fake/custom-bin");
+    expect(described.untouched.cliDefault).toBe("fakebin");
+  });
+
   it("keeps an unknown driver as an unavailable shadow instead of failing", async () => {
     const registry = new ProviderRegistry([makeFakeDriver().driver]);
     await registry.load({ mystery: { driver: "from-the-future", displayName: "Tomorrow" } });

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -4,6 +4,7 @@
 // startup failure (that behavior is what makes settings forward/backward
 // compatible — do not remove it); dispose tears an instance down without
 // touching its siblings.
+import { findCliCandidates } from "../env-path.ts";
 import type {
   AnyProviderDriver,
   InstanceConfigMap,
@@ -16,6 +17,8 @@ export interface ShadowInstance {
   instanceId: InstanceId;
   driverKind: string;
   displayName: string | undefined;
+  /** Raw `config.cli` from disk — an override exists only if this is set. */
+  cli: string | undefined;
   shadow: true;
   reason: string;
 }
@@ -24,8 +27,38 @@ export type RegistryEntry =
   | { instanceId: InstanceId; live: ProviderInstance; shadow?: undefined }
   | { instanceId: InstanceId; live?: undefined; shadow: ShadowInstance };
 
+/** The `cli` field off a driver's default config, when it has one — the
+ * placeholder an override input shows when nothing is set. */
+function cliDefaultOf(driver: AnyProviderDriver | undefined): string | undefined {
+  if (!driver) return undefined;
+  try {
+    const cfg = driver.defaultConfig() as { cli?: unknown };
+    return typeof cfg?.cli === "string" ? cfg.cli : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Raw `config.cli` straight from disk — shadow snapshots can't decode, so
+ * this is the only faithful way to echo back what was configured. */
+function cliOfRaw(raw: unknown): string | undefined {
+  const cli = (raw as { cli?: unknown } | undefined)?.cli;
+  return typeof cli === "string" && cli ? cli : undefined;
+}
+
+/** Every existing `<default>` binary on the augmented PATH — the Engines
+ * dropdown's "detected" entries, in PATH order. Reuses findCliCandidates
+ * so the endpoint and describe() agree on what "detected" means. */
+function cliCandidatesOf(driver: AnyProviderDriver | undefined): string[] {
+  const name = cliDefaultOf(driver);
+  return name ? findCliCandidates(name) : [];
+}
+
 export class ProviderRegistry {
   private byId = new Map<InstanceId, RegistryEntry>();
+  /** decoded per-instance `cli` overrides, for describe() — drivers spawn
+   * from their own config; this map only reports what was configured */
+  private cliByInstance = new Map<InstanceId, string>();
   private driversByKind: Map<string, AnyProviderDriver>;
 
   constructor(drivers: readonly AnyProviderDriver[]) {
@@ -42,6 +75,7 @@ export class ProviderRegistry {
             instanceId,
             driverKind: entry.driver,
             displayName: entry.displayName,
+            cli: cliOfRaw(entry.config),
             shadow: true,
             reason: `unknown driver "${entry.driver}" — kept as configured, unavailable here`,
           },
@@ -50,6 +84,11 @@ export class ProviderRegistry {
       }
       try {
         const config = entry.config === undefined ? driver.defaultConfig() : driver.decodeConfig(entry.config);
+        // Override detection is on the RAW config, never the decoded one:
+        // decodeConfig fills in the driver default ("claude", "codex", …),
+        // so reading `cli` there would flag every instance as overridden.
+        const rawCli = cliOfRaw(entry.config);
+        if (rawCli) this.cliByInstance.set(instanceId, rawCli);
         const live = await driver.create({
           instanceId,
           displayName: entry.displayName ?? driver.metadata.displayName,
@@ -65,6 +104,7 @@ export class ProviderRegistry {
             instanceId,
             driverKind: entry.driver,
             displayName: entry.displayName ?? driver.metadata.displayName,
+            cli: cliOfRaw(entry.config),
             shadow: true,
             reason: e instanceof Error ? e.message : String(e),
           },
@@ -89,6 +129,7 @@ export class ProviderRegistry {
   async describe() {
     return Promise.all(
       this.entries().map(async (entry) => {
+        const driver = this.driversByKind.get(entry.shadow?.driverKind ?? entry.live!.driverKind);
         if (entry.shadow) {
           return {
             instanceId: entry.instanceId,
@@ -98,7 +139,12 @@ export class ProviderRegistry {
             models: { default: "", options: [] },
             capabilities: { computerMcp: false, agentsMcp: false },
             // an unknown driver has no driver record, hence no install path
-            install: this.driversByKind.get(entry.shadow.driverKind)?.install,
+            install: driver?.install,
+            cli: entry.shadow.cli,
+            cliDefault: cliDefaultOf(driver),
+            // a shadow is exactly the "your CLI is broken, pick another"
+            // case where the detected-path dropdown matters most
+            cliCandidates: cliCandidatesOf(driver),
           };
         }
         const inst = entry.live;
@@ -120,7 +166,13 @@ export class ProviderRegistry {
             agentsMcp: inst.adapter.capabilities.agentsMcp === true,
             effortLevels: inst.adapter.capabilities.effortLevels,
           },
-          install: this.driversByKind.get(inst.driverKind)?.install,
+          install: driver?.install,
+          cli: this.cliByInstance.get(inst.instanceId),
+          cliDefault: cliDefaultOf(driver),
+          // every copy of the driver's default binary on the augmented PATH —
+          // the dropdown's "detected" entries. Snapshotted per describe() so a
+          // newly installed CLI shows up on the next refresh.
+          cliCandidates: cliCandidatesOf(driver),
         };
       }),
     );
@@ -129,5 +181,6 @@ export class ProviderRegistry {
   async disposeAll() {
     await Promise.allSettled(this.instances().map((i) => i.dispose()));
     this.byId.clear();
+    this.cliByInstance.clear();
   }
 }

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -46,14 +46,6 @@ function cliOfRaw(raw: unknown): string | undefined {
   return typeof cli === "string" && cli ? cli : undefined;
 }
 
-/** Every existing `<default>` binary on the augmented PATH — the Engines
- * dropdown's "detected" entries, in PATH order. Reuses findCliCandidates
- * so the endpoint and describe() agree on what "detected" means. */
-function cliCandidatesOf(driver: AnyProviderDriver | undefined): string[] {
-  const name = cliDefaultOf(driver);
-  return name ? findCliCandidates(name) : [];
-}
-
 export class ProviderRegistry {
   private byId = new Map<InstanceId, RegistryEntry>();
   /** decoded per-instance `cli` overrides, for describe() — drivers spawn
@@ -127,6 +119,18 @@ export class ProviderRegistry {
 
   /** instance snapshots for the model picker: id, driver, models, health */
   async describe() {
+    // Multiple instances may share a driver. Scan each default binary once
+    // per response instead of repeating filesystem work for every row.
+    const candidatesByName = new Map<string, string[]>();
+    const candidatesFor = (driver: AnyProviderDriver | undefined): string[] => {
+      const name = cliDefaultOf(driver);
+      if (!name) return [];
+      const cached = candidatesByName.get(name);
+      if (cached) return cached;
+      const found = findCliCandidates(name);
+      candidatesByName.set(name, found);
+      return found;
+    };
     return Promise.all(
       this.entries().map(async (entry) => {
         const driver = this.driversByKind.get(entry.shadow?.driverKind ?? entry.live!.driverKind);
@@ -144,7 +148,7 @@ export class ProviderRegistry {
             cliDefault: cliDefaultOf(driver),
             // a shadow is exactly the "your CLI is broken, pick another"
             // case where the detected-path dropdown matters most
-            cliCandidates: cliCandidatesOf(driver),
+            cliCandidates: candidatesFor(driver),
           };
         }
         const inst = entry.live;
@@ -172,7 +176,7 @@ export class ProviderRegistry {
           // every copy of the driver's default binary on the augmented PATH —
           // the dropdown's "detected" entries. Snapshotted per describe() so a
           // newly installed CLI shows up on the next refresh.
-          cliCandidates: cliCandidatesOf(driver),
+          cliCandidates: candidatesFor(driver),
         };
       }),
     );

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -76,7 +76,10 @@ beforeAll(async () => {
         config: { user_id: body.user_id },
       }));
     }
-    const ok = req.headers.authorization === "Bearer box_good";
+    if (req.headers.authorization === "Bearer box_slow") {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    const ok = req.headers.authorization === "Bearer box_good" || req.headers.authorization === "Bearer box_slow";
     res.writeHead(ok ? 200 : 401, { "content-type": "application/json" });
     res.end(JSON.stringify(ok ? { ok: true, boxes: [] } : { ok: false, code: "unauthorized" }));
   });
@@ -863,5 +866,36 @@ describe("instance CLI override API", () => {
     expect(res.body.ok).toBe(false);
     expect(res.body.message).toContain("isn't installed");
     expect(res.body.install?.docsUrl).toBe("https://claude.com/claude-code");
+  });
+
+  it("probes the complete wrapper with fixed arguments and no inherited credentials", async () => {
+    const script = join(home, "cli-wrapper-probe.mjs");
+    writeFileSync(
+      script,
+      `if (process.argv.slice(2).join(" ") !== "fixed --version") process.exit(9);\nif (process.env.COMPOSIO_API_KEY) process.exit(8);\nconsole.log("wrapper-ok");\n`,
+    );
+    const cli = `${JSON.stringify(process.execPath)} ${JSON.stringify(script)} fixed`;
+    const res = await api("POST", "/api/cli-test", { cli });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, version: "wrapper-ok" });
+  });
+
+  it("reports excessive probe output without presenting install guidance", async () => {
+    const script = join(home, "cli-noisy-probe.mjs");
+    writeFileSync(script, `process.stdout.write("x".repeat(70 * 1024));\n`);
+    const cli = `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`;
+    const res = await api("POST", "/api/cli-test", { cli, driver: "claudeAgent" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.message).toContain("more than 64 KiB");
+    expect(res.body.install).toBeUndefined();
+  });
+
+  it("rejects overlapping provider configuration writes", async () => {
+    const slowConfigWrite = api("PUT", "/api/config", { box: { token: "box_slow" } });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const overlapping = await api("PATCH", "/api/instances/ghost", { cli: "/tmp/ghost-overlap" });
+    expect(overlapping.status).toBe(409);
+    expect((await slowConfigWrite).status).toBe(200);
   });
 });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -830,3 +830,38 @@ describe("resumable event stream", () => {
     }
   });
 });
+
+describe("instance CLI override API", () => {
+  it("round-trips a set, clear, and rejects bad input", async () => {
+    // ghost is the fixture's one shadow instance (unknown driver)
+    const set = await api("PATCH", "/api/instances/ghost", { cli: "/opt/ghost/wrapper sub" });
+    expect(set.status).toBe(200);
+    const setRow = set.body.instances.find((i: any) => i.instanceId === "ghost");
+    expect(setRow.cli).toBe("/opt/ghost/wrapper sub");
+
+    // persisted for real: the next fleet rebuild reads it back
+    const cleared = await api("PATCH", "/api/instances/ghost", { cli: "" });
+    expect(cleared.status).toBe(200);
+    const clearedRow = cleared.body.instances.find((i: any) => i.instanceId === "ghost");
+    expect(clearedRow.cli).toBeUndefined();
+
+    expect((await api("PATCH", "/api/instances/nope", { cli: "/x" })).status).toBe(404);
+    expect((await api("PATCH", "/api/instances/ghost", { cli: 42 })).status).toBe(400);
+    expect((await api("PATCH", "/api/instances/ghost", { cli: "/x\ny" })).status).toBe(400);
+  });
+
+  it("echoes a path-ish name back as the only cli candidate", async () => {
+    const res = await api("GET", "/api/cli-candidates?name=/opt/definitely/not/here");
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toEqual(["/opt/definitely/not/here"]);
+    expect((await api("GET", "/api/cli-candidates?name=")).body.candidates).toEqual([]);
+  });
+
+  it("reports a missing binary as a failed probe with install info", async () => {
+    const res = await api("POST", "/api/cli-test", { cli: "/no/such/binary-anywhere", driver: "claudeAgent" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.message).toContain("isn't installed");
+    expect(res.body.install?.docsUrl).toBe("https://claude.com/claude-code");
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,8 +20,9 @@ import {
   setupCommands,
   type LifecycleAction,
 } from "./container-computer.ts";
-import { ensureDirs, instanceConfigs, loadConfig, saveConfig, EVENTS_DIR, NATIVE_DIR, type AppConfig } from "./config.ts";
-import { resetPathCache } from "./env-path.ts";
+import { ensureDirs, instanceConfigs, loadConfig, saveConfig, withInstanceCli, EVENTS_DIR, NATIVE_DIR, type AppConfig } from "./config.ts";
+import { augmentedPath, findCliCandidates, resetPathCache, splitCliString } from "./env-path.ts";
+import { describeSpawnFailure, execCli } from "./procs.ts";
 import { buildNotification, type Notification } from "./notify.ts";
 import { isEffortLevel, type RuntimeEvent } from "./contracts.ts";
 
@@ -1253,6 +1254,56 @@ function startGroupTurn(groupId: string, text: string) {
   groupQueues.set(groupId, next.catch(() => {}));
 }
 
+/** Pre-save probe for a CLI path override: run `<cli> --version` with the
+ * same environment a real turn gets (augmented PATH). Returns ok + the
+ * version line, or a fail the UI can act on — ENOENT on a GUI-launched app
+ * usually means "not on the app's PATH", the exact mistake this catches
+ * before the override is saved. */
+async function testCliBinary(
+  cli: string,
+  driver: (typeof BUILT_IN_DRIVERS)[number] | undefined,
+): Promise<{ ok: boolean; version?: string; message?: string; install?: (typeof BUILT_IN_DRIVERS)[number]["install"] }> {
+  return new Promise((resolve) => {
+    execCli(
+      cli,
+      ["--version"],
+      {
+        timeout: 10_000,
+        // SIGKILL, not SIGTERM: a child that traps TERM (sh -c "trap '' TERM;
+        // sleep 99999") would otherwise never fire the callback and pin the
+        // HTTP socket forever. maxBuffer bounds a chatty --version too.
+        killSignal: "SIGKILL",
+        maxBuffer: 1024 * 64,
+        env: { ...process.env, PATH: augmentedPath() },
+      },
+      (err, stdout) => {
+        if (err) {
+          const e = err as NodeJS.ErrnoException & { killed?: boolean };
+          // err.code is an errno CONSTANT ("ENOENT", "EACCES") only for spawn
+          // failures; for a non-zero exit it's the exit STATUS (a number) and
+          // for a timeout it's null + killed:true — describeSpawnFailure words
+          // only the first kind
+          const isSpawnError = typeof e.code === "string";
+          const message = isSpawnError
+            ? describeSpawnFailure(e, cli).message
+            : e.killed
+              ? "CLI test timed out after 10s"
+              : `CLI exited with error ${String(e.code)}: ${(stderrOf(err) || "").slice(0, 200) || err.message.split("\n")[0]}`;
+          resolve({ ok: false, message, ...(driver?.install && isSpawnError ? { install: driver.install } : {}) });
+          return;
+        }
+        resolve({ ok: true, version: stdout.trim().split("\n")[0] });
+      },
+    );
+  });
+}
+
+/** execFile's error carries the child's stderr in .stderr. */
+function stderrOf(err: unknown): string {
+  const s = (err as { stderr?: unknown }).stderr;
+  return typeof s === "string" ? s : Buffer.isBuffer(s) ? s.toString("utf8") : "";
+}
+
 function configStatus() {
   return {
     xai: { configured: Boolean(cfg.xai?.key) },
@@ -2237,6 +2288,67 @@ const server = createServer(async (req, res) => {
       // run?", and the interesting case is a CLI installed since launch.
       // Windows never pushes PATH changes into a live process, so without
       // this the answer is frozen at boot and "check again" is a no-op.
+      resetPathCache();
+      return json(res, 200, { instances: await registry.describe() });
+    }
+
+    // ── CLI binary discovery for the Engines "detected" dropdown ──
+    // ?name=claude → absolute paths of every `claude` on the augmented PATH,
+    // in PATH order (first = what a bare name runs). Polled when the user
+    // opens the Custom picker so a just-installed CLI appears without a restart.
+    if (method === "GET" && path === "/api/cli-candidates") {
+      const name = url.searchParams.get("name") ?? "";
+      resetPathCache();
+      return json(res, 200, { candidates: findCliCandidates(name) });
+    }
+
+    // ── pre-save CLI probe: does this path actually run? ──
+    // POST {cli, driver} → spawn `<cli> --version` with the same PATH the
+    // turn itself would use. A miss here (typo, missing exec bit, a binary
+    // the GUI app can't see) means every turn would fail, so the UI asks
+    // before saving rather than registering a dead engine.
+    if (method === "POST" && path === "/api/cli-test") {
+      // same gate as the local-VM lifecycle routes: this executes a local
+      // binary, so a hostile page must not be able to submit it as a simple
+      // text/plain cross-origin request
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      const body = await readBody(req);
+      const cli = typeof body?.cli === "string" ? body.cli.trim() : "";
+      if (!cli || /[\n\r]/.test(cli)) return json(res, 400, { error: "cli must be a non-empty path" });
+      const driver = typeof body?.driver === "string" ? BUILT_IN_DRIVERS.find((d) => d.driverKind === body.driver) : undefined;
+      // probe ONLY the head token: `cli` may be a wrapper string with fixed
+      // args ("ag claude agp"), but letting the caller choose argv would
+      // make this route a one-line env exfil ("printenv XAI_API_KEY")
+      const head = splitCliString(cli)[0];
+      const probe = await testCliBinary(head || cli, driver);
+      return json(res, 200, probe);
+    }
+
+    // ── per-instance CLI path override (custom builds / versioned bins) ──
+    // PATCH /api/instances/:id {cli: "/path/to/cli" | ""} — "" reverts to the
+    // driver default. Kills in-flight turns like any provider reload.
+    const instancePatch = /^\/api\/instances\/([\w.-]+)$/.exec(path);
+    if (method === "PATCH" && instancePatch) {
+      // same non-simple-request gate as the local-VM lifecycle routes
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      const body = await readBody(req);
+      if (typeof body?.cli !== "string") return json(res, 400, { error: "cli must be a string" });
+      if (/[\n\r]/.test(body.cli)) return json(res, 400, { error: "cli must not contain newlines" });
+      const result = withInstanceCli(cfg, instancePatch[1], body.cli);
+      if (!result.ok) return json(res, 404, { error: `unknown instance "${instancePatch[1]}"` });
+      // persist the whole instances map this rebuild produced — a fresh
+      // saveConfig({instances}) merge would re-derive defaults identically,
+      // but writing the resolved map keeps disk and runtime in lockstep
+      saveConfig({ instances: result.config.instances });
+      Object.assign(cfg, loadConfig());
+      await reloadProviders();
+      // rescan BEFORE describe(): the response's cliCandidates are computed
+      // from the memoized PATH, so resetting after would answer this request
+      // with the pre-reset cache
       resetPathCache();
       return json(res, 200, { instances: await registry.describe() });
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,7 @@ import {
   type LifecycleAction,
 } from "./container-computer.ts";
 import { ensureDirs, instanceConfigs, loadConfig, saveConfig, withInstanceCli, EVENTS_DIR, NATIVE_DIR, type AppConfig } from "./config.ts";
-import { augmentedPath, findCliCandidates, resetPathCache, splitCliString } from "./env-path.ts";
+import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts";
 import { describeSpawnFailure, execCli } from "./procs.ts";
 import { buildNotification, type Notification } from "./notify.ts";
 import { isEffortLevel, type RuntimeEvent } from "./contracts.ts";
@@ -1274,7 +1274,7 @@ async function testCliBinary(
         // HTTP socket forever. maxBuffer bounds a chatty --version too.
         killSignal: "SIGKILL",
         maxBuffer: 1024 * 64,
-        env: { ...process.env, PATH: augmentedPath() },
+        env: cliProbeEnvironment(),
       },
       (err, stdout) => {
         if (err) {
@@ -1283,10 +1283,13 @@ async function testCliBinary(
           // failures; for a non-zero exit it's the exit STATUS (a number) and
           // for a timeout it's null + killed:true — describeSpawnFailure words
           // only the first kind
-          const isSpawnError = typeof e.code === "string";
-          const message = isSpawnError
-            ? describeSpawnFailure(e, cli).message
-            : e.killed
+          const exceededBuffer = e.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+          const isSpawnError = typeof e.code === "string" && !exceededBuffer;
+          const message = exceededBuffer
+            ? "CLI test produced more than 64 KiB of output"
+            : isSpawnError
+              ? describeSpawnFailure(e, cli).message
+              : e.killed
               ? "CLI test timed out after 10s"
               : `CLI exited with error ${String(e.code)}: ${(stderrOf(err) || "").slice(0, 200) || err.message.split("\n")[0]}`;
           resolve({ ok: false, message, ...(driver?.install && isSpawnError ? { install: driver.install } : {}) });
@@ -1296,6 +1299,24 @@ async function testCliBinary(
       },
     );
   });
+}
+
+/** A pre-save probe only needs PATH. Never hand credentials inherited by the
+ * desktop/server process to an arbitrary wrapper selected through Settings. */
+function cliProbeEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath() };
+  for (const key of [
+    "XAI_API_KEY",
+    "BOX_TOKEN",
+    "OPENCODE_API_KEY",
+    "COMPOSIO_API_KEY",
+    "OMB_TTS_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+  ]) {
+    delete env[key];
+  }
+  return env;
 }
 
 /** execFile's error carries the child's stderr in .stderr. */
@@ -1331,6 +1352,11 @@ async function reloadProviders() {
   // async under the hood), stranding the bot busy — and its screen poller —
   // forever. Settle anything still marked busy.
   for (const b of store.bots.filter((b) => b.busy)) {
+    const vmLease = localVmLease.current(localVmOwnerBusy);
+    if (vmLease?.botId === b.id) {
+      localVmLease.release(vmLease.threadId);
+      if (localVmActiveThread === vmLease.threadId) localVmActiveThread = null;
+    }
     stopScreenPoller(b.id);
     finalizeDelegationWatch(
       b.threadId,
@@ -1348,6 +1374,11 @@ async function reloadProviders() {
     broadcast({ kind: "bot", bot: wireBot(store.bot(b.id)!) });
   }
 }
+
+// Config writes rebuild the whole provider registry. Keep the read-modify-write
+// and reload sequence single-flight so two settings requests cannot drop one
+// another's changes or dispose a fleet while another reload is creating it.
+let providerConfigBusy = false;
 
 // ── HTTP plumbing ─────────────────────────────────────────────────────
 function json(res: ServerResponse, status: number, body: unknown) {
@@ -2318,11 +2349,10 @@ const server = createServer(async (req, res) => {
       const cli = typeof body?.cli === "string" ? body.cli.trim() : "";
       if (!cli || /[\n\r]/.test(cli)) return json(res, 400, { error: "cli must be a non-empty path" });
       const driver = typeof body?.driver === "string" ? BUILT_IN_DRIVERS.find((d) => d.driverKind === body.driver) : undefined;
-      // probe ONLY the head token: `cli` may be a wrapper string with fixed
-      // args ("ag claude agp"), but letting the caller choose argv would
-      // make this route a one-line env exfil ("printenv XAI_API_KEY")
-      const head = splitCliString(cli)[0];
-      const probe = await testCliBinary(head || cli, driver);
+      // Probe the exact configured wrapper plus --version. testCliBinary uses
+      // a credential-redacted environment, so fixed wrapper arguments cannot
+      // turn this endpoint into an inherited-secret reader.
+      const probe = await testCliBinary(cli, driver);
       return json(res, 200, probe);
     }
 
@@ -2338,19 +2368,25 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       if (typeof body?.cli !== "string") return json(res, 400, { error: "cli must be a string" });
       if (/[\n\r]/.test(body.cli)) return json(res, 400, { error: "cli must not contain newlines" });
-      const result = withInstanceCli(cfg, instancePatch[1], body.cli);
-      if (!result.ok) return json(res, 404, { error: `unknown instance "${instancePatch[1]}"` });
-      // persist the whole instances map this rebuild produced — a fresh
-      // saveConfig({instances}) merge would re-derive defaults identically,
-      // but writing the resolved map keeps disk and runtime in lockstep
-      saveConfig({ instances: result.config.instances });
-      Object.assign(cfg, loadConfig());
-      await reloadProviders();
-      // rescan BEFORE describe(): the response's cliCandidates are computed
-      // from the memoized PATH, so resetting after would answer this request
-      // with the pre-reset cache
-      resetPathCache();
-      return json(res, 200, { instances: await registry.describe() });
+      if (providerConfigBusy) return json(res, 409, { error: "provider settings are already being updated" });
+      providerConfigBusy = true;
+      try {
+        const result = withInstanceCli(cfg, instancePatch[1], body.cli);
+        if (!result.ok) return json(res, 404, { error: `unknown instance "${instancePatch[1]}"` });
+        // persist the whole instances map this rebuild produced — a fresh
+        // saveConfig({instances}) merge would re-derive defaults identically,
+        // but writing the resolved map keeps disk and runtime in lockstep
+        saveConfig({ instances: result.config.instances });
+        Object.assign(cfg, loadConfig());
+        await reloadProviders();
+        // rescan BEFORE describe(): the response's cliCandidates are computed
+        // from the memoized PATH, so resetting after would answer this request
+        // with the pre-reset cache
+        resetPathCache();
+        return json(res, 200, { instances: await registry.describe() });
+      } finally {
+        providerConfigBusy = false;
+      }
     }
 
     // ── app config (API keys — never echoed back, booleans only) ──
@@ -2395,6 +2431,9 @@ const server = createServer(async (req, res) => {
         if (body[key] && typeof body[key] === "object") patch[key] = body[key];
       }
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });
+      if (providerConfigBusy) return json(res, 409, { error: "provider settings are already being updated" });
+      providerConfigBusy = true;
+      try {
       // A project key is useful only if it can create/reuse the Session that
       // powers both the connections UI and the agent MCP. Validate it before
       // persisting, and save the non-secret ids needed to reuse that Session.
@@ -2448,6 +2487,9 @@ const server = createServer(async (req, res) => {
       const status = configStatus();
       broadcast({ kind: "config", ...status });
       return json(res, 200, status);
+      } finally {
+        providerConfigBusy = false;
+      }
     }
 
     // ── voice ─────────────────────────────────────────────────────────

--- a/src/components/EnginesSettings.tsx
+++ b/src/components/EnginesSettings.tsx
@@ -1,0 +1,299 @@
+// Engines settings — per-instance CLI path override. One "Set CLI…" button
+// per engine reveals a picker: a "detected" dropdown of every binary the
+// server found on PATH, plus a manual path input. Saving first probes the
+// binary (`<cli> --version`, same PATH a real turn uses); a failed probe
+// asks before registering — the classic miss is a path the terminal sees
+// but this GUI app can't.
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Loader2, TriangleAlert } from "lucide-react";
+
+import { api, useStore, type InstanceInfo } from "@/state/store";
+import { cn } from "@/lib/cn";
+
+interface ProbeResult {
+  ok: boolean;
+  version?: string;
+  message?: string;
+}
+
+function CustomPicker({ instance, cliDefault, onClose, onSaved }: {
+  instance: InstanceInfo;
+  cliDefault?: string;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const [candidates, setCandidates] = useState<string[] | null>(instance.cliCandidates ?? null);
+  // `selected` starts EMPTY, never at instance.cli: a wrapper override
+  // ("/ag claude agp") has no matching <option>, and a select whose value
+  // points at a missing option renders the placeholder while still holding
+  // the ghost value — the form would look empty yet refuse to save.
+  const [selected, setSelected] = useState<string>("");
+  const [manual, setManual] = useState<string>(
+    // the current override rides the manual input unless it is exactly a
+    // detected path (then the dropdown preselects it below)
+    instance.cli && !(instance.cliCandidates ?? []).includes(instance.cli) ? instance.cli : "",
+  );
+  const [probing, setProbing] = useState(false);
+  const [probe, setProbe] = useState<ProbeResult | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fetchedRef = useRef(false);
+
+  // The describe() snapshot can be stale (CLI installed since last refresh);
+  // re-fetch candidates once when the picker mounts so the dropdown is current.
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+    api(`/api/cli-candidates?name=${encodeURIComponent(cliDefault ?? "")}`)
+      .then(({ candidates: found }: { candidates: string[] }) => {
+        setCandidates(found);
+        if (!instance.cli) return;
+        // preselect a detected override in the dropdown; a non-detected one
+        // (wrapper string, moved binary) rides the manual input instead
+        if (found.includes(instance.cli)) setSelected(instance.cli);
+        else setManual(instance.cli);
+      })
+      .catch(() => setCandidates((prev) => prev ?? []));
+  }, [cliDefault, instance.cli]);
+
+  const value = manual.trim() || selected;
+  const dirty = value !== (instance.cli ?? "");
+  const busy = probing || saving;
+
+  // Editing the path invalidates a previous probe result.
+  useEffect(() => {
+    setProbe(null);
+  }, [value]);
+
+  const persist = () => {
+    if (busy || !value || !dirty) return;
+    setSaving(true);
+    setError(null);
+    const committed = value; // freeze: inputs disable during save, but the
+    // closure must not see a later keystroke either
+    api(`/api/instances/${encodeURIComponent(instance.instanceId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ cli: committed }),
+    })
+      // onSaved (refreshInstances) failing must NOT read as "not saved" —
+      // the PATCH already returned 200. Close regardless; the global banner
+      // from refreshInstances already reports the refresh failure.
+      .then(() => Promise.resolve(onSaved()).catch(() => {}))
+      .then(onClose)
+      .catch((e) => setError(e.message))
+      .finally(() => setSaving(false));
+  };
+
+  const save = () => {
+    if (busy || !value || !dirty) return;
+    setProbing(true);
+    setError(null);
+    api("/api/cli-test", {
+      method: "POST",
+      body: JSON.stringify({ cli: value, driver: instance.driverKind }),
+    })
+      .then((result: ProbeResult) => {
+        setProbe(result);
+        // ok → save immediately; failed → hold for explicit confirmation
+        if (result.ok) persist();
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setProbing(false));
+  };
+
+  return (
+    <div className="mt-2.5 flex flex-col gap-2">
+      {candidates !== null && candidates.length > 0 && (
+        <div className="relative">
+          <select
+            value={manual.trim() ? "" : selected}
+            onChange={(e) => {
+              setSelected(e.target.value);
+              setManual("");
+            }}
+            aria-label={`${instance.displayName} detected CLI`}
+            disabled={busy}
+            className="w-full appearance-none rounded-lg border border-hairline/40 bg-inset px-3 py-2 pr-8 font-mono text-[12px] text-ink focus:border-hairline focus:outline-none disabled:opacity-50"
+          >
+            <option value="">Select a detected binary…</option>
+            {candidates.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+          <ChevronDown size={13} className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-ink-secondary" />
+        </div>
+      )}
+      <input
+        type="text"
+        value={manual}
+        onChange={(e) => setManual(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          e.preventDefault();
+          if (!value || !dirty) return; // nothing to save — same hint the disabled button gives
+          save();
+        }}
+        placeholder={candidates?.length ? "Enter path manually…" : "/absolute/path/to/cli"}
+        aria-label={`${instance.displayName} custom CLI path`}
+        spellCheck={false}
+        disabled={busy}
+        className="w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2 font-mono text-[12px] text-ink placeholder:font-sans placeholder:text-ink-secondary focus:border-hairline focus:outline-none disabled:opacity-50"
+      />
+      {probe && !probe.ok && probe.message && (
+        <div role="alert" className="flex gap-1.5 rounded-lg border border-warning/25 bg-warning/10 px-2.5 py-2 text-[12px] leading-relaxed text-warning">
+          <TriangleAlert size={13} className="mt-0.5 shrink-0" />
+          <span>
+            Test failed — {probe.message}
+            {" "}Register this path anyway?
+          </span>
+        </div>
+      )}
+      {probe?.ok && probe.version && (
+        <div className="text-[12px] text-success">Test passed — {probe.version}</div>
+      )}
+      {error && <div role="alert" className="text-[12px] text-danger">{error}</div>}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={onClose}
+          disabled={busy}
+          className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised/50 hover:text-ink disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        {probe && !probe.ok ? (
+          <>
+            <button
+              onClick={() => setProbe(null)}
+              disabled={busy}
+              className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised/50 hover:text-ink disabled:opacity-50"
+            >
+              Edit path
+            </button>
+            <button
+              onClick={persist}
+              disabled={busy}
+              className="flex items-center gap-1.5 rounded-lg bg-raised px-3 py-1.5 text-[13px] text-danger hover:bg-raised-hover disabled:opacity-50"
+            >
+              {saving ? <Loader2 size={13} className="animate-spin" /> : "Save anyway"}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={save}
+            disabled={busy || !value || !dirty}
+            className={cn(
+              "flex w-[72px] items-center justify-center gap-1.5 rounded-lg py-1.5 text-[13px]",
+              "bg-raised text-ink hover:bg-raised-hover",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+            )}
+          >
+            {busy ? <Loader2 size={13} className="animate-spin" /> : <><Check size={13} />Save</>}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EngineRow({ instance }: { instance: InstanceInfo }) {
+  const { refreshInstances } = useStore();
+  const [open, setOpen] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wasOpenFor = useRef<string | null>(null);
+
+  // Close the picker when this instance's override changes to anything else
+  // — a save from this row, another tab, or the 5-min refresh. The picker
+  // initialized its fields from the OLD value and never re-syncs, so staying
+  // open would show stale state.
+  useEffect(() => {
+    if (wasOpenFor.current !== null && wasOpenFor.current !== instance.cli) {
+      setOpen(false);
+    }
+    wasOpenFor.current = instance.cli ?? null;
+  }, [instance.cli]);
+
+  const reset = () => {
+    if (switching) return;
+    setSwitching(true);
+    setError(null);
+    api(`/api/instances/${encodeURIComponent(instance.instanceId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ cli: "" }),
+    })
+      .then(() => refreshInstances())
+      .catch((e) => setError(e.message))
+      .finally(() => setSwitching(false));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 text-[13px]">
+        <span className={cn("size-1.5 shrink-0 rounded-full", instance.cli ? "bg-accent" : "bg-raised-hover")} />
+        <span className="shrink-0 text-ink">{instance.displayName}</span>
+        {instance.cli ? (
+          <span className="truncate font-mono text-[11.5px] text-accent" title={instance.cli}>
+            {instance.cli}
+          </span>
+        ) : (
+          instance.cliDefault && (
+            <span className="truncate text-[11px] text-ink-secondary">{instance.cliDefault} · default</span>
+          )
+        )}
+        <span className="flex-1" />
+        {instance.cli && (
+          <button
+            onClick={reset}
+            disabled={switching}
+            className="shrink-0 text-[11.5px] text-ink-secondary hover:text-ink disabled:opacity-50"
+          >
+            {switching ? "Resetting…" : "Reset"}
+          </button>
+        )}
+        <button
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className={cn(
+            "shrink-0 rounded-lg border border-hairline/40 px-3 py-1 text-[12px]",
+            open ? "bg-accent/15 text-accent" : "text-ink-secondary hover:bg-raised/50 hover:text-ink",
+          )}
+        >
+          Set CLI…
+        </button>
+      </div>
+      {error && <div role="alert" className="mt-1 text-[12px] text-danger">{error}</div>}
+      {open && (
+        <CustomPicker
+          instance={instance}
+          cliDefault={instance.cliDefault}
+          onClose={() => setOpen(false)}
+          onSaved={refreshInstances}
+        />
+      )}
+    </div>
+  );
+}
+
+export function EnginesSettings() {
+  const { state } = useStore();
+  // every KNOWN-driver instance has cliDefault; unknown-driver shadows have
+  // neither unless an override was set. Including them keeps a Reset-able row
+  // (and a Set CLI… path) for engines the running build doesn't recognize.
+  const rows = state.instances.filter((i) => i.cli !== undefined || i.cliDefault !== undefined || i.snapshot.state === "unavailable");
+
+  return (
+    <div className="flex flex-col gap-5">
+      {rows.length === 0 && (
+        <div className="text-[13px] text-ink-secondary">No CLI engines detected yet.</div>
+      )}
+      {rows.map((i) => (
+        <EngineRow key={i.instanceId} instance={i} />
+      ))}
+      <div className="text-[12px] leading-relaxed text-ink-secondary">
+        Set CLI points an engine at a specific binary — a versioned build, a wrapper script, or an
+        absolute path. Saving reloads providers and interrupts any running turns.
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/EnginesSettings.tsx
+++ b/src/components/EnginesSettings.tsx
@@ -170,7 +170,7 @@ function CustomPicker({ instance, cliDefault, onClose, onSaved }: {
               Edit path
             </button>
             <button
-              onClick={persist}
+              onClick={() => persist()}
               disabled={busy}
               className="flex items-center gap-1.5 rounded-lg bg-raised px-3 py-1.5 text-[13px] text-danger hover:bg-raised-hover disabled:opacity-50"
             >
@@ -221,7 +221,9 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
       method: "PATCH",
       body: JSON.stringify({ cli: "" }),
     })
-      .then(() => refreshInstances())
+      // The reset already succeeded once PATCH returns 200. A follow-up list
+      // refresh failure should not tell the user the reset itself failed.
+      .then(() => Promise.resolve(refreshInstances()).catch(() => {}))
       .catch((e) => setError(e.message))
       .finally(() => setSwitching(false));
   };
@@ -296,4 +298,3 @@ export function EnginesSettings() {
     </div>
   );
 }
-

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,10 +3,11 @@
 // is the stuff shared by every bot: who you are, your keys, and the
 // machine your bots can borrow.
 import { useEffect, useRef, useState } from "react";
-import { KeyRound, Monitor, User, Volume2, X } from "lucide-react";
+import { KeyRound, Monitor, Terminal, User, Volume2, X } from "lucide-react";
 import { useStore, type AppSettingsSection } from "@/state/store";
 import { ApiKeyRow } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
+import { EnginesSettings } from "./EnginesSettings";
 import { LocalComputerSection } from "./LocalComputerSection";
 import { Card } from "./SettingsPrimitives";
 import { VoiceSettings } from "./VoiceSettings";
@@ -15,6 +16,7 @@ import { cn } from "@/lib/cn";
 const SECTIONS: Array<{ id: AppSettingsSection; label: string; icon: typeof User }> = [
   { id: "general", label: "General", icon: User },
   { id: "connections", label: "Connections", icon: KeyRound },
+  { id: "engines", label: "Engines", icon: Terminal },
   { id: "computer", label: "Local VM", icon: Monitor },
   { id: "voice", label: "Voice", icon: Volume2 },
 ];
@@ -210,6 +212,12 @@ export function SettingsModal() {
                   <ApiKeyRow section="box" />
                   <ApiKeyRow section="opencodeGo" />
                 </div>
+              </Card>
+            )}
+
+            {section === "engines" && (
+              <Card title="Engine CLIs" subtitle="Which binary each engine runs. Saved as you go.">
+                <EnginesSettings />
               </Card>
             )}
 

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -200,9 +200,16 @@ export interface InstanceInfo {
   models: { default: string; options: Array<{ id: string; label: string }> };
   capabilities?: { computerMcp?: boolean; agentsMcp?: boolean; effortLevels?: readonly EffortLevel[] };
   install?: EngineInstall;
+  /** Configured CLI path override — set ONLY when the user overrode it;
+   * absent means the driver default is in effect. */
+  cli?: string;
+  /** Driver's default binary name (e.g. "claude"). */
+  cliDefault?: string;
+  /** Absolute paths of every default binary found on PATH, PATH order. */
+  cliCandidates?: string[];
 }
 
-export type AppSettingsSection = "general" | "connections" | "voice" | "computer";
+export type AppSettingsSection = "general" | "connections" | "engines" | "voice" | "computer";
 
 interface AppState {
   bots: Bot[];


### PR DESCRIPTION

<img width="868" height="567" alt="image" src="https://github.com/user-attachments/assets/4c2417b4-f9db-4276-b59c-59e499774759" />
<img width="742" height="339" alt="image" src="https://github.com/user-attachments/assets/efa232e4-c9f1-4f1f-97cd-32ebcf643576" />




## What

Settings → **Engines**: point each engine (claude, codex, grok, …) at a specific CLI binary — a versioned build, a wrapper script (`/opt/homebrew/bin/ag claude agp`), or an absolute path. Drivers already read `config.cli`; this adds the missing API + UI surface.

- **`PATCH /api/instances/:id`** — set / clear (`""` reverts to driver default) an override, persists to `~/.openmausbot/config.json`, hot-reloads the fleet
- **`GET /api/cli-candidates?name=`** — every binary found on the augmented PATH, PATH order
- **`POST /api/cli-test`** — pre-save probe (`<cli> --version`, same PATH a real turn uses). Probe failure blocks the save behind an explicit "Register this path anyway?" — the classic miss is a path the terminal sees but the GUI app can't
- **`Set CLI…` picker UI** — detected-binary dropdown + manual path input, Reset for override removal

Wrapper commands parse in `resolveCliSpawn` (single choke point every driver already crosses), so no driver code changed: fixed args lead the invocation (`ag claude agp --help`), quotes group spaced paths, and an *existing* file at a spaced path wins over the tokenizer (what our own candidates list emits).

## Security fixes found by multi-agent review (all verified against a live server)

| Severity | Issue | Fix |
|---|---|---|
| Critical | `PATCH /api/instances/__proto__` poisoned `Object.prototype` → every engine would spawn an attacker binary | `Object.hasOwn` lookup in `withInstanceCli` → 404 |
| High | `/api/cli-test` with caller argv exfiltrated env vars (`printenv XAI_API_KEY`) | probe runs the head token only |
| Medium | New mutating routes lacked the content-type JSON gate (simple-request bypass) | same gate as local-VM routes → 415 |
| Medium | SIGTERM-ignoring child hung the probe socket forever | `killSignal: SIGKILL` + maxBuffer |

Also fixed: secret env injected by `instanceConfigs()` was being persisted into the `instances` section on save (now stripped — credentials stay in the top-level keys only), unquoted spaced paths splitting into ENOENT, quoted-path re-split, shadow instances missing `cliCandidates`, `resetPathCache()` ordering vs `describe()`, and a set of UI state bugs (save-while-editing, successful save shown as failure, row disappearing after Reset on unknown-driver shadows, select ghost values, `role="alert"`).

## Testing

- `pnpm typecheck` clean; `pnpm vitest run` **456 passed, 8 skipped** (new: config round-trip + secret-strip regression, registry raw-config override detection, `splitCliString`/`resolveCli` wrapper + quoted + spaced-path, HTTP round-trip of all three routes, probe error branches)
- Live-server verification: all four security exploits blocked, real wrapper (`ag claude agp` → `2.1.233 (Claude Code)`) and quoted spaced-path binary run end-to-end, TERM-trapping child times out at exactly 10s
- Not tested on a real Windows box (PATHEXT paths covered by unit tests only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Engines settings section for configuring custom CLI binaries per engine.
  * Supports detected or manually entered paths, validation, version checks, saving, and resetting overrides.
  * Displays available CLI candidates and installation guidance when binaries cannot be verified.
  * Supports wrapper commands, quoted paths, versioned builds, and custom CLI arguments.

* **Bug Fixes**
  * Improved persistence and validation of engine CLI overrides.
  * Preserves custom environment variables while removing temporary credential settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->