### PR TITLE
Run a bot on a local model with no CLI and no account (local driver)

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -34,6 +34,8 @@ describe("default fleet", () => {
     const map = instanceConfigs({});
     expect(map.qwen).toEqual({ driver: "qwenAgent", environment: {} });
     expect(map.hermes).toEqual({ driver: "hermesAgent", environment: {} });
+    // and the no-CLI path: Ollama spoken to directly
+    expect(map.local).toEqual({ driver: "local", config: { host: "ollama" }, environment: {} });
   });
 
   it("adds missing custom-only engines onto an existing product fleet", () => {
@@ -41,6 +43,7 @@ describe("default fleet", () => {
     expect(map.claude.driver).toBe("claudeAgent");
     expect(map.qwen?.driver).toBe("qwenAgent");
     expect(map.hermes?.driver).toBe("hermesAgent");
+    expect(map.local?.driver).toBe("local");
   });
 
   it("does not expand a one-off shadow fleet", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -219,10 +219,14 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     computer: { driver: "boxAgent" },
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
+    // the no-CLI path: Ollama spoken to directly. Unavailable until Ollama
+    // is running, like every engine before its CLI is installed.
+    local: { driver: "local", config: { host: "ollama" } },
   };
   const CUSTOM_ONLY = {
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
+    local: { driver: "local", config: { host: "ollama" } },
   } as const;
   const configured = cfg.instances && Object.keys(cfg.instances).length ? cfg.instances : null;
   const map: InstanceConfigMap = configured ? { ...configured } : { ...DEFAULT_FLEET };

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -184,6 +184,12 @@ export interface ProviderAdapter {
      * the driver cannot set effort, so the app never offers the control —
      * same rule as computerMcp: never show a knob the driver cannot turn. */
     effortLevels?: readonly EffortLevel[];
+    /** True when the driver keeps a live session across turns and can take
+     * a user message MID-TURN (delivered before the model's next call —
+     * "steer"). The composer stays open during a turn on such an engine;
+     * others keep the queue-one-and-wait behaviour. Same rule as the other
+     * flags: never show a control the driver cannot honour. */
+    queueing?: boolean;
   };
   sendTurn(input: SendTurnInput): Promise<TurnStartResult>;
   interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void>;
@@ -197,6 +203,10 @@ export interface ProviderAdapter {
     requestId: string,
     decision: { behavior: "allow" | "deny" | "answer"; message?: string },
   ): Promise<RequestOutcome>;
+  /** Deliver a user message into the RUNNING turn on this thread. Resolves
+   * false when there is no live turn to steer (the caller then sends it as
+   * a normal turn). Only drivers with `capabilities.queueing` implement it. */
+  steer?(threadId: ThreadId, text: string): Promise<boolean>;
   hasSession(threadId: ThreadId): boolean;
   stopAll(): Promise<void>;
   onEvent(listener: RuntimeEventListener): () => void;
@@ -238,7 +248,16 @@ export interface EngineInstall {
 // a rejection to an unavailable shadow snapshot.
 export interface ModelCatalog {
   default: string;
-  options: Array<{ id: string; label: string; custom?: boolean; loaded?: boolean }>;
+  options: Array<{
+    id: string;
+    label: string;
+    custom?: boolean;
+    loaded?: boolean;
+    /** total context window in tokens, when the driver knows it — sizes
+     * the model-facing rebuild (server/context-rebuild.ts). Unknown falls
+     * back to a pattern table over the model id, then a conservative default. */
+    contextWindow?: number;
+  }>;
 }
 
 export interface DriverCreateInput<Config> {

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -218,6 +218,9 @@ export interface ProviderSnapshot {
   reason?: string;
   authenticated?: boolean;
   version?: string | null;
+  /** Installed but not running (a local server that isn't up): the setup
+   * card offers install.signInCommand as "start it", not an install. */
+  notRunning?: boolean;
 }
 
 // ── engine install descriptor ───────────────────────────────────────────

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -6,6 +6,7 @@ import { BoxAgentDriver } from "./boxagent.ts";
 import { ClaudeDriver } from "./claude.ts";
 import { CodexDriver } from "./codex.ts";
 import { GrokDriver } from "./grok.ts";
+import { LocalDriver } from "./local.ts";
 import { GrokAgentDriver } from "./acp/grok.ts";
 import { GeminiAgentDriver } from "./acp/gemini.ts";
 import { KimiAgentDriver } from "./acp/kimi.ts";
@@ -27,4 +28,5 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   CodexDriver,
   AntigravityDriver,
   BoxAgentDriver,
+  LocalDriver,
 ];

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -6,7 +6,7 @@
 // These used to be POSIX-only: the fake CLI is a shebang script Windows
 // cannot exec, and the broker is a unix socket. Both now go through
 // resolveCliSpawn / permissionSocketPath, so they run everywhere.
-import { chmodSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -404,6 +404,81 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
     conn.end();
   });
+
+  // ── live session across turns (steer / follow-up / idle close) ────────
+
+  it("a message sent mid-turn is steered into the running turn, not a new one", async () => {
+    await create("slow");
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-steer", text: "first" });
+    // the fake leaves a gap after the tool result — steer into it
+    await recorder.until((e) => e.type === "item.completed" && e.itemType === "tool");
+    expect(instance.adapter.capabilities.queueing).toBe(true);
+    await expect(instance.adapter.steer!("t-steer", "and also this")).resolves.toBe(true);
+    await recorder.until((e) => e.type === "turn.completed");
+    // one turn, one result; the reply carries the folded message
+    expect(recorder.events.filter((e) => e.type === "turn.completed")).toHaveLength(1);
+    const reply = recorder.events.find((e) => e.type === "item.completed" && e.itemType === "assistant_text" && (e as { text: string }).text.startsWith("reply to:")) as { text: string };
+    expect(reply.text).toContain("steered: and also this");
+    expect(recorder.events.every((e) => e.turnId === turnId)).toBe(true);
+    // nothing running now: steer has nowhere to go
+    await expect(instance.adapter.steer!("t-steer", "late")).resolves.toBe(false);
+  });
+
+  it("the next turn on the same thread reuses the live process instead of spawning", async () => {
+    await create();
+    process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+    await instance.adapter.sendTurn({ threadId: "t-live", text: "one" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const inits1 = recorder.events.filter((e) => e.type === "session.started").length;
+    // second turn: same contract, same session id → same process. The fake
+    // dumps argv only on its FIRST prompt, so a re-dump would mean a respawn.
+    const dumpBefore = readFileSync(join(scratch, "dump.json"), "utf8");
+    // the harness resumes with the id the CLI announced — pass that one
+    const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+    const second = await instance.adapter.sendTurn({ threadId: "t-live", text: "two", resumeCursor: announced });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === second.turnId);
+    expect(readFileSync(join(scratch, "dump.json"), "utf8")).toBe(dumpBefore);
+    // and the CLI announced init again on the same process (the real one does)
+    expect(recorder.events.filter((e) => e.type === "session.started").length).toBeGreaterThan(inits1);
+    expect(recorder.events.filter((e) => e.type === "turn.started")).toHaveLength(2);
+    expect(recorder.events.filter((e) => e.type === "turn.completed")).toHaveLength(2);
+  });
+
+  it("a changed spawn contract (another model) closes the live process and resumes in a new one", async () => {
+    await create();
+    process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+    await instance.adapter.sendTurn({ threadId: "t-switch", text: "one" });
+    await recorder.until((e) => e.type === "turn.completed");
+    // a fresh process rewrites the dump; the fake ONLY dumps its first prompt
+    rmSync(join(scratch, "dump.json"));
+    const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+    await instance.adapter.sendTurn({ threadId: "t-switch", text: "two", model: "claude-other", resumeCursor: announced });
+    await recorder.until((e) => e.type === "turn.completed" && recorder.events.filter((x) => x.type === "turn.completed").length === 2);
+    const dump = JSON.parse(readFileSync(join(scratch, "dump.json"), "utf8"));
+    expect(dump.argv).toContain("--resume");
+    expect(dump.argv).toContain("claude-other");
+  });
+
+  it("closes an idle session after the idle window", async () => {
+    process.env.OMB_CLAUDE_SESSION_IDLE_MS = "10000"; // the floor
+    try {
+      await create();
+      await instance.adapter.sendTurn({ threadId: "t-idle", text: "one" });
+      await recorder.until((e) => e.type === "turn.completed");
+      // the process is alive between turns…
+      await expect(instance.adapter.steer!("t-idle", "x")).resolves.toBe(false); // no running turn, but session exists
+      // …and after the idle window it is gone: the next turn spawns anew
+      // (observable as a fresh dump)
+      process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+      await new Promise((r) => setTimeout(r, 11_000));
+      const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+      await instance.adapter.sendTurn({ threadId: "t-idle", text: "two", resumeCursor: announced });
+      await recorder.until((e) => e.type === "turn.completed" && recorder.events.filter((x) => x.type === "turn.completed").length === 2);
+      expect(JSON.parse(readFileSync(join(scratch, "dump.json"), "utf8")).argv).toContain("--resume");
+    } finally {
+      delete process.env.OMB_CLAUDE_SESSION_IDLE_MS;
+    }
+  }, 30_000);
 
   it("passes effort to the CLI, and omits the flag when unset", async () => {
     await create();

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -339,6 +339,59 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
     // one active turn per thread; a second send while busy is a caller bug
     const active = new Map<string, { stop: () => void; turnId: string; broker?: ReturnType<typeof createPermissionBroker> }>();
 
+    // One live CLI process per thread, kept across turns. Under
+    // --input-format stream-json the CLI settles a turn with `result` while
+    // stdin stays open, takes the next user message on the same stdin as a
+    // new turn, and folds a message that arrives MID-turn into the running
+    // one before its next model call (verified against 2.1.221 — that fold
+    // is what "steer" is). So a session is spawned once, reused while its
+    // spawn contract (args, MCP config, cwd, model) is unchanged, closed
+    // after SESSION_IDLE_MS of quiet, and resumed by --resume when needed.
+    interface Session {
+      child: ReturnType<typeof spawnCli>;
+      broker?: ReturnType<typeof createPermissionBroker>;
+      mcpConfigPath: string | null;
+      /** the spawn contract — a different one means a fresh process */
+      argsKey: string;
+      /** the CLI's session id from `init`, what --resume takes later */
+      sessionId: string | null;
+      /** the running turn, or null between turns */
+      turn: { turnId: string; settled: boolean; sawStreamDelta: boolean } | null;
+      idleTimer: ReturnType<typeof setTimeout> | null;
+      closing: boolean;
+      stderr: string;
+    }
+    const sessions = new Map<string, Session>();
+    const SESSION_IDLE_MS = Math.max(10_000, Number(process.env.OMB_CLAUDE_SESSION_IDLE_MS) || 10 * 60_000);
+
+    const closeSession = (threadId: string, why: string) => {
+      const s = sessions.get(threadId);
+      if (!s || s.closing) return;
+      s.closing = true;
+      if (s.idleTimer) clearTimeout(s.idleTimer);
+      appendNative(threadId, { dir: "out", source: "claude.session", msg: { close: why } });
+      // stdin EOF is the CLI's exit signal; give it a moment, then insist
+      try {
+        s.child.stdin.end();
+      } catch {}
+      const kill = setTimeout(() => {
+        if (s.child.exitCode === null) killCliTree(s.child);
+      }, 5_000);
+      kill.unref?.();
+    };
+    const armIdle = (threadId: string) => {
+      const s = sessions.get(threadId);
+      if (!s) return;
+      if (s.idleTimer) clearTimeout(s.idleTimer);
+      s.idleTimer = setTimeout(() => closeSession(threadId, "idle"), SESSION_IDLE_MS);
+      s.idleTimer.unref?.();
+    };
+    const writeUser = (s: Session, threadId: string, text: string) => {
+      const promptMsg = { type: "user", message: { role: "user", content: text } };
+      s.child.stdin.write(JSON.stringify(promptMsg) + "\n");
+      appendNative(threadId, { dir: "out", source: "claude.sdk.message", msg: promptMsg });
+    };
+
     const emit = (event: RuntimeEvent) => {
       for (const l of [...listeners]) l(event);
     };
@@ -367,8 +420,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         "--include-partial-messages",
         "--permission-mode", config.permissionMode === "auto" ? "acceptEdits" : config.permissionMode,
       ];
-      if (sessionId) args.push("--resume", sessionId);
-      else args.push("--session-id", newSessionId!);
       const turnEnvironment: NodeJS.ProcessEnv = { ...process.env, ...input.environment };
       const injected = applyClaudeInject({ ...turnEnvironment }, turn.model);
       if (injected.model) args.push("--model", injected.model);
@@ -468,32 +519,74 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
 
       const env = claudeEnvironment(turn.model, turnEnvironment);
+      const cwd = turn.cwd ?? homedir();
+      // everything that shapes the process, minus session/turn specifics
+      // (the --mcp-config file is a fresh temp path each time; its CONTENT
+      // is what matters and mcpServers carries that)
+      const keyArgs = args.filter((a, i) => a !== "--mcp-config" && args[i - 1] !== "--mcp-config");
+      const argsKey = JSON.stringify({ args: keyArgs, mcpServers, cwd, model: injected.model ?? null, base: env.ANTHROPIC_BASE_URL ?? null });
 
-      const child = spawnCli(config.cli, args, {
-        cwd: turn.cwd ?? homedir(),
-        env,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-
-      let settled = false;
-      const settle = (ok: boolean, stopReason: string | null, cost: number | null = null) => {
-        if (settled) return;
-        settled = true;
-        broker?.close();
-        // the config file holds live credentials — it must not outlive the turn
+      // Reuse the live process when it is idle, unchanged, and is the session
+      // the harness wants resumed. Anything else: close it and spawn fresh
+      // (with --resume, so the conversation continues in the new process).
+      const live = sessions.get(threadId);
+      if (live && !live.turn && !live.closing && live.child.exitCode === null && live.argsKey === argsKey && (!sessionId || sessionId === live.sessionId)) {
+        if (live.idleTimer) clearTimeout(live.idleTimer);
+        live.turn = { turnId, settled: false, sawStreamDelta: false };
+        active.set(threadId, { stop: () => killCliTree(live.child), turnId, broker: live.broker });
+        emit({ ...base(threadId, turnId), type: "turn.started" });
+        writeUser(live, threadId, turn.text);
+        // the MCP config was for the first spawn; nothing to clean here
         if (mcpConfigPath) {
           try {
             rmSync(dirname(mcpConfigPath), { recursive: true, force: true });
           } catch {}
         }
-        active.delete(threadId);
-        emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost });
-      };
+        broker?.close(); // the session's own broker stays; this one was provisional
+        return { turnId };
+      }
+      if (live) closeSession(threadId, "spawn contract changed");
+      if (sessionId) args.push("--resume", sessionId);
+      else args.push("--session-id", newSessionId!);
 
-      // token streaming: true while --include-partial-messages is delivering
-      // text deltas for the current assistant message, so the whole-message
-      // frame that follows doesn't re-emit the same text as one big delta
-      let sawStreamDelta = false;
+      const child = spawnCli(config.cli, args, {
+        cwd,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const session: Session = {
+        child,
+        broker,
+        mcpConfigPath,
+        argsKey,
+        sessionId: sessionId ?? newSessionId,
+        turn: { turnId, settled: false, sawStreamDelta: false },
+        idleTimer: null,
+        closing: false,
+        stderr: "",
+      };
+      sessions.set(threadId, session);
+
+      // settles the TURN, not the process: the CLI stays for the next
+      // message until it has been quiet for SESSION_IDLE_MS
+      const settle = (ok: boolean, stopReason: string | null, cost: number | null = null) => {
+        const t = session.turn;
+        if (!t || t.settled) return;
+        t.settled = true;
+        // the config file holds live credentials — the CLI read it at start;
+        // it must not sit on disk for the life of the session
+        if (session.mcpConfigPath) {
+          try {
+            rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+          } catch {}
+          session.mcpConfigPath = null;
+        }
+        active.delete(threadId);
+        session.turn = null;
+        emit({ ...base(threadId, t.turnId), type: "turn.completed", ok, stopReason, cost });
+        if (session.child.exitCode === null && !session.closing) armIdle(threadId);
+      };
+      const currentTurnId = () => session.turn?.turnId ?? turnId;
 
       const handleLine = (line: string) => {
         let o: any;
@@ -506,9 +599,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         switch (o.type) {
           case "system":
             if (o.subtype === "init") {
-              emit({ ...base(threadId, turnId), type: "session.started", sessionId: o.session_id, model: o.model });
+              if (typeof o.session_id === "string") session.sessionId = o.session_id;
+              emit({ ...base(threadId, currentTurnId()), type: "session.started", sessionId: o.session_id, model: o.model });
             } else if (o.subtype === "thinking_tokens") {
-              emit({ ...base(threadId, turnId), type: "item.updated", itemType: "reasoning", tokens: o.estimated_tokens });
+              emit({ ...base(threadId, currentTurnId()), type: "item.updated", itemType: "reasoning", tokens: o.estimated_tokens });
             }
             break;
           case "stream_event": {
@@ -519,10 +613,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             if (ev.type !== "content_block_delta") break;
             const d = ev.delta ?? {};
             if (d.type === "text_delta" && typeof d.text === "string" && d.text) {
-              sawStreamDelta = true;
-              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta: d.text });
+              if (session.turn) session.turn.sawStreamDelta = true;
+              emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "assistant_text", delta: d.text });
             } else if (d.type === "thinking_delta" && typeof d.thinking === "string" && d.thinking) {
-              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "reasoning_text", delta: d.thinking });
+              emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "reasoning_text", delta: d.thinking });
             }
             break;
           }
