### PR TITLE
Add secure in-chat connector authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,8 @@ electron/resources/speech-helper
 electron/resources/OpenMausBot Speech.app
 release
 .omb-scratch
+.wrangler/
+.dev.vars
+.dev.vars.*
+cloudflare/composio-broker/worker-configuration.d.ts
 .claude/worktrees/

--- a/cloudflare/composio-broker/README.md
+++ b/cloudflare/composio-broker/README.md
@@ -1,0 +1,24 @@
+# OpenMausBot connected-apps broker
+
+This Worker keeps the shared Composio project key out of desktop builds. Each
+installation receives a random bearer token stored only as a SHA-256 hash in
+D1. The Worker gives that installation its own Composio user/session, proxies
+MCP traffic, and returns short-lived Connect Links to the local app.
+
+The desktop never receives the project key. Authorization links are returned
+only on demand and are never persisted in chat messages.
+
+Deployment for this repository:
+
+1. `pnpm broker:types`
+2. `pnpm exec wrangler d1 migrations apply openmausbot-composio --remote --config cloudflare/composio-broker/wrangler.jsonc`
+3. For an existing Worker, run `pnpm exec wrangler secret put COMPOSIO_API_KEY --config cloudflare/composio-broker/wrangler.jsonc`, then `pnpm broker:deploy`.
+4. For the very first deploy, put `COMPOSIO_API_KEY=...` in the ignored `.dev.vars.production` file and run `pnpm exec wrangler deploy --config cloudflare/composio-broker/wrangler.jsonc --secrets-file .dev.vars.production`. Delete the file immediately afterward.
+
+Forks should create their own D1 database and rate-limit namespaces, replace
+the IDs in `wrangler.jsonc`, deploy under their own Worker name, and set
+`OMB_COMPOSIO_BROKER_URL` in their packaged build. Running only the local
+server with a Composio project key remains the no-Cloudflare self-host path.
+
+Set `REGISTRATION_MODE` to `closed` to stop issuing new installation tokens
+without affecting existing users.

--- a/cloudflare/composio-broker/migrations/0001_installations.sql
+++ b/cloudflare/composio-broker/migrations/0001_installations.sql
@@ -1,0 +1,11 @@
+CREATE TABLE installations (
+  id TEXT PRIMARY KEY,
+  token_hash TEXT NOT NULL UNIQUE,
+  composio_user_id TEXT NOT NULL UNIQUE,
+  session_id TEXT,
+  created_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  disabled_at INTEGER
+);
+
+CREATE INDEX installations_last_seen_idx ON installations(last_seen_at);

--- a/cloudflare/composio-broker/src/index.test.ts
+++ b/cloudflare/composio-broker/src/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSession, sha256 } from "./index";
+
+describe("connected-apps broker boundaries", () => {
+  it("accepts only HTTPS Composio MCP endpoints", () => {
+    expect(parseSession({
+      session_id: "session-1",
+      mcp: { url: "https://mcp.composio.dev/session", headers: { "x-session": "one", host: "bad" } },
+    })).toEqual({
+      sessionId: "session-1",
+      url: "https://mcp.composio.dev/session",
+      headers: { "x-session": "one" },
+    });
+    expect(() => parseSession({ session_id: "session-1", mcp: { url: "https://attacker.example/mcp" } })).toThrow(/untrusted/i);
+    expect(() => parseSession({ session_id: "session-1", mcp: { url: "http://mcp.composio.dev/session" } })).toThrow(/untrusted/i);
+  });
+
+  it("hashes installation tokens before storage", async () => {
+    await expect(sha256("openmausbot")).resolves.toBe("63c74f70a9d4681c334e84001935955a75245ea5b16b9c37c808e85c69963705");
+  });
+});

