### PR TITLE
Nudge a looping bot out of it, and stop it at the ceiling

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -184,6 +184,12 @@ export interface ProviderAdapter {
      * the driver cannot set effort, so the app never offers the control —
      * same rule as computerMcp: never show a knob the driver cannot turn. */
     effortLevels?: readonly EffortLevel[];
+    /** True when the driver keeps a live session across turns and can take
+     * a user message MID-TURN (delivered before the model's next call —
+     * "steer"). The composer stays open during a turn on such an engine;
+     * others keep the queue-one-and-wait behaviour. Same rule as the other
+     * flags: never show a control the driver cannot honour. */
+    queueing?: boolean;
   };
   sendTurn(input: SendTurnInput): Promise<TurnStartResult>;
   interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void>;
@@ -197,6 +203,10 @@ export interface ProviderAdapter {
     requestId: string,
     decision: { behavior: "allow" | "deny" | "answer"; message?: string },
   ): Promise<RequestOutcome>;
+  /** Deliver a user message into the RUNNING turn on this thread. Resolves
+   * false when there is no live turn to steer (the caller then sends it as
+   * a normal turn). Only drivers with `capabilities.queueing` implement it. */
+  steer?(threadId: ThreadId, text: string): Promise<boolean>;
   hasSession(threadId: ThreadId): boolean;
   stopAll(): Promise<void>;
   onEvent(listener: RuntimeEventListener): () => void;
@@ -238,7 +248,16 @@ export interface EngineInstall {
 // a rejection to an unavailable shadow snapshot.
 export interface ModelCatalog {
   default: string;
-  options: Array<{ id: string; label: string; custom?: boolean; loaded?: boolean }>;
+  options: Array<{
+    id: string;
+    label: string;
+    custom?: boolean;
+    loaded?: boolean;
+    /** total context window in tokens, when the driver knows it — sizes
+     * the model-facing rebuild (server/context-rebuild.ts). Unknown falls
+     * back to a pattern table over the model id, then a conservative default. */
+    contextWindow?: number;
+  }>;
 }
 
 export interface DriverCreateInput<Config> {

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -92,7 +92,15 @@ export type RuntimeEvent = RuntimeEventBase &
         cost?: number | null;
         denials?: string[];
       }
-    | { type: "item.started"; itemType: "tool" | "reasoning"; title?: string }
+    | {
+        type: "item.started";
+        itemType: "tool" | "reasoning";
+        title?: string;
+        /** the call's arguments in one line (a command, a path, a URL) when
+         * the driver can see them — what makes "the same call again" a
+         * meaningful thing to count (repeat detection). Not shown as-is. */
+        args?: string;
+      }
     | { type: "item.updated"; itemType: "tool" | "reasoning"; tokens?: number | null }
     | { type: "item.completed"; itemType: "tool"; ok: boolean }
     | { type: "item.completed"; itemType: "assistant_text"; text: string }

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -6,7 +6,7 @@
 // These used to be POSIX-only: the fake CLI is a shebang script Windows
 // cannot exec, and the broker is a unix socket. Both now go through
 // resolveCliSpawn / permissionSocketPath, so they run everywhere.
-import { chmodSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -404,6 +404,81 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
     conn.end();
   });
+
+  // ── live session across turns (steer / follow-up / idle close) ────────
+
+  it("a message sent mid-turn is steered into the running turn, not a new one", async () => {
+    await create("slow");
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-steer", text: "first" });
+    // the fake leaves a gap after the tool result — steer into it
+    await recorder.until((e) => e.type === "item.completed" && e.itemType === "tool");
+    expect(instance.adapter.capabilities.queueing).toBe(true);
+    await expect(instance.adapter.steer!("t-steer", "and also this")).resolves.toBe(true);
+    await recorder.until((e) => e.type === "turn.completed");
+    // one turn, one result; the reply carries the folded message
+    expect(recorder.events.filter((e) => e.type === "turn.completed")).toHaveLength(1);
+    const reply = recorder.events.find((e) => e.type === "item.completed" && e.itemType === "assistant_text" && (e as { text: string }).text.startsWith("reply to:")) as { text: string };
+    expect(reply.text).toContain("steered: and also this");
+    expect(recorder.events.every((e) => e.turnId === turnId)).toBe(true);
+    // nothing running now: steer has nowhere to go
+    await expect(instance.adapter.steer!("t-steer", "late")).resolves.toBe(false);
+  });
+
+  it("the next turn on the same thread reuses the live process instead of spawning", async () => {
+    await create();
+    process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+    await instance.adapter.sendTurn({ threadId: "t-live", text: "one" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const inits1 = recorder.events.filter((e) => e.type === "session.started").length;
+    // second turn: same contract, same session id → same process. The fake
+    // dumps argv only on its FIRST prompt, so a re-dump would mean a respawn.
+    const dumpBefore = readFileSync(join(scratch, "dump.json"), "utf8");
+    // the harness resumes with the id the CLI announced — pass that one
+    const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+    const second = await instance.adapter.sendTurn({ threadId: "t-live", text: "two", resumeCursor: announced });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === second.turnId);
+    expect(readFileSync(join(scratch, "dump.json"), "utf8")).toBe(dumpBefore);
+    // and the CLI announced init again on the same process (the real one does)
+    expect(recorder.events.filter((e) => e.type === "session.started").length).toBeGreaterThan(inits1);
+    expect(recorder.events.filter((e) => e.type === "turn.started")).toHaveLength(2);
+    expect(recorder.events.filter((e) => e.type === "turn.completed")).toHaveLength(2);
+  });
+
+  it("a changed spawn contract (another model) closes the live process and resumes in a new one", async () => {
+    await create();
+    process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+    await instance.adapter.sendTurn({ threadId: "t-switch", text: "one" });
+    await recorder.until((e) => e.type === "turn.completed");
+    // a fresh process rewrites the dump; the fake ONLY dumps its first prompt
+    rmSync(join(scratch, "dump.json"));
+    const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+    await instance.adapter.sendTurn({ threadId: "t-switch", text: "two", model: "claude-other", resumeCursor: announced });
+    await recorder.until((e) => e.type === "turn.completed" && recorder.events.filter((x) => x.type === "turn.completed").length === 2);
+    const dump = JSON.parse(readFileSync(join(scratch, "dump.json"), "utf8"));
+    expect(dump.argv).toContain("--resume");
+    expect(dump.argv).toContain("claude-other");
+  });
+
+  it("closes an idle session after the idle window", async () => {
+    process.env.OMB_CLAUDE_SESSION_IDLE_MS = "10000"; // the floor
+    try {
+      await create();
+      await instance.adapter.sendTurn({ threadId: "t-idle", text: "one" });
+      await recorder.until((e) => e.type === "turn.completed");
+      // the process is alive between turns…
+      await expect(instance.adapter.steer!("t-idle", "x")).resolves.toBe(false); // no running turn, but session exists
+      // …and after the idle window it is gone: the next turn spawns anew
+      // (observable as a fresh dump)
+      process.env.FAKE_CLAUDE_DUMP = join(scratch, "dump.json");
+      await new Promise((r) => setTimeout(r, 11_000));
+      const announced = (recorder.events.find((e) => e.type === "session.started") as { sessionId: string }).sessionId;
+      await instance.adapter.sendTurn({ threadId: "t-idle", text: "two", resumeCursor: announced });
+      await recorder.until((e) => e.type === "turn.completed" && recorder.events.filter((x) => x.type === "turn.completed").length === 2);
+      expect(JSON.parse(readFileSync(join(scratch, "dump.json"), "utf8")).argv).toContain("--resume");
+    } finally {
+      delete process.env.OMB_CLAUDE_SESSION_IDLE_MS;
+    }
+  }, 30_000);
 
   it("passes effort to the CLI, and omits the flag when unset", async () => {
     await create();

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -480,6 +480,14 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     }
   }, 30_000);
 
