### PR TITLE
Walk every address the Mac answers on, not just the one in the QR

### DIFF
--- a/companion/src/control.ts
+++ b/companion/src/control.ts
@@ -16,6 +16,7 @@ import { createServer, type Server, type ServerResponse } from "node:http";
 
 import type { DeviceRegistry } from "./devices.ts";
 import { lanAddresses, tailnetName, tailscaleAddress } from "./listener.ts";
+import { defaultHostName } from "./mdns.ts";
 
 /** What the pairing page needs to render itself and act on what you click. */
 export interface ControlOptions {
@@ -80,6 +81,34 @@ const json = (res: ServerResponse, status: number, body: unknown) => {
   res.end(text);
 };
 
+/** Every host a phone could dial for this computer, best first.
+ *
+ * One address is one point of failure: a phone paired over the tailnet keeps
+ * a MagicDNS name that stops resolving the moment either device leaves the
+ * tailnet — while the same computer sits reachable on the LAN. Handing the
+ * phone the whole ordered list at pairing time is what lets it walk to the
+ * next candidate instead of failing forever on the first.
+ *
+ * The order is the reachability story: the MagicDNS name works from anywhere
+ * the tailnet does, the LAN addresses work on this network, and the sidecar's
+ * synthetic mDNS name comes last because it only resolves while the sidecar
+ * itself is running. The bare tailnet address is deliberately absent — iOS
+ * refuses plain HTTP to 100.64/10, so it would be a candidate that can never
+ * succeed. */
+export function hostCandidates(
+  addresses: string[] = lanAddresses(),
+  magicDnsName: string | null = tailnetName(),
+): string[] {
+  const tailscale = tailscaleAddress(addresses);
+  const out: string[] = [];
+  if (tailscale && magicDnsName) out.push(magicDnsName);
+  for (const address of addresses) {
+    if (address !== tailscale) out.push(address);
+  }
+  out.push(defaultHostName());
+  return out;
+}
+
 /** Everything the page shows, in one object: where to connect, whether a
  * pairing window is open, and which phones are paired. Recomputed per request
  * rather than cached — addresses change when you join another network. */
@@ -98,6 +127,9 @@ export function companionState(options: ControlOptions) {
     ...(tailscale ? { tailscale } : {}),
     ...(tailscale && name ? { tailnetName: name } : {}),
     lan: addresses.find((a) => a !== tailscale) ?? null,
+    // The ordered fallback list the pairing QR hands the phone, so it can
+    // walk to the next address when the first stops resolving.
+    hosts: hostCandidates(addresses, name),
     pairing: pairing ? { code: pairing.code, token: pairing.token, expiresAt: pairing.expiresAt } : null,
     devices: options.devices.list(),
     discovery: options.discovery(),

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -19,7 +19,7 @@
 // off switch, and it is a more honest one than a flag in a file.
 import { createServer } from "node:http";
 
-import { createControlServer } from "./control.ts";
+import { createControlServer, hostCandidates } from "./control.ts";
 import { DeviceRegistry } from "./devices.ts";
 import { lanAddresses, refreshTailnetName, tailnetName, tailscaleAddress } from "./listener.ts";
 import {
@@ -121,6 +121,10 @@ const companion = createServer(
     authenticate: (token) => devices.authenticate(token),
     redeem: (code, deviceName) => devices.redeem(code, deviceName),
     serverName: machineName,
+    // Recomputed per pairing rather than cached: addresses change when the
+    // machine joins another network, and a pairing is exactly the moment the
+    // list has to be right.
+    hosts: () => hostCandidates(),
   }),
 );
 

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -32,6 +32,11 @@ export interface ProxyOptions {
   ) => { token: string; device: unknown } | { error: string };
   /** What the phone should call this computer in its connection list. */
   serverName: () => string;
+  /** Every host the phone could dial later, best first — sent with the
+   * pairing response so the app can fall back when the address it paired on
+   * stops resolving. Optional and advisory: a phone that never receives it
+   * simply keeps dialing the one host it paired with. */
+  hosts?: () => string[];
   /** How long the harness may take to produce response *headers*. Optional,
    * and only ever set by tests — the default is the one that ships. */
   headersTimeoutMs?: number;
@@ -162,7 +167,18 @@ export function createProxyHandler(options: ProxyOptions) {
           // `code` remains accepted for manual entry and older mobile builds.
           const result = options.redeem(String(body.credential ?? body.code ?? ""), body.deviceName);
           if ("error" in result) return sendJson(res, 401, { error: result.error });
-          return sendJson(res, 201, { ...result, serverName: options.serverName() });
+          // `hosts` rides along whichever way the phone paired — QR, typed
+          // address, or discovery — so every paired device learns the full
+          // fallback list, not just the ones that scanned a QR. Absent, not
+          // empty, when there is nothing to offer: absent is what a sidecar
+          // predating the field sends, and one decode path beats two.
+          const hosts = options.hosts?.() ?? [];
+          const response: typeof result & { serverName: string; hosts?: string[] } = {
+            ...result,
+            serverName: options.serverName(),
+          };
+          if (hosts.length) response.hosts = hosts;
+          return sendJson(res, 201, response);
         },
         (error: Error) => sendJson(res, 400, { error: error.message }),
       );

