### PR TITLE
Give the update buttons a state to click into

### DIFF
--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -63,6 +63,11 @@ export function createUpdaterCoordinator(updater, setState) {
 
     const operation = { promise: null };
     downloadOperation = operation;
+    // Own the state before the request goes out: the first "download-progress"
+    // can be seconds away (connection setup, redirects), and until then the
+    // renderer would still show an untouched "Download" button. No percent yet
+    // — the UI reads a missing percent as "starting".
+    setState({ status: "downloading" });
     try {
       operation.promise = Promise.resolve(updater.downloadUpdate())
         .catch((error) => handleRejectedOperation(true, error))

--- a/electron/updater-coordinator.node-test.mjs
+++ b/electron/updater-coordinator.node-test.mjs
@@ -115,6 +115,23 @@ test("a manual request during a background check preserves user-visible errors",
   assert.deepEqual(getState(), { status: "error", message: "background request failed" });
 });
 
+test("download reports downloading before the first progress event", async () => {
+  const { updater, coordinator, getState, states } = harness();
+  const pending = deferred();
+  // a real transfer stays silent until bytes arrive; the button must not wait
+  updater.downloadUpdate = () => pending.promise;
+
+  const download = coordinator.download();
+  assert.deepEqual(getState(), { status: "downloading" });
+  assert.equal(states[0].status, "downloading");
+
+  updater.emit("download-progress", { percent: 12 });
+  assert.deepEqual(getState(), { status: "downloading", percent: 12 });
+
+  pending.resolve();
+  await download;
+});
+
 test("an active download state survives a later background check failure", async () => {
   const { updater, coordinator, getState } = harness();
   const downloadPending = deferred();

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -15,7 +15,7 @@ const require = createRequire(import.meta.url);
 
 let autoUpdater = null;
 let win = null;
-// status: idle | checking | available | downloading | downloaded | error
+// status: idle | checking | available | downloading | downloaded | installing | error
 let state = { status: "idle" };
 let updaterCoordinator = null;
 
@@ -33,9 +33,13 @@ export function registerUpdaterIpc() {
   ipcMain.handle("update:check", () => updaterCoordinator?.check(true));
   ipcMain.handle("update:download", () => updaterCoordinator?.download());
   ipcMain.handle("update:install", () => {
+    if (!autoUpdater) return;
+    // Tearing down the window and relaunching takes a beat; announce it so the
+    // button greys out instead of looking like the click was swallowed.
+    setState({ status: "installing" });
     // isSilent, isForceRunAfter — relaunch straight into the new version
     try {
-      autoUpdater?.quitAndInstall(true, true);
+      autoUpdater.quitAndInstall(true, true);
     } catch (e) {
       setState({ status: "error", message: String(e?.message ?? e) });
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,6 +55,11 @@ function UpdateButton() {
   const s = useUpdaterState();
   const [checkedAt, setCheckedAt] = useState(0);
   const updater = window.ogb?.updater;
+  const status = s?.status ?? "idle";
+  // download and install both round-trip through main before the status
+  // changes — spin on the click itself, and let the new status clear it
+  const [pending, setPending] = useState(false);
+  useEffect(() => setPending(false), [status]);
   // a check that found nothing lands back on idle — acknowledge it for 3s
   const upToDate = Boolean(checkedAt) && (!s || s.status === "idle") && Date.now() - checkedAt < 3000;
   useEffect(() => {
@@ -64,26 +69,36 @@ function UpdateButton() {
   }, [upToDate]);
   if (!updater) return null;
 
-  const status = s?.status ?? "idle";
-  const working = status === "checking" || status === "downloading";
+  const working =
+    pending || status === "checking" || status === "downloading" || status === "installing";
   const label =
     status === "available"
       ? `Version ${s?.version ?? ""} available — download`
       : status === "downloading"
-        ? `Downloading… ${Math.round(s?.percent ?? 0)}%`
+        ? s?.percent == null
+          ? "Starting download…"
+          : `Downloading… ${Math.round(s.percent)}%`
         : status === "downloaded"
           ? `Version ${s?.version ?? ""} ready — restart to update`
-          : status === "checking"
-            ? "Checking for updates…"
-            : upToDate
-              ? "You're up to date"
-              : "Check for updates";
+          : status === "installing"
+            ? "Restarting to update…"
+            : status === "checking"
+              ? "Checking for updates…"
+              : upToDate
+                ? "You're up to date"
+                : "Check for updates";
 
   return (
     <button
       onClick={() => {
-        if (status === "downloaded") return void updater.install();
-        if (status === "available") return void updater.download();
+        if (status === "downloaded") {
+          setPending(true);
+          return void updater.install();
+        }
+        if (status === "available") {
+          setPending(true);
+          return void updater.download();
+        }
         setCheckedAt(Date.now());
         void updater.check();
       }}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -2,9 +2,16 @@
 // preload's updater bridge. Renders nothing in the browser/dev (no bridge)
 // and while idle/checking; appears only when actionable: an update to
 // download, a download in progress, a restart to apply, or an error.
-import { useState } from "react";
-import { ArrowDownToLine, RefreshCw, Sparkles, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ArrowDownToLine, Loader2, RefreshCw, Sparkles, X } from "lucide-react";
 import { useUpdaterState } from "@/lib/updater";
+import { cn } from "@/lib/cn";
+
+// The one action button in the card. Disabled drops the accent fill for the
+// flat raised grey — the "I heard you" the click needs while the main process
+// gets going.
+const primaryAction =
+  "flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-1.5 text-[13px] font-medium text-white transition-colors disabled:cursor-default disabled:bg-raised disabled:text-ink-secondary";
 
 // electron-updater surfaces failures as a whole HTTP dump — status line,
 // every response header, stack trace. That is unreadable in a 300px popup,
@@ -24,10 +31,21 @@ export function UpdateBanner() {
   // dismissal is per status+version, so the popup returns for the next
   // update (and when an available one finishes downloading)
   const [dismissed, setDismissed] = useState<string | null>(null);
+  // A click has to go renderer → main → broadcast before the real status
+  // arrives. Latch the pressed button as busy on the same frame so it greys
+  // out immediately; the incoming status clears the latch.
+  const [pending, setPending] = useState<"download" | "install" | "check" | null>(null);
+  const status = s?.status;
+  useEffect(() => setPending(null), [status]);
+
   if (!s || s.status === "idle" || s.status === "checking") return null;
   const key = `${s.status}:${s.version ?? ""}`;
   if (dismissed === key) return null;
   const updater = window.ogb!.updater!;
+
+  // while busy the card owns the moment: no dismissing, no second click
+  const installing = s.status === "installing";
+  const busy = s.status === "downloading" || installing;
 
   const title =
     s.status === "available"
@@ -36,15 +54,22 @@ export function UpdateBanner() {
         ? `Downloading ${s.version ?? "update"}…`
         : s.status === "downloaded"
           ? `${s.version} is ready`
-          : "Update check failed";
+          : installing
+            ? "Restarting to update…"
+            : "Update check failed";
   const subtitle =
     s.status === "available"
       ? "A newer version is ready to download."
       : s.status === "downloading"
-        ? `${Math.round(s.percent ?? 0)}%`
+        ? // no percent yet means the transfer hasn't reported in — don't imply 0
+          s.percent == null
+          ? "Starting download…"
+          : `${Math.round(s.percent)}%`
         : s.status === "downloaded"
           ? "Restart to finish updating."
-          : friendlyError(s.message);
+          : installing
+            ? "OpenMausBot will reopen in a moment."
+            : friendlyError(s.message);
 
   return (
     <div className="animate-panel-in fixed bottom-4 left-4 z-50 w-[300px] rounded-xl border border-hairline/40 bg-panel p-3.5 shadow-2xl shadow-black/50">
@@ -58,7 +83,7 @@ export function UpdateBanner() {
             {subtitle}
           </div>
         </div>
-        {s.status !== "downloading" && (
+        {!busy && (
           <button
             onClick={() => setDismissed(key)}
             className="shrink-0 rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
@@ -72,41 +97,92 @@ export function UpdateBanner() {
       {s.status === "downloading" && (
         <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-raised">
           <div
-            className="h-full rounded-full bg-accent transition-[width]"
-            style={{ width: `${Math.min(100, Math.max(0, s.percent ?? 0))}%` }}
+            className={cn(
+              "h-full rounded-full bg-accent transition-[width]",
+              // before the first progress report, a sliver that breathes beats
+              // a zero-width bar that looks stalled
+              s.percent == null && "w-1/4 animate-pulse",
+            )}
+            style={s.percent == null ? undefined : { width: `${Math.min(100, Math.max(0, s.percent))}%` }}
           />
         </div>
       )}
 
-      {s.status !== "downloading" && (
+      {installing && (
+        <div className="mt-2.5 flex gap-2">
+          <button
+            disabled
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-raised py-1.5 text-[13px] font-medium text-ink-secondary"
+          >
+            <Loader2 size={13} className="animate-spin" /> Restarting…
+          </button>
+        </div>
+      )}
+
+      {!busy && (
         <div className="mt-2.5 flex gap-2">
           {s.status === "available" && (
             <button
-              onClick={() => void updater.download()}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-1.5 text-[13px] font-medium text-white"
+              onClick={() => {
+                setPending("download");
+                void updater.download();
+              }}
+              disabled={pending !== null}
+              className={primaryAction}
             >
-              <ArrowDownToLine size={13} /> Download
+              {pending === "download" ? (
+                <>
+                  <Loader2 size={13} className="animate-spin" /> Starting…
+                </>
+              ) : (
+                <>
+                  <ArrowDownToLine size={13} /> Download
+                </>
+              )}
             </button>
           )}
           {s.status === "downloaded" && (
             <button
-              onClick={() => void updater.install()}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-1.5 text-[13px] font-medium text-white"
+              onClick={() => {
+                setPending("install");
+                void updater.install();
+              }}
+              disabled={pending !== null}
+              className={primaryAction}
             >
-              <RefreshCw size={13} /> Restart to update
+              {pending === "install" ? (
+                <>
+                  <Loader2 size={13} className="animate-spin" /> Restarting…
+                </>
+              ) : (
+                <>
+                  <RefreshCw size={13} /> Restart to update
+                </>
+              )}
             </button>
           )}
           {s.status === "error" && (
             <button
-              onClick={() => void updater.check()}
-              className="flex-1 rounded-lg bg-raised py-1.5 text-[13px] text-ink hover:bg-raised-hover"
+              onClick={() => {
+                setPending("check");
+                void updater.check();
+              }}
+              disabled={pending !== null}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-raised py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:text-ink-secondary disabled:hover:bg-raised"
             >
-              Try again
+              {pending === "check" ? (
+                <>
+                  <Loader2 size={13} className="animate-spin" /> Checking…
+                </>
+              ) : (
+                "Try again"
+              )}
             </button>
           )}
           <button
             onClick={() => setDismissed(key)}
-            className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
+            disabled={pending !== null}
+            className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50 disabled:hover:bg-transparent"
           >
             Later
           </button>

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -71,7 +71,14 @@ declare global {
 }
 
 export interface UpdaterState {
-  status: "idle" | "checking" | "available" | "downloading" | "downloaded" | "error";
+  status:
+    | "idle"
+    | "checking"
+    | "available"
+    | "downloading"
+    | "downloaded"
+    | "installing"
+    | "error";
   version?: string;
   percent?: number;
   message?: string;


### PR DESCRIPTION
Clicking **Download** or **Restart to update** in the update card left the button looking untouched — the download was actually running, and the restart was actually happening, but nothing on screen said so. Same dead click on the sidebar's update button.

Neither was a styling problem. The state machine had nothing to report:

- **`download()`** waited for electron-updater's first `download-progress` event before claiming `downloading`. That event is seconds out while the connection is set up, so the card kept rendering an untouched Download button while bytes were already moving. It now takes the state before the request goes out — percent-less, and the UI reads a missing percent as "Starting download…" rather than a stalled 0%.
- **`update:install`** called `quitAndInstall` and set no state at all, so the restart button had nothing to react to during the second or two before the window tore down. Added an `installing` status.

On top of the main-process fix, each button latches itself busy on click and lets the incoming status clear the latch, so the grey lands on the click's own frame instead of after the IPC round trip. While busy the card drops its dismiss X and Later so it can't be half-closed mid-install.

| Click | Immediately | Then |
|---|---|---|
| Download | greys to raised fill, spinner + "Starting…" | progress bar ("Starting download…" → percentages) |
| Restart to update | greys out, spinner + "Restarting…" | "Restarting to update… / OpenMausBot will reopen in a moment." until the app quits |
| Try again (error) | greys out, spinner + "Checking…" | card hides or reports the result |

The progress bar shows a pulsing quarter-width sliver before the first percent arrives, instead of a zero-width bar that reads as stalled.

## Testing

- `pnpm test:updater` — 12/12 pass, including a new case asserting `downloading` lands before the first progress event
- `pnpm vitest run` — 466 pass, 8 skipped
- `pnpm typecheck` — 3 pre-existing errors, all unrelated (`react-markdown`, `remark-gfm`, `shiki` are absent from `node_modules`); nothing in the touched files errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer update progress feedback, including an indeterminate state before download progress is available.
  - Added an installation status with restart feedback.
  - Update controls now show busy indicators and prevent duplicate actions during downloads or installation.

- **Bug Fixes**
  - Improved update state handling so download and installation actions remain accurately represented throughout the process.
  - Progress displays are now constrained to valid values and update correctly when progress begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->