### PR TITLE
fix: reject colliding ask ids in the permission broker

### DIFF
--- a/docs/plans/2026-08-18-001-fix-permission-broker-ask-id-collision-plan.md
+++ b/docs/plans/2026-08-18-001-fix-permission-broker-ask-id-collision-plan.md
@@ -1,0 +1,124 @@
+---
+title: "fix: Reject colliding ask ids in the permission broker"
+plan_type: fix
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+created: 2026-08-18
+---
+
+# fix: Reject colliding ask ids in the permission broker
+
+## Summary
+
+`createPermissionBroker()` in [server/drivers/claude.ts](server/drivers/claude.ts) registers every incoming `{t:"ask", id, ...}` message into a shared `pending` Map keyed by `askId`, with no check for an existing entry. Two asks arriving with the same id — across any connection on the broker, since `pending` is server-scoped, not per-connection — silently collide: the second `pending.set()` overwrites the first, `onAsk` still fires for both (two `request.opened` cards can appear), and when the *first* ask's `finish()` later runs, `pending.delete(askId)` removes the second (still-displayed) entry too, leaving it permanently unanswerable — a zombie card via id collision, distinct from the post-close timing class fixed for #211.
+
+This plan adds an ingestion-time guard that detects a colliding id **before** `onAsk` fires or `pending` is touched, auto-denies the colliding ask directly on its own connection, and leaves the original pending entry untouched. It also documents why real-world collision is very unlikely (both ask producers mint a fresh `randomUUID()` per ask, with no retry/replay path that reuses one) and adds regression coverage for the guard.
+
+## Problem Frame
+
+**Root cause:** [server/drivers/claude.ts:245](server/drivers/claude.ts#L245) — `pending.set(askId, { ask, finish })` runs unconditionally on every parsed `ask` line, regardless of whether `askId` is already a key in `pending`.
+
+**Why it matters even though collision is rare:** the failure mode is silent and asymmetric — a legitimate first ask can be permanently orphaned by a later id collision it has no way to detect, and the user is left with an unanswerable UI card and no diagnostic. A cheap ingestion-time guard turns an unbounded, hard-to-debug failure into an observable, fail-safe one.
+
+**Scope:** `server/drivers/claude.ts`'s `createPermissionBroker()` only. `server/permission-proxy.ts` (the id producer) is investigated but not modified — its `randomUUID()` generation is already correct.
+
+## Investigation Finding (documents Requirement 1)
+
+Both ask producers mint a fresh id per ask, with no path that resends an existing id:
+
+- [server/permission-proxy.ts:107](server/permission-proxy.ts#L107) — `const askId = randomUUID();` runs once per `tools/call` (`approve` or `ask_user`), inside the MCP `tools/call` handler. Each call gets its own `Promise` registered in the proxy's local `waiting` map keyed by that same id; there is no retry loop that reuses an id after a timeout or error — a fresh `tools/call` from the CLI always mints a fresh id.
+- [server/drivers/claude.ts:226](server/drivers/claude.ts#L226) — the broker's own fallback, `const askId = String(msg.id ?? newId())`, only fires when the incoming message omits `id` entirely, and `newId()` ([server/contracts.ts:304](server/contracts.ts#L304)) is `crypto.randomUUID()` — cryptographically random, not a counter.
+
+Realistic collision sources are therefore: (a) astronomically unlikely UUID collision, or (b) a buggy or adversarial client on the permission socket sending a hand-crafted duplicate `id`. Neither is a legitimate retry/replay path — this confirms the guard is a defense-in-depth fix for a currently-hypothetical but real class of bug (and for any future ask producer that does not mint ids as carefully), not a fix for an observed collision.
+
+## Key Technical Decisions
+
+**KTD1 — Guard fires at ingestion, before `onAsk`/`pending.set`, not inside `finish`.** Checking `pending.has(askId)` immediately after parsing the line and rejecting there means the colliding ask never becomes a UI card and the original pending entry is never touched. Rejected alternative: letting both asks through and trying to disambiguate in `finish`/`answer` by giving the second entry a synthetic key — this still creates a zombie card in the UI (since `onAsk` already fired) and adds complexity to `answer()`'s public contract for a case that should never reach the UI at all.
+
+**KTD2 — Auto-deny the colliding ask on its own connection, do not silently drop it.** The proxy side (`server/permission-proxy.ts:117`) is `await new Promise` waiting on a `t:"answer"` for its `askId` — if the broker drops the line instead of answering, that `tools/call` hangs until the CLI's own timeout (if any) rather than failing fast. Sending back `{t:"answer", id, behavior:"deny", message}` immediately keeps the contract every caller of the socket already expects (`server/permission-proxy.ts:49-53` matches `t==="answer"` by id and resolves its waiter) and fails closed, consistent with the existing broker philosophy at [server/drivers/claude.ts:250-252](server/drivers/claude.ts#L250-L252) ("keep the turn fail-closed, but leave an actionable diagnostic").
+
+**KTD3 — Log via `console.error`, matching the existing broker diagnostic pattern.** [server/drivers/claude.ts:253-255](server/drivers/claude.ts#L253-L255) already logs broker-unavailable errors this way; a colliding-id log line follows the same convention rather than introducing a new logging channel or telemetry event type for what is expected to be a near-never-fired guard.
+
+**KTD4 (session-settled: user-directed — chosen over bundling into the #211 branch/PR: the bug is a distinct, out-of-scope class from #211's post-close timing bug)** — this fix ships as its own PR on a fresh branch off `main`, not folded into the #211 zombie-card fix.
+
+## Implementation Units
+
+### U1. Guard against colliding ask ids in `createPermissionBroker()`
+
+**Goal:** Detect an incoming `ask` whose `id` already has a live entry in `pending`, auto-deny it on its own connection without registering it or invoking `onAsk`, and leave the original pending entry untouched.
+
+**Requirements:** Investigation Finding above (documents why the guard is defense-in-depth); KTD1, KTD2, KTD3.
+
+**Dependencies:** None.
+
+**Files:**
+- `server/drivers/claude.ts` (modify `createPermissionBroker`, roughly lines 219–246)
+- `server/drivers/claude.test.ts` (new test — see U2)
+
+**Approach:**
+1. Immediately after `const askId = String(msg.id ?? newId());` (line 226) and before constructing `ask`/`finish`/`timer`, check `if (pending.has(askId))`.
+2. On collision: write `{t:"answer", id: askId, behavior:"deny", message: <fixed diagnostic string>}` to `conn` (guard the write in `try/catch`, matching the existing style at line 232-234), `console.error` a one-line diagnostic naming the socket path and colliding id, and `continue` the `while` loop — skip constructing `ask`, `finish`, `timer`, `pending.set`, and `opts.onAsk` entirely for this line.
+3. Do not touch the existing entry in `pending` for that id in any way; it resolves exactly as it would have without the collision.
+4. Introduce one exported or module-scope constant for the deny message (e.g. alongside `QUESTION_TIMEOUT_NOTE`/`DENY_TIMEOUT_NOTE`) rather than an inline string literal, matching the file's existing convention for user-facing broker messages.
+
+**Patterns to follow:** the existing timeout-deny messages `QUESTION_TIMEOUT_NOTE`/`DENY_TIMEOUT_NOTE` and their use in the `finish` timeout branch (lines 237-243); the `server.on("error", ...)` diagnostic-logging convention (lines 253-255); the `try { conn.write(...) } catch {}` pattern already used for answer writes (lines 232-234).
+
+**Test scenarios:**
+- Happy path (no regression): a normal single ask still registers in `pending`, still fires `onAsk`, and still resolves via `answer()` — covered by existing tests in `claude.test.ts`; no new happy-path test needed here beyond confirming existing tests still pass.
+- Collision, same connection: two `{t:"ask", id:"dup-1", ...}` lines written back-to-back on the same socket connection before the first is answered. Expect exactly one `request.opened` event for `dup-1`, and the second `ask` line is answered on the wire with `{t:"answer", id:"dup-1", behavior:"deny", ...}` while the first ask's own `pending` entry remains resolvable afterward by `answer("dup-1", "allow")`. Covers the connection-write half of KTD1/KTD2.
+- Collision, cross-connection: an ask with id `dup-2` is opened on one connection; a second connection (simulating a second proxy) sends an `ask` with the same id `dup-2` before the first resolves. Expect the second connection receives an immediate deny answer, no second `request.opened` fires, and the first connection's pending entry for `dup-2` still resolves correctly via `answer()`. This is the scenario the bug report specifically calls out (`pending` is server-scoped, not per-connection).
+- Post-resolution reuse is *not* a collision: after `dup-3` is answered (its `pending` entry removed via `finish`), a brand-new ask reusing id `dup-3` is accepted normally (registers, fires `onAsk`, answerable). Confirms the guard only blocks a *live* collision, not id reuse after resolution — an important boundary since `pending.delete` already frees the key.
+
+**Verification:** All four scenarios above pass; existing `claude.test.ts` permission-broker tests (lines 341-410) continue to pass unmodified.
+
+### U2. Regression test for the id-collision guard
+
+**Goal:** Add automated coverage for U1's guard in `server/drivers/claude.test.ts`, following the existing socket-level test pattern used for the permission broker.
+
+**Requirements:** U1's test scenarios above.
+
+**Dependencies:** U1 (guard must exist for the test to assert against).
+
+**Files:**
+- `server/drivers/claude.test.ts` (new `it(...)` blocks in the existing permission-broker `describe` block, near lines 341-410)
+
+**Approach:**
+1. Follow the existing pattern at [server/drivers/claude.test.ts:341-380](server/drivers/claude.test.ts#L341-L380): `create("hang")`, send a turn, wait for `session.started`, `connect(permissionSocketPath(threadId))`, write raw `{t:"ask", ...}` JSON lines, and assert on `recorder` events (`request.opened`) and on raw socket reads (the `{t:"answer", ...}` line).
+2. For the same-connection collision scenario, reuse one `conn` for both `ask` writes and collect both answer lines by buffering on `data` (the existing `answered` promise pattern only resolves once — extend it to collect an array of parsed lines, or resolve two separate promises keyed by array index).
+3. For the cross-connection scenario, open two `connect(...)` sockets against the same `permissionSocketPath(threadId)` and write one ask on each.
+4. For the post-resolution reuse scenario, answer the first ask via `instance.adapter.respondToRequest(...)` (as in the existing test at line 372) before writing the second `ask` line with the same id, then assert the second one *does* produce a `request.opened`.
+5. Clean up every opened `conn` with `conn.end()` and finish each test by interrupting the turn and awaiting `turn.completed`, matching existing tests.
+
+**Patterns to follow:** [server/drivers/claude.test.ts:341-410](server/drivers/claude.test.ts#L341-L410) — the three existing permission-broker tests, especially the raw-socket write/read helpers and the `recorder.until(...)` assertions.
+
+**Test scenarios:** (implements U1's scenarios as executable tests — no separate list; see U1's "Collision, same connection", "Collision, cross-connection", and "Post-resolution reuse is not a collision" scenarios verbatim.)
+
+**Verification:** `npm test -- server/drivers/claude.test.ts` (or the project's equivalent test command) passes, including the three new cases, with no changes needed to unrelated existing tests in the file.
+
+## Scope Boundaries
+
+**In scope:** the `createPermissionBroker()` ingestion guard in `server/drivers/claude.ts`, its regression tests, and documenting the investigation finding.
+
+**Out of scope:**
+- The #211 post-close timing fix (`fix/claude-turn-teardown-zombie-teardown-cards` branch) — already a separate, merged/pending change.
+- Modifying `server/permission-proxy.ts`'s id generation — investigation confirmed it already mints correctly.
+- Any telemetry/metrics pipeline beyond the existing `console.error` diagnostic convention.
+
+### Deferred to Follow-Up Work
+None identified — this is a small, self-contained defensive fix.
+
+## Verification Contract
+
+- Existing permission-broker tests in `server/drivers/claude.test.ts` (lines 341-410) continue to pass unmodified.
+- New tests (U2) cover: same-connection collision, cross-connection collision, and post-resolution id reuse (non-collision).
+- Manual reasoning check: confirm the guard never fires `opts.onAsk` for a colliding id (no zombie card is ever created, as opposed to created-then-orphaned).
+
+## Definition of Done
+
+- [ ] `createPermissionBroker()` rejects a colliding `askId` at ingestion with an immediate deny answer and a diagnostic log, per KTD1-KTD3.
+- [ ] The original pending entry for a colliding id is provably unaffected (still resolves normally).
+- [ ] Regression tests for same-connection collision, cross-connection collision, and post-resolution reuse are added and passing.
+- [ ] No changes to `server/permission-proxy.ts`.
+- [ ] Full test suite passes.

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -449,9 +449,15 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-1");
     conn.write(JSON.stringify({ t: "ask", id: "dup-1", tool: "Bash", input: { command: "echo two" } }) + "\n");
 
-    // the collision is denied immediately, on the wire, without a second
-    // request.opened ever firing
-    expect(await nextAnswer()).toMatchObject({ behavior: "deny" });
+    // the collision is denied immediately, on the wire, with the duplicate's
+    // own id and the fixed denial message — and without a second
+    // request.opened ever firing for it
+    expect(await nextAnswer()).toMatchObject({
+      id: "dup-1",
+      behavior: "deny",
+      message: "OpenMausBot: duplicate ask id — skipping this request.",
+    });
+    expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-1")).toHaveLength(1);
 
     // the original ask is untouched and still resolves normally
     await expect(instance.adapter.respondToRequest("t-perm-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
@@ -478,7 +484,12 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const conn2 = await connectSocket(permissionSocketPath("t-perm-dup-2"));
     const conn2Answer = answerQueue(conn2)();
     conn2.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo two" } }) + "\n");
-    expect(await conn2Answer).toMatchObject({ behavior: "deny" });
+    expect(await conn2Answer).toMatchObject({
+      id: "dup-2",
+      behavior: "deny",
+      message: "OpenMausBot: duplicate ask id — skipping this request.",
+    });
+    expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-2")).toHaveLength(1);
 
     // the original, opened on conn1, still resolves normally
     await expect(instance.adapter.respondToRequest("t-perm-dup-2", "dup-2", { behavior: "allow" })).resolves.toBe(
@@ -515,6 +526,37 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     conn.end();
     await instance.adapter.interruptTurn("t-perm-dup-3");
+    await recorder.until((e) => e.type === "turn.completed");
+  });
+
+  it("denies a colliding ask id for question-kind asks too, without disturbing the original", async () => {
+    await create("hang");
+    await instance.adapter.sendTurn({ threadId: "t-perm-dup-4", text: "go" });
+    await recorder.until((e) => e.type === "session.started");
+
+    const conn = await connectSocket(permissionSocketPath("t-perm-dup-4"));
+    const nextAnswer = answerQueue(conn);
+
+    conn.write(JSON.stringify({ t: "ask", id: "dup-4", kind: "question", tool: "ask_user", input: { question: "one?" } }) + "\n");
+    await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-4");
+    conn.write(JSON.stringify({ t: "ask", id: "dup-4", kind: "question", tool: "ask_user", input: { question: "two?" } }) + "\n");
+
+    // same collision guard applies regardless of ask kind
+    expect(await nextAnswer()).toMatchObject({
+      id: "dup-4",
+      behavior: "deny",
+      message: "OpenMausBot: duplicate ask id — skipping this request.",
+    });
+    expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-4")).toHaveLength(1);
+
+    // the original question is untouched and still resolves normally
+    await expect(
+      instance.adapter.respondToRequest("t-perm-dup-4", "dup-4", { behavior: "answer", message: "yes" }),
+    ).resolves.toBe("answered");
+    expect(await nextAnswer()).toMatchObject({ behavior: "answer" });
+
+    conn.end();
+    await instance.adapter.interruptTurn("t-perm-dup-4");
     await recorder.until((e) => e.type === "turn.completed");
   });
 

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -7,7 +7,7 @@
 // cannot exec, and the broker is a unix socket. Both now go through
 // resolveCliSpawn / permissionSocketPath, so they run everywhere.
 import { chmodSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
-import { connect } from "node:net";
+import { connect, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,11 +22,30 @@ import { removeTempDir } from "../testing/cleanup.ts";
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
 
 /** Connect to a broker socket and resolve once the connection is live. */
-function connectSocket(path: string) {
-  const conn = connect(path);
-  return new Promise<ReturnType<typeof connect>>((resolve, reject) => {
-    conn.on("connect", () => resolve(conn));
-    conn.on("error", reject);
+function connectSocket(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    let retriesLeft = 20;
+    const tryConnect = () => {
+      const conn = connect(path);
+      const onConnect = () => {
+        conn.removeListener("error", onError);
+        resolve(conn);
+      };
+      const onError = (error: NodeJS.ErrnoException) => {
+        conn.removeListener("connect", onConnect);
+        conn.destroy();
+        // A Windows named pipe can briefly disappear while the server creates
+        // its next pipe instance for another simultaneous client.
+        if (process.platform === "win32" && error.code === "ENOENT" && retriesLeft-- > 0) {
+          setTimeout(tryConnect, 25);
+          return;
+        }
+        reject(error);
+      };
+      conn.once("connect", onConnect);
+      conn.once("error", onError);
+    };
+    tryConnect();
   });
 }
 

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -21,6 +21,32 @@ import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
 
+/** Connect to a broker socket and resolve once the connection is live. */
+function connectSocket(path: string) {
+  const conn = connect(path);
+  return new Promise<ReturnType<typeof connect>>((resolve, reject) => {
+    conn.on("connect", () => resolve(conn));
+    conn.on("error", reject);
+  });
+}
+
+/** Returns a function that resolves, in order, with each `\n`-delimited JSON
+ * message the broker writes back on `conn` — one call per expected answer. */
+function answerQueue(conn: ReturnType<typeof connect>) {
+  const waiters: Array<(msg: any) => void> = [];
+  let buf = "";
+  conn.on("data", (chunk) => {
+    buf += chunk;
+    let nl;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      waiters.shift()?.(JSON.parse(line));
+    }
+  });
+  return () => new Promise<any>((resolve) => waiters.push(resolve));
+}
+
 describe("ClaudeDriver.decodeConfig", () => {
   it("defaults to the claude binary with acceptEdits", () => {
     expect(ClaudeDriver.decodeConfig({})).toEqual({ cli: "claude", permissionMode: "acceptEdits" });
@@ -414,26 +440,8 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({ threadId: "t-perm-dup-1", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = connect(permissionSocketPath("t-perm-dup-1"));
-    const answers: Array<{ behavior: string; message?: string }> = [];
-    const waiters: Array<(a: { behavior: string; message?: string }) => void> = [];
-    let buf = "";
-    conn.on("data", (c) => {
-      buf += c;
-      let nl;
-      while ((nl = buf.indexOf("\n")) !== -1) {
-        const line = buf.slice(0, nl);
-        buf = buf.slice(nl + 1);
-        const parsed = JSON.parse(line);
-        answers.push(parsed);
-        waiters.shift()?.(parsed);
-      }
-    });
-    const nextAnswer = () => new Promise<{ behavior: string; message?: string }>((resolve) => waiters.push(resolve));
-    await new Promise<void>((resolve, reject) => {
-      conn.on("connect", resolve);
-      conn.on("error", reject);
-    });
+    const conn = await connectSocket(permissionSocketPath("t-perm-dup-1"));
+    const nextAnswer = answerQueue(conn);
 
     // two asks with the same id on one connection, second sent before the
     // first is resolved
@@ -443,8 +451,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     // the collision is denied immediately, on the wire, without a second
     // request.opened ever firing
-    const duplicateAnswer = await nextAnswer();
-    expect(duplicateAnswer).toMatchObject({ behavior: "deny" });
+    expect(await nextAnswer()).toMatchObject({ behavior: "deny" });
 
     // the original ask is untouched and still resolves normally
     await expect(instance.adapter.respondToRequest("t-perm-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
@@ -462,29 +469,14 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({ threadId: "t-perm-dup-2", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn1 = connect(permissionSocketPath("t-perm-dup-2"));
-    await new Promise<void>((resolve, reject) => {
-      conn1.on("connect", resolve);
-      conn1.on("error", reject);
-    });
+    const conn1 = await connectSocket(permissionSocketPath("t-perm-dup-2"));
     conn1.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-2");
 
     // `pending` is shared across every connection on the broker, so a
     // second connection reusing the same id must collide too
-    const conn2 = connect(permissionSocketPath("t-perm-dup-2"));
-    const conn2Answer = new Promise<{ behavior: string }>((resolve) => {
-      let buf2 = "";
-      conn2.on("data", (c) => {
-        buf2 += c;
-        const nl = buf2.indexOf("\n");
-        if (nl !== -1) resolve(JSON.parse(buf2.slice(0, nl)));
-      });
-    });
-    await new Promise<void>((resolve, reject) => {
-      conn2.on("connect", resolve);
-      conn2.on("error", reject);
-    });
+    const conn2 = await connectSocket(permissionSocketPath("t-perm-dup-2"));
+    const conn2Answer = answerQueue(conn2)();
     conn2.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo two" } }) + "\n");
     expect(await conn2Answer).toMatchObject({ behavior: "deny" });
 
@@ -504,11 +496,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({ threadId: "t-perm-dup-3", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = connect(permissionSocketPath("t-perm-dup-3"));
-    await new Promise<void>((resolve, reject) => {
-      conn.on("connect", resolve);
-      conn.on("error", reject);
-    });
+    const conn = await connectSocket(permissionSocketPath("t-perm-dup-3"));
 
     conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo one");

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -409,6 +409,127 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     conn.end();
   });
 
+  it("denies a colliding ask id on the same connection without orphaning the original", async () => {
+    await create("hang");
+    await instance.adapter.sendTurn({ threadId: "t-perm-dup-1", text: "go" });
+    await recorder.until((e) => e.type === "session.started");
+
+    const conn = connect(permissionSocketPath("t-perm-dup-1"));
+    const answers: Array<{ behavior: string; message?: string }> = [];
+    const waiters: Array<(a: { behavior: string; message?: string }) => void> = [];
+    let buf = "";
+    conn.on("data", (c) => {
+      buf += c;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        const parsed = JSON.parse(line);
+        answers.push(parsed);
+        waiters.shift()?.(parsed);
+      }
+    });
+    const nextAnswer = () => new Promise<{ behavior: string; message?: string }>((resolve) => waiters.push(resolve));
+    await new Promise<void>((resolve, reject) => {
+      conn.on("connect", resolve);
+      conn.on("error", reject);
+    });
+
+    // two asks with the same id on one connection, second sent before the
+    // first is resolved
+    conn.write(JSON.stringify({ t: "ask", id: "dup-1", tool: "Bash", input: { command: "echo one" } }) + "\n");
+    await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-1");
+    conn.write(JSON.stringify({ t: "ask", id: "dup-1", tool: "Bash", input: { command: "echo two" } }) + "\n");
+
+    // the collision is denied immediately, on the wire, without a second
+    // request.opened ever firing
+    const duplicateAnswer = await nextAnswer();
+    expect(duplicateAnswer).toMatchObject({ behavior: "deny" });
+
+    // the original ask is untouched and still resolves normally
+    await expect(instance.adapter.respondToRequest("t-perm-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
+      "allowed-once",
+    );
+    expect(await nextAnswer()).toMatchObject({ behavior: "allow" });
+
+    conn.end();
+    await instance.adapter.interruptTurn("t-perm-dup-1");
+    await recorder.until((e) => e.type === "turn.completed");
+  });
+
+  it("denies a colliding ask id from a second connection on the same broker", async () => {
+    await create("hang");
+    await instance.adapter.sendTurn({ threadId: "t-perm-dup-2", text: "go" });
+    await recorder.until((e) => e.type === "session.started");
+
+    const conn1 = connect(permissionSocketPath("t-perm-dup-2"));
+    await new Promise<void>((resolve, reject) => {
+      conn1.on("connect", resolve);
+      conn1.on("error", reject);
+    });
+    conn1.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo one" } }) + "\n");
+    await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-2");
+
+    // `pending` is shared across every connection on the broker, so a
+    // second connection reusing the same id must collide too
+    const conn2 = connect(permissionSocketPath("t-perm-dup-2"));
+    const conn2Answer = new Promise<{ behavior: string }>((resolve) => {
+      let buf2 = "";
+      conn2.on("data", (c) => {
+        buf2 += c;
+        const nl = buf2.indexOf("\n");
+        if (nl !== -1) resolve(JSON.parse(buf2.slice(0, nl)));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      conn2.on("connect", resolve);
+      conn2.on("error", reject);
+    });
+    conn2.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo two" } }) + "\n");
+    expect(await conn2Answer).toMatchObject({ behavior: "deny" });
+
+    // the original, opened on conn1, still resolves normally
+    await expect(instance.adapter.respondToRequest("t-perm-dup-2", "dup-2", { behavior: "allow" })).resolves.toBe(
+      "allowed-once",
+    );
+
+    conn1.end();
+    conn2.end();
+    await instance.adapter.interruptTurn("t-perm-dup-2");
+    await recorder.until((e) => e.type === "turn.completed");
+  });
+
+  it("accepts an ask id reused after the original already resolved — not a collision", async () => {
+    await create("hang");
+    await instance.adapter.sendTurn({ threadId: "t-perm-dup-3", text: "go" });
+    await recorder.until((e) => e.type === "session.started");
+
+    const conn = connect(permissionSocketPath("t-perm-dup-3"));
+    await new Promise<void>((resolve, reject) => {
+      conn.on("connect", resolve);
+      conn.on("error", reject);
+    });
+
+    conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo one" } }) + "\n");
+    await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo one");
+    await expect(instance.adapter.respondToRequest("t-perm-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+      "allowed-once",
+    );
+
+    // the id is free again once its ask resolved — reusing it is not a
+    // collision and should open normally (distinct summary proves this is a
+    // fresh request.opened, not the first one already seen by the recorder)
+    conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo two" } }) + "\n");
+    await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo two");
+    await expect(instance.adapter.respondToRequest("t-perm-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+      "allowed-once",
+    );
+
+    conn.end();
+    await instance.adapter.interruptTurn("t-perm-dup-3");
+    await recorder.until((e) => e.type === "turn.completed");
+  });
+
   it("passes effort to the CLI, and omits the flag when unset", async () => {
     await create();
     const dump = join(scratch, "effort.json");

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -177,6 +177,7 @@ type AskResolutionSource = "user" | "timeout" | "system";
 const DENY_TIMEOUT_NOTE =
   "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
 const QUESTION_TIMEOUT_NOTE = "OpenMausBot: nobody answered in time. Use your best judgment and continue.";
+const DUPLICATE_ASK_ID_NOTE = "OpenMausBot: duplicate ask id — skipping this request.";
 
 /** One human-readable line for an ask — what the card subtitle shows. */
 function askSummary(ask: Ask): string {
@@ -224,6 +225,20 @@ function createPermissionBroker(opts: {
         }
         if (msg.t !== "ask") continue;
         const askId = String(msg.id ?? newId());
+        // `pending` is server-scoped, not per-connection: two asks with the
+        // same id — a buggy/adversarial client, never a legitimate retry
+        // (permission-proxy mints a fresh randomUUID per ask) — would
+        // otherwise let the second `pending.set` silently overwrite the
+        // first, orphaning it as an unanswerable card once the first
+        // resolves and deletes the shared key. Reject before either ask
+        // becomes visible to onAsk.
+        if (pending.has(askId)) {
+          console.error(`permission broker on ${opts.socketPath}: duplicate ask id ${askId} — denying`);
+          try {
+            conn.write(JSON.stringify({ t: "answer", id: askId, behavior: "deny", message: DUPLICATE_ASK_ID_NOTE }) + "\n");
+          } catch {}
+          continue;
+        }
         const kind = msg.kind === "question" ? ("question" as const) : ("permission" as const);
         const ask: Ask = { id: askId, kind, tool: msg.tool ?? "tool", input: msg.input ?? {}, at: Date.now() };
         const finish = (behavior: AskBehavior, message: string | undefined, source: AskResolutionSource) => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -233,7 +233,9 @@ function createPermissionBroker(opts: {
         // resolves and deletes the shared key. Reject before either ask
         // becomes visible to onAsk.
         if (pending.has(askId)) {
-          console.error(`permission broker on ${opts.socketPath}: duplicate ask id ${askId} — denying`);
+          // askId is client-controlled; JSON.stringify escapes newlines and
+          // control characters so it can't corrupt the log line or terminal.
+          console.error(`permission broker on ${opts.socketPath}: duplicate ask id ${JSON.stringify(askId)} — denying`);
           try {
             conn.write(JSON.stringify({ t: "answer", id: askId, behavior: "deny", message: DUPLICATE_ASK_ID_NOTE }) + "\n");
           } catch {}


### PR DESCRIPTION
## What changed

`createPermissionBroker()`'s socket handler now rejects an incoming permission/question ask whose `id` already has a live entry in its `pending` map, instead of silently overwriting it.

## Why

`pending` is scoped to the whole broker, not to one connection. Two asks arriving with the same id — a buggy or adversarial client, since the CLI's own permission-proxy always mints a fresh UUID per ask — would let the second `pending.set()` clobber the first. Once the *original* ask resolved, its `finish()` deleted the shared key by id and took the second, still-visible request card down with it, leaving it permanently unanswerable. The guard now denies the colliding ask immediately, on the wire, before it ever reaches `onAsk` — so it can no longer orphan a legitimate request or open a second UI card for the same id. Confirmed via `server/permission-proxy.ts` that no legitimate retry path reuses an ask id, so this is a defense-in-depth fix rather than a response to an observed collision.

## How it was verified

- `npx vitest run server/drivers/claude.test.ts` — 31/31 pass, including 3 new regression tests: same-connection collision, cross-connection collision (the case that motivated this fix, since `pending` is broker-wide), and reuse of an id after the original already resolved (confirmed as *not* a collision).
- `npx tsc --noEmit` — clean.

## Screenshots (UI changes)

N/A — backend-only change to the permission broker's socket handling.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate active permission requests from being processed simultaneously.
  * Duplicate requests are denied immediately with a clear message.
  * Original pending requests remain intact, and IDs can be reused after resolution.
  * Improved duplicate handling across the same and separate connections.
  * Applied protection consistently to permission and question requests.

* **Documentation**
  * Added implementation and verification guidance for duplicate request protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->