### PR TITLE
Keep the chat tail still when a reply settles

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -31,6 +31,7 @@ import {
 import { EngineSetup } from "./EngineSetup";
 import { MausAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
+import { showWorkingDots } from "@/lib/turn-tail";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { OptionCard } from "./OptionCard";
 import { ApprovalCard } from "./ApprovalCard";
@@ -830,7 +831,7 @@ export function ChatView({ bot }: { bot: Bot }) {
           {streaming ? (
             <StreamingBubble text={streaming} />
           ) : (
-            bot.busy && (
+            showWorkingDots(bot.busy, streaming, messages.at(-1)) && (
               <div className="flex justify-start">
                 <div className="flex items-center gap-2.5 rounded-2xl bg-raised px-4 py-3">
                   <span className="flex items-center gap-1.5">

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -22,6 +22,7 @@ import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
+import { showWorkingDots } from "@/lib/turn-tail";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -367,7 +368,7 @@ export function GroupView({ group }: { group: Group }) {
             </div>
           )}
           <Transcript group={group} members={members} />
-          {speaker && !streaming && (
+          {speaker && showWorkingDots(true, streaming, group.messages.at(-1), speaker.id) && (
             <>
               <ClusterLabel bot={speaker} name={speaker.name} color={speaker.color} />
               <div className="flex justify-start">

--- a/src/lib/turn-tail.test.ts
+++ b/src/lib/turn-tail.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import type { Message } from "@/state/store";
+import { showWorkingDots } from "./turn-tail";
+
+const msg = (m: Partial<Message>): Message => ({ id: "m1", role: "bot", kind: "text", at: 1, ...m });
+
+describe("showWorkingDots", () => {
+  it("hides the dots when the bot is idle or a stream is rendering", () => {
+    expect(showWorkingDots(false, undefined, msg({ role: "user" }))).toBe(false);
+    expect(showWorkingDots(true, "partial reply…", msg({ role: "user" }))).toBe(false);
+  });
+
+  it("shows the dots while a turn runs with nothing settled yet", () => {
+    expect(showWorkingDots(true, undefined, undefined)).toBe(true);
+    expect(showWorkingDots(true, undefined, msg({ role: "user" }))).toBe(true);
+    expect(showWorkingDots(true, undefined, msg({ kind: "activity" }))).toBe(true);
+    expect(showWorkingDots(true, undefined, msg({ kind: "options" }))).toBe(true);
+  });
+
+  it("keeps the dots hidden after the reply settles, while busy winds down", () => {
+    // the end-of-stream window: reply landed, turn.completed + busy:false
+    // still in flight — re-showing the dots here is the jitter
+    expect(showWorkingDots(true, undefined, msg({}))).toBe(false);
+  });
+
+  it("rooms: a settled reply only covers the bot that said it", () => {
+    const fromA = msg({ from: { botId: "a", name: "A", color: "blue" } });
+    expect(showWorkingDots(true, undefined, fromA, "a")).toBe(false);
+    // the floor moved on — the next speaker's dots are real information
+    expect(showWorkingDots(true, undefined, fromA, "b")).toBe(true);
+    // no attribution (older data) — fail toward showing the indicator
+    expect(showWorkingDots(true, undefined, msg({}), "a")).toBe(true);
+  });
+});

--- a/src/lib/turn-tail.ts
+++ b/src/lib/turn-tail.ts
@@ -1,0 +1,28 @@
+import type { Message } from "@/state/store";
+
+/** Whether the transcript tail should show the "working" dots.
+ *
+ * A turn ends across three server frames: the settled reply (`message`),
+ * `turn.completed`, then the bot patch that flips `busy` off. Deriving the
+ * dots from `busy && !streaming` alone re-shows them in that window — the
+ * reply lands, the dots pop back under it for a beat, then vanish — and the
+ * pinned scroll re-anchors around each height change. That grow-shrink-jump
+ * is the end-of-stream jitter. A settled reply at the tail means there is
+ * nothing to wait for, so the dots stay hidden until something actually new
+ * starts: a tool chip, the user's next prompt, or (in rooms) a different
+ * speaker taking the floor.
+ */
+export function showWorkingDots(
+  busy: boolean | undefined,
+  streaming: string | undefined,
+  lastMessage: Message | undefined,
+  /** rooms: the bot currently speaking. A settled reply from a PREVIOUS
+   * speaker doesn't cover this one — its dots are real information. */
+  speakerBotId?: string,
+): boolean {
+  if (!busy || streaming) return false;
+  if (!lastMessage) return true;
+  const settledReply = lastMessage.role === "bot" && lastMessage.kind === "text";
+  if (!settledReply) return true;
+  return speakerBotId !== undefined && lastMessage.from?.botId !== speakerBotId;
+}


### PR DESCRIPTION
## In plain terms

When a streamed reply finishes, the whole chat visibly jitters — content jumps down and back up, like the section refreshed itself.

## Why it happened

A turn ends across **three separate server frames**, each its own React commit:

1. `message` — the settled reply lands (and the in-flight stream bubble clears)
2. `runtime` `turn.completed`
3. `bot` — `busy` flips off

The tail rendered its "working" dots from `busy && !streaming` alone. In the window between frames 1 and 3 that condition is true again, so the dots **popped back in under the reply that just landed**, then vanished a beat later. Every one of those height changes re-fired the pinned-scroll `scrollTo(scrollHeight)` after paint — the tail grew, shrank, and jumped within ~100ms. That oscillation is the jitter; rooms had the same flash via `speaker && !streaming`.

(For comparison, the upstream chat harness this app's streaming model follows explicitly keys its working-indicator teardown on turn lifecycle so it "must not flicker through that window" — this brings us to parity.)

## The fix

`showWorkingDots()` in `src/lib/turn-tail.ts`, used by both ChatView and GroupView: a settled bot text at the end of the transcript means there is nothing to wait for, so the dots stay hidden until something actually **new** starts — a tool chip (multi-part turns keep their feedback), the next user prompt, or in rooms a **different speaker** taking the floor. Rooms gate per speaker; a message with no `from` attribution fails toward showing the indicator.

No changes to streaming, scroll pinning, or the server fold — one render condition, extracted where it's testable.

## Test plan

- [x] `src/lib/turn-tail.test.ts` (4): idle/streaming hide; unsettled turn shows (no messages / user text / activity / options card); settled reply hides through the wind-down window; rooms per-speaker + missing-attribution branches
- [x] Mutation check: inverting the settled-reply branch fails 3 of 4 tests
- [x] `pnpm typecheck` clean; full `pnpm vitest run` green (725 passed); touched files clean under `oxlint`
- [ ] Reviewer eyeball: stream a long reply → at completion the reply should simply stop growing, with no dots flash and no scroll jump; in a room, when bot A finishes and bot B speaks next, B's dots still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working indicators in chat and group conversations.
  * Indicators now account for streaming responses, completed replies, active speakers, and the latest message.
  * Prevented indicators from appearing while content is streaming or briefly reappearing after a response finishes.
  * Improved attribution of working states when multiple speakers are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->