### PR TITLE
fix(claude): isolate collision-test broker pipe names on Windows

### DIFF
--- a/docs/plans/2026-08-18-002-fix-windows-pipe-name-collision-in-collision-tests-plan.md
+++ b/docs/plans/2026-08-18-002-fix-windows-pipe-name-collision-in-collision-tests-plan.md
@@ -1,0 +1,114 @@
+---
+title: "Fix Windows pipe-name collision in permission broker tests - Plan"
+type: fix
+date: 2026-08-18
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# Fix Windows pipe-name collision in permission broker tests
+
+## Goal Capsule
+
+Make PR #230's four new permission-broker collision tests pass on Windows by eliminating the named-pipe name collision between them: all four tests use thread ids that truncate to the same 8-char tag, producing the same Windows pipe name, and a lingering pipe from a prior test makes the next test's broker `listen()` fail with `EADDRINUSE`. The fix gives each test a unique thread id that yields a unique tag, plus a deterministic tag-uniqueness assertion so a re-collision fails on every platform, not just on a timing-dependent Windows run. The production collision guard in `server/drivers/claude.ts` is verified sound and stays untouched. Stop condition: `pnpm exec vitest run server/drivers/claude.test.ts` passes on macOS and Ubuntu, and the Windows `typecheck + test (windows-latest)` job is green on two consecutive runs.
+
+## Product Contract
+
+### Summary
+
+The Windows CI job fails on PR #230 at exactly one test in the vitest run: `denies a colliding ask id from a second connection on the same broker`, with `Error: connect ENOENT \\.\pipe\openmausbot-perm-1892-t-perm-d`. The same job log shows the real cause: `permission broker unavailable on \\.\pipe\openmausbot-perm-1892-t-perm-d: listen EADDRINUSE: address already in use`. The broker for that test never started because the pipe name was already held by the previous collision test. All four collision tests produce the same pipe name. (The full `pnpm test` job also runs broker:test, updater, and packaged-server; those never executed in the failing run because `vitest run` exited non-zero first, so their Windows status is not evidenced by this run.)
+
+### Problem Frame
+
+`permissionSocketPath(threadId)` truncates the thread id to an 8-char tag (`server/drivers/claude.ts:192-195`). The four collision tests use thread ids `t-perm-dup-1`, `t-perm-dup-2`, `t-perm-dup-3`, `t-perm-dup-4`, which all truncate to `t-perm-d`. On Windows, `brokerSocketPath` builds `\\.\pipe\openmausbot-perm-<pid>-t-perm-d` (`server/procs.ts:114-119`).
+
+On POSIX, `createPermissionBroker` calls `unlinkSync(opts.socketPath)` before `listen()` (`server/drivers/claude.ts:208-210`), which removes the previous test's socket file, so re-listening the same name succeeds. On Windows, `unlinkSync` on a `\\.\pipe\...` path is a no-op — a named pipe is not a filesystem entry. The OS holds the pipe name briefly after the prior broker's `server.close()`, so the next test's `listen()` fails with `EADDRINUSE` and the broker never starts. The test's `connectSocket` then fails with `ENOENT` because no pipe is listening. The observed run failed only 1 of the 4 same-name tests, confirming the release window is short and the failure is timing-dependent.
+
+The pre-existing broker tests never hit this because they use distinct thread ids (`t-perm-abc`, `t-perm-stop`) with distinct tags. The production code never hits this because real thread ids are UUIDs, though the 8-char truncation is a latent collision risk there too — out of scope for this plan.
+
+### Requirements
+
+**Windows pipe-name isolation**
+
+- R1. Each of the four collision tests must use a broker pipe name unique to that test, so no test's broker `listen()` can collide with a prior test's lingering pipe.
+
+**Deterministic regression guard**
+
+- R2. A platform-independent assertion verifies the four collision tests' thread ids yield four distinct `permissionSocketPath()` values, so a future tag re-collision fails on every platform instead of surfacing only as a timing-dependent Windows failure.
+
+**Regression preservation**
+
+- R3. All four collision tests keep their exact assertions: full deny payload (`id`, `behavior: "deny"`, `message`), exactly one `request.opened` per colliding id, the original ask still resolvable, and post-resolution id reuse accepted.
+
+**Scope boundary**
+
+- R4. No production file changes: `server/drivers/claude.ts` and `server/permission-proxy.ts` are unchanged by this plan. The 8-char tag truncation in `permissionSocketPath` is not modified.
+
+**Verification**
+
+- R5. `pnpm exec vitest run server/drivers/claude.test.ts` passes on macOS and Ubuntu (33 tests declared; 32 pass and 1 is skipped — the Windows-only pipe-naming test). The Windows `typecheck + test (windows-latest)` CI job is green on two consecutive runs.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Fix the test thread ids, not the production tag logic. (session-settled: user-directed — chosen over modifying `permissionSocketPath`/`brokerSocketPath`: production behavior is correct for real UUID thread ids, and changing the tag scheme would alter production socket names and risk breaking the packaged app's pipe contract.)
+- KTD2. Give each collision test a thread id whose 8-char tag is unique. Use ids that survive truncation: `t-dup-1`, `t-dup-2`, `t-dup-3`, `t-dup-4` → tags `t-dup-1`, `t-dup-2`, `t-dup-3`, `t-dup-4`, which are unique, collide with no other thread id in the file, and match the ask ids already used in each test. Rationale: the ask ids in the tests are already `dup-1`..`dup-4`; aligning the thread id to the ask id keeps the tests readable and guarantees unique tags.
+- KTD3. No retry, no sleeps, and no workaround-style helper changes for the collision. (session-settled: user-directed — chosen over the bot's retry-with-backoff fix and over helper hardening: the log proves the failure is a pre-connect `EADDRINUSE`/`ENOENT` caused by pipe-name collision, which no connect retry or answer buffering can fix.) A dead-broker fail-fast improvement to `answerQueue` is deferred to follow-up, not part of this fix.
+- KTD4. Verification must not rely on a single green Windows run, because the failure is timing-dependent (1 of 4 same-name tests failed in the observed run). Require the deterministic tag-uniqueness assertion (R2) plus two consecutive green Windows runs before the Definition of Done is met. Rationale: a no-op change could pass a single run by timing luck; the deterministic assertion and the two-run gate remove that ambiguity.
+
+### Sources
+
+- Windows job log (admin-gated, obtained via authenticated `gh`): `permission broker unavailable on \\.\pipe\openmausbot-perm-1892-t-perm-d: listen EADDRINUSE: address already in use` followed by `Error: connect ENOENT \\.\pipe\openmausbot-perm-1892-t-perm-d` on the `denies a colliding ask id from a second connection on the same broker` test.
+- `server/drivers/claude.ts:192-195` — `permissionSocketPath` 8-char tag truncation.
+- `server/procs.ts:114-119` — Windows named-pipe name construction with `process.pid`.
+- `server/drivers/claude.ts:208-210` — `unlinkSync` before `listen()` (POSIX-only effective).
+- `server/drivers/claude.test.ts:438-561` — the four collision tests with thread ids `t-perm-dup-1..4`.
+
+## Implementation Units
+
+### U1. Give each collision test a unique pipe name and assert tag uniqueness
+
+**Goal:** No two collision tests share a broker pipe name on any platform, and any future tag re-collision fails deterministically.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** None.
+
+**Files:** `server/drivers/claude.test.ts` (thread ids in the four tests at lines 438-561; a new assertion block in the same file).
+
+**Approach:**
+1. Change the thread id in each of the four collision tests so its 8-char tag is unique: `t-perm-dup-1` → `t-dup-1`, `t-perm-dup-2` → `t-dup-2`, `t-perm-dup-3` → `t-dup-3`, `t-perm-dup-4` → `t-dup-4`.
+2. Keep the ask ids (`dup-1`..`dup-4`) unchanged; they already match the new thread id suffix, keeping the tests readable.
+3. Confirm each `permissionSocketPath("<threadId>")` call in the test body uses the new thread id consistently (conn, respondToRequest, interruptTurn).
+4. Add a small deterministic assertion in the same file (e.g. in the `ClaudeDriver.decodeConfig` describe block or a dedicated `it`): `expect(new Set(["t-dup-1", "t-dup-2", "t-dup-3", "t-dup-4"].map(permissionSocketPath)).size).toBe(4)`. This runs on every platform and fails on any future tag re-collision.
+
+**Test scenarios:**
+- All four collision tests still pass on POSIX with their exact assertions (R3) — the change is only the pipe name.
+- The new tag-uniqueness assertion passes on POSIX and Windows (R2): `permissionSocketPath("t-dup-1")` → tag `t-dup-1`, etc., all distinct.
+- Reasoning check: `t-dup-1..4` collide with no other thread id in the file (the other broker tests use `t-perm-abc`, `t-perm-stop`, `t-perm-2`; all tags distinct).
+
+**Verification:** `pnpm exec vitest run server/drivers/claude.test.ts` passes on macOS/Ubuntu; Windows CI job is green on two consecutive runs.
+
+## Verification Contract
+
+- `pnpm exec vitest run server/drivers/claude.test.ts` — 33 tests declared; on Windows, 33 pass; on macOS and Ubuntu, 32 pass and 1 is skipped (the Windows-only pipe-naming test at line 66).
+- `pnpm typecheck` — clean.
+- Full `pnpm test` on macOS (vitest + broker:test + updater + packaged-server).
+- The Windows `typecheck + test (windows-latest)` job is green on two consecutive runs. If it is not, obtain the job log (authenticated `gh api repos/milind-soni/OpenMausBot/actions/jobs/<id>/logs`) and name the failing test before any further change; do not guess a second fix.
+
+## Definition of Done
+
+- [ ] U1 landed: the four collision tests use unique thread ids/tags; no two share a pipe name.
+- [ ] The tag-uniqueness assertion (R2) is present and passes on all platforms.
+- [ ] All four collision tests retain their exact assertions and pass.
+- [ ] No production files changed (`server/drivers/claude.ts`, `server/permission-proxy.ts` clean in the diff).
+- [ ] macOS and Ubuntu: claude test file and full `pnpm test` pass; typecheck clean.
+- [ ] Windows CI job is green on two consecutive runs.
+
+## Deferred to Follow-Up
+
+- `answerQueue` error/close rejection: add `error`/`close` handlers so a dead broker rejects pending waiters with a named error instead of hanging to the 20 s vitest timeout. Not part of this fix — it was not the failure mode (the broker never started in the failing test, so no waiter was ever pending on a dead connection), and the new branches would ship without an exercising test. If added later, it needs a scenario that actually kills a broker mid-test and asserts the named rejection.
+- Windows-equivalent of the broker's POSIX-only `unlinkSync`-before-listen: the platform asymmetry is the root cause; a later hardening could retry-on-`EADDRINUSE` or otherwise release the name. Out of scope here because unique names sidestep the collision.

--- a/docs/plans/2026-08-18-002-fix-windows-pipe-name-collision-in-collision-tests-plan.md
+++ b/docs/plans/2026-08-18-002-fix-windows-pipe-name-collision-in-collision-tests-plan.md
@@ -26,7 +26,7 @@ The Windows CI job fails on PR #230 at exactly one test in the vitest run: `deni
 
 On POSIX, `createPermissionBroker` calls `unlinkSync(opts.socketPath)` before `listen()` (`server/drivers/claude.ts:208-210`), which removes the previous test's socket file, so re-listening the same name succeeds. On Windows, `unlinkSync` on a `\\.\pipe\...` path is a no-op — a named pipe is not a filesystem entry. The OS holds the pipe name briefly after the prior broker's `server.close()`, so the next test's `listen()` fails with `EADDRINUSE` and the broker never starts. The test's `connectSocket` then fails with `ENOENT` because no pipe is listening. The observed run failed only 1 of the 4 same-name tests, confirming the release window is short and the failure is timing-dependent.
 
-The pre-existing broker tests never hit this because they use distinct thread ids (`t-perm-abc`, `t-perm-stop`) with distinct tags. The production code never hits this because real thread ids are UUIDs, though the 8-char truncation is a latent collision risk there too — out of scope for this plan.
+The pre-existing broker tests never hit this because they use distinct thread ids (`t-perm-abc`, `t-perm-stop`) with distinct tags. The production code is unlikely to hit this in normal operation because real thread ids are UUIDs, though the 8-char truncation remains a latent collision risk there — out of scope for this plan.
 
 ### Requirements
 

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -85,6 +85,11 @@ describe("ClaudeDriver.decodeConfig", () => {
   it.skipIf(process.platform !== "win32")("names permission pipes per harness process", () => {
     expect(permissionSocketPath("thread-abc")).toBe(`\\\\.\\pipe\\openmausbot-perm-${process.pid}-thread-a`);
   });
+
+  it("gives each collision test a distinct broker pipe path", () => {
+    const paths = ["t-dup-1", "t-dup-2", "t-dup-3", "t-dup-4"].map(permissionSocketPath);
+    expect(new Set(paths).size).toBe(4);
+  });
 });
 
 describe("ClaudeDriver turns (fake CLI)", () => {
@@ -456,10 +461,10 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
   it("denies a colliding ask id on the same connection without orphaning the original", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-perm-dup-1", text: "go" });
+    await instance.adapter.sendTurn({ threadId: "t-dup-1", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-perm-dup-1"));
+    const conn = await connectSocket(permissionSocketPath("t-dup-1"));
     const nextAnswer = answerQueue(conn);
 
     // two asks with the same id on one connection, second sent before the
@@ -479,28 +484,28 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-1")).toHaveLength(1);
 
     // the original ask is untouched and still resolves normally
-    await expect(instance.adapter.respondToRequest("t-perm-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest("t-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
     expect(await nextAnswer()).toMatchObject({ behavior: "allow" });
 
     conn.end();
-    await instance.adapter.interruptTurn("t-perm-dup-1");
+    await instance.adapter.interruptTurn("t-dup-1");
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("denies a colliding ask id from a second connection on the same broker", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-perm-dup-2", text: "go" });
+    await instance.adapter.sendTurn({ threadId: "t-dup-2", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn1 = await connectSocket(permissionSocketPath("t-perm-dup-2"));
+    const conn1 = await connectSocket(permissionSocketPath("t-dup-2"));
     conn1.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-2");
 
     // `pending` is shared across every connection on the broker, so a
     // second connection reusing the same id must collide too
-    const conn2 = await connectSocket(permissionSocketPath("t-perm-dup-2"));
+    const conn2 = await connectSocket(permissionSocketPath("t-dup-2"));
     const conn2Answer = answerQueue(conn2)();
     conn2.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo two" } }) + "\n");
     expect(await conn2Answer).toMatchObject({
@@ -511,26 +516,26 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-2")).toHaveLength(1);
 
     // the original, opened on conn1, still resolves normally
-    await expect(instance.adapter.respondToRequest("t-perm-dup-2", "dup-2", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest("t-dup-2", "dup-2", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
     conn1.end();
     conn2.end();
-    await instance.adapter.interruptTurn("t-perm-dup-2");
+    await instance.adapter.interruptTurn("t-dup-2");
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("accepts an ask id reused after the original already resolved — not a collision", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-perm-dup-3", text: "go" });
+    await instance.adapter.sendTurn({ threadId: "t-dup-3", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-perm-dup-3"));
+    const conn = await connectSocket(permissionSocketPath("t-dup-3"));
 
     conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo one");
-    await expect(instance.adapter.respondToRequest("t-perm-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest("t-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
@@ -539,21 +544,21 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     // fresh request.opened, not the first one already seen by the recorder)
     conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo two" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo two");
-    await expect(instance.adapter.respondToRequest("t-perm-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest("t-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
     conn.end();
-    await instance.adapter.interruptTurn("t-perm-dup-3");
+    await instance.adapter.interruptTurn("t-dup-3");
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("denies a colliding ask id for question-kind asks too, without disturbing the original", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-perm-dup-4", text: "go" });
+    await instance.adapter.sendTurn({ threadId: "t-dup-4", text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-perm-dup-4"));
+    const conn = await connectSocket(permissionSocketPath("t-dup-4"));
     const nextAnswer = answerQueue(conn);
 
     conn.write(JSON.stringify({ t: "ask", id: "dup-4", kind: "question", tool: "ask_user", input: { question: "one?" } }) + "\n");
@@ -570,12 +575,12 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     // the original question is untouched and still resolves normally
     await expect(
-      instance.adapter.respondToRequest("t-perm-dup-4", "dup-4", { behavior: "answer", message: "yes" }),
+      instance.adapter.respondToRequest("t-dup-4", "dup-4", { behavior: "answer", message: "yes" }),
     ).resolves.toBe("answered");
     expect(await nextAnswer()).toMatchObject({ behavior: "answer" });
 
     conn.end();
-    await instance.adapter.interruptTurn("t-perm-dup-4");
+    await instance.adapter.interruptTurn("t-dup-4");
     await recorder.until((e) => e.type === "turn.completed");
   });
 

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -21,6 +21,10 @@ import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
 
+/** Thread ids for the four ask-id-collision tests. Each must truncate to a
+ * unique 8-char tag so no two tests share a broker socket/pipe name. */
+const COLLISION_THREAD_IDS = ["t-dup-1", "t-dup-2", "t-dup-3", "t-dup-4"];
+
 /** Connect to a broker socket and resolve once the connection is live. */
 function connectSocket(path: string): Promise<Socket> {
   return new Promise((resolve, reject) => {
@@ -87,8 +91,8 @@ describe("ClaudeDriver.decodeConfig", () => {
   });
 
   it("gives each collision test a distinct broker pipe path", () => {
-    const paths = ["t-dup-1", "t-dup-2", "t-dup-3", "t-dup-4"].map(permissionSocketPath);
-    expect(new Set(paths).size).toBe(4);
+    const paths = COLLISION_THREAD_IDS.map(permissionSocketPath);
+    expect(new Set(paths).size).toBe(COLLISION_THREAD_IDS.length);
   });
 });
 
@@ -461,10 +465,10 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
   it("denies a colliding ask id on the same connection without orphaning the original", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-dup-1", text: "go" });
+    await instance.adapter.sendTurn({ threadId: COLLISION_THREAD_IDS[0], text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-dup-1"));
+    const conn = await connectSocket(permissionSocketPath(COLLISION_THREAD_IDS[0]));
     const nextAnswer = answerQueue(conn);
 
     // two asks with the same id on one connection, second sent before the
@@ -484,28 +488,28 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-1")).toHaveLength(1);
 
     // the original ask is untouched and still resolves normally
-    await expect(instance.adapter.respondToRequest("t-dup-1", "dup-1", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest(COLLISION_THREAD_IDS[0], "dup-1", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
     expect(await nextAnswer()).toMatchObject({ behavior: "allow" });
 
     conn.end();
-    await instance.adapter.interruptTurn("t-dup-1");
+    await instance.adapter.interruptTurn(COLLISION_THREAD_IDS[0]);
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("denies a colliding ask id from a second connection on the same broker", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-dup-2", text: "go" });
+    await instance.adapter.sendTurn({ threadId: COLLISION_THREAD_IDS[1], text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn1 = await connectSocket(permissionSocketPath("t-dup-2"));
+    const conn1 = await connectSocket(permissionSocketPath(COLLISION_THREAD_IDS[1]));
     conn1.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-2");
 
     // `pending` is shared across every connection on the broker, so a
     // second connection reusing the same id must collide too
-    const conn2 = await connectSocket(permissionSocketPath("t-dup-2"));
+    const conn2 = await connectSocket(permissionSocketPath(COLLISION_THREAD_IDS[1]));
     const conn2Answer = answerQueue(conn2)();
     conn2.write(JSON.stringify({ t: "ask", id: "dup-2", tool: "Bash", input: { command: "echo two" } }) + "\n");
     expect(await conn2Answer).toMatchObject({
@@ -516,26 +520,26 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.filter((e) => e.type === "request.opened" && e.requestId === "dup-2")).toHaveLength(1);
 
     // the original, opened on conn1, still resolves normally
-    await expect(instance.adapter.respondToRequest("t-dup-2", "dup-2", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest(COLLISION_THREAD_IDS[1], "dup-2", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
     conn1.end();
     conn2.end();
-    await instance.adapter.interruptTurn("t-dup-2");
+    await instance.adapter.interruptTurn(COLLISION_THREAD_IDS[1]);
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("accepts an ask id reused after the original already resolved — not a collision", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-dup-3", text: "go" });
+    await instance.adapter.sendTurn({ threadId: COLLISION_THREAD_IDS[2], text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-dup-3"));
+    const conn = await connectSocket(permissionSocketPath(COLLISION_THREAD_IDS[2]));
 
     conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo one" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo one");
-    await expect(instance.adapter.respondToRequest("t-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest(COLLISION_THREAD_IDS[2], "dup-3", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
@@ -544,21 +548,21 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     // fresh request.opened, not the first one already seen by the recorder)
     conn.write(JSON.stringify({ t: "ask", id: "dup-3", tool: "Bash", input: { command: "echo two" } }) + "\n");
     await recorder.until((e) => e.type === "request.opened" && e.requestId === "dup-3" && e.summary === "echo two");
-    await expect(instance.adapter.respondToRequest("t-dup-3", "dup-3", { behavior: "allow" })).resolves.toBe(
+    await expect(instance.adapter.respondToRequest(COLLISION_THREAD_IDS[2], "dup-3", { behavior: "allow" })).resolves.toBe(
       "allowed-once",
     );
 
     conn.end();
-    await instance.adapter.interruptTurn("t-dup-3");
+    await instance.adapter.interruptTurn(COLLISION_THREAD_IDS[2]);
     await recorder.until((e) => e.type === "turn.completed");
   });
 
   it("denies a colliding ask id for question-kind asks too, without disturbing the original", async () => {
     await create("hang");
-    await instance.adapter.sendTurn({ threadId: "t-dup-4", text: "go" });
+    await instance.adapter.sendTurn({ threadId: COLLISION_THREAD_IDS[3], text: "go" });
     await recorder.until((e) => e.type === "session.started");
 
-    const conn = await connectSocket(permissionSocketPath("t-dup-4"));
+    const conn = await connectSocket(permissionSocketPath(COLLISION_THREAD_IDS[3]));
     const nextAnswer = answerQueue(conn);
 
     conn.write(JSON.stringify({ t: "ask", id: "dup-4", kind: "question", tool: "ask_user", input: { question: "one?" } }) + "\n");
@@ -575,12 +579,12 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     // the original question is untouched and still resolves normally
     await expect(
-      instance.adapter.respondToRequest("t-dup-4", "dup-4", { behavior: "answer", message: "yes" }),
+      instance.adapter.respondToRequest(COLLISION_THREAD_IDS[3], "dup-4", { behavior: "answer", message: "yes" }),
     ).resolves.toBe("answered");
     expect(await nextAnswer()).toMatchObject({ behavior: "answer" });
 
     conn.end();
-    await instance.adapter.interruptTurn("t-dup-4");
+    await instance.adapter.interruptTurn(COLLISION_THREAD_IDS[3]);
     await recorder.until((e) => e.type === "turn.completed");
   });
 


### PR DESCRIPTION
## What changed

The four ask-id-collision tests used thread ids `t-perm-dup-1..4`, which all truncate to the same 8-char tag (`t-perm-d`) in `permissionSocketPath()`. On Windows that gave every test the same named pipe (`\\.\pipe\openmausbot-perm-<pid>-t-perm-d`), so a pipe still held by a prior test made the next broker's `listen()` fail with `EADDRINUSE` — surfacing as `connect ENOENT` in the cross-connection test.

The thread ids are renamed to `t-dup-1..4` (each truncates to a unique tag), and a platform-independent assertion verifies the four ids yield distinct `permissionSocketPath()` values, so a future tag re-collision fails on every platform instead of as a timing-dependent Windows flake. The tests and assertion read from one `COLLISION_THREAD_IDS` constant so they cannot drift apart.

## Why

The `typecheck + test (windows-latest)` CI job failed on PR #230 at `denies a colliding ask id from a second connection on the same broker` with `connect ENOENT`. The job log shows the real cause: `permission broker unavailable ... listen EADDRINUSE: address already in use`. On POSIX `unlinkSync` before `listen()` clears the old socket file, so the collision never fired; on Windows a named pipe is not a filesystem entry, so the OS-held pipe name from the prior test blocked the next broker. The pre-existing broker tests never hit this because their thread ids truncate to distinct tags.

## How it was verified

- `pnpm exec vitest run server/drivers/claude.test.ts` — 33 tests, 32 pass + 1 skip (the Windows-only pipe-naming test) on macOS.
- `pnpm typecheck` — clean.
- Full `pnpm test` on macOS — vitest, broker:test, updater, and packaged-server all pass.
- Windows CI re-run is the remaining gate; the deterministic tag-uniqueness assertion makes the fix platform-verifiable regardless.

## Screenshots (UI changes)

N/A — backend test change only.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permission-broker collision testing on Windows by ensuring test identifiers remain unique after path truncation.
  - Preserved existing permission collision, reuse, and question-asking behavior while preventing test interference.

- **Tests**
  - Added platform-independent checks confirming broker paths remain distinct.
  - Expanded validation guidance across macOS, Ubuntu, and repeated Windows test runs.

- **Documentation**
  - Added an implementation plan covering the Windows collision-test fix and validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->