--- a/companion/test/control.test.ts
+++ b/companion/test/control.test.ts
@@ -7,7 +7,7 @@
 import { type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { createControlServer, originIsLoopback } from "../src/control.ts";
+import { createControlServer, hostCandidates, originIsLoopback } from "../src/control.ts";
 import { DeviceRegistry } from "../src/devices.ts";
 
 let control: Server;
@@ -138,6 +138,35 @@ describe("origins the control server will change state for", () => {
     const { status, body } = await ask("GET", "/state", { origin: "https://evil.example" });
     expect(status).toBe(403);
     expect(body.error).toContain("cross-origin");
+  });
+});
+
+describe("hostCandidates", () => {
+  it("orders by reachability: tailnet name, then LAN, then the mDNS name last", () => {
+    // 100.121.5.6 is the bare tailnet address: excluded outright, because iOS
+    // refuses plain HTTP to 100.64/10 and a candidate that can never succeed
+    // only slows the walk down. The synthetic mDNS name is last — it resolves
+    // only while the sidecar runs.
+    const hosts = hostCandidates(["100.121.5.6", "192.168.1.42", "10.0.0.7"], "macbook.tail1234.ts.net");
+    expect(hosts.slice(0, 3)).toEqual(["macbook.tail1234.ts.net", "192.168.1.42", "10.0.0.7"]);
+    expect(hosts.at(-1)).toMatch(/^openmausbot-[0-9a-f]{8}\.local$/);
+    expect(hosts).not.toContain("100.121.5.6");
+  });
+
+  it("skips the tailnet name when Tailscale is not part of the picture", () => {
+    // A MagicDNS name left over from a cached read is only dialable while a
+    // tailnet address exists; without one it would be a dead first candidate.
+    expect(hostCandidates(["192.168.1.42"], "stale.tail1234.ts.net")[0]).toBe("192.168.1.42");
+    expect(hostCandidates(["100.121.5.6", "192.168.1.42"], null)[0]).toBe("192.168.1.42");
+  });
+
+  it("is what /state hands the pairing panel", async () => {
+    const { status, body } = await ask("GET", "/state");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.hosts)).toBe(true);
+    // Whatever this machine's interfaces are, the mDNS fallback is always
+    // present and always last.
+    expect(body.hosts.at(-1)).toMatch(/^openmausbot-[0-9a-f]{8}\.local$/);
   });
 });
 

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -551,6 +551,7 @@ describe("pairing, end to end", () => {
         authenticate: (t) => registry.authenticate(t ?? undefined),
         redeem: (code, deviceName) => registry.redeem(code, deviceName),
         serverName: () => "Ada's computer",
+        hosts: () => ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"],
       }),
     );
     await new Promise<void>((r) => paired.listen(0, "127.0.0.1", r));