@@ -531,20 +625,20 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             const text = firstText(msg.content);
             if (text.trim()) {
               // fallback delta for CLIs/paths that never streamed the block
-              if (!sawStreamDelta) {
-                emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta: text });
+              if (!session.turn?.sawStreamDelta) {
+                emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "assistant_text", delta: text });
               }
-              sawStreamDelta = false;
-              emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+              if (session.turn) session.turn.sawStreamDelta = false;
+              emit({ ...base(threadId, currentTurnId()), type: "item.completed", itemType: "assistant_text", text });
             }
             for (const b of Array.isArray(msg.content) ? msg.content : []) {
               if (b.type === "tool_use") {
-                emit({ ...base(threadId, turnId), type: "item.started", itemType: "tool", itemId: b.id, title: b.name });
+                emit({ ...base(threadId, currentTurnId()), type: "item.started", itemType: "tool", itemId: b.id, title: b.name });
               }
             }
             if (msg.usage) {
               emit({
-                ...base(threadId, turnId),
+                ...base(threadId, currentTurnId()),
                 type: "thread.token-usage.updated",
                 input: (msg.usage.input_tokens || 0) + (msg.usage.cache_read_input_tokens || 0),
                 output: msg.usage.output_tokens || 0,
@@ -555,7 +649,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           case "user":
             for (const b of Array.isArray(o.message?.content) ? o.message.content : []) {
               if (b.type === "tool_result") {
-                emit({ ...base(threadId, turnId), type: "item.completed", itemType: "tool", itemId: b.tool_use_id, ok: !b.is_error });
+                emit({ ...base(threadId, currentTurnId()), type: "item.completed", itemType: "tool", itemId: b.tool_use_id, ok: !b.is_error });
               }
             }
             break;
@@ -579,39 +673,57 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         }
       });
 
