### PR TITLE
Fix Podman Local VM image resolution

### DIFF
--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -501,6 +501,12 @@ describe("setupCommands", () => {
     expect(setupCommands("docker", "linux").run).toContain(IMAGE);
   });
 
+  it("uses an explicit local image name so Podman never resolves the managed build on Docker Hub", () => {
+    expect(IMAGE).toMatch(/^localhost\/openmausbot\/cua-local-vm:/);
+    expect(setupCommands("podman", "darwin").run).toContain(IMAGE);
+    expect(setupCommands("podman", "darwin").run).not.toContain("docker.io/openmausbot");
+  });
+
   it("generates Apple container lifecycle commands without Docker-only flags", () => {
     const commands = setupCommands("container", "darwin");
     expect(commands.runtimeStart).toBe("container system start");

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -30,9 +30,12 @@ export const BASE_IMAGE_REPOSITORY = "docker.io/trycua/xfce-cua";
 // Official multi-architecture Cua XFCE 0.1.0 manifest (amd64 + arm64).
 export const BASE_IMAGE_DIGEST = "sha256:274eb636f5cf3fc58f705916ee72b7a701270b3877369d08533a385c5325be9b";
 export const BASE_IMAGE = `${BASE_IMAGE_REPOSITORY}@${BASE_IMAGE_DIGEST}`;
-// This tag is built locally from the pinned Cua base. Image and container
-// labels below are the authoritative compatibility check, not the mutable tag.
-export const IMAGE_REPOSITORY = "openmausbot/cua-local-vm";
+// This tag is built locally from the pinned Cua base. The explicit localhost
+// registry is required by Podman: it prepends localhost to unqualified build
+// tags, then may otherwise resolve the same name to Docker Hub when running it.
+// Image and container labels below remain the authoritative compatibility
+// check, not the mutable tag.
+export const IMAGE_REPOSITORY = "localhost/openmausbot/cua-local-vm";
 export const IMAGE_LAYER_VERSION = "3";
 export const IMAGE_LAYER_LABEL = "com.openmausbot.image-layer";
 export const IMAGE = `${IMAGE_REPOSITORY}:driver-${CUA_DRIVER_VERSION}-v${IMAGE_LAYER_VERSION}`;


### PR DESCRIPTION
## What changed

- Tag the locally built Cua VM image under the explicit `localhost/` registry.
- Add a regression test ensuring Podman commands keep the image local and never resolve it through Docker Hub.

## Why

Podman prepends `localhost/` to unqualified image names produced by `podman build`. OpenMausBot later referred to the same image without that prefix, so Podman could miss the local build and try to pull `docker.io/openmausbot/cua-local-vm`, which does not exist publicly.

This fixes #231.

## Validation

- `pnpm vitest run server/container-computer.test.ts` — 26 passed
- `pnpm typecheck` — passed
- `pnpm test` — 103 Vitest files / 1,013 tests passed, broker tests passed, updater tests passed, packaged-server smoke passed

The focused anti-slop lint command continues to report existing findings elsewhere in the two files; the changed lines introduce no new lint findings.