@@ -598,9 +599,12 @@ describe("pairing, end to end", () => {
       expect(res.status).toBe(201);
       // SAFETY: a 201 from /api/pair carries exactly this shape — the
       // sidecar's own contract, pinned by the expects that follow.
-      const body = (await res.json()) as { token: string; serverName: string };
+      const body = (await res.json()) as { token: string; serverName: string; hosts: string[] };
       expect(body.serverName).toBe("Ada's computer");
       expect(body.token).toMatch(/^omb_/);
+      // The fallback list rides on the redeem response so a phone that paired
+      // by typed address learns the other ways to reach this computer too.
+      expect(body.hosts).toEqual(["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"]);
 
       // and the token works on the real API, through the real proxy
       const bots = await fetch(`${base}/api/bots`, { headers: { authorization: `Bearer ${body.token}` } });

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -42,6 +42,14 @@ final class Session: ObservableObject {
     @Published private(set) var pairingInvite: PairingInvite?
 
     private var client: CompanionClient?
+    /// The device token, kept in memory so the client can be rebuilt when the
+    /// dial moves to another stored host. The keychain remains the only place
+    /// it is persisted.
+    private var token: String?
+    /// Which of the connection's stored hosts the next attempt dials. The
+    /// walk advances on address-shaped failures and the winner is promoted —
+    /// and persisted — when a stream goes live.
+    private var rotation = CandidateRotation(hosts: [])
     private var streamTask: Task<Void, Never>?
     /// Identifies the task currently stored in `streamTask`. A cancelled task
     /// can finish after its replacement starts; its cleanup must not clear
@@ -112,6 +120,10 @@ final class Session: ObservableObject {
         guard let stored else { return } // no token: genuinely not paired
 
         connection = saved
+        token = stored
+        // `orderedHosts` puts the stored host first, so the address that
+        // worked last time is the one dialed first this time.
+        rotation = CandidateRotation(hosts: saved.orderedHosts)
         client = CompanionClient(connection: saved, token: stored)
         status = .connecting
     }
@@ -128,11 +140,18 @@ final class Session: ObservableObject {
         // prefer the name the computer calls itself over the Bonjour label
         var stored = connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
+        // The computer knows every address it answers on, and what it says at
+        // redeem time beats whatever the invite carried. Then the host that
+        // just redeemed the code leads: it demonstrably works from here.
+        if let hosts = paired.hosts, !hosts.isEmpty { stored.hosts = hosts }
+        stored.promote(stored.host)
 
         try Keychain.save(paired.token, for: stored.id)
         UserDefaults.standard.set(try? JSONEncoder().encode(stored), forKey: Self.connectionKey)
 
         self.connection = stored
+        self.token = paired.token
+        self.rotation = CandidateRotation(hosts: stored.orderedHosts)
         self.client = CompanionClient(connection: stored, token: paired.token)
         self.state = CompanionState()
         // A fresh pairing settles any restore that was still waiting on the
@@ -165,6 +184,8 @@ final class Session: ObservableObject {
         UserDefaults.standard.removeObject(forKey: Self.connectionKey)
         connection = nil
         client = nil
+        token = nil
+        rotation = CandidateRotation(hosts: [])
         state = CompanionState()
         NotificationCoordinator.shared.setBadge(0)
         status = .unpaired
@@ -273,6 +294,9 @@ final class Session: ObservableObject {
                             state.resetCursor(cursor)
                         }
                         status = .live
+                        // this candidate carried a live stream — dial it
+                        // first from now on, including next launch
+                        promoteWorkingHost()
                         continue
                     }
                     state.apply(frame)
@@ -297,7 +321,7 @@ final class Session: ObservableObject {
                     return
                 }
                 log.error("stream failed: \(error.localizedDescription, privacy: .public)")
-                status = .offline(error.localizedDescription)
+                status = .offline(failureMessage(for: error))
             }
 
             if Task.isCancelled { return }
@@ -314,6 +338,60 @@ final class Session: ObservableObject {
         log.info("hydrated \(fleet.bots.count, privacy: .public) bots, \(fleet.groups.count, privacy: .public) rooms")
         state.hydrate(fleet)
         NotificationCoordinator.shared.setBadge(state.unreadCount)
+    }
+
+    // MARK: - Which address to dial
+
+    /// Turn a stream failure into advice a person can act on — and, when the
+    /// failure is about the address rather than the pairing, move the dial to
+    /// the next stored host so the retry that follows tries somewhere new.
+    /// A 401 never reaches here: the unauthorized path returns above, which
+    /// is what keeps a token problem from masquerading as an address walk.
+    private func failureMessage(for error: Error) -> String {
+        guard let urlError = error as? URLError, let connection else {
+            return error.localizedDescription
+        }
+        let failed = rotation.current.isEmpty ? connection.host : rotation.current
+        var next: String?
+        if ConnectionAdvice.shouldTryAnotherHost(urlError.code), rotation.count > 1 {
+            let candidate = rotation.advance()
+            if let token {
+                client = CompanionClient(connection: connection.dialing(candidate), token: token)
+            }
+            next = candidate
+            log.info("advancing to candidate host \(candidate, privacy: .public)")
+        }
+        return ConnectionAdvice.message(for: urlError.code, host: failed, port: connection.port, tryingNext: next)
+    }
+
+    /// The candidate that just carried a live stream dials first from now on.
+    /// Persisted, so the next launch starts from the address that works
+    /// rather than re-walking the list from a stale front-runner.
+    private func promoteWorkingHost() {
+        let winner = rotation.current
+        guard !winner.isEmpty, var updated = connection,
+              updated.host != Connection.urlHost(winner) else { return }
+        updated.promote(winner)
+        connection = updated
+        UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
+    }
+
+    /// Replace the stored address by hand, keeping the pairing and its token.
+    /// False when the text does not parse as a host or host:port.
+    @discardableResult
+    func updateAddress(_ text: String) -> Bool {
+        guard var updated = connection, let parsed = Connection.parse(text) else { return false }
+        updated.port = parsed.port
+        updated.promote(parsed.host)
+        connection = updated
+        UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
+        rotation = CandidateRotation(hosts: updated.orderedHosts)
+        if let token { client = CompanionClient(connection: updated, token: token) }
+        // Dial the new address now rather than on the next backoff tick —
+        // someone who just typed an address is watching the banner.
+        restartStream()
+        connect()
+        return true
     }
 
     // MARK: - Actions

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -9,6 +9,8 @@ import CompanionCore
 struct SettingsView: View {
     @EnvironmentObject private var session: Session
     @State private var confirmingSignOut = false
+    @State private var editingAddress = false
+    @State private var addressText = ""
 
     var body: some View {
         Form {
@@ -16,6 +18,15 @@ struct SettingsView: View {
                 if let connection = session.connection {
                     LabeledContent("Name", value: connection.name)
                     LabeledContent("Address", value: "\(connection.host):\(connection.port)")
+                    // The stored address can simply go stale — a tailnet name
+                    // on a phone that left the tailnet, a LAN address after
+                    // the router reshuffled. Editing it here keeps the
+                    // pairing; the alternative is a walk to the computer for
+                    // a new code.
+                    Button("Edit address") {
+                        addressText = "\(connection.host):\(connection.port)"
+                        editingAddress = true
+                    }
                 }
                 LabeledContent("Connection", value: statusText)
             }
@@ -47,6 +58,19 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .task { await session.refreshNotificationAuthorization() }
+        .alert("Edit address", isPresented: $editingAddress) {
+            TextField("192.168.1.42:8810", text: $addressText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Button("Save") {
+                if !session.updateAddress(addressText) {
+                    session.actionError = "That should look like 192.168.1.42:8810, or a name like macbook.tail1234.ts.net."
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Enter whatever the Companion panel on your computer shows. The pairing itself is kept.")
+        }
         .confirmationDialog(
             "Unpair this phone?",
             isPresented: $confirmingSignOut,

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -16,12 +16,18 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     public var name: String
     public var host: String
     public var port: Int
+    /// Every other address the computer answered on at pairing time, best
+    /// first — the tailnet name, the LAN address, the sidecar's mDNS name.
+    /// Optional so connections saved before fallbacks existed still decode;
+    /// read through `orderedHosts`, which is never empty.
+    public var hosts: [String]?
 
-    public init(id: String = UUID().uuidString, name: String, host: String, port: Int) {
+    public init(id: String = UUID().uuidString, name: String, host: String, port: Int, hosts: [String]? = nil) {
         self.id = id
         self.name = name
         self.host = Self.urlHost(host)
         self.port = port
+        self.hosts = hosts
     }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
@@ -148,6 +154,19 @@ public struct PairingInvite: Equatable, Sendable {
                 (!$0.isASCII && !$0.isNewline) || $0.asciiValue.map { $0 >= 32 && $0 != 127 } == true
             }
             if !cleaned.isEmpty { connection.name = String(cleaned.prefix(80)) }
+        }
+        // The desktop's ordered fallback list, comma-joined. Advisory rather
+        // than load-bearing: a bad entry costs one failed dial when its turn
+        // comes, so unusable candidates are dropped instead of failing the
+        // whole invite. 253 bytes is the DNS name ceiling.
+        if let list = values["hosts"] {
+            let candidates = list.split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { candidate in
+                    !candidate.isEmpty && candidate.utf8.count <= 253 &&
+                        !candidate.contains(where: { $0.isWhitespace || "/?#".contains($0) })
+                }
+            if !candidates.isEmpty { connection.hosts = Array(candidates.prefix(8)) }
         }
         return PairingInvite(connection: connection, credential: credential)
     }

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -1,0 +1,129 @@
+// Reaching the same computer at whichever of its addresses still works.
+//
+// Pairing stores one host, and one host is one point of failure: a phone
+// paired over the tailnet keeps a MagicDNS name that stops resolving the
+// moment either device leaves the tailnet — while the same computer sits
+// reachable on the LAN right there. The fix is late binding: the connection
+// carries every address the computer answered on at pairing time, and the
+// dial walks that list when a failure is about the *address* rather than the
+// pairing. Both halves are pure — no sockets, no clocks — so the rules can
+// be tested without a network; `Session` owns when they run.
+import Foundation
+
+/// The ordered walk through a connection's stored hosts.
+///
+/// Advance on an address-shaped failure, promote on success. Advancing wraps
+/// rather than giving up, because the retry loop it lives in already backs
+/// off between attempts and a network that comes back deserves a second lap.
+public struct CandidateRotation: Equatable, Sendable {
+    public private(set) var hosts: [String]
+    private var index: Int
+
+    public init(hosts: [String]) {
+        self.hosts = hosts
+        index = 0
+    }
+
+    /// The host the next attempt should dial. Empty only when there are no
+    /// hosts at all, which a real connection never produces.
+    public var current: String {
+        hosts.indices.contains(index) ? hosts[index] : ""
+    }
+
+    public var count: Int { hosts.count }
+
+    /// Move to the next candidate and return it, wrapping past the end.
+    @discardableResult
+    public mutating func advance() -> String {
+        guard !hosts.isEmpty else { return "" }
+        index = (index + 1) % hosts.count
+        return current
+    }
+
+    /// The stored order after a success: the host that just worked first, so
+    /// the next launch dials it before anything that was failing, and the
+    /// rest keeping their relative order.
+    public func promoted() -> [String] {
+        guard hosts.indices.contains(index) else { return hosts }
+        return [hosts[index]] + hosts.enumerated().filter { $0.offset != index }.map(\.element)
+    }
+}
+
+/// What to do with a connection failure: whether another stored address is
+/// worth trying, and what to tell the person watching the banner.
+public enum ConnectionAdvice {
+    /// True only for failures about the address — the name did not resolve,
+    /// nothing answered there, the route timed out. Everything else stays
+    /// put: a 401 is a token problem that every address would repeat, and
+    /// "offline" fails identically wherever the dial points.
+    public static func shouldTryAnotherHost(_ code: URLError.Code) -> Bool {
+        switch code {
+        case .cannotFindHost, .cannotConnectToHost, .timedOut, .secureConnectionFailed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The offline banner as advice rather than an NSURLError string.
+    ///
+    /// Each code names the thing the person can actually check — the raw
+    /// "A server with the specified hostname could not be found" says nothing
+    /// about tailnets, and it is precisely the tailnet case that produces it.
+    /// `tryingNext` is the candidate the walk moved to, when it moved.
+    public static func message(
+        for code: URLError.Code,
+        host: String,
+        port: Int,
+        tryingNext next: String? = nil
+    ) -> String {
+        let advice: String
+        switch code {
+        case .cannotFindHost:
+            advice = "\u{201C}\(host)\u{201D} didn't resolve. If that's a Tailscale name, this phone may not be on the tailnet."
+        case .cannotConnectToHost:
+            advice = "Reached your computer, but the companion isn't answering on port \(port) — open OpenMausBot → Settings → Companion."
+        case .timedOut:
+            advice = "No route to your computer at \(host) — different network, or a firewall."
+        case .notConnectedToInternet:
+            advice = "You're offline."
+        default:
+            advice = "Could not reach \(host): \(URLError(code).localizedDescription)"
+        }
+        let fallback = next.map { " Trying \($0) next." } ?? ""
+        return advice + fallback + " The app keeps retrying automatically."
+    }
+}
+
+extension Connection {
+    /// Every host this connection may dial, best first and never empty: the
+    /// stored `host` leads, then the pairing-time fallbacks, deduplicated
+    /// after the same normalization dialing applies.
+    public var orderedHosts: [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for candidate in [host] + (hosts ?? []) {
+            let normalized = Self.urlHost(candidate)
+            if seen.insert(normalized).inserted { out.append(normalized) }
+        }
+        return out
+    }
+
+    /// A copy dialing `candidate` — same pairing, same port, different
+    /// address. The stored order is untouched; committing a winner is
+    /// `promote`, and only success earns it.
+    public func dialing(_ candidate: String) -> Connection {
+        var copy = self
+        copy.host = Self.urlHost(candidate)
+        return copy
+    }
+
+    /// `winner` becomes the host dialed first from now on — the one that just
+    /// carried traffic, or the one the user typed in by hand.
+    public mutating func promote(_ winner: String) {
+        let normalized = Self.urlHost(winner)
+        let rest = orderedHosts.filter { $0 != normalized }
+        host = normalized
+        hosts = [normalized] + rest
+    }
+}

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -259,6 +259,10 @@ public struct PairResponse: Codable, Sendable {
     /// What the computer calls itself — worth showing so someone with two
     /// paired machines can tell them apart.
     public var serverName: String
+    /// Every address the computer answers on, best first. Stored with the
+    /// connection so the app can walk to the next one when the address it
+    /// paired on stops resolving. Absent from older sidecars.
+    public var hosts: [String]?
 }
 
 /// A freshly minted provider viewer. It is deliberately not Codable for

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -59,6 +59,44 @@ final class ConnectionTests: XCTestCase {
         XCTAssertEqual(PairingInvite.parse(url)?.credential, "004209")
     }
 
+    func testCarriesTheFallbackHostsFromTheInvite() throws {
+        let url = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&code=004209" +
+            "&hosts=macbook.tail1234.ts.net,192.168.1.42,openmausbot-aa.local"))
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+        XCTAssertEqual(invite.connection.hosts, ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"])
+    }
+
+    func testDropsUnusableFallbackHostsWithoutRefusingTheInvite() throws {
+        // Fallbacks are advisory: a bad one costs a single failed dial when
+        // its turn comes, so it is filtered rather than fatal.
+        let url = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=mac.local&code=004209&hosts=%20192.168.1.42%20,,bad%2Fslash,has%20space"))
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+        XCTAssertEqual(invite.connection.hosts, ["192.168.1.42"])
+
+        // and an invite with no usable candidate keeps the single address
+        let empty = try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=004209&hosts=bad%2Fslash"))
+        XCTAssertNil(PairingInvite.parse(empty)?.connection.hosts)
+    }
+
+    func testASavedConnectionWithoutFallbacksStillDecodes() throws {
+        // Exactly what UserDefaults holds for anyone who paired before
+        // fallback hosts existed — `hosts` must stay optional forever.
+        let data = Data(#"{"id":"saved","name":"Mac","host":"mac.tail1234.ts.net","port":8810}"#.utf8)
+        let saved = try JSONDecoder().decode(Connection.self, from: data)
+        XCTAssertNil(saved.hosts)
+        XCTAssertEqual(saved.orderedHosts, ["mac.tail1234.ts.net"])
+    }
+
+    func testAPairResponseWithAndWithoutHostsDecodes() throws {
+        let older = Data(#"{"token":"omb_x","device":{"id":"d","name":"p","createdAt":1,"lastSeenAt":1},"serverName":"Mac"}"#.utf8)
+        XCTAssertNil(try JSONDecoder().decode(PairResponse.self, from: older).hosts)
+
+        let newer = Data(#"{"token":"omb_x","device":{"id":"d","name":"p","createdAt":1,"lastSeenAt":1},"serverName":"Mac","hosts":["a.ts.net","192.168.1.42"]}"#.utf8)
+        XCTAssertEqual(try JSONDecoder().decode(PairResponse.self, from: newer).hosts, ["a.ts.net", "192.168.1.42"])
+    }
+
     func testRejectsAnUntrustedOrMalformedPairingInvite() throws {
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "https://example.com/pair?address=mac.local&code=123456"))))
         XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=12345"))))

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+final class FailoverTests: XCTestCase {
+    // MARK: - CandidateRotation
+
+    func testWalksTheCandidatesInOrderAndWraps() {
+        var rotation = CandidateRotation(hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"])
+        XCTAssertEqual(rotation.current, "mac.tail1234.ts.net")
+        XCTAssertEqual(rotation.advance(), "192.168.1.42")
+        XCTAssertEqual(rotation.advance(), "openmausbot-aa.local")
+        // Wraps rather than giving up: the retry loop backs off between laps,
+        // and a network that comes back deserves another try at the front.
+        XCTAssertEqual(rotation.advance(), "mac.tail1234.ts.net")
+    }
+
+    func testPromotesTheWorkingCandidateToTheFront() {
+        var rotation = CandidateRotation(hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"])
+        rotation.advance() // the tailnet name failed; the LAN address carried a stream
+        XCTAssertEqual(rotation.promoted(), ["192.168.1.42", "mac.tail1234.ts.net", "openmausbot-aa.local"])
+    }
+
+    func testPromotionWithoutAWalkChangesNothing() {
+        let rotation = CandidateRotation(hosts: ["mac.tail1234.ts.net", "192.168.1.42"])
+        XCTAssertEqual(rotation.promoted(), ["mac.tail1234.ts.net", "192.168.1.42"])
+    }
+
+    func testSurvivesAnEmptyCandidateList() {
+        // A real connection never produces one, but the type must not trap.
+        var rotation = CandidateRotation(hosts: [])
+        XCTAssertEqual(rotation.current, "")
+        XCTAssertEqual(rotation.advance(), "")
+        XCTAssertEqual(rotation.promoted(), [])
+    }
+
+    // MARK: - Which failures move the dial
+
+    func testRotatesOnAddressFailuresAndNothingElse() {
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.cannotFindHost)) // -1003
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.cannotConnectToHost)) // -1004
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.timedOut)) // -1001
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.secureConnectionFailed)) // -1200
+
+        // Offline fails on every address, and cancellation is deliberate.
+        XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.notConnectedToInternet)) // -1009
+        XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.cancelled))
+        XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.networkConnectionLost))
+    }
+
+    // MARK: - The advice strings
+
+    func testUnresolvedHostNamesTheTailnetPossibility() {
+        let message = ConnectionAdvice.message(for: .cannotFindHost, host: "mac.tail1234.ts.net", port: 8810)
+        XCTAssertTrue(message.contains("mac.tail1234.ts.net"))
+        XCTAssertTrue(message.contains("tailnet"))
+        XCTAssertTrue(message.contains("retrying automatically"))
+    }
+
+    func testRefusedConnectionPointsAtTheCompanionToggle() {
+        let message = ConnectionAdvice.message(for: .cannotConnectToHost, host: "192.168.1.42", port: 8810)
+        XCTAssertTrue(message.contains("port 8810"))
+        XCTAssertTrue(message.contains("Settings → Companion"))
+    }
+
+    func testTimeoutBlamesTheRouteNotTheApp() {
+        let message = ConnectionAdvice.message(for: .timedOut, host: "192.168.1.42", port: 8810)
+        XCTAssertTrue(message.contains("No route"))
+        XCTAssertTrue(message.contains("firewall"))
+    }
+
+    func testOfflineSaysOffline() {
+        XCTAssertTrue(ConnectionAdvice.message(for: .notConnectedToInternet, host: "x", port: 8810)
+            .contains("You're offline."))
+    }
+
+    func testAdviceNamesTheCandidateBeingTriedNext() {
+        let message = ConnectionAdvice.message(
+            for: .cannotFindHost,
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            tryingNext: "192.168.1.42"
+        )
+        XCTAssertTrue(message.contains("Trying 192.168.1.42 next."))
+    }
+
+    // MARK: - Connection candidate helpers
+
+    func testOrderedHostsLeadsWithTheStoredHostAndDeduplicates() {
+        let connection = Connection(
+            name: "Mac",
+            host: "192.168.1.42",
+            port: 8810,
+            hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"]
+        )
+        XCTAssertEqual(connection.orderedHosts, ["192.168.1.42", "mac.tail1234.ts.net", "openmausbot-aa.local"])
+    }
+
+    func testOrderedHostsFallsBackToTheSingleStoredHost() {
+        // A connection saved before fallbacks existed still dials.
+        let connection = Connection(name: "Mac", host: "mac.tail1234.ts.net", port: 8810)
+        XCTAssertEqual(connection.orderedHosts, ["mac.tail1234.ts.net"])
+    }
+
+    func testDialingSwapsTheHostWithoutTouchingTheStoredOrder() {
+        let connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["mac.tail1234.ts.net", "192.168.1.42"]
+        )
+        let dialed = connection.dialing("192.168.1.42")
+        XCTAssertEqual(dialed.host, "192.168.1.42")
+        XCTAssertEqual(dialed.baseURL?.absoluteString, "http://192.168.1.42:8810")
+        XCTAssertEqual(dialed.hosts, connection.hosts)
+        XCTAssertEqual(dialed.id, connection.id) // same pairing, same keychain entry
+    }
+
+    func testPromoteReordersAndKeepsEveryCandidate() {
+        var connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"]
+        )
+        connection.promote("192.168.1.42")
+        XCTAssertEqual(connection.host, "192.168.1.42")
+        XCTAssertEqual(connection.hosts, ["192.168.1.42", "mac.tail1234.ts.net", "openmausbot-aa.local"])
+
+        // A hand-typed address the list has never seen joins at the front —
+        // the stored fallbacks remain worth walking behind it.
+        connection.promote("10.0.0.7")
+        XCTAssertEqual(connection.hosts?.first, "10.0.0.7")
+        XCTAssertEqual(connection.hosts?.count, 4)
+    }
+}

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -41,6 +41,8 @@ interface CompanionState {
    * exceptions match by name rather than by subnet. */
   tailnetName?: string;
   lan?: string | null;
+  /** Ordered fallback hosts for the phone — tailnet name, LAN, mDNS last. */
+  hosts?: string[];
   /** Bonjour: when advertising, the phone finds this computer by name. */
   discovery?: { advertising: boolean; name: string };
   /** Why it is not running, or not answering. */
@@ -162,6 +164,7 @@ export function CompanionSection() {
           code: state.pairing.code,
           token: state.pairing.token,
           name: state.discovery?.name,
+          hosts: state.hosts,
         })
       : null;
 

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -33,4 +33,35 @@ describe("companionPairingLink", () => {
     const link = companionPairingLink({ address: "2001:db8::1", port: 8810, code: "123456", token });
     expect(new URL(link!).searchParams.get("address")).toBe("[2001:db8::1]:8810");
   });