--- a/cloudflare/composio-broker/src/index.ts
+++ b/cloudflare/composio-broker/src/index.ts
@@ -1,0 +1,263 @@
+interface InstallationRow {
+  id: string;
+  composio_user_id: string;
+  session_id: string | null;
+  disabled_at: number | null;
+}
+
+interface ComposioSession {
+  sessionId: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+const JSON_HEADERS = { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" };
+const MAX_MCP_BODY = 2 * 1024 * 1024;
+
+function json(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), { status, headers: JSON_HEADERS });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function randomToken() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256(value: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function parseSession(value: unknown): ComposioSession {
+  if (!isRecord(value) || typeof value.session_id !== "string" || !isRecord(value.mcp)) {
+    throw new Error("Composio returned an invalid session");
+  }
+  if (typeof value.mcp.url !== "string") throw new Error("Composio returned no MCP URL");
+  const url = new URL(value.mcp.url);
+  if (url.protocol !== "https:" || (url.hostname !== "composio.dev" && !url.hostname.endsWith(".composio.dev"))) {
+    throw new Error("Composio returned an untrusted MCP URL");
+  }
+  const headers: Record<string, string> = {};
+  if (isRecord(value.mcp.headers)) {
+    for (const [name, header] of Object.entries(value.mcp.headers)) {
+      if (typeof header !== "string" || /^(host|cookie|content-length)$/i.test(name)) continue;
+      headers[name] = header;
+    }
+  }
+  return { sessionId: value.session_id, url: url.toString(), headers };
+}
+
+async function upstreamError(response: Response, fallback: string) {
+  const text = await response.text().catch(() => "");
+  try {
+    const body = JSON.parse(text) as { message?: unknown; error?: unknown };
+    const nested = isRecord(body.error) ? body.error.message ?? body.error.error : body.error;
+    return String(body.message ?? nested ?? fallback).slice(0, 240);
+  } catch {
+    return text.trim().slice(0, 240) || fallback;
+  }
+}
+
+function composioRequest(env: Env, path: string, init?: RequestInit) {
+  return fetch(`${env.COMPOSIO_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      accept: "application/json",
+      "x-api-key": env.COMPOSIO_API_KEY,
+      ...(init?.body ? { "content-type": "application/json" } : {}),
+      ...init?.headers,
+    },
+    signal: init?.signal ?? AbortSignal.timeout(30_000),
+  });
+}
+
+async function getSession(env: Env, sessionId: string) {
+  const response = await composioRequest(env, `/tool_router/session/${encodeURIComponent(sessionId)}`);
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(await upstreamError(response, `Session lookup failed (${response.status})`));
+  return parseSession(await response.json());
+}
+
+async function createSession(env: Env, userId: string) {
+  const response = await composioRequest(env, "/tool_router/session", {
+    method: "POST",
+    body: JSON.stringify({
+      user_id: userId,
+      manage_connections: {
+        enable: true,
+        enable_wait_for_connections: true,
+        enable_connection_removal: true,
+      },
+    }),
+  });
+  if (!response.ok) throw new Error(await upstreamError(response, `Session creation failed (${response.status})`));
+  return parseSession(await response.json());
+}
+
+async function ensureSession(installation: InstallationRow, env: Env, ctx: ExecutionContext) {
+  if (!(await env.SESSION_LIMITER.limit({ key: installation.id })).success) {
+    throw new Response(JSON.stringify({ error: "too many connected-app requests" }), { status: 429, headers: JSON_HEADERS });
+  }
+  let session = installation.session_id ? await getSession(env, installation.session_id) : null;
+  if (!session) {
+    session = await createSession(env, installation.composio_user_id);
+    await env.DB.prepare("UPDATE installations SET session_id = ?, last_seen_at = ? WHERE id = ?")
+      .bind(session.sessionId, Date.now(), installation.id)
+      .run();
+  } else {
+    ctx.waitUntil(
+      env.DB.prepare("UPDATE installations SET last_seen_at = ? WHERE id = ?")
+        .bind(Date.now(), installation.id)
+        .run()
+        .catch((error: unknown) => console.error(JSON.stringify({ message: "last-seen update failed", id: installation.id, error: String(error) }))),
+    );
+  }
+  return session;
+}
+
+async function authenticate(request: Request, env: Env) {
+  const token = request.headers.get("authorization")?.match(/^Bearer ([0-9a-f]{64})$/)?.[1];
+  if (!token) return null;
+  const row = await env.DB.prepare(
+    "SELECT id, composio_user_id, session_id, disabled_at FROM installations WHERE token_hash = ?",
+  ).bind(await sha256(token)).first<InstallationRow>();
+  return row && row.disabled_at === null ? row : null;
+}
+
+async function register(request: Request, env: Env) {
+  if (env.REGISTRATION_MODE !== "open") return json({ error: "registration is temporarily closed" }, 503);
+  const fingerprint = `${request.headers.get("cf-connecting-ip") ?? "unknown"}|${request.headers.get("user-agent") ?? "unknown"}`;
+  if (!(await env.REGISTRATION_LIMITER.limit({ key: await sha256(fingerprint.slice(0, 512)) })).success) {
+    return json({ error: "too many registration attempts" }, 429);
+  }
+  const installationId = crypto.randomUUID();
+  const token = randomToken();
+  const now = Date.now();
+  await env.DB.prepare(
+    "INSERT INTO installations (id, token_hash, composio_user_id, created_at, last_seen_at) VALUES (?, ?, ?, ?, ?)",
+  ).bind(installationId, await sha256(token), `omb_${installationId.replaceAll("-", "")}`, now, now).run();
+  console.log(JSON.stringify({ message: "installation registered", installationId }));
+  return json({ installationId, token }, 201);
+}
+
+async function proxyMcp(request: Request, installation: InstallationRow, env: Env, ctx: ExecutionContext) {
+  const declared = Number(request.headers.get("content-length") ?? "0");
+  if (declared > MAX_MCP_BODY) return json({ error: "MCP request is too large" }, 413);
+  const body = await request.arrayBuffer();
+  if (body.byteLength > MAX_MCP_BODY) return json({ error: "MCP request is too large" }, 413);
+  const session = await ensureSession(installation, env, ctx);
+  const response = await fetch(session.url, {
+    method: "POST",
+    headers: {
+      ...session.headers,
+      "x-api-key": env.COMPOSIO_API_KEY,
+      "content-type": request.headers.get("content-type") ?? "application/json",
+      accept: "application/json, text/event-stream",
+      ...(request.headers.get("mcp-session-id") ? { "mcp-session-id": request.headers.get("mcp-session-id")! } : {}),
+    },
+    body,
+    signal: AbortSignal.timeout(10 * 60_000),
+  });
+  const headers = new Headers({
+    "content-type": response.headers.get("content-type") ?? "application/json",
+    "cache-control": "no-store",
+  });
+  const mcpSession = response.headers.get("mcp-session-id");
+  if (mcpSession) headers.set("mcp-session-id", mcpSession);
+  return new Response(response.body, { status: response.status, headers });
+}
+
+async function catalog(env: Env) {
+  const response = await fetch(`${env.COMPOSIO_TOOLKIT_BASE}/toolkits?limit=500&sort_by=usage`, {
+    headers: { accept: "application/json", "x-api-key": env.COMPOSIO_API_KEY },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) return json({ error: await upstreamError(response, "Catalog unavailable") }, 502);
+  return new Response(response.body, {
+    headers: { "content-type": response.headers.get("content-type") ?? "application/json", "cache-control": "private, max-age=600" },
+  });
+}
+
+async function connectionStatus(url: URL, installation: InstallationRow, env: Env, ctx: ExecutionContext) {
+  const slugs = [...new Set((url.searchParams.get("services") ?? "").split(",").map((slug) => slug.toLowerCase()).filter(Boolean))].slice(0, 50);
+  const session = await ensureSession(installation, env, ctx);
+  const response = await composioRequest(
+    env,
+    `/tool_router/session/${encodeURIComponent(session.sessionId)}/toolkits?${new URLSearchParams({ limit: "50", toolkits: slugs.join(",") })}`,
+  );
+  if (!response.ok) return json({ error: await upstreamError(response, "Connection status unavailable") }, 502);
+  const body = await response.json() as { items?: Array<{ slug?: string; is_no_auth?: boolean; connected_account?: { status?: string } }> };
+  const items = new Map((body.items ?? []).map((item) => [item.slug?.toLowerCase(), item]));
+  return json({ services: Object.fromEntries(slugs.map((slug) => {
+    const item = items.get(slug);
+    const status = item?.connected_account?.status ?? (item?.is_no_auth ? "ACTIVE" : "not_connected");
+    return [slug, { connected: item?.is_no_auth === true || /^active$/i.test(status), pending: /^(initiated|initializing|pending)$/i.test(status), status }];
+  })) });
+}
+
+async function authorize(slug: string, installation: InstallationRow, env: Env, ctx: ExecutionContext) {
+  const session = await ensureSession(installation, env, ctx);
+  const response = await composioRequest(env, `/tool_router/session/${encodeURIComponent(session.sessionId)}/link`, {
+    method: "POST",
+    body: JSON.stringify({ toolkit: slug }),
+  });
+  if (!response.ok) return json({ error: await upstreamError(response, "Authorization unavailable") }, 502);
+  const body = await response.json() as { redirect_url?: string };
+  if (!body.redirect_url) return json({ error: "Composio returned no authorization link" }, 502);
+  const redirect = new URL(body.redirect_url);
+  if (redirect.protocol !== "https:" || (redirect.hostname !== "composio.dev" && !redirect.hostname.endsWith(".composio.dev"))) {
+    return json({ error: "Composio returned an untrusted authorization link" }, 502);
+  }
+  return json({ url: redirect.toString() });
+}
+
+async function disconnect(slug: string, installation: InstallationRow, env: Env, ctx: ExecutionContext) {
+  const session = await ensureSession(installation, env, ctx);
+  const list = await composioRequest(
+    env,
+    `/tool_router/session/${encodeURIComponent(session.sessionId)}/toolkits?${new URLSearchParams({ limit: "50", toolkits: slug })}`,
+  );
+  if (!list.ok) return json({ error: await upstreamError(list, "Connection lookup unavailable") }, 502);
+  const body = await list.json() as { items?: Array<{ slug?: string; connected_account?: { id?: string } }> };
+  const id = body.items?.find((item) => item.slug?.toLowerCase() === slug)?.connected_account?.id;
+  if (!id) return json({ removed: 0 });
+  const response = await composioRequest(env, `/connected_accounts/${encodeURIComponent(id)}?revoke_on_delete=true`, { method: "DELETE" });
+  if (!response.ok) return json({ error: await upstreamError(response, "Disconnect failed") }, 502);
+  return json({ removed: 1 });
+}
+
+async function route(request: Request, env: Env, ctx: ExecutionContext) {
+  const url = new URL(request.url);
+  if (request.method === "GET" && url.pathname === "/health") return json({ service: "openmausbot-composio", ready: Boolean(env.COMPOSIO_API_KEY) });
+  if (request.method === "POST" && url.pathname === "/v1/installations") return register(request, env);
+  if (!url.pathname.startsWith("/v1/")) return json({ error: "not found" }, 404);
+  const installation = await authenticate(request, env);
+  if (!installation) return json({ error: "unauthorized" }, 401);
+  if (request.method === "GET" && url.pathname === "/v1/me") return json({ installationId: installation.id });
+  if (request.method === "POST" && url.pathname === "/v1/mcp") return proxyMcp(request, installation, env, ctx);
+  if (request.method === "GET" && url.pathname === "/v1/catalog") return catalog(env);
+  if (request.method === "GET" && url.pathname === "/v1/connectors") return connectionStatus(url, installation, env, ctx);
+  const match = url.pathname.match(/^\/v1\/connectors\/([a-z0-9][a-z0-9_-]{0,80})(?:\/(authorize))?$/);
+  if (match?.[2] && request.method === "POST") return authorize(match[1], installation, env, ctx);
+  if (match && !match[2] && request.method === "DELETE") return disconnect(match[1], installation, env, ctx);
+  return json({ error: "not found" }, 404);
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    try {
+      return await route(request, env, ctx);
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error(JSON.stringify({ message: "request failed", path: new URL(request.url).pathname, error: error instanceof Error ? error.message : String(error) }));
+      return json({ error: "service unavailable" }, 503);
+    }
+  },
+} satisfies ExportedHandler<Env>;
+
+export { parseSession, sha256 };

--- a/cloudflare/composio-broker/tsconfig.json
+++ b/cloudflare/composio-broker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2024", "WebWorker"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "worker-configuration.d.ts"]
+}

--- a/cloudflare/composio-broker/vitest.config.ts
+++ b/cloudflare/composio-broker/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/cloudflare/composio-broker/wrangler.jsonc
+++ b/cloudflare/composio-broker/wrangler.jsonc
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "openmausbot-composio",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-18",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "vars": {
+    "COMPOSIO_API_BASE": "https://backend.composio.dev/api/v3.1",
+    "COMPOSIO_TOOLKIT_BASE": "https://backend.composio.dev/api/v3",
+    "REGISTRATION_MODE": "open"
+  },
+  "secrets": { "required": ["COMPOSIO_API_KEY"] },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "openmausbot-composio",
+      "database_id": "435bcde1-c017-416f-b041-7ffc508e9d88",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "ratelimits": [
+    { "name": "REGISTRATION_LIMITER", "namespace_id": "8261701", "simple": { "limit": 30, "period": 60 } },
+    { "name": "SESSION_LIMITER", "namespace_id": "8261702", "simple": { "limit": 120, "period": 60 } }
+  ],
+  "observability": {
+    "enabled": true,
+    "logs": { "enabled": true, "head_sampling_rate": 1 },
+    "traces": { "enabled": true, "head_sampling_rate": 0.05 }
+  }
+}

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -14,6 +14,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
 // resolve to ::1 and paint a black window
 const DEV_URL = process.env.ELECTRON_START_URL ?? "http://127.0.0.1:5199";
+const DEFAULT_COMPOSIO_BROKER_URL = "https://openmausbot-composio.milindsoni201.workers.dev";
 let SERVER_PORT = 8799;
 const APP_ICON = path.join(__dirname, "resources/app-icon.png");
 
@@ -92,6 +93,54 @@ async function secureComposioConfig() {
   }
 }
 
+function composioBrokerUrl() {
+  const configured = process.env.OMB_COMPOSIO_BROKER_URL?.trim();
+  return configured || (app.isPackaged ? DEFAULT_COMPOSIO_BROKER_URL : "");
+}
+
+async function ensureManagedComposioCredentials() {
+  const brokerUrl = composioBrokerUrl();
+  if (!brokerUrl) return;
+  if (/^[0-9a-f]{64}$/.test(secureCredentials.composioBrokerToken ?? "")) {
+    try {
+      const check = await fetch(`${brokerUrl}/v1/me`, {
+        headers: { authorization: `Bearer ${secureCredentials.composioBrokerToken}` },
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (check.ok) return;
+      // Only a definitive auth failure rotates the credential. A transient
+      // outage keeps the existing identity so reconnecting cannot strand
+      // the user's already-authorized accounts under a new installation.
+      if (check.status !== 401) return;
+      delete secureCredentials.composioBrokerToken;
+      delete secureCredentials.composioInstallationId;
+    } catch {
+      return;
+    }
+  }
+  try {
+    const response = await fetch(`${brokerUrl}/v1/installations`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+      signal: AbortSignal.timeout(15_000),
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) throw new Error(body?.error || `HTTP ${response.status}`);
+    if (!/^[0-9a-f]{64}$/.test(body?.token ?? "") || typeof body?.installationId !== "string") {
+      throw new Error("the connected-apps service returned invalid credentials");
+    }
+    secureCredentials.composioBrokerToken = body.token;
+    secureCredentials.composioInstallationId = body.installationId;
+    await saveSecureCredentials(secureCredentials);
+    slog("connected-apps installation registered");
+  } catch (error) {
+    // Never block app startup on a hosted integration. A user running their
+    // own Composio project key still has the local fallback below.
+    slog(`connected-apps registration failed: ${error?.message ?? error}`);
+  }
+}
+
 // The packaged app has no terminal: everything about the server child's life
 // goes to server.log in the OS log dir (~/Library/Logs/OpenMausBot on macOS,
 // Console.app-visible; %APPDATA%\OpenMausBot\logs on Windows), which is also
@@ -130,6 +179,12 @@ async function startServerOn(port) {
       OMB_USER_DATA: app.getPath("userData"),
       ...(secureCredentials.composioApiKey
         ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
+        : {}),
+      ...(composioBrokerUrl() && secureCredentials.composioBrokerToken
+        ? {
+            OMB_COMPOSIO_BROKER_URL: composioBrokerUrl(),
+            OMB_COMPOSIO_BROKER_TOKEN: secureCredentials.composioBrokerToken,
+          }
         : {}),
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -432,6 +487,7 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     secureCredentials = await loadSecureCredentials();
     await secureComposioConfig();
+    await ensureManagedComposioCredentials();
   }
   // getDisplayMedia in the renderer → this handler → ScreenCaptureKit, all
   // inside the app's own processes — the one capture path macOS reliably

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:desktop": "electron .",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
-    "test": "vitest run && pnpm test:updater && pnpm test:packaged-server",
+    "test": "vitest run && pnpm broker:test && pnpm test:updater && pnpm test:packaged-server",
     "test:updater": "node --test electron/updater-coordinator.node-test.mjs",
     "bench:observation": "node --experimental-strip-types scripts/bench-observation.ts",
     "test:watch": "vitest",
@@ -48,7 +48,11 @@
     "package:linux": "pnpm package:prepare && electron-builder --linux --x64 --publish never",
     "package:linux:dir": "pnpm package:prepare && electron-builder --linux dir --x64 --publish never",
     "package": "pnpm package:mac",
-    "test:packaged-server": "pnpm build:server && node scripts/smoke-packaged-server.mjs"
+    "test:packaged-server": "pnpm build:server && node scripts/smoke-packaged-server.mjs",
+    "broker:types": "wrangler types --config cloudflare/composio-broker/wrangler.jsonc cloudflare/composio-broker/worker-configuration.d.ts",
+    "broker:check": "pnpm broker:types && tsc -p cloudflare/composio-broker/tsconfig.json",
+    "broker:test": "vitest run --config cloudflare/composio-broker/vitest.config.ts",
+    "broker:deploy": "wrangler deploy --config cloudflare/composio-broker/wrangler.jsonc"
   },
   "dependencies": {
     "@trycua/cua-driver": "0.20.0",
@@ -78,6 +82,7 @@
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",
     "vite": "^7.1.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "wrangler": "4.123.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      wrangler:
+        specifier: 4.123.0
+        version: 4.123.0(@cloudflare/workers-types@5.20260818.1)
 
 packages:
 
@@ -173,6 +176,56 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@5.20260818.1':
+    resolution: {integrity: sha512-a89taQDbqb7Ni+xAVSsiOSd5wQPcbBJBnZgIG3EujVdDcdQkGVwab3xa2e9z29uqtMQb/P2gYDeDcNXcBRSWQQ==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@electron-internal/extract-zip@1.0.5':
     resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
     engines: {node: '>=22.12.0'}
@@ -217,16 +270,37 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.2':
     resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.2':
@@ -235,16 +309,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.2':
     resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.2':
@@ -253,10 +345,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -265,10 +369,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.2':
@@ -277,10 +393,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.2':
@@ -289,10 +417,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -301,10 +441,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.2':
@@ -313,16 +465,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.2':
     resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.2':
@@ -331,10 +501,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.2':
     resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.2':
@@ -343,11 +525,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.2':
     resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
@@ -355,10 +549,22 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.2':
     resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.2':
@@ -367,9 +573,177 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.2':
     resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -392,6 +766,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -555,6 +932,15 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@posthog/browser-common@0.5.0':
     resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
@@ -740,6 +1126,13 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.24':
+    resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1115,6 +1508,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -1247,6 +1643,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js@3.50.0:
     resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
@@ -1386,6 +1786,9 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1407,6 +1810,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
@@ -1693,6 +2101,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -1963,6 +2375,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  miniflare@5.20260811.1-alpha:
+    resolution: {integrity: sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -2077,6 +2493,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2279,6 +2698,10 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2351,6 +2774,10 @@ packages:
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2439,6 +2866,9 @@ packages:
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2597,12 +3027,39 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260811.1:
+    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.123.0:
+    resolution: {integrity: sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260811.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -2633,6 +3090,12 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2754,6 +3217,36 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260811.1
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workers-types@5.20260818.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@electron-internal/extract-zip@1.0.5': {}
 
   '@electron/asar@3.4.1':
@@ -2848,82 +3341,271 @@ snapshots:
       - supports-color
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
     optional: true
 
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@isaacs/fs-minipass@4.0.1':
@@ -2945,6 +3627,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3049,6 +3736,18 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@posthog/browser-common@0.5.0':
     dependencies:
@@ -3179,6 +3878,10 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.24': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3565,6 +4268,8 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
+  blake3-wasm@2.1.5: {}
+
   bluebird@3.7.2: {}
 
   boolean@3.2.0:
@@ -3699,6 +4404,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js@3.50.0: {}
 
@@ -3886,6 +4593,8 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -3905,6 +4614,35 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -4247,6 +4985,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@4.1.5: {}
 
   lazy-val@1.0.5: {}
 
@@ -4690,6 +5430,18 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  miniflare@5.20260811.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260811.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -4811,6 +5563,8 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -5072,6 +5826,38 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -5150,6 +5936,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5222,8 +6010,11 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.29.0:
-    optional: true
+  undici@7.29.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unified@11.0.5:
     dependencies:
@@ -5360,6 +6151,31 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260811.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
+      '@cloudflare/workerd-linux-64': 1.20260811.1
+      '@cloudflare/workerd-linux-arm64': 1.20260811.1
+      '@cloudflare/workerd-windows-64': 1.20260811.1
+
+  wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260811.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260818.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5367,6 +6183,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   xmlbuilder@15.1.1: {}
 
@@ -5391,6 +6209,19 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.24
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod@4.4.3: {}
 

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -30,6 +30,7 @@ const ENTRY_POINTS = [
   "computer-proxy.ts",
   "container-mcp.ts",
   "permission-proxy.ts",
+  "connector-proxy.ts",
   "drivers/agents-proxy.ts",
   "drivers/dweb-proxy.ts",
 ];

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -101,6 +101,11 @@ describe.sequential("Composio Sessions", () => {
     });
     expect(calls.filter((call) => call.method === "POST" && call.path.endsWith("/session")).at(-1)?.body).toEqual({
       user_id: "openmausbot_existing",
+      manage_connections: {
+        enable: true,
+        enable_wait_for_connections: true,
+        enable_connection_removal: true,
+      },
     });
 
     const reused = await prepareProjectSession("ak_test", created);
@@ -115,9 +120,23 @@ describe.sequential("Composio Sessions", () => {
     const cfg: AppConfig = {
       composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
     };
-    await expect(mcpIntegration(cfg)).resolves.toEqual({
-      url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
-      headers: { "x-api-key": "ak_test" },
+    const integration = await mcpIntegration(cfg, {
+      harnessUrl: "http://127.0.0.1:8799",
+      commsToken: "secret",
+      botId: "bot-1",
+      threadId: "thread-1",
+    });
+    expect(integration).toMatchObject({
+      command: process.execPath,
+      args: [expect.stringContaining("connector-proxy")],
+      env: {
+        OMB_CONNECTOR_UPSTREAM_URL: "http://127.0.0.1:8799/api/internal/connectors/mcp",
+        OMB_CONNECTOR_UPSTREAM_HEADERS: JSON.stringify({ authorization: "Bearer secret" }),
+        OMB_HARNESS_URL: "http://127.0.0.1:8799",
+        OMB_COMMS_TOKEN: "secret",
+        OMB_BOT_ID: "bot-1",
+        OMB_THREAD_ID: "thread-1",
+      },
     });
   });
 

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -2,6 +2,7 @@
 // Session owns connection state, auth links and the MCP endpoint.
 import { saveConfig, type AppConfig } from "./config.ts";
 import { randomUUID } from "node:crypto";
+import { SPAWNED_PROXIES } from "./proxy-paths.ts";
 
 const DEFAULT_BACKEND_ORIGIN = "https://backend.composio.dev";
 
@@ -20,8 +21,50 @@ interface SessionResponse {
 }
 
 export interface ComposioMcpIntegration {
-  url: string;
-  headers: Record<string, string>;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+interface IntegrationContext {
+  harnessUrl: string;
+  commsToken: string;
+  botId: string;
+  threadId: string;
+}
+
+function brokerAccess(): { url: string; token: string } | null {
+  const url = process.env.OMB_COMPOSIO_BROKER_URL?.trim().replace(/\/$/, "");
+  const token = process.env.OMB_COMPOSIO_BROKER_TOKEN?.trim();
+  if (!url || !token) return null;
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" && parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") {
+    throw new Error("The connected-apps service must use HTTPS");
+  }
+  return { url, token };
+}
+
+export function connectionMode(cfg: AppConfig): "managed" | "self-hosted" | "unavailable" {
+  if (brokerAccess()) return "managed";
+  return cfg.composio?.apiKey ? "self-hosted" : "unavailable";
+}
+
+export function configured(cfg: AppConfig): boolean {
+  return connectionMode(cfg) !== "unavailable";
+}
+
+async function brokerRequest(path: string, init?: RequestInit): Promise<Response> {
+  const broker = brokerAccess();
+  if (!broker) throw new Error("The connected-apps service is unavailable");
+  return fetch(`${broker.url}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${broker.token}`,
+      ...(init?.body ? { "content-type": "application/json" } : {}),
+      ...init?.headers,
+    },
+    signal: init?.signal ?? AbortSignal.timeout(30_000),
+  });
 }
 
 function projectHeaders(apiKey: string, json = false) {
@@ -39,6 +82,15 @@ async function responseError(res: Response, fallback: string) {
   } catch {
     return raw.trim().slice(0, 300) || fallback;
   }
+}
+
+function trustedAuthUrl(value: unknown, slug: string): string {
+  if (typeof value !== "string") throw new Error(`Connected-apps service returned no authorization link for ${slug}`);
+  const url = new URL(value);
+  if (url.protocol !== "https:" || (url.hostname !== "composio.dev" && !url.hostname.endsWith(".composio.dev"))) {
+    throw new Error("Connected-apps service returned an untrusted authorization link");
+  }
+  return url.toString();
 }
 
 async function getProjectSession(apiKey: string, sessionId: string): Promise<SessionResponse | null> {
@@ -75,7 +127,14 @@ export async function prepareProjectSession(
   const res = await fetch(`${apiBase()}/tool_router/session`, {
     method: "POST",
     headers: projectHeaders(trimmed, true),
-    body: JSON.stringify({ user_id: userId }),
+    body: JSON.stringify({
+      user_id: userId,
+      manage_connections: {
+        enable: true,
+        enable_wait_for_connections: true,
+        enable_connection_removal: true,
+      },
+    }),
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) throw new Error(await responseError(res, `Composio rejected this key (HTTP ${res.status})`));
@@ -102,15 +161,76 @@ async function ensureProjectSession(cfg: AppConfig): Promise<SessionResponse> {
   return created;
 }
 
-export async function mcpIntegration(cfg: AppConfig): Promise<ComposioMcpIntegration | null> {
-  if (!cfg.composio?.apiKey) return null;
-  const session = await ensureProjectSession(cfg);
-  return { url: session.mcp.url, headers: { "x-api-key": cfg.composio.apiKey } };
+export async function mcpIntegration(
+  cfg: AppConfig,
+  context: IntegrationContext,
+): Promise<ComposioMcpIntegration | null> {
+  if (!configured(cfg)) return null;
+  return {
+    command: process.execPath,
+    args: [SPAWNED_PROXIES.connectors],
+    env: {
+      ELECTRON_RUN_AS_NODE: "1",
+      // The provider-facing bridge receives only this boot's loopback token.
+      // Project/broker credentials stay in the harness process, so a coding
+      // agent that prints its environment cannot export a durable secret.
+      OMB_CONNECTOR_UPSTREAM_URL: `${context.harnessUrl}/api/internal/connectors/mcp`,
+      OMB_CONNECTOR_UPSTREAM_HEADERS: JSON.stringify({ authorization: `Bearer ${context.commsToken}` }),
+      OMB_HARNESS_URL: context.harnessUrl,
+      OMB_COMMS_TOKEN: context.commsToken,
+      OMB_BOT_ID: context.botId,
+      OMB_THREAD_ID: context.threadId,
+    },
+  };
+}
+
+export async function relayMcp(
+  cfg: AppConfig,
+  payload: unknown,
+  transportSessionId?: string,
+): Promise<{ status: number; bytes: Uint8Array; contentType: string; transportSessionId?: string }> {
+  const broker = brokerAccess();
+  let url: string;
+  const headers = new Headers({
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+  });
+  if (transportSessionId) headers.set("mcp-session-id", transportSessionId);
+  if (broker) {
+    url = `${broker.url}/v1/mcp`;
+    headers.set("authorization", `Bearer ${broker.token}`);
+  } else {
+    if (!cfg.composio?.apiKey) throw new Error("Connected apps are unavailable");
+    const session = await ensureProjectSession(cfg);
+    url = session.mcp.url;
+    headers.set("x-api-key", cfg.composio.apiKey);
+  }
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(10 * 60_000),
+  });
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > 20 * 1024 * 1024) throw new Error("Connected-app response exceeded 20 MB");
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > 20 * 1024 * 1024) throw new Error("Connected-app response exceeded 20 MB");
+  return {
+    status: response.status,
+    bytes,
+    contentType: response.headers.get("content-type") ?? "application/json",
+    transportSessionId: response.headers.get("mcp-session-id") ?? undefined,
+  };
 }
 
 /** Connection status per service slug: { slack: { connected, status } }. */
 export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
-  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  if (brokerAccess() || !cfg.composio?.apiKey) {
+    const response = await brokerRequest(`/v1/connectors?${new URLSearchParams({ services: slugs.join(",") })}`);
+    if (!response.ok) throw new Error(await responseError(response, `Connected apps: HTTP ${response.status}`));
+    const body = (await response.json()) as { services?: Record<string, { connected: boolean; pending?: boolean; status?: string }> };
+    return body.services ?? {};
+  }
   const session = await ensureProjectSession(cfg);
   const params = new URLSearchParams({ limit: "50" });
   if (slugs.length) params.set("toolkits", slugs.join(","));
@@ -175,7 +295,11 @@ export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
 
 /** Disconnect a service: remove every connected account for the slug. */
 export async function removeService(cfg: AppConfig, slug: string) {
-  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  if (brokerAccess() || !cfg.composio?.apiKey) {
+    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(slug)}`, { method: "DELETE" });
+    if (!response.ok) throw new Error(await responseError(response, `Connected apps: HTTP ${response.status}`));
+    return response.json() as Promise<{ removed: number }>;
+  }
   const session = await ensureProjectSession(cfg);
   const params = new URLSearchParams({ limit: "50", toolkits: slug });
   const list = await fetch(
@@ -196,7 +320,12 @@ export async function removeService(cfg: AppConfig, slug: string) {
 
 /** Mint a browser auth link for one service. Returns { url } or throws. */
 export async function authorizeService(cfg: AppConfig, slug: string) {
-  if (!cfg.composio?.apiKey) throw new Error("No Composio project key configured");
+  if (brokerAccess() || !cfg.composio?.apiKey) {
+    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(slug)}/authorize`, { method: "POST" });
+    if (!response.ok) throw new Error(await responseError(response, `Connected apps: HTTP ${response.status}`));
+    const body = (await response.json()) as { url?: string };
+    return { url: trustedAuthUrl(body.url, slug) };
+  }
   const session = await ensureProjectSession(cfg);
   const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/link`, {
     method: "POST",
@@ -206,8 +335,7 @@ export async function authorizeService(cfg: AppConfig, slug: string) {
   });
   if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
   const body = (await res.json()) as { redirect_url?: string };
-  if (!body.redirect_url) throw new Error(`Composio returned no auth link for ${slug}`);
-  return { url: body.redirect_url };
+  return { url: trustedAuthUrl(body.redirect_url, slug) };
 }
 
 // ── marketplace catalog ────────────────────────────────────────────────
@@ -260,13 +388,15 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
   if (toolkitCache && Date.now() - toolkitCache.at < 10 * 60_000) {
     return { cards: toolkitCache.cards, source: "api" };
   }
-  const backendKey = cfg.composio?.apiKey;
-  if (backendKey) {
+  const backendKey = brokerAccess() ? undefined : cfg.composio?.apiKey;
+  if (backendKey || brokerAccess()) {
     try {
-      const res = await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
-        headers: { "x-api-key": backendKey },
-        signal: AbortSignal.timeout(15_000),
-      });
+      const res = backendKey
+        ? await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
+            headers: { "x-api-key": backendKey },
+            signal: AbortSignal.timeout(15_000),
+          })
+        : await brokerRequest("/v1/catalog", { signal: AbortSignal.timeout(15_000) });
       if (res.ok) {
         const json: any = await res.json();
         const items = json.items ?? json.data ?? [];
@@ -287,6 +417,20 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
     }
   }
   return { cards: CURATED, source: "curated" };
+}
+
+export async function toolkitCard(cfg: AppConfig, slug: string): Promise<ToolkitCard> {
+  const normalized = slug.toLowerCase();
+  const { cards } = await listToolkits(cfg);
+  return cards.find((card) => card.slug.toLowerCase() === normalized)
+    ?? CURATED.find((card) => card.slug === normalized)
+    ?? {
+      slug: normalized,
+      label: normalized.replace(/[-_]+/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase()),
+      blurb: "Connect this app so your bot can continue",
+      logo: null,
+      domain: null,
+    };
 }
 
 export const CURATED_SLUGS = CURATED.map((c) => c.slug);

--- a/server/connector-proxy.test.ts
+++ b/server/connector-proxy.test.ts
@@ -1,0 +1,94 @@
+import { createServer, type RequestListener, type Server } from "node:http";
+import { once } from "node:events";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import readline from "node:readline";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ENTRY = join(dirname(fileURLToPath(import.meta.url)), "connector-proxy.ts");
+let child: ChildProcessWithoutNullStreams | null = null;
+let server: Server | null = null;
+
+async function listen(handler: RequestListener) {
+  server = createServer(handler);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function start(env: Record<string, string>) {
+  child = spawn(process.execPath, ["--experimental-strip-types", ENTRY], {
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return readline.createInterface({ input: child.stdout });
+}
+
+function nextJson(lines: readline.Interface) {
+  return new Promise<Record<string, any>>((resolve, reject) => {
+    lines.once("line", (line) => {
+      try { resolve(JSON.parse(line)); } catch (error) { reject(error); }
+    });
+  });
+}
+
+afterEach(async () => {
+  child?.kill("SIGKILL");
+  child = null;
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = null;
+});
+
+describe("connector MCP bridge", () => {
+  it("turns agent connection requests into authenticated chat-card requests", async () => {
+    let received: any = null;
+    const harness = await listen((request, response) => {
+      let body = "";
+      request.on("data", (chunk) => { body += chunk; });
+      request.on("end", () => {
+        received = { authorization: request.headers.authorization, body: JSON.parse(body) };
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      });
+    });
+    const lines = start({
+      OMB_HARNESS_URL: harness,
+      OMB_COMMS_TOKEN: "bridge-secret",
+      OMB_BOT_ID: "bot-1",
+      OMB_THREAD_ID: "thread-1",
+    });
+    child!.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "COMPOSIO_MANAGE_CONNECTIONS", arguments: { toolkits: ["GMAIL"] } },
+    })}\n`);
+    const reply = await nextJson(lines);
+    expect(reply.id).toBe(7);
+    expect(reply.result.content[0].text).toMatch(/secure connection card/i);
+    expect(received.authorization).toBe("Bearer bridge-secret");
+    expect(received.body).toMatchObject({ botId: "bot-1", threadId: "thread-1", slugs: ["gmail"] });
+    expect(received.body.resumeKey).toMatch(/^[\w-]{8,100}$/);
+  });
+
+  it("relays ordinary MCP JSON-RPC without exposing upstream headers on stdout", async () => {
+    let upstreamAuthorization = "";
+    const upstream = await listen((request, response) => {
+      upstreamAuthorization = String(request.headers.authorization ?? "");
+      response.writeHead(200, { "content-type": "application/json", "mcp-session-id": "transport-1" });
+      response.end(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { protocolVersion: "2025-06-18" } }));
+    });
+    const lines = start({
+      OMB_CONNECTOR_UPSTREAM_URL: upstream,
+      OMB_CONNECTOR_UPSTREAM_HEADERS: JSON.stringify({ authorization: "Bearer upstream-secret" }),
+    });
+    child!.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "initialize", params: {} })}\n`);
+    const reply = await nextJson(lines);
+    expect(reply).toEqual({ jsonrpc: "2.0", id: 2, result: { protocolVersion: "2025-06-18" } });
+    expect(upstreamAuthorization).toBe("Bearer upstream-secret");
+    expect(JSON.stringify(reply)).not.toContain("upstream-secret");
+  });
+});

