### PR TITLE
Add a floating cursor above Automations to clear the team

### DIFF
--- a/src/components/ClearTeamSprite.tsx
+++ b/src/components/ClearTeamSprite.tsx
@@ -6,14 +6,16 @@ import { cn } from "@/lib/cn";
 import { useStore } from "@/state/store";
 import { MausAvatar } from "./Avatar";
 
-const ARM_MS = 320;
+const ARM_MS = 280;
 
 export function ClearTeamSprite() {
   const { state, dispatch } = useStore();
   const [asking, setAsking] = useState(false);
   const [hovered, setHovered] = useState(false);
+  const [pressing, setPressing] = useState(false);
   const rootRef = useRef<HTMLButtonElement>(null);
   const armedRef = useRef(false);
+  const pressTimer = useRef<number | null>(null);
 
   const bots = state.bots;
   useEffect(() => {
@@ -21,29 +23,42 @@ export function ClearTeamSprite() {
   }, [bots.length]);
 
   useEffect(() => {
-    if (!asking) {
+    if (!asking && !pressing) {
       armedRef.current = false;
       return;
     }
-    const arm = window.setTimeout(() => {
-      armedRef.current = true;
-    }, ARM_MS);
+    const arm = asking
+      ? window.setTimeout(() => {
+          armedRef.current = true;
+        }, ARM_MS)
+      : null;
+    const cancel = () => {
+      if (pressTimer.current) window.clearTimeout(pressTimer.current);
+      setPressing(false);
+      setAsking(false);
+    };
     const onKey = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.stopPropagation();
-      setAsking(false);
+      cancel();
     };
     const onDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setAsking(false);
+      if (!rootRef.current?.contains(event.target as Node)) cancel();
     };
     document.addEventListener("keydown", onKey, true);
     window.addEventListener("mousedown", onDown);
     return () => {
-      window.clearTimeout(arm);
+      if (arm) window.clearTimeout(arm);
       document.removeEventListener("keydown", onKey, true);
       window.removeEventListener("mousedown", onDown);
     };
-  }, [asking]);
+  }, [asking, pressing]);
+
+  useEffect(() => {
+    return () => {
+      if (pressTimer.current) window.clearTimeout(pressTimer.current);
+    };
+  }, []);
 
   if (bots.length === 0) return null;
 
