### PR TITLE
fix desktop sync for phone-created bots

### DIFF
--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { initialState, reducer, type Bot, type Message } from "./store";
+
+describe("cross-client bot creation", () => {
+  it("adds an announced bot before its greeting frames arrive", () => {
+    const announced = {
+      id: "phone-bot",
+      threadId: "phone-thread",
+      name: "Scout",
+      title: "",
+      description: "",
+      notifications: true,
+      color: "green",
+      unread: false,
+      modelSelection: { instanceId: "codex", model: "default" },
+    } satisfies Omit<Bot, "messages">;
+
+    const added = reducer(initialState, { type: "botPatched", bot: announced });
+
+    expect(added.bots).toEqual([{ ...announced, messages: [] }]);
+
+    const greeting = {
+      id: "greeting",
+      role: "bot",
+      kind: "text",
+      text: "Hey — I'm Scout. Nice to meet you.",
+      at: 2,
+    } satisfies Message;
+    const greeted = reducer(added, {
+      type: "messageAdded",
+      threadId: announced.threadId,
+      message: greeting,
+    });
+
+    expect(greeted.bots[0]?.messages).toEqual([greeting]);
+  });
+});

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -294,6 +294,8 @@ export interface AppState {
   } | null;
 }
 
+type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
+
 export type Action =
   | { type: "hydrate"; bots: Bot[]; groups: Group[] }
   | { type: "showRoutines" }
@@ -353,7 +355,7 @@ export type Action =
   | { type: "deleteBot"; botId: string }
   | { type: "duplicateBot"; botId: string }
   | { type: "markUnread"; botId: string }
-  | { type: "botPatched"; bot: Partial<Bot> & { id: string } }
+  | { type: "botPatched"; bot: BotAnnouncement }
   | { type: "messageAdded"; threadId: string; message: Message }
   | { type: "messagePatched"; threadId: string; message: Message }
   | { type: "screenFrame"; botId: string; png: string; mime: string }
@@ -423,7 +425,7 @@ function patchCard(state: AppState, botId: string, messageId: string, patch: Par
   }));
 }
 
-function reducer(state: AppState, action: Action): AppState {
+export function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
     case "hydrate": {
       const known = (id: string) => action.bots.some((b) => b.id === id) || action.groups.some((g) => g.id === id);
@@ -545,12 +547,15 @@ function reducer(state: AppState, action: Action): AppState {
       return updateBot(withMascotMotion(state, action.botId, "surprise"), action.botId, (b) => ({ ...b, unread: true }));
     case "botPatched": {
       const before = state.bots.find((b) => b.id === action.bot.id);
-      // A bot event can announce a bot created by another app window (team
-      // import). Patch events for unknown partial records remain ignored.
+      // Bot frames are complete except for their transcript. An unknown one
+      // was created by another client (the phone, another app window, or a
+      // team import), so add it now; the following message frames will fill
+      // its greeting without waiting for a full-page hydration.
       if (!before) {
-        return Array.isArray(action.bot.messages)
-          ? { ...state, bots: [action.bot as Bot, ...state.bots] }
-          : state;
+        return {
+          ...state,
+          bots: [{ ...action.bot, messages: action.bot.messages ?? [] }, ...state.bots],
+        };
       }
       const kind =
         action.bot.unread && !before?.unread
@@ -832,7 +837,7 @@ function reducer(state: AppState, action: Action): AppState {
 /** Newest screen frames whose pixels stay in memory per thread. */
 const MAX_KEPT_SCREEN_FRAMES = 8;
 
-const initialState: AppState = {
+export const initialState: AppState = {
   bots: [],
   groups: [],
   instances: [],
@@ -1292,7 +1297,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           clearStream(frame.threadId);
           break;
         case "bot": {
-          const bot = frame.bot as Partial<Bot> & { id: string };
+          const bot = frame.bot as BotAnnouncement;
           // reading the selected chat clears its badge immediately
           if (bot.unread && bot.id === stateRef.current.selectedId) {
             bot.unread = false;


### PR DESCRIPTION
## What changed

- treat a complete bot SSE announcement as a cross-client creation when the desktop does not know its id
- insert that bot immediately with an empty transcript
- continue folding the following greeting/message frames into the new bot
- add a reducer regression test for the exact phone-created-bot event sequence

## Root cause

The phone successfully created and persisted the bot, then applied the HTTP response locally. The desktop received the server's slim bot announcement but ignored unknown bots unless the event also carried a `messages` array. A full desktop refresh hydrated the bot, which made this look like creation had failed.

## Impact

Bots created by the iOS companion, another desktop window, or an import now appear in every connected desktop roster immediately without a reload.

## Validation

- targeted reducer regression — passed
- `pnpm typecheck` — passed
- `pnpm test` — 973 passed, 8 skipped
- updater coordinator tests — 12 passed
- packaged-server smoke test — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-client bot updates so newly encountered bots are added correctly.
  * Ensured greeting messages are appended to the appropriate bot conversation, even when the bot was not previously loaded.

* **Tests**
  * Added coverage for bot creation and message handling across clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->