### PR TITLE
fix(dev): honor OMB_PORT in the vite proxy, allow OMB_UI_PORT

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     // IPv4 explicitly — a bare ::1 bind makes localhost a coin-flip for
     // clients that resolve IPv4 first
     host: "127.0.0.1",
-    port: 5199,
+    port: Number(process.env.OMB_UI_PORT) || 5199,
     // packager output lands inside the repo — its HTML files must never
     // trigger dev full-page reloads
     watch: {
@@ -39,7 +39,7 @@ export default defineConfig({
     // talks to /api — clients hold no transports
     proxy: {
       "/api": {
-        target: `http://127.0.0.1:${process.env.OGB_PORT || 8799}`,
+        target: `http://127.0.0.1:${process.env.OMB_PORT || process.env.OGB_PORT || 8799}`,
       },
     },
   },


### PR DESCRIPTION
## The problem

The harness server reads `OMB_PORT || OGB_PORT || 8799` ([`server/index.ts:80`](https://github.com/milind-soni/OpenMausBot/blob/main/server/index.ts#L80)), but the dev proxy only read the legacy `OGB_PORT` ([`vite.config.ts:42`](https://github.com/milind-soni/OpenMausBot/blob/main/vite.config.ts#L42)).

So setting `OMB_PORT` — the documented, non-legacy name — moves the server but not the proxy. `pnpm dev` silently keeps talking to 8799 and every `/api` call 404s, with nothing pointing at the cause.

## Why it matters

Running a second instance beside the first is already almost supported:

- `OMB_DATA_DIR` isolates the fleet ([`server/config.ts:66`](https://github.com/milind-soni/OpenMausBot/blob/main/server/config.ts#L66))
- Electron probes `8799 / 18799 / 28799` ([`electron/main.mjs:173`](https://github.com/milind-soni/OpenMausBot/blob/main/electron/main.mjs#L173))

The dev UI was the one piece that couldn't follow. The vite dev port was hardcoded as well, so two `pnpm dev` processes collide on 5199.

## The change

- proxy target reads `OMB_PORT` first, keeping `OGB_PORT` as fallback
- dev server port reads `OMB_UI_PORT`, defaulting to 5199

Two lines. Fully backward compatible — with both variables unset the behavior is byte-identical to before.

## Verification

```sh
pnpm typecheck   # passes
npx oxlint vite.config.ts   # clean
```

Two instances side by side:

```sh
# instance A — unchanged defaults
pnpm dev:server && pnpm dev

# instance B
OMB_DATA_DIR="$HOME/.openmausbot-dev" OMB_PORT=18799 pnpm dev:server
OMB_PORT=18799 OMB_UI_PORT=15199 pnpm dev
```

Happy to drop the `OMB_UI_PORT` half if you'd rather keep the dev port fixed — the proxy fix is the part that's actually a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * The development server port can now be customized through `OMB_UI_PORT`, with port 5199 used by default.
  * API proxy routing now supports configurable backend ports, with fallback options for improved setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->