### PR TITLE
Keep the companion alive: autostart, dev entry, network-change re-advertise, open health

### DIFF
--- a/companion/src/advertise-watch.ts
+++ b/companion/src/advertise-watch.ts
@@ -1,0 +1,102 @@
+// Keeps the Bonjour record in step with the network this machine is on.
+//
+// Advertising used to happen once, at startup, and that failed in both
+// directions: a laptop opened before wifi associates has no addresses yet, so
+// `advertise` returned false and the sidecar silently never advertised; and a
+// DHCP move or network change left the A records pointing at addresses the
+// machine no longer holds, so the phone found a computer it could not reach.
+// Either way `discovery.advertising` told the panel a story that had stopped
+// being true.
+//
+// The cure is a watcher, not an event: Node has no portable "interfaces
+// changed" signal, and a poll every few seconds against the interface table
+// costs nothing. Only the *set* of addresses matters — a tick that sees the
+// same set does nothing, so re-announcing (which resets caches network-wide)
+// happens exactly on transitions.
+
+/** What the watcher needs: the current addresses, and the two moves it can
+ * make. It never touches a socket itself, which is what makes it testable. */
+export interface AddressWatchOptions {
+  /** The addresses worth advertising right now. */
+  addresses: () => string[];
+  /** Rebuild and announce the service record from the current addresses.
+   * Resolves false when the responder could not start (port 5353 busy,
+   * multicast off) — a condition, never an error. */
+  advertise: () => Promise<boolean>;
+  /** Withdraw the record and close the responder, so caches forget us rather
+   * than pointing phones at addresses we no longer hold. */
+  withdraw: () => Promise<void>;
+  log?: (line: string) => void;
+}
+
+export interface AddressWatcher {
+  /** One comparison of the address set against what was last acted on,
+   * re-advertising or withdrawing on a change. Exposed for the first run and
+   * for tests; the interval calls the same code. */
+  check: () => Promise<void>;
+  start: (intervalMs?: number) => void;
+  stop: () => void;
+}
+
+/** How often the interface table is consulted. Reading it is a syscall, not
+ * a packet — nothing goes on the wire unless something changed. */
+const DEFAULT_INTERVAL_MS = 5000;
+
+export function createAddressWatcher(options: AddressWatchOptions): AddressWatcher {
+  // The set last *acted on*, as a canonical key. `null` means "never", which
+  // is distinct from "empty": the first check must act — and say so — even on
+  // a machine with no network yet, because silence there was the original bug.
+  let known: string | null = null;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let inflight = false;
+
+  const check = async (): Promise<void> => {
+    // `advertise` withdraws and rebinds a socket; a tick that lands while one
+    // is still doing that must not start a second. The skipped tick loses
+    // nothing — the next one sees the same table and acts then.
+    if (inflight) return;
+    const current = [...options.addresses()].sort();
+    const key = current.join(",");
+    if (key === known) return;
+    inflight = true;
+    try {
+      if (current.length === 0) {
+        options.log?.("no LAN addresses — advertising paused until a network appears");
+        await options.withdraw();
+      } else {
+        const ok = await options.advertise();
+        options.log?.(
+          ok
+            ? `advertising on ${current.join(", ")}`
+            : "could not advertise — pairing by typed address still works",
+        );
+      }
+      // Recorded even when advertising failed: the failure is tied to this
+      // network state (port 5353 taken, multicast off), so retrying every
+      // five seconds would log the same sentence forever. The next *change*
+      // tries again, which is also what heals a responder freed later.
+      known = key;
+    } catch (error) {
+      // An advertise that throws (a malformed record) is logged and not
+      // recorded, so it does not read as "advertising" to anyone — but the
+      // watcher itself must survive it, or one bad tick ends discovery.
+      options.log?.(`advertise failed: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      inflight = false;
+    }
+  };
+
+  return {
+    check,
+    start: (intervalMs = DEFAULT_INTERVAL_MS) => {
+      if (timer) return;
+      timer = setInterval(() => void check(), intervalMs);
+      // discovery upkeep must never be what keeps the process alive
+      timer.unref?.();
+    },
+    stop: () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+  };
+}

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -19,6 +19,7 @@
 // off switch, and it is a more honest one than a flag in a file.
 import { createServer } from "node:http";
 
+import { createAddressWatcher } from "./advertise-watch.ts";
 import { createControlServer } from "./control.ts";
 import { DeviceRegistry } from "./devices.ts";
 import { lanAddresses, refreshTailnetName, tailnetName, tailscaleAddress } from "./listener.ts";
@@ -97,6 +98,17 @@ async function refreshMachineName(): Promise<void> {
 
 const devices = new DeviceRegistry();
 const mdns = new MdnsResponder();
+
+/** Keeps the Bonjour record matching the interface table: advertise when a
+ * network appears, re-advertise when DHCP moves us, withdraw when it goes —
+ * so `mdns.advertising` stays a true statement rather than a boot-time one. */
+const watcher = createAddressWatcher({
+  addresses: advertisableAddresses,
+  // service() reads the current addresses, so a re-advertise carries them
+  advertise: () => mdns.advertise(service()),
+  withdraw: () => mdns.stop(),
+  log: (line) => console.log(`bonjour: ${line}`),
+});
 
 /** This machine as a Bonjour record: one DNS label, the device port, and the
  * addresses a phone could reach it on. */
@@ -207,9 +219,13 @@ async function main(): Promise<void> {
   // another responder, multicast off, a guest network that isolates its
   // clients. Pairing by typed address still works, and the control page says
   // so rather than pretending the list will fill in.
-  await mdns.advertise(service()).catch((error: unknown) => {
-    console.warn(`bonjour unavailable: ${error instanceof Error ? error.message : String(error)}`);
-  });
+  //
+  // Through the watcher rather than a single advertise: a laptop opened
+  // before wifi associates has no addresses yet, and addresses change under
+  // a running sidecar. The first check advertises (or says why not), and the
+  // interval re-advertises on every change after that.
+  await watcher.check();
+  watcher.start();
 
   const addresses = lanAddresses();
   const tailscale = tailscaleAddress(addresses);
@@ -230,6 +246,9 @@ async function main(): Promise<void> {
  * is the off switch, so it has to actually stop. */
 const shutdown = async (signal: string): Promise<void> => {
   console.log(`\n${signal} — stopping`);
+  // the watcher first, or a tick could re-advertise the record the next
+  // line just withdrew
+  watcher.stop();
   await mdns.stop().catch(() => {});
   // close() waits for open connections, and an SSE stream never ends on its
   // own — drop the sockets so "stop" means stopped, now.

--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -51,9 +51,6 @@ export function isCloudDesktopJoin(method: string, path: string): boolean {
  * fails to match and is denied rather than forwarded — the failure mode of
  * a strict pattern is a closed door, which is the one to have. */
 const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
-  // liveness — not used by the app, but it is the first thing anyone curls
-  // when pairing will not work, and it discloses nothing
-  { method: "GET", path: /^\/api\/health$/ },
   // configured-or-not booleans. The write side is refused below: reading
   // which providers are set up is not reading their keys.
   { method: "GET", path: /^\/api\/config$/ },
@@ -126,6 +123,11 @@ const EXPLAINED: ReadonlyArray<{ path: RegExp; error: string }> = [
 export function denyReason({ path, method, authenticated }: RouteRequest): Denial | null {
   // Pairing is the one thing a device does before it has a credential.
   if (method === "POST" && path === "/api/pair") return null;
+  // Liveness is the other: it exists to be the first thing anyone curls when
+  // pairing will not work, and behind the token check it answered 401 to
+  // exactly the person it was for — which reads as "broken" rather than
+  // "unpaired". It discloses nothing a port scan would not.
+  if (method === "GET" && path === "/api/health") return null;
 
   if (!authenticated) {
     return { status: 401, error: "pair this device from the OpenMausBot companion on your computer" };

--- a/companion/test/advertise-watch.test.ts
+++ b/companion/test/advertise-watch.test.ts
@@ -1,0 +1,141 @@
+// The re-advertise contract. What matters is *when* the watcher moves — on a
+// change to the address set and never otherwise — because every advertise is
+// a socket rebind plus a network-wide announcement, and every missed one is a
+// phone holding stale A records. No sockets here: the watcher takes its
+// addresses and its two moves as functions, and these tests hand it fakes.
+import { describe, expect, it } from "vitest";
+
+import { createAddressWatcher, type AddressWatchOptions } from "../src/advertise-watch.ts";
+
+function rig(initial: string[], overrides: Partial<AddressWatchOptions> = {}) {
+  let addresses = initial;
+  const calls: string[] = [];
+  const logs: string[] = [];
+  const watcher = createAddressWatcher({
+    addresses: () => addresses,
+    advertise: async () => {
+      calls.push(`advertise ${[...addresses].sort().join(",")}`);
+      return true;
+    },
+    withdraw: async () => {
+      calls.push("withdraw");
+    },
+    log: (line) => logs.push(line),
+    ...overrides,
+  });
+  return {
+    watcher,
+    calls,
+    logs,
+    set: (next: string[]) => {
+      addresses = next;
+    },
+  };
+}
+
+describe("address watcher", () => {
+  it("advertises when the network appears after startup", async () => {
+    const { watcher, calls, logs, set } = rig([]);
+    await watcher.check();
+    // The original bug was silence here: no addresses meant no advertise and
+    // no record of why. The first check must say so out loud.
+    expect(calls).toEqual(["withdraw"]);
+    expect(logs.join("\n")).toMatch(/no LAN addresses/);
+
+    set(["192.168.1.42"]);
+    await watcher.check();
+    expect(calls).toEqual(["withdraw", "advertise 192.168.1.42"]);
+  });
+
+  it("does nothing while the address set holds still", async () => {
+    const { watcher, calls } = rig(["192.168.1.42"]);
+    await watcher.check();
+    await watcher.check();
+    await watcher.check();
+    expect(calls).toEqual(["advertise 192.168.1.42"]);
+  });
+
+  it("re-advertises when DHCP moves the machine", async () => {
+    const { watcher, calls, set } = rig(["192.168.1.42"]);
+    await watcher.check();
+    set(["10.0.0.7"]);
+    await watcher.check();
+    expect(calls).toEqual(["advertise 192.168.1.42", "advertise 10.0.0.7"]);
+  });
+
+  it("treats a reordered address list as unchanged", async () => {
+    const { watcher, calls, set } = rig(["10.0.0.7", "192.168.1.42"]);
+    await watcher.check();
+    set(["192.168.1.42", "10.0.0.7"]);
+    await watcher.check();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("withdraws when the last address disappears, and comes back with it", async () => {
+    const { watcher, calls, set } = rig(["192.168.1.42"]);
+    await watcher.check();
+    set([]);
+    await watcher.check();
+    // withdrawn, not left rotting in caches pointing at a dead address
+    expect(calls).toEqual(["advertise 192.168.1.42", "withdraw"]);
+    set(["192.168.1.42"]);
+    await watcher.check();
+    expect(calls).toEqual(["advertise 192.168.1.42", "withdraw", "advertise 192.168.1.42"]);
+  });
+
+  it("does not retry a failed advertise until the network changes", async () => {
+    const { watcher, calls, logs, set } = rig(["192.168.1.42"], {
+      advertise: async () => {
+        calls.push("advertise");
+        return false;
+      },
+    });
+    await watcher.check();
+    await watcher.check();
+    // Port 5353 busy is tied to this network state — one attempt per state,
+    // or the log repeats the same sentence every five seconds forever.
+    expect(calls).toEqual(["advertise"]);
+    expect(logs.join("\n")).toMatch(/could not advertise/);
+    set(["10.0.0.7"]);
+    await watcher.check();
+    expect(calls).toEqual(["advertise", "advertise"]);
+  });
+
+  it("survives an advertise that throws, and tries again next tick", async () => {
+    let attempts = 0;
+    const { watcher, calls, logs } = rig(["192.168.1.42"], {
+      advertise: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("label longer than 63 bytes");
+        calls.push("advertise");
+        return true;
+      },
+    });
+    await watcher.check();
+    expect(logs.join("\n")).toMatch(/label longer than 63 bytes/);
+    // a throw is not recorded as acted-on, so the same set is retried
+    await watcher.check();
+    expect(calls).toEqual(["advertise"]);
+  });
+
+  it("never overlaps a check with one still in flight", async () => {
+    let release = (): void => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let advertises = 0;
+    const { watcher } = rig(["192.168.1.42"], {
+      advertise: async () => {
+        advertises += 1;
+        await gate;
+        return true;
+      },
+    });
+    const first = watcher.check();
+    // lands while the first advertise is mid-rebind; must not fork a second
+    const second = watcher.check();
+    release();
+    await Promise.all([first, second]);
+    expect(advertises).toBe(1);
+  });
+});

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -18,7 +18,13 @@ describe("credentials", () => {
   it("lets an unpaired device pair, and do nothing else", () => {
     expect(ask("POST", "/api/pair", false)).toBeNull();
     expect(ask("GET", "/api/bots", false)?.status).toBe(401);
-    expect(ask("GET", "/api/health", false)?.status).toBe(401);
+  });
+
+  it("lets anyone curl liveness — it is the unauthenticated smoke test", () => {
+    expect(ask("GET", "/api/health", false)).toBeNull();
+    // the bypass is one method on one path, not a family
+    expect(ask("POST", "/api/health", false)?.status).toBe(401);
+    expect(ask("GET", "/api/healthz", false)?.status).toBe(401);
   });
 });
 

--- a/electron/companion-entry.mjs
+++ b/electron/companion-entry.mjs
@@ -1,0 +1,27 @@
+// Which file the companion sidecar is forked from, and with which Node flags.
+//
+// Pure on purpose: companion.mjs imports Electron and so cannot be loaded by
+// the test runner, and the packaged/built/source ladder below is exactly the
+// kind of decision that breaks silently — dev worked because someone had run
+// `pnpm build:companion` months ago, packaged worked because CI stages the
+// resources, and the one machine with neither got a toggle that lied.
+import path from "node:path";
+
+/** Where to fork the sidecar from, or null when nothing runnable exists.
+ *
+ * Packaged, only the staged resource counts — a packaged app has no sources.
+ * In dev the compiled output is preferred when someone has built it (it is
+ * what ships, so running it catches packaging drift), and the TypeScript
+ * source is the fallback, run the same way the `companion` script in
+ * package.json runs it: Node's own type stripping, no build step required.
+ * `execArgv` travels with the entry because the two are one decision — the
+ * source entry without the flag is a SyntaxError at fork. */
+export function resolveCompanionEntry({ isPackaged, resourcesPath, appPath, exists }) {
+  const packaged = path.join(resourcesPath, "companion", "index.js");
+  if (isPackaged) return exists(packaged) ? { entry: packaged, execArgv: [] } : null;
+  const built = path.join(appPath, "dist-companion", "index.js");
+  if (exists(built)) return { entry: built, execArgv: [] };
+  const source = path.join(appPath, "companion", "src", "index.ts");
+  if (exists(source)) return { entry: source, execArgv: ["--experimental-strip-types"] };
+  return null;
+}

--- a/electron/companion-entry.test.mjs
+++ b/electron/companion-entry.test.mjs
@@ -1,0 +1,44 @@
+// The packaged/built/source ladder for the sidecar's entry point. The case
+// that used to be missing is the third rung: a dev checkout where nobody has
+// run `pnpm build:companion`, which is most dev checkouts.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolveCompanionEntry } from "./companion-entry.mjs";
+
+const RESOURCES = path.join("/tmp", "resources");
+const APP = path.join("/tmp", "app");
+const PACKAGED = path.join(RESOURCES, "companion", "index.js");
+const BUILT = path.join(APP, "dist-companion", "index.js");
+const SOURCE = path.join(APP, "companion", "src", "index.ts");
+
+const resolve = (isPackaged, present) =>
+  resolveCompanionEntry({
+    isPackaged,
+    resourcesPath: RESOURCES,
+    appPath: APP,
+    exists: (candidate) => present.includes(candidate),
+  });
+
+describe("companion entry resolution", () => {
+  it("packaged: only the staged resource counts", () => {
+    expect(resolve(true, [PACKAGED, BUILT, SOURCE])).toEqual({ entry: PACKAGED, execArgv: [] });
+    // sources exist on a dev machine running a packaged build; they are not runnable resources
+    expect(resolve(true, [BUILT, SOURCE])).toBeNull();
+  });
+
+  it("dev: prefers the compiled output when someone has built it", () => {
+    expect(resolve(false, [BUILT, SOURCE])).toEqual({ entry: BUILT, execArgv: [] });
+  });
+
+  it("dev: falls back to the TypeScript source, with type stripping", () => {
+    expect(resolve(false, [SOURCE])).toEqual({
+      entry: SOURCE,
+      execArgv: ["--experimental-strip-types"],
+    });
+  });
+
+  it("dev: a checkout with neither is a null, not a spawn error", () => {
+    expect(resolve(false, [])).toBeNull();
+  });
+});

--- a/electron/companion.mjs
+++ b/electron/companion.mjs
@@ -13,6 +13,7 @@
 import { app, utilityProcess } from "electron";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveCompanionEntry } from "./companion-entry.mjs";
 
 // Passed to the fork rather than left to the sidecar's own defaults, so the
 // port this file fetches the control API on cannot drift from the port the
@@ -25,19 +26,62 @@ const COMPANION_PORT = 8810;
 let proc = null;
 let lastError = null;
 
-/** Where the sidecar's compiled entry lives.
+/** Where the sidecar's entry lives, and the Node flags it needs.
  *
- * Packaged, it is staged into resources alongside the harness. In dev there
- * is no such directory, so it comes from dist-companion — which means
- * `pnpm build:companion` has to have been run at least once. Returning null
- * rather than a path that does not exist is what lets the toggle say so
- * instead of failing with a spawn error nobody can read. */
-const entryPoint = (resourcesPath) => {
-  const packaged = path.join(resourcesPath, "companion", "index.js");
-  if (app.isPackaged) return fs.existsSync(packaged) ? packaged : null;
-  const built = path.join(app.getAppPath(), "dist-companion", "index.js");
-  return fs.existsSync(built) ? built : null;
-};
+ * Packaged, it is staged into resources alongside the harness. In dev the
+ * compiled dist-companion output is preferred when it exists, and the
+ * TypeScript source is the fallback — run with type stripping, exactly as
+ * the `companion` script runs it — so the toggle works without a build step
+ * nobody remembers. Returning null rather than a path that does not exist is
+ * what lets the toggle say so instead of failing with a spawn error nobody
+ * can read. */
+const entryPoint = (resourcesPath) =>
+  resolveCompanionEntry({
+    isPackaged: app.isPackaged,
+    resourcesPath,
+    appPath: app.getAppPath(),
+    exists: fs.existsSync,
+  });
+
+// ── the remembered toggle ────────────────────────────────────────────────
+// The Settings toggle used to be the only thing that ever started the
+// sidecar, so a paired phone died with every relaunch of the app: port 8810
+// stayed closed until the user rediscovered the switch. The position of the
+// toggle is state worth keeping, and it lives in the app's own userData —
+// like cua-connection.json — because the app owns the toggle. Not in the
+// sidecar's ~/.openmausbot-companion, which is the child process's directory,
+// and not in the harness's config.json, which is somebody else's data layout.
+
+const settingsFile = () => path.join(app.getPath("userData"), "companion-settings.json");
+
+/** Whether the user left the companion on. Anything unreadable is "off" —
+ * the flag opens a network listener, so it fails closed. */
+export function companionEnabledAtRest() {
+  try {
+    return JSON.parse(fs.readFileSync(settingsFile(), "utf8"))?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Remember the toggle's position. Written via temp-and-rename so a crash
+ * mid-write cannot leave a truncated file; a failed write costs auto-start
+ * on the next launch, never the toggle itself. */
+export function rememberCompanionEnabled(enabled) {
+  const file = settingsFile();
+  const temporary = `${file}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(temporary, JSON.stringify({ enabled }, null, 2));
+    fs.renameSync(temporary, file);
+  } catch {
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      /* never created, or already renamed */
+    }
+  }
+}
 
 /** Ask the sidecar's own control server, which is the same API the standalone
  * page uses. Short timeout: this is loopback, and a spinner in Settings that
@@ -94,22 +138,28 @@ export function stopCompanion() {
 async function start({ resourcesPath, harnessPort, log }) {
   if (proc) return companionState();
   lastError = null;
-  const entry = entryPoint(resourcesPath);
-  if (!entry) {
+  const resolved = entryPoint(resourcesPath);
+  if (!resolved) {
+    // In dev this now means even companion/src is gone — a broken checkout,
+    // not a missing build step, so the old "run pnpm build:companion" advice
+    // would send someone to a command that cannot help.
     lastError = app.isPackaged
       ? "the companion is missing from this build"
-      : "run `pnpm build:companion` once, then try again";
+      : "the companion sources are missing from this checkout";
     return companionState();
   }
-  log?.(`companion fork ${entry}`);
+  log?.(`companion fork ${resolved.entry}`);
 
-  const child = utilityProcess.fork(entry, [], {
+  const child = utilityProcess.fork(resolved.entry, [], {
     env: {
       ...process.env,
       OMB_PORT: String(harnessPort),
       OMB_COMPANION_PORT: String(COMPANION_PORT),
       OMB_CONTROL_PORT: String(CONTROL_PORT),
     },
+    // how the TS-source fallback gets --experimental-strip-types; empty for
+    // compiled entries
+    execArgv: resolved.execArgv,
     stdio: ["ignore", "pipe", "pipe"],
   });
   child.stdout?.on("data", (d) => log?.(`[companion] ${String(d).trimEnd()}`));

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -149,10 +149,12 @@ async function ensureManagedComposioCredentials() {
 const LOG_DIR = app.getPath("logs");
 let logStream = null;
 import {
+  companionEnabledAtRest,
   companionPairing,
   companionCloudDesktopAccess,
   companionRevoke,
   companionState,
+  rememberCompanionEnabled,
   startCompanion,
   stopCompanion,
 } from "./companion.mjs";
@@ -441,10 +443,22 @@ ipcMain.handle("speech:finish", () => {
 // on and off, look at it, open or cancel a pairing window, and remove a
 // device. It cannot reach the sidecar's control port itself.
 ipcMain.handle("companion:state", () => companionState());
-ipcMain.handle("companion:start", () =>
-  startCompanion({ resourcesPath: process.resourcesPath, harnessPort: SERVER_PORT, log: slog }),
-);
-ipcMain.handle("companion:stop", () => stopCompanion());
+ipcMain.handle("companion:start", async () => {
+  const state = await startCompanion({
+    resourcesPath: process.resourcesPath,
+    harnessPort: SERVER_PORT,
+    log: slog,
+  });
+  // Remember only a start that worked: persisting the intent behind a failed
+  // one would greet every launch with the same error for a toggle the panel
+  // showed as off.
+  if (state.enabled && !state.error) rememberCompanionEnabled(true);
+  return state;
+});
+ipcMain.handle("companion:stop", () => {
+  rememberCompanionEnabled(false);
+  return stopCompanion();
+});
 ipcMain.handle("companion:pairing", (_event, open) => companionPairing(Boolean(open)));
 ipcMain.handle("companion:cloud-desktop", (_event, deviceId, allowed) =>
   companionCloudDesktopAccess(deviceId, Boolean(allowed)),
@@ -521,6 +535,14 @@ app.whenReady().then(async () => {
         })
       : Promise.resolve({ mode: "unavailable", reason: "unsupported-platform" });
   if (app.isPackaged) serverReady = await startServerPackaged();
+  // The companion the user left on comes back without anyone finding the
+  // toggle again — one attempt, after the harness port is settled, with the
+  // exact options the IPC handler uses. A failure surfaces in companionState
+  // (the panel shows the error) rather than retrying; and it never delays
+  // the window.
+  if (serverReady && companionEnabledAtRest()) {
+    void startCompanion({ resourcesPath: process.resourcesPath, harnessPort: SERVER_PORT, log: slog });
+  }
   const win = createWindow();
   // in-app auto-update (packaged only) — checks GitHub releases, downloads on
   // the user's click, installs on "Restart to update"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch": "vitest",
     "test:cua": "pnpm build:cua && node scripts/smoke-cua.mjs",
     "test:cua-container": "node scripts/smoke-cua-container.mjs",
-    "check:electron": "node --check electron/main.mjs && node --check electron/companion.mjs && node --check electron/terminal-launch.mjs && node --check electron/preload.cjs && node --check electron/capabilities.cjs && node --check electron/cua-connection.cjs && node --check electron/cua.mjs && node --check electron/speech.mjs",
+    "check:electron": "node --check electron/main.mjs && node --check electron/companion.mjs && node --check electron/companion-entry.mjs && node --check electron/terminal-launch.mjs && node --check electron/preload.cjs && node --check electron/capabilities.cjs && node --check electron/cua-connection.cjs && node --check electron/cua.mjs && node --check electron/speech.mjs",
     "preview": "vite preview",
     "build:server": "tsc -p tsconfig.server.build.json && node scripts/bundle-server.mjs",
     "build:companion": "tsc -p tsconfig.companion.build.json",


### PR DESCRIPTION
## In plain terms

The companion sidecar had lifecycle holes that made the phone unable to connect with no explanation: it never survived a Mac restart, never started in dev without an undocumented build step, went silently invisible when it started before wifi associated (or when the network changed), and its documented smoke-test endpoint required auth.

## Fixes

- **Survives restarts.** The toggle's position persists in `<userData>/companion-settings.json` (temp-then-rename; unreadable = off — the flag opens a network listener, so it fails closed). On app ready, one non-blocking start attempt with the exact options the toggle uses. Only a start that *worked* is remembered — persisting a failed start's intent would greet every launch with the same error for a toggle shown as off. Stop always clears it.
- **Dev just works.** Entry resolution extracted into a pure, tested ladder: packaged resource → `dist-companion/index.js` → `companion/src/index.ts` with `--experimental-strip-types` (same as the `companion` script). Smoke-verified the TS-source path boots and answers `/state`.
- **Advertising follows the network.** A 5s address watcher (unref'd, transition-driven): empty→nonempty advertises, any change re-advertises, nonempty→empty withdraws so caches forget stale A records. In-flight guard against overlapping rebinds; a `false` advertise (5353 busy) waits for the next network change instead of log-spamming. `discovery.advertising` is a live getter, so the desktop panel now falls to its "no network address yet" copy instead of claiming a phone can find the computer.
- **`GET /api/health` is unauthenticated** (that exact method+path only), next to the pairing bypass — restoring the smoke test the route file was written to provide. Body unchanged.

## Test plan

- [x] +18 tests (suite 985 → 1005): 8 address-watcher (all transitions), 5 entry-ladder, routes assertions for the health bypass
- [x] Mutation check: inverting the change-detection branch fails all 8 watcher tests
- [x] `pnpm typecheck`, `pnpm check:electron` green; full suite green; zero new oxlint findings (one pre-existing removed)
- [ ] Reviewer eyeball: toggle Companion on → quit → relaunch → `lsof -iTCP:8810` shows it listening without touching Settings; `curl http://<lan-ip>:8810/api/health` answers without a token

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companion advertising now automatically follows network address changes, including withdrawal when no network address is available.
  * The companion can restore its enabled state when the app starts.
  * Added support for reliably starting the companion in packaged and development environments.
  * Health checks are now available before pairing.
* **Bug Fixes**
  * Improved companion shutdown and startup handling to prevent stale advertising or unintended reactivation.
  * Added safeguards for failed or interrupted network advertising updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->