### PR TITLE
Fix Composio OAuth connection flow

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -295,6 +295,25 @@ ipcMain.handle("engine:open-terminal", async (_event, command) => {
   return openBlankTerminal();
 });
 
+// OAuth/connect links are returned asynchronously, after Chromium's direct
+// click gesture has ended. Opening them through window.open can therefore be
+// rejected as a popup before setWindowOpenHandler ever sees the URL. Keep the
+// renderer sandboxed and let the main process open only ordinary web links.
+ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
+  if (typeof rawUrl !== "string") throw new Error("A web address is required");
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("That web address is invalid");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Only web links can be opened");
+  }
+  await shell.openExternal(url.toString());
+  return true;
+});
+
 ipcMain.handle("perm:status", () => ({
   mic:
     process.platform === "darwin"

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -42,6 +42,9 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Copies an engine install command and opens a blank terminal. Resolves
    * false if no terminal could be launched; the clipboard still has it. */
   openInstallTerminal: (command) => ipcRenderer.invoke("engine:open-terminal", command),
+  /** Open a web link in the default browser. Unlike renderer window.open,
+   * this remains reliable after an asynchronous API request. */
+  openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
   /** Store a provider credential with OS-backed encryption. */
   setCredential: (name, value) => ipcRenderer.invoke("credential:set", name, value),
 

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -13,6 +13,7 @@ import {
 let api: Server;
 let base = "";
 const calls: Array<{ method: string; path: string; query: string; body: any }> = [];
+let malformedConnectedAccounts = false;
 
 beforeAll(async () => {
   api = createServer(async (req, res) => {
@@ -55,6 +56,7 @@ beforeAll(async () => {
     }
     if (req.method === "GET" && url.pathname === "/api/v3.1/connected_accounts") {
       res.writeHead(200, { "content-type": "application/json" });
+      if (malformedConnectedAccounts) return res.end(JSON.stringify({ items: {} }));
       return res.end(JSON.stringify({
         items: [
           { toolkit: { slug: "github" }, status: "ACTIVE", updated_at: "2026-08-17T08:00:00Z" },
@@ -139,5 +141,20 @@ describe.sequential("Composio Sessions", () => {
         && call.path.endsWith("/connected_accounts/ca_github")
         && call.query === "?revoke_on_delete=true",
     )).toBe(true);
+  });
+
+  it("falls back to session toolkit state when connected-account items is malformed", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    malformedConnectedAccounts = true;
+    try {
+      await expect(connectionStatus(cfg, ["github", "slack"])).resolves.toEqual({
+        github: { connected: true, pending: false, status: "ACTIVE" },
+        slack: { connected: false, pending: false, status: "not_connected" },
+      });
+    } finally {
+      malformedConnectedAccounts = false;
+    }
   });
 });

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -53,6 +53,16 @@ beforeAll(async () => {
         ],
       }));
     }
+    if (req.method === "GET" && url.pathname === "/api/v3.1/connected_accounts") {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        items: [
+          { toolkit: { slug: "github" }, status: "ACTIVE", updated_at: "2026-08-17T08:00:00Z" },
+          { toolkit: { slug: "notion" }, status: "INITIATED", updated_at: "2026-08-17T08:01:00Z" },
+          { toolkit: { slug: "linear" }, status: "EXPIRED", updated_at: "2026-08-17T08:02:00Z" },
+        ],
+      }));
+    }
     if (req.method === "POST" && url.pathname.endsWith("/link")) {
       res.writeHead(201, { "content-type": "application/json" });
       return res.end(JSON.stringify({ redirect_url: `https://connect.composio.dev/link/${body.toolkit}` }));
@@ -113,11 +123,12 @@ describe.sequential("Composio Sessions", () => {
     const cfg: AppConfig = {
       composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
     };
-    await expect(connectionStatus(cfg, ["github", "gmail", "slack", "notion"])).resolves.toEqual({
-      github: { connected: true, status: "ACTIVE" },
-      gmail: { connected: true, status: "ACTIVE" },
-      slack: { connected: false, status: "not_connected" },
-      notion: { connected: false, status: "not_connected" },
+    await expect(connectionStatus(cfg, ["github", "gmail", "slack", "notion", "linear"])).resolves.toEqual({
+      github: { connected: true, pending: false, status: "ACTIVE" },
+      gmail: { connected: true, pending: false, status: "ACTIVE" },
+      slack: { connected: false, pending: false, status: "not_connected" },
+      notion: { connected: false, pending: true, status: "INITIATED" },
+      linear: { connected: false, pending: false, status: "EXPIRED" },
     });
     await expect(authorizeService(cfg, "github")).resolves.toEqual({
       url: "https://connect.composio.dev/link/github",

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -114,18 +114,61 @@ export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
   const session = await ensureProjectSession(cfg);
   const params = new URLSearchParams({ limit: "50" });
   if (slugs.length) params.set("toolkits", slugs.join(","));
-  const res = await fetch(
-    `${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`,
-    { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) },
-  );
+  const userId = session.config?.user_id ?? cfg.composio.userId;
+  const [res, accounts] = await Promise.all([
+    fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`, {
+      headers: projectHeaders(cfg.composio.apiKey),
+      signal: AbortSignal.timeout(15_000),
+    }),
+    // Session toolkits only include an account once it is usable. Read the
+    // account lifecycle too so the UI can distinguish an OAuth flow that is
+    // still waiting in the browser from one that expired or failed. Scoped
+    // keys may omit connected-account read permission, so this is additive:
+    // the normal session result remains the fallback.
+    userId
+      ? fetch(
+          `${apiBase()}/connected_accounts?${new URLSearchParams({ limit: "50", user_ids: userId })}`,
+          { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) },
+        )
+          .then(async (accountRes) => {
+            if (!accountRes.ok) return [];
+            const accountBody = (await accountRes.json()) as {
+              items?: Array<{ toolkit?: { slug?: string }; status?: string; updated_at?: string }>;
+            };
+            return accountBody.items ?? [];
+          })
+          .catch(() => [])
+      : Promise.resolve([]),
+  ]);
   if (!res.ok) throw new Error(await responseError(res, `Composio toolkits: HTTP ${res.status}`));
   const body = (await res.json()) as { items?: Array<{ slug?: string; is_no_auth?: boolean; connected_account?: { status?: string } }> };
   const bySlug = new Map((body.items ?? []).map((item) => [item.slug?.toLowerCase(), item]));
+  const accountBySlug = new Map<string, { status?: string; updated_at?: string }>();
+  for (const account of accounts) {
+    const slug = account.toolkit?.slug?.toLowerCase();
+    if (!slug || !slugs.some((candidate) => candidate.toLowerCase() === slug)) continue;
+    const current = accountBySlug.get(slug);
+    // Prefer an active account. Otherwise the API is newest-first, but keep
+    // the timestamp comparison explicit so response ordering cannot lie.
+    if (
+      !current
+      || /^active$/i.test(account.status ?? "")
+      || (!/^active$/i.test(current.status ?? "") && (account.updated_at ?? "") > (current.updated_at ?? ""))
+    ) {
+      accountBySlug.set(slug, account);
+    }
+  }
   return Object.fromEntries(
     slugs.map((slug) => {
       const item = bySlug.get(slug.toLowerCase());
-      const state = item?.connected_account?.status ?? (item?.is_no_auth ? "ACTIVE" : "not_connected");
-      return [slug, { connected: item?.is_no_auth === true || /^active$/i.test(state), status: state }];
+      const account = accountBySlug.get(slug.toLowerCase());
+      const state = item?.connected_account?.status
+        ?? (item?.is_no_auth ? "ACTIVE" : account?.status ?? "not_connected");
+      return [slug, {
+        connected: item?.is_no_auth === true || /^active$/i.test(state),
+        pending: /^(initiated|initializing|pending)$/i.test(state),
+        status: state,
+      }];
     }),
   );
 }

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -135,7 +135,7 @@ export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
             const accountBody = (await accountRes.json()) as {
               items?: Array<{ toolkit?: { slug?: string }; status?: string; updated_at?: string }>;
             };
-            return accountBody.items ?? [];
+            return Array.isArray(accountBody?.items) ? accountBody.items : [];
           })
           .catch(() => [])
       : Promise.resolve([]),

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeCurrentConnectorStatus, type ConnectorStatus } from "./PluginsPanel";
+
+describe("connected-app status races", () => {
+  it("does not let an older not_connected response erase a newer OAuth attempt", async () => {
+    const generations = new Map([["gmail", 0]]);
+    const initialRequestGenerations = new Map(generations);
+    let deliverInitialResponse: (value: Record<string, ConnectorStatus>) => void = () => {};
+    const delayedInitialResponse = new Promise<Record<string, ConnectorStatus>>((resolve) => {
+      deliverInitialResponse = resolve;
+    });
+
+    generations.set("gmail", 1);
+    const localOAuthState = {
+      gmail: { connected: false, pending: true, status: "INITIATED" },
+    };
+    deliverInitialResponse({ gmail: { connected: false, pending: false, status: "not_connected" } });
+
+    const merged = mergeCurrentConnectorStatus(
+      localOAuthState,
+      await delayedInitialResponse,
+      generations,
+      initialRequestGenerations,
+    );
+
+    expect(merged.gmail).toEqual({ connected: false, pending: true, status: "INITIATED" });
+  });
+
+  it("still applies a response from the current generation", () => {
+    const generations = new Map([["gmail", 1]]);
+    const merged = mergeCurrentConnectorStatus(
+      { gmail: { connected: false, pending: true, status: "INITIATED" } },
+      { gmail: { connected: true, pending: false, status: "ACTIVE" } },
+      generations,
+      new Map(generations),
+    );
+
+    expect(merged.gmail).toEqual({ connected: true, pending: false, status: "ACTIVE" });
+  });
+});

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -44,23 +44,40 @@ export function PluginsPanel() {
   const [cards, setCards] = useState<ToolkitCard[] | null>(null);
   const [source, setSource] = useState<"api" | "curated">("curated");
   const [configured, setConfigured] = useState(true);
-  const [status, setStatus] = useState<Record<string, { connected: boolean }>>({});
+  const [status, setStatus] = useState<Record<string, { connected: boolean; pending?: boolean; status?: string }>>({});
+  const [pendingUrls, setPendingUrls] = useState<Record<string, string>>({});
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
-  const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, { connected: boolean }>> => {
+  const pollTimers = useRef(new Map<string, ReturnType<typeof setInterval>>());
+
+  const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, { connected: boolean; pending?: boolean; status?: string }>> => {
     if (!slugs.length) return Promise.resolve({});
     setRefreshing(true);
     return api(`/api/connectors?services=${slugs.join(",")}`)
       .then((r) => {
-        const services: Record<string, { connected: boolean }> = r.services ?? {};
-        setStatus(services);
+        const services: Record<string, { connected: boolean; pending?: boolean; status?: string }> = r.services ?? {};
+        // A one-service OAuth poll must not erase every other app's state.
+        setStatus((current) => ({ ...current, ...services }));
+        for (const [slug, state] of Object.entries(services)) {
+          if (state.connected) setPendingUrls((current) => {
+            if (!current[slug]) return current;
+            const next = { ...current };
+            delete next[slug];
+            return next;
+          });
+        }
         return services;
       })
       .catch(() => ({}))
       .finally(() => setRefreshing(false));
+  }, []);
+
+  useEffect(() => () => {
+    for (const timer of pollTimers.current.values()) clearInterval(timer);
+    pollTimers.current.clear();
   }, []);
 
   useEffect(() => {
@@ -121,24 +138,48 @@ export function PluginsPanel() {
     };
   }, [dispatch]);
 
-  const connect = (slug: string) => {
+  const openConnectUrl = async (url: string) => {
+    if (window.ogb?.openExternal) {
+      await window.ogb.openExternal(url);
+      return;
+    }
+    // Browser development fallback. If a popup blocker rejects the first
+    // asynchronous open, the visible Continue button retries from a direct
+    // user gesture using the URL retained in pendingUrls.
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (!opened) throw new Error("Your browser blocked the connection page. Click Continue to open it.");
+  };
+
+  const startPolling = (slug: string) => {
+    const old = pollTimers.current.get(slug);
+    if (old) clearInterval(old);
+    let tries = 0;
+    const timer = setInterval(() => {
+      void refreshStatus([slug]).then((services) => {
+        const state = services[slug];
+        if (++tries >= 24 || state?.connected || (state?.status && /^(expired|failed)$/i.test(state.status))) {
+          clearInterval(timer);
+          pollTimers.current.delete(slug);
+        }
+      });
+    }, 5000);
+    pollTimers.current.set(slug, timer);
+  };
+
+  const connect = async (slug: string) => {
     setBusySlug(slug);
     setError(null);
-    api(`/api/connectors/${slug}/authorize`, { method: "POST" })
-      .then(({ url }) => {
-        window.open(url);
-        // the user finishes OAuth in the browser; poll a few times to catch it.
-        // check the freshly-fetched result, not the `status` captured in this
-        // closure — that snapshot never updates, so it would always poll 6×
-        let tries = 0;
-        const timer = setInterval(() => {
-          void refreshStatus([slug]).then((s) => {
-            if (++tries >= 6 || s[slug]?.connected) clearInterval(timer);
-          });
-        }, 5000);
-      })
-      .catch((e) => setError(e.message))
-      .finally(() => setBusySlug(null));
+    try {
+      const { url } = await api(`/api/connectors/${slug}/authorize`, { method: "POST" });
+      setPendingUrls((current) => ({ ...current, [slug]: url }));
+      setStatus((current) => ({ ...current, [slug]: { connected: false, pending: true, status: "INITIATED" } }));
+      startPolling(slug);
+      await openConnectUrl(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusySlug(null);
+    }
   };
 
   const disconnect = (slug: string) => {
@@ -236,7 +277,10 @@ export function PluginsPanel() {
             </div>
           ) : (
             visible.map((card, i) => {
-              const connected = status[card.slug]?.connected;
+              const serviceStatus = status[card.slug];
+              const connected = serviceStatus?.connected;
+              const pending = serviceStatus?.pending;
+              const failed = serviceStatus?.status && /^(expired|failed)$/i.test(serviceStatus.status);
               const busy = busySlug === card.slug;
               return (
                 <div
@@ -252,11 +296,19 @@ export function PluginsPanel() {
                       {card.label}
                       {connected && <span className="size-1.5 rounded-full bg-success" />}
                     </div>
-                    <div className="truncate text-[12px] text-ink-secondary">{card.blurb}</div>
+                    <div className="truncate text-[12px] text-ink-secondary">
+                      {pending ? "Finish setup in your browser" : failed ? "Authorization expired — try again" : card.blurb}
+                    </div>
                   </div>
                   <button
                     disabled={!configured || busy}
-                    onClick={() => (connected ? disconnect(card.slug) : connect(card.slug))}
+                    onClick={() => {
+                      if (connected) disconnect(card.slug);
+                      else if (pending && pendingUrls[card.slug]) {
+                        setError(null);
+                        void openConnectUrl(pendingUrls[card.slug]).catch((e) => setError(e.message));
+                      } else void connect(card.slug);
+                    }}
                     className={cn(
                       "w-[92px] rounded-lg py-1.5 text-[13px] disabled:opacity-50",
                       connected
@@ -268,6 +320,10 @@ export function PluginsPanel() {
                       <Loader2 size={13} className="mx-auto animate-spin" />
                     ) : connected ? (
                       "Disconnect"
+                    ) : pending ? (
+                      "Continue"
+                    ) : failed ? (
+                      "Retry"
                     ) : (
                       "Connect"
                     )}

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -146,8 +146,12 @@ export function PluginsPanel() {
     // Browser development fallback. If a popup blocker rejects the first
     // asynchronous open, the visible Continue button retries from a direct
     // user gesture using the URL retained in pendingUrls.
-    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    const opened = window.open(url, "_blank");
     if (!opened) throw new Error("Your browser blocked the connection page. Click Continue to open it.");
+    // Some browsers return null whenever `noopener` is passed as a feature,
+    // even when the tab opened successfully. Clear opener explicitly so a
+    // real null remains a reliable popup-blocked signal.
+    opened.opener = null;
   };
 
   const startPolling = (slug: string) => {

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -15,6 +15,26 @@ interface ToolkitCard {
   domain: string | null;
 }
 
+export interface ConnectorStatus {
+  connected: boolean;
+  pending?: boolean;
+  status?: string;
+}
+
+export function mergeCurrentConnectorStatus(
+  current: Record<string, ConnectorStatus>,
+  incoming: Record<string, ConnectorStatus>,
+  latestGenerations: ReadonlyMap<string, number>,
+  requestGenerations: ReadonlyMap<string, number>,
+) {
+  const next = { ...current };
+  for (const [slug, state] of Object.entries(incoming)) {
+    if ((latestGenerations.get(slug) ?? 0) !== (requestGenerations.get(slug) ?? 0)) continue;
+    next[slug] = state;
+  }
+  return next;
+}
+
 function ServiceIcon({ card }: { card: ToolkitCard }) {
   // 0 = official logo, 1 = favicon by domain, 2 = monogram
   const [stage, setStage] = useState(card.logo ? 0 : card.domain ? 1 : 2);
@@ -44,7 +64,7 @@ export function PluginsPanel() {
   const [cards, setCards] = useState<ToolkitCard[] | null>(null);
   const [source, setSource] = useState<"api" | "curated">("curated");
   const [configured, setConfigured] = useState(true);
-  const [status, setStatus] = useState<Record<string, { connected: boolean; pending?: boolean; status?: string }>>({});
+  const [status, setStatus] = useState<Record<string, ConnectorStatus>>({});
   const [pendingUrls, setPendingUrls] = useState<Record<string, string>>({});
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -52,17 +72,27 @@ export function PluginsPanel() {
   const [search, setSearch] = useState("");
 
   const pollTimers = useRef(new Map<string, ReturnType<typeof setInterval>>());
+  const statusGenerations = useRef(new Map<string, number>());
 
-  const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, { connected: boolean; pending?: boolean; status?: string }>> => {
+  const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, ConnectorStatus>> => {
     if (!slugs.length) return Promise.resolve({});
+    const requestGenerations = new Map(slugs.map((slug) => [slug, statusGenerations.current.get(slug) ?? 0]));
     setRefreshing(true);
     return api(`/api/connectors?services=${slugs.join(",")}`)
       .then((r) => {
-        const services: Record<string, { connected: boolean; pending?: boolean; status?: string }> = r.services ?? {};
+        const services: Record<string, ConnectorStatus> = r.services ?? {};
         // A one-service OAuth poll must not erase every other app's state.
-        setStatus((current) => ({ ...current, ...services }));
+        // A request that began before Connect must also not erase the newer
+        // local INITIATED state when its stale not_connected result arrives.
+        setStatus((current) => mergeCurrentConnectorStatus(
+          current,
+          services,
+          statusGenerations.current,
+          requestGenerations,
+        ));
         for (const [slug, state] of Object.entries(services)) {
-          if (state.connected) setPendingUrls((current) => {
+          const isCurrent = (statusGenerations.current.get(slug) ?? 0) === (requestGenerations.get(slug) ?? 0);
+          if (isCurrent && state.connected) setPendingUrls((current) => {
             if (!current[slug]) return current;
             const next = { ...current };
             delete next[slug];
@@ -171,6 +201,7 @@ export function PluginsPanel() {
   };
 
   const connect = async (slug: string) => {
+    statusGenerations.current.set(slug, (statusGenerations.current.get(slug) ?? 0) + 1);
     setBusySlug(slug);
     setError(null);
     try {

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -176,12 +176,12 @@ export function PluginsPanel() {
     // Browser development fallback. If a popup blocker rejects the first
     // asynchronous open, the visible Continue button retries from a direct
     // user gesture using the URL retained in pendingUrls.
-    const opened = window.open(url, "_blank");
+    const opened = window.open("", "_blank");
     if (!opened) throw new Error("Your browser blocked the connection page. Click Continue to open it.");
-    // Some browsers return null whenever `noopener` is passed as a feature,
-    // even when the tab opened successfully. Clear opener explicitly so a
-    // real null remains a reliable popup-blocked signal.
+    // Open a same-origin blank page first so the OAuth origin never receives
+    // an opener reference, while a real null remains a reliable blocked signal.
     opened.opener = null;
+    opened.location.replace(url);
   };
 
   const startPolling = (slug: string) => {

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -57,6 +57,8 @@ declare global {
       /** Copies an engine install command and opens a blank terminal. False
        * when no terminal could be launched; the clipboard still has it. */
       openInstallTerminal?(command: string): Promise<boolean>;
+      /** Opens an http(s) link in the user's default browser. */
+      openExternal?(url: string): Promise<boolean>;
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(name: "composioApiKey", value: string): Promise<ConfigStatus>;
       /** In-app auto-update (packaged app only; dormant in dev). onState


### PR DESCRIPTION
## What changed

- open Composio authorization links through a safe Electron main-process bridge, avoiding popup blocking after the async link request
- keep an explicit pending/continue state while the user finishes OAuth
- report `INITIATED`, `EXPIRED`, and `FAILED` account lifecycle states instead of flattening them all to disconnected
- merge one-app polling updates into existing connection state instead of wiping every other app's badge
- poll for up to two minutes and stop cleanly on success or terminal failure

## Root cause

The renderer called `window.open()` only after the authorization API promise resolved. Chromium could reject that as a popup because the original click gesture had ended. Composio consequently created a connected-account record, but OAuth never started; the live record expired with `Connection expired before authorization was started`. The UI then flattened that state to disconnected. One-service status polling also replaced the entire status map.

## Impact

Clicking Connect now reliably opens the system browser in the desktop app. The panel keeps a visible Continue action and explains pending or expired authorization, and completed connections remain visible to the Claude agent's already-mounted Composio MCP tools.

## Validation

- `pnpm typecheck`
- `pnpm check:electron`
- `pnpm test` — 475 passed, 8 skipped, plus 11 updater tests
- `pnpm build`
- live Composio MCP initialize/tools-list check
- live account-state check against the current Composio session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for opening secure external authorization links in the desktop app, with browser fallback.
  - Plugin connection cards now show setup progress, pending, success, and failure states.
  - Added Continue, Retry, Connect, and Disconnect actions for authorization flows.

- **Bug Fixes**
  - Improved connection status accuracy across services, including active, pending, and expired connections.
  - Preserved existing states during refreshes and ignored outdated authorization responses.
  - Added safer handling for invalid external links and incomplete connection data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->