### PR TITLE
Bundle the server's dependencies so the packaged app can start

### DIFF
--- a/.github/workflows/package-win.yml
+++ b/.github/workflows/package-win.yml
@@ -76,6 +76,32 @@ jobs:
           echo "--- app-update.yml ---"; cat "$res/app-update.yml" 2>/dev/null || true
           exit $fail
 
+      # index.js EXISTING is not the same as index.js RUNNING. 0.1.24 shipped a
+      # server that died instantly on ERR_MODULE_NOT_FOUND because tsc left a
+      # bare `zod` import in a tree that carries no node_modules — and the
+      # existence check above passed it. Start the real packaged copy here,
+      # where node_modules genuinely is not present.
+      - name: start the packaged server
+        shell: bash
+        run: |
+          res=release/win-unpacked/resources
+          HOME="$RUNNER_TEMP/omb-smoke" USERPROFILE="$RUNNER_TEMP/omb-smoke" \
+            OMB_PORT=21987 node "$res/server/index.js" > "$RUNNER_TEMP/server.log" 2>&1 &
+          pid=$!
+          for _ in $(seq 1 90); do
+            if curl -fsS --max-time 2 http://127.0.0.1:21987/api/health >/dev/null 2>&1; then
+              echo "packaged server answered /api/health ✓"
+              kill $pid 2>/dev/null || true
+              exit 0
+            fi
+            kill -0 $pid 2>/dev/null || break
+            sleep 1
+          done
+          echo "::error::the packaged server never served /api/health"
+          cat "$RUNNER_TEMP/server.log" || true
+          kill $pid 2>/dev/null || true
+          exit 1
+
       - uses: actions/upload-artifact@v4
         with:
           name: windows-installer

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "package:linux": "pnpm package:prepare && electron-builder --linux --x64 --publish never",
     "package:linux:dir": "pnpm package:prepare && electron-builder --linux dir --x64 --publish never",
     "package": "pnpm package:mac",
