### PR TITLE
Add shareable community team library

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -224,9 +224,10 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
-  it("exports selected bots without a room and imports the team with fresh IDs", async () => {
+  it("exports every visible bot and imports the team without creating a room", async () => {
     const first = (await api("POST", "/api/bots")).body.bot;
     const second = (await api("POST", "/api/bots")).body.bot;
+    const hidden = (await api("POST", "/api/bots")).body.bot;
     await api("PATCH", `/api/bots/${first.id}`, {
       name: "Mira",
       title: "Project Lead",
@@ -242,67 +243,50 @@ describe("harness HTTP API", () => {
       description: "Finds evidence",
       color: "cyan",
     });
+    await api("PATCH", `/api/bots/${hidden.id}`, { name: "Archived", hidden: true });
 
-    const roomsBeforeSelectionExport = (await api("GET", "/api/bots")).body.groups.length;
-    const selectedExport = await api("POST", "/api/teams/export", {
-      name: "Field Team",
-      memberIds: [first.id, second.id],
-    });
-    expect(selectedExport.status).toBe(200);
-    expect(selectedExport.body).toMatchObject({
-      format: "openmaus.team",
-      version: 1,
-      team: {
-        name: "Field Team",
-        members: [
-          { key: "mira", name: "Mira", title: "Project Lead", appearance: { color: "purple" } },
-          { key: "scout", name: "Scout", title: "Researcher", appearance: { color: "cyan" } },
-        ],
-        room: {
-          name: "Field Team",
-          bulletin: "",
-          defaultResponder: { kind: "everyone" },
-        },
-      },
-    });
-    expect(JSON.stringify(selectedExport.body)).not.toMatch(/autoApprove|alwaysAllow|modelSelection|threadId/);
-    expect((await api("GET", "/api/bots")).body.groups).toHaveLength(roomsBeforeSelectionExport);
-    expect((await api("POST", "/api/teams/export", { name: "", memberIds: [first.id] })).status).toBe(400);
-    expect((await api("POST", "/api/teams/export", { name: "Empty", memberIds: [] })).status).toBe(400);
-    expect((await api("POST", "/api/teams/export", { name: "Missing", memberIds: ["no-such-bot"] })).status).toBe(400);
-
-    const importManifest = structuredClone(selectedExport.body);
-    importManifest.team.room = {
-      name: "Launch Crew",
-      bulletin: "Prepare the launch together",
-      defaultResponder: { kind: "member", member: "scout" },
-    };
+    const stateBefore = (await api("GET", "/api/bots")).body;
+    const roomsBefore = stateBefore.groups.length;
+    const visibleNames = stateBefore.bots
+      .filter((bot: { hidden?: boolean }) => !bot.hidden)
+      .map((bot: { name: string }) => bot.name);
+    const exported = await api("POST", "/api/teams/export", { name: "Field Team" });
+    expect(exported.status).toBe(200);
+    expect(exported.body).toMatchObject({ format: "openmaus.team", version: 2, team: { name: "Field Team" } });
+    expect(exported.body.team.members.map((member: { name: string }) => member.name)).toEqual(visibleNames);
+    expect(exported.body.team.members).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: "mira", name: "Mira", title: "Project Lead", appearance: { color: "purple", mascotExpression: "focused" } }),
+      expect.objectContaining({ key: "scout", name: "Scout", title: "Researcher", appearance: { color: "cyan" } }),
+    ]));
+    expect(exported.body.team).not.toHaveProperty("room");
+    expect(JSON.stringify(exported.body)).not.toMatch(/Archived|autoApprove|alwaysAllow|modelSelection|threadId/);
+    expect((await api("GET", "/api/bots")).body.groups).toHaveLength(roomsBefore);
+    expect((await api("POST", "/api/teams/export", {})).body.team.name).toBe("My OpenMaus Team");
 
     const stream = await openSse(`${BASE}/api/events`);
     try {
       await stream.until((frame) => frame.kind === "hello");
-      const imported = await api("POST", "/api/teams/import", importManifest);
+      const imported = await api("POST", "/api/teams/import", exported.body);
       expect(imported.status).toBe(201);
-      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(["Mira", "Scout"]);
+      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(visibleNames);
       expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
       expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
-      expect(imported.body.group.memberIds).toEqual(imported.body.bots.map((bot: { id: string }) => bot.id));
-      expect(imported.body.group.defaultResponder).toEqual({ kind: "member", botId: imported.body.bots[1].id });
+      expect(imported.body).not.toHaveProperty("group");
 
-      await stream.until((frame) => frame.kind === "group" && frame.group?.id === imported.body.group.id);
+      const lastImported = imported.body.bots.at(-1)!;
+      await stream.until((frame) => frame.kind === "bot" && frame.bot?.id === lastImported.id);
       const importedBotIds = new Set(imported.body.bots.map((bot: { id: string }) => bot.id));
       const importFrames = stream.frames.filter(
-        (frame) =>
-          (frame.kind === "bot" && importedBotIds.has(frame.bot?.id)) ||
-          (frame.kind === "group" && frame.group?.id === imported.body.group.id),
+        (frame) => frame.kind === "bot" && importedBotIds.has(frame.bot?.id),
       );
-      expect(importFrames.map((frame) => frame.kind)).toEqual(["bot", "bot", "group"]);
+      expect(importFrames).toHaveLength(imported.body.bots.length);
+      expect(importFrames.every((frame) => frame.kind === "bot")).toBe(true);
+      expect((await api("GET", "/api/bots")).body.groups).toHaveLength(roomsBefore);
 
-      const invalid = await api("POST", "/api/teams/import", { ...importManifest, version: 2 });
+      const invalid = await api("POST", "/api/teams/import", { ...exported.body, version: 3 });
       expect(invalid.status).toBe(400);
 
-      expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
-      for (const bot of [first, second, ...imported.body.bots]) {
+      for (const bot of [first, second, hidden, ...imported.body.bots]) {
         expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
       }
     } finally {

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,7 @@ import { readCuaConnection } from "./local-computer.ts";
 import { LocalVmIdleTimer } from "./local-vm-idle.ts";
 import { LocalVmLease } from "./local-vm-lease.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
+import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
 import { listenWebhookIngress, webhookCredential, type WebhookIngress } from "./webhook-ingress.ts";
 import { WebhookManager } from "./webhooks.ts";
@@ -1807,16 +1808,15 @@ const server = createServer(async (req, res) => {
     }
     if (method === "POST" && path === "/api/teams/export") {
       const body = await readBody(req);
-      const name = typeof body.name === "string" ? body.name.trim() : "";
-      const rawMemberIds = Array.isArray(body.memberIds) ? body.memberIds : [];
-      if (!name) return json(res, 400, { error: "team name is required" });
-      if (rawMemberIds.length === 0) return json(res, 400, { error: "a team needs at least one bot" });
-      if (
-        rawMemberIds.some((id: unknown) => typeof id !== "string" || !store.bot(id)) ||
-        new Set(rawMemberIds).size !== rawMemberIds.length
-      ) {
-        return json(res, 400, { error: "team members are invalid" });
-      }
+      const profileName = cfg.profile?.name?.trim();
+      const name =
+        typeof body.name === "string" && body.name.trim()
+          ? body.name.trim()
+          : profileName
+            ? `${profileName}'s Team`
+            : "My OpenMaus Team";
+      const memberIds = store.bots.filter((bot) => !bot.hidden).map((bot) => bot.id);
+      if (memberIds.length === 0) return json(res, 400, { error: "Create a bot before exporting your team" });
       try {
         return json(
           res,
@@ -1824,15 +1824,41 @@ const server = createServer(async (req, res) => {
           createTeamManifest(
             {
               name,
-              memberIds: rawMemberIds as string[],
-              bulletin: "",
-              defaultResponder: { kind: "everyone" },
+              memberIds,
             },
             store.bots,
           ),
         );
       } catch (error) {
         return json(res, 400, { error: error instanceof Error ? error.message : "Team could not be exported" });
+      }
+    }
+    if (method === "GET" && path === "/api/team-library/catalog") {
+      try {
+        return json(res, 200, await fetchTeamCatalog());
+      } catch (error) {
+        return json(res, 502, { error: error instanceof Error ? error.message : "The team library is unavailable" });
+      }
+    }
+    m = path.match(/^\/api\/team-library\/teams\/([a-z0-9][a-z0-9-]*)$/);
+    if (m && method === "GET") {
+      try {
+        return json(res, 200, await fetchLibraryTeam(m[1]));
+      } catch (error) {
+        const status = (error as { status?: number }).status === 404 ? 404 : 502;
+        return json(res, status, { error: error instanceof Error ? error.message : "The team could not be loaded" });
+      }
+    }
+    if (method === "POST" && path === "/api/team-library/github") {
+      const body = await readBody(req);
+      if (typeof body.url !== "string" || !body.url.trim()) {
+        return json(res, 400, { error: "A GitHub URL is required" });
+      }
+      try {
+        return json(res, 200, await fetchGithubTeam(body.url));
+      } catch (error) {
+        const status = (error as { status?: number }).status === 404 ? 404 : 400;
+        return json(res, status, { error: error instanceof Error ? error.message : "The GitHub team could not be loaded" });
       }
     }
     if (method === "POST" && path === "/api/teams/import") {
@@ -1845,7 +1871,6 @@ const server = createServer(async (req, res) => {
       }
 
       const importedBots: ReturnType<typeof store.createBot>[] = [];
-      let importedGroupId: string | null = null;
       try {
         const selection = await defaultSelection();
         for (const member of manifest.team.members) {
@@ -1860,36 +1885,10 @@ const server = createServer(async (req, res) => {
             }),
           );
         }
-        const idByKey = new Map(
-          manifest.team.members.map((member, index) => [member.key, importedBots[index]!.id]),
-        );
-        const group = store.createGroup(
-          manifest.team.room.name,
-          importedBots.map((bot) => bot.id),
-        );
-        importedGroupId = group.id;
-        const responder = manifest.team.room.defaultResponder;
-        const defaultResponder: GroupDefaultResponder =
-          responder.kind === "member"
-            ? { kind: "member", botId: idByKey.get(responder.member)! }
-            : { kind: responder.kind };
-        const configuredGroup = store.patchGroup(group.id, {
-          bulletin: manifest.team.room.bulletin,
-          defaultResponder,
-        });
-        if (!configuredGroup) throw new Error("The imported room could not be configured");
-
         const publicBots = importedBots.map(publicBot);
-        // Other open windows need the new members before the room that
-        // references them. The importing window also folds the HTTP result.
         for (const bot of publicBots) broadcast({ kind: "bot", bot });
-        broadcast({ kind: "group", group: configuredGroup });
-        return json(res, 201, {
-          bots: publicBots,
-          group: { ...configuredGroup, messages: [] },
-        });
+        return json(res, 201, { bots: publicBots });
       } catch (error) {
-        if (importedGroupId) store.deleteGroup(importedGroupId);
         for (const bot of importedBots) store.deleteBot(bot.id);
         throw error;
       }

--- a/server/team-library.test.ts
+++ b/server/team-library.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  TEAM_LIBRARY_CATALOG_URL,
+  TEAM_LIBRARY_RAW_ROOT,
+  fetchGithubTeam,
+  fetchLibraryTeam,
+  githubManifestUrls,
+  parseTeamCatalog,
+} from "./team-library.ts";
+
+const manifest = {
+  format: "openmaus.team",
+  version: 2,
+  team: {
+    name: "Engineering",
+    members: [
+      {
+        key: "lead",
+        name: "Ada",
+        title: "Tech Lead",
+        description: "Coordinates the work",
+        appearance: { color: "purple" },
+      },
+    ],
+  },
+};
+
+const catalog = {
+  format: "openmaus.catalog",
+  version: 1,
+  teams: [
+    {
+      slug: "engineering",
+      name: "Engineering Team",
+      summary: "Plan and ship software.",
+      category: "Engineering",
+      manifest: "teams/engineering/team.mausteam.json",
+      readme: "teams/engineering/README.md",
+      members: 1,
+      skills: ["teams/engineering/skills/release/SKILL.md"],
+      requires: { apps: ["GitHub"] },
+    },
+  ],
+};
+
+function response(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("team library", () => {
+  it("validates catalog paths and adds the trusted repository URL", () => {
+    const parsed = parseTeamCatalog(catalog);
+    expect(parsed.repositoryUrl).toBe("https://github.com/milind-soni/openmausbot-teams");
+    expect(parsed.teams[0]).toMatchObject({ slug: "engineering", members: 1 });
+
+    const unsafe = structuredClone(catalog);
+    unsafe.teams[0]!.manifest = "../private.json";
+    expect(() => parseTeamCatalog(unsafe)).toThrow("safe catalog path");
+  });
+
+  it("loads only the manifest selected by the trusted catalog", async () => {
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      if (target === TEAM_LIBRARY_CATALOG_URL) return response(catalog);
+      if (target === `${TEAM_LIBRARY_RAW_ROOT}/teams/engineering/team.mausteam.json`) return response(manifest);
+      return response({}, 404);
+    }) as unknown as typeof fetch;
+
+    const loaded = await fetchLibraryTeam("engineering", fetcher);
+    expect(loaded.team.name).toBe("Engineering");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes public GitHub repository, blob, and raw links", () => {
+    expect(githubManifestUrls("https://github.com/acme/team")).toEqual([
+      "https://raw.githubusercontent.com/acme/team/main/team.mausteam.json",
+      "https://raw.githubusercontent.com/acme/team/master/team.mausteam.json",
+    ]);
+    expect(githubManifestUrls("https://github.com/acme/team/blob/main/presets/seo.mausteam.json")).toEqual([
+      "https://raw.githubusercontent.com/acme/team/main/presets/seo.mausteam.json",
+    ]);
+    expect(githubManifestUrls("https://raw.githubusercontent.com/acme/team/main/team.mausteam.json")).toEqual([
+      "https://raw.githubusercontent.com/acme/team/main/team.mausteam.json",
+    ]);
+    expect(() => githubManifestUrls("http://example.com/team.json")).toThrow("public HTTPS GitHub");
+    expect(() => githubManifestUrls("https://github.com/acme/team/blob/main/run.sh")).toThrow("JSON team file");
+  });
+
+  it("falls back from main to master for a repository link", async () => {
+    const fetcher = vi.fn(async (url: string | URL | Request) =>
+      String(url).includes("/main/") ? response({}, 404) : response(manifest),
+    ) as unknown as typeof fetch;
+
+    const loaded = await fetchGithubTeam("https://github.com/acme/team", fetcher);
+    expect(loaded.team.members[0]?.name).toBe("Ada");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/team-library.ts
+++ b/server/team-library.ts
@@ -1,0 +1,193 @@
+import { parseTeamManifest, type ParsedTeamManifest } from "./team-manifest.ts";
+
+export const TEAM_LIBRARY_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
+export const TEAM_LIBRARY_RAW_ROOT = "https://raw.githubusercontent.com/milind-soni/openmausbot-teams/main";
+export const TEAM_LIBRARY_CATALOG_URL = `${TEAM_LIBRARY_RAW_ROOT}/catalog.json`;
+
+const MAX_CATALOG_BYTES = 256_000;
+const MAX_MANIFEST_BYTES = 1_000_000;
+
+export interface TeamCatalogEntry {
+  slug: string;
+  name: string;
+  summary: string;
+  category: string;
+  manifest: string;
+  readme: string;
+  members: number;
+  skills: string[];
+  requires: { apps: string[] };
+}
+
+export interface TeamCatalog {
+  format: "openmaus.catalog";
+  version: 1;
+  repositoryUrl: typeof TEAM_LIBRARY_REPOSITORY;
+  teams: TeamCatalogEntry[];
+}
+
+type Fetcher = typeof fetch;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+function text(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} is required`);
+  const normalized = value.trim();
+  if (normalized.length > max) throw new Error(`${field} is too long`);
+  return normalized;
+}
+
+function relativeFile(value: unknown, field: string, suffix: string, prefix: string): string {
+  const path = text(value, field, 300);
+  if (
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    path.split("/").some((part) => !part || part === "." || part === "..") ||
+    !path.startsWith(prefix) ||
+    !path.endsWith(suffix)
+  ) {
+    throw new Error(`${field} is not a safe catalog path`);
+  }
+  return path;
+}
+
+function stringList(value: unknown, field: string, maxItems: number): string[] {
+  if (!Array.isArray(value) || value.length > maxItems) throw new Error(`${field} is invalid`);
+  return value.map((item, index) => text(item, `${field}[${index}]`, 100));
+}
+
+/** Validate the remotely maintained index before any of it reaches the renderer. */
+export function parseTeamCatalog(value: unknown): TeamCatalog {
+  if (!isRecord(value) || value.format !== "openmaus.catalog" || value.version !== 1) {
+    throw new Error("The team library catalog is not supported");
+  }
+  if (!Array.isArray(value.teams) || value.teams.length > 100) {
+    throw new Error("The team library catalog is invalid");
+  }
+  const slugs = new Set<string>();
+  const teams = value.teams.map((raw, index): TeamCatalogEntry => {
+    const field = `teams[${index}]`;
+    if (!isRecord(raw)) throw new Error(`${field} is invalid`);
+    const slug = text(raw.slug, `${field}.slug`, 80);
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(slug) || slugs.has(slug)) {
+      throw new Error(`${field}.slug is invalid`);
+    }
+    slugs.add(slug);
+    const prefix = `teams/${slug}/`;
+    const requires = isRecord(raw.requires) ? raw.requires : {};
+    return {
+      slug,
+      name: text(raw.name, `${field}.name`, 100),
+      summary: text(raw.summary, `${field}.summary`, 300),
+      category: text(raw.category, `${field}.category`, 80),
+      manifest: relativeFile(raw.manifest, `${field}.manifest`, ".mausteam.json", prefix),
+      readme: relativeFile(raw.readme, `${field}.readme`, "README.md", prefix),
+      members:
+        typeof raw.members === "number" && Number.isSafeInteger(raw.members) && raw.members > 0 && raw.members <= 200
+          ? raw.members
+          : (() => { throw new Error(`${field}.members is invalid`); })(),
+      skills: Array.isArray(raw.skills)
+        ? raw.skills.map((skill, skillIndex) =>
+            relativeFile(skill, `${field}.skills[${skillIndex}]`, "SKILL.md", `${prefix}skills/`),
+          )
+        : (() => { throw new Error(`${field}.skills is invalid`); })(),
+      requires: { apps: stringList(requires.apps ?? [], `${field}.requires.apps`, 30) },
+    };
+  });
+  return {
+    format: "openmaus.catalog",
+    version: 1,
+    repositoryUrl: TEAM_LIBRARY_REPOSITORY,
+    teams,
+  };
+}
+
+async function fetchJson(url: string, maxBytes: number, fetcher: Fetcher): Promise<unknown> {
+  const response = await fetcher(url, {
+    headers: { accept: "application/json, text/plain;q=0.9" },
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    const error = Object.assign(new Error(`GitHub returned HTTP ${response.status}`), { status: response.status });
+    throw error;
+  }
+  const announced = Number(response.headers.get("content-length") ?? 0);
+  if (announced > maxBytes) throw new Error("The remote team file is too large");
+  const raw = await response.text();
+  if (Buffer.byteLength(raw) > maxBytes) throw new Error("The remote team file is too large");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error("GitHub did not return valid JSON");
+  }
+}
+
+export async function fetchTeamCatalog(fetcher: Fetcher = fetch): Promise<TeamCatalog> {
+  return parseTeamCatalog(await fetchJson(TEAM_LIBRARY_CATALOG_URL, MAX_CATALOG_BYTES, fetcher));
+}
+
+export async function fetchLibraryTeam(slug: string, fetcher: Fetcher = fetch): Promise<ParsedTeamManifest> {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) throw new Error("That team name is invalid");
+  const catalog = await fetchTeamCatalog(fetcher);
+  const entry = catalog.teams.find((team) => team.slug === slug);
+  if (!entry) throw Object.assign(new Error("That library team was not found"), { status: 404 });
+  const value = await fetchJson(`${TEAM_LIBRARY_RAW_ROOT}/${entry.manifest}`, MAX_MANIFEST_BYTES, fetcher);
+  return parseTeamManifest(value);
+}
+
+function safeSegment(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(value) && value !== "." && value !== "..";
+}
+
+/** Resolve only public GitHub JSON files. Other hosts never reach server fetch. */
+export function githubManifestUrls(input: string): string[] {
+  let url: URL;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    throw new Error("Enter a valid GitHub URL");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.port) {
+    throw new Error("Only public HTTPS GitHub links are supported");
+  }
+  const parts = url.pathname.split("/").filter(Boolean).map((part) => decodeURIComponent(part));
+  if (!parts.every(safeSegment)) throw new Error("That GitHub path is not supported");
+
+  if (url.hostname === "github.com" || url.hostname === "www.github.com") {
+    if (parts.length === 2) {
+      const [owner, repo] = parts;
+      return [
+        `https://raw.githubusercontent.com/${owner}/${repo}/main/team.mausteam.json`,
+        `https://raw.githubusercontent.com/${owner}/${repo}/master/team.mausteam.json`,
+      ];
+    }
+    if (parts.length >= 5 && (parts[2] === "blob" || parts[2] === "raw")) {
+      const [owner, repo, , ref, ...file] = parts;
+      if (!file.at(-1)?.endsWith(".json")) throw new Error("The GitHub link must point to a JSON team file");
+      return [`https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${file.join("/")}`];
+    }
+  }
+
+  if (url.hostname === "raw.githubusercontent.com" && parts.length >= 4) {
+    if (!parts.at(-1)?.endsWith(".json")) throw new Error("The GitHub link must point to a JSON team file");
+    return [`https://raw.githubusercontent.com/${parts.join("/")}`];
+  }
+
+  throw new Error("Paste a GitHub repository or JSON file link");
+}
+
+export async function fetchGithubTeam(input: string, fetcher: Fetcher = fetch): Promise<ParsedTeamManifest> {
+  const urls = githubManifestUrls(input);
+  let lastError: unknown;
+  for (const url of urls) {
+    try {
+      return parseTeamManifest(await fetchJson(url, MAX_MANIFEST_BYTES, fetcher));
+    } catch (error) {
+      lastError = error;
+      if ((error as { status?: number }).status !== 404) throw error;
+    }
+  }
+  throw lastError ?? new Error("No team.mausteam.json file was found in that repository");
+}

--- a/server/team-manifest.test.ts
+++ b/server/team-manifest.test.ts
@@ -3,13 +3,11 @@ import { describe, expect, it } from "vitest";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
 
 describe("team manifests", () => {
-  it("exports portable member keys and room routing without runtime state", () => {
+  it("exports portable member keys without room or runtime state", () => {
     const manifest = createTeamManifest(
       {
         name: "Launch Crew",
         memberIds: ["bot-a", "bot-b"],
-        bulletin: "Ship together",
-        defaultResponder: { kind: "member", botId: "bot-b" },
       },
       [
         {
@@ -32,20 +30,17 @@ describe("team manifests", () => {
 
     expect(manifest).toMatchObject({
       format: "openmaus.team",
-      version: 1,
+      version: 2,
       team: {
         name: "Launch Crew",
         members: [{ key: "mira" }, { key: "mira-2" }],
-        room: {
-          bulletin: "Ship together",
-          defaultResponder: { kind: "member", member: "mira-2" },
-        },
       },
     });
+    expect(manifest.team).not.toHaveProperty("room");
     expect(JSON.stringify(manifest)).not.toMatch(/bot-a|bot-b|thread|model|permission|message/i);
   });
 
-  it("parses the supported portable fields and drops unrelated settings", () => {
+  it("parses legacy room files while dropping unrelated settings", () => {
     const manifest = parseTeamManifest({
       format: "openmaus.team",
       version: 1,
@@ -86,6 +81,28 @@ describe("team manifests", () => {
     });
   });
 
+  it("parses room-free version 2 files", () => {
+    const manifest = parseTeamManifest({
+      format: "openmaus.team",
+      version: 2,
+      team: {
+        name: "Engineering",
+        members: [
+          {
+            key: "lead",
+            name: "Ada",
+            title: "Tech Lead",
+            description: "Coordinates the work",
+            appearance: { color: "purple" },
+          },
+        ],
+      },
+    });
+
+    expect(manifest.team.name).toBe("Engineering");
+    expect(manifest.team).not.toHaveProperty("room");
+  });
+
   it("rejects unsupported versions and dangling member references", () => {
     expect(() => parseTeamManifest({ format: "openmaus.team", version: 99 })).toThrow("not supported");
     expect(() =>
@@ -117,8 +134,6 @@ describe("team manifests", () => {
         {
           name: "x".repeat(101),
           memberIds: ["one"],
-          bulletin: "",
-          defaultResponder: { kind: "member", botId: "one" },
         },
         [
           {
@@ -132,7 +147,7 @@ describe("team manifests", () => {
       ),
     ).toThrow("team.name is too long");
 
-    const bots = Array.from({ length: 51 }, (_, index) => ({
+    const bots = Array.from({ length: 201 }, (_, index) => ({
       id: `bot-${index}`,
       name: `Bot ${index}`,
       title: "",
@@ -144,11 +159,9 @@ describe("team manifests", () => {
         {
           name: "Too many",
           memberIds: bots.map((bot) => bot.id),
-          bulletin: "",
-          defaultResponder: { kind: "everyone" },
         },
         bots,
       ),
-    ).toThrow("at most 50 members");
+    ).toThrow("at most 200 members");
   });
 });

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -1,7 +1,9 @@
-import type { GroupDefaultResponder, MausColor } from "./store.ts";
+import type { MausColor } from "./store.ts";
 
 export const TEAM_MANIFEST_FORMAT = "openmaus.team" as const;
-export const TEAM_MANIFEST_VERSION = 1 as const;
+export const TEAM_MANIFEST_VERSION = 2 as const;
+export const LEGACY_TEAM_MANIFEST_VERSION = 1 as const;
+export const MAX_TEAM_MEMBERS = 200;
 
 const COLORS: readonly MausColor[] = [
   "green",
@@ -32,18 +34,31 @@ export type TeamManifestResponder =
   | { kind: "everyone" }
   | { kind: "mentions" };
 
-export interface TeamManifestV1 {
+export interface TeamManifestRoom {
+  name: string;
+  bulletin: string;
+  defaultResponder: TeamManifestResponder;
+}
+
+export interface ParsedTeamManifest {
+  format: typeof TEAM_MANIFEST_FORMAT;
+  version: typeof LEGACY_TEAM_MANIFEST_VERSION | typeof TEAM_MANIFEST_VERSION;
+  team: {
+    name: string;
+    description?: string;
+    members: TeamManifestMember[];
+    /** Present on legacy v1 files. New imports intentionally do not create it. */
+    room?: TeamManifestRoom;
+  };
+}
+
+export interface TeamManifestV2 {
   format: typeof TEAM_MANIFEST_FORMAT;
   version: typeof TEAM_MANIFEST_VERSION;
   team: {
     name: string;
     description?: string;
     members: TeamManifestMember[];
-    room: {
-      name: string;
-      bulletin: string;
-      defaultResponder: TeamManifestResponder;
-    };
   };
 }
 
@@ -59,8 +74,6 @@ interface ExportableBot {
 interface ExportableTeam {
   name: string;
   memberIds: string[];
-  bulletin: string;
-  defaultResponder: GroupDefaultResponder;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -82,10 +95,10 @@ function optionalString(value: unknown, field: string, max: number): string | un
 }
 
 /** Parse an untrusted shared file into the small, portable subset we support. */
-export function parseTeamManifest(value: unknown): TeamManifestV1 {
+export function parseTeamManifest(value: unknown): ParsedTeamManifest {
   if (!isRecord(value)) throw new Error("This is not a team file");
   if (value.format !== TEAM_MANIFEST_FORMAT) throw new Error("This is not an OpenMaus team file");
-  if (value.version !== TEAM_MANIFEST_VERSION) {
+  if (value.version !== LEGACY_TEAM_MANIFEST_VERSION && value.version !== TEAM_MANIFEST_VERSION) {
     throw new Error(`Team file version ${String(value.version)} is not supported`);
   }
   if (!isRecord(value.team)) throw new Error("team is required");
@@ -96,7 +109,9 @@ export function parseTeamManifest(value: unknown): TeamManifestV1 {
   if (!Array.isArray(team.members) || team.members.length === 0) {
     throw new Error("A team needs at least one member");
   }
-  if (team.members.length > 50) throw new Error("A team can have at most 50 members");
+  if (team.members.length > MAX_TEAM_MEMBERS) {
+    throw new Error(`A team can have at most ${MAX_TEAM_MEMBERS} members`);
+  }
 
   const seenKeys = new Set<string>();
   const members = team.members.map((raw, index): TeamManifestMember => {
@@ -132,36 +147,42 @@ export function parseTeamManifest(value: unknown): TeamManifestV1 {
     };
   });
 
-  if (!isRecord(team.room)) throw new Error("team.room is required");
-  const responder = team.room.defaultResponder;
-  if (!isRecord(responder) || typeof responder.kind !== "string") {
-    throw new Error("team.room.defaultResponder is required");
-  }
-  let defaultResponder: TeamManifestResponder;
-  if (responder.kind === "everyone" || responder.kind === "mentions") {
-    defaultResponder = { kind: responder.kind };
-  } else if (responder.kind === "member") {
-    const member = requiredString(responder.member, "team.room.defaultResponder.member", 64);
-    if (!seenKeys.has(member)) throw new Error(`Unknown default responder: ${member}`);
-    defaultResponder = { kind: "member", member };
-  } else {
-    throw new Error(`Unknown default responder kind: ${responder.kind}`);
-  }
-
-  return {
+  const parsed: ParsedTeamManifest = {
     format: TEAM_MANIFEST_FORMAT,
-    version: TEAM_MANIFEST_VERSION,
+    version: value.version,
     team: {
       name,
       ...(description ? { description } : {}),
       members,
-      room: {
-        name: requiredString(team.room.name, "team.room.name", 100),
-        bulletin: optionalString(team.room.bulletin, "team.room.bulletin", 12_000) ?? "",
-        defaultResponder,
-      },
     },
   };
+
+  // Version 1 bundled a room with every team. Validate it for compatibility,
+  // but importing a definition no longer creates that room implicitly.
+  if (value.version === LEGACY_TEAM_MANIFEST_VERSION) {
+    if (!isRecord(team.room)) throw new Error("team.room is required");
+    const responder = team.room.defaultResponder;
+    if (!isRecord(responder) || typeof responder.kind !== "string") {
+      throw new Error("team.room.defaultResponder is required");
+    }
+    let defaultResponder: TeamManifestResponder;
+    if (responder.kind === "everyone" || responder.kind === "mentions") {
+      defaultResponder = { kind: responder.kind };
+    } else if (responder.kind === "member") {
+      const member = requiredString(responder.member, "team.room.defaultResponder.member", 64);
+      if (!seenKeys.has(member)) throw new Error(`Unknown default responder: ${member}`);
+      defaultResponder = { kind: "member", member };
+    } else {
+      throw new Error(`Unknown default responder kind: ${responder.kind}`);
+    }
+    parsed.team.room = {
+      name: requiredString(team.room.name, "team.room.name", 100),
+      bulletin: optionalString(team.room.bulletin, "team.room.bulletin", 12_000) ?? "",
+      defaultResponder,
+    };
+  }
+
+  return parsed;
 }
 
 function memberKey(name: string, index: number, used: Set<string>): string {
@@ -181,15 +202,13 @@ function memberKey(name: string, index: number, used: Set<string>): string {
 }
 
 /** Build a shareable definition only: no IDs, transcripts, engines or permissions. */
-export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]): TeamManifestV1 {
+export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]): TeamManifestV2 {
   const byId = new Map(bots.map((bot) => [bot.id, bot]));
   const usedKeys = new Set<string>();
-  const keyById = new Map<string, string>();
   const members = team.memberIds.map((id, index) => {
     const bot = byId.get(id);
     if (!bot) throw new Error(`Team member ${id} no longer exists`);
     const key = memberKey(bot.name, index, usedKeys);
-    keyById.set(id, key);
     return {
       key,
       name: bot.name,
@@ -202,29 +221,15 @@ export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]):
     };
   });
 
-  let defaultResponder: TeamManifestResponder;
-  if (team.defaultResponder.kind === "member") {
-    const member = keyById.get(team.defaultResponder.botId) ?? members[0]?.key;
-    if (!member) throw new Error("A team needs at least one member");
-    defaultResponder = { kind: "member", member };
-  } else {
-    defaultResponder = { kind: team.defaultResponder.kind };
-  }
-
-  const manifest: TeamManifestV1 = {
+  const manifest: TeamManifestV2 = {
     format: TEAM_MANIFEST_FORMAT,
     version: TEAM_MANIFEST_VERSION,
     team: {
       name: team.name,
       members,
-      room: {
-        name: team.name,
-        bulletin: team.bulletin,
-        defaultResponder,
-      },
     },
   };
   // Keep export and import in lockstep: a file produced here must satisfy
   // the exact same limits and normalization as an untrusted shared file.
-  return parseTeamManifest(manifest);
+  return parseTeamManifest(manifest) as TeamManifestV2;
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -41,6 +41,7 @@ import { SpeakButton } from "./SpeakButton";
 import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
 import { webhookMessageView } from "@/lib/webhook-message";
+import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 
 /** Long user messages collapse behind a fade so pasted walls of text don't
  * bury the conversation; bots get full markdown. */
@@ -641,29 +642,41 @@ export function ChatView({ bot }: { bot: Bot }) {
   // false for a frame, and breaking there kills follow permanently
   // (upstream-verified failure). Scrolling back to the end re-arms it.
   const [follow, setFollow] = useState(true);
+  const followRef = useRef(true);
+  const previousScrollTop = useRef(0);
   const touchY = useRef(0);
 
-  useEffect(() => setFollow(true), [bot.id]);
+  const setBottomFollow = useCallback((next: boolean) => {
+    followRef.current = next;
+    setFollow(next);
+  }, []);
+
+  useEffect(() => setBottomFollow(true), [bot.id, setBottomFollow]);
   useEffect(() => {
-    if (follow) scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const el = scrollRef.current;
+    if (!el || !followRef.current) return;
+    el.scrollTo({ top: el.scrollHeight });
+    previousScrollTop.current = el.scrollTop;
   }, [bot.id, messages.length, streaming, reasoning, bot.busy, follow]);
 
   // keyboard is a scroll gesture too (upstream lesson): PageUp/Home break
   // follow like an upward wheel; the at-end onScroll check re-arms it
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "PageUp" || (e.key === "Home" && !(e.target instanceof HTMLTextAreaElement))) setFollow(false);
+      if (e.key === "PageUp" || (e.key === "Home" && !(e.target instanceof HTMLTextAreaElement))) {
+        setBottomFollow(false);
+      }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [setBottomFollow]);
 
   const atEnd = () => {
     const el = scrollRef.current;
-    return !el || el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    return !el || el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_FOLLOW_THRESHOLD;
   };
   const jumpToLatest = () => {
-    setFollow(true);
+    setBottomFollow(true);
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   };
 
@@ -749,17 +762,27 @@ export function ChatView({ bot }: { bot: Bot }) {
         ref={scrollRef}
         className="flex-1 overflow-y-auto px-5 [overflow-anchor:none]"
         onWheel={(e) => {
-          if (e.deltaY < 0) setFollow(false);
-          else if (atEnd()) setFollow(true);
+          if (e.deltaY < 0) setBottomFollow(false);
+          else if (atEnd()) setBottomFollow(true);
         }}
         onTouchStart={(e) => (touchY.current = e.touches[0]?.clientY ?? 0)}
         onTouchMove={(e) => {
           const y = e.touches[0]?.clientY ?? 0;
-          if (y > touchY.current + 4) setFollow(false);
-          else if (atEnd()) setFollow(true);
+          if (y > touchY.current + 4) setBottomFollow(false);
+          else if (atEnd()) setBottomFollow(true);
         }}
         onScroll={() => {
-          if (!follow && atEnd()) setFollow(true);
+          const el = scrollRef.current;
+          if (!el) return;
+          const scrollTop = el.scrollTop;
+          const resume = shouldResumeBottomFollow({
+            following: followRef.current,
+            previousScrollTop: previousScrollTop.current,
+            scrollTop,
+            distanceFromBottom: el.scrollHeight - scrollTop - el.clientHeight,
+          });
+          previousScrollTop.current = scrollTop;
+          if (resume) setBottomFollow(true);
         }}
       >
         <div

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -2,7 +2,7 @@
 // carry the personality; avatars inside the room stay still so a busy group
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
-import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, ChevronDown, Pin } from "lucide-react";
 import {
   useStore,
@@ -21,6 +21,7 @@ import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
+import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -193,6 +194,8 @@ export function GroupView({ group }: { group: Group }) {
   const streaming = stream.streaming[group.threadId];
   const scrollRef = useRef<HTMLDivElement>(null);
   const [follow, setFollow] = useState(true);
+  const followRef = useRef(true);
+  const previousScrollTop = useRef(0);
   const touchY = useRef(0);
   const [bulletinOpen, setBulletinOpen] = useState(false);
   const [bulletinDraft, setBulletinDraft] = useState(group.bulletin);
@@ -203,15 +206,23 @@ export function GroupView({ group }: { group: Group }) {
   );
   const speaker = members.find((b) => b.id === group.busyBotId);
 
-  useEffect(() => setFollow(true), [group.id]);
+  const setBottomFollow = useCallback((next: boolean) => {
+    followRef.current = next;
+    setFollow(next);
+  }, []);
+
+  useEffect(() => setBottomFollow(true), [group.id, setBottomFollow]);
   useEffect(() => setBulletinDraft(group.bulletin), [group.id, group.bulletin]);
   useEffect(() => {
-    if (follow) scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const el = scrollRef.current;
+    if (!el || !followRef.current) return;
+    el.scrollTo({ top: el.scrollHeight });
+    previousScrollTop.current = el.scrollTop;
   }, [group.id, group.messages.length, streaming, group.busyBotId, follow]);
 
   const atEnd = () => {
     const el = scrollRef.current;
-    return !el || el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    return !el || el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_FOLLOW_THRESHOLD;
   };
 
   const saveBulletin = () => {
@@ -305,17 +316,27 @@ export function GroupView({ group }: { group: Group }) {
         ref={scrollRef}
         className="flex-1 overflow-y-auto px-5 [overflow-anchor:none]"
         onWheel={(e) => {
-          if (e.deltaY < 0) setFollow(false);
-          else if (atEnd()) setFollow(true);
+          if (e.deltaY < 0) setBottomFollow(false);
+          else if (atEnd()) setBottomFollow(true);
         }}
         onTouchStart={(e) => (touchY.current = e.touches[0]?.clientY ?? 0)}
         onTouchMove={(e) => {
           const y = e.touches[0]?.clientY ?? 0;
-          if (y > touchY.current + 4) setFollow(false);
-          else if (atEnd()) setFollow(true);
+          if (y > touchY.current + 4) setBottomFollow(false);
+          else if (atEnd()) setBottomFollow(true);
         }}
         onScroll={() => {
-          if (!follow && atEnd()) setFollow(true);
+          const el = scrollRef.current;
+          if (!el) return;
+          const scrollTop = el.scrollTop;
+          const resume = shouldResumeBottomFollow({
+            following: followRef.current,
+            previousScrollTop: previousScrollTop.current,
+            scrollTop,
+            distanceFromBottom: el.scrollHeight - scrollTop - el.clientHeight,
+          });
+          previousScrollTop.current = scrollTop;
+          if (resume) setBottomFollow(true);
         }}
       >
         <div
@@ -370,7 +391,7 @@ export function GroupView({ group }: { group: Group }) {
       {!follow && (
         <button
           onClick={() => {
-            setFollow(true);
+            setBottomFollow(true);
             scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
           }}
           aria-label="Jump to latest messages"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,8 +11,8 @@ import {
   Copy,
   Crown,
   EyeOff,
-  FileUp,
   FolderPlus,
+  Library,
   Loader2,
   Pencil,
   Pin,
@@ -25,13 +25,14 @@ import {
   Trash2,
   Users,
 } from "lucide-react";
-import { api, useStore, formatTime, visibleMessages, type Bot, type Group } from "@/state/store";
+import { useStore, formatTime, visibleMessages, type Bot, type Group } from "@/state/store";
 import { MausAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
-import { downloadSelectedTeam } from "@/lib/team-files";
+import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { TeamLibraryPanel } from "./TeamLibraryPanel";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
 function profileInitials(profile?: { name?: string; email?: string }): string {
@@ -268,363 +269,6 @@ function RoomContextMenu({
         <Trash2 size={16} />
         Delete Room
       </button>
-    </div>,
-    document.body,
-  );
-}
-
-interface PendingTeamImport {
-  manifest: unknown;
-  name: string;
-  roomName: string;
-  members: Array<{ name: string; title: string }>;
-}
-
-function importPreview(manifest: unknown): PendingTeamImport {
-  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
-    throw new Error("This file does not contain a team.");
-  }
-  const root = manifest as Record<string, unknown>;
-  if (root.format !== "openmaus.team") throw new Error("This is not an OpenMaus team file.");
-  if (root.version !== 1) throw new Error(`Team file version ${String(root.version)} is not supported.`);
-  if (!root.team || typeof root.team !== "object" || Array.isArray(root.team)) {
-    throw new Error("This team file is missing its team definition.");
-  }
-  const team = root.team as Record<string, unknown>;
-  if (typeof team.name !== "string" || !team.name.trim()) throw new Error("This team does not have a name.");
-  if (!Array.isArray(team.members) || team.members.length === 0) throw new Error("This team has no members.");
-  const members = team.members.map((member, index) => {
-    if (!member || typeof member !== "object" || Array.isArray(member)) {
-      throw new Error(`Team member ${index + 1} is invalid.`);
-    }
-    const value = member as Record<string, unknown>;
-    if (typeof value.name !== "string" || !value.name.trim()) {
-      throw new Error(`Team member ${index + 1} does not have a name.`);
-    }
-    return {
-      name: value.name.trim(),
-      title: typeof value.title === "string" ? value.title.trim() : "",
-    };
-  });
-  const room = team.room;
-  const roomName =
-    room && typeof room === "object" && !Array.isArray(room) && typeof (room as Record<string, unknown>).name === "string"
-      ? String((room as Record<string, unknown>).name).trim()
-      : team.name.trim();
-  return { manifest, name: team.name.trim(), roomName, members };
-}
-
-function ImportTeamPanel({
-  pending,
-  onClose,
-  onImported,
-  returnFocusRef,
-}: {
-  pending: PendingTeamImport;
-  onClose: () => void;
-  onImported: (name: string) => void;
-  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
-}) {
-  const { dispatch } = useStore();
-  const [working, setWorking] = useState(false);
-  const [error, setError] = useState("");
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const confirmRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    confirmRef.current?.focus();
-    return () => returnFocusRef.current?.focus();
-  }, [returnFocusRef]);
-
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !working) {
-        event.preventDefault();
-        event.stopPropagation();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      );
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable.at(-1)!;
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose, working]);
-
-  const importTeam = async () => {
-    setWorking(true);
-    setError("");
-    try {
-      const response = (await api("/api/teams/import", {
-        method: "POST",
-        body: JSON.stringify(pending.manifest),
-      })) as { bots: Bot[]; group: Group };
-      for (const bot of response.bots) dispatch({ type: "botAdded", bot });
-      dispatch({ type: "groupPatched", group: response.group });
-      dispatch({ type: "select", id: response.group.id });
-      track("team_imported", { members: response.bots.length });
-      onImported(pending.name);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setWorking(false);
-    }
-  };
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45"
-      onMouseDown={(event) => event.target === event.currentTarget && !working && onClose()}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="import-team-title"
-        tabIndex={-1}
-        className="w-[420px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl"
-      >
-        <div id="import-team-title" className="text-[17px] font-semibold text-ink">Import {pending.name}?</div>
-        <div className="mt-1 text-[13px] text-ink-secondary">
-          This creates {pending.members.length} new {pending.members.length === 1 ? "bot" : "bots"} and the room “{pending.roomName}”.
-        </div>
-        <div className="mt-4 max-h-64 space-y-1 overflow-y-auto rounded-xl bg-raised/50 p-2">
-          {pending.members.map((member, index) => (
-            <div key={`${member.name}-${index}`} className="flex items-baseline gap-2 rounded-lg px-2.5 py-2">
-              <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{member.name}</span>
-              <span className="max-w-[190px] truncate text-[12.5px] text-ink-secondary">
-                {member.title || "General assistant"}
-              </span>
-            </div>
-          ))}
-        </div>
-        <div className="mt-3 text-[12.5px] leading-relaxed text-ink-secondary">
-          The bots will use your default engine. Conversations, permissions, and computer access are never imported.
-        </div>
-        {error && <div role="alert" className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
-        <div className="mt-5 flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            disabled={working}
-            className="rounded-lg px-3.5 py-2 text-[13.5px] text-ink-secondary hover:bg-raised disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            ref={confirmRef}
-            onClick={() => void importTeam()}
-            disabled={working}
-            className="flex items-center gap-2 rounded-lg bg-accent px-3.5 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
-          >
-            {working ? <Loader2 size={15} className="animate-spin" /> : <FileUp size={15} />}
-            {working ? "Importing…" : "Import Team"}
-          </button>
-        </div>
-      </div>
-    </div>,
-    document.body,
-  );
-}
-
-function ExportTeamPanel({
-  onClose,
-  onExported,
-  returnFocusRef,
-}: {
-  onClose: () => void;
-  onExported: (name: string) => void;
-  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
-}) {
-  const { state } = useStore();
-  const [name, setName] = useState("");
-  const [picked, setPicked] = useState<Set<string>>(new Set());
-  const [working, setWorking] = useState(false);
-  const [error, setError] = useState("");
-  const bots = state.bots.filter((bot) => !bot.hidden);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const nameRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    nameRef.current?.focus();
-    return () => returnFocusRef.current?.focus();
-  }, [returnFocusRef]);
-
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !working) {
-        event.preventDefault();
-        event.stopPropagation();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      );
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable.at(-1)!;
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose, working]);
-
-  const toggle = (id: string) => {
-    setPicked((previous) => {
-      const next = new Set(previous);
-      if (next.has(id)) next.delete(id);
-      else if (next.size < 50) next.add(id);
-      return next;
-    });
-  };
-
-  const exportTeam = async () => {
-    const teamName = name.trim();
-    if (!teamName || picked.size === 0) return;
-    setWorking(true);
-    setError("");
-    try {
-      const exported = await downloadSelectedTeam(teamName, [...picked]);
-      track("team_exported", { members: exported.members });
-      onExported(exported.name);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setWorking(false);
-    }
-  };
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45"
-      onMouseDown={(event) => event.target === event.currentTarget && !working && onClose()}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="export-team-title"
-        tabIndex={-1}
-        className="w-[380px] max-w-[calc(100vw-32px)] rounded-2xl border border-hairline/50 bg-card p-5 shadow-2xl"
-      >
-        <div id="export-team-title" className="text-[17px] font-semibold text-ink">Export Team</div>
-        <div className="mt-1 text-[13px] text-ink-secondary">
-          Choose any bots to share. You do not need to create a room first.
-        </div>
-        <input
-          ref={nameRef}
-          value={name}
-          maxLength={100}
-          disabled={working}
-          onChange={(event) => setName(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") void exportTeam();
-          }}
-          placeholder="Team name"
-          aria-label="Team name"
-          className="mt-4 w-full rounded-lg bg-raised/70 px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none disabled:opacity-60"
-        />
-        <div className="mt-3 flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-xl bg-raised/30 p-1.5">
-          {bots.length === 0 && (
-            <div className="px-2 py-5 text-center text-[13px] text-ink-secondary">
-              Create a bot first, then it can be shared as part of a team.
-            </div>
-          )}
-          {bots.map((bot) => {
-            const selected = picked.has(bot.id);
-            const capped = !selected && picked.size >= 50;
-            return (
-              <button
-                key={bot.id}
-                type="button"
-                aria-pressed={selected}
-                disabled={working || capped}
-                onClick={() => toggle(bot.id)}
-                className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left hover:bg-raised/70 disabled:opacity-40"
-              >
-                <MausAvatar color={bot.color} state="happy" size={28} />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[14px] text-ink">{bot.name}</span>
-                  {bot.title && <span className="block truncate text-[11.5px] text-ink-secondary">{bot.title}</span>}
-                </span>
-                <span
-                  className={cn(
-                    "flex size-[18px] shrink-0 items-center justify-center rounded-full border",
-                    selected ? "border-accent bg-accent text-white" : "border-hairline/60",
-                  )}
-                >
-                  {selected && <Check size={12} />}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        <div className="mt-3 text-[12.5px] leading-relaxed text-ink-secondary">
-          Messages, permissions, credentials, engines, and computer access are never included.
-        </div>
-        {error && (
-          <div role="alert" className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">
-            {error}
-          </div>
-        )}
-        <div className="mt-5 flex items-center justify-between gap-3">
-          <span className="text-[12.5px] text-ink-secondary">
-            {picked.size} {picked.size === 1 ? "bot" : "bots"} selected
-          </span>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={working}
-              className="rounded-lg px-3.5 py-2 text-[13.5px] text-ink-secondary hover:bg-raised disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => void exportTeam()}
-              disabled={working || !name.trim() || picked.size === 0}
-              className="flex items-center gap-2 rounded-lg bg-accent px-3.5 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-40"
-            >
-              {working ? <Loader2 size={15} className="animate-spin" /> : <ArrowDownToLine size={15} />}
-              {working ? "Exporting…" : "Export"}
-            </button>
-          </div>
-        </div>
-      </div>
     </div>,
     document.body,
   );
@@ -878,14 +522,13 @@ function BotListItem({ bot, onMenu }: { bot: Bot; onMenu: (menu: MenuState) => v
 export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
-  const importInputRef = useRef<HTMLInputElement>(null);
   const importReturnRef = useRef<HTMLButtonElement>(null);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [roomMenu, setRoomMenu] = useState<{ groupId: string; x: number; y: number } | null>(null);
   const [plusOpen, setPlusOpen] = useState(false);
   const [newRoom, setNewRoom] = useState(false);
-  const [exportTeamOpen, setExportTeamOpen] = useState(false);
-  const [pendingImport, setPendingImport] = useState<PendingTeamImport | null>(null);
+  const [teamLibraryOpen, setTeamLibraryOpen] = useState(false);
+  const [exportingTeam, setExportingTeam] = useState(false);
   const [teamFeedback, setTeamFeedback] = useState<{ error: boolean; text: string } | null>(null);
   const [query, setQuery] = useState("");
 
@@ -908,23 +551,20 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     return () => window.clearTimeout(timer);
   }, [teamFeedback]);
 
-  const chooseTeamFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.currentTarget.files?.[0];
-    event.currentTarget.value = "";
-    if (!file) return;
-    if (file.size > 1_000_000) {
-      setTeamFeedback({ error: true, text: "That team file is too large." });
-      return;
-    }
+  const exportAllBots = async () => {
+    setExportingTeam(true);
+    setTeamFeedback(null);
     try {
-      const manifest: unknown = JSON.parse(await file.text());
-      setPendingImport(importPreview(manifest));
-      setTeamFeedback(null);
+      const exported = await downloadAllBots();
+      track("team_exported", { members: exported.members, scope: "all_visible" });
+      setTeamFeedback({ error: false, text: `${exported.members} bots exported` });
     } catch (cause) {
       setTeamFeedback({
         error: true,
-        text: cause instanceof SyntaxError ? "That team file is not valid JSON." : cause instanceof Error ? cause.message : String(cause),
+        text: cause instanceof Error ? cause.message : String(cause),
       });
+    } finally {
+      setExportingTeam(false);
     }
   };
 
@@ -1017,37 +657,29 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                 <button
                   onClick={() => {
                     setPlusOpen(false);
-                    setExportTeamOpen(true);
+                    void exportAllBots();
                   }}
+                  disabled={exportingTeam}
                   className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
                 >
-                  <ArrowDownToLine size={16} className="text-ink-secondary" />
-                  Export Team
+                  {exportingTeam ? <Loader2 size={16} className="animate-spin text-ink-secondary" /> : <ArrowDownToLine size={16} className="text-ink-secondary" />}
+                  {exportingTeam ? "Exporting…" : "Export all bots"}
                 </button>
                 <button
                   onClick={() => {
                     setPlusOpen(false);
-                    importInputRef.current?.click();
+                    setTeamLibraryOpen(true);
                   }}
                   className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
                 >
-                  <FileUp size={16} className="text-ink-secondary" />
-                  Import Team
+                  <Library size={16} className="text-ink-secondary" />
+                  Add Team
                 </button>
               </div>
             </>
           )}
         </div>
       </div>
-
-      <input
-        ref={importInputRef}
-        type="file"
-        accept=".json,.mausteam.json,application/json"
-        onChange={(event) => void chooseTeamFile(event)}
-        className="hidden"
-        aria-label="Choose an OpenMaus team file"
-      />
 
       {/* Search */}
       <div className="px-3 pt-2 pb-3">
@@ -1135,24 +767,13 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         />
       )}
       {newRoom && <NewRoomPanel onClose={() => setNewRoom(false)} />}
-      {exportTeamOpen && (
-        <ExportTeamPanel
+      {teamLibraryOpen && (
+        <TeamLibraryPanel
           returnFocusRef={importReturnRef}
-          onClose={() => setExportTeamOpen(false)}
-          onExported={(name) => {
-            setExportTeamOpen(false);
-            setTeamFeedback({ error: false, text: `${name} exported` });
-          }}
-        />
-      )}
-      {pendingImport && (
-        <ImportTeamPanel
-          pending={pendingImport}
-          returnFocusRef={importReturnRef}
-          onClose={() => setPendingImport(null)}
-          onImported={(name) => {
-            setPendingImport(null);
-            setTeamFeedback({ error: false, text: `${name} imported` });
+          onClose={() => setTeamLibraryOpen(false)}
+          onImported={(name, members) => {
+            setTeamLibraryOpen(false);
+            setTeamFeedback({ error: false, text: `${name} imported · ${members} ${members === 1 ? "bot" : "bots"}` });
           }}
         />
       )}

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -1,0 +1,465 @@
+import { track } from "@/lib/analytics";
+import { teamImportPreview, type PendingTeamImport } from "@/lib/team-import";
+import { api, useStore, type Bot } from "@/state/store";
+import {
+  ArrowLeft,
+  ExternalLink,
+  FileJson,
+  Github,
+  Library,
+  Link as LinkIcon,
+  Loader2,
+  UploadCloud,
+  Users,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const MAX_TEAM_FILE_BYTES = 1_000_000;
+const COMMUNITY_TEAMS_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
+
+interface TeamCatalogEntry {
+  slug: string;
+  name: string;
+  summary: string;
+  category: string;
+  manifest: string;
+  readme: string;
+  members: number;
+  skills: string[];
+  requires: { apps: string[] };
+}
+
+interface TeamCatalog {
+  repositoryUrl: string;
+  teams: TeamCatalogEntry[];
+}
+
+type ImportSource = "library" | "file" | "github";
+type ImportTab = "explore" | "file" | "github";
+
+async function openExternal(url: string): Promise<void> {
+  if (window.ogb?.openExternal) {
+    await window.ogb.openExternal(url);
+    return;
+  }
+  const opened = window.open(url, "_blank", "noopener,noreferrer");
+  if (opened) opened.opener = null;
+}
+
+function teamSourceUrl(repositoryUrl: string, entry: TeamCatalogEntry): string {
+  const folder = entry.readme.replace(/\/README\.md$/, "");
+  return `${repositoryUrl}/tree/main/${folder}`;
+}
+
+export function TeamLibraryPanel({
+  onClose,
+  onImported,
+  returnFocusRef,
+}: {
+  onClose: () => void;
+  onImported: (name: string, members: number) => void;
+  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
+}) {
+  const { dispatch } = useStore();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [tab, setTab] = useState<ImportTab>("explore");
+  const [catalog, setCatalog] = useState<TeamCatalog | null>(null);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState("");
+  const [busySlug, setBusySlug] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingTeamImport | null>(null);
+  const [source, setSource] = useState<ImportSource>("file");
+  const [githubUrl, setGithubUrl] = useState("");
+  const [githubLoading, setGithubLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadCatalog = useCallback(async () => {
+    setCatalogLoading(true);
+    setCatalogError("");
+    try {
+      const result = (await api("/api/team-library/catalog")) as TeamCatalog;
+      setCatalog(result);
+    } catch (cause) {
+      setCatalogError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setCatalogLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadCatalog();
+  }, [loadCatalog]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+    return () => returnFocusRef.current?.focus();
+  }, [returnFocusRef]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !importing) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (pending) setPending(null);
+        else onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      const items = Array.from(
+        dialog?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (!dialog || items.length === 0) return;
+      const first = items[0]!;
+      const last = items.at(-1)!;
+      if (event.shiftKey && (document.activeElement === first || !dialog.contains(document.activeElement))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [importing, onClose, pending]);
+
+  const previewManifest = (manifest: unknown, nextSource: ImportSource) => {
+    setPending(teamImportPreview(manifest));
+    setSource(nextSource);
+    setError("");
+  };
+
+  const readFile = async (file: File) => {
+    if (file.size > MAX_TEAM_FILE_BYTES) throw new Error("That team file is too large.");
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(await file.text());
+    } catch (cause) {
+      if (cause instanceof SyntaxError) throw new Error("That team file is not valid JSON.");
+      throw cause;
+    }
+    previewManifest(manifest, "file");
+  };
+
+  const loadLibraryTeam = async (entry: TeamCatalogEntry) => {
+    setBusySlug(entry.slug);
+    setError("");
+    try {
+      previewManifest(await api(`/api/team-library/teams/${entry.slug}`), "library");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusySlug(null);
+    }
+  };
+
+  const loadGithubTeam = async () => {
+    if (!githubUrl.trim()) return;
+    setGithubLoading(true);
+    setError("");
+    try {
+      const manifest = await api("/api/team-library/github", {
+        method: "POST",
+        body: JSON.stringify({ url: githubUrl.trim() }),
+      });
+      previewManifest(manifest, "github");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setGithubLoading(false);
+    }
+  };
+
+  const importTeam = async () => {
+    if (!pending) return;
+    setImporting(true);
+    setError("");
+    try {
+      const response = (await api("/api/teams/import", {
+        method: "POST",
+        body: JSON.stringify(pending.manifest),
+      })) as { bots: Bot[] };
+      for (const bot of response.bots) dispatch({ type: "botAdded", bot });
+      const first = response.bots[0];
+      if (first) dispatch({ type: "select", id: first.id });
+      track("team_imported", { members: response.bots.length, source });
+      onImported(pending.name, response.bots.length);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-4"
+      onMouseDown={(event) => event.target === event.currentTarget && !importing && onClose()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="team-library-title"
+        tabIndex={-1}
+        className="flex max-h-[min(760px,calc(100vh-32px))] w-[760px] max-w-full flex-col overflow-hidden rounded-2xl border border-hairline/50 bg-card shadow-2xl"
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-hairline/40 px-5 py-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              {pending && (
+                <button
+                  onClick={() => {
+                    setPending(null);
+                    setError("");
+                  }}
+                  disabled={importing}
+                  className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+                  aria-label="Back to team library"
+                >
+                  <ArrowLeft size={17} />
+                </button>
+              )}
+              <h2 id="team-library-title" className="truncate text-[19px] font-semibold text-ink">
+                {pending ? `Import ${pending.name}?` : "Add a team"}
+              </h2>
+            </div>
+            <p className="mt-1 text-[13px] text-ink-secondary">
+              {pending
+                ? `This creates ${pending.members.length} new ${pending.members.length === 1 ? "bot" : "bots"}. No room is created.`
+                : "Start with a community team, a local file, or a public GitHub link."}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <button
+              onClick={() => void openExternal(catalog?.repositoryUrl ?? COMMUNITY_TEAMS_REPOSITORY)}
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink"
+              title="Open the community team repository"
+            >
+              <Github size={15} />
+              <span className="max-sm:hidden">Community repo</span>
+              <ExternalLink size={12} />
+            </button>
+            <button
+              onClick={onClose}
+              disabled={importing}
+              className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+              aria-label="Close team library"
+            >
+              <X size={19} />
+            </button>
+          </div>
+        </header>
+
+        {pending ? (
+          <div className="min-h-0 flex-1 overflow-y-auto p-5">
+            {pending.description && <p className="mb-4 text-[13.5px] leading-relaxed text-ink-secondary">{pending.description}</p>}
+            <div className="space-y-1 rounded-xl bg-raised/45 p-2">
+              {pending.members.map((member, index) => (
+                <div key={`${member.name}-${index}`} className="flex items-baseline gap-3 rounded-lg px-2.5 py-2">
+                  <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{member.name}</span>
+                  <span className="max-w-[280px] truncate text-[12.5px] text-ink-secondary">
+                    {member.title || "General assistant"}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-[12.5px] leading-relaxed text-ink-secondary">
+              Bots use your default engine. Conversations, API keys, permissions, provider sessions, and computer access are never imported.
+            </p>
+            {source === "library" && (
+              <p className="mt-2 text-[12.5px] leading-relaxed text-ink-secondary">
+                The team&apos;s role playbooks are available in the community repo for you to review; this import currently adds the bot roles only.
+              </p>
+            )}
+            {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+          </div>
+        ) : (
+          <>
+            <div className="flex gap-1 border-b border-hairline/40 px-5 pt-3" role="tablist" aria-label="Team import source">
+              {([
+                ["explore", Library, "Explore"],
+                ["file", FileJson, "From file"],
+                ["github", Github, "From GitHub"],
+              ] as const).map(([value, Icon, label]) => (
+                <button
+                  key={value}
+                  role="tab"
+                  aria-selected={tab === value}
+                  onClick={() => {
+                    setTab(value);
+                    setError("");
+                  }}
+                  className={`flex items-center gap-2 border-b-2 px-3 py-2 text-[13.5px] transition-colors ${
+                    tab === value ? "border-accent text-ink" : "border-transparent text-ink-secondary hover:text-ink"
+                  }`}
+                >
+                  <Icon size={15} /> {label}
+                </button>
+              ))}
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto p-5">
+              {tab === "explore" && (
+                <div>
+                  {catalogLoading && (
+                    <div className="flex items-center justify-center gap-2 py-20 text-[13px] text-ink-secondary">
+                      <Loader2 size={17} className="animate-spin" /> Loading community teams…
+                    </div>
+                  )}
+                  {!catalogLoading && catalogError && (
+                    <div className="rounded-xl border border-danger/20 bg-danger/5 p-4 text-[13px] text-danger">
+                      <p>{catalogError}</p>
+                      <button onClick={() => void loadCatalog()} className="mt-3 rounded-lg bg-raised px-3 py-1.5 text-ink hover:bg-raised/80">
+                        Try again
+                      </button>
+                    </div>
+                  )}
+                  {!catalogLoading && catalog && (
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      {catalog.teams.map((entry) => (
+                        <article key={entry.slug} className="flex min-h-52 flex-col rounded-xl border border-hairline/45 bg-raised/25 p-4">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <span className="text-[11px] font-medium uppercase tracking-wide text-accent">{entry.category}</span>
+                              <h3 className="mt-0.5 text-[15px] font-semibold text-ink">{entry.name}</h3>
+                            </div>
+                            <button
+                              onClick={() => void openExternal(teamSourceUrl(catalog.repositoryUrl, entry))}
+                              className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+                              title={`View ${entry.name} on GitHub`}
+                              aria-label={`View ${entry.name} on GitHub`}
+                            >
+                              <ExternalLink size={14} />
+                            </button>
+                          </div>
+                          <p className="mt-2 text-[12.5px] leading-relaxed text-ink-secondary">{entry.summary}</p>
+                          <div className="mt-3 flex flex-wrap gap-1.5 text-[11.5px] text-ink-secondary">
+                            <span className="flex items-center gap-1 rounded-md bg-raised px-2 py-1"><Users size={12} /> {entry.members} bots</span>
+                            <span className="rounded-md bg-raised px-2 py-1">{entry.skills.length} playbooks</span>
+                          </div>
+                          {entry.requires.apps.length > 0 && (
+                            <p className="mt-2 line-clamp-2 text-[11.5px] text-ink-secondary">
+                              Works with {entry.requires.apps.join(", ")}
+                            </p>
+                          )}
+                          <button
+                            onClick={() => void loadLibraryTeam(entry)}
+                            disabled={busySlug !== null}
+                            className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+                          >
+                            {busySlug === entry.slug && <Loader2 size={14} className="animate-spin" />}
+                            {busySlug === entry.slug ? "Loading…" : "Preview team"}
+                          </button>
+                        </article>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {tab === "file" && (
+                <div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".json,.mausteam.json,application/json"
+                    className="hidden"
+                    onChange={(event) => {
+                      const file = event.currentTarget.files?.[0];
+                      event.currentTarget.value = "";
+                      if (!file) return;
+                      void readFile(file).catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)));
+                    }}
+                  />
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    onDragEnter={(event) => {
+                      event.preventDefault();
+                      setDragging(true);
+                    }}
+                    onDragOver={(event) => event.preventDefault()}
+                    onDragLeave={() => setDragging(false)}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      setDragging(false);
+                      const file = event.dataTransfer.files[0];
+                      if (file) void readFile(file).catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)));
+                    }}
+                    className={`flex min-h-64 w-full flex-col items-center justify-center rounded-2xl border border-dashed px-6 text-center transition-colors ${
+                      dragging ? "border-accent bg-accent/5" : "border-hairline bg-raised/20 hover:bg-raised/40"
+                    }`}
+                  >
+                    <UploadCloud size={32} className="text-accent" />
+                    <span className="mt-3 text-[15px] font-medium text-ink">Drop a team JSON here</span>
+                    <span className="mt-1 text-[12.5px] text-ink-secondary">or click to choose a `.mausteam.json` file</span>
+                  </button>
+                </div>
+              )}
+
+              {tab === "github" && (
+                <div className="mx-auto max-w-xl py-8">
+                  <div className="flex size-11 items-center justify-center rounded-xl bg-raised text-ink-secondary"><LinkIcon size={21} /></div>
+                  <h3 className="mt-4 text-[16px] font-semibold text-ink">Load a public GitHub team</h3>
+                  <p className="mt-1 text-[13px] leading-relaxed text-ink-secondary">
+                    Paste a repository containing `team.mausteam.json`, or a direct GitHub link to any OpenMaus team JSON file.
+                  </p>
+                  <div className="mt-4 flex gap-2">
+                    <input
+                      value={githubUrl}
+                      onChange={(event) => setGithubUrl(event.target.value)}
+                      onKeyDown={(event) => event.key === "Enter" && void loadGithubTeam()}
+                      placeholder="https://github.com/owner/team-repo"
+                      aria-label="GitHub team URL"
+                      className="min-w-0 flex-1 rounded-lg bg-raised/70 px-3 py-2.5 text-[13.5px] text-ink placeholder:text-ink-secondary focus:outline-none"
+                    />
+                    <button
+                      onClick={() => void loadGithubTeam()}
+                      disabled={!githubUrl.trim() || githubLoading}
+                      className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-40"
+                    >
+                      {githubLoading && <Loader2 size={14} className="animate-spin" />}
+                      {githubLoading ? "Loading…" : "Load"}
+                    </button>
+                  </div>
+                  <p className="mt-3 text-[11.5px] text-ink-secondary">Only public HTTPS links from github.com are fetched.</p>
+                </div>
+              )}
+
+              {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+            </div>
+          </>
+        )}
+
+        {pending && (
+          <footer className="flex items-center justify-end gap-2 border-t border-hairline/40 px-5 py-4">
+            <button
+              onClick={() => setPending(null)}
+              disabled={importing}
+              className="rounded-lg px-3.5 py-2 text-[13.5px] text-ink-secondary hover:bg-raised disabled:opacity-50"
+            >
+              Back
+            </button>
+            <button
+              onClick={() => void importTeam()}
+              disabled={importing}
+              className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
+            >
+              {importing && <Loader2 size={15} className="animate-spin" />}
+              {importing ? "Importing…" : `Import ${pending.members.length} ${pending.members.length === 1 ? "bot" : "bots"}`}
+            </button>
+          </footer>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/lib/bottom-follow.test.ts
+++ b/src/lib/bottom-follow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "./bottom-follow";
+
+describe("shouldResumeBottomFollow", () => {
+  it("does not re-pin a small upward scroll inside the near-bottom zone", () => {
+    expect(
+      shouldResumeBottomFollow({
+        following: false,
+        previousScrollTop: 1_000,
+        scrollTop: 992,
+        distanceFromBottom: 8,
+      }),
+    ).toBe(false);
+  });
+
+  it("re-pins after scrolling downward to the end", () => {
+    expect(
+      shouldResumeBottomFollow({
+        following: false,
+        previousScrollTop: 992,
+        scrollTop: 1_000,
+        distanceFromBottom: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays detached while downward movement remains away from the end", () => {
+    expect(
+      shouldResumeBottomFollow({
+        following: false,
+        previousScrollTop: 500,
+        scrollTop: 600,
+        distanceFromBottom: BOTTOM_FOLLOW_THRESHOLD,
+      }),
+    ).toBe(false);
+  });
+
+  it("does nothing when bottom-follow is already active", () => {
+    expect(
+      shouldResumeBottomFollow({
+        following: true,
+        previousScrollTop: 992,
+        scrollTop: 1_000,
+        distanceFromBottom: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/bottom-follow.ts
+++ b/src/lib/bottom-follow.ts
@@ -1,0 +1,20 @@
+export const BOTTOM_FOLLOW_THRESHOLD = 48;
+
+/**
+ * Resume automatic bottom-follow only when the reader is moving toward the
+ * latest message. An upward movement can still be within the near-bottom
+ * threshold and must never re-pin the transcript.
+ */
+export function shouldResumeBottomFollow({
+  following,
+  previousScrollTop,
+  scrollTop,
+  distanceFromBottom,
+}: {
+  following: boolean;
+  previousScrollTop: number;
+  scrollTop: number;
+  distanceFromBottom: number;
+}): boolean {
+  return !following && scrollTop > previousScrollTop && distanceFromBottom < BOTTOM_FOLLOW_THRESHOLD;
+}

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -28,14 +28,11 @@ function downloadManifest(manifest: ExportedTeam): { name: string; members: numb
   return { name: manifest.team.name, members: manifest.team.members.length };
 }
 
-/** Export an ad-hoc selection of bots without creating a room first. */
-export async function downloadSelectedTeam(
-  name: string,
-  memberIds: string[],
-): Promise<{ name: string; members: number }> {
+/** Export every active sidebar bot in one click. The server excludes hidden bots. */
+export async function downloadAllBots(): Promise<{ name: string; members: number }> {
   const manifest = (await api("/api/teams/export", {
     method: "POST",
-    body: JSON.stringify({ name, memberIds }),
+    body: "{}",
   })) as ExportedTeam;
   return downloadManifest(manifest);
 }

--- a/src/lib/team-import.test.ts
+++ b/src/lib/team-import.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { teamImportPreview } from "./team-import";
+
+describe("team import preview", () => {
+  it.each([1, 2])("previews version %s team files", (version) => {
+    const preview = teamImportPreview({
+      format: "openmaus.team",
+      version,
+      team: {
+        name: " Engineering ",
+        description: " Ships software ",
+        members: [{ name: " Ada ", title: " Tech Lead " }],
+        ...(version === 1
+          ? { room: { name: "Engineering", bulletin: "", defaultResponder: { kind: "everyone" } } }
+          : {}),
+      },
+    });
+
+    expect(preview).toMatchObject({
+      name: "Engineering",
+      description: "Ships software",
+      members: [{ name: "Ada", title: "Tech Lead" }],
+    });
+  });
+
+  it("rejects unsupported and empty files", () => {
+    expect(() => teamImportPreview({ format: "openmaus.team", version: 3, team: {} })).toThrow("not supported");
+    expect(() =>
+      teamImportPreview({ format: "openmaus.team", version: 2, team: { name: "Empty", members: [] } }),
+    ).toThrow("no members");
+  });
+});

--- a/src/lib/team-import.ts
+++ b/src/lib/team-import.ts
@@ -1,0 +1,44 @@
+export interface PendingTeamImport {
+  manifest: unknown;
+  name: string;
+  description: string;
+  members: Array<{ name: string; title: string }>;
+}
+
+/** Small client-side preview only; the server remains the trust boundary. */
+export function teamImportPreview(manifest: unknown): PendingTeamImport {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("This file does not contain a team.");
+  }
+  const root = manifest as Record<string, unknown>;
+  if (root.format !== "openmaus.team") throw new Error("This is not an OpenMaus team file.");
+  if (root.version !== 1 && root.version !== 2) {
+    throw new Error(`Team file version ${String(root.version)} is not supported.`);
+  }
+  if (!root.team || typeof root.team !== "object" || Array.isArray(root.team)) {
+    throw new Error("This team file is missing its team definition.");
+  }
+  const team = root.team as Record<string, unknown>;
+  if (typeof team.name !== "string" || !team.name.trim()) throw new Error("This team does not have a name.");
+  if (!Array.isArray(team.members) || team.members.length === 0) throw new Error("This team has no members.");
+  if (team.members.length > 200) throw new Error("This team has too many members.");
+  const members = team.members.map((member, index) => {
+    if (!member || typeof member !== "object" || Array.isArray(member)) {
+      throw new Error(`Team member ${index + 1} is invalid.`);
+    }
+    const value = member as Record<string, unknown>;
+    if (typeof value.name !== "string" || !value.name.trim()) {
+      throw new Error(`Team member ${index + 1} does not have a name.`);
+    }
+    return {
+      name: value.name.trim(),
+      title: typeof value.title === "string" ? value.title.trim() : "",
+    };
+  });
+  return {
+    manifest,
+    name: team.name.trim(),
+    description: typeof team.description === "string" ? team.description.trim() : "",
+    members,
+  };
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -472,7 +472,9 @@ function reducer(state: AppState, action: Action): AppState {
     case "botAdded":
       return withMascotMotion({
         ...state,
-        bots: [action.bot, ...state.bots],
+        // An HTTP create/import response and its SSE broadcast can race. Fold
+        // both paths without ever showing the same bot twice.
+        bots: [action.bot, ...state.bots.filter((bot) => bot.id !== action.bot.id)],
         activeView: "chat",
         selectedId: action.bot.id,
       }, action.bot.id, "arrive");


### PR DESCRIPTION
## What changed

- replace the bot-selection export dialog with a one-click **Export all bots** action
- make exported team files room-free while preserving imports for legacy v1 files
- add an **Add Team** library with Explore, drag-and-drop file, and public GitHub URL flows
- load curated teams from [openmausbot-teams](https://github.com/milind-soni/openmausbot-teams)
- link the community repository from the library header and every team card
- import bots without creating a room and de-duplicate HTTP/SSE import updates
- validate remote catalog paths, GitHub hosts, file sizes, and manifest fields before import
- fix the chat and room scroll jitter when leaving the bottom of a conversation

The scroll bug came from re-enabling bottom-follow while the first small upward movement was still inside the 48px near-bottom zone. Bottom-follow now detaches synchronously and only re-arms from a scroll event moving downward toward the latest message.

The catalog's Markdown role playbooks are linked for review; the current importer intentionally installs only portable bot roles and appearance. Conversations, credentials, permissions, engines, sessions, and computer access are never included.

## Validation

- `pnpm typecheck`
- `pnpm test` — 540 passed, 8 skipped
- updater tests — 12 passed
- `pnpm check:electron`
- production Vite build
- regression tests for upward, downward, detached, and already-following scroll states
- manual UI check of Explore, file/GitHub preview, import, repository links, and no-room behavior