+  it("item.started carries the call's arguments, so repeats are countable in auto mode", async () => {
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-args", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const started = recorder.events.find((e) => e.type === "item.started" && e.itemType === "tool") as { title?: string; args?: string };
+    expect(started).toMatchObject({ title: "Bash", args: "echo hi" });
+  });
+
   it("passes effort to the CLI, and omits the flag when unset", async () => {
     await create();
     const dump = join(scratch, "effort.json");

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -191,6 +191,19 @@ function askSummary(ask: Ask): string {
   return text === "{}" ? (ask.tool ?? "tool") : text.slice(0, 200);
 }
 
+/** A tool call's arguments in one line — the same shape askSummary gives a
+ * permission card, for calls that never ask (auto mode). Empty when the
+ * input carries nothing recognisable. */
+export function toolArgsSummary(input: unknown): string {
+  if (!input || typeof input !== "object") return "";
+  const o = input as Record<string, unknown>;
+  for (const key of ["command", "file_path", "path", "url", "pattern", "query", "prompt"]) {
+    if (typeof o[key] === "string" && (o[key] as string).trim()) return (o[key] as string).slice(0, 200);
+  }
+  const text = JSON.stringify(o);
+  return text === "{}" ? "" : text.slice(0, 200);
+}
+
 export function permissionSocketPath(threadId: string) {
   const tag = threadId.replace(/[^\w-]/g, "").slice(0, 8);
   return brokerSocketPath(DATA_DIR, tag);
@@ -633,7 +646,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             }
             for (const b of Array.isArray(msg.content) ? msg.content : []) {
               if (b.type === "tool_use") {
-                emit({ ...base(threadId, currentTurnId()), type: "item.started", itemType: "tool", itemId: b.id, title: b.name });
+                // the call's arguments in one line, so the harness can tell
+                // "git status" from "rm -rf" when it counts repeats
+                const args = toolArgsSummary(b.input);
+                emit({ ...base(threadId, currentTurnId()), type: "item.started", itemType: "tool", itemId: b.id, title: b.name, ...(args ? { args } : {}) });
               }
             }
             if (msg.usage) {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -339,6 +339,59 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
     // one active turn per thread; a second send while busy is a caller bug
     const active = new Map<string, { stop: () => void; turnId: string; broker?: ReturnType<typeof createPermissionBroker> }>();
 
+    // One live CLI process per thread, kept across turns. Under
+    // --input-format stream-json the CLI settles a turn with `result` while
+    // stdin stays open, takes the next user message on the same stdin as a
+    // new turn, and folds a message that arrives MID-turn into the running
+    // one before its next model call (verified against 2.1.221 — that fold
+    // is what "steer" is). So a session is spawned once, reused while its
+    // spawn contract (args, MCP config, cwd, model) is unchanged, closed
+    // after SESSION_IDLE_MS of quiet, and resumed by --resume when needed.
+    interface Session {
+      child: ReturnType<typeof spawnCli>;
+      broker?: ReturnType<typeof createPermissionBroker>;
+      mcpConfigPath: string | null;
+      /** the spawn contract — a different one means a fresh process */
+      argsKey: string;
+      /** the CLI's session id from `init`, what --resume takes later */
+      sessionId: string | null;
+      /** the running turn, or null between turns */
+      turn: { turnId: string; settled: boolean; sawStreamDelta: boolean } | null;
+      idleTimer: ReturnType<typeof setTimeout> | null;
+      closing: boolean;
+      stderr: string;
+    }
+    const sessions = new Map<string, Session>();
+    const SESSION_IDLE_MS = Math.max(10_000, Number(process.env.OMB_CLAUDE_SESSION_IDLE_MS) || 10 * 60_000);
+
+    const closeSession = (threadId: string, why: string) => {
+      const s = sessions.get(threadId);
+      if (!s || s.closing) return;
+      s.closing = true;
+      if (s.idleTimer) clearTimeout(s.idleTimer);
+      appendNative(threadId, { dir: "out", source: "claude.session", msg: { close: why } });
+      // stdin EOF is the CLI's exit signal; give it a moment, then insist
+      try {
+        s.child.stdin.end();
+      } catch {}
+      const kill = setTimeout(() => {
+        if (s.child.exitCode === null) killCliTree(s.child);
+      }, 5_000);
+      kill.unref?.();
+    };
+    const armIdle = (threadId: string) => {
+      const s = sessions.get(threadId);
+      if (!s) return;
+      if (s.idleTimer) clearTimeout(s.idleTimer);
+      s.idleTimer = setTimeout(() => closeSession(threadId, "idle"), SESSION_IDLE_MS);
+      s.idleTimer.unref?.();
+    };
+    const writeUser = (s: Session, threadId: string, text: string) => {
+      const promptMsg = { type: "user", message: { role: "user", content: text } };
+      s.child.stdin.write(JSON.stringify(promptMsg) + "\n");
+      appendNative(threadId, { dir: "out", source: "claude.sdk.message", msg: promptMsg });
+    };
+
     const emit = (event: RuntimeEvent) => {
       for (const l of [...listeners]) l(event);
     };
@@ -367,8 +420,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         "--include-partial-messages",
         "--permission-mode", config.permissionMode === "auto" ? "acceptEdits" : config.permissionMode,
       ];
-      if (sessionId) args.push("--resume", sessionId);
-      else args.push("--session-id", newSessionId!);
       const turnEnvironment: NodeJS.ProcessEnv = { ...process.env, ...input.environment };
       const injected = applyClaudeInject({ ...turnEnvironment }, turn.model);
       if (injected.model) args.push("--model", injected.model);
@@ -468,32 +519,74 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
 
       const env = claudeEnvironment(turn.model, turnEnvironment);
+      const cwd = turn.cwd ?? homedir();
+      // everything that shapes the process, minus session/turn specifics
+      // (the --mcp-config file is a fresh temp path each time; its CONTENT
+      // is what matters and mcpServers carries that)
+      const keyArgs = args.filter((a, i) => a !== "--mcp-config" && args[i - 1] !== "--mcp-config");
+      const argsKey = JSON.stringify({ args: keyArgs, mcpServers, cwd, model: injected.model ?? null, base: env.ANTHROPIC_BASE_URL ?? null });
 
-      const child = spawnCli(config.cli, args, {
-        cwd: turn.cwd ?? homedir(),
-        env,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-
-      let settled = false;
-      const settle = (ok: boolean, stopReason: string | null, cost: number | null = null) => {
-        if (settled) return;
-        settled = true;
-        broker?.close();
-        // the config file holds live credentials — it must not outlive the turn
+      // Reuse the live process when it is idle, unchanged, and is the session
+      // the harness wants resumed. Anything else: close it and spawn fresh
+      // (with --resume, so the conversation continues in the new process).
+      const live = sessions.get(threadId);
+      if (live && !live.turn && !live.closing && live.child.exitCode === null && live.argsKey === argsKey && (!sessionId || sessionId === live.sessionId)) {
+        if (live.idleTimer) clearTimeout(live.idleTimer);
+        live.turn = { turnId, settled: false, sawStreamDelta: false };
+        active.set(threadId, { stop: () => killCliTree(live.child), turnId, broker: live.broker });
+        emit({ ...base(threadId, turnId), type: "turn.started" });
+        writeUser(live, threadId, turn.text);
+        // the MCP config was for the first spawn; nothing to clean here
         if (mcpConfigPath) {
           try {
             rmSync(dirname(mcpConfigPath), { recursive: true, force: true });
           } catch {}
         }
-        active.delete(threadId);
-        emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost });
-      };
+        broker?.close(); // the session's own broker stays; this one was provisional
+        return { turnId };
+      }
+      if (live) closeSession(threadId, "spawn contract changed");
+      if (sessionId) args.push("--resume", sessionId);
+      else args.push("--session-id", newSessionId!);
 
-      // token streaming: true while --include-partial-messages is delivering
-      // text deltas for the current assistant message, so the whole-message
-      // frame that follows doesn't re-emit the same text as one big delta
-      let sawStreamDelta = false;
+      const child = spawnCli(config.cli, args, {
+        cwd,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const session: Session = {
+        child,
+        broker,
+        mcpConfigPath,
+        argsKey,
+        sessionId: sessionId ?? newSessionId,
+        turn: { turnId, settled: false, sawStreamDelta: false },
+        idleTimer: null,
+        closing: false,
+        stderr: "",
+      };
+      sessions.set(threadId, session);
+
+      // settles the TURN, not the process: the CLI stays for the next
+      // message until it has been quiet for SESSION_IDLE_MS
+      const settle = (ok: boolean, stopReason: string | null, cost: number | null = null) => {
+        const t = session.turn;
+        if (!t || t.settled) return;
+        t.settled = true;
+        // the config file holds live credentials — the CLI read it at start;
+        // it must not sit on disk for the life of the session
+        if (session.mcpConfigPath) {
+          try {
+            rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+          } catch {}
+          session.mcpConfigPath = null;
+        }
+        active.delete(threadId);
+        session.turn = null;
+        emit({ ...base(threadId, t.turnId), type: "turn.completed", ok, stopReason, cost });
+        if (session.child.exitCode === null && !session.closing) armIdle(threadId);
+      };
+      const currentTurnId = () => session.turn?.turnId ?? turnId;
 
       const handleLine = (line: string) => {
         let o: any;
@@ -506,9 +599,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         switch (o.type) {
           case "system":
             if (o.subtype === "init") {
-              emit({ ...base(threadId, turnId), type: "session.started", sessionId: o.session_id, model: o.model });
+              if (typeof o.session_id === "string") session.sessionId = o.session_id;
+              emit({ ...base(threadId, currentTurnId()), type: "session.started", sessionId: o.session_id, model: o.model });
             } else if (o.subtype === "thinking_tokens") {
-              emit({ ...base(threadId, turnId), type: "item.updated", itemType: "reasoning", tokens: o.estimated_tokens });
+              emit({ ...base(threadId, currentTurnId()), type: "item.updated", itemType: "reasoning", tokens: o.estimated_tokens });
             }
             break;
           case "stream_event": {
@@ -519,10 +613,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             if (ev.type !== "content_block_delta") break;
             const d = ev.delta ?? {};
             if (d.type === "text_delta" && typeof d.text === "string" && d.text) {
-              sawStreamDelta = true;
-              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta: d.text });
+              if (session.turn) session.turn.sawStreamDelta = true;
+              emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "assistant_text", delta: d.text });
             } else if (d.type === "thinking_delta" && typeof d.thinking === "string" && d.thinking) {
-              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "reasoning_text", delta: d.thinking });
+              emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "reasoning_text", delta: d.thinking });
             }
             break;
           }
