### PR TITLE
Working folder: pin the default for cloud runs, clear via an empty field

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -993,6 +993,10 @@ async function startTurn(
       // the private bot workspace. A legacy task with an existing provider
       // session deliberately pins to null (the old home-folder behavior),
       // because moving a live session would break resume.
+      // A cloud run happens on the box, where a host folder means nothing:
+      // pin the task to the default so the header chip never shows the
+      // bot's folder for a task that runs elsewhere.
+      if (opts?.runOn === "cloud") store.pinTaskCwd(bot.id, threadId, undefined, { none: true });
       const pinnedCwd =
         privateWorkspace && opts?.runOn !== "cloud"
           ? store.pinTaskCwd(bot.id, threadId, privateWorkspace)

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -353,3 +353,18 @@ describe("Store task working folder", () => {
     expect(store.pinTaskCwd(bot.id, bot.threadId)).toBeNull();
   });
 });
+
+describe("Store task working folder — cloud runs", () => {
+  beforeEach(() => {
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+  it("a cloud run pins the default so the bot's host folder never shows for that task", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    store.patchBot(bot.id, { cwd: "/tmp/project-a" });
+    expect(store.pinTaskCwd(bot.id, bot.threadId, undefined, { none: true })).toBeNull();
+    expect(store.taskByThread(bot.id, bot.threadId)?.cwd).toBeNull();
+    // and it stays pinned even if a host run follows
+    expect(store.pinTaskCwd(bot.id, bot.threadId)).toBeNull();
+  });
+});

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -362,6 +362,7 @@ describe("Store task working folder — cloud runs", () => {
     const store = new Store(selection);
     const bot = store.createBot();
     store.patchBot(bot.id, { cwd: "/tmp/project-a" });
+    expect(store.pinTaskCwd(bot.id, bot.threadId)).toBe("/tmp/project-a");
     expect(store.pinTaskCwd(bot.id, bot.threadId, undefined, { none: true })).toBeNull();
     expect(store.taskByThread(bot.id, bot.threadId)?.cwd).toBeNull();
     // and it stays pinned even if a host run follows

--- a/server/store.ts
+++ b/server/store.ts
@@ -705,10 +705,15 @@ export class Store {
     const bot = this.bot(botId);
     const task = bot ? this.taskByThread(botId, threadId) : undefined;
     if (!bot || !task) return null;
+    if (opts.none) {
+      if (task.cwd !== null) {
+        task.cwd = null;
+        this.saveBots();
+      }
+      return null;
+    }
     if (task.cwd === undefined) {
-      // a cloud run has no host folder at all — pin the default so the UI
-      // never shows the bot's folder for a task that runs elsewhere
-      task.cwd = opts.none ? null : Object.keys(task.resumeCursors).length === 0 ? (bot.cwd ?? fallbackCwd ?? null) : null;
+      task.cwd = Object.keys(task.resumeCursors).length === 0 ? (bot.cwd ?? fallbackCwd ?? null) : null;
       this.saveBots();
     }
     return task.cwd;

--- a/server/store.ts
+++ b/server/store.ts
@@ -701,12 +701,14 @@ export class Store {
    * current folder — unless the task already has a session (a thread from
    * before folders existed), which pins to the default so the folder can't
    * move under it. Returns the pinned value: a path, or null for default. */
-  pinTaskCwd(botId: string, threadId: string, fallbackCwd?: string): string | null {
+  pinTaskCwd(botId: string, threadId: string, fallbackCwd?: string, opts: { none?: boolean } = {}): string | null {
     const bot = this.bot(botId);
     const task = bot ? this.taskByThread(botId, threadId) : undefined;
     if (!bot || !task) return null;
     if (task.cwd === undefined) {
-      task.cwd = Object.keys(task.resumeCursors).length === 0 ? (bot.cwd ?? fallbackCwd ?? null) : null;
+      // a cloud run has no host folder at all — pin the default so the UI
+      // never shows the bot's folder for a task that runs elsewhere
+      task.cwd = opts.none ? null : Object.keys(task.resumeCursors).length === 0 ? (bot.cwd ?? fallbackCwd ?? null) : null;
       this.saveBots();
     }
     return task.cwd;

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -88,7 +88,8 @@ function WorkingFolder({ bot }: { bot: Bot }) {
           className="mt-3 flex items-center gap-2"
           onSubmit={(e) => {
             e.preventDefault();
-            void save(draft ?? bot.cwd ?? "");
+            // an emptied field clears the folder — the server wants null
+            void save((draft ?? bot.cwd ?? "").trim() || null);
           }}
         >
           <input


### PR DESCRIPTION
## In plain language

Two small follow-ups from CodeRabbit's review of #183 (already merged):

1. **Cloud runs no longer show a host folder.** A routine that runs on the cloud box has no relationship to your Mac's folders, but the header chip could still show the bot's working folder for that task. Now a cloud task is pinned to "no folder" and the chip stays hidden.
2. **Clearing the folder by emptying the text field works.** In the non-desktop UI, deleting the path and saving sent `""`, which the server rejected. It now sends `null`, which is what "clear" means.

The third finding (the `~` shortening matching `/Users/annex` under `/Users/ann`) was already fixed on main in `src/lib/short-path.ts`.

## Test plan
- [x] `store.test.ts` (+1): a cloud run pins `null` and it stays pinned
- [x] `pnpm typecheck` clean; `pnpm vitest run` green (78 files, 722 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud tasks now run without exposing or inheriting a private host working folder.
  * Users can clear a task’s working folder by submitting an empty value in settings.

* **Bug Fixes**
  * Prevented later host runs from replacing a cloud task’s default working-folder setting.
  * Improved handling of whitespace and empty working-folder values.
  * Ensured cleared working-folder settings are consistently saved and applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->