+
+  it("carries the ordered fallback hosts, comma-joined", () => {
+    const link = companionPairingLink({
+      address: "macbook.tail1234.ts.net",
+      port: 8810,
+      code: "004209",
+      token,
+      hosts: ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"],
+    });
+    expect(new URL(link!).searchParams.get("hosts")).toBe(
+      "macbook.tail1234.ts.net,192.168.1.42,openmausbot-abcd1234.local",
+    );
+  });
+
+  it("drops unusable fallback hosts without breaking the link", () => {
+    // A bad candidate costs the phone one failed dial at most, and an empty
+    // list is a link that simply carries no fallbacks — pairing still works.
+    const link = companionPairingLink({
+      address: "mac.local",
+      port: 8810,
+      code: "004209",
+      token,
+      hosts: ["  192.168.1.42  ", "", "has space", "has/slash", "a,b"],
+    });
+    const url = new URL(link!);
+    expect(url.searchParams.get("hosts")).toBe("192.168.1.42");
+    expect(url.searchParams.get("address")).toBe("mac.local:8810");
+
+    const none = companionPairingLink({ address: "mac.local", port: 8810, code: "004209", token, hosts: [] });
+    expect(new URL(none!).searchParams.get("hosts")).toBeNull();
+  });
 });

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -4,14 +4,24 @@ interface CompanionPairingLinkOptions {
   code: string;
   token: string;
   name?: string;
+  /** Every host the phone could dial later, best first. Carried alongside
+   * `address` so the app can fall back when the paired host stops resolving
+   * — a tailnet name is unreachable the moment the phone leaves the tailnet,
+   * while the LAN address keeps working. Older mobile builds ignore it. */
+  hosts?: string[];
 }