@@ -531,20 +625,20 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             const text = firstText(msg.content);
             if (text.trim()) {
               // fallback delta for CLIs/paths that never streamed the block
-              if (!sawStreamDelta) {
-                emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta: text });
+              if (!session.turn?.sawStreamDelta) {
+                emit({ ...base(threadId, currentTurnId()), type: "content.delta", streamKind: "assistant_text", delta: text });
               }
-              sawStreamDelta = false;
-              emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+              if (session.turn) session.turn.sawStreamDelta = false;
+              emit({ ...base(threadId, currentTurnId()), type: "item.completed", itemType: "assistant_text", text });
             }
             for (const b of Array.isArray(msg.content) ? msg.content : []) {
               if (b.type === "tool_use") {
-                emit({ ...base(threadId, turnId), type: "item.started", itemType: "tool", itemId: b.id, title: b.name });
+                emit({ ...base(threadId, currentTurnId()), type: "item.started", itemType: "tool", itemId: b.id, title: b.name });
               }
             }
             if (msg.usage) {
               emit({
-                ...base(threadId, turnId),
+                ...base(threadId, currentTurnId()),
                 type: "thread.token-usage.updated",
                 input: (msg.usage.input_tokens || 0) + (msg.usage.cache_read_input_tokens || 0),
                 output: msg.usage.output_tokens || 0,
@@ -555,7 +649,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           case "user":
             for (const b of Array.isArray(o.message?.content) ? o.message.content : []) {
               if (b.type === "tool_result") {
-                emit({ ...base(threadId, turnId), type: "item.completed", itemType: "tool", itemId: b.tool_use_id, ok: !b.is_error });
+                emit({ ...base(threadId, currentTurnId()), type: "item.completed", itemType: "tool", itemId: b.tool_use_id, ok: !b.is_error });
               }
             }
             break;
@@ -579,39 +673,57 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         }
       });
 
