### PR TITLE
Queue messages to a busy bot and send them when it settles

### DIFF
--- a/server/branching.test.ts
+++ b/server/branching.test.ts
@@ -29,6 +29,8 @@ interface Msg {
   kind: string;
   text?: string;
   parentId?: string | null;
+  /** steer-queue: waiting to auto-send when the live turn settles */
+  queued?: boolean;
 }
 
 /** Client-side view of the active branch: walk parentId links from the leaf. */
@@ -182,9 +184,12 @@ posixOnly("conversation branching e2e (fake ACP fleet)", () => {
       expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first try" })).status).toBe(202);
       await waitFor(async () => (await getBot(created.id)).busy === true, "the hung turn to start");
 
-      // a second send while busy is refused — never a parallel turn
+      // a second send while busy queues (steer-queue) — never a parallel
+      // turn: the words land in the transcript, the live turn keeps running
       const parallel = await api("POST", `/api/bots/${created.id}/messages`, { text: "sneaky second" });
-      expect(parallel.status).toBe(409);
+      expect(parallel.status).toBe(202);
+      expect(parallel.body.queued).toBe(true);
+      expect((await getBot(created.id)).busy).toBe(true);
 
       // switching versions under a live turn is refused too
       const bot0 = await getBot(created.id);
@@ -198,9 +203,16 @@ posixOnly("conversation branching e2e (fake ACP fleet)", () => {
       expect(midTurn.status).toBe(409);
       expect((await getBot(created.id)).messages.filter((m: Msg) => m.text === "second try")).toHaveLength(0);
 
-      // stop the turn, then the same edit forks the conversation
+      // stop the turn; the queued "sneaky second" auto-runs on settle
+      // (stop-then-steer), so that drained turn must be stopped too before
+      // the thread is truly quiet enough to edit
       expect((await api("POST", `/api/bots/${created.id}/interrupt`)).status).toBe(200);
-      await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle", 20_000);
+      await waitFor(async () => {
+        const b = await getBot(created.id);
+        return b.busy === true && b.messages.some((m: Msg) => m.text === "sneaky second" && !m.queued);
+      }, "the queued message to drain into its own turn", 20_000);
+      expect((await api("POST", `/api/bots/${created.id}/interrupt`)).status).toBe(200);
+      await waitFor(async () => (await getBot(created.id)).busy === false, "the drained turn to settle", 20_000);
       expect((await api("POST", `/api/bots/${created.id}/messages/${first.id}/edit`, { text: "second try" })).status).toBe(202);
 
       await waitFor(async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
 import { _loadPending, discardDelegations, drainDelegations, pendingThreads, queueDelegation, type QueueResult } from "./delegations.ts";
+import { drainSteeredMessages, queueSteeredMessage } from "./steer-queue.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { cancelPeerApprovalsFor, dismissStalePeerCards, requestPeerApproval, resolvePeerComms, type ApprovalBus } from "./peer-approval.ts";
@@ -910,6 +911,40 @@ bus.subscribe((event: RuntimeEvent) => {
   drainDelegations(commsBus, approvalBus, event.threadId, runDelegatedTurn);
 });
 
+// ── steer-queue drain: messages sent while the bot was busy ────────────
+// Runs on ANY turn.completed rather than resolving the settling thread: a
+// bot busy in a room settles on the room's thread, and by the time this
+// subscriber runs the main fold has already dropped the speaker record —
+// so the drain matches on "this queue's bot is idle now" instead.
+// Registration order puts this after the main fold, so busy is already
+// false when it looks. Deliberately NOT gated on event.ok (unlike the
+// delegation drain above): queued delegations are a bot's fan-out and
+// dropping them on Stop is a safety property, but queued messages are the
+// user's own words — stop-then-steer is the point, so an interrupted turn
+// drains too.
+bus.subscribe((event: RuntimeEvent) => {
+  if (event.type !== "turn.completed") return;
+  drainQueuedSends();
+});
+
+function drainQueuedSends() {
+  drainSteeredMessages(store, (botId, threadId, prompt, userMessage) =>
+    // A plain attended turn — no automationSource, no unattended, no comms
+    // depth: exactly what typing the same words into an idle bot would run.
+    // The messages are already in the transcript; userMessage keeps
+    // startTurn from appending the joined prompt as a duplicate.
+    startTurn(botId, prompt, { threadId, userMessage }).catch((err) => {
+      store.appendMessage(threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: {
+          name: `error: queued message could not start — ${(err instanceof Error ? err.message : String(err)).slice(0, 120)}`,
+          ok: false,
+        },
+      });
+    }),
+  );
+}
 
 // ── live screen: poll the bot's box while it works ────────────────────
 // Frames stream to clients as SSE {kind:'screen'} (the "Bot's screen"
@@ -1335,6 +1370,9 @@ async function startTurn(
       });
       store.setActivity(bot.id, "idle");
       opts?.onDispatchError?.(message);
+      // a dispatch failure never emits turn.completed, so the settle-driven
+      // drain would strand anything queued behind this turn
+      drainQueuedSends();
     }
   })();
 }