-    "test:packaged-server": "node scripts/smoke-packaged-server.mjs"
+    "test:packaged-server": "pnpm build:server && node scripts/smoke-packaged-server.mjs"
   },
   "dependencies": {
     "@trycua/cua-driver": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev:desktop": "electron .",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
-    "test": "vitest run && pnpm test:updater",
+    "test": "vitest run && pnpm test:updater && pnpm test:packaged-server",
     "test:updater": "node --test electron/updater-coordinator.node-test.mjs",
     "bench:observation": "node --experimental-strip-types scripts/bench-observation.ts",
     "test:watch": "vitest",
@@ -36,7 +36,7 @@
     "test:cua-container": "node scripts/smoke-cua-container.mjs",
     "check:electron": "node --check electron/main.mjs && node --check electron/terminal-launch.mjs && node --check electron/preload.cjs && node --check electron/capabilities.cjs && node --check electron/cua-connection.cjs && node --check electron/cua.mjs && node --check electron/speech.mjs",
     "preview": "vite preview",
-    "build:server": "tsc -p tsconfig.server.build.json",
+    "build:server": "tsc -p tsconfig.server.build.json && node scripts/bundle-server.mjs",
     "build:speech": "node electron/build-speech-helper.mjs",
     "build:cua": "node scripts/prepare-cua.mjs",
     "build:updater": "node scripts/bundle-updater.mjs",
@@ -45,7 +45,8 @@
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
     "package:linux": "pnpm package:prepare && electron-builder --linux --x64 --publish never",
     "package:linux:dir": "pnpm package:prepare && electron-builder --linux dir --x64 --publish never",
-    "package": "pnpm package:mac"
+    "package": "pnpm package:mac",
+    "test:packaged-server": "node scripts/smoke-packaged-server.mjs"
   },
   "dependencies": {
     "@trycua/cua-driver": "0.20.0",

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -1,0 +1,48 @@
+// Bundle each harness-server entry point into a self-contained ESM file.
+//
+// Why this exists: the packaged app ships ZERO node_modules (see the files:
+// exclusion in electron-builder.yml), so anything the server imports by bare
+// specifier has to be inlined — `tsc` only transpiles, it leaves
+// `import { z } from "zod"` verbatim and the packaged server dies at startup
+// with ERR_MODULE_NOT_FOUND. That shipped once, in 0.1.24.
+//
+// Bundling every entry point rather than only index.ts is deliberate: the
+// proxies are spawned as their own processes and today import nothing from
+// node_modules, but nothing stops the next one from doing so, and the failure
+// is invisible until a packaged build is actually launched.
+//
+// Entry points must keep their exact relative paths under dist-server — the
+// server locates each proxy by path (server/index.ts:108,
+// container-computer.ts:773, drivers/acp/core.ts:43), preferring the .ts in
+// dev and falling back to the sibling .js in the packaged tree. outbase keeps
+// drivers/ nested; import.meta.url still resolves to the same location, so
+// that lookup is unaffected.
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const server = join(root, "server");
+
+// Every file run as its own process. Keep in sync with the spawn sites above.
+const ENTRY_POINTS = [
+  "index.ts",
+  "computer-proxy.ts",
+  "container-mcp.ts",
+  "permission-proxy.ts",
+  "drivers/agents-proxy.ts",
+  "drivers/dweb-proxy.ts",
+];
+
+await build({
+  entryPoints: ENTRY_POINTS.map((entry) => join(server, entry)),
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "esm",
+  outbase: server,
+  outdir: join(root, "dist-server"),
+  // Written after tsc, replacing its output for these entry points.
+  allowOverwrite: true,
+  logLevel: "info",
+});

--- a/scripts/smoke-packaged-server.mjs
+++ b/scripts/smoke-packaged-server.mjs
@@ -1,0 +1,73 @@
+// Prove the built server actually STARTS with no node_modules in reach.
+//
+// 0.1.24 shipped a server that died on every launch with
+//   ERR_MODULE_NOT_FOUND: Cannot find package 'zod'
+// because `tsc` leaves bare imports verbatim and the packaged app carries no
+// node_modules. Every existing gate passed it: the unit suite runs in the repo
+// (where zod resolves), and the packaging check only asserts index.js EXISTS.
+//
+// So this copies dist-server OUT of the repo before running it. Inside the
+// repo a bare import still resolves by walking up to ./node_modules and the
+// test passes on a build that would be dead in the field — which is precisely
+// how the bug escaped. The copy is the whole point; do not "simplify" it away.
+import { spawn } from "node:child_process";
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const staging = mkdtempSync(join(tmpdir(), "omb-smoke-"));
+const home = mkdtempSync(join(tmpdir(), "omb-smoke-home-"));
+const port = 21000 + Math.floor(Math.random() * 9000);
+
+cpSync(join(root, "dist-server"), join(staging, "server"), { recursive: true });
+
+const child = spawn(process.execPath, [join(staging, "server", "index.js")], {
+  cwd: staging,
+  env: {
+    ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+    ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+    HOME: home,
+    USERPROFILE: home,
+    OMB_PORT: String(port),
+  },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let output = "";
+child.stdout.on("data", (chunk) => (output += chunk));
+child.stderr.on("data", (chunk) => (output += chunk));
+
+const cleanup = () => {
+  child.kill("SIGKILL");
+  rmSync(staging, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+};
+
+const deadline = Date.now() + 45_000;
+let listening = false;
+while (Date.now() < deadline) {
+  if (child.exitCode !== null) break;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`);
+    if (res.ok) {
+      listening = true;
+      break;
+    }
+  } catch {
+    /* not up yet */
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300));
+}
+
+cleanup();
+
+if (!listening) {
+  console.error(`the packaged server never served /api/health on port ${port}.`);
+  console.error(`exit code: ${child.exitCode}`);
+  console.error(output.trim() || "(no output)");
+  process.exit(1);
+}
+
+console.log(`packaged server started with no node_modules in reach (port ${port}) ✓`);

--- a/scripts/smoke-packaged-server.mjs
+++ b/scripts/smoke-packaged-server.mjs
@@ -39,10 +39,20 @@ let output = "";
 child.stdout.on("data", (chunk) => (output += chunk));
 child.stderr.on("data", (chunk) => (output += chunk));
 
+// Best-effort by design. Windows holds file handles open a little longer than
+// the process that owned them, so removing the scratch dir immediately after
+// the kill raises EPERM; Linux runners can raise EACCES the same way. Scratch
+// cleanup must never decide whether the build is good — it failed a green run
+// on Windows once already, and see f66d30f for the same lesson on Linux.
 const cleanup = () => {
   child.kill("SIGKILL");
-  rmSync(staging, { recursive: true, force: true });
-  rmSync(home, { recursive: true, force: true });
+  for (const dir of [staging, home]) {
+    try {
+      rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch {
+      /* the OS will reap it; the assertion below is what matters */
+    }
+  }
 };
 
 const deadline = Date.now() + 45_000;


### PR DESCRIPTION
## What happened

0.1.24 built, signed, notarized, stapled and installed cleanly — then died on every launch:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'
  imported from .../Resources/server/config.js
```

Caught by the launch check during the release; **0.1.24 was never published**.

## Why

The packaged app ships no `node_modules` by design — `electron-builder.yml:21` calls the three pieces self-contained and `:33` excludes them. `build:server` was plain `tsc`, which transpiles without bundling, so the `zod` import added in #194 survived verbatim into a tree with nothing to resolve it against.

`zod` was the **first bare import the server ever had**, so this invariant had never actually been exercised.

## The fix

Bundle every server entry point with esbuild after `tsc`, mirroring `scripts/bundle-updater.mjs`, which already vendors `electron-updater` for exactly this reason.

All six entry points are bundled rather than only `index.ts`: the proxies run as their own processes and import nothing external *today*, but the next one that does would fail the same silent way. Entry points keep their relative paths under `dist-server`, which the proxy lookups (`index.ts:108`, `container-computer.ts:773`, `drivers/acp/core.ts:43`) depend on.

## Why both existing gates missed it

- the unit suite runs **inside the repo**, where a bare import resolves by walking up to `./node_modules`
- the Windows packaging check asserts `server/index.js` **exists** — it never starts it

So the new smoke test copies `dist-server` **out of the repo** before running it, and CI now starts the real packaged copy on the runner where `node_modules` genuinely is not present.

## Verification

- `pnpm test` — 721 passed / 8 skipped across 78 files, plus updater (12) and the new smoke test
- `pnpm typecheck` clean
- **mutation-checked**: rebuilding with plain `tsc` (the 0.1.24 state) fails the smoke test with the original `ERR_MODULE_NOT_FOUND`, so the test genuinely detects this bug rather than merely passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged server reliability so it can start independently without repository dependencies.
  * Added health checks to detect startup failures and provide clearer diagnostics.

* **Tests**
  * Added automated smoke tests for packaged server builds on Windows and other supported environments.
  * Packaging tests now verify that the server responds successfully before completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->