-      let stderr = "";
       child.stderr.on("data", (c) => {
-        stderr += c;
-        if (stderr.length > 8192) stderr = stderr.slice(-8192);
+        session.stderr += c;
+        if (session.stderr.length > 8192) session.stderr = session.stderr.slice(-8192);
       });
 
       child.on("error", (e) => {
-        emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
+        emit({ ...base(threadId, currentTurnId()), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
 
       child.on("close", (code) => {
-        if (!settled) {
+        // a turn still running when the process died is a failed turn; a
+        // process that exited between turns (idle close, contract change)
+        // is just a session ending
+        if (session.turn && !session.turn.settled) {
           emit({
-            ...base(threadId, turnId),
+            ...base(threadId, currentTurnId()),
             type: "runtime.error",
-            message: `claude exited ${code} before result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
+            message: `claude exited ${code} before result${session.stderr ? `: ${session.stderr.trim().slice(-300)}` : ""}`,
           });
           settle(false, "exit_before_result");
         }
+        if (session.idleTimer) clearTimeout(session.idleTimer);
+        session.broker?.close();
+        if (session.mcpConfigPath) {
+          try {
+            rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+          } catch {}
+        }
+        if (sessions.get(threadId) === session) sessions.delete(threadId);
       });
 
       const stop = () => killCliTree(child);
       active.set(threadId, { stop, turnId, broker });
       emit({ ...base(threadId, turnId), type: "turn.started" });
 
-      // prompt over stdin as a stream-json message — never argv (ARG_MAX)
-      const promptMsg = { type: "user", message: { role: "user", content: turn.text } };
-      child.stdin.write(JSON.stringify(promptMsg) + "\n");
-      child.stdin.end();
-      appendNative(threadId, { dir: "out", source: "claude.sdk.message", msg: promptMsg });
+      // prompt over stdin as a stream-json message — never argv (ARG_MAX).
+      // stdin stays OPEN: that is what keeps the session alive for a
+      // mid-turn steer or the next turn; closeSession() ends it.
+      writeUser(session, threadId, turn.text);
 
       return { turnId };
+    };
+
+    /** A user message into the running turn: the CLI delivers it before its
+     * next model call. False when nothing is running here to steer. */
+    const steer = async (threadId: string, text: string): Promise<boolean> => {
+      const s = sessions.get(threadId);
+      if (!s || !s.turn || s.turn.settled || s.closing || s.child.exitCode !== null) return false;
+      writeUser(s, threadId, text);
+      return true;
     };
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
@@ -644,13 +756,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           computerMcp: true,
           composioMcp: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
+          queueing: true,
         },
         sendTurn,
+        steer,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async (threadId, requestId, decision) => {
           // fail-closed by construction: no broker, or an ask that already
           // timed out / settled, is `unavailable` — the caller denies
-          const broker = active.get(threadId)?.broker;
+          const broker = sessions.get(threadId)?.broker ?? active.get(threadId)?.broker;
           if (!broker) return "unavailable";
           const behavior = decision.behavior === "answer" ? "answer" : decision.behavior;
           if (!broker.answer(requestId, behavior, decision.message)) return "unavailable";
@@ -659,6 +773,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         hasSession: (threadId) => active.has(threadId),
         stopAll: async () => {
           for (const { stop } of active.values()) stop();
+          for (const threadId of [...sessions.keys()]) closeSession(threadId, "stopAll");
         },
         onEvent: (listener) => {
           listeners.add(listener);

--- a/server/drivers/local-inject.test.ts
+++ b/server/drivers/local-inject.test.ts
@@ -20,6 +20,7 @@ import {
   codexLocalProviderArgs,
   decodeInjectId,
   encodeInjectId,
+  contextWindowsFromPs,
   loadedIdsFromPayloads,
   LOCAL_HOSTS,
   mergeLocalInject,
@@ -42,6 +43,28 @@ describe("inject ids", () => {
   it("rejects official cloud slugs", () => {
     expect(decodeInjectId("claude-sonnet-5")).toBeNull();
     expect(decodeInjectId("gpt-5.6-sol")).toBeNull();
+  });
+});
+
+describe("contextWindowsFromPs", () => {
+  it("reads Ollama's per-model context_length from /api/ps, keyed by full and base id", () => {
+    const windows = contextWindowsFromPs({
+      models: [
+        { name: "qwen3:8b", model: "qwen3:8b", context_length: 40960 },
+        { name: "llama3.2:latest", model: "llama3.2:latest", context_length: 8192 },
+        { name: "no-ctx:1b", model: "no-ctx:1b" },
+        { name: "bad:1b", model: "bad:1b", context_length: -1 },
+      ],
+    });
+    expect(windows.get("qwen3:8b")).toBe(40960);
+    expect(windows.get("qwen3")).toBe(40960);
+    expect(windows.get("llama3.2:latest")).toBe(8192);
+    expect(windows.has("no-ctx:1b")).toBe(false);
+    expect(windows.has("bad:1b")).toBe(false);
+  });
+  it("tolerates payloads that are not a ps listing", () => {
+    expect(contextWindowsFromPs(null).size).toBe(0);
+    expect(contextWindowsFromPs({ data: [] }).size).toBe(0);
   });
 });
 

--- a/server/drivers/local-inject.ts
+++ b/server/drivers/local-inject.ts
@@ -38,6 +38,30 @@ export interface InjectedModel {
   label: string;
   /** In VRAM / running on the host right now — Custom pins these first. */
   loaded?: boolean;
+  /** the host's own word on the model's context window (Ollama reports it
+   * for running models in /api/ps) — sizes the model-facing rebuild instead
+   * of guessing from the name */
+  contextWindow?: number;
+}
+
+/** Ollama's /api/ps lists running models with their context_length; a
+ * small model's real window matters more than a big one's — an 8k model
+ * guessed at 32k gets a rebuild it cannot hold. */
+export function contextWindowsFromPs(extra: unknown): Map<string, number> {
+  const out = new Map<string, number>();
+  const rec = extra && typeof extra === "object" ? (extra as { models?: unknown }) : null;
+  if (!rec || !Array.isArray(rec.models)) return out;
+  for (const m of rec.models) {
+    if (!m || typeof m !== "object") continue;
+    const row = m as { name?: unknown; model?: unknown; context_length?: unknown };
+    const id = typeof row.model === "string" ? row.model : typeof row.name === "string" ? row.name : null;
+    const ctx = typeof row.context_length === "number" && Number.isFinite(row.context_length) && row.context_length > 0 ? row.context_length : null;
+    if (id && ctx) {
+      out.set(id, ctx);
+      out.set(id.split(":")[0]!, ctx);
+    }
+  }
+  return out;
 }
 
 export function encodeInjectId(host: string, model: string): string {
@@ -258,17 +282,20 @@ export async function probeLocalInjects(
       const extraIds = extra ? idsFromModelsPayload(extra) : [];
       const loaded = loadedIdsFromPayloads(host, catalog ?? extra, extra);
       const ids = [...new Set([...catalogIds, ...extraIds, ...loaded])];
-      return { host, ids, loaded };
+      const windows = contextWindowsFromPs(extra);
+      return { host, ids, loaded, windows };
     }),
   );
-  for (const { host, ids, loaded } of pages) {
+  for (const { host, ids, loaded, windows } of pages) {
     for (const model of ids) {
+      const contextWindow = windows.get(model);
       found.push({
         id: encodeInjectId(host.id, model),
         host: host.id,
         model,
         label: `${model} (${host.label})`,
         loaded: loaded.has(model),
+        ...(contextWindow ? { contextWindow } : {}),
       });
     }
   }
@@ -292,10 +319,17 @@ export async function mergeLocalInject(
     const existing = options.find((option) => option.id === extra.id);
     if (existing) {
       if (extra.loaded) existing.loaded = true;
+      if (extra.contextWindow) existing.contextWindow = extra.contextWindow;
       continue;
     }
     seen.add(extra.id);
-    options.push({ id: extra.id, label: extra.label, custom: true, ...(extra.loaded ? { loaded: true } : {}) });
+    options.push({
+      id: extra.id,
+      label: extra.label,
+      custom: true,
+      ...(extra.loaded ? { loaded: true } : {}),
+      ...(extra.contextWindow ? { contextWindow: extra.contextWindow } : {}),
+    });
   }
   return { default: catalog.default, options };
 }

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -171,6 +171,7 @@ export class ProviderRegistry {
             agentsMcp: inst.adapter.capabilities.agentsMcp === true,
             composioMcp: inst.adapter.capabilities.composioMcp === true,
             effortLevels: inst.adapter.capabilities.effortLevels,
+            queueing: inst.adapter.capabilities.queueing === true,
           },
           access: driver?.metadata.access ?? "subscription",
           install: driver?.install,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2648,6 +2648,24 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const text = String(body.text ?? "").trim();
       if (!text) return json(res, 400, { error: "text required" });
+      // A message during a running turn: engines that keep a live session
+      // (capabilities.queueing) take it INTO the turn — the model sees it
+      // before its next call, the way typing into Claude Code's own UI mid-
+      // task does. It lands in the transcript in order. Engines without
+      // that keep the 409 the composer already knows how to queue behind.
+      const busyBot = store.bot(m[1]);
+      if (busyBot?.busy && !busyBot.hidden) {
+        const instance = registry.get(busyBot.modelSelection.instanceId);
+        if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
+          const steered = await instance.adapter.steer(busyBot.threadId, text).catch(() => false);
+          if (steered) {
+            store.appendMessage(busyBot.threadId, { role: "user", kind: "text", text, steered: true });
+            return json(res, 202, { ok: true, steered: true });
+          }
+          // the turn settled between the busy check and the write — fall
+          // through and send it as the next turn instead
+        }
+      }
       await startTurn(m[1], text);
       return json(res, 202, { ok: true });
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,6 +70,7 @@ import { readCuaConnection } from "./local-computer.ts";
 import { LocalVmIdleTimer } from "./local-vm-idle.ts";
 import { LocalVmLease } from "./local-vm-lease.ts";
 import { RepeatDetector, callKey } from "./repeat-detector.ts";
+import { REPEAT_THRESHOLDS, repeatAction } from "./repeat-policy.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
 import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
@@ -418,7 +419,7 @@ const turnUsage = new Map<string, { input: number; output: number }>();
 // Bounded per active turn. OpenHands uses a bounded recent-event scan for
 // the same class of stuck-loop detection; retaining an unlimited set of
 // unique arguments would let one pathological turn grow the server forever.
-const repeats = new RepeatDetector({ thresholds: [5, 10, 20], maxKeysPerThread: 256 });
+const repeats = new RepeatDetector({ thresholds: [...REPEAT_THRESHOLDS], maxKeysPerThread: 256 });
 
 // ── stall watchdog ─────────────────────────────────────────────────────
 // ask_bot has a 4-minute ceiling and room turns a 5-minute one; the main
@@ -815,21 +816,37 @@ bus.subscribe((event: RuntimeEvent) => {
   if (event.type === "turn.completed" || event.type === "session.exited") return void repeats.settle(event.threadId);
   let key: string | null = null;
   if (event.type === "item.started" && event.itemType === "tool") {
-    // a title with more than a bare identifier is a call with arguments
-    // (ACP: "echo hi", "Read src/x.ts"); a bare "Bash" is not countable
-    const title = event.title ?? "";
-    if (/\s|\//.test(title.trim())) key = callKey("tool", title);
+    if (event.args) {
+      // the driver saw the call's arguments (Claude's tool_use input)
+      key = callKey(event.title ?? "tool", event.args);
+    } else {
+      // a title with more than a bare identifier is a call with arguments
+      // (ACP: "echo hi", "Read src/x.ts"); a bare "Bash" is not countable
+      const title = event.title ?? "";
+      if (/\s|\//.test(title.trim())) key = callKey("tool", title);
+    }
   } else if (event.type === "request.opened" && event.requestType === "permission") key = callKey(event.tool, event.summary);
   if (!key) return;
   const { threshold } = repeats.record(event.threadId, key);
   if (!threshold) return;
   const [tool, ...rest] = key.split(":");
   const args = rest.join(":");
-  store.appendMessage(event.threadId, {
-    role: "bot",
-    kind: "activity",
-    tool: { name: `Same call repeated ${threshold}× — ${tool}: ${args.slice(0, 80)}${args.length > 80 ? "…" : ""} — it may be stuck`, ok: false },
-  });
+  // enforcement (plan item 3.3): nudge the model out of the loop where the
+  // engine takes a message mid-turn; stop the turn at the ceiling either way
+  const bot = store.botByThread(event.threadId);
+  const instance = bot ? registry.get(bot.modelSelection.instanceId) : null;
+  const canSteer = Boolean(instance?.adapter.capabilities.queueing && instance.adapter.steer);
+  const action = repeatAction({ threshold, tool, args, canSteer });
+  store.appendMessage(event.threadId, { role: "bot", kind: "activity", tool: { name: action.chip, ok: false } });
+  if (action.steer && instance?.adapter.steer) {
+    void instance.adapter.steer(event.threadId, action.steer).catch(() => {});
+  }
+  if (action.stop && bot && instance) {
+    repeats.settle(event.threadId);
+    if (routines?.activeRunForBot(bot.id)) void routines.cancelRun(routines.activeRunForBot(bot.id)!.id).catch(() => {});
+    else void instance.adapter.interruptTurn(event.threadId).catch(() => {});
+    finalizeDelegationWatch(event.threadId, false, "", "Delegated turn stopped — the same call kept repeating");
+  }
 });
 
 // Drain queued delegations for a source thread after its turn settles.

--- a/server/repeat-enforcement-e2e.test.ts
+++ b/server/repeat-enforcement-e2e.test.ts
@@ -1,0 +1,106 @@
+// Loop enforcement, end to end: the fake claude runs the same call over and
+// over inside one turn. At 5 the harness nudges the model (steered into the
+// live session — the fake folds it into its reply) and chips; at the
+// ceiling it stops the turn.
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+posixOnly("repeat-call enforcement e2e", () => {
+  let child: ChildProcess;
+  let home: string;
+  let stderr = "";
+  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+    const res = await fetch(`${BASE}${path}`, { method, headers: body ? { "content-type": "application/json" } : undefined, body: body ? JSON.stringify(body) : undefined });
+    return { status: res.status, body: await res.json() };
+  };
+  const getBot = async (id: string) => (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === id);
+  const waitFor = async (predicate: () => Promise<boolean>, what: string, ms = 30_000) => {
+    const deadline = Date.now() + ms;
+    while (!(await predicate())) {
+      if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+
+  beforeAll(async () => {
+    chmodSync(FAKE_CLAUDE, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-repeat-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          loop: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "loop" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+          hard: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "loop-hard" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+        },
+      }),
+    );
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: { ...(process.env.PATH ? { PATH: process.env.PATH } : {}), HOME: home, USERPROFILE: home, OMB_PORT: String(PORT) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        if ((await fetch(`${BASE}/api/health`)).ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("nudges the model into the running turn at 5 identical calls, and says so", async () => {
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "loop", model: "claude-fake" } });
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "go" })).status).toBe(202);
+    await waitFor(async () => (await getBot(created.id)).busy === false, "the loop turn to settle");
+    const bot = await getBot(created.id);
+    const chips = bot.messages.filter((m: any) => m.kind === "activity").map((m: any) => m.tool?.name ?? "");
+    // the 5× chip says the bot was nudged (Claude can take a message mid-turn)
+    expect(chips.some((c: string) => /Same call repeated 5×.*Bash: git status.*nudged/.test(c))).toBe(true);
+    // and the nudge reached the model inside the SAME turn: the reply folds it in
+    const reply = bot.messages.find((m: any) => m.role === "bot" && m.kind === "text" && m.text?.startsWith("loop reply"));
+    expect(reply?.text).toMatch(/steered: OpenMausBot: you have now run the same call 5 times/);
+    // one turn, not stopped: no stop chip
+    expect(chips.some((c: string) => /stopped — the same call/.test(c))).toBe(false);
+  }, 40_000);
+
+  it("stops the turn at the ceiling when the loop never breaks", async () => {
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "hard", model: "claude-fake" } });
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "go" })).status).toBe(202);
+    await waitFor(async () => {
+      const b = await getBot(created.id);
+      return !b.busy && b.messages.some((m: any) => m.kind === "activity" && /^error: stopped — the same call repeated 20×/.test(m.tool?.name ?? ""));
+    }, "the turn to be stopped at 20 repeats", 40_000);
+    const bot = await getBot(created.id);
+    const chips = bot.messages.filter((m: any) => m.kind === "activity").map((m: any) => m.tool?.name ?? "");
+    // it was nudged twice on the way (5, 10) before the ceiling
+    expect(chips.filter((c: string) => /nudged/.test(c)).length).toBe(2);
+  }, 60_000);
+});

--- a/server/repeat-policy.test.ts
+++ b/server/repeat-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { REPEAT_THRESHOLDS, repeatAction } from "./repeat-policy.ts";
+
+describe("repeatAction", () => {
+  it("nudges into the turn on an engine that can take a message mid-turn", () => {
+    const a = repeatAction({ threshold: 5, tool: "Bash", args: "git status", canSteer: true });
+    expect(a.stop).toBeUndefined();
+    expect(a.chip).toMatch(/repeated 5×.*Bash: git status.*nudged/);
+    expect(a.steer).toMatch(/run the same call 5 times.*Bash: git status/);
+    expect(a.steer).toMatch(/stopped at 20/);
+  });
+
+  it("only chips on an engine that cannot be steered", () => {
+    const a = repeatAction({ threshold: 10, tool: "Bash", args: "git status", canSteer: false });
+    expect(a.steer).toBeUndefined();
+    expect(a.stop).toBeUndefined();
+    expect(a.chip).toMatch(/repeated 10×.*it may be stuck/);
+  });
+
+  it("stops at the ceiling regardless of engine", () => {
+    for (const canSteer of [true, false]) {
+      const a = repeatAction({ threshold: 20, tool: "Bash", args: "git status", canSteer });
+      expect(a.stop).toBe(true);
+      expect(a.steer).toBeUndefined();
+      expect(a.chip).toMatch(/^error: stopped — the same call repeated 20×/);
+    }
+  });
+
+  it("clips long arguments in the human-facing text", () => {
+    const a = repeatAction({ threshold: 5, tool: "Bash", args: "x".repeat(200), canSteer: false });
+    expect(a.chip).toContain("x".repeat(80) + "…");
+    expect(a.chip.length).toBeLessThan(200);
+  });
+
+  it("thresholds are the detector's: 5, 10, 20", () => {
+    expect([...REPEAT_THRESHOLDS]).toEqual([5, 10, 20]);
+  });
+});

--- a/server/repeat-policy.ts
+++ b/server/repeat-policy.ts
@@ -1,0 +1,47 @@
+// What to DO about a bot repeating itself, given what the harness can do
+// for its engine. Detection (repeat-detector.ts) counts; this decides. Kept
+// pure so the escalation is testable without a bus.
+//
+//   5×, 10× — a chip for the human, and, on an engine that takes a message
+//             mid-turn (capabilities.queueing), a nudge steered into the
+//             turn: the model reads it before its next call and, in
+//             practice, breaks the loop. Engines without steer get the chip.
+//   20×      — stop the turn. At that point it is only spending money.
+//
+// Per-call deadlines are deliberately absent: for CLI engines the harness
+// does not own the call, so the only honest deadline is "stop the turn",
+// and the stall watchdog already does that on silence.
+
+export const REPEAT_THRESHOLDS = [5, 10, 20] as const;
+export const REPEAT_STOP_AT = 20;
+
+export interface RepeatAction {
+  /** the chip for the human, always */
+  chip: string;
+  /** a note to steer into the running turn — only when the engine can take one */
+  steer?: string;
+  /** end the turn */
+  stop?: boolean;
+}
+
+export function repeatAction(input: { threshold: number; tool: string; args: string; canSteer: boolean }): RepeatAction {
+  const { threshold, tool, args, canSteer } = input;
+  const call = `${tool}: ${args.slice(0, 80)}${args.length > 80 ? "…" : ""}`;
+  if (threshold >= REPEAT_STOP_AT) {
+    return {
+      chip: `error: stopped — the same call repeated ${threshold}× (${call})`,
+      stop: true,
+    };
+  }
+  const chip = canSteer
+    ? `Same call repeated ${threshold}× — ${call} — nudged the bot to change approach`
+    : `Same call repeated ${threshold}× — ${call} — it may be stuck`;
+  const steer = canSteer
+    ? [
+        `OpenMausBot: you have now run the same call ${threshold} times with the same arguments (${call}).`,
+        `Stop repeating it. If it is not giving you what you need, change approach, or explain what is blocking you and ask the user.`,
+        `If it keeps repeating, the turn will be stopped at ${REPEAT_STOP_AT}.`,
+      ].join(" ")
+    : undefined;
+  return { chip, ...(steer ? { steer } : {}) };
+}

--- a/server/steer-e2e.test.ts
+++ b/server/steer-e2e.test.ts
@@ -1,0 +1,133 @@
+// Mid-turn steering, end to end: boots the real harness with the fake claude
+// CLI in `slow` mode (a gap after the tool result the way a real turn has
+// between model calls), sends a message WHILE the turn runs, and asserts
+// it is taken into the turn — 202 steered, not 409; in the transcript in
+// order and marked; folded into the reply — while an engine without a live
+// session still gets the 409 the composer queues behind.
+//
+// POSIX-gated like the other CLI e2es (the fakes are shebang scripts).
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+const FAKE_ACP = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+posixOnly("mid-turn steering e2e", () => {
+  let child: ChildProcess;
+  let home: string;
+  let stderr = "";
+
+  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json() };
+  };
+  const getBot = async (id: string) => (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === id);
+  const waitFor = async (predicate: () => Promise<boolean>, what: string, ms = 30_000) => {
+    const deadline = Date.now() + ms;
+    while (!(await predicate())) {
+      if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+
+  beforeAll(async () => {
+    chmodSync(FAKE_CLAUDE, 0o755);
+    chmodSync(FAKE_ACP, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-steer-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          claude: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "slow" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+          // no live session: a message while busy is a 409 the composer queues behind
+          acp: { driver: "grokAgent", environment: { FAKE_ACP_MODE: "hang" }, config: { cli: FAKE_ACP, fullAuto: true } },
+        },
+      }),
+    );
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: { ...(process.env.PATH ? { PATH: process.env.PATH } : {}), HOME: home, USERPROFILE: home, OMB_PORT: String(PORT) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        if ((await fetch(`${BASE}/api/health`)).ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!child || child.exitCode !== null) return resolve();
+      child.on("close", () => resolve());
+      setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
+    });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it(
+    "a message during a Claude turn is steered into it: 202, in the transcript in order and marked, folded into the reply",
+    async () => {
+      const created = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "claude", model: "claude-fake" } });
+      const instances = (await api("GET", "/api/instances")).body.instances;
+      expect(instances.find((i: any) => i.instanceId === "claude").capabilities.queueing).toBe(true);
+
+      expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first" })).status).toBe(202);
+      await waitFor(async () => (await getBot(created.id)).busy === true, "the turn to start");
+      // the fake pauses after its tool result; this lands inside that gap
+      await waitFor(async () => (await getBot(created.id)).messages.some((m: any) => m.kind === "activity"), "the tool chip");
+      const second = await api("POST", `/api/bots/${created.id}/messages`, { text: "and also this" });
+      expect(second.status).toBe(202);
+      expect(second.body.steered).toBe(true);
+
+      await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle");
+      const bot = await getBot(created.id);
+      const texts = bot.messages.filter((m: any) => m.kind === "text").map((m: any) => `${m.role}:${m.text}`);
+      // order: greeting, first, the fake's opening line, the steered message
+      // (appended when it was sent — mid-turn), then ONE reply carrying it
+      expect(texts.slice(1)).toEqual([
+        "user:first",
+        "bot:hello from fake claude",
+        "user:and also this",
+        "bot:reply to: first + steered: and also this",
+      ]);
+      const steered = bot.messages.find((m: any) => m.text === "and also this");
+      expect(steered.steered).toBe(true);
+      // one turn, not two: exactly one reply
+      expect(bot.messages.filter((m: any) => m.role === "bot" && m.kind === "text" && m.text.startsWith("reply to:"))).toHaveLength(1);
+    },
+    40_000,
+  );
+
+  it("an engine without a live session still refuses a message while busy (the composer queues it)", async () => {
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "acp", model: "fake-model" } });
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first" })).status).toBe(202);
+    await waitFor(async () => (await getBot(created.id)).busy === true, "the hung turn to start");
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "second" })).status).toBe(409);
+    await api("POST", `/api/bots/${created.id}/interrupt`);
+    await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle");
+  }, 30_000);
+});

--- a/server/store.ts
+++ b/server/store.ts
@@ -63,6 +63,10 @@ export interface Message {
   /** `setup` marks an error the user fixes by installing or configuring
    * something — the UI offers setup instead of a retry that cannot work. */
   tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
+  /** user messages sent INTO a running turn (capabilities.queueing): the
+   * model saw it mid-turn, so the transcript marks it — a reader should
+   * know the reply above it may already account for this line */
+  steered?: boolean;
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -52,18 +52,36 @@ if (argv[0] === "auth" && argv[1] === "status") {
   );
 }
 
-let stdin = "";
-process.stdin.on("data", (c) => (stdin += c));
-process.stdin.on("end", () => {
-  type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
-  let prompt: JsonValue = null;
-  try {
-    prompt = JSON.parse(stdin.split("\n").find((l) => l.trim()) ?? "null");
-  } catch {
-    /* leave null — the test will see it */
-  }
+// Line-driven, like the real CLI under --input-format stream-json: each user
+// message starts a turn; a message that arrives WHILE a turn is playing is
+// folded into it (the real CLI delivers it before the next model call — the
+// harness calls that a steer); the process stays alive with stdin open and
+// exits only when stdin ends. `slow` leaves a gap between the tool result
+// and the reply so a test can steer into it.
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+const sessionId = argAfter("--resume") ?? argAfter("--session-id") ?? "fake-session";
+const model = argAfter("--model") ?? "claude-fake";
+let dumped = false;
+let initSent = false;
+let turnRunning = false;
+let steered: string[] = [];
+const queue: JsonValue[] = [];
+let stdinEnded = false;
 
-  if (process.env.FAKE_CLAUDE_DUMP) {
+const promptText = (prompt: JsonValue): string => {
+  const m = prompt && typeof prompt === "object" && !Array.isArray(prompt) ? (prompt as { message?: { content?: unknown } }).message : undefined;
+  return typeof m?.content === "string" ? m.content : "";
+};
+
+const finishIfDone = () => {
+  if (stdinEnded && !turnRunning && queue.length === 0) process.exit(0);
+};
+
+const playTurn = (prompt: JsonValue) => {
+  turnRunning = true;
+  steered = [];
+  if (!dumped && process.env.FAKE_CLAUDE_DUMP) {
+    dumped = true;
     const configPath = argAfter("--mcp-config");
     let mcpConfig: unknown = null;
     if (configPath) {
@@ -76,15 +94,14 @@ process.stdin.on("end", () => {
     writeFileSync(process.env.FAKE_CLAUDE_DUMP, JSON.stringify({ argv, env: process.env, prompt, mcpConfig }, null, 2));
   }
 
-  const sessionId = argAfter("--resume") ?? argAfter("--session-id") ?? "fake-session";
-  const model = argAfter("--model") ?? "claude-fake";
-
   if (mode === "exit-early") {
     process.stderr.write("fake-claude: simulated crash before result\n");
     process.exit(3);
   }
 
+  // the real CLI re-announces init on every turn of a live process
   out({ type: "system", subtype: "init", session_id: sessionId, model });
+  initSent = true;
 
   if (mode === "hang") {
     // stay alive until killed — lets tests exercise interrupt + the
@@ -121,6 +138,47 @@ process.stdin.on("end", () => {
     },
   });
   out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu-1", is_error: false }] } });
-  out({ type: "result", is_error: false, stop_reason: "end_turn", total_cost_usd: 0.01 });
-  process.exit(0);
+
+  const finish = () => {
+    out({ type: "result", is_error: false, stop_reason: "end_turn", total_cost_usd: 0.01, usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 } });
+    turnRunning = false;
+    if (queue.length) playTurn(queue.shift()!);
+    else finishIfDone();
+  };
+  if (mode === "slow") {
+    // a gap a test can steer into; the closing reply carries anything that
+    // was folded in, the way the real CLI includes a mid-turn message in
+    // the same turn's next model call
+    setTimeout(() => {
+      const tail = steered.length ? ` + steered: ${steered.join(" | ")}` : "";
+      out({ type: "assistant", message: { content: [{ type: "text", text: `reply to: ${promptText(prompt)}${tail}` }] } });
+      finish();
+    }, 800);
+  } else {
+    finish();
+  }
+};
+
+let buf = "";
+process.stdin.on("data", (c) => {
+  buf += c;
+  let nl;
+  while ((nl = buf.indexOf("\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    let prompt: JsonValue = null;
+    try {
+      prompt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (turnRunning) steered.push(promptText(prompt));
+    else playTurn(prompt);
+  }
 });
+process.stdin.on("end", () => {
+  stdinEnded = true;
+  finishIfDone();
+});
+void initSent;

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -132,7 +132,7 @@ const playTurn = (prompt: JsonValue) => {
     message: {
       content: [
         { type: "text", text: "hello from fake claude" },
-        { type: "tool_use", id: "tu-1", name: "Bash" },
+        { type: "tool_use", id: "tu-1", name: "Bash", input: { command: "echo hi" } },
       ],
       usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 },
     },
@@ -145,6 +145,29 @@ const playTurn = (prompt: JsonValue) => {
     if (queue.length) playTurn(queue.shift()!);
     else finishIfDone();
   };
+
+  // a bot going in circles: the SAME call again and again inside one turn.
+  // `loop` runs 6 (past the first nudge threshold) then replies, folding any
+  // steered note in like `slow`; `loop-hard` never stops — the harness must
+  // end the turn at its ceiling (the process dies with it).
+  if (mode === "loop" || mode === "loop-hard") {
+    const n = mode === "loop" ? 6 : 1000;
+    let i = 0;
+    const tick = () => {
+      if (i++ >= n) {
+        const tail = steered.length ? ` + steered: ${steered.join(" | ")}` : "";
+        out({ type: "assistant", message: { content: [{ type: "text", text: `loop reply${tail}` }] } });
+        finish();
+        return;
+      }
+      out({ type: "assistant", message: { content: [{ type: "tool_use", id: `tu-loop-${i}`, name: "Bash", input: { command: "git status" } }] } });
+      out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: `tu-loop-${i}`, is_error: false }] } });
+      setTimeout(tick, 60);
+    };
+    setTimeout(tick, 60);
+    return;
+  }
+
   if (mode === "slow") {
     // a gap a test can steer into; the closing reply carries anything that
     // was folded in, the way the real CLI includes a mid-turn message in

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -351,6 +351,11 @@ function Bubble({
               >
                 {text}
               </div>
+              {message.steered && (
+                <div className="mt-1 text-[11px] text-ink-secondary/70" title="Sent while the bot was working — it saw this before its next step, inside the same turn.">
+                  sent mid-turn
+                </div>
+              )}
               {collapsible && (
                 <button onClick={() => setExpanded(true)} className="mt-1 text-[12.5px] text-ink-secondary hover:text-ink">
                   Show full message

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -48,6 +48,10 @@ export function Composer({
   // offers members plus @everyone; explicit mentions override the room's
   // configured default responder.
   const busy = group ? Boolean(group.busyBotId) : Boolean(bot?.busy);
+  // an engine with a live session takes a message INTO the running turn;
+  // for those the composer never locks — the server steers instead of 409
+  const canSteer =
+    !group && Boolean(bot) && state.instances.find((i) => i.instanceId === bot!.modelSelection.instanceId)?.capabilities?.queueing === true;
   // a pending approval blocks the prompt until it is answered
   const threadId = group?.threadId ?? bot?.threadId ?? "";
   // the VISIBLE branch only — an approval left on a branch you edited away
@@ -136,7 +140,7 @@ export function Composer({
   const send = () => {
     const t = composeMessage(text, attachments);
     if (!t) return;
-    if (busy) {
+    if (busy && !canSteer) {
       setQueued(t);
       setText("");
       setAttachments([]);
@@ -348,7 +352,9 @@ export function Composer({
               ? "Answer the approval above to continue"
               : recording
               ? "Listening…"
-              : busy
+              : busy && canSteer
+                ? `${busyName} is working — Enter sends this into the running turn`
+                : busy
                 ? `${busyName} is working — Enter queues your message`
                 : group
                   ? `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -49,6 +49,8 @@ export interface Message {
    * narration of the same chip ("reading a file"), used by call mode. */
   /** `setup` marks an error fixed by installing something, not by retrying. */
   tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
+  /** user messages sent into a running turn — the model saw it mid-turn */
+  steered?: boolean;
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;
@@ -216,6 +218,8 @@ export interface InstanceInfo {
     agentsMcp?: boolean;
     composioMcp?: boolean;
     effortLevels?: readonly EffortLevel[];
+    /** the engine keeps a live session and takes a message mid-turn */
+    queueing?: boolean;
   };
   /** `custom` agents sit below the rail divider — no subscription catalog. */
   access?: "subscription" | "custom";


### PR DESCRIPTION
## In plain language

**When a bot gets stuck running the same command over and over, the app now steps in instead of just telling you.**

Since #200 the app has *noticed* a bot repeating the exact same tool call (same tool, same arguments) inside one turn and dropped a chip at 5, 10 and 20 repeats — but could only watch. Now:

- *At 5 and 10 repeats, on a Claude bot:* the app **nudges the model** — a note is delivered into the running turn (using #219's steering) telling it it's repeating itself and to change approach or say what's blocking it. In practice that breaks the loop. The chip reads *"Same call repeated 5× — Bash: git status — nudged the bot to change approach."* Engines that can't be steered still get the old *"it may be stuck"* chip.
- *At 20 repeats, on any engine:* the turn is **stopped** — *"error: stopped — the same call repeated 20× (Bash: git status)"*. That's the wallet-protection ceiling: by then it's only spending money.
- *A quiet fix underneath:* Claude loops in **full-auto** were invisible before (the command only showed up when a permission card asked). The driver now reports each tool call's arguments, so counting works there too.

Nothing changes for normal turns; the app just intervenes on runaway ones. Per-call timeouts are deliberately not added — for CLI engines the app doesn't own the call, and the 20-minute silence watchdog on `main` already covers stalls.

## Changes

- **`server/repeat-policy.ts`** (pure) — `repeatAction({threshold, tool, args, canSteer})`: 5/10 → chip + `steer` note (when the engine has `queueing`); 20 → `stop`. `REPEAT_THRESHOLDS`/`REPEAT_STOP_AT` shared with the detector.
- **`server/index.ts`** — the repeat subscriber (from #200) now: keys on `item.started.args` when the driver provides it; on a threshold appends the chip, `steer()`s the note where possible, and at the ceiling settles the detector, interrupts the turn (or cancels the routine run) and finalizes any delegation watch — the same shape as the stall watchdog's stop.
- **`server/contracts.ts`** — `item.started.args?: string` (additive). **`claude.ts`** — `toolArgsSummary(tool_use.input)` fills it (command / file_path / path / url / pattern / query / prompt, else compact JSON).
- **`fake-claude-cli.ts`** — `tool_use` carries `input`; new `loop` and `loop-hard` modes.

**Stacked on #219** (needs `steer()` / `capabilities.queueing`); the diff shrinks to just this once #219 lands.

Item 3.3 of `docs/plans/agent-harness-upgrades-v2.md`.

## Test plan

- [x] `repeat-policy.test.ts` (5): nudge on a steerable engine (chip + note text incl. the ceiling), chip-only otherwise, stop at 20 regardless, long-argument clipping, thresholds
- [x] `claude.test.ts` (+1): `item.started` carries `{ title: "Bash", args: "echo hi" }`
- [x] `repeat-enforcement-e2e.test.ts` (2, real server + fake claude): a 6-repeat loop gets the 5× "nudged" chip and the reply proves the note landed *inside the same turn* (`steered: OpenMausBot: you have now run the same call 5 times…`), no stop; a never-ending loop is stopped at 20 with the error chip after exactly two nudges
- [x] `pnpm typecheck` clean; `pnpm vitest run` green (95 files, 927 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send messages during active turns on supported engines, with clear “sent mid-turn” indicators.
  * Added repeat-call safeguards that provide guidance and stop persistent loops after repeated attempts.
  * Tool activity now displays concise input details.
  * Local model listings can show detected context-window sizes.

* **Bug Fixes**
  * Improved session reuse, cleanup, error reporting, and tool-call tracking for Claude-powered turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->