### PR TITLE
feat(ios): add seamless secure QR companion pairing

### DIFF
--- a/companion/README.md
+++ b/companion/README.md
@@ -84,8 +84,10 @@ on your phone, enter  macbook.tail1234.ts.net:8810
 ```
 
 Open the pairing page, click **Start pairing**, and type the six digits into
-the phone. Stopping the process is the off switch — running it *is* the
-opt-in, so there is no toggle to forget.
+the phone. The normal desktop panel also turns that short-lived code and the
+dialable address into a QR handoff, so the mobile app can fill both in without
+putting the long-lived device token in the QR. Stopping the process is the off
+switch — running it *is* the opt-in, so there is no toggle to forget.
 
 That is the standalone way to run it, and it is what to reach for when the
 harness is running on its own — a headless box, or `pnpm dev:server` in a

--- a/companion/src/control.ts
+++ b/companion/src/control.ts
@@ -98,7 +98,7 @@ export function companionState(options: ControlOptions) {
     ...(tailscale ? { tailscale } : {}),
     ...(tailscale && name ? { tailnetName: name } : {}),
     lan: addresses.find((a) => a !== tailscale) ?? null,
-    pairing: pairing ? { code: pairing.code, expiresAt: pairing.expiresAt } : null,
+    pairing: pairing ? { code: pairing.code, token: pairing.token, expiresAt: pairing.expiresAt } : null,
     devices: options.devices.list(),
     discovery: options.discovery(),
   };
@@ -163,7 +163,14 @@ export function createControlServer(options: ControlOptions): Server {
     if (method === "GET" && path === "/state") return json(res, 200, companionState(options));
     if (method === "POST" && path === "/pairing") {
       const window = options.devices.openPairing();
-      return json(res, 201, { ...companionState(options), code: window.code });
+      // Keep the freshly issued credentials at the top level as well as in
+      // `pairing`, matching the existing code response and making this write
+      // sufficient for native control clients that do not immediately poll.
+      return json(res, 201, {
+        ...companionState(options),
+        code: window.code,
+        token: window.token,
+      });
     }
     if (method === "DELETE" && path === "/pairing") {
       options.devices.closePairing();

--- a/companion/src/devices.ts
+++ b/companion/src/devices.ts
@@ -28,14 +28,16 @@ export interface DeviceRecord {
 /** What the UI is allowed to see: a device without its secret. */
 export type PublicDevice = Omit<DeviceRecord, "tokenHash">;
 
-/** A pairing window: one short-lived code, deliberately single-use.
+/** A pairing window: two short-lived credentials, deliberately single-use.
  *
- * Six digits is only 1e6 possibilities, which is brute-forceable in seconds
- * against a LAN service — so the code is never the whole defence. It lives
- * for two minutes, dies after a handful of wrong guesses, and only exists at
- * all while the user is looking at the pairing screen. */
+ * `token` is the primary path carried inside the QR code. It has enough
+ * entropy to stand on its own and is never typed or persisted. `code` is the
+ * human fallback: six digits is only 1e6 possibilities, so it lives for two
+ * minutes, dies after a handful of wrong guesses, and only exists while the
+ * user is looking at the pairing screen. Redeeming either burns both. */
 export interface PairingWindow {
   code: string;
+  token: string;
   expiresAt: number;
   attemptsLeft: number;
 }
@@ -62,9 +64,9 @@ function sameDigest(a: string, b: string): boolean {
   }
 }
 
-/** Same treatment for the pairing code, which is compared far more often
+/** Same treatment for a pairing credential, which is compared far more often
  * than it is correct. */
-function sameCode(a: string, b: string): boolean {
+function sameCredential(a: string, b: string): boolean {
   const left = Buffer.from(a, "utf8");
   const right = Buffer.from(b, "utf8");
   if (left.length !== right.length) return false;
@@ -163,6 +165,7 @@ export class DeviceRegistry {
   openPairing(): PairingWindow {
     this.window = {
       code: String(randomInt(0, 1_000_000)).padStart(6, "0"),
+      token: `omb_pair_${randomBytes(32).toString("base64url")}`,
       expiresAt: Date.now() + PAIRING_TTL_MS,
       attemptsLeft: MAX_PAIRING_ATTEMPTS,
     };
@@ -173,14 +176,15 @@ export class DeviceRegistry {
     this.window = null;
   }
 
-  /** Redeem a pairing code for a device token.
+  /** Redeem either pairing credential for a device token.
    *
    * The token is returned exactly once, here. There is no endpoint that can
    * read it back — a phone that loses it pairs again. */
-  redeem(code: string, name: unknown): { device: PublicDevice; token: string } | { error: string } {
+  redeem(credential: string, name: unknown): { device: PublicDevice; token: string } | { error: string } {
     const window = this.pairing();
     if (!window) return { error: "no pairing is in progress — open Companion settings on your computer" };
-    if (!sameCode(window.code, String(code ?? ""))) {
+    const presented = String(credential ?? "");
+    if (!sameCredential(window.code, presented) && !sameCredential(window.token, presented)) {
       window.attemptsLeft -= 1;
       // A burned window is the whole point: without this, six digits is a
       // few seconds of guessing.
@@ -188,7 +192,7 @@ export class DeviceRegistry {
         this.closePairing();
         return { error: "too many incorrect codes — start pairing again" };
       }
-      return { error: "that code is not right" };
+      return { error: "that pairing credential is not right" };
     }
     // After the code, not before. Checked first, a full fleet answers every
     // wrong guess with "too many paired devices" — which tells a guesser

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -147,7 +147,9 @@ export function createProxyHandler(options: ProxyOptions) {
     if (method === "POST" && path === "/api/pair") {
       readJson(req).then(
         (body) => {
-          const result = options.redeem(String(body.code ?? ""), body.deviceName);
+          // New clients redeem the high-entropy credential carried by the QR.
+          // `code` remains accepted for manual entry and older mobile builds.
+          const result = options.redeem(String(body.credential ?? body.code ?? ""), body.deviceName);
           if ("error" in result) return sendJson(res, 401, { error: result.error });
           return sendJson(res, 201, { ...result, serverName: options.serverName() });
         },

--- a/companion/test/devices.test.ts
+++ b/companion/test/devices.test.ts
@@ -1,6 +1,6 @@
 // Companion device registry contract. The three properties that matter:
-// a token is never recoverable from disk, a pairing code cannot be ground
-// down by guessing, and revoking a device actually revokes it.
+// a token is never recoverable from disk, pairing credentials are one-time,
+// a manual code cannot be ground down by guessing, and revocation works.
 import { readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -106,7 +106,7 @@ describe("DeviceRegistry", () => {
     const wrong = code === "000000" ? "111111" : "000000";
 
     for (let i = 1; i < MAX_PAIRING_ATTEMPTS; i++) {
-      expect(registry.redeem(wrong, "iPhone")).toEqual({ error: "that code is not right" });
+      expect(registry.redeem(wrong, "iPhone")).toEqual({ error: "that pairing credential is not right" });
       expect(registry.pairing()).not.toBeNull();
     }
     // the last one closes the window rather than counting down forever
@@ -123,6 +123,18 @@ describe("DeviceRegistry", () => {
     const { code } = registry.openPairing();
     expect(registry.redeem(code, "iPhone")).toHaveProperty("token");
     expect(registry.redeem(code, "iPad")).toMatchObject({ error: expect.stringContaining("no pairing") });
+    expect(registry.count()).toBe(1);
+  });
+
+  it("uses a high-entropy QR credential and burns the manual fallback with it", () => {
+    const registry = new DeviceRegistry();
+    const { code, token } = registry.openPairing();
+
+    expect(token).toMatch(/^omb_pair_[A-Za-z0-9_-]{43}$/);
+    expect(registry.redeem(token, "iPhone")).toHaveProperty("token");
+    expect(registry.redeem(code, "iPad")).toMatchObject({
+      error: expect.stringContaining("no pairing"),
+    });
     expect(registry.count()).toBe(1);
   });
 

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -535,11 +535,12 @@ describe("the sidecar in front of an unmodified harness", () => {
 });
 
 // The whole loop, with the real registry rather than a stub: open a pairing
-// window on the control surface, redeem the code the way the phone does, and
+// window on the control surface, redeem its QR credential the way the phone
+// does, and
 // use the token that comes back. This is the path that has no unit-test
 // equivalent — every piece is real except the phone.
 describe("pairing, end to end", () => {
-  it("turns a code shown on the computer into a working device token", async () => {
+  it("turns a QR credential into a working device token", async () => {
     const { DeviceRegistry } = await import("../src/devices.ts");
     const { createControlServer } = await import("../src/control.ts");
 
@@ -572,9 +573,13 @@ describe("pairing, end to end", () => {
 
       // the person clicks "Start pairing" on the computer
       // SAFETY: POST /pairing is this sidecar's own API and always answers
-      // with the window's code; the toMatch below fails if the shape drifts.
-      const opened = (await (await fetch(`${ctl}/pairing`, { method: "POST" })).json()) as { code: string };
+      // with both credentials; the matches below fail if the shape drifts.
+      const opened = (await (await fetch(`${ctl}/pairing`, { method: "POST" })).json()) as {
+        code: string;
+        token: string;
+      };
       expect(opened.code).toMatch(/^\d{6}$/);
+      expect(opened.token).toMatch(/^omb_pair_[A-Za-z0-9_-]{43}$/);
 
       // a wrong code is refused, and does not burn the window
       const wrong = await fetch(`${base}/api/pair`, {
@@ -584,11 +589,11 @@ describe("pairing, end to end", () => {
       });
       expect(wrong.status).toBe(401);
 
-      // the right one is redeemed exactly once, and never forwarded upstream
+      // The QR token is redeemed exactly once and never forwarded upstream.
       const res = await fetch(`${base}/api/pair`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ code: opened.code, deviceName: "Ada's iPhone" }),
+        body: JSON.stringify({ credential: opened.token, deviceName: "Ada's iPhone" }),
       });
       expect(res.status).toBe(201);
       // SAFETY: a 201 from /api/pair carries exactly this shape — the

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -12,7 +12,8 @@ The first version includes:
 
 - Bonjour discovery on the same LAN and manual address entry.
 - Remote access through a Tailscale MagicDNS name.
-- One-time pairing codes, per-device tokens, device listing, and revocation.
+- QR-first pairing with a short-lived, single-use credential and a six-digit
+  manual fallback, plus per-device tokens, device listing, and revocation.
 - Bot and room lists, paged transcripts, sending, interruption, and unread
   state.
 - Approvals and questions, including narrow “always allow” grants.
@@ -87,7 +88,7 @@ The sidecar advertises `_openmausbot._tcp` over Bonjour. The app browses with
 `NWBrowser`, resolves the chosen service, and connects directly. If multicast
 is unavailable, the desktop shows the LAN address for manual entry.
 
-LAN traffic is plain HTTP. Use it only on a network you trust. Pairing tokens
+LAN traffic is plain HTTP. Use it only on a network you trust. Device tokens
 are bearer credentials, so someone able to observe that LAN traffic could copy
 one until the device is revoked.
 
@@ -109,14 +110,27 @@ the local data in this design.
 
 ## Pairing and device security
 
-1. The user enables Companion in desktop Settings.
-2. The desktop opens a short-lived six-digit pairing window.
-3. The phone sends the code and a device name to `POST /api/pair`.
-4. The sidecar returns a random device token once and stores only its SHA-256
-   digest.
-5. The phone stores the token in Keychain and sends it as a bearer token.
-6. Revoking the device on the Mac invalidates future requests and sends the
+1. The user enables Companion in desktop Settings and starts pairing.
+2. The desktop opens a two-minute pairing window. Its QR contains the reachable
+   address and a high-entropy, single-use credential; the visible six-digit code
+   remains available for manual entry and older app builds.
+3. The phone scans and validates the invitation, shows the computer and address,
+   and asks the user to confirm before it connects. Scanning never auto-pairs.
+4. The phone sends the one-time credential and a device name to `POST /api/pair`.
+   Redeeming either the QR credential or manual code closes the entire window,
+   so neither can be replayed.
+5. The sidecar returns a separate random device token once and stores only its
+   SHA-256 digest.
+6. The phone stores the device token in Keychain and sends it as a bearer token.
+   It never persists the QR credential or manual code.
+7. Revoking the device on the Mac invalidates future requests and sends the
    phone back to pairing.
+
+This mirrors the direct-pairing security shape used by T3 Code: a high-entropy
+bootstrap credential, explicit confirmation of the scanned target, and a
+one-time exchange for a securely stored long-lived credential. An OpenMausBot
+account is not required because the phone connects directly to the user's Mac;
+authentication would only become necessary for a future hosted relay.
 
 The device-facing socket rejects browser `Origin` headers before reading a
 token. Its route policy in `companion/src/routes.ts` is default-deny: a new

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -16,6 +16,7 @@ struct CompanionApp: App {
             RootView()
                 .environmentObject(session)
                 .onAppear { session.connect() }
+                .onOpenURL { session.receivePairingURL($0) }
                 .onChange(of: scenePhase) { _, phase in
                     switch phase {
                     case .active:

--- a/ios/App/PairingScanner.swift
+++ b/ios/App/PairingScanner.swift
@@ -1,0 +1,173 @@
+// Native QR scanning for the one action where typing is needless friction.
+//
+// The scanner only recognizes QR codes and never pairs by itself. A valid
+// payload is returned to PairingView, which shows the computer name and
+// address for explicit confirmation. That mirrors T3 Code's production rule:
+// an attacker-controlled deep link or QR may prefill a target, but it cannot
+// silently authorize that target.
+import AVFoundation
+import SwiftUI
+import UIKit
+import VisionKit
+
+struct PairingScannerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    /// Return nil to accept and close, or a human-readable validation error
+    /// to keep scanning. The one-time credential never lives in this view.
+    let validate: (String) -> String?
+
+    @State private var cameraAuthorized = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+    @State private var permissionResolved = AVCaptureDevice.authorizationStatus(for: .video) != .notDetermined
+    @State private var validationError: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if !permissionResolved {
+                    ProgressView("Requesting camera access…")
+                } else if !cameraAuthorized {
+                    ContentUnavailableView {
+                        Label("Camera access needed", systemImage: "camera.fill")
+                    } description: {
+                        Text("Allow camera access to scan the pairing QR code shown by OpenMausBot.")
+                    } actions: {
+                        Button("Open Settings") {
+                            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                            UIApplication.shared.open(url)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                } else if !DataScannerViewController.isSupported || !DataScannerViewController.isAvailable {
+                    ContentUnavailableView {
+                        Label("Scanner unavailable", systemImage: "qrcode.viewfinder")
+                    } description: {
+                        Text("Use this iPhone's Camera app to scan the QR code, or enter the address and code manually.")
+                    }
+                } else {
+                    ZStack(alignment: .bottom) {
+                        PairingQRScanner { payload in
+                            if let error = validate(payload) {
+                                validationError = error
+                                return false
+                            }
+                            dismiss()
+                            return true
+                        }
+                        .ignoresSafeArea(edges: .bottom)
+
+                        VStack(spacing: 8) {
+                            Text(validationError ?? "Point the camera at the QR code on your computer")
+                                .font(.subheadline.weight(.medium))
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(validationError == nil ? Color.primary : Color.red)
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 14)
+                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18))
+                        .padding()
+                    }
+                }
+            }
+            .navigationTitle("Scan QR Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .task { await resolveCameraPermission() }
+            .onChange(of: scenePhase) { _, phase in
+                // If access was granted in Settings, recover immediately when
+                // the user returns instead of requiring the sheet to reopen.
+                if phase == .active {
+                    Task { await resolveCameraPermission() }
+                }
+            }
+        }
+    }
+
+    private func resolveCameraPermission() async {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            cameraAuthorized = true
+            permissionResolved = true
+        case .notDetermined:
+            cameraAuthorized = await AVCaptureDevice.requestAccess(for: .video)
+            permissionResolved = true
+        case .denied, .restricted:
+            cameraAuthorized = false
+            permissionResolved = true
+        @unknown default:
+            cameraAuthorized = false
+            permissionResolved = true
+        }
+    }
+}
+
+private struct PairingQRScanner: UIViewControllerRepresentable {
+    let onPayload: (String) -> Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPayload: onPayload)
+    }
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let controller = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .balanced,
+            recognizesMultipleItems: false,
+            isHighFrameRateTrackingEnabled: false,
+            isPinchToZoomEnabled: true,
+            isGuidanceEnabled: true,
+            isHighlightingEnabled: true
+        )
+        controller.delegate = context.coordinator
+        DispatchQueue.main.async {
+            try? controller.startScanning()
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ controller: DataScannerViewController, context: Context) {
+        context.coordinator.onPayload = onPayload
+        if !controller.isScanning {
+            try? controller.startScanning()
+        }
+    }
+
+    static func dismantleUIViewController(_ controller: DataScannerViewController, coordinator: Coordinator) {
+        controller.stopScanning()
+    }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        var onPayload: (String) -> Bool
+        private var locked = false
+
+        init(onPayload: @escaping (String) -> Bool) {
+            self.onPayload = onPayload
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            didAdd addedItems: [RecognizedItem],
+            allItems: [RecognizedItem]
+        ) {
+            guard !locked else { return }
+            guard let first = addedItems.first,
+                  case let .barcode(barcode) = first,
+                  let payload = barcode.payloadStringValue
+            else { return }
+
+            locked = true
+            if !onPayload(payload) {
+                // A camera reports the same QR on many consecutive frames.
+                // Give the error time to be read before allowing a retry.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                    self?.locked = false
+                }
+            }
+        }
+    }
+}

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -1,4 +1,4 @@
-// Pairing: pick the computer, type the six digits it is showing.
+// Pairing: scan the computer's QR, confirm its identity, and connect.
 //
 // Two ways in, because discovery is allowed to fail. Bonjour finds the
 // computer by name when the network cooperates; when it does not — a guest
@@ -17,9 +17,11 @@ struct PairingView: View {
 
     @State private var manualAddress = ""
     @State private var code = ""
+    @State private var scannedCredential: String?
     @State private var chosen: Connection?
     @State private var pairing = false
     @State private var failure: String?
+    @State private var showingScanner = false
     /// "Looking…" forever is not an answer. After a few seconds with nothing
     /// found, say the thing that is almost always true.
     @State private var searchedLongEnough = false
@@ -49,6 +51,15 @@ struct PairingView: View {
             }
             .onDisappear { discovery.stop() }
             .onChange(of: session.pairingInvite) { _, invite in accept(invite) }
+            .fullScreenCover(isPresented: $showingScanner) {
+                PairingScannerSheet { payload in
+                    guard let url = URL(string: payload), let invite = PairingInvite.parse(url) else {
+                        return "That isn't an OpenMausBot pairing QR code."
+                    }
+                    accept(invite)
+                    return nil
+                }
+            }
             .task {
                 try? await Task.sleep(nanoseconds: 8_000_000_000)
                 searchedLongEnough = true
@@ -62,7 +73,16 @@ struct PairingView: View {
         Section("On your computer") {
             Label("Open OpenMausBot → Settings → Companion", systemImage: "1.circle.fill")
             Label("Choose Set up a phone", systemImage: "2.circle.fill")
-            Text("Then select the computer below and enter its code. You can also scan the QR code with this phone's Camera to fill everything in automatically.")
+            Button {
+                failure = nil
+                showingScanner = true
+            } label: {
+                Label("Scan QR Code", systemImage: "qrcode.viewfinder")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Text("Scan the QR code, check the computer name, and confirm. The address and one-time credential are filled securely for you.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }
@@ -118,6 +138,7 @@ struct PairingView: View {
                     failure = "That should look like 192.168.1.42:8810."
                     return
                 }
+                scannedCredential = nil
                 chosen = connection
             }
             .disabled(manualAddress.trimmingCharacters(in: .whitespaces).isEmpty)
@@ -140,52 +161,91 @@ struct PairingView: View {
     // MARK: - The code
 
     private func codeSection(for connection: Connection) -> some View {
-        Section(connection.name) {
-            TextField("000000", text: $code)
-                .keyboardType(.numberPad)
-                .font(.system(.title, design: .monospaced))
-                .multilineTextAlignment(.center)
-                .onChange(of: code) { _, value in
-                    code = String(value.filter { $0.isASCII && $0.isNumber }.prefix(6))
-                }
+        Section(scannedCredential == nil ? connection.name : "Confirm computer") {
+            if let credential = scannedCredential {
+                Label(connection.name, systemImage: "desktopcomputer")
+                    .font(.headline)
+                LabeledContent("Address", value: "\(connection.host):\(connection.port)")
+                Text("Only continue if this is the computer whose QR code you just scanned. This phone will be able to open chats, send work, and answer approvals on it.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
 
-            Button {
-                Task { await submit(connection) }
-            } label: {
-                if pairing {
-                    ProgressView()
-                } else {
-                    Text("Connect")
+                Button {
+                    Task { await submit(connection, credential: credential) }
+                } label: {
+                    if pairing {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Pair with this computer")
+                            .frame(maxWidth: .infinity)
+                    }
                 }
+                .buttonStyle(.borderedProminent)
+                .disabled(pairing)
+            } else {
+                TextField("000000", text: $code)
+                    .keyboardType(.numberPad)
+                    .font(.system(.title, design: .monospaced))
+                    .multilineTextAlignment(.center)
+                    .onChange(of: code) { _, value in
+                        code = String(value.filter { $0.isASCII && $0.isNumber }.prefix(6))
+                    }
+
+                Button {
+                    Task { await submit(connection, credential: code) }
+                } label: {
+                    if pairing {
+                        ProgressView()
+                    } else {
+                        Text("Connect")
+                    }
+                }
+                .disabled(code.count != 6 || pairing)
             }
-            .disabled(code.count != 6 || pairing)
 
             Button("Choose a different computer", role: .cancel) {
                 chosen = nil
                 code = ""
+                scannedCredential = nil
                 failure = nil
             }
         }
     }
 
-    private func submit(_ connection: Connection) async {
+    private func submit(_ connection: Connection, credential: String) async {
         pairing = true
         failure = nil
         defer { pairing = false }
+        let cameFromScanner = scannedCredential != nil
         do {
-            try await session.pair(with: connection, code: code, deviceName: Self.deviceName())
+            try await session.pair(
+                with: connection,
+                credential: credential,
+                deviceName: Self.deviceName()
+            )
         } catch {
-            // the harness's own wording ("that code is not right", "too many
-            // incorrect codes — start pairing again") is better than ours
-            failure = error.localizedDescription
-            code = ""
+            if cameFromScanner {
+                // A one-time token may have reached the computer even if its
+                // response did not reach us. Never replay it and risk making
+                // a second device record; request a fresh window instead.
+                failure = "\(error.localizedDescription) Start pairing again on your computer and rescan the new QR code."
+                chosen = nil
+                scannedCredential = nil
+            } else {
+                // The harness's own wording ("too many incorrect codes —
+                // start pairing again") is better than ours.
+                failure = error.localizedDescription
+                code = ""
+            }
         }
     }
 
     private func accept(_ invite: PairingInvite?) {
         guard let invite else { return }
         chosen = invite.connection
-        code = invite.code
+        scannedCredential = invite.credential
+        code = ""
         failure = nil
         session.consumePairingInvite()
     }

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -30,6 +30,7 @@ struct PairingView: View {
                 if let chosen {
                     codeSection(for: chosen)
                 } else {
+                    setupSection
                     discoverySection
                     manualSection
                 }
@@ -40,15 +41,14 @@ struct PairingView: View {
                     }
                 }
 
-                Section {
-                    Text("On your computer, open OpenMausBot → Settings → Companion, turn it on, and start pairing.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
             }
             .navigationTitle("Pair with a computer")
-            .onAppear { discovery.start() }
+            .onAppear {
+                discovery.start()
+                accept(session.pairingInvite)
+            }
             .onDisappear { discovery.stop() }
+            .onChange(of: session.pairingInvite) { _, invite in accept(invite) }
             .task {
                 try? await Task.sleep(nanoseconds: 8_000_000_000)
                 searchedLongEnough = true
@@ -57,6 +57,16 @@ struct PairingView: View {
     }
 
     // MARK: - Choosing a computer
+
+    private var setupSection: some View {
+        Section("On your computer") {
+            Label("Open OpenMausBot → Settings → Companion", systemImage: "1.circle.fill")
+            Label("Choose Set up a phone", systemImage: "2.circle.fill")
+            Text("Then select the computer below and enter its code. You can also scan the QR code with this phone's Camera to fill everything in automatically.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
 
     private var discoverySection: some View {
         Section("On this network") {
@@ -136,7 +146,7 @@ struct PairingView: View {
                 .font(.system(.title, design: .monospaced))
                 .multilineTextAlignment(.center)
                 .onChange(of: code) { _, value in
-                    code = String(value.filter(\.isNumber).prefix(6))
+                    code = String(value.filter { $0.isASCII && $0.isNumber }.prefix(6))
                 }
 
             Button {
@@ -145,7 +155,7 @@ struct PairingView: View {
                 if pairing {
                     ProgressView()
                 } else {
-                    Text("Pair")
+                    Text("Connect")
                 }
             }
             .disabled(code.count != 6 || pairing)
@@ -170,6 +180,14 @@ struct PairingView: View {
             failure = error.localizedDescription
             code = ""
         }
+    }
+
+    private func accept(_ invite: PairingInvite?) {
+        guard let invite else { return }
+        chosen = invite.connection
+        code = invite.code
+        failure = nil
+        session.consumePairingInvite()
     }
 
     // MARK: - Helpers

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -38,6 +38,8 @@ final class Session: ObservableObject {
     /// One exact message the next opened chat should reveal.
     @Published private(set) var focusedMessageId: String?
     @Published private(set) var notificationAuthorization: UNAuthorizationStatus = .notDetermined
+    /// A short-lived desktop handoff waiting for PairingView to present it.
+    @Published private(set) var pairingInvite: PairingInvite?
 
     private var client: CompanionClient?
     private var streamTask: Task<Void, Never>?
@@ -133,6 +135,22 @@ final class Session: ObservableObject {
         // keychain — the token is in hand, so there is nothing left to retry.
         restorePending = false
         connect()
+    }
+
+    func receivePairingURL(_ url: URL) {
+        guard status == .unpaired else {
+            actionError = "This phone is already paired. Unpair it in Settings before connecting it to another computer."
+            return
+        }
+        guard let invite = PairingInvite.parse(url) else {
+            actionError = "That pairing code is not valid. Start pairing again on your computer."
+            return
+        }
+        pairingInvite = invite
+    }
+
+    func consumePairingInvite() {
+        pairingInvite = nil
     }
 
     func signOut() {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -116,11 +116,15 @@ final class Session: ObservableObject {
         status = .connecting
     }
 
-    /// Redeem a pairing code. On success the token goes to the keychain and
-    /// the connection to defaults — deliberately apart, so the thing that
-    /// gets backed up is never the credential.
-    func pair(with connection: Connection, code: String, deviceName: String) async throws {
-        let paired = try await CompanionClient.pair(connection: connection, code: code, deviceName: deviceName)
+    /// Redeem a one-time pairing credential. On success the device token goes
+    /// to the keychain and the connection to defaults — deliberately apart,
+    /// so the thing that gets backed up is never the credential.
+    func pair(with connection: Connection, credential: String, deviceName: String) async throws {
+        let paired = try await CompanionClient.pair(
+            connection: connection,
+            credential: credential,
+            deviceName: deviceName
+        )
         // prefer the name the computer calls itself over the Bonjour label
         var stored = connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
@@ -143,7 +147,7 @@ final class Session: ObservableObject {
             return
         }
         guard let invite = PairingInvite.parse(url) else {
-            actionError = "That pairing code is not valid. Start pairing again on your computer."
+            actionError = "That pairing invitation is not valid. Start pairing again on your computer."
             return
         }
         pairingInvite = invite

--- a/ios/AppStore/review-notes.md
+++ b/ios/AppStore/review-notes.md
@@ -6,8 +6,10 @@ To review the app:
 
 1. Install and start OpenMausBot on a Mac, Windows, or Linux computer.
 2. Open **Settings → Companion**, enable the companion, and choose **Start pairing**.
-3. On the iPhone, select the discovered computer or enter the address shown by the desktop panel.
-4. Enter the six-digit pairing code.
+3. On the iPhone, choose **Scan QR Code**, scan the code shown by the desktop,
+   review the computer and address, and confirm pairing.
+4. If the camera is unavailable, select the discovered computer or enter the
+   address and six-digit code shown by the desktop panel.
 5. Create a bot on the desktop or with the `+` button in the iPhone roster, then send a message.
 
 The phone and computer must be on the same trusted network. Alternatively, both may be signed into the same Tailscale network and the reviewer may enter the computer's `.ts.net` MagicDNS name.

--- a/ios/README.md
+++ b/ios/README.md
@@ -11,7 +11,7 @@ same harness the desktop app talks to, through the restricted sidecar described 
 ## Status
 
 Built and verified against a real harness on both a simulator and an iPhone:
-Bonjour discovery, manual LAN and Tailscale pairing, the roster, paged chat,
+QR handoff, Bonjour discovery, manual LAN and Tailscale pairing, the roster, paged chat,
 streaming replies, the computer view, and — the one that matters — an approval
 raised by a bot on the Mac, answered on the phone, with the bot carrying on.
 
@@ -55,7 +55,7 @@ ios/
     Discovery.swift              NWBrowser for _openmausbot._tcp
     Keychain.swift               the device token
     MausAvatar.swift             the mascot face, in the desktop's palette
-    PairingView.swift            find a computer, type the six digits
+    PairingView.swift            QR handoff, discovery, address and code fallback
     ChatListView.swift           roster, with "waiting on you" pulled to the top
     ChatView.swift               transcript, approval cards, composer
     ComputerView.swift           opt-in live view of a bot's computer

--- a/ios/README.md
+++ b/ios/README.md
@@ -56,6 +56,7 @@ ios/
     Keychain.swift               the device token
     MausAvatar.swift             the mascot face, in the desktop's palette
     PairingView.swift            QR handoff, discovery, address and code fallback
+    PairingScanner.swift         native QR camera, permission and recovery UI
     ChatListView.swift           roster, with "waiting on you" pulled to the top
     ChatView.swift               transcript, approval cards, composer
     ComputerView.swift           opt-in live view of a bot's computer
@@ -131,6 +132,10 @@ mean losing the ability to lock it out.
 
 - **Zero third-party dependencies.** The raw-byte SSE reader, Keychain,
   `NWBrowser`, and notifications are all first-party.
+- **QR scan confirms before connecting.** The QR carries a short-lived,
+  high-entropy credential rather than relying on the visible six-digit code.
+  The app validates the target, asks the user to confirm it, exchanges the
+  credential once, and persists only the resulting device token in Keychain.
 - **Thin client.** The harness already folds provider events into settled
   messages. The phone folds `message`, `message.patch`, and `bot` frames, plus
   the small `runtime` delta subset needed to show a reply while it is typed.

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -114,16 +114,17 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
 }
 
 /// A pairing window handed from the desktop to the app as a QR/deep link.
-/// It contains only the address and the same six-digit, two-minute code the
-/// desktop already shows. The long-lived device token is created later by
-/// `CompanionClient.pair` and never appears in the link.
+/// It contains only the address and a short-lived, single-use credential.
+/// New desktop builds put a high-entropy token in the QR; older builds carry
+/// the same six-digit code shown on screen. The long-lived device token is
+/// created later by `CompanionClient.pair` and never appears in the link.
 public struct PairingInvite: Equatable, Sendable {
     public let connection: Connection
-    public let code: String
+    public let credential: String
 
-    public init(connection: Connection, code: String) {
+    public init(connection: Connection, credential: String) {
         self.connection = connection
-        self.code = code
+        self.credential = credential
     }
 
     public static func parse(_ url: URL) -> PairingInvite? {
@@ -138,9 +139,7 @@ public struct PairingInvite: Equatable, Sendable {
             values[item.name] = value
         }
         guard let address = values["address"],
-              let code = values["code"],
-              code.utf8.count == 6,
-              code.utf8.allSatisfy({ (48...57).contains($0) }),
+              let credential = Self.credential(from: values),
               var connection = Connection.parse(address)
         else { return nil }
 
@@ -150,7 +149,25 @@ public struct PairingInvite: Equatable, Sendable {
             }
             if !cleaned.isEmpty { connection.name = String(cleaned.prefix(80)) }
         }
-        return PairingInvite(connection: connection, code: code)
+        return PairingInvite(connection: connection, credential: credential)
+    }
+
+    private static func credential(from values: [String: String]) -> String? {
+        if let token = values["token"] {
+            guard token.hasPrefix("omb_pair_"),
+                  token.utf8.count == 52,
+                  token.dropFirst("omb_pair_".count).utf8.allSatisfy({
+                      (48...57).contains($0) || (65...90).contains($0) ||
+                      (97...122).contains($0) || $0 == 45 || $0 == 95
+                  })
+            else { return nil }
+            return token
+        }
+        guard let code = values["code"],
+              code.utf8.count == 6,
+              code.utf8.allSatisfy({ (48...57).contains($0) })
+        else { return nil }
+        return code
     }
 }
 
@@ -262,15 +279,26 @@ public struct CompanionClient: Sendable {
 
     // MARK: - Pairing
 
-    /// Redeem a code for a device token. The only call made without one.
+    /// Redeem a one-time pairing credential for a device token. The only call
+    /// made without a device token.
     public static func pair(
         connection: Connection,
-        code: String,
+        credential: String,
         deviceName: String,
         session: URLSession = .shared
     ) async throws -> PairResponse {
         let client = CompanionClient(connection: connection, token: nil, session: session)
-        let pairRequest = try client.makeRequest("POST", "/api/pair", body: ["code": code, "deviceName": deviceName])
+        // A six-digit credential is an older desktop or manual entry. Keep
+        // its field name for compatibility; new QR credentials use the
+        // explicit field and are never persisted by the app.
+        let key = credential.utf8.count == 6 && credential.utf8.allSatisfy({ (48...57).contains($0) })
+            ? "code"
+            : "credential"
+        let pairRequest = try client.makeRequest(
+            "POST",
+            "/api/pair",
+            body: [key: credential, "deviceName": deviceName]
+        )
         return try await client.send(pairRequest, as: PairResponse.self)
     }
 

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -113,6 +113,47 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     }
 }
 
+/// A pairing window handed from the desktop to the app as a QR/deep link.
+/// It contains only the address and the same six-digit, two-minute code the
+/// desktop already shows. The long-lived device token is created later by
+/// `CompanionClient.pair` and never appears in the link.
+public struct PairingInvite: Equatable, Sendable {
+    public let connection: Connection
+    public let code: String
+
+    public init(connection: Connection, code: String) {
+        self.connection = connection
+        self.code = code
+    }
+
+    public static func parse(_ url: URL) -> PairingInvite? {
+        guard url.scheme?.lowercased() == "openmausbot",
+              url.host?.lowercased() == "pair",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+
+        var values: [String: String] = [:]
+        for item in components.queryItems ?? [] {
+            guard values[item.name] == nil, let value = item.value else { return nil }
+            values[item.name] = value
+        }
+        guard let address = values["address"],
+              let code = values["code"],
+              code.utf8.count == 6,
+              code.utf8.allSatisfy({ (48...57).contains($0) }),
+              var connection = Connection.parse(address)
+        else { return nil }
+
+        if let name = values["name"]?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            let cleaned = name.filter {
+                (!$0.isASCII && !$0.isNewline) || $0.asciiValue.map { $0 >= 32 && $0 != 127 } == true
+            }
+            if !cleaned.isEmpty { connection.name = String(cleaned.prefix(80)) }
+        }
+        return PairingInvite(connection: connection, code: code)
+    }
+}
+
 public enum APIError: Error, LocalizedError, Sendable {
     /// The harness answered, and said no.
     case status(code: Int, message: String?)

--- a/ios/TESTING.md
+++ b/ios/TESTING.md
@@ -158,7 +158,14 @@ paid account is required to run on your own phone.
 
 On the phone, in order:
 
-1. **Pair.** The computer should appear by name. Tap it, type the code.
+1. **Pair.** In OpenMausBot → Settings → Companion, choose **Set up a
+   phone**. Scan the QR code with the phone's Camera, open OpenMausMobile,
+   confirm that the computer and six-digit code are filled in, then tap
+   **Connect**. The computer should also appear by name for the manual path:
+   tap it and type the same code.
+   - Relaunch the app after pairing once. It should return to the roster
+     without asking for another code; that proves the device token made it
+     into Keychain rather than only living in memory.
    - If the list stays empty, check in this order:
      1. **Local Network permission.** iOS asks once, and a denial is
         permanent and silent. Settings → OpenMausBot → Local Network. If the
@@ -224,9 +231,10 @@ so this is also how the phone reaches the Mac over cellular.
    `192.168.x.x` address, the sidecar could not find the Tailscale CLI — it
    asks once at startup, so turn the Companion toggle off and on again (or
    restart `pnpm companion` if running it by hand) after Tailscale is up.
-4. **On the phone:** pair by typing that name. Discovery does not help here —
-   Bonjour is multicast and a tailnet does not carry it — so the typed address
-   is the path, and it is the one path that works from anywhere.
+4. **On the phone:** scan the Companion panel's QR code, which carries that
+   MagicDNS name, or pair by typing the name. Discovery does not help here —
+   Bonjour is multicast and a tailnet does not carry it — so the QR/manual
+   address is the path, and it is the one path that works from anywhere.
 
 **Use the name, not the address.** Both reach the harness, but only the name
 gets past App Transport Security. iOS exempts local networking, and `100.64/10`

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -43,4 +43,20 @@ final class ConnectionTests: XCTestCase {
         XCTAssertNil(Connection.parse("host/path"))
         XCTAssertNil(Connection.parse("host name"))
     }
+
+    func testParsesADesktopPairingInvite() throws {
+        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&code=004209&name=Milind%27s%20Mac"))
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+        XCTAssertEqual(invite.connection.host, "macbook.tail1234.ts.net")
+        XCTAssertEqual(invite.connection.port, 8810)
+        XCTAssertEqual(invite.connection.name, "Milind's Mac")
+        XCTAssertEqual(invite.code, "004209")
+    }
+
+    func testRejectsAnUntrustedOrMalformedPairingInvite() throws {
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "https://example.com/pair?address=mac.local&code=123456"))))
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=12345"))))
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=host%2Fpath&code=123456"))))
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=one.local&address=two.local&code=123456"))))
+    }
 }

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -45,17 +45,25 @@ final class ConnectionTests: XCTestCase {
     }
 
     func testParsesADesktopPairingInvite() throws {
-        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&code=004209&name=Milind%27s%20Mac"))
+        let token = "omb_pair_" + String(repeating: "a", count: 43)
+        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&token=\(token)&code=004209&name=Milind%27s%20Mac"))
         let invite = try XCTUnwrap(PairingInvite.parse(url))
         XCTAssertEqual(invite.connection.host, "macbook.tail1234.ts.net")
         XCTAssertEqual(invite.connection.port, 8810)
         XCTAssertEqual(invite.connection.name, "Milind's Mac")
-        XCTAssertEqual(invite.code, "004209")
+        XCTAssertEqual(invite.credential, token)
+    }
+
+    func testParsesAnOlderCodeOnlyPairingInvite() throws {
+        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=004209"))
+        XCTAssertEqual(PairingInvite.parse(url)?.credential, "004209")
     }
 
     func testRejectsAnUntrustedOrMalformedPairingInvite() throws {
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "https://example.com/pair?address=mac.local&code=123456"))))
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=12345"))))
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&token=weak"))))
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&token=weak&code=123456"))))
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=host%2Fpath&code=123456"))))
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=one.local&address=two.local&code=123456"))))
     }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -72,6 +72,9 @@ targets:
         NSLocalNetworkUsageDescription: >-
           OpenMausBot finds your computer on this network so your bots can
           reach you here.
+        NSCameraUsageDescription: >-
+          OpenMausBot uses the camera only to scan a pairing QR code shown on
+          your computer.
         NSBonjourServices:
           - _openmausbot._tcp
         # The companion listener is plain HTTP on a local address. ATS has

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -49,6 +49,10 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         LSApplicationCategoryType: public.app-category.productivity
         ITSAppUsesNonExemptEncryption: false
+        CFBundleURLTypes:
+          - CFBundleURLName: com.openmausbot.companion.pairing
+            CFBundleURLSchemes:
+              - openmausbot
         # REQUIRED, and easy to lose. Without a launch screen iOS runs the
         # app in compatibility scaling: letterboxed inside black bars, with
         # everything drawn oversized, on every modern iPhone. An empty

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
     "posthog-js": "^1.415.6",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       posthog-js:
         specifier: ^1.415.6
         version: 1.415.6
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.8)
       react:
         specifier: ^19.1.0
         version: 19.2.8
@@ -2150,6 +2153,11 @@ packages:
   pvutils@1.2.0:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
@@ -4892,6 +4900,10 @@ snapshots:
       tslib: 2.8.1
 
   pvutils@1.2.0: {}
+
+  qrcode.react@4.2.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   query-selector-shadow-dom@1.0.1: {}
 

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -29,7 +29,7 @@ interface CompanionState {
   enabled: boolean;
   port: number;
   devices: Device[];
-  pairing: { code: string; expiresAt: number } | null;
+  pairing: { code: string; token: string; expiresAt: number } | null;
   /** Every address a phone could dial, and which of them is which. */
   addresses?: string[];
   /** The tailnet address, when this machine is on one. */
@@ -158,6 +158,7 @@ export function CompanionSection() {
           address,
           port: state.port,
           code: state.pairing.code,
+          token: state.pairing.token,
           name: state.discovery?.name,
         })
       : null;

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -14,6 +14,8 @@
 // sentence of explanation rather than a bare toggle.
 import { useCallback, useEffect, useState } from "react";
 import { Loader2, Smartphone, Trash2 } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { companionPairingLink } from "../lib/companion-pairing";
 import { Card } from "./SettingsPrimitives";
 
 interface Device {
@@ -55,6 +57,7 @@ type Bridge = {
 };
 
 const bridge = (): Bridge | null =>
+  // SAFETY: the preload owns `ogb.companion`; every call is still guarded for browser builds where it is absent.
   (globalThis as { ogb?: { companion?: Bridge } }).ogb?.companion ?? null;
 
 const relative = (at: number) => {
@@ -143,13 +146,28 @@ export function CompanionSection() {
   }
 
   const secondsLeft = state.pairing ? Math.max(0, Math.round((state.pairing.expiresAt - now) / 1000)) : 0;
-  // Prefer the tailnet when there is one: it survives changing wifi, works
+  // Prefer a MagicDNS name when there is one: it survives changing wifi, works
   // away from home, and gets through a guest network that isolates its
-  // clients — the case where a LAN address looks perfectly correct and
-  // reaches nothing. The name beats the address because a phone can only
-  // use the name.
-  const tailnet = state.tailnetName ?? state.tailscale;
-  const address = tailnet ?? state.addresses?.[0];
+  // clients. A bare 100.64/10 address is not dialable by the iOS app over
+  // HTTP, so fall back to LAN instead of putting a broken address in the QR.
+  const tailnet = state.tailnetName;
+  const address = tailnet ?? state.lan ?? state.addresses?.find((candidate) => candidate !== state.tailscale);
+  const pairingLink =
+    state.pairing && address
+      ? companionPairingLink({
+          address,
+          port: state.port,
+          code: state.pairing.code,
+          name: state.discovery?.name,
+        })
+      : null;
+
+  const beginSetup = () =>
+    void act(async (companion) => {
+      const started = state.enabled ? state : await companion.start();
+      if (!started.enabled || started.error) return started;
+      return companion.pairing(true);
+    });
 
   return (
     <div className="flex flex-col gap-4">
@@ -216,44 +234,55 @@ export function CompanionSection() {
         )}
       </Card>
 
-      {state.enabled && (
-        <Card
-          title="Pair a phone"
-          subtitle={
-            state.pairing
-              ? state.discovery?.advertising
-                ? "Open OpenMausBot on your phone, pick this computer from the list, and enter the code."
-                : "Open OpenMausBot on your phone, enter the address below, then the code."
-              : "Start pairing, then enter the code on your phone. The code lasts two minutes."
-          }
-        >
-          {state.pairing ? (
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <div className="font-mono text-[28px] tracking-[0.3em] text-ink">{state.pairing.code}</div>
-                <div className="mt-1 text-[13px] text-ink-secondary">
-                  Expires in {secondsLeft}s{address ? ` · ${address}:${state.port}` : ""}
-                </div>
+      <Card
+        title="Connect a phone"
+        subtitle={
+          state.pairing
+            ? pairingLink
+              ? "Scan with your phone's Camera, then confirm in OpenMausMobile. You can also use the code manually."
+              : "Open OpenMausMobile, choose this computer, and enter the code."
+            : state.enabled
+              ? "Open a short, single-use pairing window for a trusted phone."
+              : "This turns on Companion and opens a short, single-use pairing window in one step."
+        }
+      >
+        {state.pairing ? (
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            {pairingLink && (
+              <div className="w-fit shrink-0 rounded-xl bg-white p-3" aria-label="Phone pairing QR code">
+                <QRCodeSVG value={pairingLink} size={144} level="M" bgColor="#ffffff" fgColor="#111111" />
               </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="text-[12px] font-medium uppercase tracking-wide text-ink-secondary">Manual code</div>
+              <div className="mt-1 font-mono text-[28px] tracking-[0.3em] text-ink">{state.pairing.code}</div>
+              <div className="mt-1 break-all text-[13px] text-ink-secondary">
+                Expires in {secondsLeft}s{address ? ` · ${address}:${state.port}` : ""}
+              </div>
+              {state.discovery?.advertising && (
+                <div className="mt-2 text-[13px] text-ink-secondary">
+                  Or open the mobile app and choose “{state.discovery.name}” under On this network.
+                </div>
+              )}
               <button
                 disabled={busy}
                 onClick={() => void act((c) => c.pairing(false))}
-                className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised disabled:opacity-40"
+                className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised disabled:opacity-40"
               >
                 Cancel
               </button>
             </div>
-          ) : (
-            <button
-              disabled={busy}
-              onClick={() => void act((c) => c.pairing(true))}
-              className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised disabled:opacity-40"
-            >
-              Start pairing
-            </button>
-          )}
-        </Card>
-      )}
+          </div>
+        ) : (
+          <button
+            disabled={busy}
+            onClick={beginSetup}
+            className="rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:opacity-90 disabled:opacity-40"
+          >
+            {busy ? "Preparing…" : state.devices.length ? "Pair another phone" : "Set up a phone"}
+          </button>
+        )}
+      </Card>
 
       <Card
         title="Paired devices"

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { companionPairingLink } from "./companion-pairing";
+
+describe("companionPairingLink", () => {
+  it("carries the dialable address, short-lived code, and display name", () => {
+    const link = companionPairingLink({
+      address: "macbook.tail1234.ts.net",
+      port: 8810,
+      code: "004209",
+      name: "Milind's Mac",
+    });
+
+    const url = new URL(link!);
+    expect(url.protocol).toBe("openmausbot:");
+    expect(url.host).toBe("pair");
+    expect(url.searchParams.get("address")).toBe("macbook.tail1234.ts.net:8810");
+    expect(url.searchParams.get("code")).toBe("004209");
+    expect(url.searchParams.get("name")).toBe("Milind's Mac");
+  });
+
+  it("refuses to make a link from an invalid pairing window", () => {
+    expect(companionPairingLink({ address: "", port: 8810, code: "123456" })).toBeNull();
+    expect(companionPairingLink({ address: "mac.local", port: 0, code: "123456" })).toBeNull();
+    expect(companionPairingLink({ address: "mac.local", port: 8810, code: "12345" })).toBeNull();
+  });
+
+  it("makes an IPv6 address unambiguous", () => {
+    const link = companionPairingLink({ address: "2001:db8::1", port: 8810, code: "123456" });
+    expect(new URL(link!).searchParams.get("address")).toBe("[2001:db8::1]:8810");
+  });
+});

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import { companionPairingLink } from "./companion-pairing";
 
 describe("companionPairingLink", () => {
-  it("carries the dialable address, short-lived code, and display name", () => {
+  const token = `omb_pair_${"a".repeat(43)}`;
+
+  it("carries the dialable address, one-time token, fallback code, and display name", () => {
     const link = companionPairingLink({
       address: "macbook.tail1234.ts.net",
       port: 8810,
       code: "004209",
+      token,
       name: "Milind's Mac",
     });
 
@@ -14,18 +17,20 @@ describe("companionPairingLink", () => {
     expect(url.protocol).toBe("openmausbot:");
     expect(url.host).toBe("pair");
     expect(url.searchParams.get("address")).toBe("macbook.tail1234.ts.net:8810");
+    expect(url.searchParams.get("token")).toBe(token);
     expect(url.searchParams.get("code")).toBe("004209");
     expect(url.searchParams.get("name")).toBe("Milind's Mac");
   });
 
   it("refuses to make a link from an invalid pairing window", () => {
-    expect(companionPairingLink({ address: "", port: 8810, code: "123456" })).toBeNull();
-    expect(companionPairingLink({ address: "mac.local", port: 0, code: "123456" })).toBeNull();
-    expect(companionPairingLink({ address: "mac.local", port: 8810, code: "12345" })).toBeNull();
+    expect(companionPairingLink({ address: "", port: 8810, code: "123456", token })).toBeNull();
+    expect(companionPairingLink({ address: "mac.local", port: 0, code: "123456", token })).toBeNull();
+    expect(companionPairingLink({ address: "mac.local", port: 8810, code: "12345", token })).toBeNull();
+    expect(companionPairingLink({ address: "mac.local", port: 8810, code: "123456", token: "weak" })).toBeNull();
   });
 
   it("makes an IPv6 address unambiguous", () => {
-    const link = companionPairingLink({ address: "2001:db8::1", port: 8810, code: "123456" });
+    const link = companionPairingLink({ address: "2001:db8::1", port: 8810, code: "123456", token });
     expect(new URL(link!).searchParams.get("address")).toBe("[2001:db8::1]:8810");
   });
 });

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -1,0 +1,23 @@
+interface CompanionPairingLinkOptions {
+  address: string;
+  port: number;
+  code: string;
+  name?: string;
+}
+
+/**
+ * A short-lived handoff from the trusted desktop pairing panel to the mobile
+ * app. The code still has to be redeemed with the companion; putting it in
+ * the link does not create or expose the long-lived device token.
+ */
+export function companionPairingLink({ address, port, code, name }: CompanionPairingLinkOptions): string | null {
+  const host = address.trim();
+  if (!host || !/^\d{6}$/.test(code) || !Number.isInteger(port) || port < 1 || port > 65_535) return null;
+  const dialableHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+
+  const url = new URL("openmausbot://pair");
+  url.searchParams.set("address", `${dialableHost}:${port}`);
+  url.searchParams.set("code", code);
+  if (name?.trim()) url.searchParams.set("name", name.trim());
+  return url.toString();
+}

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -2,6 +2,7 @@ interface CompanionPairingLinkOptions {
   address: string;
   port: number;
   code: string;
+  token: string;
   name?: string;
 }
 
@@ -10,13 +11,24 @@ interface CompanionPairingLinkOptions {
  * app. The code still has to be redeemed with the companion; putting it in
  * the link does not create or expose the long-lived device token.
  */
-export function companionPairingLink({ address, port, code, name }: CompanionPairingLinkOptions): string | null {
+export function companionPairingLink({ address, port, code, token, name }: CompanionPairingLinkOptions): string | null {
   const host = address.trim();
-  if (!host || !/^\d{6}$/.test(code) || !Number.isInteger(port) || port < 1 || port > 65_535) return null;
+  if (
+    !host ||
+    !/^\d{6}$/.test(code) ||
+    !/^omb_pair_[A-Za-z0-9_-]{43}$/.test(token) ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65_535
+  )
+    return null;
   const dialableHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 
   const url = new URL("openmausbot://pair");
   url.searchParams.set("address", `${dialableHost}:${port}`);
+  // The scanner uses the high-entropy token. The code remains in the link so
+  // an older mobile build can still pair during a staggered desktop rollout.
+  url.searchParams.set("token", token);
   url.searchParams.set("code", code);
   if (name?.trim()) url.searchParams.set("name", name.trim());
   return url.toString();


### PR DESCRIPTION
## What changed

- makes QR pairing the primary iPhone onboarding path while retaining Bonjour, manual address entry, and the six-digit fallback
- adds a native in-app QR scanner with camera permission recovery and an explicit computer/address confirmation step
- places a high-entropy, two-minute, single-use credential in the QR and exchanges it for the existing per-device bearer token
- keeps old desktop and mobile builds compatible during a staggered rollout
- improves the desktop Companion panel wording, reachable-address selection, QR handoff, and recovery guidance
- documents the direct LAN/Tailscale trust model and App Review flow

## Why

Typing an address and short code was unnecessarily fragile, especially over Tailscale. This adopts the strongest parts of T3 Code's direct pairing shape without adding account authentication: scan, validate, confirm the target, redeem once, then store only the resulting device token in Keychain.

## Security

- scanning never auto-pairs
- malformed secure-token invitations fail closed
- redeeming either QR credential or manual code burns the full pairing window
- QR credentials are never persisted
- long-lived device tokens remain hashed on the Mac and stored in iOS Keychain
- manual codes retain the existing expiry and attempt limit

## Validation

- `pnpm typecheck`
- full `pnpm test`: 100 files, 977 passed, 8 skipped; updater and packaged-server smoke passed
- focused companion/pairing tests: 37 passed
- `swift test`: 87 passed
- XcodeGen project generation
- unsigned iOS Simulator build with Xcode: succeeded
- fresh iPhone 17 Pro simulator onboarding inspection
- `git diff --check`

Physical-device signing still depends on the developer account/provisioning profile configured in Xcode; the native code itself builds cleanly for the simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR-code pairing for desktop and iOS companion setup.
  * Added secure, short-lived, single-use pairing credentials with six-digit code fallback.
  * Added QR scanning, invite validation, target confirmation, and camera-permission guidance on iOS.
  * Pairing links now support address selection, optional names, IPv6 formatting, and MagicDNS preferences.
  * Companion setup can start the companion process automatically and displays expiration and discovery details.

* **Documentation**
  * Updated setup, testing, and app review guidance for QR pairing and fallback methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->