### PR TITLE
Validate config, webhook, and team boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.4.3",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@oxlint/plugins": "1.78.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@oxlint/plugins':
         specifier: 1.78.0
@@ -2630,6 +2633,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5385,5 +5391,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from "vitest";
 
-import { instanceConfigs, withInstanceCli, type AppConfig } from "./config.ts";
+import {
+  instanceConfigs,
+  parseConfigPatch,
+  parseStoredConfig,
+  withInstanceCli,
+  type AppConfig,
+} from "./config.ts";
+
+describe("configuration boundaries", () => {
+  it("keeps supported stored settings and drops unrelated top-level data", () => {
+    expect(
+      parseStoredConfig({
+        profile: { name: "Ada", email: "ada@example.com" },
+        instances: { claude: { driver: "claudeAgent", config: { cli: "/opt/claude" } } },
+        unrelated: { secret: "not part of the config contract" },
+      }),
+    ).toEqual({
+      profile: { name: "Ada", email: "ada@example.com" },
+      instances: { claude: { driver: "claudeAgent", config: { cli: "/opt/claude" } } },
+    });
+  });
+
+  it("rejects malformed stored instances and API patches", () => {
+    expect(() => parseStoredConfig({ instances: { claude: { driver: 42 } } })).toThrow("instances.claude.driver");
+    expect(() => parseConfigPatch({ opencodeGo: { apiKey: 42 } })).toThrow("opencodeGo.apiKey");
+    expect(() => parseConfigPatch({ profile: [] })).toThrow("profile");
+  });
+});
 
 describe("Instance CLI override", () => {
   it("sets, replaces, and clears config.cli on a default-fleet instance", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -4,29 +4,62 @@
 import { readFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 
 import { writeFileAtomic } from "./atomic.ts";
 import type { InstanceConfigMap } from "./contracts.ts";
+import { parseJson, schemaIssue, type JsonObject, type JsonValue } from "./schema.ts";
+
+const optionalText = z.string().optional();
+const instanceConfigSchema = z.object({
+  driver: z.string().min(1),
+  displayName: optionalText,
+  accentColor: optionalText,
+  environment: z.record(z.string(), z.string()).optional(),
+  enabled: z.boolean().optional(),
+  config: z.json().optional(),
+});
+const instanceConfigMapSchema = z.record(z.string(), instanceConfigSchema);
+const appConfigSchema = z.object({
+  xai: z.object({ key: optionalText, url: optionalText }).optional(),
+  /** Project key used for Sessions, catalog and agent tools. userId/sessionId
+   * are non-secret local identifiers used to reuse one Composio Session. */
+  composio: z.object({ apiKey: optionalText, userId: optionalText, sessionId: optionalText }).optional(),
+  box: z.object({ token: optionalText }).optional(),
+  /** OpenCode Go key; persisted write-only and passed only to its child. */
+  opencodeGo: z.object({ apiKey: optionalText }).optional(),
+  /** Voice credentials and the selected voice id. */
+  tts: z.object({ key: optionalText, voice: optionalText }).optional(),
+  /** Non-secret profile details shown in the sidebar. */
+  profile: z.object({ name: optionalText, email: optionalText }).optional(),
+  instances: instanceConfigMapSchema.optional(),
+});
+const appConfigPatchSchema = appConfigSchema.omit({ instances: true });
+const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
-  /** Project key used for Sessions, catalog and agent tools. userId/sessionId
-   * are non-secret local identifiers used to reuse one Composio Session. */
-  composio?: {
-    apiKey?: string;
-    userId?: string;
-    sessionId?: string;
-  };
+  composio?: { apiKey?: string; userId?: string; sessionId?: string };
   box?: { token?: string };
-  /** OpenCode Go key; persisted write-only and passed only to its child. */
   opencodeGo?: { apiKey?: string };
-  /** Voice (ElevenLabs). `key` is the credential and is never echoed back;
-   * `voice` is the chosen voice id, which is a setting, not a secret. */
   tts?: { key?: string; voice?: string };
-  /** The person using the app (collected in onboarding, shown in the
-   * sidebar). Not a secret — echoed back by GET /api/config. */
   profile?: { name?: string; email?: string };
   instances?: InstanceConfigMap;
+}
+export type ConfigPatch = z.output<typeof appConfigPatchSchema>;
+
+export function parseStoredConfig(value: JsonValue): AppConfig {
+  const parsed = appConfigSchema.safeParse(value);
+  if (!parsed.success) throw new Error(schemaIssue(parsed.error, "Invalid stored configuration"));
+  return parsed.data;
+}
+
+export function parseConfigPatch(value: JsonValue): ConfigPatch {
+  const parsed = appConfigPatchSchema.safeParse(value);
+  if (!parsed.success) {
+    throw Object.assign(new Error(schemaIssue(parsed.error, "Invalid configuration")), { status: 400 });
+  }
+  return parsed.data;
 }
 
 // OMB_DATA_DIR isolates test/soak rigs from the user's real fleet.
@@ -51,15 +84,13 @@ export function ensureDirs() {
 export function loadConfig(): AppConfig {
   let cfg: AppConfig = {};
   try {
-    cfg = JSON.parse(readFileSync(join(DATA_DIR, "config.json"), "utf8"));
+    cfg = parseStoredConfig(parseJson(readFileSync(join(DATA_DIR, "config.json"), "utf8")));
   } catch {
     /* first run — env fallbacks below */
   }
   cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
-  cfg.composio = {
-    ...cfg.composio,
-    ...(process.env.COMPOSIO_API_KEY !== undefined ? { apiKey: process.env.COMPOSIO_API_KEY } : {}),
-  };
+  cfg.composio = { ...cfg.composio };
+  if (process.env.COMPOSIO_API_KEY !== undefined) cfg.composio.apiKey = process.env.COMPOSIO_API_KEY;
   cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
   cfg.opencodeGo = { apiKey: process.env.OPENCODE_API_KEY, ...cfg.opencodeGo };
   cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };
@@ -70,21 +101,30 @@ export function loadConfig(): AppConfig {
  * echoed back — callers report configured-or-not booleans only). */
 export function saveConfig(patch: Partial<AppConfig>): void {
   const p = join(DATA_DIR, "config.json");
-  let disk: Record<string, unknown> = {};
+  let disk: JsonObject = {};
   try {
-    disk = JSON.parse(readFileSync(p, "utf8"));
+    const parsed = jsonObjectSchema.safeParse(parseJson(readFileSync(p, "utf8")));
+    if (parsed.success) disk = parsed.data;
   } catch {
     /* first write */
   }
+  const checkedPatch = appConfigSchema.partial().parse(patch);
   for (const key of ["xai", "composio", "box", "opencodeGo", "tts", "profile"] as const) {
-    if (patch[key] && typeof patch[key] === "object") {
-      disk[key] = { ...(disk[key] as object), ...patch[key] };
-    }
+    const section = checkedPatch[key];
+    if (!section) continue;
+    const current = jsonObjectSchema.safeParse(disk[key]);
+    const merged: JsonObject = current.success ? { ...current.data } : {};
+    Object.assign(merged, section);
+    disk[key] = merged;
   }
-  if (patch.instances && typeof patch.instances === "object") {
-    const diskInstances = (disk.instances ?? {}) as Record<string, unknown>;
-    for (const [instanceId, entry] of Object.entries(patch.instances)) {
-      diskInstances[instanceId] = { ...(diskInstances[instanceId] as object), ...entry };
+  if (checkedPatch.instances) {
+    const currentInstances = jsonObjectSchema.safeParse(disk.instances);
+    const diskInstances: JsonObject = currentInstances.success ? currentInstances.data : {};
+    for (const [instanceId, entry] of Object.entries(checkedPatch.instances)) {
+      const current = jsonObjectSchema.safeParse(diskInstances[instanceId]);
+      const merged: JsonObject = current.success ? { ...current.data } : {};
+      Object.assign(merged, entry);
+      diskInstances[instanceId] = merged;
     }
     disk.instances = diskInstances;
   }
@@ -104,7 +144,7 @@ export function withInstanceCli(
   cfg: AppConfig,
   instanceId: string,
   cli: string,
-): { ok: boolean; config: AppConfig } {
+): InstanceCliUpdate {
   const next: AppConfig = structuredClone(cfg);
   const injected = injectedEnvironment(next);
   const map = instanceConfigs(next);
@@ -115,16 +155,20 @@ export function withInstanceCli(
   if (!Object.hasOwn(map, instanceId)) return { ok: false, config: cfg };
   const entry = map[instanceId];
   const cliKey = cli.trim();
-  if (cliKey) entry.config = { ...(entry.config as object), cli: cliKey };
-  else if (entry.config && typeof entry.config === "object" && "cli" in (entry.config as object)) {
-    const rest = { ...(entry.config as Record<string, unknown>) };
+  const currentConfig = jsonObjectSchema.safeParse(entry.config);
+  if (cliKey) {
+    const nextConfig: JsonObject = currentConfig.success ? { ...currentConfig.data } : {};
+    nextConfig.cli = cliKey;
+    entry.config = nextConfig;
+  } else if (currentConfig.success && Object.hasOwn(currentConfig.data, "cli")) {
+    const rest = { ...currentConfig.data };
     delete rest.cli;
     entry.config = Object.keys(rest).length ? rest : undefined;
   }
   for (const e of Object.values(map)) {
     if (!e.environment) continue;
     for (const [k, v] of Object.entries(e.environment)) {
-      if (injected[k] === v) delete e.environment[k];
+      if (injected.get(k) === v) delete e.environment[k];
     }
     if (!Object.keys(e.environment).length) delete e.environment;
   }
@@ -132,13 +176,18 @@ export function withInstanceCli(
   return { ok: true, config: next };
 }
 
+interface InstanceCliUpdate {
+  ok: boolean;
+  config: AppConfig;
+}
+
 /** The credential env instanceConfigs() injects — same keys, same rule. */
-function injectedEnvironment(cfg: AppConfig): Record<string, string> {
-  return {
-    ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
-    ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
-    ...(cfg.opencodeGo?.apiKey ? { OPENCODE_API_KEY: cfg.opencodeGo.apiKey } : {}),
-  };
+function injectedEnvironment(cfg: AppConfig): Map<string, string> {
+  const environment = new Map<string, string>();
+  if (cfg.xai?.key) environment.set("XAI_API_KEY", cfg.xai.key);
+  if (cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
+  if (cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
+  return environment;
 }
 
 // Default fleet: one instance per built-in driver (upstream
@@ -173,14 +222,13 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
           computer: { driver: "boxAgent" },
         };
   for (const entry of Object.values(map)) {
-    entry.environment = {
-      ...(cfg.xai?.key ? { XAI_API_KEY: cfg.xai.key } : {}),
-      ...(cfg.box?.token ? { BOX_TOKEN: cfg.box.token } : {}),
-      ...(entry.driver === "opencodeGo" && cfg.opencodeGo?.apiKey
-        ? { OPENCODE_API_KEY: cfg.opencodeGo.apiKey }
-        : {}),
-      ...entry.environment,
-    };
+    const environment = { ...entry.environment };
+    if (cfg.xai?.key) environment.XAI_API_KEY = cfg.xai.key;
+    if (cfg.box?.token) environment.BOX_TOKEN = cfg.box.token;
+    if (entry.driver === "opencodeGo" && cfg.opencodeGo?.apiKey) {
+      environment.OPENCODE_API_KEY = cfg.opencodeGo.apiKey;
+    }
+    entry.environment = environment;
   }
   return map;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,16 @@ import {
   setupCommands,
   type LifecycleAction,
 } from "./container-computer.ts";
-import { ensureDirs, instanceConfigs, loadConfig, saveConfig, withInstanceCli, EVENTS_DIR, NATIVE_DIR, type AppConfig } from "./config.ts";
+import {
+  ensureDirs,
+  instanceConfigs,
+  loadConfig,
+  parseConfigPatch,
+  saveConfig,
+  withInstanceCli,
+  EVENTS_DIR,
+  NATIVE_DIR,
+} from "./config.ts";
 import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts";
 import { describeSpawnFailure, execCli } from "./procs.ts";
 import { buildNotification, type Notification } from "./notify.ts";
@@ -2424,41 +2433,7 @@ const server = createServer(async (req, res) => {
     }
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);
-      const rawComposio = body.composio;
-      if (
-        rawComposio !== undefined
-        && (rawComposio === null || typeof rawComposio !== "object" || Array.isArray(rawComposio))
-      ) {
-        return json(res, 400, { error: "composio must be an object" });
-      }
-      if (rawComposio) {
-        for (const field of ["apiKey"] as const) {
-          if (
-            Object.prototype.hasOwnProperty.call(rawComposio, field)
-            && typeof (rawComposio as Record<string, unknown>)[field] !== "string"
-          ) {
-            return json(res, 400, { error: `composio.${field} must be a string` });
-          }
-        }
-      }
-      const rawOpenCode = body.opencodeGo;
-      if (
-        rawOpenCode !== undefined
-        && (rawOpenCode === null || typeof rawOpenCode !== "object" || Array.isArray(rawOpenCode))
-      ) {
-        return json(res, 400, { error: "opencodeGo must be an object" });
-      }
-      if (
-        rawOpenCode
-        && Object.prototype.hasOwnProperty.call(rawOpenCode, "apiKey")
-        && typeof (rawOpenCode as { apiKey?: unknown }).apiKey !== "string"
-      ) {
-        return json(res, 400, { error: "opencodeGo.apiKey must be a string" });
-      }
-      const patch: Record<string, object> = {};
-      for (const key of ["xai", "composio", "box", "opencodeGo", "tts", "profile"] as const) {
-        if (body[key] && typeof body[key] === "object") patch[key] = body[key];
-      }
+      const patch = parseConfigPatch(body);
       if (!Object.keys(patch).length) return json(res, 400, { error: "nothing to save" });
       if (providerConfigBusy) return json(res, 409, { error: "provider settings are already being updated" });
       providerConfigBusy = true;
@@ -2466,8 +2441,8 @@ const server = createServer(async (req, res) => {
       // A project key is useful only if it can create/reuse the Session that
       // powers both the connections UI and the agent MCP. Validate it before
       // persisting, and save the non-secret ids needed to reuse that Session.
-      const requestedComposioKey = (patch.composio as { apiKey?: unknown } | undefined)?.apiKey;
-      if (typeof requestedComposioKey === "string") {
+      const requestedComposioKey = patch.composio?.apiKey;
+      if (requestedComposioKey !== undefined) {
         if (requestedComposioKey.trim()) {
           try {
             const prepared = await composio.prepareProjectSession(requestedComposioKey, cfg.composio);
@@ -2482,16 +2457,16 @@ const server = createServer(async (req, res) => {
       // check a box token against the provider before storing it: a
       // rejected token used to save happily and only surface as a 401 in
       // another panel later, with nothing the user could act on
-      const newBoxToken = (patch.box as { token?: unknown } | undefined)?.token;
-      if (typeof newBoxToken === "string" && newBoxToken.trim()) {
+      const newBoxToken = patch.box?.token;
+      if (newBoxToken?.trim()) {
         const check = await box.verifyToken(newBoxToken.trim());
         if (!check.ok) return json(res, 400, { error: check.message });
       }
       // same rule for a voice key — and check it against the provider the
       // patch SELECTS, not the one already saved, or pasting a Cartesia key
       // while switching from ElevenLabs validates against the wrong service
-      const newTts = patch.tts as { key?: unknown } | undefined;
-      if (typeof newTts?.key === "string" && newTts.key.trim()) {
+      const newTts = patch.tts;
+      if (newTts?.key?.trim()) {
         const check = await tts.verifyKey(newTts.key.trim());
         if (!check.ok) return json(res, 400, { error: check.message });
       }
@@ -2500,11 +2475,11 @@ const server = createServer(async (req, res) => {
         // Electron stores the project key with OS-backed encryption. Persist
         // only the non-secret Session ids here, while keeping the supplied
         // key live in this process until the next launch injects it by env.
-        const composioPatch = patch.composio as NonNullable<AppConfig["composio"]>;
+        const composioPatch = patch.composio;
         const { apiKey: _secret, ...metadata } = composioPatch;
         saveConfig({ composio: { ...metadata, apiKey: "" } });
         cfg.composio = { ...cfg.composio, ...composioPatch };
-        if (typeof composioPatch.apiKey === "string") process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
+        if (composioPatch.apiKey !== undefined) process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
       } else {
         saveConfig(patch);
         Object.assign(cfg, loadConfig());

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -1,0 +1,19 @@
+import type { z } from "zod";
+
+export type JsonPrimitive = string | number | boolean | null;
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+/** JSON.parse without a reviver can only produce JSON-compatible values. */
+export function parseJson(text: string): JsonValue {
+  return JSON.parse(text);
+}
+
+export function schemaIssue(error: z.ZodError, fallback: string): string {
+  const issue = error.issues[0];
+  if (!issue) return fallback;
+  const path = issue.path.map(String).join(".");
+  return path ? `${path} ${issue.message}` : issue.message;
+}

--- a/server/team-library.ts
+++ b/server/team-library.ts
@@ -1,3 +1,4 @@
+import { parseJson, type JsonValue } from "./schema.ts";
 import { parseTeamManifest, type ParsedTeamManifest } from "./team-manifest.ts";
 
 export const TEAM_LIBRARY_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
@@ -103,7 +104,7 @@ export function parseTeamCatalog(value: unknown): TeamCatalog {
   };
 }
 
-async function fetchJson(url: string, maxBytes: number, fetcher: Fetcher): Promise<unknown> {
+async function fetchJson(url: string, maxBytes: number, fetcher: Fetcher): Promise<JsonValue> {
   const response = await fetcher(url, {
     headers: { accept: "application/json, text/plain;q=0.9" },
     redirect: "error",
@@ -118,7 +119,7 @@ async function fetchJson(url: string, maxBytes: number, fetcher: Fetcher): Promi
   const raw = await response.text();
   if (Buffer.byteLength(raw) > maxBytes) throw new Error("The remote team file is too large");
   try {
-    return JSON.parse(raw);
+    return parseJson(raw);
   } catch {
     throw new Error("GitHub did not return valid JSON");
   }

--- a/server/team-manifest.test.ts
+++ b/server/team-manifest.test.ts
@@ -128,6 +128,37 @@ describe("team manifests", () => {
     ).toThrow("Unknown default responder");
   });
 
+  it("rejects duplicate member keys and malformed appearance data", () => {
+    const member = {
+      key: "analyst",
+      name: "Ada",
+      appearance: { color: "green" },
+    };
+    const room = {
+      name: "Research",
+      bulletin: "",
+      defaultResponder: { kind: "everyone" },
+    };
+    expect(() =>
+      parseTeamManifest({
+        format: "openmaus.team",
+        version: 1,
+        team: { name: "Research", members: [member, member], room },
+      }),
+    ).toThrow("Duplicate member key");
+    expect(() =>
+      parseTeamManifest({
+        format: "openmaus.team",
+        version: 1,
+        team: {
+          name: "Research",
+          members: [{ ...member, appearance: { color: 42 } }],
+          room,
+        },
+      }),
+    ).toThrow("appearance.color");
+  });
+
   it("refuses to export values that the importer would reject", () => {
     expect(() =>
       createTeamManifest(

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+
+import { schemaIssue, type JsonValue } from "./schema.ts";
 import type { MausColor } from "./store.ts";
 
 export const TEAM_MANIFEST_FORMAT = "openmaus.team" as const;
@@ -5,7 +8,7 @@ export const TEAM_MANIFEST_VERSION = 2 as const;
 export const LEGACY_TEAM_MANIFEST_VERSION = 1 as const;
 export const MAX_TEAM_MEMBERS = 200;
 
-const COLORS: readonly MausColor[] = [
+const COLORS = [
   "green",
   "blue",
   "red",
@@ -16,7 +19,67 @@ const COLORS: readonly MausColor[] = [
   "yellow",
   "teal",
   "coral",
-];
+] as const satisfies readonly MausColor[];
+
+const requiredText = (max: number) =>
+  z.string({ error: "must be text" }).trim().min(1, { message: "is required" }).max(max, { message: "is too long" });
+
+const optionalText = (max: number) =>
+  z
+    .union([z.string({ error: "must be text" }), z.null(), z.undefined()])
+    .transform((value) => value?.trim() || undefined)
+    .refine((value) => value === undefined || value.length <= max, { message: "is too long" })
+    .optional();
+
+const responderSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("member"), member: requiredText(64) }),
+  z.object({ kind: z.literal("everyone") }),
+  z.object({ kind: z.literal("mentions") }),
+]);
+
+const memberSchema = z.object({
+  key: requiredText(64).regex(/^[a-z0-9][a-z0-9_-]*$/, {
+    message: "may only contain lowercase letters, numbers, - and _",
+  }),
+  name: requiredText(100),
+  title: optionalText(200),
+  description: optionalText(4_000),
+  appearance: z.object({
+    color: z.enum(COLORS, { error: "is not supported" }),
+    mascotExpression: optionalText(80),
+  }),
+});
+
+const membersSchema = z
+  .array(memberSchema)
+  .min(1, { message: "A team needs at least one member" })
+  .max(MAX_TEAM_MEMBERS, { message: `A team can have at most ${MAX_TEAM_MEMBERS} members` });
+
+const manifestSchema = z.discriminatedUnion("version", [
+  z.object({
+    format: z.literal(TEAM_MANIFEST_FORMAT, { error: "This is not an OpenMaus team file" }),
+    version: z.literal(LEGACY_TEAM_MANIFEST_VERSION),
+    team: z.object({
+      name: requiredText(100),
+      description: optionalText(2_000),
+      members: membersSchema,
+      room: z.object({
+        name: requiredText(100),
+        bulletin: optionalText(12_000),
+        defaultResponder: responderSchema,
+      }),
+    }),
+  }),
+  z.object({
+    format: z.literal(TEAM_MANIFEST_FORMAT, { error: "This is not an OpenMaus team file" }),
+    version: z.literal(TEAM_MANIFEST_VERSION),
+    team: z.object({
+      name: requiredText(100),
+      description: optionalText(2_000),
+      members: membersSchema,
+    }),
+  }),
+]);
 
 export interface TeamManifestMember {
   key: string;
@@ -62,6 +125,8 @@ export interface TeamManifestV2 {
   };
 }
 
+export type TeamManifestInput = JsonValue | ParsedTeamManifest | TeamManifestV2;
+
 interface ExportableBot {
   id: string;
   name: string;
@@ -76,113 +141,57 @@ interface ExportableTeam {
   memberIds: string[];
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value) && typeof value === "object" && !Array.isArray(value);
-
-function requiredString(value: unknown, field: string, max: number): string {
-  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} is required`);
-  const result = value.trim();
-  if (result.length > max) throw new Error(`${field} is too long`);
-  return result;
-}
-
-function optionalString(value: unknown, field: string, max: number): string | undefined {
-  if (value === undefined || value === null || value === "") return undefined;
-  if (typeof value !== "string") throw new Error(`${field} must be text`);
-  const result = value.trim();
-  if (result.length > max) throw new Error(`${field} is too long`);
-  return result || undefined;
-}
-
 /** Parse an untrusted shared file into the small, portable subset we support. */
-export function parseTeamManifest(value: unknown): ParsedTeamManifest {
-  if (!isRecord(value)) throw new Error("This is not a team file");
-  if (value.format !== TEAM_MANIFEST_FORMAT) throw new Error("This is not an OpenMaus team file");
-  if (value.version !== LEGACY_TEAM_MANIFEST_VERSION && value.version !== TEAM_MANIFEST_VERSION) {
-    throw new Error(`Team file version ${String(value.version)} is not supported`);
-  }
-  if (!isRecord(value.team)) throw new Error("team is required");
-
-  const team = value.team;
-  const name = requiredString(team.name, "team.name", 100);
-  const description = optionalString(team.description, "team.description", 2_000);
-  if (!Array.isArray(team.members) || team.members.length === 0) {
-    throw new Error("A team needs at least one member");
-  }
-  if (team.members.length > MAX_TEAM_MEMBERS) {
-    throw new Error(`A team can have at most ${MAX_TEAM_MEMBERS} members`);
+export function parseTeamManifest(value: TeamManifestV2): TeamManifestV2;
+export function parseTeamManifest(value: TeamManifestInput): ParsedTeamManifest;
+export function parseTeamManifest(value: TeamManifestInput): ParsedTeamManifest {
+  const parsed = manifestSchema.safeParse(value);
+  if (!parsed.success) {
+    const formatIssue = parsed.error.issues.find((issue) => issue.path[0] === "format");
+    if (formatIssue) throw new Error(formatIssue.message);
+    const versionIssue = parsed.error.issues.find((issue) => issue.path[0] === "version");
+    if (versionIssue) throw new Error("Team file version is not supported");
+    throw new Error(schemaIssue(parsed.error, "This is not a team file"));
   }
 
   const seenKeys = new Set<string>();
-  const members = team.members.map((raw, index): TeamManifestMember => {
-    const field = `team.members[${index}]`;
-    if (!isRecord(raw)) throw new Error(`${field} must be an object`);
-    const key = requiredString(raw.key, `${field}.key`, 64);
-    if (!/^[a-z0-9][a-z0-9_-]*$/.test(key)) {
-      throw new Error(`${field}.key may only contain lowercase letters, numbers, - and _`);
-    }
-    if (seenKeys.has(key)) throw new Error(`Duplicate member key: ${key}`);
-    seenKeys.add(key);
-
-    const appearance = raw.appearance;
-    if (!isRecord(appearance)) throw new Error(`${field}.appearance is required`);
-    if (typeof appearance.color !== "string" || !COLORS.includes(appearance.color as MausColor)) {
-      throw new Error(`${field}.appearance.color is not supported`);
-    }
-    const mascotExpression = optionalString(
-      appearance.mascotExpression,
-      `${field}.appearance.mascotExpression`,
-      80,
-    );
-
+  const members = parsed.data.team.members.map((member): TeamManifestMember => {
+    if (seenKeys.has(member.key)) throw new Error(`Duplicate member key: ${member.key}`);
+    seenKeys.add(member.key);
+    const appearance: TeamManifestMember["appearance"] = { color: member.appearance.color };
+    if (member.appearance.mascotExpression) appearance.mascotExpression = member.appearance.mascotExpression;
     return {
-      key,
-      name: requiredString(raw.name, `${field}.name`, 100),
-      title: optionalString(raw.title, `${field}.title`, 200) ?? "",
-      description: optionalString(raw.description, `${field}.description`, 4_000) ?? "",
-      appearance: {
-        color: appearance.color as MausColor,
-        ...(mascotExpression ? { mascotExpression } : {}),
-      },
+      key: member.key,
+      name: member.name,
+      title: member.title ?? "",
+      description: member.description ?? "",
+      appearance,
     };
   });
 
-  const parsed: ParsedTeamManifest = {
+  const result: ParsedTeamManifest = {
     format: TEAM_MANIFEST_FORMAT,
-    version: value.version,
+    version: parsed.data.version,
     team: {
-      name,
-      ...(description ? { description } : {}),
+      name: parsed.data.team.name,
       members,
     },
   };
+  if (parsed.data.team.description) result.team.description = parsed.data.team.description;
 
-  // Version 1 bundled a room with every team. Validate it for compatibility,
-  // but importing a definition no longer creates that room implicitly.
-  if (value.version === LEGACY_TEAM_MANIFEST_VERSION) {
-    if (!isRecord(team.room)) throw new Error("team.room is required");
-    const responder = team.room.defaultResponder;
-    if (!isRecord(responder) || typeof responder.kind !== "string") {
-      throw new Error("team.room.defaultResponder is required");
+  if (parsed.data.version === LEGACY_TEAM_MANIFEST_VERSION) {
+    const defaultResponder = parsed.data.team.room.defaultResponder;
+    if (defaultResponder.kind === "member" && !seenKeys.has(defaultResponder.member)) {
+      throw new Error(`Unknown default responder: ${defaultResponder.member}`);
     }
-    let defaultResponder: TeamManifestResponder;
-    if (responder.kind === "everyone" || responder.kind === "mentions") {
-      defaultResponder = { kind: responder.kind };
-    } else if (responder.kind === "member") {
-      const member = requiredString(responder.member, "team.room.defaultResponder.member", 64);
-      if (!seenKeys.has(member)) throw new Error(`Unknown default responder: ${member}`);
-      defaultResponder = { kind: "member", member };
-    } else {
-      throw new Error(`Unknown default responder kind: ${responder.kind}`);
-    }
-    parsed.team.room = {
-      name: requiredString(team.room.name, "team.room.name", 100),
-      bulletin: optionalString(team.room.bulletin, "team.room.bulletin", 12_000) ?? "",
+    result.team.room = {
+      name: parsed.data.team.room.name,
+      bulletin: parsed.data.team.room.bulletin ?? "",
       defaultResponder,
     };
   }
 
-  return parsed;
+  return result;
 }
 
 function memberKey(name: string, index: number, used: Set<string>): string {
@@ -205,19 +214,18 @@ function memberKey(name: string, index: number, used: Set<string>): string {
 export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]): TeamManifestV2 {
   const byId = new Map(bots.map((bot) => [bot.id, bot]));
   const usedKeys = new Set<string>();
-  const members = team.memberIds.map((id, index) => {
+  const members = team.memberIds.map((id, index): TeamManifestMember => {
     const bot = byId.get(id);
     if (!bot) throw new Error(`Team member ${id} no longer exists`);
     const key = memberKey(bot.name, index, usedKeys);
+    const appearance: TeamManifestMember["appearance"] = { color: bot.color };
+    if (bot.mascotExpression) appearance.mascotExpression = bot.mascotExpression;
     return {
       key,
       name: bot.name,
       title: bot.title,
       description: bot.description,
-      appearance: {
-        color: bot.color,
-        ...(bot.mascotExpression ? { mascotExpression: bot.mascotExpression } : {}),
-      },
+      appearance,
     };
   });
 
@@ -231,5 +239,5 @@ export function createTeamManifest(team: ExportableTeam, bots: ExportableBot[]):
   };
   // Keep export and import in lockstep: a file produced here must satisfy
   // the exact same limits and normalization as an untrusted shared file.
-  return parseTeamManifest(manifest) as TeamManifestV2;
+  return parseTeamManifest(manifest);
 }

--- a/server/webhook-ingress.ts
+++ b/server/webhook-ingress.ts
@@ -1,8 +1,12 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { z } from "zod";
 
+import { parseJson, type JsonValue } from "./schema.ts";
 import type { WebhookManager } from "./webhooks.ts";
 
 export const MAX_WEBHOOK_BODY_BYTES = 256 * 1024;
+const statusErrorSchema = z.object({ status: z.number().int().optional() });
+const serverAddressSchema = z.object({ port: z.number().int().min(1).max(65_535) });
 
 export interface WebhookIngress {
   server: Server;
@@ -11,7 +15,7 @@ export interface WebhookIngress {
   baseUrl: string;
 }
 
-function json(res: ServerResponse, status: number, body: unknown): void {
+function json(res: ServerResponse, status: number, body: JsonValue): void {
   res.writeHead(status, {
     "content-type": "application/json",
     "cache-control": "no-store",
@@ -32,7 +36,7 @@ function readRawBody(req: IncomingMessage): Promise<string> {
     };
     req.on("data", (chunk) => {
       if (done) return;
-      bytes += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
+      bytes += Buffer.byteLength(chunk);
       if (bytes > MAX_WEBHOOK_BODY_BYTES) return fail(413, "Webhook body is too large");
       raw += chunk;
     });
@@ -45,11 +49,11 @@ function readRawBody(req: IncomingMessage): Promise<string> {
   });
 }
 
-function parsePayload(raw: string, contentType: string): unknown {
+function parsePayload(raw: string, contentType: string): JsonValue {
   if (!raw) return {};
   if (contentType.includes("application/json") || contentType.includes("+json")) {
     try {
-      return JSON.parse(raw);
+      return parseJson(raw);
     } catch {
       throw Object.assign(new Error("Invalid JSON webhook body"), { status: 400 });
     }
@@ -123,7 +127,8 @@ export function createWebhookIngressHandler(manager: WebhookManager) {
       });
       return json(res, 202, { accepted: true, ...result });
     } catch (error) {
-      const status = Number((error as { status?: number })?.status) || 500;
+      const parsedError = statusErrorSchema.safeParse(error);
+      const status = parsedError.success ? parsedError.data.status ?? 500 : 500;
       const message = error instanceof Error ? error.message : String(error);
       // Manager-level validation records its own rejection with the parsed
       // payload. Receiver-level failures happen earlier, so record metadata
@@ -154,12 +159,12 @@ export async function listenWebhookIngress(
       resolve();
     });
   });
-  const address = server.address();
-  if (!address || typeof address === "string") {
+  const address = serverAddressSchema.safeParse(server.address());
+  if (!address.success) {
     server.close();
     throw new Error("Webhook receiver did not get a TCP address");
   }
-  return { server, host, port: address.port, baseUrl: `http://${host}:${address.port}` };
+  return { server, host, port: address.data.port, baseUrl: `http://${host}:${address.data.port}` };
 }
 
 export function webhookCredential(baseUrl: string, endpointId: string, secret: string) {

--- a/server/webhooks.test.ts
+++ b/server/webhooks.test.ts
@@ -58,6 +58,22 @@ afterEach(() => {
 });
 
 describe("WebhookManager", () => {
+  it("rejects malformed management input before it reaches stored state", () => {
+    const h = harness();
+    expect(() => h.manager.create({ name: 42, prompt: "Review it", botId: "maus-1" })).toThrow("name");
+    const created = create(h.manager);
+    expect(() => h.manager.update(created.webhook.id, { enabled: "yes" })).toThrow("enabled");
+    expect(h.manager.list()).toHaveLength(1);
+  });
+
+  it("does not trust malformed webhook records loaded from disk", () => {
+    const h = harness();
+    writeFileSync(h.file, JSON.stringify({ version: 1, webhooks: [{ id: "unsafe" }], deliveries: [] }));
+    const reloaded = new WebhookManager(h.options);
+    expect(reloaded.list()).toEqual([]);
+    expect(reloaded.listAttempts()).toEqual([]);
+  });
+
   it("stores only a secret digest and exposes the secret once", () => {
     const h = harness();
     const created = create(h.manager);

--- a/server/webhooks.ts
+++ b/server/webhooks.ts
@@ -1,10 +1,12 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { z } from "zod";
 
 import { writeFileAtomic } from "./atomic.ts";
 import { DATA_DIR } from "./config.ts";
 import type { RoutineRunOn } from "./routines.ts";
+import { parseJson, schemaIssue, type JsonValue } from "./schema.ts";
 
 export interface WebhookTrigger {
   id: string;
@@ -36,6 +38,19 @@ export interface WebhookTriggerInput {
   verificationPending?: boolean;
   eventTypes?: string[];
 }
+
+type CleanWebhookInput = Omit<
+  WebhookTrigger,
+  | "id"
+  | "endpointId"
+  | "createdAt"
+  | "updatedAt"
+  | "lastReceivedAt"
+  | "lastRunId"
+  | "deliveryCount"
+  | "verifiedAt"
+  | "verificationSample"
+>;
 
 export interface WebhookVerificationSample {
   receivedAt: number;
@@ -76,8 +91,13 @@ interface WebhookFile {
   attempts?: WebhookAttempt[];
 }
 
+interface CreatedWebhook {
+  webhook: WebhookTrigger;
+  secret: string;
+}
+
 export interface WebhookEvent {
-  payload: unknown;
+  payload: JsonValue;
   contentType?: string;
   eventName?: string;
   userAgent?: string;
@@ -95,7 +115,7 @@ export interface WebhookReceiveResult {
 export interface WebhookManagerOptions {
   file?: string;
   now?: () => number;
-  emit?: (payload: Record<string, unknown>) => void;
+  emit?: (event: WebhookManagerEvent) => void;
   botState: (botId: string) => "ready" | "busy" | "missing";
   enqueue: (input: {
     webhookId: string;
@@ -110,6 +130,11 @@ export interface WebhookManagerOptions {
   pendingRuns?: (webhookId: string) => number;
 }
 
+export type WebhookManagerEvent =
+  | { kind: "webhook"; webhook: WebhookTrigger }
+  | { kind: "webhook.deleted"; webhookId: string }
+  | { kind: "webhook.attempt"; attempt: WebhookAttempt };
+
 const MAX_DELIVERIES = 2_000;
 const MAX_ATTEMPTS = 2_000;
 const MAX_EVENT_CHARS = 48_000;
@@ -117,8 +142,75 @@ const RATE_WINDOW_MS = 60_000;
 const RATE_LIMIT = 10;
 const MAX_PENDING_RUNS = 3;
 
+const runOnSchema = z.enum(["maus", "cloud"]);
+const eventTypesSchema = z.array(z.string()).max(20).optional();
+const triggerInputSchema = z.object({
+  name: z.string(),
+  prompt: z.string(),
+  botId: z.string(),
+  runOn: runOnSchema.optional(),
+  enabled: z.boolean().optional(),
+  verificationPending: z.boolean().optional(),
+  eventTypes: eventTypesSchema,
+});
+const triggerPatchSchema = triggerInputSchema.partial();
+const verificationSampleSchema = z.object({
+  receivedAt: z.number().finite().nonnegative(),
+  eventName: z.string().optional(),
+  contentType: z.string().optional(),
+  preview: z.string(),
+});
+const storedWebhookSchema = z.object({
+  id: z.string().min(1),
+  endpointId: z.string().min(1),
+  name: z.string(),
+  prompt: z.string(),
+  botId: z.string().min(1),
+  runOn: runOnSchema,
+  enabled: z.boolean(),
+  createdAt: z.number().finite().nonnegative(),
+  updatedAt: z.number().finite().nonnegative(),
+  lastReceivedAt: z.number().finite().nonnegative().optional(),
+  lastRunId: z.string().optional(),
+  deliveryCount: z.number().int().nonnegative(),
+  verificationPending: z.boolean().optional(),
+  verifiedAt: z.number().finite().nonnegative().optional(),
+  verificationSample: verificationSampleSchema.optional(),
+  eventTypes: eventTypesSchema,
+  secretHash: z.string().regex(/^[a-f0-9]{64}$/),
+});
+const deliveryReceiptSchema = z.object({
+  key: z.string().min(1),
+  runId: z.string().min(1),
+  at: z.number().finite().nonnegative(),
+});
+const webhookAttemptSchema = z.object({
+  id: z.string().min(1),
+  webhookId: z.string().min(1),
+  receivedAt: z.number().finite().nonnegative(),
+  outcome: z.enum(["accepted", "captured", "duplicate", "ignored", "rejected"]),
+  statusCode: z.number().int().min(100).max(599),
+  eventName: z.string().optional(),
+  preview: z.string().optional(),
+  deliveryId: z.string().optional(),
+  runId: z.string().optional(),
+  reason: z.string().optional(),
+});
+const webhookFileSchema = z.object({
+  version: z.literal(1),
+  webhooks: z.array(storedWebhookSchema),
+  deliveries: z.array(deliveryReceiptSchema),
+  attempts: z.array(webhookAttemptSchema).optional(),
+});
+const taskPayloadSchema = z.object({ task: z.string().optional(), message: z.string().optional() });
+const statusErrorSchema = z.object({ status: z.number().int().optional() });
+
 function fail(status: number, message: string): never {
   throw Object.assign(new Error(message), { status });
+}
+
+function invalidInput(error: z.ZodError): never {
+  fail(400, schemaIssue(error, "Invalid webhook settings"));
 }
 
 function hashSecret(secret: string): string {
@@ -140,34 +232,42 @@ function newSecret(): string {
   return `whsec_${randomBytes(32).toString("base64url")}`;
 }
 
-function cleanInput(input: WebhookTriggerInput): Omit<WebhookTrigger, "id" | "endpointId" | "createdAt" | "updatedAt" | "lastReceivedAt" | "lastRunId" | "deliveryCount" | "verifiedAt" | "verificationSample"> {
-  const name = String(input.name ?? "").trim().slice(0, 80);
-  const prompt = String(input.prompt ?? "").trim().slice(0, 20_000);
-  const botId = String(input.botId ?? "").trim();
+function cleanInput(input: WebhookTriggerInput): CleanWebhookInput {
+  const name = input.name.trim().slice(0, 80);
+  const prompt = input.prompt.trim().slice(0, 20_000);
+  const botId = input.botId.trim();
   const runOn = input.runOn ?? "maus";
   if (!name) fail(400, "Give the webhook a name");
   if (!botId) fail(400, "Choose a MAUS");
   if (runOn !== "maus" && runOn !== "cloud") fail(400, "Choose where this webhook runs");
   const eventTypes = Array.from(new Set(
-    (Array.isArray(input.eventTypes) ? input.eventTypes : [])
-      .map((value) => String(value).trim().slice(0, 200))
+    (input.eventTypes ?? [])
+      .map((value) => value.trim().slice(0, 200))
       .filter(Boolean),
   )).slice(0, 20);
   const enabled = input.enabled !== false;
-  return {
+  const clean: CleanWebhookInput = {
     name,
     prompt,
     botId,
     runOn,
     enabled,
     verificationPending: enabled ? false : input.verificationPending === true,
-    ...(eventTypes.length ? { eventTypes } : {}),
   };
+  if (eventTypes.length) clean.eventTypes = eventTypes;
+  return clean;
 }
 
-function withoutLegacyDuration(trigger: StoredWebhookTrigger & { durationMinutes?: unknown }): StoredWebhookTrigger {
-  const { durationMinutes: _durationMinutes, ...current } = trigger;
-  return current;
+function parseTriggerInput(value: JsonValue): WebhookTriggerInput {
+  const parsed = triggerInputSchema.safeParse(value);
+  if (!parsed.success) invalidInput(parsed.error);
+  return parsed.data;
+}
+
+function parseTriggerPatch(value: JsonValue): Partial<WebhookTriggerInput> {
+  const parsed = triggerPatchSchema.safeParse(value);
+  if (!parsed.success) invalidInput(parsed.error);
+  return parsed.data;
 }
 
 function publicTrigger(trigger: StoredWebhookTrigger): WebhookTrigger {
@@ -175,12 +275,13 @@ function publicTrigger(trigger: StoredWebhookTrigger): WebhookTrigger {
   return { ...safe };
 }
 
-function serializePayload(payload: unknown): string {
+function serializePayload(payload: JsonValue): string {
   let text: string;
-  if (typeof payload === "string") text = payload;
+  const plainText = z.string().safeParse(payload);
+  if (plainText.success) text = plainText.data;
   else {
     try {
-      text = JSON.stringify(payload, null, 2);
+      text = JSON.stringify(payload, null, 2) ?? String(payload);
     } catch {
       text = String(payload);
     }
@@ -189,14 +290,14 @@ function serializePayload(payload: unknown): string {
   return `${text.slice(0, MAX_EVENT_CHARS)}\n\n[Payload truncated by OpenMausBot]`;
 }
 
-function previewPayload(payload: unknown): string {
+function previewPayload(payload: JsonValue): string {
   return serializePayload(payload).replace(/\s+/g, " ").trim().slice(0, 2_000);
 }
 
-function taskFromPayload(payload: unknown): string {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return "";
-  const record = payload as Record<string, unknown>;
-  const task = typeof record.task === "string" ? record.task : typeof record.message === "string" ? record.message : "";
+function taskFromPayload(payload: JsonValue): string {
+  const parsed = taskPayloadSchema.safeParse(payload);
+  if (!parsed.success) return "";
+  const task = parsed.data.task ?? parsed.data.message ?? "";
   return task.trim().slice(0, 20_000);
 }
 
@@ -244,10 +345,11 @@ export class WebhookManager {
     this.file = options.file ?? join(DATA_DIR, "webhooks.json");
     this.now = options.now ?? Date.now;
     try {
-      const disk = JSON.parse(readFileSync(this.file, "utf8")) as Partial<WebhookFile>;
-      this.webhooks = Array.isArray(disk.webhooks) ? disk.webhooks.map(withoutLegacyDuration) : [];
-      this.deliveries = Array.isArray(disk.deliveries) ? disk.deliveries.slice(-MAX_DELIVERIES) : [];
-      this.attempts = Array.isArray(disk.attempts) ? disk.attempts.slice(-MAX_ATTEMPTS) : [];
+      const parsed = webhookFileSchema.safeParse(parseJson(readFileSync(this.file, "utf8")));
+      if (!parsed.success) throw parsed.error;
+      this.webhooks = parsed.data.webhooks;
+      this.deliveries = parsed.data.deliveries.slice(-MAX_DELIVERIES);
+      this.attempts = (parsed.data.attempts ?? []).slice(-MAX_ATTEMPTS);
     } catch {
       this.webhooks = [];
       this.deliveries = [];
@@ -263,8 +365,8 @@ export class WebhookManager {
     return this.attempts.map((attempt) => ({ ...attempt }));
   }
 
-  create(input: WebhookTriggerInput): { webhook: WebhookTrigger; secret: string } {
-    const clean = cleanInput(input);
+  create(input: JsonValue): CreatedWebhook {
+    const clean = cleanInput(parseTriggerInput(input));
     if (this.options.botState(clean.botId) === "missing") fail(400, "That MAUS no longer exists");
     const now = this.now();
     const secret = newSecret();
@@ -283,9 +385,10 @@ export class WebhookManager {
     return { webhook: publicTrigger(trigger), secret };
   }
 
-  update(id: string, patch: Partial<WebhookTriggerInput>): WebhookTrigger | null {
+  update(id: string, value: JsonValue): WebhookTrigger | null {
     const trigger = this.webhooks.find((candidate) => candidate.id === id);
     if (!trigger) return null;
+    const patch = parseTriggerPatch(value);
     const clean = cleanInput({
       name: patch.name ?? trigger.name,
       prompt: patch.prompt ?? trigger.prompt,
@@ -355,12 +458,14 @@ export class WebhookManager {
     try {
       return this.dispatch(trigger, event);
     } catch (error) {
-      this.recordRejectedForTrigger(trigger, Number((error as { status?: number })?.status) || 500, error instanceof Error ? error.message : String(error), event);
+      const parsedError = statusErrorSchema.safeParse(error);
+      const status = parsedError.success ? parsedError.data.status ?? 500 : 500;
+      this.recordRejectedForTrigger(trigger, status, error instanceof Error ? error.message : String(error), event);
       throw error;
     }
   }
 
-  test(id: string, payload: unknown = { event: "openmaus.test", message: "Test webhook delivery" }): WebhookReceiveResult | null {
+  test(id: string, payload: JsonValue = { event: "openmaus.test", message: "Test webhook delivery" }): WebhookReceiveResult | null {
     const trigger = this.webhooks.find((candidate) => candidate.id === id);
     if (!trigger) return null;
     const eventName = trigger.eventTypes?.[0] ?? "openmaus.test";
@@ -461,12 +566,13 @@ export class WebhookManager {
     trigger.verifiedAt = receivedAt;
     trigger.lastReceivedAt = receivedAt;
     trigger.updatedAt = receivedAt;
-    trigger.verificationSample = {
+    const sample: WebhookVerificationSample = {
       receivedAt,
-      ...(event.eventName ? { eventName: event.eventName.slice(0, 200) } : {}),
-      ...(event.contentType ? { contentType: event.contentType.slice(0, 200) } : {}),
       preview: previewPayload(event.payload),
     };
+    if (event.eventName) sample.eventName = event.eventName.slice(0, 200);
+    if (event.contentType) sample.contentType = event.contentType.slice(0, 200);
+    trigger.verificationSample = sample;
     this.appendAttempt(trigger, event, {
       outcome: "captured",
       statusCode: 202,
@@ -500,12 +606,12 @@ export class WebhookManager {
       receivedAt: this.now(),
       outcome: details.outcome,
       statusCode: details.statusCode,
-      ...(event.eventName ? { eventName: event.eventName.slice(0, 200) } : {}),
-      ...(event.payload !== undefined ? { preview: previewPayload(event.payload) } : {}),
-      ...(details.deliveryId ? { deliveryId: details.deliveryId.slice(0, 200) } : {}),
-      ...(details.runId ? { runId: details.runId } : {}),
-      ...(details.reason ? { reason: details.reason } : {}),
     };
+    if (event.eventName) attempt.eventName = event.eventName.slice(0, 200);
+    if (event.payload !== undefined) attempt.preview = previewPayload(event.payload);
+    if (details.deliveryId) attempt.deliveryId = details.deliveryId.slice(0, 200);
+    if (details.runId) attempt.runId = details.runId;
+    if (details.reason) attempt.reason = details.reason;
     this.attempts.push(attempt);
     if (this.attempts.length > MAX_ATTEMPTS) this.attempts.splice(0, this.attempts.length - MAX_ATTEMPTS);
     this.options.emit?.({ kind: "webhook.attempt", attempt: { ...attempt } });


### PR DESCRIPTION
## What changed

- Add Zod schemas for stored app config, config API patches, webhook management input, persisted webhook state, and portable team manifests.
- Add a small shared JSON/schema error helper so boundary failures report the field that failed.
- Replace hand-written runtime narrowing and unchecked assertions in the scoped boundaries.
- Add failure-path tests for malformed config, webhook records, webhook management input, duplicate team members, and invalid team appearance data.

## Why

These boundaries consume disk files, HTTP bodies, webhook payloads, and shared team files. They previously trusted broad values after ad-hoc `typeof` checks and assertions, which let malformed data travel deeper into the application before failing.

## Impact

Valid config, webhook, and team behavior is unchanged. Malformed management requests now return a field-specific 400 response, corrupt stored data is not loaded into live state, and unsupported fields in shared files remain ignored. This removes all anti-slop findings from the five scoped boundary modules and reduces the repository total from 635 errors to 553 without suppressing rules.

## Validation

- `pnpm typecheck`
- `pnpm test -- --reporter=dot` — 533 Vitest tests and 12 updater tests passed; 8 skipped
- `pnpm exec vitest run server/config.test.ts server/team-manifest.test.ts server/webhooks.test.ts server/webhook-ingress.test.ts server/index.test.ts --reporter=dot` — 71 passed after rebasing onto current `main`
- `pnpm build`
- `pnpm check:electron`
- `pnpm audit --prod` — no known vulnerabilities
- Scoped anti-slop audit — 0 errors, 0 warnings
- `git diff --check`
