### PR TITLE
Fix Codex login detection when status is written to stderr

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -283,6 +283,14 @@ describe("CodexDriver turns (fake app-server)", () => {
     });
   });
 
+  it("also accepts login status from older Codex versions that used stdout", async () => {
+    await create({ mode: "logged-in-stdout" });
+    await expect(instance.snapshot()).resolves.toMatchObject({
+      state: "available",
+      authenticated: true,
+    });
+  });
+
   it("marks a Codex 401 as setup so the UI offers sign-in instead of Retry", async () => {
     await create({ mode: "unauthorized" });
     await instance.adapter.sendTurn({ threadId: "t-unauthorized", text: "hi" });

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -478,8 +478,8 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       });
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
       const authenticated = await new Promise<boolean>((resolve) => {
-        execCli(config.cli, ["login", "status"], { timeout: 8000, env }, (err, stdout) =>
-          resolve(!err && /logged in/i.test(stdout)),
+        execCli(config.cli, ["login", "status"], { timeout: 8000, env }, (err, stdout, stderr) =>
+          resolve(!err && /^logged in\b/im.test(`${stdout}\n${stderr ?? ""}`)),
         );
       });
       // childEnv drops OPENAI_API_KEY on purpose — turns run on the ChatGPT login

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -55,11 +55,11 @@ export function execCli(
   cli: string,
   args: string[],
   opts: ExecFileOptions,
-  cb: (err: Error | null, stdout: string) => void,
+  cb: (err: Error | null, stdout: string, stderr?: string) => void,
 ): void {
   const resolved = resolveCli(cli, args);
-  execFile(resolved.command, resolved.args, { ...opts, windowsHide: true }, (err, stdout) =>
-    cb(err, typeof stdout === "string" ? stdout : String(stdout)),
+  execFile(resolved.command, resolved.args, { ...opts, windowsHide: true, encoding: "utf8" }, (err, stdout, stderr) =>
+    cb(err, stdout, stderr),
   );
 }
 

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -5,7 +5,7 @@
 // real app-server, it never exits on its own — the driver kills it.
 //
 //   FAKE_CODEX_MODE   happy (default) | approval | resume | stream |
-//                     logged-out | unauthorized
+//                     logged-in-stdout | logged-out | unauthorized
 //   FAKE_CODEX_DUMP   path to write {argv, env, calls, decision} as JSON
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
@@ -14,7 +14,7 @@ import { writeFileSync } from "node:fs";
 const mode = process.env.FAKE_CODEX_MODE ?? "happy";
 
 if (process.argv[2] === "--version") {
-  process.stdout.write("codex-cli 0.146.0\n");
+  process.stdout.write("codex-cli 0.147.0\n");
   process.exit(0);
 }
 if (process.argv[2] === "login" && process.argv[3] === "status") {
@@ -22,7 +22,10 @@ if (process.argv[2] === "login" && process.argv[3] === "status") {
     process.stderr.write("Not logged in\n");
     process.exit(1);
   }
-  process.stdout.write("Logged in using ChatGPT\n");
+  // Codex 0.147.0 reports a successful login on stderr; retain a mode for
+  // older versions that wrote the same status on stdout.
+  const statusStream = mode === "logged-in-stdout" ? process.stdout : process.stderr;
+  statusStream.write("Logged in using ChatGPT\n");
   process.exit(0);
 }
 const calls: Array<{ method: string; params: unknown }> = [];


### PR DESCRIPTION
## Summary

- pass `stderr` alongside `stdout` through the shared `execCli` helper
- recognize a successful Codex login status on either output stream
- reproduce the Codex CLI 0.147.0 behavior in the fake CLI
- retain regression coverage for older versions that wrote the status to `stdout`

## Root cause

`codex login status` exits successfully, but Codex CLI 0.147.0 writes `Logged in using ChatGPT` to `stderr`. OpenMausBot only inspected `stdout`, so it reported a valid session as `authenticated: false` and unnecessarily prompted the user to run `codex login`.

## Impact

OpenMausBot now recognizes existing Codex sessions correctly. The check still fails closed when the command returns an error or reports `Not logged in`.

## Validation

- `pnpm exec vitest run server/drivers/codex.test.ts`: 19 tests passed
- `pnpm typecheck`: passed
- `pnpm exec vitest run --reporter=dot`: 106 test files passed, 1,029 tests passed, 8 skipped
- `git diff --check`: passed

`pnpm lint` remains red because of existing `anti-slop` violations outside the diff. The targeted lint run did not report any line changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex login detection across CLI output streams.
  - Correctly recognizes authenticated status from older Codex versions.
  - Improved handling of command-line error output and text encoding.
- **Tests**
  - Added coverage for login status reported through standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->