@@ -1743,6 +1781,9 @@ async function reloadProviders() {
     });
     store.setActivity(b.id, "idle");
   }
+  // killed turns settle here without a turn.completed event, so anything
+  // queued behind them drains now — onto the freshly loaded fleet
+  drainQueuedSends();
 }
 
 // Config writes rebuild the whole provider registry. Keep the read-modify-write
@@ -2676,7 +2717,17 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const text = String(body.text ?? "").trim();
       if (!text) return json(res, 400, { error: "text required" });
-      await startTurn(m[1], text);
+      const bot = store.bot(m[1]);
+      if (!bot) return json(res, 404, { error: "no such bot" });
+      // A busy bot no longer refuses the message: it lands in the thread
+      // now (marked queued) and auto-sends when the turn settles — see the
+      // steer-queue drain above. Synchronous from the busy check to the
+      // queue insert, so a settle can't slip between them and strand it.
+      if (bot.busy) {
+        const message = queueSteeredMessage(store, bot, text);
+        return json(res, 202, { ok: true, queued: true, messageId: message.id });
+      }
+      await startTurn(bot.id, text);
       return json(res, 202, { ok: true });
     }
 

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -1,0 +1,354 @@
+// Queue-and-steer for busy 1:1 bots, at two levels:
+//
+// Unit: the steer-queue module against a fake store — queue bookkeeping,
+// the drain-once property, and the joined single-prompt shape.
+//
+// e2e: the real harness server with the grokAgent driver on the fake ACP
+// CLI in echo-gated mode, whose turns stay open until a gate file exists —
+// a deterministic busy window. The echo reply carries the FULL prompt
+// (system + turn text), which pins both what a drained turn was sent (the
+// queued texts joined with newlines, in ONE turn) and what it was not (the
+// webhook untrusted-data paragraph an attended turn must never get).
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { drainSteeredMessages, queueSteeredMessage, _queuedCount, type SteerStore } from "./steer-queue.ts";
+import type { BotRecord, Message } from "./store.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// ── unit: the queue module against a fake store ────────────────────────
+function fakeBot(id: string, threadId: string, busy: boolean): BotRecord {
+  return {
+    id,
+    threadId,
+    name: id,
+    title: "",
+    description: "",
+    notifications: false,
+    color: "green",
+    unread: false,
+    modelSelection: { instanceId: "fake", model: "fake-model" },
+    resumeCursors: {},
+    busy,
+    createdAt: 0,
+  };
+}
+
+function fakeStore(bots: BotRecord[]): SteerStore & { messages: Message[] } {
+  const messages: Message[] = [];
+  let nextId = 0;
+  return {
+    messages,
+    bot: (id) => bots.find((b) => b.id === id) ?? null,
+    appendMessage: (threadId, message) => {
+      const full: Message = { id: `m${(nextId += 1)}-${threadId}`, at: Date.now(), ...message };
+      messages.push(full);
+      return full;
+    },
+    patchMessage: (_threadId, messageId, patch) => {
+      const at = messages.findIndex((m) => m.id === messageId);
+      if (at === -1) return null;
+      messages[at] = { ...messages[at], ...patch };
+      return messages[at];
+    },
+  };
+}
+
+describe("steer-queue module", () => {
+  it("appends a queued user message to the thread immediately", () => {
+    const bot = fakeBot("bot-a", "thread-a", true);
+    const store = fakeStore([bot]);
+    const message = queueSteeredMessage(store, bot, "hold that thought");
+    expect(message).toMatchObject({ role: "user", kind: "text", text: "hold that thought", queued: true });
+    expect(store.messages).toHaveLength(1);
+    expect(_queuedCount("thread-a")).toBe(1);
+    // consume it so module state never leaks into another test
+    drainSteeredMessages(fakeStore([fakeBot("bot-a", "thread-a", false)]), () => {});
+  });
+
+  it("holds the queue while the bot is busy and drains it once when idle", () => {
+    const bot = fakeBot("bot-b", "thread-b", true);
+    const store = fakeStore([bot]);
+    queueSteeredMessage(store, bot, "first note");
+    queueSteeredMessage(store, bot, "second note");
+    const run = vi.fn();
+
+    drainSteeredMessages(store, run);
+    expect(run).not.toHaveBeenCalled();
+    expect(_queuedCount("thread-b")).toBe(2);
+
+    bot.busy = false;
+    drainSteeredMessages(store, run);
+    expect(run).toHaveBeenCalledTimes(1);
+    const [botId, threadId, prompt, userMessage] = run.mock.calls[0];
+    expect(botId).toBe("bot-b");
+    expect(threadId).toBe("thread-b");
+    // ONE turn for the whole burst: the texts joined with newlines
+    expect(prompt).toBe("first note\nsecond note");
+    // the last queued message, so the caller appends nothing new
+    expect(userMessage.text).toBe("second note");
+    // the affordance is cleared the moment the queue is consumed
+    expect(store.messages.every((m) => !m.queued)).toBe(true);
+    expect(_queuedCount("thread-b")).toBe(0);
+
+    // drain-once: a second settle finds nothing and fires nothing
+    drainSteeredMessages(store, run);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires nothing when nothing is queued", () => {
+    const run = vi.fn();
+    drainSteeredMessages(fakeStore([fakeBot("bot-c", "thread-c", false)]), run);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("drops the queue of a deleted bot without running it", () => {
+    const bot = fakeBot("bot-d", "thread-d", true);
+    const store = fakeStore([bot]);
+    queueSteeredMessage(store, bot, "orphaned");
+    const run = vi.fn();
+    drainSteeredMessages(fakeStore([]), run);
+    expect(run).not.toHaveBeenCalled();
+    expect(_queuedCount("thread-d")).toBe(0);
+  });
+
+  it("skips the run when the queued messages vanished from the store", () => {
+    const bot = fakeBot("bot-e", "thread-e", true);
+    const store = fakeStore([bot]);
+    queueSteeredMessage(store, bot, "gone soon");
+    store.messages.length = 0; // the thread was deleted under the queue
+    bot.busy = false;
+    const run = vi.fn();
+    drainSteeredMessages(store, run);
+    expect(run).not.toHaveBeenCalled();
+    expect(_queuedCount("thread-e")).toBe(0);
+  });
+});
+
+// ── e2e: the real server on the gated fake ACP fleet ───────────────────
+describe("steer-queue e2e (fake ACP fleet)", () => {
+  let child: ChildProcess;
+  let home: string;
+  let stderr = "";
+  let drainGate: string;
+  let stopGate: string;
+  let stopRpcDump: string;
+
+  /** the flat command payloads these tests POST/PATCH */
+  type ApiBody = Record<string, string | boolean | { instanceId: string; model: string }>;
+
+  const api = async (method: string, path: string, body?: ApiBody): Promise<{ status: number; body: any }> => {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json() };
+  };
+
+  const botById = async (id: string) =>
+    (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === id);
+
+  const echoes = (bot: any): any[] =>
+    bot.messages.filter((m: any) => m.role === "bot" && m.kind === "text" && m.text?.startsWith("echo: "));
+
+  const until = async (probe: () => Promise<boolean>, what: string, timeoutMs = 30_000) => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (await probe()) return;
+      if (Date.now() > deadline) throw new Error(`${what} never happened. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  };
+
+  const newBot = async (instanceId: string, name: string) => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${bot.id}`, { name, modelSelection: { instanceId, model: "fake-model" } });
+    return bot;
+  };
+
+  beforeAll(async () => {
+    chmodSync(FAKE_CLI, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-steer-test-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    mkdirSync(join(home, "gates"), { recursive: true });
+    drainGate = join(home, "gates", "drain.gate");
+    stopGate = join(home, "gates", "stop.gate");
+    stopRpcDump = join(home, "gates", "stop.rpc");
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          steer: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "echo-gated", FAKE_ACP_GATE_FILE: drainGate },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
+          // the RPC dump lets the interrupt test wait for session/prompt to
+          // be in flight — interrupting earlier would be a no-op on a turn
+          // the driver has not registered yet
+          steerStop: {
+            driver: "grokAgent",
+            environment: {
+              FAKE_ACP_MODE: "echo-gated",
+              FAKE_ACP_GATE_FILE: stopGate,
+              FAKE_ACP_RPC_DUMP: stopRpcDump,
+            },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
+        },
+      }),
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(PORT),
+    };
+    if (process.env.PATH) env.PATH = process.env.PATH;
+    // Without SystemRoot, winsock fails to initialize in the child.
+    if (process.env.SystemRoot) env.SystemRoot = process.env.SystemRoot;
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        const res = await fetch(`${BASE}/api/health`);
+        if (res.ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it(
+    "queues sends while busy and drains them into exactly one attended turn",
+    async () => {
+      const bot = await newBot("steer", "Steerable");
+
+      // the first send starts a turn that stays open until the gate exists
+      const first = await api("POST", `/api/bots/${bot.id}/messages`, { text: "first task please" });
+      expect(first.status).toBe(202);
+      expect(first.body.queued).toBeUndefined();
+      expect((await botById(bot.id)).busy).toBe(true);
+
+      // sends while busy land in the transcript at once, marked queued
+      const second = await api("POST", `/api/bots/${bot.id}/messages`, { text: "steer two" });
+      expect(second.status).toBe(202);
+      expect(second.body).toMatchObject({ ok: true, queued: true });
+      const third = await api("POST", `/api/bots/${bot.id}/messages`, { text: "steer three" });
+      expect(third.body.queued).toBe(true);
+
+      let snapshot = await botById(bot.id);
+      expect(snapshot.busy).toBe(true);
+      const queuedTexts = snapshot.messages
+        .filter((m: any) => m.role === "user" && m.queued)
+        .map((m: any) => m.text);
+      expect(queuedTexts).toEqual(["steer two", "steer three"]);
+      expect(echoes(snapshot)).toHaveLength(0); // nothing has answered yet
+
+      // open the gate: turn 1 settles, and the queue drains into ONE turn
+      writeFileSync(drainGate, "open");
+      await until(async () => {
+        snapshot = await botById(bot.id);
+        return !snapshot.busy && echoes(snapshot).length >= 2;
+      }, "the queued turn");
+
+      const replies = echoes(snapshot);
+      // exactly one drained turn for two queued messages — not one each
+      expect(replies).toHaveLength(2);
+      expect(replies[0].text).toContain("first task please");
+      // the drained prompt is the queued texts joined with newlines
+      expect(replies[1].text).toContain("steer two\nsteer three");
+      // ...and it is an ordinary attended turn: no webhook untrusted-data
+      // framing, no rewind replay wrapper
+      expect(replies[1].text).not.toContain("authenticated external webhook");
+      expect(replies[1].text).not.toContain("[The user rewound");
+      // consumed: the queued affordance is gone from both messages
+      expect(snapshot.messages.some((m: any) => m.queued)).toBe(false);
+
+      // an idle send with an empty queue runs one normal turn — the drain
+      // adds nothing behind it
+      const followUp = await api("POST", `/api/bots/${bot.id}/messages`, { text: "plain follow-up" });
+      expect(followUp.body.queued).toBeUndefined();
+      await until(async () => {
+        snapshot = await botById(bot.id);
+        return !snapshot.busy && echoes(snapshot).length >= 3;
+      }, "the follow-up turn");
+      expect(echoes(snapshot)).toHaveLength(3);
+    },
+    60_000,
+  );
+
+  it(
+    "drains the queue after an interrupt — stop-then-steer",
+    async () => {
+      const bot = await newBot("steerStop", "Stoppable");
+
+      const first = await api("POST", `/api/bots/${bot.id}/messages`, { text: "long job" });
+      expect(first.status).toBe(202);
+      expect((await botById(bot.id)).busy).toBe(true);
+
+      const queued = await api("POST", `/api/bots/${bot.id}/messages`, { text: "after stop please" });
+      expect(queued.body.queued).toBe(true);
+
+      // wait for the prompt to be genuinely in flight before stopping it
+      await until(async () => {
+        try {
+          return readFileSync(stopRpcDump, "utf8").includes("session/prompt");
+        } catch {
+          return false;
+        }
+      }, "the hung prompt");
+      expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
+
+      // the interrupt settles the hung turn (ACP cancel grace), and the
+      // drain consumes the queue: its message loses the queued flag while
+      // the steered turn waits on the still-missing gate
+      await until(async () => {
+        const snapshot = await botById(bot.id);
+        const message = snapshot.messages.find((m: any) => m.text === "after stop please");
+        return Boolean(message) && !message.queued;
+      }, "the post-interrupt drain");
+
+      writeFileSync(stopGate, "open");
+      let snapshot: any;
+      await until(async () => {
+        snapshot = await botById(bot.id);
+        return !snapshot.busy && echoes(snapshot).length >= 1;
+      }, "the steered turn");
+
+      // the interrupted turn produced no reply; the steered one answers
+      const replies = echoes(snapshot);
+      expect(replies).toHaveLength(1);
+      expect(replies[0].text).toContain("after stop please");
+    },
+    60_000,
+  );
+});

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -1,0 +1,91 @@
+// Queue-and-steer for busy 1:1 bots.
+//
+// A message sent to a bot mid-turn used to bounce with a 409. Now it lands
+// in the thread immediately — visible, persisted, marked `queued` — and
+// waits here until the bot settles. On settle, every queued message for
+// the thread drains into ONE follow-up turn whose prompt is the queued
+// texts joined with newlines, so a burst of steering notes costs one turn.
+//
+// The queue itself is memory-only on purpose: each queued message is
+// already an ordinary persisted thread message, so a restart loses only
+// the "auto-run on settle" intent, never the words — the same honesty as
+// delegations and provider approvals, which also die with the process.
+// (The client renders the queued affordance only while the bot is busy, so
+// a flag stranded by a restart is invisible rather than a false promise.)
+//
+// Unlike the delegation drain, an interrupted or failed turn does NOT
+// discard this queue: delegations are a bot's fan-out (dropping them on
+// Stop is a safety property), but these are the user's own words —
+// stop-then-steer (queue a correction, hit Stop, the correction runs) is
+// the feature.
+
+import type { BotRecord, Message } from "./store.ts";
+
+/** The slice of Store this module needs — narrow so tests can fake it. */
+export interface SteerStore {
+  bot(id: string): BotRecord | null;
+  appendMessage(threadId: string, message: Omit<Message, "id" | "at">): Message;
+  patchMessage(threadId: string, messageId: string, patch: Partial<Message>): Message | null;
+}
+
+interface QueueEntry {
+  /** Kept beside the threadId because the settle that frees the bot can
+   * happen on a DIFFERENT thread (a room turn) — drain matches on "this
+   * queue's bot is idle now", which needs the bot, not the settling thread. */
+  botId: string;
+  items: Array<{ messageId: string; text: string }>;
+}
+
+const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
+
+/** Land a message in the busy bot's active thread now; it auto-sends when
+ * the turn settles. The `queued` flag is the transcript's "will send when
+ * this turn finishes" affordance — drain clears it when consumed. */
+export function queueSteeredMessage(store: SteerStore, bot: BotRecord, text: string): Message {
+  const threadId = bot.threadId;
+  const message = store.appendMessage(threadId, { role: "user", kind: "text", text, queued: true });
+  const entry = queues.get(threadId) ?? { botId: bot.id, items: [] };
+  entry.items.push({ messageId: message.id, text });
+  queues.set(threadId, entry);
+  return message;
+}
+
+/** Drain every queue whose bot is idle: one run per thread, prompt = the
+ * queued texts joined with newlines. `userMessage` is the last queued
+ * message so the caller's startTurn appends nothing new — the messages are
+ * already in the transcript. Entries are removed BEFORE running so a
+ * settle racing another settle can never fire the same queue twice. */
+export function drainSteeredMessages(
+  store: SteerStore,
+  run: (botId: string, threadId: string, prompt: string, userMessage: Message) => void | Promise<void>,
+): void {
+  // deleting only the entry being visited is safe under Map iteration
+  for (const [threadId, entry] of queues) {
+    const bot = store.bot(entry.botId);
+    if (!bot) {
+      // the bot was deleted while messages waited — nothing left to steer
+      queues.delete(threadId);
+      continue;
+    }
+    if (bot.busy) continue; // still working — the next settle tries again
+    // committed to draining: the entry leaves the map before anything runs,
+    // so a settle racing another settle can never fire the same queue twice
+    queues.delete(threadId);
+    // clear the affordance before dispatch, so the user never sees
+    // "queued" on a message the bot is already answering
+    let last: Message | null = null;
+    for (const item of entry.items) {
+      last = store.patchMessage(threadId, item.messageId, { queued: undefined }) ?? last;
+    }
+    // every queued message gone from the store = the thread itself was
+    // deleted out from under the queue; there is nothing to run against
+    if (!last) continue;
+    const prompt = entry.items.map((item) => item.text).join("\n");
+    void run(entry.botId, threadId, prompt, last);
+  }
+}
+
+/** Test helper: how many messages remain queued for a thread. */
+export function _queuedCount(threadId: string): number {
+  return queues.get(threadId)?.items.length ?? 0;
+}