-      let stderr = "";
       child.stderr.on("data", (c) => {
-        stderr += c;
-        if (stderr.length > 8192) stderr = stderr.slice(-8192);
+        session.stderr += c;
+        if (session.stderr.length > 8192) session.stderr = session.stderr.slice(-8192);
       });
 
       child.on("error", (e) => {
-        emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
+        emit({ ...base(threadId, currentTurnId()), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
 
       child.on("close", (code) => {
-        if (!settled) {
+        // a turn still running when the process died is a failed turn; a
+        // process that exited between turns (idle close, contract change)
+        // is just a session ending
+        if (session.turn && !session.turn.settled) {
           emit({
-            ...base(threadId, turnId),
+            ...base(threadId, currentTurnId()),
             type: "runtime.error",
-            message: `claude exited ${code} before result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
+            message: `claude exited ${code} before result${session.stderr ? `: ${session.stderr.trim().slice(-300)}` : ""}`,
           });
           settle(false, "exit_before_result");
         }
+        if (session.idleTimer) clearTimeout(session.idleTimer);
+        session.broker?.close();
+        if (session.mcpConfigPath) {
+          try {
+            rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+          } catch {}
+        }
+        if (sessions.get(threadId) === session) sessions.delete(threadId);
       });
 
       const stop = () => killCliTree(child);
       active.set(threadId, { stop, turnId, broker });
       emit({ ...base(threadId, turnId), type: "turn.started" });
 
-      // prompt over stdin as a stream-json message — never argv (ARG_MAX)
-      const promptMsg = { type: "user", message: { role: "user", content: turn.text } };
-      child.stdin.write(JSON.stringify(promptMsg) + "\n");
-      child.stdin.end();
-      appendNative(threadId, { dir: "out", source: "claude.sdk.message", msg: promptMsg });
+      // prompt over stdin as a stream-json message — never argv (ARG_MAX).
+      // stdin stays OPEN: that is what keeps the session alive for a
+      // mid-turn steer or the next turn; closeSession() ends it.
+      writeUser(session, threadId, turn.text);
 
       return { turnId };
+    };
+
+    /** A user message into the running turn: the CLI delivers it before its
+     * next model call. False when nothing is running here to steer. */
+    const steer = async (threadId: string, text: string): Promise<boolean> => {
+      const s = sessions.get(threadId);
+      if (!s || !s.turn || s.turn.settled || s.closing || s.child.exitCode !== null) return false;
+      writeUser(s, threadId, text);
+      return true;
     };
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
@@ -644,13 +756,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           computerMcp: true,
           composioMcp: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
+          queueing: true,
         },
         sendTurn,
+        steer,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async (threadId, requestId, decision) => {
           // fail-closed by construction: no broker, or an ask that already
           // timed out / settled, is `unavailable` — the caller denies
-          const broker = active.get(threadId)?.broker;
+          const broker = sessions.get(threadId)?.broker ?? active.get(threadId)?.broker;
           if (!broker) return "unavailable";
           const behavior = decision.behavior === "answer" ? "answer" : decision.behavior;
           if (!broker.answer(requestId, behavior, decision.message)) return "unavailable";
@@ -659,6 +773,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         hasSession: (threadId) => active.has(threadId),
         stopAll: async () => {
           for (const { stop } of active.values()) stop();
+          for (const threadId of [...sessions.keys()]) closeSession(threadId, "stopAll");
         },
         onEvent: (listener) => {
           listeners.add(listener);

--- a/server/drivers/local-inject.test.ts
+++ b/server/drivers/local-inject.test.ts
@@ -20,6 +20,7 @@ import {
   codexLocalProviderArgs,
   decodeInjectId,
   encodeInjectId,
+  contextWindowsFromPs,
   loadedIdsFromPayloads,
   LOCAL_HOSTS,
   mergeLocalInject,
@@ -42,6 +43,28 @@ describe("inject ids", () => {
   it("rejects official cloud slugs", () => {
     expect(decodeInjectId("claude-sonnet-5")).toBeNull();
     expect(decodeInjectId("gpt-5.6-sol")).toBeNull();
+  });
+});
+
+describe("contextWindowsFromPs", () => {
+  it("reads Ollama's per-model context_length from /api/ps, keyed by full and base id", () => {
+    const windows = contextWindowsFromPs({
+      models: [
+        { name: "qwen3:8b", model: "qwen3:8b", context_length: 40960 },
+        { name: "llama3.2:latest", model: "llama3.2:latest", context_length: 8192 },
+        { name: "no-ctx:1b", model: "no-ctx:1b" },
+        { name: "bad:1b", model: "bad:1b", context_length: -1 },
+      ],
+    });
+    expect(windows.get("qwen3:8b")).toBe(40960);
+    expect(windows.get("qwen3")).toBe(40960);
+    expect(windows.get("llama3.2:latest")).toBe(8192);
+    expect(windows.has("no-ctx:1b")).toBe(false);
+    expect(windows.has("bad:1b")).toBe(false);
+  });
+  it("tolerates payloads that are not a ps listing", () => {
+    expect(contextWindowsFromPs(null).size).toBe(0);
+    expect(contextWindowsFromPs({ data: [] }).size).toBe(0);
   });
 });
 

--- a/server/drivers/local-inject.ts
+++ b/server/drivers/local-inject.ts
@@ -38,6 +38,30 @@ export interface InjectedModel {
   label: string;
   /** In VRAM / running on the host right now — Custom pins these first. */
   loaded?: boolean;
+  /** the host's own word on the model's context window (Ollama reports it
+   * for running models in /api/ps) — sizes the model-facing rebuild instead
+   * of guessing from the name */
+  contextWindow?: number;
+}
+
+/** Ollama's /api/ps lists running models with their context_length; a
+ * small model's real window matters more than a big one's — an 8k model
+ * guessed at 32k gets a rebuild it cannot hold. */
+export function contextWindowsFromPs(extra: unknown): Map<string, number> {
+  const out = new Map<string, number>();
+  const rec = extra && typeof extra === "object" ? (extra as { models?: unknown }) : null;
+  if (!rec || !Array.isArray(rec.models)) return out;
+  for (const m of rec.models) {
+    if (!m || typeof m !== "object") continue;
+    const row = m as { name?: unknown; model?: unknown; context_length?: unknown };
+    const id = typeof row.model === "string" ? row.model : typeof row.name === "string" ? row.name : null;
+    const ctx = typeof row.context_length === "number" && Number.isFinite(row.context_length) && row.context_length > 0 ? row.context_length : null;
+    if (id && ctx) {
+      out.set(id, ctx);
+      out.set(id.split(":")[0]!, ctx);
+    }
+  }
+  return out;
 }
 
 export function encodeInjectId(host: string, model: string): string {
@@ -258,17 +282,20 @@ export async function probeLocalInjects(
       const extraIds = extra ? idsFromModelsPayload(extra) : [];
       const loaded = loadedIdsFromPayloads(host, catalog ?? extra, extra);
       const ids = [...new Set([...catalogIds, ...extraIds, ...loaded])];
-      return { host, ids, loaded };
+      const windows = contextWindowsFromPs(extra);
+      return { host, ids, loaded, windows };
     }),
   );
-  for (const { host, ids, loaded } of pages) {
+  for (const { host, ids, loaded, windows } of pages) {
     for (const model of ids) {
+      const contextWindow = windows.get(model);
       found.push({
         id: encodeInjectId(host.id, model),
         host: host.id,
         model,
         label: `${model} (${host.label})`,
         loaded: loaded.has(model),
+        ...(contextWindow ? { contextWindow } : {}),
       });
     }
   }
@@ -292,10 +319,17 @@ export async function mergeLocalInject(
     const existing = options.find((option) => option.id === extra.id);
     if (existing) {
       if (extra.loaded) existing.loaded = true;
+      if (extra.contextWindow) existing.contextWindow = extra.contextWindow;
       continue;
     }
     seen.add(extra.id);
-    options.push({ id: extra.id, label: extra.label, custom: true, ...(extra.loaded ? { loaded: true } : {}) });
+    options.push({
+      id: extra.id,
+      label: extra.label,
+      custom: true,
+      ...(extra.loaded ? { loaded: true } : {}),
+      ...(extra.contextWindow ? { contextWindow: extra.contextWindow } : {}),
+    });
   }
   return { default: catalog.default, options };
 }

--- a/server/drivers/local.test.ts
+++ b/server/drivers/local.test.ts
@@ -1,0 +1,129 @@
+// The local driver against a tiny fake OpenAI-shaped host: /v1/models (what
+// is pulled), /api/ps (what is running, and its window), /v1/chat/completions
+// with SSE. Also the failure that matters most for a local server: nothing
+// listening — the snapshot must say so, in the CLI engines' vocabulary.
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LocalDriver } from "./local.ts";
+import { recordEvents, type EventRecorder } from "../testing/events.ts";
+import type { ProviderInstance } from "../contracts.ts";
+
+let server: Server | null = null;
+let instance: ProviderInstance | null = null;
+let recorder: EventRecorder | null = null;
+const seen: Array<{ url: string; body: any; auth: string | undefined }> = [];
+
+function fakeHost(opts: { running?: string[]; pulled?: string[]; ctx?: Record<string, number> } = {}) {
+  const pulled = opts.pulled ?? ["qwen3:8b", "llama3.2:latest"];
+  const running = opts.running ?? ["qwen3:8b"];
+  const ctx = opts.ctx ?? { "qwen3:8b": 40960 };
+  server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      const body = raw ? JSON.parse(raw) : null;
+      seen.push({ url: req.url ?? "", body, auth: req.headers.authorization });
+      const json = (code: number, o: unknown) => {
+        res.writeHead(code, { "content-type": "application/json" });
+        res.end(JSON.stringify(o));
+      };
+      if (req.url === "/v1/models") return json(200, { object: "list", data: pulled.map((id) => ({ id, object: "model" })) });
+      if (req.url === "/api/ps") return json(200, { models: running.map((m) => ({ name: m, model: m, context_length: ctx[m] })) });
+      if (req.url === "/v1/chat/completions") {
+        if (!body.stream) return json(200, { choices: [{ message: { content: `sync reply to ${body.messages.at(-1).content}` } }], usage: { prompt_tokens: 3, completion_tokens: 4 } });
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        const send = (o: unknown) => res.write(`data: ${JSON.stringify(o)}\n\n`);
+        send({ choices: [{ delta: { content: "hello " } }] });
+        send({ choices: [{ delta: { content: "from local" } }] });
+        send({ choices: [{ delta: {} }], usage: { prompt_tokens: 12, completion_tokens: 2 } });
+        res.write("data: [DONE]\n\n");
+        return res.end();
+      }
+      json(404, { error: "nope" });
+    });
+  });
+  return new Promise<string>((resolve) => server!.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${(server!.address() as any).port}/v1`)));
+}
+
+const create = async (url: string, host = "ollama") => {
+  instance = await LocalDriver.create({ instanceId: "local-test", displayName: undefined, environment: {}, enabled: true, config: { host, url } });
+  recorder = recordEvents(instance.adapter);
+};
+
+afterEach(async () => {
+  recorder?.stop();
+  await instance?.dispose();
+  instance = null;
+  await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+  server = null;
+  seen.length = 0;
+});
+
+describe("LocalDriver", () => {
+  it("builds its catalog from the host: pulled models, running ones first and flagged, windows from /api/ps", async () => {
+    await create(await fakeHost());
+    const opts = instance!.models.options;
+    expect(opts.map((o) => o.id)).toEqual(["qwen3:8b", "llama3.2:latest"]);
+    expect(opts[0]).toMatchObject({ loaded: true, contextWindow: 40960 });
+    expect(opts[1].loaded).toBeUndefined();
+    expect(instance!.models.default).toBe("qwen3:8b");
+    expect(instance!.displayName).toBe("Ollama");
+    await expect(instance!.snapshot()).resolves.toMatchObject({ state: "available" });
+    // keyless hosts still get a bearer — some hide their models without one
+    expect(seen.find((s) => s.url === "/v1/models")?.auth).toMatch(/^Bearer /);
+  });
+
+  it("says the host isn't running when nothing listens, and recovers on refresh", async () => {
+    await create("http://127.0.0.1:1/v1"); // nothing there
+    expect(instance!.models.options).toEqual([]);
+    const snap = await instance!.snapshot();
+    expect(snap.state).toBe("unavailable");
+    expect(snap.reason).toMatch(/isn't running/);
+    // sending with no model is a clear error, not a hang
+    await expect(instance!.adapter.sendTurn({ threadId: "t", text: "hi" })).rejects.toThrow(/no model to run/);
+  });
+
+  it("streams a turn from the transcript with a system role, banks usage, settles", async () => {
+    await create(await fakeHost());
+    const { turnId } = await instance!.adapter.sendTurn({
+      threadId: "t1",
+      text: "hi",
+      system: "You are Wren.",
+      transcript: [{ role: "user", text: "earlier" }, { role: "assistant", text: "noted" }],
+    });
+    await recorder!.until((e) => e.type === "turn.completed");
+    const types = recorder!.events.map((e) => e.type);
+    expect(types).toEqual(["turn.started", "session.started", "content.delta", "content.delta", "item.completed", "thread.token-usage.updated", "turn.completed"]);
+    const done = recorder!.events.at(-1) as any;
+    expect(done).toMatchObject({ turnId, ok: true, usage: { input: 12, output: 2 } });
+    const req = seen.find((s) => s.url === "/v1/chat/completions")!;
+    expect(req.body.model).toBe("qwen3:8b");
+    expect(req.body.messages.map((m: any) => m.role)).toEqual(["system", "user", "assistant", "user"]);
+    expect(req.body.messages[0].role).toBe("system"); // not "developer"
+    expect(req.body.stream).toBe(true);
+  });
+
+  it("generateText uses the host's default model, unstreamed", async () => {
+    await create(await fakeHost());
+    await expect(instance!.generateText!("summarize this")).resolves.toBe("sync reply to summarize this");
+  });
+
+  it("interrupt aborts the in-flight request and settles as interrupted", async () => {
+    await create(await fakeHost());
+    // a host that never finishes: hold the response open
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = createServer((req, res) => {
+      if (req.url === "/v1/models") { res.writeHead(200, { "content-type": "application/json" }); return res.end(JSON.stringify({ data: [{ id: "slow" }] })); }
+      res.writeHead(200, { "content-type": "text/event-stream" }); // never ends
+    });
+    const url = await new Promise<string>((resolve) => server!.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${(server!.address() as any).port}/v1`)));
+    recorder?.stop();
+    await instance!.dispose();
+    await create(url);
+    await instance!.adapter.sendTurn({ threadId: "t2", text: "hang" });
+    await instance!.adapter.interruptTurn("t2");
+    await recorder!.until((e) => e.type === "turn.completed");
+    expect(recorder!.events.at(-1)).toMatchObject({ ok: false, stopReason: "interrupted" });
+  });
+});

--- a/server/drivers/local.ts
+++ b/server/drivers/local.ts
@@ -1,0 +1,313 @@
+// Local driver — a local OpenAI-shaped server (Ollama, LM Studio, oMLX,
+// EXO, Unsloth, or any URL) spoken to DIRECTLY, no CLI in between. The
+// no-CLI path: a bot runs on a locally pulled model with no account and no
+// agent installed. Where an agent CLI IS installed, prefer the injected
+// route (local-inject.ts) — a CLI keeps tools, approvals and the computer;
+// this driver is a chat bot, and says so in its capabilities.
+//
+// Like grok.ts it is transcript-replay (SendTurnInput.transcript feeds it,
+// sized by the harness's rebuild) and streams true token deltas. Unlike
+// grok.ts its snapshot and catalog come from the HOST: /v1/models is what
+// is pulled, /api/ps (Ollama) is what is running and how big its window is,
+// and a refused connection is "not running" with the command that starts
+// it — the same vocabulary the CLI engines use in the picker.
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { contextWindowsFromPs, hostApiKey, LOCAL_HOSTS, loadedIdsFromPayloads, type LocalHost } from "./local-inject.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "local";
+const PROBE_MS = 2_500;
+const TURN_MS = 10 * 60_000;
+
+export interface LocalConfig {
+  /** one of LOCAL_HOSTS' ids, or "custom" with a url */
+  host: string;
+  /** base URL ending in /v1 — required for custom, overrides the host default otherwise */
+  url?: string;
+}
+
+const CUSTOM: LocalHost = { id: "custom", label: "Local server", baseUrl: "http://127.0.0.1:8000/v1", apiKey: "local" };
+
+function hostFor(config: LocalConfig): LocalHost {
+  const known = LOCAL_HOSTS.find((h) => h.id === config.host);
+  const base = known ?? CUSTOM;
+  return config.url ? { ...base, baseUrl: config.url.replace(/\/$/, "") } : base;
+}
+
+function decodeConfig(raw: unknown): LocalConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const host = typeof o.host === "string" && o.host ? o.host : "ollama";
+  const url = typeof o.url === "string" && o.url.trim() ? o.url.trim() : undefined;
+  if (host === "custom" && !url) throw new Error("a custom local server needs a url");
+  return { host, url };
+}
+
+/** What to run when the host is not answering — the CLI engines' signInCommand slot. */
+function startCommandFor(host: LocalHost): string | undefined {
+  switch (host.id) {
+    case "ollama":
+    case "local_ollama":
+      return "ollama serve";
+    case "omlx":
+      return "omlx serve";
+    case "exo":
+      return "exo";
+    case "lmstudio":
+      return "open -a 'LM Studio'";
+    default:
+      return undefined;
+  }
+}
+
+/** Ollama's /api/ps lives beside /v1 on the same origin. */
+function psUrl(host: LocalHost): string | null {
+  const origin = host.baseUrl.replace(/\/v1\/?$/, "");
+  return host.id === "ollama" || host.id === "local_ollama" ? `${origin}/api/ps` : null;
+}
+
+const EMPTY: ModelCatalog = { default: "", options: [] };
+
+export const LocalDriver: ProviderDriver<LocalConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Local models", supportsMultipleInstances: true },
+  models: EMPTY,
+  install: {
+    command: {
+      darwin: "brew install ollama",
+      linux: "curl -fsSL https://ollama.com/install.sh | sh",
+    },
+    docsUrl: "https://ollama.com/download",
+    // not a sign-in — the "start it" command the setup card offers when the
+    // host is installed but not answering
+    signInCommand: "ollama serve",
+  },
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<LocalConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const host = hostFor(config);
+    const env = { ...process.env, ...input.environment };
+    // keyless servers still want a bearer — some hide their models without one
+    const apiKey = hostApiKey(host, env);
+    const headers = { authorization: `Bearer ${apiKey}`, "content-type": "application/json" };
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string }>();
+    let models: ModelCatalog = EMPTY;
+    let lastProbe: { ok: boolean; reason?: string } = { ok: false, reason: "not probed yet" };
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const getJson = async (url: string): Promise<unknown> => {
+      const res = await fetch(url, { headers, signal: AbortSignal.timeout(PROBE_MS) });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    };
+
+    /** /v1/models is what is pulled; /api/ps (Ollama) marks what is running
+     * and reports its window. Missing host → an empty catalog and a reason. */
+    const refreshModels = async () => {
+      try {
+        const catalog = await getJson(`${host.baseUrl}/models`);
+        const ps = psUrl(host);
+        const extra = ps ? await getJson(ps).catch(() => null) : null;
+        const ids = Array.isArray((catalog as { data?: unknown[] })?.data)
+          ? ((catalog as { data: Array<{ id?: unknown }> }).data.map((m) => m.id).filter((id): id is string => typeof id === "string"))
+          : [];
+        const loaded = loadedIdsFromPayloads(host, catalog, extra);
+        const windows = contextWindowsFromPs(extra);
+        // running models first, then the rest — a picker's job is to show
+        // what will answer NOW at the top
+        const sorted = [...ids].sort((a, b) => Number(loaded.has(b)) - Number(loaded.has(a)) || a.localeCompare(b));
+        models = {
+          default: sorted[0] ?? "",
+          options: sorted.map((id) => ({
+            id,
+            label: `${id} (${host.label})`,
+            ...(loaded.has(id) ? { loaded: true } : {}),
+            ...(windows.get(id) ? { contextWindow: windows.get(id) } : {}),
+          })),
+        };
+        lastProbe = { ok: true };
+      } catch (e) {
+        models = EMPTY;
+        const why = e instanceof Error ? e.message : String(e);
+        const start = startCommandFor(host);
+        lastProbe = {
+          ok: false,
+          reason: /ECONNREFUSED|fetch failed|timeout|Timeout/i.test(why)
+            ? `${host.label} isn't running at ${host.baseUrl}${start ? ` — start it with \`${start}\`` : ""}`
+            : `${host.label}: ${why}`,
+        };
+      }
+    };
+    await refreshModels();
+
+    const complete = async (
+      messages: Array<{ role: string; content: string }>,
+      model: string,
+      opts: { stream: boolean; signal?: AbortSignal; onDelta?: (d: string) => void },
+    ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+      const res = await fetch(`${host.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers,
+        // stream_options is how OpenAI-shaped servers include usage in the
+        // final SSE chunk; servers that don't know it ignore it
+        body: JSON.stringify({ model, messages, stream: opts.stream, ...(opts.stream ? { stream_options: { include_usage: true } } : {}) }),
+        signal: opts.signal ?? AbortSignal.timeout(TURN_MS),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`${host.label} HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+      }
+      if (!opts.stream) {
+        const json: any = await res.json();
+        return {
+          text: json.choices?.[0]?.message?.content ?? "",
+          usage: json.usage ? { input: json.usage.prompt_tokens ?? 0, output: json.usage.completion_tokens ?? 0 } : null,
+        };
+      }
+      let text = "";
+      let usage: { input: number; output: number } | null = null;
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line.startsWith("data:")) continue;
+          const data = line.slice(5).trim();
+          if (data === "[DONE]") continue;
+          let chunk: any;
+          try {
+            chunk = JSON.parse(data);
+          } catch {
+            continue;
+          }
+          const delta = chunk.choices?.[0]?.delta?.content;
+          if (delta) {
+            text += delta;
+            opts.onDelta?.(delta);
+          }
+          if (chunk.usage) usage = { input: chunk.usage.prompt_tokens ?? 0, output: chunk.usage.completion_tokens ?? 0 };
+        }
+      }
+      return { text, usage };
+    };
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const model = turn.model || models.default;
+      if (!model) throw new Error(`no model to run — ${lastProbe.reason ?? `pull one on ${host.label} first`}`);
+      const turnId = newId();
+      const abort = new AbortController();
+      active.set(threadId, { abort, turnId });
+
+      // `system`, not `developer`: local servers know the OpenAI shape as
+      // it was, not the newer role (learned from pi)
+      const messages = [
+        ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+        ...(turn.transcript ?? []).map((m) => ({ role: m.role === "assistant" ? "assistant" : "user", content: m.text })),
+        { role: "user", content: turn.text },
+      ];
+      appendNative(threadId, { dir: "out", source: "local.chat.completions", msg: { host: host.id, model, messages } });
+
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({ ...base(threadId, turnId), type: "session.started", sessionId: null, model });
+
+      (async () => {
+        try {
+          const { text, usage } = await complete(messages, model, {
+            stream: true,
+            signal: abort.signal,
+            onDelta: (delta) => emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta }),
+          });
+          appendNative(threadId, { dir: "in", source: "local.chat.completions", msg: { text, usage } });
+          if (text.trim()) emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+          if (usage) emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+          active.delete(threadId);
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null, ...(usage ? { usage } : {}) });
+        } catch (e) {
+          active.delete(threadId);
+          const aborted = (e as Error).name === "AbortError";
+          if (!aborted) emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: aborted ? "interrupted" : "error", cost: null });
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      await refreshModels();
+      if (!lastProbe.ok) return { state: "unavailable", reason: lastProbe.reason, notRunning: /isn't running/.test(lastProbe.reason ?? "") };
+      return { state: "available", authenticated: true, version: null };
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName ?? host.label,
+      enabled: input.enabled,
+      get models() {
+        return models;
+      },
+      refreshModels,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        // a bare API: no MCP, no asks, no computer, no live session — the
+        // injected-CLI route is where those live
+        capabilities: { sessionModelSwitch: "in-session", computerMcp: false, agentsMcp: false, composioMcp: false, queueing: false },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+        respondToRequest: async () => "unavailable" as const, // this engine has no asks to answer
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { abort } of active.values()) abort.abort();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      generateText: async (prompt: string) => {
+        const model = models.default;
+        if (!model) throw new Error(`no local model to summarize with — ${lastProbe.reason ?? "none pulled"}`);
+        const { text } = await complete([{ role: "user", content: prompt }], model, { stream: false });
+        return text;
+      },
+      dispose: async () => {
+        for (const { abort } of active.values()) abort.abort();
+        listeners.clear();
+      },
+    };
+  },
+};
+
+export { startCommandFor as localStartCommand };

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -171,6 +171,7 @@ export class ProviderRegistry {
             agentsMcp: inst.adapter.capabilities.agentsMcp === true,
             composioMcp: inst.adapter.capabilities.composioMcp === true,
             effortLevels: inst.adapter.capabilities.effortLevels,
+            queueing: inst.adapter.capabilities.queueing === true,
           },
           access: driver?.metadata.access ?? "subscription",
           install: driver?.install,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2648,6 +2648,24 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const text = String(body.text ?? "").trim();
       if (!text) return json(res, 400, { error: "text required" });