--- a/server/connector-proxy.ts
+++ b/server/connector-proxy.ts
@@ -1,0 +1,167 @@
+// Harness-owned Composio MCP bridge.
+//
+// Provider CLIs only see this stdio server. Ordinary MCP traffic is relayed
+// to the configured Composio Session, but connection requests are converted
+// into first-class OpenMausBot chat cards. The agent never authors an auth
+// URL and credentials never pass through its transcript.
+//
+// stdout is the MCP transport. Never log there.
+import readline from "node:readline";
+import { randomUUID } from "node:crypto";
+
+type Json = Record<string, unknown>;
+
+const UPSTREAM = process.env.OMB_CONNECTOR_UPSTREAM_URL ?? "";
+const HARNESS = process.env.OMB_HARNESS_URL ?? "http://127.0.0.1:8799";
+const BOT_ID = process.env.OMB_BOT_ID ?? "";
+const THREAD_ID = process.env.OMB_THREAD_ID ?? "";
+const TOKEN = process.env.OMB_COMMS_TOKEN ?? "";
+const MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+
+function parsedHeaders(): Record<string, string> {
+  try {
+    const value: unknown = JSON.parse(process.env.OMB_CONNECTOR_UPSTREAM_HEADERS ?? "{}");
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    return Object.fromEntries(
+      Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+    );
+  } catch {
+    return {};
+  }
+}
+
+const upstreamHeaders = parsedHeaders();
+let upstreamSessionId = "";
+const send = (message: Json) => process.stdout.write(`${JSON.stringify(message)}\n`);
+
+function textResult(id: unknown, text: string, isError = false): Json {
+  return { jsonrpc: "2.0", id, result: { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) } };
+}
+
+async function readBounded(response: Response): Promise<string> {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > MAX_RESPONSE_BYTES) throw new Error("connector response exceeded 20 MB");
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error("connector response exceeded 20 MB");
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+function parseUpstream(text: string, id: unknown): Json | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("{")) return JSON.parse(trimmed) as Json;
+  const frames = trimmed
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .filter((line) => line && line !== "[DONE]")
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as Json];
+      } catch {
+        return [];
+      }
+    });
+  return frames.findLast((frame) => frame.id === id) ?? frames.at(-1) ?? null;
+}
+
+async function relay(message: Json): Promise<Json | null> {
+  if (!UPSTREAM) throw new Error("connected apps are unavailable");
+  const response = await fetch(UPSTREAM, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...upstreamHeaders,
+      ...(upstreamSessionId ? { "mcp-session-id": upstreamSessionId } : {}),
+    },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10 * 60_000),
+  });
+  const nextSession = response.headers.get("mcp-session-id");
+  if (nextSession) upstreamSessionId = nextSession;
+  if (!response.ok) throw new Error(`connector service returned HTTP ${response.status}`);
+  return parseUpstream(await readBounded(response), message.id);
+}
+
+function connectorAdds(args: unknown): string[] {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return [];
+  const toolkits = (args as { toolkits?: unknown }).toolkits;
+  if (!Array.isArray(toolkits)) return [];
+  return [...new Set(toolkits.flatMap((item) => {
+    if (typeof item === "string") return [item.toLowerCase()];
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const row = item as { name?: unknown; toolkit?: unknown; action?: unknown };
+    const slug = typeof row.toolkit === "string" ? row.toolkit : row.name;
+    const action = String(row.action ?? "add").toLowerCase();
+    return typeof slug === "string" && ["add", "connect", "initiate"].includes(action) ? [slug.toLowerCase()] : [];
+  }))];
+}
+
+async function showConnectorCards(slugs: string[]): Promise<void> {
+  const response = await fetch(`${HARNESS}/api/internal/connectors/request`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify({ botId: BOT_ID, threadId: THREAD_ID, slugs, resumeKey: randomUUID() }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { error?: unknown };
+    throw new Error(String(body.error ?? `could not show connection card (HTTP ${response.status})`));
+  }
+}
+
+async function handle(message: Json): Promise<void> {
+  const id = message.id;
+  const method = String(message.method ?? "");
+  if (method === "tools/call") {
+    const params = (message.params ?? {}) as Json;
+    const name = String(params.name ?? "");
+    const slugs = /MANAGE_CONNECTIONS$/i.test(name) ? connectorAdds(params.arguments) : [];
+    if (slugs.length) {
+      await showConnectorCards(slugs);
+      send(textResult(
+        id,
+        `OpenMausBot showed the user a secure connection card for ${slugs.join(", ")}. End this turn now. The app will continue the task automatically after the connection finishes.`,
+      ));
+      return;
+    }
+    if (/WAIT_FOR_CONNECTIONS$/i.test(name)) {
+      send(textResult(id, "OpenMausBot is handling connection completion and will continue the task automatically."));
+      return;
+    }
+  }
+  const response = await relay(message);
+  if (response && id !== undefined) send(response);
+}
+
+const input = readline.createInterface({ input: process.stdin, terminal: false });
+input.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let message: Json;
+  try {
+    message = JSON.parse(trimmed) as Json;
+  } catch {
+    return;
+  }
+  void handle(message).catch((error) => {
+    if (message.id !== undefined) {
+      send(textResult(message.id, error instanceof Error ? error.message : String(error), true));
+    }
+  });
+});
+input.on("close", () => process.exit(0));

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -148,7 +148,10 @@ export interface SendTurnInput {
   system?: string;
   /** Per-bot integrations the driver may hand to the agent as tools. */
   integrations?: {
-    composio?: { url: string; headers: Record<string, string> };
+    /** A local stdio bridge owns the remote Composio transport. Keeping the
+     * bridge harness-controlled lets it turn connection requests into trusted
+     * chat cards consistently across provider CLIs. */
+    composio?: { command: string; args: string[]; env: Record<string, string> };
     /** Cloud computer, reached through OpenMausBot's REST-to-MCP adapter. */
     computer?: { kind?: "box"; boxId: string; token: string };
     /** Direct stdio connection to a Cua Driver MCP server (host or sandbox). */

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -224,12 +224,31 @@ describe("ACP turns (fake CLI)", () => {
     expect(seen.env.OPENCODE_API_KEY).toBeUndefined();
   });
 
-  // this driver has no Composio mount, so it must not claim the
-  // capability: claiming it is what would tell an ACP bot to call
-  // composio tools it was never given
-  it("does not claim the Composio capability it cannot honour", async () => {
+  // ACP session/new accepts stdio MCP entries, so connected apps use the
+  // same harness-owned bridge as Claude and Codex.
+  it("mounts connected apps as a stdio MCP server", async () => {
     await create();
-    expect(instance.adapter.capabilities.composioMcp).not.toBe(true);
+    const dump = join(scratch, "composio.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    expect(instance.adapter.capabilities.composioMcp).toBe(true);
+    await instance.adapter.sendTurn({
+      threadId: "t-composio",
+      text: "go",
+      integrations: {
+        composio: {
+          command: process.execPath,
+          args: ["/tmp/connector-proxy.js"],
+          env: { OMB_CONNECTOR_UPSTREAM_URL: "http://127.0.0.1:8799/api/internal/connectors/mcp" },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(JSON.parse(readFileSync(`${dump}.mcp.json`, "utf8"))).toContainEqual({
+      name: "composio",
+      command: process.execPath,
+      args: ["/tmp/connector-proxy.js"],
+      env: [{ name: "OMB_CONNECTOR_UPSTREAM_URL", value: "http://127.0.0.1:8799/api/internal/connectors/mcp" }],
+    });
   });
 
   it("droid takes model and autonomy over the wire, never through argv", async () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -219,6 +219,15 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         if (agents) {
           servers.push({ name: "agents", command: agents.command, args: agents.args, env: acpEnv(agents.env) });
         }
+        const composio = turn.integrations?.composio;
+        if (composio) {
+          servers.push({
+            name: "composio",
+            command: composio.command,
+            args: composio.args,
+            env: acpEnv(composio.env),
+          });
+        }
         // The bot's computer, mounted exactly like the Claude driver does.
         // Cloud boxes use the REST adapter; host and sandbox Cua connections
         // expose Cua Driver's official MCP server directly.
@@ -664,6 +673,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             sessionModelSwitch: "unsupported",
             agentsMcp: true,
             computerMcp: true,
+            composioMcp: true,
             effortLevels: support.effortLevels,
           },
           sendTurn,

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -219,8 +219,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
       text: "hi",
       integrations: {
         composio: {
-          url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
-          headers: { "x-api-key": "ak_test" },
+          command: process.execPath,
+          args: ["/tmp/connector-proxy.js"],
+          env: { OMB_CONNECTOR_UPSTREAM_URL: "https://example.test/mcp" },
         },
       },
     });
@@ -228,9 +229,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.mcpConfig.mcpServers.composio).toMatchObject({
-      type: "http",
-      url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
-      headers: { "x-api-key": "ak_test" },
+      command: process.execPath,
+      args: ["/tmp/connector-proxy.js"],
+      env: { OMB_CONNECTOR_UPSTREAM_URL: "https://example.test/mcp" },
     });
     // the user's Composio key must not be readable via `ps`
     expect(JSON.stringify(seen.argv)).not.toContain("ak_test");
@@ -253,8 +254,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
       text: "hi",
       integrations: {
         composio: {
-          url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
-          headers: { "x-api-key": "ak_test" },
+          command: process.execPath,
+          args: ["/tmp/connector-proxy.js"],
+          env: { OMB_CONNECTOR_UPSTREAM_URL: "https://example.test/mcp" },
         },
       },
     });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -377,11 +377,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       const mcpServers: Record<string, unknown> = {};
       const allowed: string[] = [];
       if (turn.integrations?.composio) {
-        mcpServers.composio = {
-          type: "http",
-          url: turn.integrations.composio.url,
-          headers: turn.integrations.composio.headers,
-        };
+        mcpServers.composio = { ...turn.integrations.composio };
         allowed.push("mcp__composio");
       }
       if (turn.integrations?.computer) {

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -122,6 +122,34 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(JSON.parse(readFileSync(dump, "utf8")).env.CODEX_HOME).toBe(codexHome);
   });
 
+  it("mounts connected apps without placing credential values in argv", async () => {
+    await create();
+    const dump = join(scratch, "composio.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+    expect(instance.adapter.capabilities.composioMcp).toBe(true);
+
+    await instance.adapter.sendTurn({
+      threadId: "t-composio",
+      text: "check mail",
+      integrations: {
+        composio: {
+          command: process.execPath,
+          args: ["/tmp/connector-proxy.js"],
+          env: {
+            OMB_CONNECTOR_UPSTREAM_URL: "http://127.0.0.1:8799/api/internal/connectors/mcp",
+            OMB_COMMS_TOKEN: "per-boot-token",
+          },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv.join(" ")).toContain("mcp_servers.openmausbot_connectors.command");
+    expect(seen.argv.join(" ")).toContain("OMB_COMMS_TOKEN");
+    expect(seen.argv.join(" ")).not.toContain("per-boot-token");
+    expect(seen.env.OMB_COMMS_TOKEN).toBe("per-boot-token");
+  });
+
   it("sends the local provider when the picker id is custom-encoded", async () => {
     await create({ environment: { UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-secret" } });
     const dump = join(scratch, "dump.json");

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -116,8 +116,20 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       const turnId = newId();
 
       const env = childEnv();
+      const appServerArgs = ["app-server", ...codexLocalProviderArgs(env, turn.model)];
+      if (turn.integrations?.composio) {
+        const bridge = turn.integrations.composio;
+        Object.assign(env, bridge.env);
+        const prefix = "mcp_servers.openmausbot_connectors";
+        appServerArgs.push(
+          "-c", `${prefix}.command=${JSON.stringify(bridge.command)}`,
+          "-c", `${prefix}.args=${JSON.stringify(bridge.args)}`,
+          "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(bridge.env))}`,
+          "-c", `${prefix}.default_tools_approval_mode="auto"`,
+        );
+      }
 
-      const child = spawnCli(config.cli, ["app-server", ...codexLocalProviderArgs(env, turn.model)], {
+      const child = spawnCli(config.cli, appServerArgs, {
         cwd: turn.cwd ?? homedir(),
         env,
         stdio: ["pipe", "pipe", "pipe"],
@@ -477,6 +489,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         provider: DRIVER_KIND,
         capabilities: {
           sessionModelSwitch: "unsupported",
+          composioMcp: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
         },
         sendTurn,

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -615,7 +615,7 @@ describe("harness HTTP API", () => {
 
     const saved = await api("PUT", "/api/config?secretStorage=external", { composio: { apiKey: "ak_good" } });
     expect(saved.status).toBe(200);
-    expect(saved.body.composio).toEqual({ configured: true });
+    expect(saved.body.composio).toEqual({ configured: true, mode: "self-hosted" });
     expect(JSON.stringify(saved.body)).not.toContain("ak_good");
 
     const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
@@ -625,7 +625,7 @@ describe("harness HTTP API", () => {
     // A later ordinary setting save reloads config; the in-process secure-env
     // override must keep Composio configured until the next app launch.
     expect((await api("PUT", "/api/config", { profile: { name: "Grace" } })).status).toBe(200);
-    expect((await api("GET", "/api/config")).body.composio).toEqual({ configured: true });
+    expect((await api("GET", "/api/config")).body.composio).toEqual({ configured: true, mode: "self-hosted" });
   });
 
   it.skipIf(process.platform === "win32")("stores the credentials file with owner-only permissions", () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -142,6 +142,15 @@ function agentsIntegration(botId: string, threadId: string, depth: number) {
   };
 }
 
+function connectedAppsIntegration(botId: string, threadId: string) {
+  return composio.mcpIntegration(cfg, {
+    harnessUrl: `http://127.0.0.1:${PORT}`,
+    commsToken: COMMS_TOKEN,
+    botId,
+    threadId,
+  });
+}
+
 /** Run a turn on `targetBotId` and resolve with its assistant text — the
  * synchronous half of ask_bot. Subscribes to the bus, folds assistant_text
  * for that thread, resolves on turn.completed (or a 4-min ceiling). */
@@ -1068,6 +1077,10 @@ async function startTurn(
     automationSource?: RoutineRunTrigger;
     /** the caller was already running unattended, so this turn is too */
     unattended?: boolean;
+    /** Resume an agent after the user completed an inline connection card.
+     * The prompt is control-plane context: it reaches the provider without
+     * masquerading as another message authored by the user. */
+    connectorContinuation?: boolean;
     onDispatchError?: (message: string) => void;
   },
 ) {
@@ -1078,12 +1091,12 @@ async function startTurn(
   // a webhook turn, or one inherited from a bot already running unattended
   if (opts?.automationSource === "webhook" || opts?.unattended) markUnattended(bot.id);
   // a person typing into this bot ends the unattended window immediately
-  else if (opts?.automationSource === undefined && !opts?.commsDepth) clearUnattended(bot.id);
+  else if (opts?.automationSource === undefined && !opts?.commsDepth && !opts?.connectorContinuation) clearUnattended(bot.id);
   const task = store.taskByThread(bot.id, threadId);
   if (!task) throw Object.assign(new Error("no such task"), { status: 404 });
   const commsDepth = opts?.commsDepth ?? 0;
   // a task takes its name from the first thing you asked it to do
-  if (text.trim()) store.titleTaskFromFirstMessage(bot.id, text, threadId);
+  if (text.trim() && !opts?.connectorContinuation) store.titleTaskFromFirstMessage(bot.id, text, threadId);
 
   const instance = opts?.runOn === "cloud"
     ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
@@ -1115,7 +1128,9 @@ async function startTurn(
   // an edit hands us its already-branched user message; a plain send appends
   let userMessage = opts?.userMessage;
   if (!userMessage) {
-    userMessage = store.appendMessage(threadId, { role: "user", kind: "text", text });
+    userMessage = opts?.connectorContinuation
+      ? { id: `connector-${randomUUID()}`, at: Date.now(), role: "user", kind: "text", text }
+      : store.appendMessage(threadId, { role: "user", kind: "text", text });
   }
 
   // transcript for API-backed drivers: settled text turns on the ACTIVE
@@ -1171,8 +1186,8 @@ async function startTurn(
       // them — a key in the config says the connections exist, not that
       // this engine can reach them — and only to a bot the user has not
       // switched off: the key is workspace-wide, the grant is per bot.
-      if (bot.composio !== false && cfg.composio?.apiKey && instance.adapter.capabilities.composioMcp === true) {
-        const connection = await composio.mcpIntegration(cfg);
+      if (bot.composio !== false && composio.configured(cfg) && instance.adapter.capabilities.composioMcp === true) {
+        const connection = await connectedAppsIntegration(bot.id, threadId);
         if (connection) integrations.composio = connection;
       }
       // CLI engines work inside the bot's own workspace directory rather
@@ -1500,6 +1515,7 @@ async function runGroupMemberTurn(
   // bots that already spoke for this user message — "@Scout ask @Pixel"
   // must not run Pixel twice (once chained, once as a direct responder)
   spoken: Set<string> = new Set(),
+  connectorContinuation?: string,
 ): Promise<boolean> {
   const group = store.group(groupId);
   const bot = store.bot(botId);
@@ -1529,6 +1545,21 @@ async function runGroupMemberTurn(
     });
     return true;
   }
+  const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
+  try {
+    if (bot.composio !== false && composio.configured(cfg) && instance.adapter.capabilities.composioMcp === true) {
+      const connection = await connectedAppsIntegration(bot.id, group.threadId);
+      if (connection) integrations.composio = connection;
+    }
+  } catch (error) {
+    store.appendMessage(group.threadId, {
+      role: "bot",
+      kind: "activity",
+      from: { botId: bot.id, name: bot.name, color: bot.color },
+      tool: { name: `error: connected apps are unavailable — ${error instanceof Error ? error.message : String(error)}`, ok: false },
+    });
+    return true;
+  }
   store.setActivity(bot.id, "working");
 
   store.patchGroup(group.id, { busyBotId: bot.id }); // the store's change stream carries the frame
@@ -1550,7 +1581,9 @@ async function runGroupMemberTurn(
     .filter(Boolean)
     .join("\n");
 
-  const text = `${serializeRoomContext(group.threadId, userName)}\n\n(Reply to the conversation above as ${bot.name}.)`;
+  const text = `${serializeRoomContext(group.threadId, userName)}\n\n(Reply to the conversation above as ${bot.name}.)${
+    connectorContinuation ? `\n\n${connectorContinuation}` : ""
+  }`;
 
   // same workspace + memory as a 1:1 turn — the room is a different
   // conversation, not a different bot
@@ -1599,6 +1632,7 @@ async function runGroupMemberTurn(
         text,
         system: roomSystem,
         cwd,
+        integrations,
         ...memberTurnSelection(bot.modelSelection),
       })
       .catch((err) => {
@@ -1678,6 +1712,102 @@ function startGroupTurn(groupId: string, text: string) {
   groupQueues.set(groupId, next.catch(() => {}));
 }
 
+const CONNECTOR_SLUG = /^[a-z0-9][a-z0-9_-]{0,80}$/;
+const pendingConnectorResumes = new Map<
+  string,
+  { botId: string; threadId: string; resumeKey: string; labels: string[] }
+>();
+
+function connectorThread(botId: string, threadId: string) {
+  const bot = store.bot(botId);
+  if (!bot) return null;
+  if (store.taskByThread(botId, threadId)) return { bot, group: undefined };
+  const group = store.groupByThread(threadId);
+  if (group?.memberIds.includes(botId)) return { bot, group };
+  return null;
+}
+
+function connectorMessage(botId: string, threadId: string, messageId: string) {
+  if (!connectorThread(botId, threadId)) return null;
+  const message = store.messagesFor(threadId).find((candidate) => candidate.id === messageId);
+  return message?.kind === "connector" && message.connector ? message : null;
+}
+
+function connectorCards(threadId: string, resumeKey: string) {
+  return store.messagesFor(threadId).filter(
+    (message) => message.kind === "connector" && message.connector?.resumeKey === resumeKey,
+  );
+}
+
+function markConnectorResumeFailed(threadId: string, resumeKey: string, error: string) {
+  for (const message of connectorCards(threadId, resumeKey)) {
+    if (!message.connector) continue;
+    store.patchMessage(threadId, message.id, {
+      connector: { ...message.connector, resumed: false, error: error.slice(0, 180) },
+    });
+  }
+}
+
+function dispatchConnectorResume(entry: { botId: string; threadId: string; resumeKey: string; labels: string[] }) {
+  const owner = connectorThread(entry.botId, entry.threadId);
+  if (!owner) return;
+  const names = entry.labels.join(", ");
+  const prompt = `OpenMausBot connection update: the user securely connected ${names}. Continue the task that paused for this connection. Do not ask them to connect it again.`;
+  if (owner.bot.busy) {
+    pendingConnectorResumes.set(`${entry.threadId}:${entry.resumeKey}`, entry);
+    return;
+  }
+  if (owner.group) {
+    const previous = groupQueues.get(owner.group.id) ?? Promise.resolve();
+    const next = previous.then(async () => {
+      const current = connectorThread(entry.botId, entry.threadId);
+      if (!current?.group) return;
+      if (current.bot.busy) {
+        pendingConnectorResumes.set(`${entry.threadId}:${entry.resumeKey}`, entry);
+        return;
+      }
+      await runGroupMemberTurn(current.group.id, entry.botId, 0, new Set(), prompt);
+    });
+    groupQueues.set(owner.group.id, next.catch((error) => {
+      markConnectorResumeFailed(entry.threadId, entry.resumeKey, error instanceof Error ? error.message : String(error));
+    }));
+    return;
+  }
+  void startTurn(entry.botId, prompt, {
+    threadId: entry.threadId,
+    connectorContinuation: true,
+    onDispatchError: (message) => markConnectorResumeFailed(entry.threadId, entry.resumeKey, message),
+  }).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/already working/i.test(message)) pendingConnectorResumes.set(`${entry.threadId}:${entry.resumeKey}`, entry);
+    else markConnectorResumeFailed(entry.threadId, entry.resumeKey, message);
+  });
+}
+
+function maybeResumeConnectors(botId: string, threadId: string, resumeKey: string) {
+  const cards = connectorCards(threadId, resumeKey);
+  if (!cards.length || cards.some((message) => message.connector?.dismissed || message.connector?.status !== "connected")) return false;
+  if (cards.every((message) => message.connector?.resumed)) return true;
+  const labels = cards.map((message) => message.connector!.label);
+  for (const message of cards) {
+    store.patchMessage(threadId, message.id, { connector: { ...message.connector!, resumed: true, error: undefined } });
+  }
+  dispatchConnectorResume({ botId, threadId, resumeKey, labels });
+  return true;
+}
+
+function drainConnectorResumes() {
+  for (const [key, entry] of pendingConnectorResumes) {
+    if (store.bot(entry.botId)?.busy) continue;
+    pendingConnectorResumes.delete(key);
+    dispatchConnectorResume(entry);
+  }
+}
+
+bus.subscribe((event: RuntimeEvent) => {
+  if (event.type === "turn.completed") drainConnectorResumes();
+});
+
 /** Pre-save probe for a CLI path override: run `<cli> --version` with the
  * same environment a real turn gets (augmented PATH). Returns ok + the
  * version line, or a fail the UI can act on — ENOENT on a GUI-launched app
@@ -1734,6 +1864,7 @@ function cliProbeEnvironment(): NodeJS.ProcessEnv {
     "BOX_TOKEN",
     "OPENCODE_API_KEY",
     "COMPOSIO_API_KEY",
+    "OMB_COMPOSIO_BROKER_TOKEN",
     "OMB_TTS_KEY",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
@@ -1753,7 +1884,8 @@ function configStatus() {
   return {
     xai: { configured: Boolean(cfg.xai?.key) },
     composio: {
-      configured: Boolean(cfg.composio?.apiKey),
+      configured: composio.configured(cfg),
+      mode: composio.connectionMode(cfg),
     },
     box: { configured: Boolean(cfg.box?.token) },
     opencodeGo: { configured: Boolean(cfg.opencodeGo?.apiKey) },
@@ -2032,6 +2164,67 @@ const server = createServer(async (req, res) => {
             ? `Queued for review — @${targetName} will only pick it up if the user approves after your turn finishes.`
             : `Delegation queued — @${targetName} will pick it up after your current turn finishes.`,
         });
+      }
+      if (method === "POST" && path === "/api/internal/connectors/mcp") {
+        const body = await readBody(req);
+        const upstream = await composio.relayMcp(
+          cfg,
+          body,
+          Array.isArray(req.headers["mcp-session-id"])
+            ? req.headers["mcp-session-id"][0]
+            : req.headers["mcp-session-id"],
+        );
+        const headers: Record<string, string> = {
+          "content-type": upstream.contentType,
+          "cache-control": "no-store",
+        };
+        if (upstream.transportSessionId) headers["mcp-session-id"] = upstream.transportSessionId;
+        res.writeHead(upstream.status, headers);
+        return res.end(Buffer.from(upstream.bytes));
+      }
+      if (method === "POST" && path === "/api/internal/connectors/request") {
+        const body = await readBody(req);
+        const botId = String(body.botId ?? "");
+        const threadId = String(body.threadId ?? "");
+        const resumeKey = String(body.resumeKey ?? "");
+        const slugs: string[] = Array.isArray(body.slugs)
+          ? [...new Set<string>(body.slugs.map((slug: unknown) => String(slug).toLowerCase()).filter((slug: string) => CONNECTOR_SLUG.test(slug)))]
+          : [];
+        const owner = connectorThread(botId, threadId);
+        if (!owner) return json(res, 403, { error: "conversation does not belong to this bot" });
+        if (!/^[\w-]{8,100}$/.test(resumeKey)) return json(res, 400, { error: "invalid resume key" });
+        if (!slugs.length || slugs.length > 12) return json(res, 400, { error: "one to twelve valid apps are required" });
+        if (!composio.configured(cfg) || owner.bot.composio === false) {
+          return json(res, 409, { error: "connected apps are not enabled for this bot" });
+        }
+        const connectionState: Record<string, { connected?: boolean }> = await composio.connectionStatus(cfg, slugs).catch(() => ({}));
+        const messageIds: string[] = [];
+        for (const slug of slugs) {
+          const existing = store.messagesFor(threadId).find(
+            (message) => message.connector?.resumeKey === resumeKey && message.connector.slug === slug,
+          );
+          if (existing) {
+            messageIds.push(existing.id);
+            continue;
+          }
+          const toolkit = await composio.toolkitCard(cfg, slug);
+          const connected = connectionState[slug]?.connected === true;
+          const message = store.appendMessage(threadId, {
+            role: "bot",
+            kind: "connector",
+            ...(owner.group ? { from: { botId: owner.bot.id, name: owner.bot.name, color: owner.bot.color } } : {}),
+            connector: {
+              slug,
+              label: toolkit.label,
+              description: toolkit.blurb || `Connect ${toolkit.label} so the bot can continue`,
+              status: connected ? "connected" : "required",
+              resumeKey,
+            },
+          });
+          messageIds.push(message.id);
+        }
+        maybeResumeConnectors(botId, threadId, resumeKey);
+        return json(res, 200, { messageIds });
       }
       return json(res, 404, { error: "unknown internal endpoint" });
     }
@@ -3162,11 +3355,11 @@ const server = createServer(async (req, res) => {
     // ── connectors (Composio) ──
     if (method === "GET" && path === "/api/connectors/catalog") {
       const { cards, source } = await composio.listToolkits(cfg);
-      return json(res, 200, { configured: Boolean(cfg.composio?.apiKey), source, cards });
+      return json(res, 200, { configured: composio.configured(cfg), mode: composio.connectionMode(cfg), source, cards });
     }
     if (method === "GET" && path === "/api/connectors") {
       const services = (url.searchParams.get("services") ?? "").split(",").filter(Boolean);
-      if (!cfg.composio?.apiKey) {
+      if (!composio.configured(cfg)) {
         return json(res, 200, { configured: false, services: {} });
       }
       const status = await composio.connectionStatus(cfg, services.length ? services : composio.CURATED_SLUGS);
@@ -3176,6 +3369,55 @@ const server = createServer(async (req, res) => {
     if (m && method === "POST") return json(res, 200, await composio.authorizeService(cfg, m[1]));
     m = path.match(/^\/api\/connectors\/([\w-]+)$/);
     if (m && method === "DELETE") return json(res, 200, await composio.removeService(cfg, m[1]));
+
+    // Inline connection cards are bound to both the bot and the exact task
+    // or room thread that created them. The browser auth URL is returned
+    // only to this local UI and is never stored in the transcript.
+    m = path.match(/^\/api\/bots\/([\w-]+)\/connector-cards\/([\w-]+)\/(authorize|status|resume|dismiss)$/);
+    if (m) {
+      const body = method === "POST" ? await readBody(req) : {};
+      const threadId = String(method === "GET" ? url.searchParams.get("threadId") ?? "" : body.threadId ?? "");
+      const message = connectorMessage(m[1], threadId, m[2]);
+      if (!message?.connector) return json(res, 404, { error: "no such connection request" });
+      const connector = message.connector;
+      if (m[3] === "authorize" && method === "POST") {
+        store.patchMessage(threadId, message.id, {
+          connector: { ...connector, status: "authorizing", error: undefined, dismissed: false },
+        });
+        try {
+          return json(res, 200, await composio.authorizeService(cfg, connector.slug));
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          store.patchMessage(threadId, message.id, {
+            connector: { ...connector, status: "failed", error: detail.slice(0, 180) },
+          });
+          throw error;
+        }
+      }
+      if (m[3] === "status" && method === "GET") {
+        const state = (await composio.connectionStatus(cfg, [connector.slug]))[connector.slug];
+        const failed = /failed|expired|revoked|error/i.test(state?.status ?? "");
+        const next = {
+          ...connector,
+          status: state?.connected ? ("connected" as const) : failed ? ("failed" as const) : ("authorizing" as const),
+          error: failed ? `Connection ${state?.status ?? "failed"}` : undefined,
+        };
+        store.patchMessage(threadId, message.id, { connector: next });
+        if (state?.connected) maybeResumeConnectors(m[1], threadId, connector.resumeKey);
+        return json(res, 200, { connected: Boolean(state?.connected), pending: Boolean(state?.pending), status: state?.status });
+      }
+      if (m[3] === "resume" && method === "POST") {
+        const resumed = maybeResumeConnectors(m[1], threadId, connector.resumeKey);
+        return resumed
+          ? json(res, 200, { resumed: true })
+          : json(res, 409, { error: "finish connecting every requested app first" });
+      }
+      if (m[3] === "dismiss" && method === "POST") {
+        store.patchMessage(threadId, message.id, { connector: { ...connector, dismissed: true } });
+        return json(res, 200, { dismissed: true });
+      }
+      return json(res, 405, { error: "method not allowed" });
+    }
 
     // ── the bot's cloud computer (Box) ──
     m = path.match(/^\/api\/bots\/([\w-]+)\/computer$/);

--- a/server/proxy-paths.ts
+++ b/server/proxy-paths.ts
@@ -39,4 +39,5 @@ export const SPAWNED_PROXIES = {
   containerMcp: resolveProxy("container-mcp"),
   agents: resolveProxy("drivers/agents-proxy"),
   dweb: resolveProxy("drivers/dweb-proxy"),
+  connectors: resolveProxy("connector-proxy"),
 } as const;

--- a/server/store.ts
+++ b/server/store.ts
@@ -50,12 +50,26 @@ export interface OptionCardData {
   allowKey?: string;
 }
 
+export interface ConnectorCardData {
+  /** Composio toolkit slug. It is validated server-side before every action. */
+  slug: string;
+  label: string;
+  description: string;
+  status: "required" | "authorizing" | "connected" | "failed";
+  /** Cards created by one agent request resume together after all connect. */
+  resumeKey: string;
+  error?: string;
+  dismissed?: boolean;
+  resumed?: boolean;
+}
+
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen";
+  kind: "text" | "options" | "activity" | "screen" | "connector";
   text?: string;
   card?: OptionCardData;
+  connector?: ConnectorCardData;
   /** activity messages: tool name + outcome. `spoken` is the same chip as
    * a phrase a voice can read ("reading a file") — computed once here so
    * call mode never has to re-derive it from the raw tool name, and absent
@@ -172,6 +186,14 @@ function redactBotAuthored<T extends Omit<Message, "id" | "at"> & { at?: number 
     if (typeof card.subtitle === "string") card.subtitle = redactSecretsInText(card.subtitle);
     if (typeof card.summary === "string") card.summary = redactSecretsInText(card.summary);
     out.card = card;
+  }
+  if (out.connector) {
+    out.connector = {
+      ...out.connector,
+      label: redactSecretsInText(out.connector.label),
+      description: redactSecretsInText(out.connector.description),
+      error: out.connector.error ? redactSecretsInText(out.connector.error) : undefined,
+    };
   }
   return out;
 }

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -207,6 +207,9 @@ function handle(msg: any) {
       }
       const servers: McpEntry[] = Array.isArray(msg.params?.mcpServers) ? msg.params.mcpServers : [];
       agentsMcp = servers.find((s: any) => s?.name === "agents") ?? null;
+      if (process.env.FAKE_ACP_DUMP) {
+        writeFileSync(`${process.env.FAKE_ACP_DUMP}.mcp.json`, JSON.stringify(servers, null, 2));
+      }
       const opts = configOptions();
       result(msg.id, opts ? { sessionId: "fake-acp-session", configOptions: opts } : { sessionId: "fake-acp-session" });
       break;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -39,6 +39,7 @@ import { ChatMarkdown } from "./ChatMarkdown";
 import { OptionCard } from "./OptionCard";
 import { ApprovalCard } from "./ApprovalCard";
 import { Composer } from "./Composer";
+import { ConnectorCard } from "./ConnectorCard";
 import { ModelPicker } from "./ModelPicker";
 import { RenameTitle } from "./RenameTitle";
 import { TaskPicker } from "./TaskPicker";
@@ -573,6 +574,8 @@ const MessagesList = memo(function MessagesList({
         const newDay = !prev || new Date(prev.at).toDateString() !== new Date(m.at).toDateString();
         const row = (() => {
           switch (m.kind) {
+            case "connector":
+              return m.connector ? <ConnectorCard botId={bot.id} threadId={bot.threadId} message={m} /> : null;
             case "options":
               // a live permission ask gets the approval box; questions and
               // the onboarding quiz keep the list card

--- a/src/components/ConnectorCard.tsx
+++ b/src/components/ConnectorCard.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Loader2, PlugZap, RefreshCw, X } from "lucide-react";
+
+import { api, type Message } from "@/state/store";
+
+async function openConnectionPage(url: string) {
+  if (window.ogb?.openExternal) {
+    await window.ogb.openExternal(url);
+    return;
+  }
+  const opened = window.open("", "_blank");
+  if (!opened) throw new Error("Your browser blocked the connection page. Allow pop-ups, then try again.");
+  opened.opener = null;
+  opened.location.replace(url);
+}
+
+export function ConnectorCard({ botId, threadId, message }: { botId: string; threadId: string; message: Message }) {
+  const connector = message.connector!;
+  const [busy, setBusy] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const polling = useRef(false);
+
+  const endpoint = `/api/bots/${encodeURIComponent(botId)}/connector-cards/${encodeURIComponent(message.id)}`;
+  const checkStatus = useCallback(async () => {
+    const result = await api(`${endpoint}/status?threadId=${encodeURIComponent(threadId)}`);
+    return Boolean(result.connected);
+  }, [endpoint, threadId]);
+
+  useEffect(() => {
+    if (connector.status !== "authorizing" || connector.dismissed) return;
+    polling.current = true;
+    let tries = 0;
+    const timer = setInterval(() => {
+      if (!polling.current) return;
+      void checkStatus()
+        .then((connected) => {
+          tries += 1;
+          if (connected || tries >= 75) {
+            polling.current = false;
+            clearInterval(timer);
+          }
+        })
+        .catch(() => {
+          tries += 1;
+          if (tries >= 75) clearInterval(timer);
+        });
+    }, 4_000);
+    return () => {
+      polling.current = false;
+      clearInterval(timer);
+    };
+  }, [checkStatus, connector.dismissed, connector.status]);
+
+  if (connector.dismissed) return null;
+
+  const connect = async () => {
+    setBusy(true);
+    setLocalError(null);
+    try {
+      const result = await api(`${endpoint}/authorize`, {
+        method: "POST",
+        body: JSON.stringify({ threadId }),
+      });
+      await openConnectionPage(String(result.url));
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const resume = async () => {
+    setBusy(true);
+    setLocalError(null);
+    try {
+      await api(`${endpoint}/resume`, { method: "POST", body: JSON.stringify({ threadId }) });
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const dismiss = () => {
+    void api(`${endpoint}/dismiss`, { method: "POST", body: JSON.stringify({ threadId }) }).catch(() => {});
+  };
+
+  const connected = connector.status === "connected";
+  const authorizing = connector.status === "authorizing";
+  const error = localError ?? connector.error;
+
+  return (
+    <div className="flex w-full justify-start">
+      <div className="w-full max-w-[520px] overflow-hidden rounded-2xl border border-hairline/50 bg-card shadow-sm">
+        <div className="flex items-start gap-3 p-4">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-raised text-[16px] font-semibold text-ink">
+            {connector.label.slice(0, 1).toUpperCase() || <PlugZap size={19} />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[14px] font-semibold text-ink">{connector.label}</span>
+              {connected && (
+                <span className="flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[11px] font-medium text-success">
+                  <Check size={11} /> Connected
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-[12.5px] leading-relaxed text-ink-secondary">
+              {connected
+                ? connector.resumed
+                  ? "Connected securely. Your bot is continuing the task."
+                  : "Connected securely. Continue the paused task when you're ready."
+                : connector.description}
+            </p>
+            {!connected && (
+              <p className="mt-1 text-[11.5px] text-ink-secondary/80">
+                Sign in or enter the app key on the secure connection page — never in chat.
+              </p>
+            )}
+            {error && <p className="mt-2 text-[12px] text-danger">{error}</p>}
+          </div>
+          {!connected && (
+            <button onClick={dismiss} aria-label="Not now" title="Not now" className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink">
+              <X size={15} />
+            </button>
+          )}
+        </div>
+        <div className="flex items-center justify-between border-t border-hairline/40 bg-panel/40 px-4 py-2.5">
+          <div className="flex items-center gap-1.5 text-[11.5px] text-ink-secondary">
+            {authorizing ? <Loader2 size={12} className="animate-spin" /> : <PlugZap size={12} />}
+            {authorizing ? "Waiting for sign-in…" : connected ? "Ready to use" : "Requested by your bot"}
+          </div>
+          {!connected ? (
+            <button
+              onClick={() => void connect()}
+              disabled={busy}
+              className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[12.5px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy || authorizing ? <Loader2 size={13} className="animate-spin" /> : <PlugZap size={13} />}
+              {authorizing ? "Open again" : connector.status === "failed" ? "Try again" : "Connect securely"}
+            </button>
+          ) : !connector.resumed ? (
+            <button
+              onClick={() => void resume()}
+              disabled={busy}
+              className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[12.5px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />} Continue task
+            </button>
+          ) : (
+            <span className="flex items-center gap-1 text-[12px] font-medium text-success"><Check size={13} /> Continuing</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -19,6 +19,7 @@ import { normalizeState } from "@/lib/mascot";
 import { effectiveDefaultResponder, groupResponseHint } from "@/lib/group-routing";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { Composer } from "./Composer";
+import { ConnectorCard } from "./ConnectorCard";
 import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
@@ -88,7 +89,9 @@ const Transcript = memo(function Transcript({
           // `tool` distinguishes a permission from a QUESTION — a question
           // only accepts an "answer", so routing it here would offer an
           // Allow the broker rejects
-          m.kind === "options" && m.card?.requestId && m.card.tool ? (
+          m.kind === "connector" && m.connector && m.from?.botId ? (
+            <ConnectorCard botId={m.from.botId} threadId={group.threadId} message={m} />
+          ) : m.kind === "options" && m.card?.requestId && m.card.tool ? (
             <div className="flex justify-start">
               <ApprovalCard bot={memberOf(m.from?.botId)} message={m} />
             </div>

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -64,6 +64,7 @@ export function PluginsPanel() {
   const [cards, setCards] = useState<ToolkitCard[] | null>(null);
   const [source, setSource] = useState<"api" | "curated">("curated");
   const [configured, setConfigured] = useState(true);
+  const [mode, setMode] = useState<"managed" | "self-hosted" | "unavailable">("unavailable");
   const [status, setStatus] = useState<Record<string, ConnectorStatus>>({});
   const [pendingUrls, setPendingUrls] = useState<Record<string, string>>({});
   const [busySlug, setBusySlug] = useState<string | null>(null);
@@ -119,6 +120,7 @@ export function PluginsPanel() {
         setCards(r.cards ?? []);
         setSource(r.source ?? "curated");
         setConfigured(Boolean(r.configured));
+        setMode(r.mode ?? "unavailable");
         if (r.configured) void refreshStatus((r.cards ?? []).map((c: ToolkitCard) => c.slug).slice(0, 40));
       })
       .catch((e) => alive && setError(e.message));
@@ -248,7 +250,7 @@ export function PluginsPanel() {
       >
         <header className="flex items-start justify-between gap-4 px-6 pb-3 pt-6 sm:px-8 sm:pt-7">
           <div>
-            <h2 id="connected-apps-title" className="text-[22px] font-semibold tracking-[-0.01em] text-ink">Plugins</h2>
+            <h2 id="connected-apps-title" className="text-[22px] font-semibold tracking-[-0.01em] text-ink">Connected apps</h2>
             <p className="mt-1 text-[13px] text-ink-secondary">Connect the apps your bots can use.</p>
           </div>
           <div className="flex items-center gap-1">
@@ -261,7 +263,7 @@ export function PluginsPanel() {
             </button>
             <button
               onClick={close}
-              aria-label="Close plugins"
+              aria-label="Close connected apps"
               className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"
             >
               <X size={21} />
@@ -270,7 +272,7 @@ export function PluginsPanel() {
         </header>
 
         <div className="flex flex-col gap-3 px-6 pb-4 pt-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
-          <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Plugin view">
+          <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Connected apps view">
             <button
               role="tab"
               aria-selected={tab === "marketplace"}
@@ -299,8 +301,8 @@ export function PluginsPanel() {
             <input
               value={search}
               onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search plugins"
-              aria-label="Search plugins"
+              placeholder="Search apps"
+              aria-label="Search apps"
               className="min-w-0 flex-1 bg-transparent text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
             />
           </label>
@@ -308,7 +310,7 @@ export function PluginsPanel() {
 
         {!configured && (
           <div className="mx-6 mb-1 rounded-xl bg-warning/10 px-4 py-3 text-[13px] text-warning sm:mx-8">
-            Add your Composio project key to connect apps.{" "}
+            Connected apps are temporarily unavailable. You can retry after restarting, or configure your own connection service.{" "}
             <button
               className="font-medium underline underline-offset-2"
               onClick={() => {
@@ -320,7 +322,7 @@ export function PluginsPanel() {
             </button>
           </div>
         )}
-        {configured && source === "curated" && (
+        {configured && source === "curated" && mode === "self-hosted" && (
           <div className="mx-6 mb-1 text-[12px] text-ink-secondary sm:mx-8">
             Showing featured apps.{" "}
             <button
@@ -330,7 +332,7 @@ export function PluginsPanel() {
                 dispatch({ type: "toggleAppSettings", open: true });
               }}
             >
-              Use your Composio key
+              Update your Composio key
             </button>{" "}
             for the full catalog.
           </div>
@@ -404,7 +406,7 @@ export function PluginsPanel() {
           {cards !== null && visible.length === 0 && (
             <div className="flex min-h-56 flex-col items-center justify-center text-center">
               <div className="text-[14px] font-medium text-ink">
-                {tab === "connected" ? "No connected plugins yet" : "No plugins found"}
+                {tab === "connected" ? "No connected apps yet" : "No apps found"}
               </div>
               <div className="mt-1 text-[12.5px] text-ink-secondary">
                 {tab === "connected" ? "Connect an app from Marketplace and it will appear here." : "Try a different search."}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -208,13 +208,23 @@ export function SettingsModal() {
 
             {section === "connections" && (
               <Card
-                title="Keys"
-                subtitle="Shared by all bots. Saving a key reloads providers instantly; keys are stored locally and never shown again."
+                title="Connections"
+                subtitle="Connected apps work automatically in the installed app. Other optional service keys stay on this computer."
               >
                 <div className="flex flex-col gap-4">
-                  <ApiKeyRow section="composio" />
+                  {state.config?.composio.mode === "managed" ? (
+                    <div className="rounded-lg border border-success/25 bg-success/10 px-3 py-2 text-[13px] text-success">
+                      Connected apps service is ready
+                    </div>
+                  ) : null}
                   <ApiKeyRow section="box" />
                   <ApiKeyRow section="opencodeGo" />
+                  <details className="rounded-lg border border-hairline/40 bg-inset px-3 py-2">
+                    <summary className="cursor-pointer text-[13px] text-ink-secondary">Self-host connected apps</summary>
+                    <div className="mt-3">
+                      <ApiKeyRow section="composio" />
+                    </div>
+                  </details>
                 </div>
               </Card>
             )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1071,7 +1071,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-raised/50"
         >
           <Puzzle size={20} className="text-ink-secondary" />
-          <span className="text-[14px] text-ink">Plugins</span>
+          <span className="text-[14px] text-ink">Connected apps</span>
         </button>
         <div className="flex items-center">
           <button

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -39,12 +39,24 @@ export interface OptionCardData {
   allowKey?: string;
 }
 
+export interface ConnectorCardData {
+  slug: string;
+  label: string;
+  description: string;
+  status: "required" | "authorizing" | "connected" | "failed";
+  resumeKey: string;
+  error?: string;
+  dismissed?: boolean;
+  resumed?: boolean;
+}
+
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen";
+  kind: "text" | "options" | "activity" | "screen" | "connector";
   text?: string;
   card?: OptionCardData;
+  connector?: ConnectorCardData;
   /** activity messages: tool name + outcome. `spoken` is the server's
    * narration of the same chip ("reading a file"), used by call mode. */
   /** `setup` marks an error fixed by installing something, not by retrying. */
@@ -196,7 +208,7 @@ export function messageVersions(bot: Bot, message: Message): Message[] {
 /** GET /api/config — configured flags only; secrets are never echoed. */
 export interface ConfigStatus {
   xai?: { configured: boolean };
-  composio: { configured: boolean };
+  composio: { configured: boolean; mode?: "managed" | "self-hosted" | "unavailable" };
   box: { configured: boolean };
   opencodeGo?: { configured: boolean };
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND


### PR DESCRIPTION
## What changed

- Adds trusted in-chat connector cards when an agent needs Gmail or another connected app.
- Opens authorization in the system browser, polls connection state, and automatically resumes the exact task once every requested app is connected.
- Makes connector mounting work across Claude, Codex, and ACP-based providers without exposing durable credentials to provider processes.
- Replaces the normal Composio-key setup with a managed per-installation broker while preserving a documented self-host path.
- Adds a Cloudflare Worker backed by D1, per-route rate limits, hashed installation tokens, strict Composio URL validation, and secure project-key storage.

## Why

Users should be able to ask an agent to use an app without knowing what an API key or MCP server is. The previous flow required configuration outside the conversation and could leave the agent unable to continue after authorization.

## User impact

When a connector is missing, OpenMausBot now shows a first-party card directly in chat. The user clicks **Connect securely**, completes authorization on Composio, and the bot continues automatically. Self-hosters can deploy the included broker or continue using a direct project key as an advanced fallback.

## Security design

- The Composio project key remains only in the Cloudflare Worker secret store.
- Installation tokens are stored hashed in D1 and encrypted locally with Electron safe storage.
- Provider processes receive only a per-boot loopback token, never the durable broker token.
- Authorization URLs are never persisted and must be HTTPS URLs on `*.composio.dev`.
- Connector actions and continuation are bound to the originating bot, thread, message, and resume key.

## Validation

- `pnpm test` — 976 application tests passed, 8 skipped; broker, updater, and packaged-server checks also passed.
- `pnpm build`
- `pnpm broker:check`
- Live Cloudflare smoke test for registration, identity, catalog, status, authorization, and cleanup.

The production broker is deployed at `https://openmausbot-composio.milindsoni201.workers.dev`.