--- a/server/store.ts
+++ b/server/store.ts
@@ -77,6 +77,11 @@ export interface Message {
   /** comm chips: "Messaged @X" in the caller's chat, linking to the
    * bot⇄bot channel where the exchange is mirrored. */
   comm?: { groupId: string; withBotId: string; withName: string; withColor: string };
+  /** user messages sent while the bot was mid-turn, waiting in the
+   * steer-queue to auto-send on settle. Cleared when the drain consumes
+   * them; a true stranded by a restart is inert because the client only
+   * shows the affordance while the bot is busy. */
+  queued?: boolean;
 }
 
 export type GroupDefaultResponder =

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -13,6 +13,11 @@
 //                     peer, and reply with what the peer said — the comms e2e)
 //                   | delegate-peer (same as ask-peer but uses delegate_bot —
 //                     returns immediately, the peer runs after our turn)
+//                   | echo-gated (reply by echoing the full prompt, and when
+//                     FAKE_ACP_GATE_FILE is set hold the turn open until that
+//                     file exists — a deterministic busy window for the
+//                     steer-queue e2e, with the echo pinning exactly what a
+//                     drained turn was sent)
 //   FAKE_ACP_DUMP   path to write {argv, env} as JSON, so a test can assert
 //                   argv shape (agent/stdio flags) and env hygiene
 //   FAKE_ACP_MODELS      comma-separated model ids. Enables the opencode-shaped