+      // A message during a running turn: engines that keep a live session
+      // (capabilities.queueing) take it INTO the turn — the model sees it
+      // before its next call, the way typing into Claude Code's own UI mid-
+      // task does. It lands in the transcript in order. Engines without
+      // that keep the 409 the composer already knows how to queue behind.
+      const busyBot = store.bot(m[1]);
+      if (busyBot?.busy && !busyBot.hidden) {
+        const instance = registry.get(busyBot.modelSelection.instanceId);
+        if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
+          const steered = await instance.adapter.steer(busyBot.threadId, text).catch(() => false);
+          if (steered) {
+            store.appendMessage(busyBot.threadId, { role: "user", kind: "text", text, steered: true });
+            return json(res, 202, { ok: true, steered: true });
+          }
+          // the turn settled between the busy check and the write — fall
+          // through and send it as the next turn instead
+        }
+      }
       await startTurn(m[1], text);
       return json(res, 202, { ok: true });
     }

--- a/server/steer-e2e.test.ts
+++ b/server/steer-e2e.test.ts
@@ -1,0 +1,133 @@
+// Mid-turn steering, end to end: boots the real harness with the fake claude
+// CLI in `slow` mode (a gap after the tool result the way a real turn has
+// between model calls), sends a message WHILE the turn runs, and asserts
+// it is taken into the turn — 202 steered, not 409; in the transcript in
+// order and marked; folded into the reply — while an engine without a live
+// session still gets the 409 the composer queues behind.
+//
+// POSIX-gated like the other CLI e2es (the fakes are shebang scripts).
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+const FAKE_ACP = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+posixOnly("mid-turn steering e2e", () => {
+  let child: ChildProcess;
+  let home: string;
+  let stderr = "";
+
+  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json() };
+  };
+  const getBot = async (id: string) => (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === id);
+  const waitFor = async (predicate: () => Promise<boolean>, what: string, ms = 30_000) => {
+    const deadline = Date.now() + ms;
+    while (!(await predicate())) {
+      if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+
+  beforeAll(async () => {
+    chmodSync(FAKE_CLAUDE, 0o755);
+    chmodSync(FAKE_ACP, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-steer-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          claude: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "slow" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+          // no live session: a message while busy is a 409 the composer queues behind
+          acp: { driver: "grokAgent", environment: { FAKE_ACP_MODE: "hang" }, config: { cli: FAKE_ACP, fullAuto: true } },
+        },
+      }),
+    );
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: { ...(process.env.PATH ? { PATH: process.env.PATH } : {}), HOME: home, USERPROFILE: home, OMB_PORT: String(PORT) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        if ((await fetch(`${BASE}/api/health`)).ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it(
+    "a message during a Claude turn is steered into it: 202, in the transcript in order and marked, folded into the reply",
+    async () => {
+      const created = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "claude", model: "claude-fake" } });
+      const instances = (await api("GET", "/api/instances")).body.instances;
+      expect(instances.find((i: any) => i.instanceId === "claude").capabilities.queueing).toBe(true);
+
+      expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first" })).status).toBe(202);
+      await waitFor(async () => (await getBot(created.id)).busy === true, "the turn to start");
+      // the fake pauses after its tool result; this lands inside that gap
+      await waitFor(async () => (await getBot(created.id)).messages.some((m: any) => m.kind === "activity"), "the tool chip");
+      const second = await api("POST", `/api/bots/${created.id}/messages`, { text: "and also this" });
+      expect(second.status).toBe(202);
+      expect(second.body.steered).toBe(true);
+
+      await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle");
+      const bot = await getBot(created.id);
+      const texts = bot.messages.filter((m: any) => m.kind === "text").map((m: any) => `${m.role}:${m.text}`);
+      // order: greeting, first, the fake's opening line, the steered message
+      // (appended when it was sent — mid-turn), then ONE reply carrying it
+      expect(texts.slice(1)).toEqual([
+        "user:first",
+        "bot:hello from fake claude",
+        "user:and also this",
+        "bot:reply to: first + steered: and also this",
+      ]);
+      const steered = bot.messages.find((m: any) => m.text === "and also this");
+      expect(steered.steered).toBe(true);
+      // one turn, not two: exactly one reply
+      expect(bot.messages.filter((m: any) => m.role === "bot" && m.kind === "text" && m.text.startsWith("reply to:"))).toHaveLength(1);
+    },
+    40_000,
+  );
+
+  it("an engine without a live session still refuses a message while busy (the composer queues it)", async () => {
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "acp", model: "fake-model" } });
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first" })).status).toBe(202);
+    await waitFor(async () => (await getBot(created.id)).busy === true, "the hung turn to start");
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "second" })).status).toBe(409);
+    await api("POST", `/api/bots/${created.id}/interrupt`);
+    await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle");
+  }, 30_000);
+});