@@ -66,28 +81,31 @@ export function ClearTeamSprite() {
         onMouseLeave={() => setHovered(false)}
         onClick={() => {
           if (!asking) {
-            setAsking(true);
+            setPressing(true);
+            if (pressTimer.current) window.clearTimeout(pressTimer.current);
+            pressTimer.current = window.setTimeout(() => {
+              setPressing(false);
+              setAsking(true);
+            }, 160);
             return;
           }
           if (armedRef.current) confirm();
         }}
-        className={cn(
-          "relative flex h-11 items-center justify-center overflow-visible rounded-xl",
-          asking ? "min-w-[9.5rem] px-2.5" : "w-11",
-        )}
+        className="relative flex h-11 w-[9.5rem] items-center justify-center overflow-visible rounded-xl"
       >
         <span
           className={cn(
-            "pointer-events-none absolute transition duration-300 ease-out",
-            asking ? "scale-50 opacity-0" : "animate-mascot-drift scale-100 opacity-100",
+            "pointer-events-none absolute transition-opacity duration-200 ease-in-out",
+            asking ? "opacity-0" : "opacity-100",
+            pressing && "animate-mascot-press",
           )}
         >
           <MausAvatar color="green" state={face} size={34} animated />
         </span>
         <span
           className={cn(
-            "text-[13px] font-medium tracking-tight text-ink transition duration-300 ease-out",
-            asking ? "scale-100 opacity-100" : "pointer-events-none scale-75 opacity-0",
+            "pointer-events-none whitespace-nowrap text-[13px] font-medium tracking-tight text-ink transition-opacity duration-200 ease-in-out",
+            asking ? "opacity-100" : "opacity-0",
           )}
         >
           delete all bots?

--- a/src/components/ClearTeamSprite.tsx
+++ b/src/components/ClearTeamSprite.tsx
@@ -1,0 +1,98 @@
+// A small brand cursor that hangs above Automations. Same face engine as
+// the bots. Clicking it turns the arrow into the question — no trash icon.
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/cn";
+import { useStore } from "@/state/store";
+import { MausAvatar } from "./Avatar";
+
+const ARM_MS = 320;
+
+export function ClearTeamSprite() {
+  const { state, dispatch } = useStore();
+  const [asking, setAsking] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const rootRef = useRef<HTMLButtonElement>(null);
+  const armedRef = useRef(false);
+
+  const bots = state.bots;
+  useEffect(() => {
+    if (bots.length === 0) setAsking(false);
+  }, [bots.length]);
+
+  useEffect(() => {
+    if (!asking) {
+      armedRef.current = false;
+      return;
+    }
+    const arm = window.setTimeout(() => {
+      armedRef.current = true;
+    }, ARM_MS);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+      setAsking(false);
+    };
+    const onDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setAsking(false);
+    };
+    document.addEventListener("keydown", onKey, true);
+    window.addEventListener("mousedown", onDown);
+    return () => {
+      window.clearTimeout(arm);
+      document.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("mousedown", onDown);
+    };
+  }, [asking]);
+
+  if (bots.length === 0) return null;
+
+  const face = asking ? "surprised" : hovered ? "curious" : "playful";
+
+  const confirm = () => {
+    const ids = bots.map((bot) => bot.id);
+    setAsking(false);
+    for (const botId of ids) dispatch({ type: "deleteBot", botId });
+  };
+
+  return (
+    <div className="flex justify-center pb-1 pt-0.5">
+      <button
+        ref={rootRef}
+        type="button"
+        aria-label={asking ? "Delete all bots?" : "Clear the team"}
+        aria-expanded={asking}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onClick={() => {
+          if (!asking) {
+            setAsking(true);
+            return;
+          }
+          if (armedRef.current) confirm();
+        }}
+        className={cn(
+          "relative flex h-11 items-center justify-center overflow-visible rounded-xl",
+          asking ? "min-w-[9.5rem] px-2.5" : "w-11",
+        )}
+      >
+        <span
+          className={cn(
+            "pointer-events-none absolute transition duration-300 ease-out",
+            asking ? "scale-50 opacity-0" : "animate-mascot-drift scale-100 opacity-100",
+          )}
+        >
+          <MausAvatar color="green" state={face} size={34} animated />
+        </span>
+        <span
+          className={cn(
+            "text-[13px] font-medium tracking-tight text-ink transition duration-300 ease-out",
+            asking ? "scale-100 opacity-100" : "pointer-events-none scale-75 opacity-0",
+          )}
+        >
+          delete all bots?
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,6 +47,7 @@ import { cn } from "@/lib/cn";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
+import { ClearTeamSprite } from "./ClearTeamSprite";
 import { RenameTitle } from "./RenameTitle";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
@@ -1108,6 +1109,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
 
       {/* Footer */}
       <div className="px-3 pb-3 pt-2">
+        <ClearTeamSprite />
         <button
           onClick={() => dispatch({ type: "showRoutines" })}
           className={cn(

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,7 +7,7 @@
   --animate-caret: caret-blink 1s step-end infinite;
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-shimmer: shimmer 2s linear infinite;
-  --animate-mascot-drift: mascot-drift 5.6s ease-in-out infinite;
+  --animate-mascot-press: mascot-press 0.28s ease-out;
 
   --color-app: #070707;
   --color-panel: #111111;
@@ -87,15 +87,14 @@ body {
   background-clip: text;
   color: transparent;
 }
-@keyframes mascot-drift {
-  0%, 100% { transform: translate3d(4px, 1px, 0) rotate(-8deg); }
-  25% { transform: translate3d(-6px, -8px, 0) rotate(5deg); }
-  50% { transform: translate3d(7px, -3px, 0) rotate(-3deg); }
-  75% { transform: translate3d(-3px, -7px, 0) rotate(7deg); }
+@keyframes mascot-press {
+  0% { transform: translate3d(0, 0, 0) scale(1); }
+  45% { transform: translate3d(0, 2px, 0) scale(0.94); }
+  100% { transform: translate3d(0, 0, 0) scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-caret, .animate-msg-in, .animate-shimmer, .animate-mascot-drift { animation: none; }
+  .animate-caret, .animate-msg-in, .animate-shimmer, .animate-mascot-press { animation: none; }
   .thinking-shimmer { background: none; color: var(--color-ink-secondary); }
   /* The drawer still moves, it just arrives instantly. */
   aside { transition: none; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,6 +7,7 @@
   --animate-caret: caret-blink 1s step-end infinite;
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-shimmer: shimmer 2s linear infinite;
+  --animate-mascot-drift: mascot-drift 5.6s ease-in-out infinite;
 
   --color-app: #070707;
   --color-panel: #111111;
@@ -86,8 +87,15 @@ body {
   background-clip: text;
   color: transparent;
 }
+@keyframes mascot-drift {
+  0%, 100% { transform: translate3d(4px, 1px, 0) rotate(-8deg); }
+  25% { transform: translate3d(-6px, -8px, 0) rotate(5deg); }
+  50% { transform: translate3d(7px, -3px, 0) rotate(-3deg); }
+  75% { transform: translate3d(-3px, -7px, 0) rotate(7deg); }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .animate-caret, .animate-msg-in, .animate-shimmer { animation: none; }
+  .animate-caret, .animate-msg-in, .animate-shimmer, .animate-mascot-drift { animation: none; }
   .thinking-shimmer { background: none; color: var(--color-ink-secondary); }
   /* The drawer still moves, it just arrives instantly. */
   aside { transition: none; }


### PR DESCRIPTION
## Why

Clearing every bot should not need a trash icon or a “delete bots” label in the sidebar.

## What

- A still brand cursor hangs above Automations.
- Click it: a short press, then it becomes **delete all bots?**
- Click again to confirm. Escape or a click outside fades the question back to the cursor without squashing the text.

## How to try

1. Have at least one bot.
2. Click the cursor above Automations.
3. Click away — the label should fade out in place.
4. Open it again and click the question to delete every bot.