+
+/** How many fallback hosts a link will carry. The list is tiny in practice
+ * (tailnet name, a LAN address or two, the mDNS name); the cap only keeps a
+ * pathological interface list from bloating the QR code. */
+const MAX_HOSTS = 8;
 
 /**
  * A short-lived handoff from the trusted desktop pairing panel to the mobile
  * app. The code still has to be redeemed with the companion; putting it in
  * the link does not create or expose the long-lived device token.
  */
-export function companionPairingLink({ address, port, code, token, name }: CompanionPairingLinkOptions): string | null {
+export function companionPairingLink({ address, port, code, token, name, hosts }: CompanionPairingLinkOptions): string | null {
   const host = address.trim();
   if (
     !host ||
@@ -31,5 +41,13 @@ export function companionPairingLink({ address, port, code, token, name }: Compa
   url.searchParams.set("token", token);
   url.searchParams.set("code", code);
   if (name?.trim()) url.searchParams.set("name", name.trim());
+  // Comma-joined, which no hostname or IP literal can contain. Filtered
+  // rather than refused: a bad candidate costs the phone one failed dial,
+  // and dropping the whole link over it would break pairing entirely.
+  const candidates = (hosts ?? [])
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate && !/[\s/?#,[\]]/.test(candidate))
+    .slice(0, MAX_HOSTS);
+  if (candidates.length) url.searchParams.set("hosts", candidates.join(","));
   return url.toString();
 }


### PR DESCRIPTION
## In plain terms

A phone paired over Tailscale stores the Mac's MagicDNS name — and the moment either device leaves the tailnet, the app dies forever on "A server with the specified hostname could not be found", even though the same Mac is sitting reachable on the LAN. Now pairing hands the phone every address the computer answers on, the app walks that list when a failure is about the address, and the error banner says what to actually check.

## How

- **Pairing carries ordered host candidates.** The sidecar computes `[MagicDNS name (only while a tailnet address exists), LAN IPv4s, openmausbot-<hash>.local last]` — the bare 100.64/10 address is deliberately excluded (iOS ATS can never dial it), and the synthetic .local name is last because it only resolves while the sidecar runs. Rides the QR (`hosts=` param) and the pair-redeem response additively: old phone + new desktop ignores it, new phone + old desktop behaves exactly as before; old saved connections decode with `hosts = nil` and fall back to `[host]`.
- **Late binding with rotation.** `CandidateRotation` (pure, unit-tested): advance on address-shaped failures only (−1003 cannotFindHost, −1004 cannotConnectToHost, −1001 timedOut, −1200 TLS), wrap past the end (the existing 1→15s backoff paces the laps), promote-on-success persisted so the next launch dials the working address first. A 401 never rotates — that's a token problem every address would repeat; offline never rotates either.
- **Errors become advice.** −1003 → "'x.ts.net' didn't resolve. If that's a Tailscale name, this phone may not be on the tailnet." · −1004 → "Reached your computer, but the companion isn't answering on port 8810 — open OpenMausBot → Settings → Companion." · −1001 → "No route — different network, or a firewall." · names the candidate being tried next · always says the app keeps retrying.
- **The stored address is editable** (Settings → Edit address): reparses host:port, keeps the pairing and token, redials immediately.

## Test plan

- [x] Swift: 106/106 (`swift test`), +18 new (14 rotation, 4 connection decode/back-compat); app target built via `xcodegen + xcodebuild -sdk iphonesimulator` — BUILD SUCCEEDED
- [x] TS: typecheck clean; full vitest green (1017 passed); zero new oxlint findings
- [x] Mutation checks: demote-instead-of-promote fails 5 tests; dropping the advance step fails 6
- [x] Merged current main (advertise-watch overlap resolved)
- [ ] Reviewer eyeball (the real-world case): pair via QR while the Mac is on Tailscale → stop Tailscale on the phone → app should land on the LAN address by itself within a few seconds, with the banner narrating the walk

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic connection fallback across available computer addresses.
  * Pairing links now include alternate hosts to improve connectivity.
  * Added the ability to edit the saved computer address without re-pairing.
  * Successful connections are remembered and prioritized for future use.
* **Bug Fixes**
  * Improved connection error guidance and retry behavior.
  * Invalid or unusable fallback addresses are filtered automatically.
  * Signing out now clears saved connection fallback information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->