@@ -27,7 +32,7 @@
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
 import { spawn } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "happy";
 // opencode-shaped surface: the session carries its own model catalog and the
@@ -290,6 +295,27 @@ function handle(msg: any) {
             out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `peer error: ${(e as Error).message}` } } } });
             complete();
           });
+        return;
+      }
+      if (mode === "echo-gated") {
+        // echoing the WHOLE prompt (system + turn text) lets a test assert
+        // both what a drained turn was sent and what it was NOT sent (e.g.
+        // the webhook untrusted-data paragraph a steered turn must not get)
+        const promptText = String(msg.params?.prompt?.[0]?.text ?? "");
+        const finish = () => {
+          out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `echo: ${promptText}` } } } });
+          complete();
+        };
+        const gate = process.env.FAKE_ACP_GATE_FILE;
+        if (gate && !existsSync(gate)) {
+          const poll = setInterval(() => {
+            if (!existsSync(gate)) return;
+            clearInterval(poll);
+            finish();
+          }, 50);
+          return;
+        }
+        finish();
         return;
       }
       if (mode === "delegate-peer" && agentsMcp) {

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Clock,
   Copy,
   Crown,
   Folder,
@@ -397,6 +398,13 @@ function Bubble({
           {formatTime(message.at)}
         </span>
       </div>
+      {/* busy-gated so a flag stranded by a server restart shows nothing */}
+      {user && message.queued && bot.busy && (
+        <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
+          <Clock size={11} aria-hidden="true" />
+          <span>Queued — sends when this turn finishes</span>
+        </div>
+      )}
       <ReactionChips threadId={bot.threadId} message={message} align={user ? "right" : "left"} />
       {versions.length > 1 && (
         <div className="mt-1 flex items-center gap-0.5 pr-1 text-[12px] text-ink-secondary">

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -128,15 +128,17 @@ export function Composer({
     });
   };
 
-  // One message may be queued while the bot works; it auto-sends the moment
-  // the turn settles. Enter during a turn queues instead of silently dying.
+  // Rooms hold one message client-side while a member speaks; it auto-sends
+  // the moment the room settles. 1:1 sends go straight to the server even
+  // mid-turn — the harness queues them (steer-queue), so the message shows
+  // in the transcript immediately with a queued affordance.
   const [queued, setQueued] = useState<string | null>(null);
   // a chip on its own is a message: the send control has to appear for it
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
     const t = composeMessage(text, attachments);
     if (!t) return;
-    if (busy) {
+    if (busy && group) {
       setQueued(t);
       setText("");
       setAttachments([]);
@@ -147,19 +149,18 @@ export function Composer({
       track("message_sent", { room: true });
     } else if (bot) {
       dispatch({ type: "send", botId: bot.id, text: t });
-      track("message_sent", { driver: bot.modelSelection?.instanceId });
+      track("message_sent", { driver: bot.modelSelection?.instanceId, queued: busy });
     }
     setText("");
     setAttachments([]);
   };
   useEffect(() => {
-    if (!busy && queued) {
-      if (group) dispatch({ type: "sendGroup", groupId: group.id, text: queued });
-      else if (bot) dispatch({ type: "send", botId: bot.id, text: queued });
-      track("message_sent", { queued: true });
+    if (!busy && queued && group) {
+      dispatch({ type: "sendGroup", groupId: group.id, text: queued });
+      track("message_sent", { room: true, queued: true });
       setQueued(null);
     }
-  }, [busy, queued, bot, group, dispatch]);
+  }, [busy, queued, group, dispatch]);
 
   // native dictation: partials stream into the input while the Swift
   // helper runs; the final transcript stays in the box, ready to edit/send
@@ -349,7 +350,9 @@ export function Composer({
               : recording
               ? "Listening…"
               : busy
-                ? `${busyName} is working — Enter queues your message`
+                ? group
+                  ? `${busyName} is working — Enter queues your message`
+                  : `${busyName} is working — sends when this turn finishes`
                 : group
                   ? `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`
                   : `Message ${bot?.name ?? ""}`
@@ -389,7 +392,7 @@ export function Composer({
           <button
             onClick={send}
             aria-label={busy ? "Queue message" : "Send message"}
-            title={busy ? "Queue — sends when the bot finishes" : "Send"}
+            title={busy ? "Sends when the current turn finishes" : "Send"}
             className={cn(
               "flex size-8 shrink-0 items-center justify-center rounded-full text-white",
               busy ? "bg-raised text-ink-secondary hover:bg-raised-hover" : "bg-accent hover:brightness-110",

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -62,6 +62,10 @@ export interface Message {
   reactions?: Array<{ emoji: string; by: string }>;
   /** comm chips: "Messaged @X" linking to the bot⇄bot channel. */
   comm?: { groupId: string; withBotId: string; withName: string; withColor: MausColor };
+  /** sent while the bot was mid-turn; auto-sends when the turn settles.
+   * Rendered only while the bot is busy, so a flag stranded by a server
+   * restart never shows a promise nothing will keep. */
+  queued?: boolean;
 }
 
 export type GroupDefaultResponder =


### PR DESCRIPTION
## In plain terms

Messaging a busy bot no longer bounces with "try again later". Your message lands in the transcript immediately with a quiet "Queued — sends when this turn finishes" note, and auto-sends the moment the bot settles. Several queued messages drain into ONE follow-up turn. Stop-then-steer works: queue a correction, hit Stop, the correction runs.

## Design

- **Server-side queue** (`server/steer-queue.ts`): the busy-check-to-queue-insert is synchronous so a settle can't slip between them and strand a message. Drain runs on `turn.completed` — and on the two settle paths that never emit it (dispatch failure, provider reload). Entries leave the map before anything runs, so racing settles can never fire the same queue twice.
- **Drained turns are plain attended turns** — no `automationSource`, no unattended marking, no comms depth: exactly what typing the same words into an idle bot would run. Deliberately NOT gated on `event.ok`: dropping queued *delegations* on Stop is a safety property, but these are the user's own words — an interrupted turn drains too.
- **Memory-only queue, honestly**: each queued message is already an ordinary persisted thread message, so a restart loses only the auto-send intent, never the words. The client renders the affordance only while the bot is busy, so a flag stranded by a restart shows nothing rather than promising a send that won't happen.
- Scope: 1:1 chats. Rooms keep their existing client-side hold-one behavior.
- `branching.test.ts`'s "second send while busy → 409" assertion encoded the old contract; it now asserts 202 + `queued:true` + still exactly one live turn, and stops the drained turn before the edit-fork half.

## Test plan

- [x] 7 new tests in `server/steer-queue.test.ts` (queue while busy → one drained turn with joined prompt; nothing drains when empty; deleted bot/thread cleanup; drained turn is attended — asserted via a full-loop fake-engine e2e with a file-gated busy window)
- [x] Mutation check: removing the drain-once delete fails 4 tests
- [x] Rebased onto current main; `pnpm typecheck` clean; full `pnpm vitest run` green (939 passed); no new oxlint findings (Composer's hits are pre-existing, verified against base)
- [ ] Reviewer eyeball: send while a bot works → message appears with the queued note → turn ends → queued message auto-sends as its own turn; queue one, hit Stop → it still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
