### PR TITLE
fix: re-probe login shell PATH on engine rescan

### DIFF
--- a/server/env-path.test.ts
+++ b/server/env-path.test.ts
@@ -5,9 +5,9 @@ import { execFile } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { augmentedPath, resetPathCacheForTests, splitCliString } from "./env-path.ts";
+import { augmentedPath, resetPathCache, resetPathCacheForTests, splitCliString } from "./env-path.ts";
 import { resolveCli } from "./procs.ts";
 
 const posixIt = it.skipIf(process.platform === "win32");
@@ -75,6 +75,33 @@ describe("augmentedPath", () => {
       );
     });
     expect(stdout.trim()).toBe("found-me");
+  });
+
+  posixIt("keeps the last login-shell PATH available during a rescan", async () => {
+    const shell = join(homedir(), "fake-login-shell");
+    const rcOnlyBin = join(homedir(), "rc-only", "bin");
+    writeFileSync(shell, `#!/bin/sh\nprintf '__OMB_PATH__%s' '${rcOnlyBin}'\n`);
+    chmodSync(shell, 0o755);
+
+    const previousShell = process.env.SHELL;
+    const previousVitest = process.env.VITEST;
+    try {
+      process.env.SHELL = shell;
+      delete process.env.VITEST;
+      resetPathCacheForTests();
+
+      augmentedPath();
+      await vi.waitFor(() => expect(augmentedPath().split(delimiter)).toContain(rcOnlyBin));
+
+      resetPathCache();
+      expect(augmentedPath().split(delimiter)).toContain(rcOnlyBin);
+    } finally {
+      if (previousShell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = previousShell;
+      if (previousVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = previousVitest;
+      resetPathCacheForTests();
+    }
   });
 
   it("skips known dirs that do not exist", () => {

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -74,6 +74,7 @@ function windowsKnownDirs(): string[] {
 
 let cached: string | null = null;
 let probed = false;
+let loginShellPath: string | null = null;
 
 /** Drop the memoized PATH so the next augmentedPath() rescans. Called when
  * the app re-probes engines, so "check again" can find something installed
@@ -94,6 +95,10 @@ export function augmentedPath(): string {
     cached = mergePaths([
       ...(process.env.OMB_EXTRA_PATH ? process.env.OMB_EXTRA_PATH.split(delimiter) : []),
       ...(process.env.PATH ? process.env.PATH.split(delimiter) : []),
+      // Keep the last successful login-shell result while a rescan starts a
+      // fresh asynchronous probe. Otherwise resetPathCache() would make
+      // rc-only CLIs disappear again for the response that triggered it.
+      ...(loginShellPath ? loginShellPath.split(delimiter) : []),
       // Both platforms scan their standard install locations; only the
       // login-shell probe below stays unix-only, since Windows has no
       // equivalent rc file to source.
@@ -126,6 +131,7 @@ function probeLoginShellPath(): void {
       if (err || !stdout) return;
       const m = /__OMB_PATH__([^\n]*)/.exec(stdout);
       if (!m || !m[1]) return;
+      loginShellPath = m[1];
       cached = mergePaths([...(cached ?? "").split(delimiter), ...m[1].split(delimiter)]);
     },
   );
@@ -135,6 +141,7 @@ function probeLoginShellPath(): void {
 export function resetPathCacheForTests(): void {
   cached = null;
   probed = false;
+  loginShellPath = null;
 }
 
 /** Every `name` binary on the augmented PATH as absolute paths, in PATH

--- a/server/env-path.ts
+++ b/server/env-path.ts
@@ -35,6 +35,7 @@ function knownDirs(): string[] {
     join(home, ".npm-global", "bin"), // npm prefix ~/.npm-global (claude, opencode)
     join(home, ".kimi-code", "bin"), // kimi-code installer
     join(home, ".grok", "bin"), // x.ai installer
+    join(home, ".opencode", "bin"), // opencode installer
     join(home, ".claude", "local"), // claude "local install"
     "/opt/homebrew/bin", // brew, Apple silicon
     "/usr/local/bin", // brew Intel / classic installs
@@ -76,9 +77,15 @@ let probed = false;
 
 /** Drop the memoized PATH so the next augmentedPath() rescans. Called when
  * the app re-probes engines, so "check again" can find something installed
- * since launch instead of answering from the PATH we booted with. */
+ * since launch instead of answering from the PATH we booted with. `probed`
+ * must reset too: the login-shell probe merges rc-file PATH entries (e.g.
+ * ~/.kimi-code/bin exported from .zshrc) into the cache asynchronously,
+ * and without resetting it a rescan would rebuild the cache without those
+ * entries and never re-probe — "check again" would permanently lose
+ * anything only the login shell's rc file knows about. */
 export function resetPathCache(): void {
   cached = null;
+  probed = false;
 }
 
 /** Current best PATH, synchronously. Cheap after the first call. */


### PR DESCRIPTION
## Bug

On macOS, an engine whose CLI bin dir is *only* on the login-shell `PATH` (exported from `~/.zshrc` / `~/.bashrc` — e.g. `kimi-code` installed at `~/.kimi-code/bin/kimi`, exported by its own installer) shows up as **"`kimi` CLI not found"** in the engine picker every time the picker reopens, until the app is fully restarted.

### Root cause

`server/env-path.ts` memoizes the augmented PATH behind two module-level flags: `cached` (the merged PATH returned by `augmentedPath()`) and `probed` (whether the one-shot login-shell probe has been kicked off).

On the first call to `augmentedPath()`, `cached` is built from inherited `PATH` + `knownDirs()`, and `probeLoginShellPath()` is launched in the background. When the probe completes, it merges the rc-file `PATH` entries (`~/.kimi-code/bin`, etc.) into `cached`.

`GET /api/instances` (the "what engines can I run?" endpoint, hit every time the model picker opens) calls `resetPathCache()` first to re-detect engines on demand. Today's `resetPathCache()`:

```ts
export function resetPathCache(): void {
  cached = null;
}
```

…clears `cached` but **not** `probed`. So after the first re-probe:

1. `cached` is rebuilt from `knownDirs()` only — the rc-only entries (`~/.kimi-code/bin`) are gone.
2. Because `probed === true`, `probeLoginShellPath()` is never fired again, so they are never re-merged.

Restarting the app temporarily fixes it (fresh module state) until the next picker open drops it again. Engine snapshots run with `env.PATH = augmentedPath()`, so the missing rc-only directory on `augmentedPath()` is what makes the picker report "not found".

`resetPathCacheForTests()` already resets both flags — that asymmetry is what tipped the investigation.

## Fix

Two changes in `server/env-path.ts`:

- `resetPathCache()` now also resets `probed = false`, so the next `augmentedPath()` kicks off `probeLoginShellPath()` again, and the rc-file `PATH` entries get re-merged into the rebuilt cache.
- Added `~/.opencode/bin` to the macOS `knownDirs()` list alongside the existing kimi-code / grok entries, so the opencode installer's standalone bin dir is also findable without going through the login-shell probe.

## Testing

`pnpm vitest run server/env-path.test.ts` — 12 passed, 7 skipped (Windows-only). Result:

```
Test Files  1 passed (1)
     Tests  12 passed | 7 skipped (19)
```

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command availability by recognizing the OpenCode installer directory.
  * Preserved login-shell PATH entries during asynchronous rescans and cache resets.
  * Ensured environment path state resets correctly during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->