--- a/server/store.ts
+++ b/server/store.ts
@@ -63,6 +63,10 @@ export interface Message {
   /** `setup` marks an error the user fixes by installing or configuring
    * something — the UI offers setup instead of a retry that cannot work. */
   tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
+  /** user messages sent INTO a running turn (capabilities.queueing): the
+   * model saw it mid-turn, so the transcript marks it — a reader should
+   * know the reply above it may already account for this line */
+  steered?: boolean;
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -52,18 +52,36 @@ if (argv[0] === "auth" && argv[1] === "status") {
   );
 }
 
-let stdin = "";
-process.stdin.on("data", (c) => (stdin += c));
-process.stdin.on("end", () => {
-  type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
-  let prompt: JsonValue = null;
-  try {
-    prompt = JSON.parse(stdin.split("\n").find((l) => l.trim()) ?? "null");
-  } catch {
-    /* leave null — the test will see it */
-  }
+// Line-driven, like the real CLI under --input-format stream-json: each user
+// message starts a turn; a message that arrives WHILE a turn is playing is
+// folded into it (the real CLI delivers it before the next model call — the
+// harness calls that a steer); the process stays alive with stdin open and
+// exits only when stdin ends. `slow` leaves a gap between the tool result
+// and the reply so a test can steer into it.
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+const sessionId = argAfter("--resume") ?? argAfter("--session-id") ?? "fake-session";
+const model = argAfter("--model") ?? "claude-fake";
+let dumped = false;
+let initSent = false;
+let turnRunning = false;
+let steered: string[] = [];
+const queue: JsonValue[] = [];
+let stdinEnded = false;
 
-  if (process.env.FAKE_CLAUDE_DUMP) {
+const promptText = (prompt: JsonValue): string => {
+  const m = prompt && typeof prompt === "object" && !Array.isArray(prompt) ? (prompt as { message?: { content?: unknown } }).message : undefined;
+  return typeof m?.content === "string" ? m.content : "";
+};
+
+const finishIfDone = () => {
+  if (stdinEnded && !turnRunning && queue.length === 0) process.exit(0);
+};
+
+const playTurn = (prompt: JsonValue) => {
+  turnRunning = true;
+  steered = [];
+  if (!dumped && process.env.FAKE_CLAUDE_DUMP) {
+    dumped = true;
     const configPath = argAfter("--mcp-config");
     let mcpConfig: unknown = null;
     if (configPath) {
@@ -76,15 +94,14 @@ process.stdin.on("end", () => {
     writeFileSync(process.env.FAKE_CLAUDE_DUMP, JSON.stringify({ argv, env: process.env, prompt, mcpConfig }, null, 2));
   }
 
-  const sessionId = argAfter("--resume") ?? argAfter("--session-id") ?? "fake-session";
-  const model = argAfter("--model") ?? "claude-fake";
-
   if (mode === "exit-early") {
     process.stderr.write("fake-claude: simulated crash before result\n");
     process.exit(3);
   }
 
+  // the real CLI re-announces init on every turn of a live process
   out({ type: "system", subtype: "init", session_id: sessionId, model });
+  initSent = true;
 
   if (mode === "hang") {
     // stay alive until killed — lets tests exercise interrupt + the
@@ -121,6 +138,47 @@ process.stdin.on("end", () => {
     },
   });
   out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu-1", is_error: false }] } });
-  out({ type: "result", is_error: false, stop_reason: "end_turn", total_cost_usd: 0.01 });
-  process.exit(0);
+
+  const finish = () => {
+    out({ type: "result", is_error: false, stop_reason: "end_turn", total_cost_usd: 0.01, usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 } });
+    turnRunning = false;
+    if (queue.length) playTurn(queue.shift()!);
+    else finishIfDone();
+  };
+  if (mode === "slow") {
+    // a gap a test can steer into; the closing reply carries anything that
+    // was folded in, the way the real CLI includes a mid-turn message in
+    // the same turn's next model call
+    setTimeout(() => {
+      const tail = steered.length ? ` + steered: ${steered.join(" | ")}` : "";
+      out({ type: "assistant", message: { content: [{ type: "text", text: `reply to: ${promptText(prompt)}${tail}` }] } });
+      finish();
+    }, 800);
+  } else {
+    finish();
+  }
+};
+
+let buf = "";
+process.stdin.on("data", (c) => {
+  buf += c;
+  let nl;
+  while ((nl = buf.indexOf("\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    let prompt: JsonValue = null;
+    try {
+      prompt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (turnRunning) steered.push(promptText(prompt));
+    else playTurn(prompt);
+  }
 });
+process.stdin.on("end", () => {
+  stdinEnded = true;
+  finishIfDone();
+});
+void initSent;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -351,6 +351,11 @@ function Bubble({
               >
                 {text}
               </div>
+              {message.steered && (
+                <div className="mt-1 text-[11px] text-ink-secondary/70" title="Sent while the bot was working — it saw this before its next step, inside the same turn.">
+                  sent mid-turn
+                </div>
+              )}
               {collapsible && (
                 <button onClick={() => setExpanded(true)} className="mt-1 text-[12.5px] text-ink-secondary hover:text-ink">
                   Show full message

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -48,6 +48,10 @@ export function Composer({
   // offers members plus @everyone; explicit mentions override the room's
   // configured default responder.
   const busy = group ? Boolean(group.busyBotId) : Boolean(bot?.busy);
+  // an engine with a live session takes a message INTO the running turn;
+  // for those the composer never locks — the server steers instead of 409
+  const canSteer =
+    !group && Boolean(bot) && state.instances.find((i) => i.instanceId === bot!.modelSelection.instanceId)?.capabilities?.queueing === true;
   // a pending approval blocks the prompt until it is answered
   const threadId = group?.threadId ?? bot?.threadId ?? "";
   // the VISIBLE branch only — an approval left on a branch you edited away
@@ -136,7 +140,7 @@ export function Composer({
   const send = () => {
     const t = composeMessage(text, attachments);
     if (!t) return;
-    if (busy) {
+    if (busy && !canSteer) {
       setQueued(t);
       setText("");
       setAttachments([]);
@@ -348,7 +352,9 @@ export function Composer({
               ? "Answer the approval above to continue"
               : recording
               ? "Listening…"
-              : busy
+              : busy && canSteer
+                ? `${busyName} is working — Enter sends this into the running turn`
+                : busy
                 ? `${busyName} is working — Enter queues your message`
                 : group
                   ? `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -119,11 +119,15 @@ export function EngineSetup({
   const installCommand = installCommandFor(install);
   const signInCommand = install?.signInCommand;
   const signInOnly = intent === "cloud" && needsSignIn(instance);
-  const command = signInOnly ? signInCommand : installCommand;
-  const title = signInOnly ? `Sign in to ${instance.displayName}` : `Install ${instance.displayName}`;
+  // a local server that is installed but not up: the fix is to start it
+  const startOnly = Boolean(instance.snapshot.notRunning && signInCommand);
+  const command = signInOnly || startOnly ? signInCommand : installCommand;
+  const title = signInOnly ? `Sign in to ${instance.displayName}` : startOnly ? `Start ${instance.displayName}` : `Install ${instance.displayName}`;
   const description = signInOnly
     ? "Finish the account sign-in in Terminal. Reopen this menu afterward and we’ll check again."
-    : intent === "inject"
+    : startOnly
+      ? "It’s installed but not answering. Start it, then reopen this menu and we’ll check again."
+      : intent === "inject"
       ? "Install the agent once, then you can run it with local models—no cloud sign-in required."
       : `Install the command-line app once. Models will appear here as soon as it’s ready${signInCommand ? "; sign-in may follow" : ""}.`;
 
@@ -144,7 +148,7 @@ export function EngineSetup({
     <div className={cn("rounded-xl border border-hairline/40 bg-raised/30 p-3", className)}>
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-inset text-ink-secondary">
-          {signInOnly ? <LogIn size={14} /> : <Download size={14} />}
+          {signInOnly || startOnly ? <LogIn size={14} /> : <Download size={14} />}
         </span>
         <div className="min-w-0">
           <div className="text-[13px] font-semibold text-ink">{title}</div>
@@ -153,7 +157,7 @@ export function EngineSetup({
       </div>
 
       {command ? (
-        <CommandRow command={command} actionLabel={signInOnly ? "Open sign-in in Terminal" : "Open install in Terminal"} />
+        <CommandRow command={command} actionLabel={signInOnly ? "Open sign-in in Terminal" : startOnly ? "Start in Terminal" : "Open install in Terminal"} />
       ) : (
         <p className="mt-3 rounded-lg bg-inset px-2.5 py-2 text-[12px] leading-relaxed text-ink-secondary">
           There isn’t a one-line installer for this platform. Use the setup guide below.

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -49,6 +49,8 @@ export interface Message {
    * narration of the same chip ("reading a file"), used by call mode. */
   /** `setup` marks an error fixed by installing something, not by retrying. */
   tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
+  /** user messages sent into a running turn — the model saw it mid-turn */
+  steered?: boolean;
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;
@@ -216,6 +218,8 @@ export interface InstanceInfo {
     agentsMcp?: boolean;
     composioMcp?: boolean;
     effortLevels?: readonly EffortLevel[];
+    /** the engine keeps a live session and takes a message mid-turn */
+    queueing?: boolean;
   };
   /** `custom` agents sit below the rail divider — no subscription catalog. */
   access?: "subscription" | "custom";

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -211,6 +211,8 @@ export interface InstanceInfo {
     reason?: string;
     authenticated?: boolean;
     version?: string | null;
+    /** installed but not running — the setup card offers "start it" */
+    notRunning?: boolean;
   };
   models: { default: string; options: Array<{ id: string; label: string; custom?: boolean; loaded?: boolean }> };
   capabilities?: {


### PR DESCRIPTION
## In plain language

**A bot can now run on a local model with nothing else installed** — no Claude Code, no Codex, no account. Just Ollama (or LM Studio / oMLX / EXO / Unsloth) running on the machine.

- *What changes in the app:* a new **"Local models"** engine in the model picker (below the rail, with the other custom engines). If Ollama is installed but not running, its card says **"Start Ollama"** with `ollama serve` and a "Start in Terminal" button — not an install card. Once it's up, the models you've pulled appear, running ones first and flagged, and you pick one like any other model.
- *What kind of bot you get:* a plain chat bot — streams token by token, remembers the thread — with **no tools, no computer, no approvals** (it's a bare API; the card's capabilities say so). When you *do* have Claude Code or Codex installed, keep using the existing route where a CLI is pointed at Ollama — that one keeps tools.
- If the host goes away mid-conversation you get a clear *"no model to run — Ollama isn't running…"*, not a hang.

## Why this shape

`main` already covers local models by **injecting** them into installed agent CLIs (#174/#177): the better route when a CLI exists. The plan's 3.1 "done when" — *a bot runs on a locally pulled model with no cloud credentials configured anywhere* — still failed on a CLI-less machine. This fills exactly that gap and nothing more.

## Changes

- **`server/drivers/local.ts`** — factored from `grok.ts`: OpenAI-shaped `/v1/chat/completions` SSE client, transcript replay (fed by the harness's rebuild), `generateText`, `system` role (not `developer` — local servers know the classic shape), bearer on keyless hosts (some hide models without one). Hosts from `LOCAL_HOSTS` or `{ host: "custom", url }`. Catalog from the host: `/v1/models` = pulled, `/api/ps` (Ollama) = running (+ real `contextWindow` from #219's `contextWindowsFromPs`); `refreshModels()` re-probes without a restart. Capabilities: `computerMcp/agentsMcp/composioMcp/queueing` all `false`.
- **`server/contracts.ts`** — `ProviderSnapshot.notRunning?: boolean` (additive). **`EngineSetup.tsx`** — when set and `install.signInCommand` exists, the card is *"Start X"* with that command.
- **`server/drivers/builtIn.ts`** / **`server/config.ts`** — registered; a default `local` (Ollama) instance ships into existing fleets the same way Qwen/Hermes did (`CUSTOM_ONLY`).
- Install descriptor: `brew install ollama` / the curl installer for linux, docs link, `signInCommand: ollama serve` (the "start it" slot).

Not in scope: vLLM as a named host (use `custom`), tools for the bare API (the injected-CLI route is for that), model-free tool-result pruning (waits for #193's rebuild).

**Stacked on #219** (uses `contextWindowsFromPs` and `capabilities.queueing`); the diff shrinks to just this driver once #219 lands.

Item 3.1 of `docs/plans/agent-harness-upgrades-v2.md`.

## Test plan

- [x] `server/drivers/local.test.ts` (5, against a fake OpenAI-shaped host): catalog from `/v1/models` + `/api/ps` (running first, flagged, window), bearer sent; nothing listening → `unavailable` "isn't running" and a clear send error; a streamed turn (system → transcript → user, `system` role, usage banked, settles); `generateText`; interrupt aborts and settles `interrupted`
- [x] `server/config.test.ts` — `local` in the default fleet and added onto existing product fleets
- [x] `pnpm typecheck` clean; `pnpm vitest run` green (94 files, 924 passed)
- [x] Manual: on this Mac (Ollama installed, not running) the picker shows the "Start Ollama" card with `ollama serve`; `/api/instances` reports `notRunning: true` with the reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for local AI engines, including Ollama and other OpenAI-compatible servers.
  - Local engines now show available models, running status, and context limits.
  - Messages can be sent into active turns when supported, with clear in-chat indicators.
  - Claude sessions now persist across turns and support mid-turn steering.

- **Improvements**
  - Engine setup now provides start commands for installed but stopped engines.
  - Added interruption, streaming, usage tracking, and improved session cleanup for local engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->