### PR TITLE
Integrate exact search landing with transcript windows

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -211,8 +211,15 @@ describe("harness HTTP API", () => {
     const hits = await api("GET", "/api/search?q=nice%20to%20meet");
     expect(hits.status).toBe(200);
     const hit = hits.body.hits.find((h: { botId?: string }) => h.botId === bot.id);
-    expect(hit).toMatchObject({ botId: bot.id, threadId: bot.threadId, name: bot.name });
+    expect(hit).toMatchObject({
+      botId: bot.id,
+      threadId: bot.threadId,
+      name: bot.name,
+      kind: "text",
+      onActivePath: true,
+    });
     expect(hit.snippet.toLowerCase()).toContain("nice to meet");
+    expect(hit.snippet.slice(hit.matchStart, hit.matchStart + hit.matchLength).toLowerCase()).toBe("nice to meet");
     expect((await api("GET", "/api/search?q=")).body.hits).toEqual([]);
 
     const markdown = await fetch(`${BASE}/api/threads/${bot.threadId}/export`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -2160,6 +2160,7 @@ const server = createServer(async (req, res) => {
         .map((hit) => {
           const bot = store.botByThread(hit.threadId);
           const group = bot ? undefined : store.groupByThread(hit.threadId);
+          if (!bot && !group) return null;
           const active = onActivePath(hit.threadId, hit.messageId);
           if (bot) {
             const task = store.taskByThread(bot.id, hit.threadId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -2148,15 +2148,24 @@ const server = createServer(async (req, res) => {
       const q = url.searchParams.get("q") ?? "";
       const rawLimit = url.searchParams.get("limit");
       const limit = rawLimit ? Math.min(Math.max(Number(rawLimit) || 0, 1), 100) : 40;
+      // whether each hit sits on its thread's visible branch — a click on
+      // one that does not has to switch versions first (and only then)
+      const activePaths = new Map<string, Set<string>>();
+      const onActivePath = (threadId: string, messageId: string) => {
+        let ids = activePaths.get(threadId);
+        if (!ids) activePaths.set(threadId, (ids = new Set(store.activePath(threadId).map((m) => m.id))));
+        return ids.has(messageId);
+      };
       const hits = searchMessages(q, limit)
         .map((hit) => {
           const bot = store.botByThread(hit.threadId);
           const group = bot ? undefined : store.groupByThread(hit.threadId);
+          const active = onActivePath(hit.threadId, hit.messageId);
           if (bot) {
             const task = store.taskByThread(bot.id, hit.threadId);
-            return { ...hit, botId: bot.id, name: bot.name, task: task?.title };
+            return { ...hit, botId: bot.id, name: bot.name, task: task?.title, onActivePath: active };
           }
-          if (group) return { ...hit, groupId: group.id, name: group.name };
+          if (group) return { ...hit, groupId: group.id, name: group.name, onActivePath: active };
           return null;
         })
         .filter((hit): hit is NonNullable<typeof hit> => hit !== null);

--- a/server/message-db.test.ts
+++ b/server/message-db.test.ts
@@ -119,6 +119,25 @@ describe("message-db", () => {
     expect(searchMessages("")).toEqual([]);
   });
 
+  it("search reports the match offset for highlighting, and finds activity chips by tool name", () => {
+    insertMessage("t7", msg("m1", "please\n\n   run   the migration now"));
+    insertMessage("t7", { ...msg("m2", ""), kind: "activity", role: "bot", tool: { name: "Bash: alembic upgrade head", ok: true } } as Message);
+    insertMessage("t7", { ...msg("m3", "we spoke about it"), from: { botId: "b2", name: "Scout", color: "green" } } as Message);
+
+    const text = searchMessages("the migration")[0];
+    expect(text.messageId).toBe("m1");
+    // whitespace folded in the snippet, offset points at the folded match
+    expect(text.snippet.slice(text.matchStart, text.matchStart + text.matchLength)).toBe("the migration");
+
+    // "which bot ran that migration" — the tool name is searchable
+    const chip = searchMessages("alembic")[0];
+    expect(chip).toMatchObject({ messageId: "m2", kind: "activity" });
+    expect(chip.snippet).toContain("alembic upgrade head");
+
+    // room attribution rides along
+    expect(searchMessages("spoke")[0].from).toBe("Scout");
+  });
+
   it("Store round-trips branching through the DB across a restart", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -229,7 +229,8 @@ export function searchMessages(query: string, limit = 40): SearchHit[] {
       kind: row.kind,
       snippet,
       matchStart: matchStart < 0 ? head.length : matchStart,
-      matchLength: folded.length,
+      // A defensive fallback must not mark arbitrary snippet text as the hit.
+      matchLength: matchStart < 0 ? 0 : folded.length,
       ...(row.from_name ? { from: row.from_name } : {}),
     };
   });

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -172,8 +172,14 @@ export interface SearchHit {
   messageId: string;
   at: number;
   role: string;
+  kind: string;
   /** the matched text, trimmed to a window around the first hit */
   snippet: string;
+  /** where the match sits inside `snippet`, for highlighting */
+  matchStart: number;
+  matchLength: number;
+  /** room messages: which member said it */
+  from?: string;
 }
 
 /** Case-insensitive substring search over text messages, newest first.
@@ -184,20 +190,48 @@ export function searchMessages(query: string, limit = 40): SearchHit[] {
   if (!needle) return [];
   // escape LIKE wildcards so a literal % or _ in the query stays literal
   const pattern = `%${needle.replace(/([\\%_])/g, "\\$1")}%`;
+  // text messages by their text; activity chips by the tool name — "which
+  // bot ran that migration" is a tool-name question. The chip's name lives
+  // in the row's json; a JSON1 extract keeps this one query.
   const rows = db()
     .prepare(
-      "SELECT thread_id, id, at, role, text FROM messages " +
-        "WHERE kind = 'text' AND text IS NOT NULL AND lower(text) LIKE ? ESCAPE '\\' " +
+      "SELECT thread_id, id, at, role, kind, text, json_extract(json, '$.tool.name') AS tool_name, json_extract(json, '$.from.name') AS from_name FROM messages " +
+        "WHERE (kind = 'text' AND text IS NOT NULL AND lower(text) LIKE ? ESCAPE '\\') " +
+        "   OR (kind = 'activity' AND tool_name IS NOT NULL AND lower(tool_name) LIKE ? ESCAPE '\\') " +
         "ORDER BY at DESC LIMIT ?",
     )
-    .all(pattern, limit) as Array<{ thread_id: string; id: string; at: number; role: string; text: string }>;
+    .all(pattern, pattern, limit) as Array<{
+    thread_id: string;
+    id: string;
+    at: number;
+    role: string;
+    kind: string;
+    text: string | null;
+    tool_name: string | null;
+    from_name: string | null;
+  }>;
   return rows.map((row) => {
-    const hitAt = row.text.toLowerCase().indexOf(needle);
+    const haystack = row.kind === "activity" ? (row.tool_name ?? "") : (row.text ?? "");
+    const hitAt = Math.max(0, haystack.toLowerCase().indexOf(needle));
     const start = Math.max(0, hitAt - 60);
-    const end = Math.min(row.text.length, hitAt + needle.length + 90);
-    const snippet =
-      (start > 0 ? "…" : "") + row.text.slice(start, end).replace(/\s+/g, " ").trim() + (end < row.text.length ? "…" : "");
-    return { threadId: row.thread_id, messageId: row.id, at: row.at, role: row.role, snippet };
+    const end = Math.min(haystack.length, hitAt + needle.length + 90);
+    const head = start > 0 ? "…" : "";
+    const body = haystack.slice(start, end).replace(/\s+/g, " ").trim();
+    const snippet = head + body + (end < haystack.length ? "…" : "");
+    // whitespace folding can shift the offset; find the match again inside
+    const folded = needle.replace(/\s+/g, " ");
+    const matchStart = snippet.toLowerCase().indexOf(folded);
+    return {
+      threadId: row.thread_id,
+      messageId: row.id,
+      at: row.at,
+      role: row.role,
+      kind: row.kind,
+      snippet,
+      matchStart: matchStart < 0 ? head.length : matchStart,
+      matchLength: folded.length,
+      ...(row.from_name ? { from: row.from_name } : {}),
+    };
   });
 }
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -706,7 +706,7 @@ export function ChatView({ bot }: { bot: Bot }) {
   const appliedFocus = useRef<number | null>(null);
   useEffect(() => {
     const focus = state.focusMessage;
-    if (!focus || focus.threadId !== bot.threadId || appliedFocus.current === focus.nonce) return;
+    if (!focus || focus.consumed || focus.threadId !== bot.threadId || appliedFocus.current === focus.nonce) return;
     const targetIndex = messages.findIndex((message) => message.id === focus.messageId);
     if (targetIndex < 0) return;
     appliedFocus.current = focus.nonce;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -43,9 +43,16 @@ import { ReactionBar, ReactionChips } from "./Reactions";
 import { SpeakButton } from "./SpeakButton";
 import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
+import { useFocusMessage } from "@/lib/focus-message";
 import { webhookMessageView } from "@/lib/webhook-message";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
-import { expandWindowStart, resolveTranscriptWindow, tailWindowStart } from "@/lib/transcript-window";
+import {
+  TRANSCRIPT_WINDOW_SIZE,
+  expandWindowStart,
+  focusWindowRange,
+  resolveTranscriptWindow,
+  tailWindowStart,
+} from "@/lib/transcript-window";
 
 /** Long user messages collapse behind a fade so pasted walls of text don't
  * bury the conversation; bots get full markdown. */
@@ -594,7 +601,7 @@ const MessagesList = memo(function MessagesList({
         })();
         if (!row) return null;
         return (
-          <div key={m.id} className="contents">
+          <div key={m.id} className="contents" data-mid={m.id}>
             {newDay && <DaySeparator at={m.at} />}
             {row}
           </div>
@@ -623,18 +630,28 @@ export function ChatView({ bot }: { bot: Bot }) {
   // never flashes into the new one. Everything derived below (lastBotTextId,
   // lastUserMessage, working dots) stays computed from the FULL list.
   const transcriptKey = `${bot.id}:${bot.threadId}`;
-  const [transcriptWindow, setTranscriptWindow] = useState(() => ({
+  const [transcriptWindow, setTranscriptWindow] = useState<{
+    key: string;
+    start: number;
+    end: number | null;
+  }>(() => ({
     key: transcriptKey,
     start: tailWindowStart(messages.length),
+    end: null,
   }));
   if (transcriptWindow.key !== transcriptKey) {
-    setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(messages.length) });
+    setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(messages.length), end: null });
   }
   const {
     visible: windowedMessages,
     hiddenCount,
+    laterCount,
     startIndex,
-  } = useMemo(() => resolveTranscriptWindow(messages, transcriptWindow.start), [messages, transcriptWindow.start]);
+    endIndex,
+  } = useMemo(
+    () => resolveTranscriptWindow(messages, transcriptWindow.start, TRANSCRIPT_WINDOW_SIZE, transcriptWindow.end),
+    [messages, transcriptWindow.start, transcriptWindow.end],
+  );
 
   const lastBotTextId = useMemo(
     () => [...messages].reverse().find((m) => m.role === "bot" && m.kind === "text")?.id,
@@ -682,6 +699,23 @@ export function ChatView({ bot }: { bot: Bot }) {
   }, []);
 
   useEffect(() => setBottomFollow(true), [bot.id, setBottomFollow]);
+
+  // A search result may be hundreds of rows before the mounted tail. Open a
+  // bounded window around it first; useFocusMessage then scrolls and flashes
+  // the row after React commits that window.
+  const appliedFocus = useRef<number | null>(null);
+  useEffect(() => {
+    const focus = state.focusMessage;
+    if (!focus || focus.threadId !== bot.threadId || appliedFocus.current === focus.nonce) return;
+    const targetIndex = messages.findIndex((message) => message.id === focus.messageId);
+    if (targetIndex < 0) return;
+    appliedFocus.current = focus.nonce;
+    const range = focusWindowRange(messages.length, targetIndex);
+    setBottomFollow(false);
+    setTranscriptWindow({ key: transcriptKey, start: range.start, end: range.end });
+  }, [bot.threadId, messages, setBottomFollow, state.focusMessage, transcriptKey]);
+  useFocusMessage(bot.threadId, messages.length > 0);
+
   // deps track the FULL messages.length, so expanding the window (which only
   // changes windowedMessages) can never re-trigger this bottom scrollTo
   useEffect(() => {
@@ -701,7 +735,7 @@ export function ChatView({ bot }: { bot: Bot }) {
     // event pin the viewport back to the bottom
     setBottomFollow(false);
     const start = expandWindowStart(startIndex);
-    setTranscriptWindow((w) => ({ key: w.key, start }));
+    setTranscriptWindow((w) => ({ ...w, start }));
   };
   useLayoutEffect(() => {
     const el = scrollRef.current;
@@ -712,6 +746,12 @@ export function ChatView({ bot }: { bot: Bot }) {
     // downward user scroll
     previousScrollTop.current = el.scrollTop;
   }, [transcriptWindow.start]);
+
+  const showLater = () => {
+    setBottomFollow(false);
+    const nextEnd = Math.min(messages.length, endIndex + TRANSCRIPT_WINDOW_SIZE);
+    setTranscriptWindow((w) => ({ ...w, end: nextEnd >= messages.length ? null : nextEnd }));
+  };
 
   // keyboard is a scroll gesture too (upstream lesson): PageUp/Home break
   // follow like an upward wheel; the at-end onScroll check re-arms it
@@ -731,7 +771,10 @@ export function ChatView({ bot }: { bot: Bot }) {
   };
   const jumpToLatest = () => {
     setBottomFollow(true);
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(messages.length), end: null });
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    });
   };
 
   // on Windows the frameless window's min/max/close overlay sits at the
@@ -874,6 +917,16 @@ export function ChatView({ bot }: { bot: Bot }) {
             onSubmitEdit={submitEdit}
             onRegenerate={regenerate}
           />
+          {laterCount > 0 && (
+            <div className="flex justify-center">
+              <button
+                onClick={showLater}
+                className="rounded-full border border-hairline/40 bg-panel px-3 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink"
+              >
+                Show later messages ({laterCount} more)
+              </button>
+            </div>
+          )}
           {provisioning && (
             <div className="flex justify-start">
               <div className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary">

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import { api, useStore, type Bot, type Group } from "@/state/store";
 import { rankByName } from "@/lib/palette-rank";
 import { cn } from "@/lib/cn";
 import type { SearchHit } from "@/lib/search-hit";
+import { landOnSearchHit } from "@/lib/focus-message";
 
 type PaletteEntry =
   | { kind: "bot"; bot: Bot }
@@ -90,29 +91,8 @@ export function CommandPalette() {
   const activate = async (entry: PaletteEntry) => {
     if (entry.kind === "message") {
       const hit = entry.hit;
-      const id = hit.botId ?? hit.groupId;
-      if (!id) return;
-      const targetBot = hit.botId ? state.bots.find((b) => b.id === hit.botId) : undefined;
-      const targetGroup = hit.groupId ? state.groups.find((g) => g.id === hit.groupId) : undefined;
-      if (!targetBot && !targetGroup) return;
       try {
-        dispatch({ type: "select", id });
-        // Wait for the exact task before focusing; the old optimistic action
-        // raced the focus request against loading its messages.
-        if (targetBot && targetBot.threadId !== hit.threadId) {
-          const result = await api(`/api/bots/${targetBot.id}/tasks/${hit.threadId}`, { method: "POST" });
-          if (result?.bot) dispatch({ type: "taskSwitched", bot: result.bot });
-        }
-        if (targetBot && !hit.onActivePath) {
-          const branch = await api(`/api/bots/${targetBot.id}/active-branch`, {
-            method: "POST",
-            body: JSON.stringify({ messageId: hit.messageId }),
-          });
-          if (branch?.activeLeafId) {
-            dispatch({ type: "threadActive", threadId: hit.threadId, activeLeafId: branch.activeLeafId });
-          }
-        }
-        dispatch({ type: "focusMessage", threadId: hit.threadId, messageId: hit.messageId });
+        await landOnSearchHit(hit, state, dispatch);
       } catch (error) {
         dispatch({ type: "error", message: error instanceof Error ? error.message : String(error) });
       }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -6,30 +6,18 @@ import { Bot as BotIcon, MessageSquare, Search, Users } from "lucide-react";
 import { api, useStore, type Bot, type Group } from "@/state/store";
 import { rankByName } from "@/lib/palette-rank";
 import { cn } from "@/lib/cn";
-
-/** One /api/search result: a text message somewhere in a transcript. */
-interface MessageHit {
-  threadId: string;
-  messageId: string;
-  at: number;
-  role: string;
-  snippet: string;
-  name: string;
-  botId?: string;
-  groupId?: string;
-  task?: string;
-}
+import type { SearchHit } from "@/lib/search-hit";
 
 type PaletteEntry =
   | { kind: "bot"; bot: Bot }
   | { kind: "room"; group: Group }
-  | { kind: "message"; hit: MessageHit };
+  | { kind: "message"; hit: SearchHit };
 
 export function CommandPalette() {
   const { state, dispatch } = useStore();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [messageHits, setMessageHits] = useState<MessageHit[]>([]);
+  const [messageHits, setMessageHits] = useState<SearchHit[]>([]);
   const [cursor, setCursor] = useState(0);
   const selectedRef = useRef<HTMLButtonElement>(null);
 
@@ -65,10 +53,13 @@ export function CommandPalette() {
       setMessageHits([]);
       return;
     }
+    // Results for the previous query must not remain clickable while the
+    // debounce and request for this query are pending.
+    setMessageHits([]);
     let alive = true;
     const timer = setTimeout(() => {
       api(`/api/search?q=${encodeURIComponent(q)}&limit=12`)
-        .then((result: { hits?: MessageHit[] }) => alive && setMessageHits(result.hits ?? []))
+        .then((result: { hits?: SearchHit[] }) => alive && setMessageHits(result.hits ?? []))
         .catch(() => alive && setMessageHits([]));
     }, 150);
     return () => {
@@ -96,17 +87,34 @@ export function CommandPalette() {
   // hits arriving or rows filtering away can strand the cursor past the end
   const selected = entries.length ? Math.min(cursor, entries.length - 1) : 0;
 
-  const activate = (entry: PaletteEntry) => {
+  const activate = async (entry: PaletteEntry) => {
     if (entry.kind === "message") {
       const hit = entry.hit;
       const id = hit.botId ?? hit.groupId;
       if (!id) return;
-      dispatch({ type: "select", id });
-      // a hit on a non-active task opens THAT task, not whichever one the
-      // bot happens to have in front (same rule as the sidebar search)
       const targetBot = hit.botId ? state.bots.find((b) => b.id === hit.botId) : undefined;
-      if (targetBot && targetBot.threadId !== hit.threadId) {
-        dispatch({ type: "switchTask", botId: targetBot.id, threadId: hit.threadId });
+      const targetGroup = hit.groupId ? state.groups.find((g) => g.id === hit.groupId) : undefined;
+      if (!targetBot && !targetGroup) return;
+      try {
+        dispatch({ type: "select", id });
+        // Wait for the exact task before focusing; the old optimistic action
+        // raced the focus request against loading its messages.
+        if (targetBot && targetBot.threadId !== hit.threadId) {
+          const result = await api(`/api/bots/${targetBot.id}/tasks/${hit.threadId}`, { method: "POST" });
+          if (result?.bot) dispatch({ type: "taskSwitched", bot: result.bot });
+        }
+        if (targetBot && !hit.onActivePath) {
+          const branch = await api(`/api/bots/${targetBot.id}/active-branch`, {
+            method: "POST",
+            body: JSON.stringify({ messageId: hit.messageId }),
+          });
+          if (branch?.activeLeafId) {
+            dispatch({ type: "threadActive", threadId: hit.threadId, activeLeafId: branch.activeLeafId });
+          }
+        }
+        dispatch({ type: "focusMessage", threadId: hit.threadId, messageId: hit.messageId });
+      } catch (error) {
+        dispatch({ type: "error", message: error instanceof Error ? error.message : String(error) });
       }
     } else {
       dispatch({ type: "select", id: entry.kind === "bot" ? entry.bot.id : entry.group.id });
@@ -129,7 +137,7 @@ export function CommandPalette() {
     } else if (e.key === "Enter") {
       e.preventDefault();
       const entry = entries[selected];
-      if (entry) activate(entry);
+      if (entry) void activate(entry);
     }
   };
 
@@ -195,7 +203,7 @@ export function CommandPalette() {
             row(
               `bot:${bot.id}`,
               i,
-              () => activate({ kind: "bot", bot }),
+              () => void activate({ kind: "bot", bot }),
               <>
                 <BotIcon size={16} className="shrink-0 text-ink-secondary" />
                 <span className="truncate text-[14px] text-ink">{bot.name}</span>
@@ -214,7 +222,7 @@ export function CommandPalette() {
             row(
               `room:${group.id}`,
               roomOffset + i,
-              () => activate({ kind: "room", group }),
+              () => void activate({ kind: "room", group }),
               <>
                 <Users size={16} className="shrink-0 text-ink-secondary" />
                 <span className="truncate text-[14px] text-ink">{group.name}</span>
@@ -227,22 +235,27 @@ export function CommandPalette() {
             </div>
           )}
           {q &&
-            messageHits.map((hit, i) =>
-              row(
+            messageHits.map((hit, i) => {
+              const before = hit.snippet.slice(0, hit.matchStart);
+              const match = hit.snippet.slice(hit.matchStart, hit.matchStart + hit.matchLength);
+              const after = hit.snippet.slice(hit.matchStart + hit.matchLength);
+              return row(
                 `msg:${hit.threadId}:${hit.messageId}`,
                 messageOffset + i,
-                () => activate({ kind: "message", hit }),
+                () => void activate({ kind: "message", hit }),
                 <>
                   <span className="flex items-center gap-2 truncate text-[13px] font-medium text-ink">
                     <MessageSquare size={13} className="shrink-0 text-ink-secondary" />
                     {hit.name}
                     {hit.task ? <span className="font-normal text-ink-secondary"> · {hit.task}</span> : null}
                   </span>
-                  <span className="line-clamp-2 text-[12.5px] text-ink-secondary">{hit.snippet}</span>
+                  <span className="line-clamp-2 text-[12.5px] text-ink-secondary">
+                    {before}<mark className="rounded-sm bg-accent/25 px-0.5 text-ink">{match}</mark>{after}
+                  </span>
                 </>,
                 true,
-              ),
-            )}
+              );
+            })}
         </div>
       </div>
     </div>

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -22,9 +22,16 @@ import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { cn } from "@/lib/cn";
+import { useFocusMessage } from "@/lib/focus-message";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 import { showWorkingDots } from "@/lib/turn-tail";
-import { expandWindowStart, resolveTranscriptWindow, tailWindowStart } from "@/lib/transcript-window";
+import {
+  TRANSCRIPT_WINDOW_SIZE,
+  expandWindowStart,
+  focusWindowRange,
+  resolveTranscriptWindow,
+  tailWindowStart,
+} from "@/lib/transcript-window";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -116,7 +123,7 @@ const Transcript = memo(function Transcript({
           ) : null;
         if (!row) return null;
         return (
-          <div key={m.id} className="contents">
+          <div key={m.id} className="contents" data-mid={m.id}>
             {newDay && (
               <div className="py-3 text-center text-[13px] text-ink-secondary">
                 {dayLabel(m.at)} {formatTime(m.at)}
@@ -216,20 +223,27 @@ export function GroupView({ group }: { group: Group }) {
   // the anchored boundary re-tails on a render-phase reset when the room (or
   // its thread) changes. Working dots below stay on the FULL list's tail.
   const transcriptKey = `${group.id}:${group.threadId}`;
-  const [transcriptWindow, setTranscriptWindow] = useState(() => ({
+  const [transcriptWindow, setTranscriptWindow] = useState<{
+    key: string;
+    start: number;
+    end: number | null;
+  }>(() => ({
     key: transcriptKey,
     start: tailWindowStart(group.messages.length),
+    end: null,
   }));
   if (transcriptWindow.key !== transcriptKey) {
-    setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(group.messages.length) });
+    setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(group.messages.length), end: null });
   }
   const {
     visible: windowedMessages,
     hiddenCount,
+    laterCount,
     startIndex,
+    endIndex,
   } = useMemo(
-    () => resolveTranscriptWindow(group.messages, transcriptWindow.start),
-    [group.messages, transcriptWindow.start],
+    () => resolveTranscriptWindow(group.messages, transcriptWindow.start, TRANSCRIPT_WINDOW_SIZE, transcriptWindow.end),
+    [group.messages, transcriptWindow.start, transcriptWindow.end],
   );
 
   const setBottomFollow = useCallback((next: boolean) => {
@@ -238,6 +252,20 @@ export function GroupView({ group }: { group: Group }) {
   }, []);
 
   useEffect(() => setBottomFollow(true), [group.id, setBottomFollow]);
+
+  const appliedFocus = useRef<number | null>(null);
+  useEffect(() => {
+    const focus = state.focusMessage;
+    if (!focus || focus.threadId !== group.threadId || appliedFocus.current === focus.nonce) return;
+    const targetIndex = group.messages.findIndex((message) => message.id === focus.messageId);
+    if (targetIndex < 0) return;
+    appliedFocus.current = focus.nonce;
+    const range = focusWindowRange(group.messages.length, targetIndex);
+    setBottomFollow(false);
+    setTranscriptWindow({ key: transcriptKey, start: range.start, end: range.end });
+  }, [group.messages, group.threadId, setBottomFollow, state.focusMessage, transcriptKey]);
+  useFocusMessage(group.threadId, group.messages.length > 0);
+
   useEffect(() => setBulletinDraft(group.bulletin), [group.id, group.bulletin]);
   // deps track the FULL messages.length, so expanding the window (which only
   // changes windowedMessages) can never re-trigger this bottom scrollTo
@@ -258,7 +286,7 @@ export function GroupView({ group }: { group: Group }) {
     // event pin the viewport back to the bottom
     setBottomFollow(false);
     const start = expandWindowStart(startIndex);
-    setTranscriptWindow((w) => ({ key: w.key, start }));
+    setTranscriptWindow((w) => ({ ...w, start }));
   };
   useLayoutEffect(() => {
     const el = scrollRef.current;
@@ -269,6 +297,12 @@ export function GroupView({ group }: { group: Group }) {
     // downward user scroll
     previousScrollTop.current = el.scrollTop;
   }, [transcriptWindow.start]);
+
+  const showLater = () => {
+    setBottomFollow(false);
+    const nextEnd = Math.min(group.messages.length, endIndex + TRANSCRIPT_WINDOW_SIZE);
+    setTranscriptWindow((w) => ({ ...w, end: nextEnd >= group.messages.length ? null : nextEnd }));
+  };
 
   const atEnd = () => {
     const el = scrollRef.current;
@@ -427,6 +461,16 @@ export function GroupView({ group }: { group: Group }) {
             </div>
           )}
           <Transcript group={group} members={members} messages={windowedMessages} />
+          {laterCount > 0 && (
+            <div className="flex justify-center">
+              <button
+                onClick={showLater}
+                className="rounded-full border border-hairline/40 bg-panel px-3 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink"
+              >
+                Show later messages ({laterCount} more)
+              </button>
+            </div>
+          )}
           {speaker && showWorkingDots(true, streaming, group.messages.at(-1), speaker.id) && (
             <>
               <ClusterLabel bot={speaker} name={speaker.name} color={speaker.color} />
@@ -452,7 +496,10 @@ export function GroupView({ group }: { group: Group }) {
         <button
           onClick={() => {
             setBottomFollow(true);
-            scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+            setTranscriptWindow({ key: transcriptKey, start: tailWindowStart(group.messages.length), end: null });
+            requestAnimationFrame(() => {
+              scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+            });
           }}
           aria-label="Jump to latest messages"
           className="animate-pop-in absolute bottom-24 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-hairline/40 bg-raised px-3 py-1.5 text-[12.5px] text-ink shadow-lg hover:bg-raised-hover"

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -256,7 +256,7 @@ export function GroupView({ group }: { group: Group }) {
   const appliedFocus = useRef<number | null>(null);
   useEffect(() => {
     const focus = state.focusMessage;
-    if (!focus || focus.threadId !== group.threadId || appliedFocus.current === focus.nonce) return;
+    if (!focus || focus.consumed || focus.threadId !== group.threadId || appliedFocus.current === focus.nonce) return;
     const targetIndex = group.messages.findIndex((message) => message.id === focus.messageId);
     if (targetIndex < 0) return;
     appliedFocus.current = focus.nonce;

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,124 @@
+// Message hits under the sidebar's search box. The box already filters bots
+// by name; from two characters on it also asks the server for messages
+// across every bot task and room, and a click lands on the message — right
+// bot, right task, right branch — rather than just opening the chat.
+import { useEffect, useState } from "react";
+import { GitBranch, Wrench } from "lucide-react";
+import { api, useStore, formatTime, type Bot } from "@/state/store";
+import { MausAvatar } from "./Avatar";
+import { cn } from "@/lib/cn";
+import type { SearchHit } from "@/lib/search-hit";
+
+export const MIN_QUERY = 2;
+const DEBOUNCE_MS = 250;
+
+export function SearchResults({ query, onLanded }: { query: string; onLanded: () => void }) {
+  const { state, dispatch } = useStore();
+  const [hits, setHits] = useState<SearchHit[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const q = query.trim();
+
+  useEffect(() => {
+    if (q.length < MIN_QUERY) {
+      setHits(null);
+      setError(null);
+      return;
+    }
+    // Do not leave the previous query's hits clickable while the debounced
+    // request for this query is still in flight.
+    setHits(null);
+    setError(null);
+    let alive = true;
+    const t = setTimeout(() => {
+      api(`/api/search?q=${encodeURIComponent(q)}&limit=40`)
+        .then((r: { hits: SearchHit[] }) => alive && (setHits(r.hits), setError(null)))
+        .catch((e: unknown) => alive && setError(e instanceof Error ? e.message : String(e)));
+    }, DEBOUNCE_MS);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [q]);
+
+  if (q.length < MIN_QUERY) return null;
+
+  const land = async (hit: SearchHit) => {
+    try {
+      const ownerId = hit.botId ?? hit.groupId;
+      if (!ownerId) throw new Error("That conversation is no longer available.");
+      dispatch({ type: "select", id: ownerId });
+      if (hit.botId) {
+        const bot = state.bots.find((b) => b.id === hit.botId);
+        if (bot && bot.threadId !== hit.threadId) {
+          // another task: switch first so the thread's messages are on screen
+          const r = await api(`/api/bots/${hit.botId}/tasks/${hit.threadId}`, { method: "POST" });
+          if (r?.bot) dispatch({ type: "taskSwitched", bot: r.bot as Bot });
+        }
+        // only when the hit is on an abandoned version — this rewinds the
+        // leaf and marks the provider session stale, so never do it idly
+        if (!hit.onActivePath) {
+          const branch = await api(`/api/bots/${hit.botId}/active-branch`, {
+            method: "POST",
+            body: JSON.stringify({ messageId: hit.messageId }),
+          });
+          // The store also broadcasts this over SSE, but apply the response
+          // now so rendering the target never depends on cross-stream timing.
+          if (branch?.activeLeafId) {
+            dispatch({ type: "threadActive", threadId: hit.threadId, activeLeafId: branch.activeLeafId });
+          }
+        }
+      }
+      dispatch({ type: "focusMessage", threadId: hit.threadId, messageId: hit.messageId });
+      onLanded();
+    } catch (e) {
+      dispatch({ type: "error", message: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  return (
+    <div className="mt-2 border-t border-hairline/40 pt-2">
+      <div className="px-3 pb-1 text-[11px] font-medium uppercase tracking-wide text-ink-secondary">
+        Messages{hits ? ` · ${hits.length}${hits.length === 40 ? "+" : ""}` : ""}
+      </div>
+      {error && <div className="px-3 py-2 text-[12.5px] text-danger">couldn't search: {error}</div>}
+      {hits && hits.length === 0 && !error && <div className="px-3 py-3 text-[13px] text-ink-secondary">No messages match “{q}”</div>}
+      {hits?.map((hit) => {
+        const bot = hit.botId ? state.bots.find((b) => b.id === hit.botId) : undefined;
+        const before = hit.snippet.slice(0, hit.matchStart);
+        const match = hit.snippet.slice(hit.matchStart, hit.matchStart + hit.matchLength);
+        const after = hit.snippet.slice(hit.matchStart + hit.matchLength);
+        return (
+          <button
+            key={`${hit.threadId}:${hit.messageId}`}
+            onClick={() => void land(hit)}
+            className="flex w-full items-start gap-2.5 rounded-lg px-3 py-2 text-left hover:bg-raised/60"
+          >
+            {bot ? (
+              <MausAvatar color={bot.color} state="idle" size={26} animated={false} />
+            ) : (
+              <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-raised text-[11px] text-ink-secondary">#</span>
+            )}
+            <span className="min-w-0 flex-1">
+              <span className="flex items-baseline gap-1.5 text-[12px] text-ink-secondary">
+                <span className="truncate font-medium text-ink">{hit.from ?? hit.name}</span>
+                {hit.task ? <span className="truncate">· {hit.task}</span> : null}
+                <span className="ml-auto shrink-0 tabular-nums">{formatTime(hit.at)}</span>
+              </span>
+              <span className={cn("mt-0.5 line-clamp-2 text-[12.5px] leading-snug", hit.role === "user" ? "text-ink" : "text-ink-secondary")}>
+                {hit.kind === "activity" && <Wrench size={11} className="mr-1 inline text-ink-secondary" />}
+                {before}
+                <mark className="rounded-sm bg-accent/25 px-0.5 text-ink">{match}</mark>
+                {after}
+              </span>
+              {!hit.onActivePath && (
+                <span className="mt-0.5 flex items-center gap-1 text-[11px] text-ink-secondary">
+                  <GitBranch size={10} /> other version
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -4,10 +4,11 @@
 // bot, right task, right branch — rather than just opening the chat.
 import { useEffect, useState } from "react";
 import { GitBranch, Wrench } from "lucide-react";
-import { api, useStore, formatTime, type Bot } from "@/state/store";
+import { api, useStore, formatTime } from "@/state/store";
 import { MausAvatar } from "./Avatar";
 import { cn } from "@/lib/cn";
 import type { SearchHit } from "@/lib/search-hit";
+import { landOnSearchHit } from "@/lib/focus-message";
 
 export const MIN_QUERY = 2;
 const DEBOUNCE_MS = 250;
@@ -44,31 +45,7 @@ export function SearchResults({ query, onLanded }: { query: string; onLanded: ()
 
   const land = async (hit: SearchHit) => {
     try {
-      const ownerId = hit.botId ?? hit.groupId;
-      if (!ownerId) throw new Error("That conversation is no longer available.");
-      dispatch({ type: "select", id: ownerId });
-      if (hit.botId) {
-        const bot = state.bots.find((b) => b.id === hit.botId);
-        if (bot && bot.threadId !== hit.threadId) {
-          // another task: switch first so the thread's messages are on screen
-          const r = await api(`/api/bots/${hit.botId}/tasks/${hit.threadId}`, { method: "POST" });
-          if (r?.bot) dispatch({ type: "taskSwitched", bot: r.bot as Bot });
-        }
-        // only when the hit is on an abandoned version — this rewinds the
-        // leaf and marks the provider session stale, so never do it idly
-        if (!hit.onActivePath) {
-          const branch = await api(`/api/bots/${hit.botId}/active-branch`, {
-            method: "POST",
-            body: JSON.stringify({ messageId: hit.messageId }),
-          });
-          // The store also broadcasts this over SSE, but apply the response
-          // now so rendering the target never depends on cross-stream timing.
-          if (branch?.activeLeafId) {
-            dispatch({ type: "threadActive", threadId: hit.threadId, activeLeafId: branch.activeLeafId });
-          }
-        }
-      }
-      dispatch({ type: "focusMessage", threadId: hit.threadId, messageId: hit.messageId });
+      await landOnSearchHit(hit, state, dispatch);
       onLanded();
     } catch (e) {
       dispatch({ type: "error", message: e instanceof Error ? e.message : String(e) });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
-import { SearchResults } from "./SearchResults";
+import { MIN_QUERY, SearchResults } from "./SearchResults";
 import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
 
@@ -1022,7 +1022,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       {/* Bot list */}
       <div className="flex-1 overflow-y-auto px-2">
         <div className="flex flex-col gap-0.5">
-          {!chiefBot && visibleBots.length === 0 && visibleGroups.length === 0 && q && q.length < 2 && (
+          {!chiefBot && visibleBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
           )}
           {chiefBot && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,24 +28,13 @@ import {
 } from "lucide-react";
 import { api, useStore, formatTime, visibleMessages, type Bot, type Group } from "@/state/store";
 
-/** One /api/search result: a text message somewhere in a transcript. */
-interface MessageHit {
-  threadId: string;
-  messageId: string;
-  at: number;
-  role: string;
-  snippet: string;
-  name: string;
-  botId?: string;
-  groupId?: string;
-  task?: string;
-}
 import { MausAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
+import { SearchResults } from "./SearchResults";
 import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
 
@@ -764,7 +753,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     restoreBot?: { id: string; name: string };
   } | null>(null);
   const [query, setQuery] = useState("");
-  const [messageHits, setMessageHits] = useState<MessageHit[]>([]);
 
   // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Bound only while the
   // drawer is open — on mobile, exactly when a bot/room context menu or the
@@ -887,24 +875,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   const q = query.trim().toLowerCase();
 
   // Message search rides the same box as the name filter: names match
-  // instantly from local state; transcript hits arrive from /api/search a
-  // debounce later. A stale response for an outdated query is dropped.
-  useEffect(() => {
-    if (!q) {
-      setMessageHits([]);
-      return;
-    }
-    let alive = true;
-    const timer = setTimeout(() => {
-      api(`/api/search?q=${encodeURIComponent(q)}&limit=12`)
-        .then((result: { hits?: MessageHit[] }) => alive && setMessageHits(result.hits ?? []))
-        .catch(() => alive && setMessageHits([]));
-    }, 250);
-    return () => {
-      alive = false;
-      clearTimeout(timer);
-    };
-  }, [q]);
+  // instantly from local state; transcript hits are the SearchResults
+  // section below the list (debounced, lands on the message).
 
   const matchingBots = state.bots
     .filter((b) => !b.hidden)
@@ -1041,7 +1013,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => e.key === "Escape" && setQuery("")}
             placeholder="Search"
-            aria-label="Search bots"
+            aria-label="Search bots and messages"
             className="w-full bg-transparent text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
           />
         </div>
@@ -1050,7 +1022,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       {/* Bot list */}
       <div className="flex-1 overflow-y-auto px-2">
         <div className="flex flex-col gap-0.5">
-          {!chiefBot && visibleBots.length === 0 && visibleGroups.length === 0 && messageHits.length === 0 && q && (
+          {!chiefBot && visibleBots.length === 0 && visibleGroups.length === 0 && q && q.length < 2 && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
           )}
           {chiefBot && (
@@ -1075,35 +1047,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
               archiveDisabled={activeBotCount <= 1}
             />
           ))}
-          {q && messageHits.length > 0 && (
-            <div className="mt-3">
-              <div className="px-3 pb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-                In conversations
-              </div>
-              {messageHits.map((hit) => (
-                <button
-                  key={`${hit.threadId}:${hit.messageId}`}
-                  onClick={() => {
-                    const targetBot = hit.botId ? state.bots.find((b) => b.id === hit.botId) : undefined;
-                    dispatch({ type: "select", id: hit.botId ?? hit.groupId ?? "" });
-                    // a hit on a non-active task opens THAT task, not
-                    // whichever one the bot happens to have in front
-                    if (targetBot && targetBot.threadId !== hit.threadId) {
-                      dispatch({ type: "switchTask", botId: targetBot.id, threadId: hit.threadId });
-                    }
-                    setQuery("");
-                  }}
-                  className="flex w-full flex-col gap-0.5 rounded-xl px-3 py-2 text-left hover:bg-raised/50"
-                >
-                  <span className="truncate text-[13px] font-medium text-ink">
-                    {hit.name}
-                    {hit.task ? <span className="font-normal text-ink-secondary"> · {hit.task}</span> : null}
-                  </span>
-                  <span className="line-clamp-2 text-[12.5px] text-ink-secondary">{hit.snippet}</span>
-                </button>
-              ))}
-            </div>
-          )}
+          <SearchResults query={query} onLanded={() => setQuery("")} />
         </div>
       </div>
 

--- a/src/lib/focus-message.ts
+++ b/src/lib/focus-message.ts
@@ -3,15 +3,44 @@
 // so the wrapper carries data-mid and its last child — the bubble/chip,
 // after any day separator — is what gets scrolled and highlighted.
 import { useEffect } from "react";
-import { useStore } from "@/state/store";
+import { api, useStore, type Action, type AppState } from "@/state/store";
+import type { SearchHit } from "@/lib/search-hit";
 
 const FLASH_CLASSES = ["ring-2", "ring-accent/70", "rounded-2xl", "transition-shadow"];
 
+/** Select and prepare the exact conversation represented by a search hit. */
+export async function landOnSearchHit(
+  hit: SearchHit,
+  state: Pick<AppState, "bots" | "groups">,
+  dispatch: React.Dispatch<Action>,
+): Promise<void> {
+  const ownerId = hit.botId ?? hit.groupId;
+  const bot = hit.botId ? state.bots.find((candidate) => candidate.id === hit.botId) : undefined;
+  const group = hit.groupId ? state.groups.find((candidate) => candidate.id === hit.groupId) : undefined;
+  if (!ownerId || (!bot && !group)) throw new Error("That conversation is no longer available.");
+
+  dispatch({ type: "select", id: ownerId });
+  if (bot && bot.threadId !== hit.threadId) {
+    const result = await api(`/api/bots/${bot.id}/tasks/${hit.threadId}`, { method: "POST" });
+    if (result?.bot) dispatch({ type: "taskSwitched", bot: result.bot });
+  }
+  if (bot && !hit.onActivePath) {
+    const branch = await api(`/api/bots/${bot.id}/active-branch`, {
+      method: "POST",
+      body: JSON.stringify({ messageId: hit.messageId }),
+    });
+    if (branch?.activeLeafId) {
+      dispatch({ type: "threadActive", threadId: hit.threadId, activeLeafId: branch.activeLeafId });
+    }
+  }
+  dispatch({ type: "focusMessage", threadId: hit.threadId, messageId: hit.messageId });
+}
+
 export function useFocusMessage(threadId: string, ready: boolean) {
-  const { state } = useStore();
+  const { state, dispatch } = useStore();
   const focus = state.focusMessage;
   useEffect(() => {
-    if (!focus || focus.threadId !== threadId || !ready) return;
+    if (!focus || focus.consumed || focus.threadId !== threadId || !ready) return;
     // messages may land a tick after the task switch; try briefly
     let tries = 0;
     let cancelled = false;
@@ -29,6 +58,10 @@ export function useFocusMessage(threadId: string, ready: boolean) {
       const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
       target.scrollIntoView({ block: "center", behavior: reducedMotion ? "auto" : "smooth" });
       target.classList.add(...FLASH_CLASSES);
+      // Consume only after the target is mounted and the flash has begun.
+      // `consumed` is intentionally not an effect dependency, so this active
+      // flash survives the bookkeeping update while future remounts ignore it.
+      dispatch({ type: "focusMessageConsumed", nonce: focus.nonce });
       flashTimer = setTimeout(() => target?.classList.remove(...FLASH_CLASSES), 1800);
     };
     attempt();
@@ -38,5 +71,5 @@ export function useFocusMessage(threadId: string, ready: boolean) {
       if (flashTimer) clearTimeout(flashTimer);
       target?.classList.remove(...FLASH_CLASSES);
     };
-  }, [focus?.nonce, focus?.threadId, focus?.messageId, threadId, ready]);
+  }, [dispatch, focus?.nonce, focus?.threadId, focus?.messageId, threadId, ready]);
 }

--- a/src/lib/focus-message.ts
+++ b/src/lib/focus-message.ts
@@ -1,0 +1,42 @@
+// Landing on a message: after a search hit, scroll the row into view and
+// flash it. Rows are wrapped in `display: contents` (no box of their own),
+// so the wrapper carries data-mid and its last child — the bubble/chip,
+// after any day separator — is what gets scrolled and highlighted.
+import { useEffect } from "react";
+import { useStore } from "@/state/store";
+
+const FLASH_CLASSES = ["ring-2", "ring-accent/70", "rounded-2xl", "transition-shadow"];
+
+export function useFocusMessage(threadId: string, ready: boolean) {
+  const { state } = useStore();
+  const focus = state.focusMessage;
+  useEffect(() => {
+    if (!focus || focus.threadId !== threadId || !ready) return;
+    // messages may land a tick after the task switch; try briefly
+    let tries = 0;
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let flashTimer: ReturnType<typeof setTimeout> | null = null;
+    let target: HTMLElement | null = null;
+    const attempt = () => {
+      if (cancelled) return;
+      const wrapper = document.querySelector<HTMLElement>(`[data-mid="${CSS.escape(focus.messageId)}"]`);
+      target = wrapper?.lastElementChild as HTMLElement | null;
+      if (!target) {
+        if (tries++ < 20) retryTimer = setTimeout(attempt, 100);
+        return;
+      }
+      const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+      target.scrollIntoView({ block: "center", behavior: reducedMotion ? "auto" : "smooth" });
+      target.classList.add(...FLASH_CLASSES);
+      flashTimer = setTimeout(() => target?.classList.remove(...FLASH_CLASSES), 1800);
+    };
+    attempt();
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (flashTimer) clearTimeout(flashTimer);
+      target?.classList.remove(...FLASH_CLASSES);
+    };
+  }, [focus?.nonce, focus?.threadId, focus?.messageId, threadId, ready]);
+}

--- a/src/lib/search-hit.ts
+++ b/src/lib/search-hit.ts
@@ -1,0 +1,17 @@
+/** One /api/search hit, resolved to the bot or room that owns it. */
+export interface SearchHit {
+  botId?: string;
+  groupId?: string;
+  name: string;
+  threadId: string;
+  task?: string;
+  messageId: string;
+  role: string;
+  kind: string;
+  from?: string;
+  at: number;
+  snippet: string;
+  matchStart: number;
+  matchLength: number;
+  onActivePath: boolean;
+}

--- a/src/lib/transcript-window.test.ts
+++ b/src/lib/transcript-window.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   TRANSCRIPT_WINDOW_SIZE,
   expandWindowStart,
+  focusWindowRange,
   resolveTranscriptWindow,
   tailWindowStart,
 } from "./transcript-window";
@@ -47,6 +48,7 @@ describe("resolveTranscriptWindow", () => {
     expect(result.visible).toHaveLength(10);
     expect(result.hiddenCount).toBe(0);
     expect(result.startIndex).toBe(0);
+    expect(result.laterCount).toBe(0);
   });
 
   it("windows a long thread to its tail", () => {
@@ -100,5 +102,35 @@ describe("resolveTranscriptWindow", () => {
     const result = resolveTranscriptWindow(thread(10), tailWindowStart(10, 4), 4);
     expect(result.visible).toHaveLength(4);
     expect(result.hiddenCount).toBe(6);
+  });
+
+  it("keeps a finite search-focus window instead of mounting through the tail", () => {
+    const result = resolveTranscriptWindow(thread(1_000), 440, TRANSCRIPT_WINDOW_SIZE, 560);
+    expect(result.visible).toHaveLength(TRANSCRIPT_WINDOW_SIZE);
+    expect(result.visible[0]).toBe(440);
+    expect(result.visible.at(-1)).toBe(559);
+    expect(result.hiddenCount).toBe(440);
+    expect(result.laterCount).toBe(440);
+    expect(result.endIndex).toBe(560);
+  });
+
+  it("falls back to the tail if a finite window becomes invalid after a rewind", () => {
+    const result = resolveTranscriptWindow(thread(100), 440, TRANSCRIPT_WINDOW_SIZE, 560);
+    expect(result.visible[0]).toBe(0);
+    expect(result.visible.at(-1)).toBe(99);
+    expect(result.laterCount).toBe(0);
+  });
+});
+
+describe("focusWindowRange", () => {
+  it.each([10, 500, 990])("contains target %i in a bounded window", (target) => {
+    const range = focusWindowRange(1_000, target);
+    expect(target).toBeGreaterThanOrEqual(range.start);
+    expect(target).toBeLessThan(range.end);
+    expect(range.end - range.start).toBeLessThanOrEqual(TRANSCRIPT_WINDOW_SIZE);
+  });
+
+  it("uses the full short transcript", () => {
+    expect(focusWindowRange(20, 10)).toEqual({ start: 0, end: 20 });
   });
 });

--- a/src/lib/transcript-window.ts
+++ b/src/lib/transcript-window.ts
@@ -8,9 +8,18 @@ export interface TranscriptWindow<T> {
   visible: T[];
   /** Messages hidden before the window — the pill's "(X more)" count. */
   hiddenCount: number;
+  /** Messages hidden after a finite search-focus window. */
+  laterCount: number;
   /** The boundary actually applied after clamping; expand steps from this,
    * not from the stored value, so a clamped window expands predictably. */
   startIndex: number;
+  /** Exclusive end boundary, or the current list length for a tail window. */
+  endIndex: number;
+}
+
+export interface TranscriptWindowRange {
+  start: number;
+  end: number;
 }
 
 /** Boundary for a fresh window: the last `size` messages. */
@@ -23,6 +32,20 @@ export function expandWindowStart(startIndex: number, size: number = TRANSCRIPT_
   return Math.max(0, startIndex - size);
 }
 
+/** A bounded window containing a search target. Keeping this finite avoids
+ * mounting an entire old transcript merely to land on one result. */
+export function focusWindowRange(
+  total: number,
+  targetIndex: number,
+  size: number = TRANSCRIPT_WINDOW_SIZE,
+): TranscriptWindowRange {
+  const safeTotal = Math.max(0, total);
+  const safeSize = Math.max(1, size);
+  const target = Math.max(0, Math.min(targetIndex, Math.max(0, safeTotal - 1)));
+  const start = Math.max(0, Math.min(target - Math.floor(safeSize / 2), Math.max(0, safeTotal - safeSize)));
+  return { start, end: Math.min(safeTotal, start + safeSize) };
+}
+
 /** Resolve a stored boundary against the current list. The boundary is
  * anchored — appends grow the window instead of sliding it, so rows the
  * reader is looking at never drop out from under them. Anchoring means a
@@ -33,8 +56,20 @@ export function resolveTranscriptWindow<T>(
   messages: readonly T[],
   startIndex: number,
   size: number = TRANSCRIPT_WINDOW_SIZE,
+  endIndex: number | null = null,
 ): TranscriptWindow<T> {
+  const requestedEnd = endIndex === null ? messages.length : Math.max(0, Math.min(messages.length, endIndex));
+  const invalidFiniteWindow = endIndex !== null && startIndex >= requestedEnd;
   const start =
-    startIndex >= messages.length ? tailWindowStart(messages.length, size) : Math.max(0, startIndex);
-  return { visible: messages.slice(start), hiddenCount: start, startIndex: start };
+    startIndex >= messages.length || invalidFiniteWindow
+      ? tailWindowStart(messages.length, size)
+      : Math.max(0, startIndex);
+  const end = invalidFiniteWindow ? messages.length : Math.max(start, requestedEnd);
+  return {
+    visible: messages.slice(start, end),
+    hiddenCount: start,
+    laterCount: messages.length - end,
+    startIndex: start,
+    endIndex: end,
+  };
 }

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -259,6 +259,9 @@ interface AppState {
   screens: Record<string, { png: string; mime: string }>;
   /** bots whose cloud computer is being provisioned */
   provisioning: Record<string, boolean>;
+  /** a search hit to scroll to once its thread is on screen; nonce lets the
+   * same message be focused twice in a row */
+  focusMessage: { threadId: string; messageId: string; nonce: number } | null;
   connected: boolean;
   error: string | null;
   mascotMotion: {
@@ -339,6 +342,7 @@ type Action =
   | { type: "toggleSettings"; open?: boolean }
   | { type: "togglePlugins"; open?: boolean }
   | { type: "toggleComputer"; open?: boolean }
+  | { type: "focusMessage"; threadId: string; messageId: string }
   | { type: "toggleAppSettings"; open?: boolean; section?: AppSettingsSection }
   | {
       type: "updateBot";
@@ -664,6 +668,15 @@ function reducer(state: AppState, action: Action): AppState {
     }
     case "togglePlugins":
       return { ...state, pluginsOpen: action.open ?? !state.pluginsOpen };
+    case "focusMessage":
+      return {
+        ...state,
+        focusMessage: {
+          threadId: action.threadId,
+          messageId: action.messageId,
+          nonce: (state.focusMessage?.nonce ?? 0) + 1,
+        },
+      };
     case "toggleComputer": {
       const open = action.open ?? !state.computerOpen;
       return {
@@ -795,6 +808,7 @@ const initialState: AppState = {
   appSettingsSection: "general",
   screens: {},
   provisioning: {},
+  focusMessage: null,
   connected: false,
   error: null,
   mascotMotion: null,

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -237,7 +237,7 @@ export type AppSettingsSection =
   | "voice"
   | "computer";
 
-interface AppState {
+export interface AppState {
   bots: Bot[];
   groups: Group[];
   instances: InstanceInfo[];
@@ -261,7 +261,7 @@ interface AppState {
   provisioning: Record<string, boolean>;
   /** a search hit to scroll to once its thread is on screen; nonce lets the
    * same message be focused twice in a row */
-  focusMessage: { threadId: string; messageId: string; nonce: number } | null;
+  focusMessage: { threadId: string; messageId: string; nonce: number; consumed: boolean } | null;
   connected: boolean;
   error: string | null;
   mascotMotion: {
@@ -271,7 +271,7 @@ interface AppState {
   } | null;
 }
 
-type Action =
+export type Action =
   | { type: "hydrate"; bots: Bot[]; groups: Group[] }
   | { type: "showRoutines" }
   | { type: "routinesHydrated"; routines: Routine[]; runs: RoutineRun[] }
@@ -343,6 +343,7 @@ type Action =
   | { type: "togglePlugins"; open?: boolean }
   | { type: "toggleComputer"; open?: boolean }
   | { type: "focusMessage"; threadId: string; messageId: string }
+  | { type: "focusMessageConsumed"; nonce: number }
   | { type: "toggleAppSettings"; open?: boolean; section?: AppSettingsSection }
   | {
       type: "updateBot";
@@ -675,8 +676,12 @@ function reducer(state: AppState, action: Action): AppState {
           threadId: action.threadId,
           messageId: action.messageId,
           nonce: (state.focusMessage?.nonce ?? 0) + 1,
+          consumed: false,
         },
       };
+    case "focusMessageConsumed":
+      if (!state.focusMessage || state.focusMessage.nonce !== action.nonce) return state;
+      return { ...state, focusMessage: { ...state.focusMessage, consumed: true } };
     case "toggleComputer": {
       const open = action.open ?? !state.computerOpen;
       return {


### PR DESCRIPTION
## What changed

- searches text messages and tool activity across every bot task and room
- makes sidebar and Cmd+K hits open the exact task, branch, and message
- highlights the matching text and briefly flashes the landed message
- opens a bounded transcript window around old hits, with earlier/later controls and a reliable jump back to latest

## Why

PR #186 had the useful search landing work, but main gained Cmd+K search and 120-row transcript windowing while it was under review. Retrying DOM focus could never find an old result outside the mounted window, and Cmd+K could race task loading. This integrates the feature with both newer systems without giving up transcript performance.

Supersedes #186.

## Validation

- 92 test files: 911 passed, 8 skipped
- updater coordinator tests: 12 passed
- packaged server smoke test passed without node_modules in reach
- production build passed
- Electron syntax checks passed

Repository-wide lint is currently red on pre-existing anti-slop findings across main; this change does not introduce the initializer assertion it initially flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message search across text and activity/tool names.
  * Search results highlight exact matches and show metadata, attribution, and active-branch status.
  * Selecting a result opens the relevant conversation, branch, task, and message.
  * Added focused-message navigation with automatic scrolling and temporary highlighting.
  * Added loading of earlier and later transcript messages around search results.

* **Bug Fixes**
  * Improved whitespace-normalized match highlighting and stale-result handling.
  * Added clearer error handling when a search result cannot be opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->