### PR TITLE
Credential vault — secure store, management UI, and fill trust boundary

### DIFF
--- a/docs/superpowers/specs/2026-08-19-bot-credential-vault-design.md
+++ b/docs/superpowers/specs/2026-08-19-bot-credential-vault-design.md
@@ -1,0 +1,177 @@
+# Bot credential vault — design
+
+- Status: proposed (spec only; no code)
+- Author decisions captured: 2026-08-19
+- Scope: let a bot sign in to the user's own accounts (Gmail → Google Drive/Sheets, and the long tail of password sites) **inside an isolated computer**, without the model ever seeing the secret, across macOS / Windows / Linux and the iOS / Android companions.
+
+---
+
+## 1. The problem, stated precisely
+
+A user wants a bot to do real work in a logged-in session — open their Gmail in a VM, pull a sheet from Drive — without using the OAuth plugin (Composio) and without typing the password themselves every time.
+
+The naïve version ("store the password, have the bot type it") fails on the security bar the user set: **robust, not easily breached, on every platform.** Two independent threats have to be defended at once (the user chose "both, equally"):
+
+- **T1 — a tricked or misbehaving bot.** The model is prompt-injected by a web page, or goes off-script, and tries to exfiltrate the credential or sign in to the wrong (phishing) site.
+- **T2 — someone with access to the machine.** A stolen laptop, a second OS user, a backup that leaks. They should not be able to read the vault.
+
+The design is organised around one invariant that answers T1, plus standard at-rest hygiene that answers T2.
+
+### The core invariant
+
+> **The model never sees the secret.** Not in a prompt, a tool argument, a tool result, a transcript line, or a screenshot it is given to read.
+
+If a credential ever enters the model's context it is effectively public: it lands in the native protocol log, in the replayed/compacted context (portable context, plan item 2.2), on the provider's servers, and in whatever the model chooses to echo. Content redaction (plan item 2.4) catches *shaped* secrets like `sk-…`; a Gmail password has no shape, so redaction cannot be the control. Exfiltration must be **structurally impossible**, not discouraged.
+
+---
+
+## 2. What we build vs. what we reuse
+
+**We do not build a password manager.** "Cannot be easily breached" is a bar that audited managers (Bitwarden, KeePassXC, 1Password) spent a decade reaching; an MIT side-project vault will not match them and should not pretend to. The security contribution that is genuinely OpenMausBot's is the **blind fill**: the model-out-of-the-loop, origin-pinned, approved delivery of a secret into a browser. Storage can be the user's existing manager or an audited open format.
+
+### Licensing (the project is MIT and must stay free)
+
+Rule: **spawn or talk to GPL tools over a process boundary; only link MIT/BSD/Apache code.** This is exactly how the harness already treats engines (it spawns the `claude`/`codex` CLIs, it does not vendor them).
+
+| Component | License | Use |
+|---|---|---|
+| **OS keystores** — macOS Keychain, Windows DPAPI, Linux libsecret (via Electron `safeStorage`) | OS | link — Phase 1 default |
+| **KDBX format** + `kdbxweb` | format open; lib **MIT** | vendor — Phase 2 |
+| KeePassXC app / `keepassxc-cli` | GPLv3 | spawn/protocol only — Phase 3 |
+| Bitwarden `bw` CLI; Vaultwarden server | GPLv3 client; AGPL server | spawn `bw`; user self-hosts Vaultwarden free — Phase 3 |
+| 1Password `op` CLI | proprietary, CLI free | optional spawn — Phase 3 |
+
+Vendoring any GPL/AGPL **code** into this MIT repo is prohibited; every one of the above except the OS keystores and `kdbxweb` is reached only as a separate process.
+
+---
+
+## 3. Architecture — a `CredentialProvider` port with adapters
+
+The same move the harness makes for engines: one narrow interface, adapters behind it, the user picks. Adapters differ only in *where the ciphertext lives and how it is unlocked*; the blind-fill path above them is identical.
+
+```ts
+interface CredentialProvider {
+  /** metadata only — never a secret. Called by the HARNESS with the real
+   *  origin it read from the browser, not by the model. */
+  lookup(origin: string): Promise<VaultMatch[]>;   // [{ id, username, hasTotp }]
+  /** type a field into the isolated computer via the CUA driver. The secret
+   *  is decrypted in Electron main, typed, and zeroed — it never crosses
+   *  into the harness server, a tool argument, or a tool result. */
+  fill(entryId: string, field: "username" | "password" | "totp", target: FillTarget): Promise<FillOutcome>;
+  list(): Promise<VaultEntryMeta[]>;               // for the Settings UI, metadata only
+  upsert / remove(...)                             // CRUD, Electron-main only, Touch-ID/Hello gated
+}
+type FillOutcome = "filled" | "no-match" | "needs-approval" | "locked" | "unavailable";
+```
+
+Adapters (shipped in phases, §8):
+
+1. **Built-in keystore** (Phase 1, default, zero setup). Ciphertext in `credentials.bin`'s successor, encrypted by a key held only in the OS keystore via `safeStorage` (the mechanism already used for the Composio key — `electron/main.mjs` `CREDENTIALS_FILE`). Where no keystore exists (Linux server, headless), a master **passphrase** with Argon2id is the fallback.
+2. **KDBX file** (Phase 2). `kdbxweb` (MIT) opens the user's own `.kdbx` (Argon2 KDF, AES-256/ChaCha20 — an audited format). The payoff is interop: the **same file opens in KeePassXC on desktop, Strongbox on iOS, KeePassDX on Android**, so we get cross-platform and mobile without writing any mobile crypto. Sync is the user's (iCloud/Drive/Syncthing) — not ours.
+3. **External manager** (Phase 3, BYO). Bitwarden/Vaultwarden via `bw`, 1Password via `op`, KeePassXC via its browser-integration protocol. The user keeps their manager; we only ever ask "the entry for *this origin*, for *this bot*, please."
+
+---
+
+## 4. At rest (answers T2)
+
+- Vault file is **ciphertext only**. No key material, no plaintext secret, ever written under `~/.openmausbot` or into `config.json`. (The store already redacts its native protocol tee; the stronger guarantee here is that there is nothing to redact — the harness server process never holds a secret.)
+- The decryption key lives in the **OS keystore** (Keychain / DPAPI / libsecret). Losing the file without the machine's keystore yields nothing.
+- **Unlock** = OS biometric/credential once per app session: Touch ID via `systemPreferences`/LocalAuthentication (macOS, present today), **Windows Hello** via `UserConsentVerifier` (a small native helper, or passphrase fallback if we avoid a native module), Polkit/passphrase on Linux. Optional **"ask every fill"** per high-value entry. Auto-relock on OS screen-lock/sleep and after N idle minutes.
+- Secrets are decrypted **only in Electron main**, one field at a time, held in a buffer for the duration of a fill, then zeroed. They are never sent over the harness's HTTP/SSE surface.
+- **Backup/export** is an explicit, biometric-gated action producing a passphrase-encrypted bundle (or is simply "your `.kdbx`" under the Phase-2 adapter). No silent sync.
+
+---
+
+## 5. In use — the blind fill (answers T1)
+
+The only moment a secret is in motion. Five controls, all enforced by the **harness**, none trusting the model:
+
+1. **Origin read by the harness, not the model.** The computer proxy already exposes `browser_snapshot` (structured element refs) and semantic `browser_click`/`browser_fill` into the box (`server/computer-proxy.ts`). The vault fill reads the **browser's real current origin** from that channel (address bar / accessibility tree / the automation context's `page.url()`), never from the model's description of the page. This is the anti-phishing control: a credential for `accounts.google.com` is only ever typed into a page whose real origin is `accounts.google.com`, exactly like a browser password manager's domain match.
+2. **Blind tool surface.** The model's tool is `vault_fill({ field })` — **no secret in, no secret out.** The harness matches origin → vault, and on a unique allowed match types the field through the CUA driver. The tool *result* is only `"filled" | "no-match" | "needs-approval"`.
+3. **Masked frames.** The screenshot handed back to the model after a fill has password-field regions blanked, and no frame is returned while a reveal-password toggle is on. (Browsers render `••••`, but a "show password" click would otherwise leak it into the very screenshot the model reads.)
+4. **Authority gating.** Per-entry allowlist of which **bots** may use it and which **contexts** ("vm" | "box" — never "host", §6); a per-fill **approval card** reusing the existing Allow/Deny pattern — *"Brody wants to sign in to accounts.google.com as you@gmail.com"* (never the password) — with an "always allow on this origin for this bot" that behaves like the existing narrow `alwaysAllow` grant.
+5. **Audit.** Every fill → a chip in the chat and an append-only vault log row (origin, bot, time, approver). Never the secret.
+
+2FA: TOTP seeds live in the vault; `vault_fill({ field: "totp" })` generates the code in Electron and types it. SMS/push MFA keeps today's rule (the system prompt already says *"at a sign-in, password, MFA, CAPTCHA… stop and ask the user to complete it on the visible computer"*, `server/index.ts`): hand control to the human.
+
+### The one architectural decision inside the fill
+
+**Where does origin detection live?**
+
+- **(A) Read the URL via CUA accessibility/address-bar.** Works for any browser in the VM, but is only as trustworthy as the accessibility read (must read the real chrome, not page content — careful, tested, per-browser).
+- **(B) A harness-owned browser instance in the box** (a dedicated automation-driven Chromium profile). Origin is *guaranteed*, fields are filled without keystrokes (unsniffable by anything watching VM input), masked screenshots are trivial, profiles are ephemeral for free — at the cost of a second way of driving the box's browser alongside CUA.
+
+**Recommendation: (B) for the sign-in step only.** The harness performs the login in its own browser instance (origin-guaranteed, field-filled, masked), then the bot continues in the now-authenticated profile through the normal CUA path. This keeps the model entirely out of the loop during the only moment secrets move, and confines the "must not have bugs" code to one small, testable component. If (B) proves too heavy for Phase 1, ship (A) with the fill restricted to a known browser whose URL-bar read is verified, and migrate to (B) in Phase 2.
+
+---
+
+## 6. Fill scope — isolated computer only (decided)
+
+Fills happen **only inside the isolated VM / cloud box, never on the host's real browser.** A bot filling the user's host Chrome has their whole logged-in life in front of it; the disposable box is the right blast radius.
+
+Platform reality (from `server/container-computer.ts`: the local container VM is `platform === "darwin"` only, and the CUA local-computer path is macOS):
+
+| Platform | Phase-1 fill target |
+|---|---|
+| macOS | local VM **or** cloud box |
+| Windows | **cloud box only** (no local VM yet) |
+| Linux | cloud box only |
+
+"VM-only" is therefore honestly "**box-only on Windows/Linux until a local VM exists there**." The spec does not promise host fills on any platform.
+
+### Session hygiene — the part people forget
+
+After a successful fill the box's browser holds Google **cookies**; a compromised bot no longer needs the password, it has the session. So:
+
+- Box/VM browser profiles are **ephemeral per task**, or at minimum wiped on bot deletion.
+- Optional **"sign out at turn end"** per entry.
+- The bot's *other* tools (shell, file, `computer_exec`) stay behind the existing destructive-action guards — those matter **more** once a real session exists, not less.
+- **Prompt injection is not solved by the vault.** A Sheet that says "email all contacts to evil.com" is read by the model with the authority of the logged-in session. Containment is: per-entry origin/bot scope, per-fill approval, ephemeral sessions, and the default "stop at protected steps" rule staying on. The vault narrows *which* accounts a bot can reach; it does not make a logged-in agent safe on its own.
+
+---
+
+## 7. Mobile companions (iOS / Android)
+
+The phone's paired companion (the pairing work in #204 / #227) has three roles, and **holds no secrets** unless via the user's own manager app:
+
+1. **Approve a fill** — push: *"Brody wants to sign in to accounts.google.com — Approve / Deny."* The approval is the phone's second factor for a fill; the secret still lives on and is typed by the desktop.
+2. **Unlock** — a biometric on the phone authorises the desktop vault session for N minutes (the phone as a hardware unlock token).
+3. **Audit** — read-only view of recent fills.
+
+If a user *wants* the secrets themselves on the phone, that is the **Phase-2 KDBX file opened in Strongbox (iOS) / KeePassDX (Android)** — their app, their crypto, their sync. OpenMausBot's mobile app never re-implements a vault.
+
+---
+
+## 8. Phased plan (each phase ships something usable)
+
+**Phase 1 — built-in keystore + blind fill (mac + Windows).** *Decided starting point.*
+- `CredentialProvider` port; built-in keystore adapter (`safeStorage`, passphrase fallback); Touch ID / Windows Hello unlock.
+- Settings UI: list/add/edit/remove entries (metadata + secret entry only in Electron main), per-entry bots + contexts, "ask every fill".
+- `vault_fill` tool on the computer-proxy path; harness-side origin detection (start with (A) on a verified browser, or (B) if feasible), masked frames, approval card, audit chip.
+- Fill target: local VM (mac) / cloud box (Win). Ephemeral profile on bot delete.
+- *Done when:* a bot signs into a real account inside the box, the secret appears nowhere in the transcript / native log / any tool payload, and a stolen `credentials.bin` without the keystore reveals nothing.
+
+**Phase 2 — KDBX adapter.** Cross-platform robust storage; unlocks Strongbox/KeePassDX interop; migrate origin detection to (B) if Phase 1 shipped (A). Optional "sign out at turn end".
+
+**Phase 3 — BYO managers + phone actions.** `bw` / `op` / KeePassXC adapters; phone-side approve / unlock / audit over the companion channel; per-org policy (which entries, which bots).
+
+Explicitly **out of scope** (so it does not quietly grow): host-browser autofill, our own cloud sync, sharing vaults across machines, re-implementing passkeys (defer to the OS), and any "let the model see it just this once" escape hatch — that last one is the entire failure mode.
+
+---
+
+## 9. Open questions to resolve before Phase 1 code
+
+1. **Origin detection (A) vs (B):** can the harness read the box browser's real URL reliably enough for (A) on macOS's CUA path, or do we commit to (B)'s owned browser from the start? Needs a spike against the local VM's actual browser.
+2. **Windows Hello without a native module:** is the passphrase fallback acceptable for Phase 1 on Windows, with Hello deferred?
+3. **Ephemeral profile granularity:** per task, per bot, or per fill? Per-task is the likely default; confirm against how the box lifecycle works today.
+4. **Approval fatigue vs. safety:** default to "ask every fill" or "ask once per origin+bot"? Suggest ask-every-fill for the first release, relax later.
+5. **What identifies "origin" for non-web logins** (a desktop app in the VM, an `ssh` prompt)? Phase 1 is web-only; note it.
+
+---
+
+## 10. Why this meets the bar
+
+- **T1 (tricked bot):** the model never holds the secret; the harness pins the fill to the browser's real origin; every fill is scoped to bot+context and approved; sessions are ephemeral. A compromised model cannot read, phish, or export a credential — the worst it can do is trigger an approval prompt the user denies.
+- **T2 (machine access):** ciphertext-only at rest, key in the OS keystore, biometric unlock, short in-memory lifetime, no plaintext or key on disk.
+- **Free & legal:** OS keystores and `kdbxweb` are link-safe (OS / MIT); every heavier manager is reached as a separate process, keeping this repo MIT.
+- **Every platform:** keystore adapter on mac/Win/Linux desktop; KDBX gives desktop↔mobile interop through the user's own KeePass-family apps; the companion phones approve/unlock/audit without holding secrets.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,8 +8,10 @@ import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
+import vaultModule from "./vault.cjs";
 
 const { desktopCapabilities } = capabilitiesModule;
+const { createVault } = vaultModule;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
@@ -380,6 +382,18 @@ ipcMain.handle("desktop:pick-folder", async (event, current) => {
   });
   return result.canceled ? null : (result.filePaths[0] ?? null);
 });
+
+// ── credential vault ──────────────────────────────────────────────────
+// Secrets a bot may sign in with. They live here in main, keystore-
+// encrypted, and are handed to the renderer only as metadata; the raw
+// secret leaves this process only when typed into an isolated computer
+// during a blind fill (a later phase). See docs/superpowers/specs/
+// 2026-08-19-bot-credential-vault-design.md.
+const vault = createVault({ userData: app.getPath("userData"), log: slog });
+ipcMain.handle("vault:list", () => vault.list());
+ipcMain.handle("vault:upsert", (_event, input) => vault.upsert(input ?? {}));
+ipcMain.handle("vault:remove", (_event, id) => vault.remove(String(id)));
+ipcMain.handle("vault:reveal", (_event, id) => vault.reveal(String(id)));
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
   if (typeof rawUrl !== "string") throw new Error("A web address is required");

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -10,10 +10,14 @@ import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 import vaultModule from "./vault.cjs";
 import vaultBridgeModule from "./vault-bridge.cjs";
+import vaultFillCuaModule from "./vault-fill-cua.cjs";
+import totpModule from "./totp.cjs";
 
 const { desktopCapabilities } = capabilitiesModule;
 const { createVault } = vaultModule;
 const { startVaultBridge } = vaultBridgeModule;
+const { cuaFillSeams } = vaultFillCuaModule;
+const { generateTotp } = totpModule;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
@@ -396,6 +400,33 @@ ipcMain.handle("vault:list", () => vault.list());
 ipcMain.handle("vault:upsert", (_event, input) => vault.upsert(input ?? {}));
 ipcMain.handle("vault:remove", (_event, id) => vault.remove(String(id)));
 ipcMain.handle("vault:reveal", (_event, id) => vault.reveal(String(id)));
+// Diagnostic: run the real fill chain (read the page's origin, match this
+// entry, type into the focused browser field) so a user can verify the
+// blind fill against a live browser without a bot. The production bot path
+// is VM/box-only; this explicit, user-clicked test uses whatever computer
+// is connected. Returns only an outcome — never the secret.
+ipcMain.handle("vault:test-fill", async (_event, id, field) => {
+  const entries = await vault.list();
+  const meta = entries.find((e) => e.id === String(id));
+  if (!meta) return { outcome: "no-match", reason: "no such entry" };
+  const seams = cuaFillSeams({ userData: app.getPath("userData"), home: app.getPath("home"), totp: (s) => generateTotp(s) });
+  let origin;
+  try {
+    origin = await seams.readOrigin({ context: "vm", threadId: "test" });
+  } catch (err) {
+    return { outcome: "no-origin", reason: String(err?.message ?? err) };
+  }
+  // reuse the exact scoping the bridge enforces (origin + bot + context)
+  const match = (await vault.matchForFill({ origin, botId: (meta.allowedBots[0] ?? "test"), context: (meta.contexts[0] ?? "vm") })).find((e) => e.id === meta.id);
+  if (!match) return { outcome: "no-match", origin, entryOrigin: meta.origin };
+  try {
+    await seams.fillIntoComputer({ entry: match, field: field === "username" || field === "totp" ? field : "password", context: "vm", threadId: "test", botId: "test" });
+    await vault.markUsed(match.id);
+    return { outcome: "filled", origin };
+  } catch (err) {
+    return { outcome: "fill-failed", reason: String(err?.message ?? err), origin };
+  }
+});
 // The fill bridge: the server may REQUEST a fill over loopback; main
 // decrypts and types into the isolated computer, and answers with an
 // outcome only — the secret never leaves this process to the server. The
@@ -403,16 +434,21 @@ ipcMain.handle("vault:reveal", (_event, id) => vault.reveal(String(id)));
 // is wired in a live-VM session; until then a fill reports unavailable
 // rather than pretending. See the Phase-1b design.
 let vaultBridge = null;
-startVaultBridge({
-  userData: app.getPath("userData"),
-  vault,
-  log: slog,
-  fillIntoComputer: async () => {
-    throw new Error("VM credential fill is not yet wired on this build");
-  },
-})
-  .then((b) => (vaultBridge = b))
-  .catch((err) => slog(`vault bridge failed to start: ${err?.message ?? err}`));
+{
+  // TOTP is generated in main from the stored seed — never leaves this process
+  const totp = (seed) => generateTotp(seed);
+  const seams = cuaFillSeams({ userData: app.getPath("userData"), home: app.getPath("home"), totp });
+  startVaultBridge({
+    userData: app.getPath("userData"),
+    vault,
+    log: slog,
+    readOrigin: seams.readOrigin,
+    fillIntoComputer: seams.fillIntoComputer,
+    totp,
+  })
+    .then((b) => (vaultBridge = b))
+    .catch((err) => slog(`vault bridge failed to start: ${err?.message ?? err}`));
+}
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
   if (typeof rawUrl !== "string") throw new Error("A web address is required");

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -9,9 +9,11 @@ import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 import vaultModule from "./vault.cjs";
+import vaultBridgeModule from "./vault-bridge.cjs";
 
 const { desktopCapabilities } = capabilitiesModule;
 const { createVault } = vaultModule;
+const { startVaultBridge } = vaultBridgeModule;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
@@ -394,6 +396,23 @@ ipcMain.handle("vault:list", () => vault.list());
 ipcMain.handle("vault:upsert", (_event, input) => vault.upsert(input ?? {}));
 ipcMain.handle("vault:remove", (_event, id) => vault.remove(String(id)));
 ipcMain.handle("vault:reveal", (_event, id) => vault.reveal(String(id)));
+// The fill bridge: the server may REQUEST a fill over loopback; main
+// decrypts and types into the isolated computer, and answers with an
+// outcome only — the secret never leaves this process to the server. The
+// actual keystroke into the VM (approach B, a harness-owned login browser)
+// is wired in a live-VM session; until then a fill reports unavailable
+// rather than pretending. See the Phase-1b design.
+let vaultBridge = null;
+startVaultBridge({
+  userData: app.getPath("userData"),
+  vault,
+  log: slog,
+  fillIntoComputer: async () => {
+    throw new Error("VM credential fill is not yet wired on this build");
+  },
+})
+  .then((b) => (vaultBridge = b))
+  .catch((err) => slog(`vault bridge failed to start: ${err?.message ?? err}`));
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
   if (typeof rawUrl !== "string") throw new Error("A web address is required");

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -71,6 +71,7 @@ contextBridge.exposeInMainWorld("ogb", {
     upsert: (input) => ipcRenderer.invoke("vault:upsert", input),
     remove: (id) => ipcRenderer.invoke("vault:remove", id),
     reveal: (id) => ipcRenderer.invoke("vault:reveal", id),
+    testFill: (id, field) => ipcRenderer.invoke("vault:test-fill", id, field),
   },
   /** Native folder picker for a bot's working folder; null when cancelled. */
   pickFolder: (current) => ipcRenderer.invoke("desktop:pick-folder", current),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -64,6 +64,14 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Open a web link in the default browser. Unlike renderer window.open,
    * this remains reliable after an asynchronous API request. */
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
+  /** The credential vault (secrets a bot may sign in with). The renderer
+   * only ever sees metadata; the raw secret never crosses this bridge. */
+  vault: {
+    list: () => ipcRenderer.invoke("vault:list"),
+    upsert: (input) => ipcRenderer.invoke("vault:upsert", input),
+    remove: (id) => ipcRenderer.invoke("vault:remove", id),
+    reveal: (id) => ipcRenderer.invoke("vault:reveal", id),
+  },
   /** Native folder picker for a bot's working folder; null when cancelled. */
   pickFolder: (current) => ipcRenderer.invoke("desktop:pick-folder", current),
   /** Store a provider credential with OS-backed encryption. */

--- a/electron/totp.cjs
+++ b/electron/totp.cjs
@@ -1,0 +1,35 @@
+// RFC 6238 TOTP, dependency-free, main-side. The seed never leaves main;
+// this turns it into the 6-digit code that is typed into the computer.
+const crypto = require("node:crypto");
+
+/** Decode a base32 (RFC 4648) secret, ignoring spaces and padding. */
+function base32Decode(input) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const clean = String(input).toUpperCase().replace(/[\s=]/g, "");
+  let bits = "";
+  for (const ch of clean) {
+    const idx = alphabet.indexOf(ch);
+    if (idx === -1) throw new Error("invalid base32 in TOTP seed");
+    bits += idx.toString(2).padStart(5, "0");
+  }
+  const bytes = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) bytes.push(parseInt(bits.slice(i, i + 8), 2));
+  return Buffer.from(bytes);
+}
+
+/** @param {string} seed base32 secret @param {{ now?: number, digits?: number, period?: number }} [opts] */
+function generateTotp(seed, opts = {}) {
+  const digits = opts.digits ?? 6;
+  const period = opts.period ?? 30;
+  const counter = Math.floor((opts.now ?? Date.now()) / 1000 / period);
+  const key = base32Decode(seed);
+  const buf = Buffer.alloc(8);
+  buf.writeUInt32BE(Math.floor(counter / 2 ** 32), 0);
+  buf.writeUInt32BE(counter >>> 0, 4);
+  const hmac = crypto.createHmac("sha1", key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code = ((hmac[offset] & 0x7f) << 24) | (hmac[offset + 1] << 16) | (hmac[offset + 2] << 8) | hmac[offset + 3];
+  return (code % 10 ** digits).toString().padStart(digits, "0");
+}
+
+module.exports = { generateTotp, base32Decode };

--- a/electron/totp.node-test.mjs
+++ b/electron/totp.node-test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const { generateTotp } = require("./totp.cjs");
+
+test("matches RFC 6238 SHA-1 test vectors", () => {
+  // the RFC's canonical seed is ASCII "12345678901234567890" → base32:
+  const seed = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+  assert.equal(generateTotp(seed, { now: 59_000, digits: 8 }), "94287082");
+  assert.equal(generateTotp(seed, { now: 1111111109_000, digits: 8 }), "07081804");
+});
+test("6 digits by default, tolerates spaces in the seed", () => {
+  const code = generateTotp("JBSW Y3DP EHPK 3PXP", { now: 0 });
+  assert.match(code, /^\d{6}$/);
+});
+test("rejects a non-base32 seed", () => {
+  assert.throws(() => generateTotp("not base 32 !!!"));
+});

--- a/electron/vault-bridge.cjs
+++ b/electron/vault-bridge.cjs
@@ -32,6 +32,7 @@ function timingSafeEqual(a, b) {
  *   vault: import("./vault.cjs").Vault,
  *   log?: (m: string) => void,
  *   fillIntoComputer: (job: { entry: any, field: "username"|"password"|"totp", context: "vm"|"box", threadId: string, botId: string }) => Promise<void>,
+ *   readOrigin?: (ctx: { context: "vm"|"box", threadId: string }) => Promise<string>,
  *   totp?: (seed: string) => string,
  * }} deps
  */
@@ -74,7 +75,19 @@ function startVaultBridge(deps) {
       return doFill(entry, pending.field, pending.context, pending.botId, pending.threadId);
     }
 
-    const matches = await deps.vault.matchForFill({ origin, botId, context });
+    // main reads the REAL origin itself when it can, so a compromised
+    // server cannot steer the match; the body origin is only a fallback for
+    // callers (and tests) without a live browser.
+    let realOrigin = origin;
+    if (deps.readOrigin) {
+      try {
+        realOrigin = await deps.readOrigin({ context, threadId });
+      } catch (err) {
+        log(`vault fill: could not read origin: ${err?.message ?? err}`);
+        return { outcome: "no-match", reason: "no-origin" };
+      }
+    }
+    const matches = await deps.vault.matchForFill({ origin: realOrigin, botId, context });
     // zero, or ambiguous (more than one for the same origin+bot) → refuse.
     // Ambiguity must never resolve to "guess one"; the user disambiguates.
     if (matches.length !== 1) return { outcome: "no-match", count: matches.length };
@@ -82,7 +95,7 @@ function startVaultBridge(deps) {
 
     if (entry.askEveryFill !== false) {
       const approvalToken = crypto.randomBytes(18).toString("hex");
-      pendingApprovals.set(approvalToken, { entryId: entry.id, field, context, botId, threadId, origin, at: Date.now() });
+      pendingApprovals.set(approvalToken, { entryId: entry.id, field, context, botId, threadId, origin: realOrigin, at: Date.now() });
       // metadata only — the card the harness raises shows who/where, never the secret
       return { outcome: "needs-approval", approvalToken, origin: entry.origin, username: entry.username };
     }

--- a/electron/vault-bridge.cjs
+++ b/electron/vault-bridge.cjs
@@ -1,0 +1,146 @@
+// The vault fill bridge — the trust boundary for Phase 1b.
+//
+// The secret lives in Electron main and must NEVER reach the harness server
+// or the model. But the server is what drives the VM and knows when a bot
+// wants to sign in. So the direction is: the server REQUESTS a fill over a
+// loopback endpoint main owns; main validates, decrypts, types into the
+// isolated computer, and answers with an OUTCOME only. A secret is never in
+// a response body, so the channel cannot leak one even if misused.
+//
+// Auth mirrors the harness's own /api/internal guard: a random token +
+// loopback-only bind. The {port, token} descriptor is written to a 0600 file
+// in the shared userData dir (like cua-connection.json), so the standalone
+// dev server and the packaged forked server both find it the same way.
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const DESCRIPTOR = "vault-bridge.json";
+const APPROVAL_TTL_MS = 5 * 60_000;
+
+function timingSafeEqual(a, b) {
+  const ab = Buffer.from(a ?? "");
+  const bb = Buffer.from(b ?? "");
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/**
+ * @param {{
+ *   userData: string,
+ *   vault: import("./vault.cjs").Vault,
+ *   log?: (m: string) => void,
+ *   fillIntoComputer: (job: { entry: any, field: "username"|"password"|"totp", context: "vm"|"box", threadId: string, botId: string }) => Promise<void>,
+ *   totp?: (seed: string) => string,
+ * }} deps
+ */
+function startVaultBridge(deps) {
+  const log = deps.log ?? (() => {});
+  const token = crypto.randomBytes(24).toString("hex");
+  // approvalToken -> { entryId, field, context, botId, threadId, at }
+  const pendingApprovals = new Map();
+
+  const gc = () => {
+    const now = Date.now();
+    for (const [k, v] of pendingApprovals) if (now - v.at > APPROVAL_TTL_MS) pendingApprovals.delete(k);
+  };
+
+  /** Do the fill for a validated match. Returns an outcome, never a secret. */
+  const doFill = async (entry, field, context, botId, threadId) => {
+    if (field === "totp") {
+      if (!entry.totpSeed) return { outcome: "no-match" };
+    }
+    await deps.fillIntoComputer({ entry, field, context, threadId, botId });
+    await deps.vault.markUsed(entry.id);
+    return { outcome: "filled" };
+  };
+
+  const handleFill = async (body) => {
+    gc();
+    const botId = String(body?.botId ?? "");
+    const threadId = String(body?.threadId ?? "");
+    const origin = String(body?.origin ?? "");
+    const field = body?.field === "username" || body?.field === "totp" ? body.field : "password";
+    const context = body?.context === "box" ? "box" : "vm";
+
+    // an approval token from a prior needs-approval → validate and fill
+    if (body?.approvalToken) {
+      const pending = pendingApprovals.get(String(body.approvalToken));
+      pendingApprovals.delete(String(body.approvalToken));
+      if (!pending || Date.now() - pending.at > APPROVAL_TTL_MS) return { outcome: "unavailable" };
+      const entry = (await deps.vault.matchForFill({ origin: pending.origin, botId: pending.botId, context: pending.context })).find((e) => e.id === pending.entryId);
+      if (!entry) return { outcome: "no-match" };
+      return doFill(entry, pending.field, pending.context, pending.botId, pending.threadId);
+    }
+
+    const matches = await deps.vault.matchForFill({ origin, botId, context });
+    // zero, or ambiguous (more than one for the same origin+bot) → refuse.
+    // Ambiguity must never resolve to "guess one"; the user disambiguates.
+    if (matches.length !== 1) return { outcome: "no-match", count: matches.length };
+    const entry = matches[0];
+
+    if (entry.askEveryFill !== false) {
+      const approvalToken = crypto.randomBytes(18).toString("hex");
+      pendingApprovals.set(approvalToken, { entryId: entry.id, field, context, botId, threadId, origin, at: Date.now() });
+      // metadata only — the card the harness raises shows who/where, never the secret
+      return { outcome: "needs-approval", approvalToken, origin: entry.origin, username: entry.username };
+    }
+    return doFill(entry, field, context, botId, threadId);
+  };
+
+  const server = http.createServer((req, res) => {
+    const send = (code, obj) => {
+      res.writeHead(code, { "content-type": "application/json" });
+      res.end(JSON.stringify(obj));
+    };
+    // loopback-only, even though we bind to 127.0.0.1: defence in depth
+    const host = (req.headers.host ?? "").split(":")[0];
+    if (host !== "127.0.0.1" && host !== "localhost") return send(403, { error: "forbidden" });
+    if (!timingSafeEqual(req.headers.authorization ?? "", `Bearer ${token}`)) return send(401, { error: "unauthorized" });
+    if (req.method !== "POST" || req.url !== "/vault/fill") return send(404, { error: "not found" });
+    let raw = "";
+    req.on("data", (c) => {
+      raw += c;
+      if (raw.length > 8192) req.destroy();
+    });
+    req.on("end", () => {
+      let body;
+      try {
+        body = JSON.parse(raw || "{}");
+      } catch {
+        return send(400, { error: "bad json" });
+      }
+      handleFill(body)
+        .then((outcome) => send(200, outcome))
+        .catch((err) => {
+          log(`vault fill failed: ${err?.message ?? err}`);
+          send(200, { outcome: "unavailable" });
+        });
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      const file = path.join(deps.userData, DESCRIPTOR);
+      try {
+        fs.writeFileSync(file, JSON.stringify({ port, token }), { mode: 0o600 });
+      } catch (err) {
+        log(`vault bridge descriptor write failed: ${err?.message ?? err}`);
+      }
+      log(`vault bridge on 127.0.0.1:${port}`);
+      resolve({
+        port,
+        stop: () => {
+          try {
+            fs.unlinkSync(file);
+          } catch {}
+          server.close();
+        },
+      });
+    });
+  });
+}
+
+module.exports = { startVaultBridge, DESCRIPTOR };

--- a/electron/vault-bridge.node-test.mjs
+++ b/electron/vault-bridge.node-test.mjs
@@ -1,0 +1,126 @@
+// The vault fill bridge's trust boundary, off-Electron: real HTTP, a fake
+// keystore-backed vault, a fill SINK that records what would be typed. The
+// point is to prove the boundary — auth, loopback, origin/ambiguity refusal,
+// approval flow — AND that a response body never carries a secret.
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { Vault } = require("./vault.cjs");
+const { startVaultBridge, DESCRIPTOR } = require("./vault-bridge.cjs");
+
+const fakeStore = {
+  isAsyncEncryptionAvailable: async () => true,
+  encryptStringAsync: async (s) => Buffer.from(s, "utf8").toString("base64"),
+  decryptStringAsync: async (b) => ({ result: Buffer.from(b.toString(), "base64").toString("utf8") }),
+};
+
+async function harness(seed = async () => {}) {
+  const dir = mkdtempSync(join(tmpdir(), "omb-vbridge-"));
+  const vault = new Vault({ file: join(dir, "vault.bin"), storage: fakeStore, touchId: async () => {} });
+  await seed(vault);
+  /** what was "typed" into the computer — the secret only ever reaches here */
+  const sink = [];
+  const bridge = await startVaultBridge({
+    userData: dir,
+    vault,
+    fillIntoComputer: async (job) => {
+      const value = job.field === "totp" ? "123456" : job.field === "username" ? job.entry.username : job.entry.secret;
+      sink.push({ field: job.field, value, context: job.context, botId: job.botId });
+    },
+  });
+  const { port, token } = JSON.parse(readFileSync(join(dir, DESCRIPTOR), "utf8"));
+  const call = (body, auth = `Bearer ${token}`) =>
+    fetch(`http://127.0.0.1:${port}/vault/fill`, { method: "POST", headers: { "content-type": "application/json", authorization: auth }, body: JSON.stringify(body) });
+  return { dir, vault, sink, port, token, call, stop: bridge.stop };
+}
+
+test("rejects a missing or wrong token, and a non-fill route", async () => {
+  const h = await harness();
+  try {
+    assert.equal((await h.call({}, "")).status, 401);
+    assert.equal((await h.call({}, "Bearer nope")).status, 401);
+    const bad = await fetch(`http://127.0.0.1:${h.port}/other`, { method: "POST", headers: { authorization: `Bearer ${h.token}` } });
+    assert.equal(bad.status, 404);
+  } finally {
+    h.stop();
+    rmSync(h.dir, { recursive: true, force: true });
+  }
+});
+
+test("no vault match → no-match, nothing typed", async () => {
+  const h = await harness();
+  try {
+    const r = await (await h.call({ botId: "b", threadId: "t", origin: "accounts.google.com", field: "password" })).json();
+    assert.equal(r.outcome, "no-match");
+    assert.equal(h.sink.length, 0);
+  } finally {
+    h.stop();
+    rmSync(h.dir, { recursive: true, force: true });
+  }
+});
+
+test("askEveryFill: first call needs approval (metadata only, no secret), the token then fills", async () => {
+  const h = await harness(async (v) => {
+    await v.upsert({ origin: "accounts.google.com", username: "me@gmail.com", secret: "hunter2", allowedBots: ["brody"], contexts: ["vm"], askEveryFill: true });
+  });
+  try {
+    const first = await (await h.call({ botId: "brody", threadId: "t", origin: "https://accounts.google.com/signin", field: "password", context: "vm" })).json();
+    assert.equal(first.outcome, "needs-approval");
+    assert.equal(first.username, "me@gmail.com");
+    assert.equal(first.origin, "https://accounts.google.com");
+    // the needs-approval body carries NO secret
+    assert.equal(JSON.stringify(first).includes("hunter2"), false);
+    assert.equal(h.sink.length, 0);
+
+    const done = await (await h.call({ approvalToken: first.approvalToken })).json();
+    assert.equal(done.outcome, "filled");
+    // the secret reached ONLY the fill sink
+    assert.deepEqual(h.sink, [{ field: "password", value: "hunter2", context: "vm", botId: "brody" }]);
+    assert.equal(JSON.stringify(done).includes("hunter2"), false);
+
+    // the approval token is single-use
+    assert.equal((await (await h.call({ approvalToken: first.approvalToken })).json()).outcome, "unavailable");
+  } finally {
+    h.stop();
+    rmSync(h.dir, { recursive: true, force: true });
+  }
+});
+
+test("askEveryFill:false fills immediately; the response still has no secret", async () => {
+  const h = await harness(async (v) => {
+    await v.upsert({ origin: "example.com", username: "u", secret: "s3cr3t", allowedBots: [], contexts: ["vm"], askEveryFill: false });
+  });
+  try {
+    const r = await (await h.call({ botId: "anyone", threadId: "t", origin: "example.com", field: "password", context: "vm" })).json();
+    assert.equal(r.outcome, "filled");
+    assert.equal(h.sink[0].value, "s3cr3t");
+    assert.equal(JSON.stringify(r).includes("s3cr3t"), false);
+  } finally {
+    h.stop();
+    rmSync(h.dir, { recursive: true, force: true });
+  }
+});
+
+test("a lookalike origin never matches (anti-phishing), and ambiguity refuses", async () => {
+  const h = await harness(async (v) => {
+    await v.upsert({ origin: "accounts.google.com", username: "a", secret: "s1", askEveryFill: false });
+    await v.upsert({ origin: "accounts.google.com", username: "b", secret: "s2", askEveryFill: false });
+  });
+  try {
+    // phishing lookalike
+    assert.equal((await (await h.call({ botId: "x", threadId: "t", origin: "https://accounts-google.com", field: "password" })).json()).outcome, "no-match");
+    // two entries for the same origin: ambiguous → refuse, never guess
+    const amb = await (await h.call({ botId: "x", threadId: "t", origin: "accounts.google.com", field: "password" })).json();
+    assert.equal(amb.outcome, "no-match");
+    assert.equal(amb.count, 2);
+    assert.equal(h.sink.length, 0);
+  } finally {
+    h.stop();
+    rmSync(h.dir, { recursive: true, force: true });
+  }
+});

--- a/electron/vault-fill-cua.cjs
+++ b/electron/vault-fill-cua.cjs
@@ -1,0 +1,107 @@
+// The CUA realisation of the blind fill (Phase 1b, approach B).
+//
+// Runs in Electron main, so the secret never leaves this process. Uses the
+// cua-driver `page` tool — the same browser automation the agent's computer
+// uses — to (1) read the page's REAL origin via location.origin (the
+// anti-phishing anchor: it comes from the browser, never from the model)
+// and (2) fill the focused field via CDP Input.insertText (no synthesized
+// keystrokes to sniff). On the isolated VM the browser runs with remote-
+// debugging so CDP answers directly; on a host browser the user must enable
+// "JavaScript from Apple Events" once (macOS Chrome), which is why fills are
+// VM/box-only in production.
+//
+// This module shells `cua-driver call <tool> <json> --socket <sock>`, the
+// same protocol the server-side computer proxy speaks, reading the socket
+// from the cua-connection descriptor main already writes.
+const { execFile } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function cuaConnection(userData, home) {
+  const candidates = [];
+  if (userData) candidates.push(path.join(userData, "cua-connection.json"));
+  if (process.platform === "darwin") {
+    for (const d of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+      candidates.push(path.join(home, "Library", "Application Support", d, "cua-connection.json"));
+    }
+  }
+  for (const file of [...new Set(candidates)]) {
+    try {
+      const d = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (d && d.mode !== "unavailable" && typeof d.mcpCommand === "string" && typeof d.socketPath === "string") {
+        return { binary: d.mcpCommand, socket: d.socketPath };
+      }
+    } catch {
+      /* missing / stale */
+    }
+  }
+  return null;
+}
+
+function call(binary, socket, tool, args, timeoutMs = 15_000) {
+  return new Promise((resolve, reject) => {
+    execFile(binary, ["call", tool, JSON.stringify(args), "--socket", socket], { timeout: timeoutMs, maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) return reject(new Error((stderr || err.message || "").toString().slice(0, 200)));
+      let parsed = null;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        parsed = { raw: String(stdout).trim() };
+      }
+      resolve(parsed);
+    });
+  });
+}
+
+/** The frontmost on-screen browser window, or null. */
+async function frontBrowser(binary, socket) {
+  const res = await call(binary, socket, "list_windows", {});
+  const windows = (res && (res.windows || res.result?.windows)) || [];
+  const browsers = windows.filter((w) => w.is_on_screen && /Chrome|Chromium|Brave|Edge|Arc|Safari|Firefox/i.test(w.app_name || ""));
+  if (!browsers.length) return null;
+  browsers.sort((a, b) => (a.z_index ?? 0) - (b.z_index ?? 0)); // topmost first
+  const w = browsers[0];
+  return { pid: w.pid, windowId: w.window_id };
+}
+
+/** location.origin from the live browser — the security anchor. */
+async function readOrigin(deps) {
+  const conn = cuaConnection(deps.userData, deps.home);
+  if (!conn) throw new Error("no computer connection");
+  const b = await frontBrowser(conn.binary, conn.socket);
+  if (!b) throw new Error("no browser window in the computer");
+  const res = await call(conn.binary, conn.socket, "page", { action: "execute_javascript", pid: b.pid, window_id: b.windowId, javascript: "location.origin" });
+  const value = typeof res?.result === "string" ? res.result : typeof res?.value === "string" ? res.value : typeof res?.raw === "string" ? res.raw : null;
+  if (!value || !/^https?:\/\//i.test(value)) throw new Error(`could not read the page origin (${JSON.stringify(res).slice(0, 120)})`);
+  return value.trim();
+}
+
+/** Type a value into whatever field currently holds focus in the browser.
+ * The secret arrives here, in main, and goes straight to the browser via
+ * CDP insert_text; it is not returned or logged. */
+async function fillIntoComputer(deps, job) {
+  const conn = cuaConnection(deps.userData, deps.home);
+  if (!conn) throw new Error("no computer connection");
+  const b = await frontBrowser(conn.binary, conn.socket);
+  if (!b) throw new Error("no browser window in the computer");
+  const value =
+    job.field === "totp"
+      ? (deps.totp ?? (() => { throw new Error("no TOTP generator"); }))(job.entry.totpSeed)
+      : job.field === "username"
+        ? job.entry.username
+        : job.entry.secret;
+  // insert_text writes at the current DOM focus — the model focused the
+  // field before calling vault_fill. No keystroke events, nothing to sniff.
+  await call(conn.binary, conn.socket, "page", { action: "insert_text", pid: b.pid, window_id: b.windowId, text: value });
+}
+
+/** Bind the seams the bridge expects, closing over userData/home. */
+function cuaFillSeams(opts) {
+  const deps = { userData: opts.userData, home: opts.home, totp: opts.totp };
+  return {
+    readOrigin: () => readOrigin(deps),
+    fillIntoComputer: (job) => fillIntoComputer(deps, job),
+  };
+}
+
+module.exports = { cuaFillSeams, readOrigin, fillIntoComputer, cuaConnection };

--- a/electron/vault.cjs
+++ b/electron/vault.cjs
@@ -1,0 +1,177 @@
+// The credential vault — Phase 1a of the bot vault design.
+//
+// Secrets a bot may sign in WITH live here, in Electron main, encrypted at
+// rest by the OS keystore (safeStorage → macOS Keychain / Windows DPAPI /
+// Linux libsecret). They never leave this process as plaintext except when
+// TYPED into an isolated computer during a blind fill (Phase 1b) — never to
+// the harness server, never to the model, never into a tool argument or
+// transcript. This module owns only storage and the metadata the UI needs;
+// the fill itself is main-side too (a later phase) so a secret never crosses
+// the process boundary to the server.
+//
+// The vault file is separate from credentials.bin (API keys): different
+// lifetime, different blast radius, and a corrupt vault must not take the
+// app's own keys down with it.
+const { safeStorage, systemPreferences } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+/** @typedef {{ id: string, origin: string, username: string, secret: string,
+ *   totpSeed?: string, allowedBots: string[], contexts: ("vm"|"box")[],
+ *   askEveryFill: boolean, createdAt: number, updatedAt: number,
+ *   lastUsedAt?: number }} VaultEntry */
+
+function normalizeOrigin(raw) {
+  const s = String(raw ?? "").trim();
+  if (!s) return "";
+  try {
+    // accept a bare host or a full URL; store the ORIGIN (scheme+host[+port])
+    const u = new URL(/^https?:\/\//i.test(s) ? s : `https://${s}`);
+    return u.origin.toLowerCase();
+  } catch {
+    return s.toLowerCase();
+  }
+}
+
+class Vault {
+  /** @param {{ file: string, log?: (m: string) => void, storage?: any, touchId?: (reason: string) => Promise<void> }} opts */
+  constructor(opts) {
+    this.file = opts.file;
+    this.log = opts.log ?? (() => {});
+    // injectable so the security-relevant logic is testable off-Electron;
+    // in the app it is the OS keystore
+    this.storage = opts.storage ?? safeStorage;
+    this.touchId = opts.touchId;
+    /** @type {VaultEntry[]} */
+    this.entries = [];
+    this.loaded = false;
+  }
+
+  async #load() {
+    if (this.loaded) return;
+    this.loaded = true;
+    try {
+      if (!fs.existsSync(this.file) || !(await this.storage.isAsyncEncryptionAvailable())) return;
+      const decrypted = await this.storage.decryptStringAsync(fs.readFileSync(this.file));
+      const parsed = JSON.parse(decrypted.result);
+      if (Array.isArray(parsed)) this.entries = parsed;
+    } catch (error) {
+      this.log(`vault load failed: ${error?.message ?? error}`);
+    }
+  }
+
+  async #save() {
+    if (!(await this.storage.isAsyncEncryptionAvailable())) {
+      throw new Error("The operating-system credential store is unavailable, so the vault cannot be saved securely.");
+    }
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    const encrypted = await this.storage.encryptStringAsync(JSON.stringify(this.entries));
+    const tmp = `${this.file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, encrypted, { mode: 0o600 });
+    fs.renameSync(tmp, this.file);
+  }
+
+  /** Metadata only — never a secret. Safe to hand to the renderer. */
+  async list() {
+    await this.#load();
+    return this.entries.map((e) => ({
+      id: e.id,
+      origin: e.origin,
+      username: e.username,
+      hasTotp: Boolean(e.totpSeed),
+      allowedBots: e.allowedBots ?? [],
+      contexts: e.contexts ?? ["vm", "box"],
+      askEveryFill: e.askEveryFill !== false,
+      createdAt: e.createdAt,
+      updatedAt: e.updatedAt,
+      lastUsedAt: e.lastUsedAt,
+    }));
+  }
+
+  /** Add or replace an entry. `input.secret` empty on an edit keeps the old one. */
+  async upsert(input) {
+    await this.#load();
+    const origin = normalizeOrigin(input.origin);
+    if (!origin) throw new Error("A site (origin) is required.");
+    const username = String(input.username ?? "").trim();
+    const now = Date.now();
+    const existing = input.id ? this.entries.find((e) => e.id === input.id) : undefined;
+    const secret = typeof input.secret === "string" && input.secret !== "" ? input.secret : existing?.secret;
+    if (!secret) throw new Error("A password is required.");
+    /** @type {VaultEntry} */
+    const entry = {
+      id: existing?.id ?? crypto.randomUUID(),
+      origin,
+      username,
+      secret,
+      totpSeed: typeof input.totpSeed === "string" && input.totpSeed.trim() ? input.totpSeed.replace(/\s+/g, "").toUpperCase() : existing?.totpSeed,
+      allowedBots: Array.isArray(input.allowedBots) ? input.allowedBots.filter((b) => typeof b === "string") : (existing?.allowedBots ?? []),
+      contexts: Array.isArray(input.contexts) && input.contexts.length ? input.contexts.filter((c) => c === "vm" || c === "box") : (existing?.contexts ?? ["vm", "box"]),
+      askEveryFill: input.askEveryFill !== false,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      lastUsedAt: existing?.lastUsedAt,
+    };
+    if (existing) this.entries = this.entries.map((e) => (e.id === existing.id ? entry : e));
+    else this.entries.unshift(entry);
+    await this.#save();
+    return { id: entry.id };
+  }
+
+  async remove(id) {
+    await this.#load();
+    const before = this.entries.length;
+    this.entries = this.entries.filter((e) => e.id !== id);
+    if (this.entries.length !== before) await this.#save();
+    return { removed: before !== this.entries.length };
+  }
+
+  /** Reveal one secret to the USER, gated by an OS auth prompt where the
+   * platform offers one (Touch ID). Never used by the fill path — the model
+   * side is blind; this exists only so a person can check what they stored. */
+  async reveal(id) {
+    await this.#load();
+    const entry = this.entries.find((e) => e.id === id);
+    if (!entry) throw new Error("No such entry.");
+    const prompt = this.touchId ?? ((reason) =>
+      process.platform === "darwin" && systemPreferences.canPromptTouchID?.()
+        ? systemPreferences.promptTouchID(reason)
+        : Promise.resolve());
+    try {
+      await prompt("reveal a stored password");
+    } catch {
+      throw new Error("Authentication was cancelled.");
+    }
+    return { secret: entry.secret, totpSeed: entry.totpSeed ?? null };
+  }
+
+  /** For the fill path (Phase 1b, main-side): the entries whose origin
+   * matches AND that allow this bot in this context. Returns FULL entries —
+   * callers must be in Electron main and must never forward the secret. */
+  async matchForFill({ origin, botId, context }) {
+    await this.#load();
+    const want = normalizeOrigin(origin);
+    return this.entries.filter(
+      (e) =>
+        e.origin === want &&
+        (e.allowedBots.length === 0 || e.allowedBots.includes(botId)) &&
+        (e.contexts ?? ["vm", "box"]).includes(context),
+    );
+  }
+
+  async markUsed(id) {
+    await this.#load();
+    const entry = this.entries.find((e) => e.id === id);
+    if (!entry) return;
+    entry.lastUsedAt = Date.now();
+    await this.#save();
+  }
+}
+
+/** @param {{ userData: string, log?: (m: string) => void }} opts */
+function createVault(opts) {
+  return new Vault({ file: path.join(opts.userData, "vault.bin"), log: opts.log });
+}
+
+module.exports = { createVault, normalizeOrigin, Vault };

--- a/electron/vault.node-test.mjs
+++ b/electron/vault.node-test.mjs
@@ -1,0 +1,106 @@
+// Pure vault logic, off-Electron: a fake keystore backend stands in for
+// safeStorage so the security-relevant behaviour — metadata never carries a
+// secret, and a fill only matches the right origin+bot+context — is tested
+// without the Electron runtime.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { Vault, normalizeOrigin } = require("./vault.cjs");
+
+// a reversible "keystore": good enough to prove round-trips, not real crypto
+const fakeStore = {
+  isAsyncEncryptionAvailable: async () => true,
+  encryptStringAsync: async (s) => Buffer.from(s, "utf8").toString("base64"),
+  decryptStringAsync: async (buf) => ({ result: Buffer.from(buf.toString(), "base64").toString("utf8") }),
+};
+const newVault = () => {
+  const dir = mkdtempSync(join(tmpdir(), "omb-vault-"));
+  const vault = new Vault({ file: join(dir, "vault.bin"), storage: fakeStore, touchId: async () => {} });
+  return { vault, dir };
+};
+
+test("normalizeOrigin stores scheme+host, accepts bare host or full URL", () => {
+  assert.equal(normalizeOrigin("accounts.google.com"), "https://accounts.google.com");
+  assert.equal(normalizeOrigin("https://mail.google.com/mail/u/0/#inbox"), "https://mail.google.com");
+  assert.equal(normalizeOrigin("HTTP://Example.com:8080/x"), "http://example.com:8080");
+  assert.equal(normalizeOrigin("  "), "");
+});
+
+test("list() returns metadata and NEVER the secret or totp seed", async () => {
+  const { vault, dir } = newVault();
+  try {
+    await vault.upsert({ origin: "accounts.google.com", username: "me@gmail.com", secret: "hunter2", totpSeed: "JBSW Y3DP", allowedBots: ["b1"], contexts: ["vm"] });
+    const list = await vault.list();
+    assert.equal(list.length, 1);
+    const row = list[0];
+    assert.equal(row.username, "me@gmail.com");
+    assert.equal(row.origin, "https://accounts.google.com");
+    assert.equal(row.hasTotp, true);
+    // the wire shape carries no secret material at all
+    assert.equal(JSON.stringify(row).includes("hunter2"), false);
+    assert.equal(JSON.stringify(row).includes("JBSWY3DP"), false);
+    assert.equal("secret" in row, false);
+    assert.equal("totpSeed" in row, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("matchForFill scopes by origin, allowed bot, and context", async () => {
+  const { vault, dir } = newVault();
+  try {
+    await vault.upsert({ origin: "accounts.google.com", username: "me", secret: "s", allowedBots: ["brody"], contexts: ["vm"] });
+    // right origin, right bot, right context → matches
+    assert.equal((await vault.matchForFill({ origin: "https://accounts.google.com/signin", botId: "brody", context: "vm" })).length, 1);
+    // wrong origin (a lookalike) → no match, the anti-phishing control
+    assert.equal((await vault.matchForFill({ origin: "https://accounts-google.com", botId: "brody", context: "vm" })).length, 0);
+    // wrong bot → no match
+    assert.equal((await vault.matchForFill({ origin: "accounts.google.com", botId: "someone-else", context: "vm" })).length, 0);
+    // wrong context (host is never allowed; only vm here) → no match
+    assert.equal((await vault.matchForFill({ origin: "accounts.google.com", botId: "brody", context: "box" })).length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an empty allowedBots means any bot; contexts default to vm+box", async () => {
+  const { vault, dir } = newVault();
+  try {
+    await vault.upsert({ origin: "example.com", username: "u", secret: "s", allowedBots: [], contexts: [] });
+    assert.equal((await vault.matchForFill({ origin: "example.com", botId: "anyone", context: "box" })).length, 1);
+    assert.equal((await vault.matchForFill({ origin: "example.com", botId: "anyone", context: "vm" })).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("edit keeps the old secret when none is supplied; reveal returns it; remove deletes", async () => {
+  const { vault, dir } = newVault();
+  try {
+    const { id } = await vault.upsert({ origin: "example.com", username: "u", secret: "s3cr3t" });
+    await vault.upsert({ id, origin: "example.com", username: "u2", secret: "" }); // rename only
+    const [row] = await vault.list();
+    assert.equal(row.username, "u2");
+    assert.equal((await vault.reveal(id)).secret, "s3cr3t");
+    assert.equal((await vault.remove(id)).removed, true);
+    assert.equal((await vault.list()).length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("survives a reload — a new Vault over the same file reads it back", async () => {
+  const { vault, dir } = newVault();
+  try {
+    await vault.upsert({ origin: "example.com", username: "u", secret: "s" });
+    const again = new Vault({ file: join(dir, "vault.bin"), storage: fakeStore });
+    assert.equal((await again.list()).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/server/vault-client.test.ts
+++ b/server/vault-client.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readVaultBridge, requestVaultFill } from "./vault-client.ts";
+
+const dirs: string[] = [];
+const tmp = () => {
+  const d = mkdtempSync(join(tmpdir(), "omb-vaultclient-"));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("readVaultBridge", () => {
+  it("reads a valid descriptor and rejects a malformed one", () => {
+    const d = tmp();
+    writeFileSync(join(d, "vault-bridge.json"), JSON.stringify({ port: 51234, token: "abc" }));
+    expect(readVaultBridge({ userData: d, platform: "linux" })).toEqual({ port: 51234, token: "abc" });
+    writeFileSync(join(d, "vault-bridge.json"), "{not json");
+    expect(readVaultBridge({ userData: d, platform: "linux" })).toBeNull();
+    expect(readVaultBridge({ userData: tmp(), platform: "linux" })).toBeNull();
+  });
+});
+
+describe("requestVaultFill", () => {
+  it("is unavailable when no bridge descriptor exists", async () => {
+    const prev = process.env.OMB_USER_DATA;
+    process.env.OMB_USER_DATA = tmp();
+    try {
+      expect(await requestVaultFill({ botId: "b", threadId: "t", origin: "x", field: "password", context: "vm" })).toEqual({ outcome: "unavailable" });
+    } finally {
+      if (prev === undefined) delete process.env.OMB_USER_DATA;
+      else process.env.OMB_USER_DATA = prev;
+    }
+  });
+
+  it("carries the request to the bridge and returns its outcome verbatim", async () => {
+    const d = tmp();
+    writeFileSync(join(d, "vault-bridge.json"), JSON.stringify({ port: 9, token: "tok" }));
+    const prev = process.env.OMB_USER_DATA;
+    process.env.OMB_USER_DATA = d;
+    let seen: { url: string; auth: string | null; body: any } | null = null;
+    const fakeFetch = (async (url: string, init: RequestInit) => {
+      seen = { url: String(url), auth: (init.headers as Record<string, string>).authorization ?? null, body: JSON.parse(String(init.body)) };
+      return new Response(JSON.stringify({ outcome: "needs-approval", approvalToken: "a1", origin: "https://accounts.google.com", username: "me" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await requestVaultFill({ botId: "brody", threadId: "t1", origin: "accounts.google.com", field: "password", context: "vm" }, fakeFetch);
+      expect(out).toEqual({ outcome: "needs-approval", approvalToken: "a1", origin: "https://accounts.google.com", username: "me" });
+      expect(seen!.url).toBe("http://127.0.0.1:9/vault/fill");
+      expect(seen!.auth).toBe("Bearer tok");
+      expect(seen!.body).toMatchObject({ botId: "brody", origin: "accounts.google.com", field: "password" });
+    } finally {
+      if (prev === undefined) delete process.env.OMB_USER_DATA;
+      else process.env.OMB_USER_DATA = prev;
+    }
+  });
+});

--- a/server/vault-client.ts
+++ b/server/vault-client.ts
@@ -1,0 +1,71 @@
+// The harness's side of the vault fill bridge. The secret lives in Electron
+// main; this asks main to fill it and receives an OUTCOME only. There is no
+// path here that could carry a secret — by construction, not by discipline.
+//
+// The {port, token} descriptor is written by main to userData/vault-bridge
+// .json (the same shared-file pattern as cua-connection.json), so the
+// standalone dev server and the packaged forked server both find it.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type VaultFillOutcome =
+  | { outcome: "filled" }
+  | { outcome: "no-match"; count?: number }
+  | { outcome: "needs-approval"; approvalToken: string; origin: string; username: string }
+  | { outcome: "unavailable" };
+
+export interface VaultFillRequest {
+  botId: string;
+  threadId: string;
+  /** the browser's REAL origin, read by the harness — never the model's claim */
+  origin: string;
+  field: "username" | "password" | "totp";
+  context: "vm" | "box";
+  /** returned by a prior needs-approval, after the user approved the card */
+  approvalToken?: string;
+}
+
+function descriptorCandidates(userData: string | undefined, home: string, platform: NodeJS.Platform): string[] {
+  const out = userData ? [join(userData, "vault-bridge.json")] : [];
+  if (platform === "darwin") {
+    for (const dir of ["OpenMausBot", "openmausbot", "OpenGrokBot", "opengrokbot"]) {
+      out.push(join(home, "Library", "Application Support", dir, "vault-bridge.json"));
+    }
+  }
+  return [...new Set(out)];
+}
+
+export function readVaultBridge(opts: { userData?: string; home?: string; platform?: NodeJS.Platform } = {}): { port: number; token: string } | null {
+  const userData = opts.userData ?? process.env.OMB_USER_DATA;
+  const home = opts.home ?? homedir();
+  const platform = opts.platform ?? process.platform;
+  for (const file of descriptorCandidates(userData, home, platform)) {
+    try {
+      const d = JSON.parse(readFileSync(file, "utf8"));
+      if (typeof d?.port === "number" && typeof d?.token === "string") return { port: d.port, token: d.token };
+    } catch {
+      /* missing / stale — unavailable */
+    }
+  }
+  return null;
+}
+
+/** Ask main to fill. `unavailable` when the bridge is absent (browser build,
+ * or a main that predates the vault) — the caller treats it as "can't fill". */
+export async function requestVaultFill(req: VaultFillRequest, fetchImpl: typeof fetch = fetch): Promise<VaultFillOutcome> {
+  const bridge = readVaultBridge();
+  if (!bridge) return { outcome: "unavailable" };
+  try {
+    const res = await fetchImpl(`http://127.0.0.1:${bridge.port}/vault/fill`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${bridge.token}` },
+      body: JSON.stringify(req),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return { outcome: "unavailable" };
+    return (await res.json()) as VaultFillOutcome;
+  } catch {
+    return { outcome: "unavailable" };
+  }
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,7 +3,7 @@
 // is the stuff shared by every bot: who you are, your keys, and the
 // machine your bots can borrow.
 import { useEffect, useRef, useState } from "react";
-import { Coins, KeyRound, Monitor, Smartphone, Terminal, User, Volume2, X } from "lucide-react";
+import { Coins, KeyRound, KeySquare, Monitor, Smartphone, Terminal, User, Volume2, X } from "lucide-react";
 import { useStore, type AppSettingsSection } from "@/state/store";
 import { ApiKeyRow } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
@@ -12,6 +12,7 @@ import { LocalComputerSection } from "./LocalComputerSection";
 import { CompanionSection } from "./CompanionSection";
 import { Card } from "./SettingsPrimitives";
 import { UsageSection } from "./UsageSection";
+import { VaultSection } from "./VaultSection";
 import { VoiceSettings } from "./VoiceSettings";
 import { cn } from "@/lib/cn";
 
@@ -23,6 +24,7 @@ const SECTIONS: Array<{ id: AppSettingsSection; label: string; icon: typeof User
   { id: "computer", label: "Local VM", icon: Monitor },
   { id: "voice", label: "Voice", icon: Volume2 },
   { id: "usage", label: "Usage", icon: Coins },
+  { id: "vault", label: "Vault", icon: KeySquare },
 ];
 
 /** Name + email, persisted to /api/config {profile} on blur. */
@@ -242,6 +244,8 @@ export function SettingsModal() {
             {section === "computer" && <LocalComputerSection />}
 
             {section === "usage" && <UsageSection />}
+
+            {section === "vault" && <VaultSection />}
           </div>
         </div>
       </div>

--- a/src/components/VaultSection.tsx
+++ b/src/components/VaultSection.tsx
@@ -1,0 +1,303 @@
+// App Settings → Vault. Where a user stores the sign-ins a bot may use to
+// reach the user's own accounts (Gmail → Drive/Sheets, and the long tail of
+// password sites) inside an isolated computer, WITHOUT the OAuth plugin.
+//
+// The renderer only ever sees metadata: the origin, the username, whether a
+// TOTP seed is set, and the scope (which bots, which contexts). The password
+// itself lives in Electron main, encrypted by the OS keystore, and is shown
+// back only through an OS-auth-gated reveal. The model never sees it at all —
+// a fill (a later phase) types it into the isolated computer without the
+// secret ever crossing into the harness or a tool call.
+//
+// See docs/superpowers/specs/2026-08-19-bot-credential-vault-design.md.
+import { useEffect, useState } from "react";
+import { Eye, KeySquare, Loader2, Plus, ShieldCheck, Trash2 } from "lucide-react";
+import { useStore } from "@/state/store";
+import { Card } from "./SettingsPrimitives";
+import { MausAvatar } from "./Avatar";
+import { cn } from "@/lib/cn";
+import type { MausColor } from "@/lib/mascot";
+
+const inputCls =
+  "w-full rounded-lg border border-hairline/40 bg-inset px-3 py-2.5 text-[14px] text-ink placeholder:text-ink-secondary focus:border-hairline focus:outline-none";
+
+const CONTEXT_LABEL: Record<VaultContext, string> = { vm: "Local VM", box: "Cloud box" };
+
+function hostOf(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}
+
+export function VaultSection() {
+  const { state } = useStore();
+  const bridge = window.ogb?.vault;
+  const [entries, setEntries] = useState<VaultEntryMeta[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<VaultEntryMeta | "new" | null>(null);
+  const bots = state.bots.filter((b) => !b.hidden);
+
+  const load = () => {
+    bridge
+      ?.list()
+      .then((e) => (setEntries(e), setError(null)))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  };
+  useEffect(load, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!bridge) {
+    return (
+      <Card title="Vault" subtitle="Sign-ins your bots may use inside an isolated computer.">
+        <div className="text-[13px] text-ink-secondary">
+          The vault needs the desktop app — it stores passwords in your operating system's keychain. It isn't available in the browser.
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      title="Vault"
+      subtitle="Sign-ins a bot may use to reach your own accounts inside an isolated computer. Passwords are stored in your OS keychain and never shown to the AI."
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start gap-2 rounded-xl border border-hairline/40 bg-inset/50 px-3.5 py-2.5 text-[12px] leading-relaxed text-ink-secondary">
+          <ShieldCheck size={15} className="mt-0.5 shrink-0 text-[#38d591]" />
+          <span>
+            The model never sees these passwords. When a bot signs in, the app types the credential straight into the isolated computer — it never enters a prompt, a tool result, or the transcript. Fills happen only in a Local VM or Cloud box, never your own browser.
+          </span>
+        </div>
+
+        {error && <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+
+        {editing ? (
+          <VaultForm
+            entry={editing === "new" ? null : editing}
+            bots={bots}
+            onDone={(changed) => {
+              setEditing(null);
+              if (changed) load();
+            }}
+          />
+        ) : (
+          <>
+            {entries === null ? (
+              <div className="flex items-center gap-2 py-4 text-ink-secondary">
+                <Loader2 size={15} className="animate-spin" /> Loading…
+              </div>
+            ) : entries.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-hairline/50 px-4 py-6 text-center text-[13px] text-ink-secondary">
+                No sign-ins yet. Add one to let a bot log in on your behalf inside a VM.
+              </div>
+            ) : (
+              <div className="flex flex-col divide-y divide-hairline/20">
+                {entries.map((entry) => (
+                  <VaultRow key={entry.id} entry={entry} bots={bots} onEdit={() => setEditing(entry)} onChanged={load} onError={setError} />
+                ))}
+              </div>
+            )}
+            <button
+              onClick={() => setEditing("new")}
+              className="mt-1 flex items-center justify-center gap-1.5 rounded-lg bg-accent py-2.5 text-[14px] font-medium text-white hover:brightness-110"
+            >
+              <Plus size={15} /> Add a sign-in
+            </button>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function VaultRow({
+  entry,
+  bots,
+  onEdit,
+  onChanged,
+  onError,
+}: {
+  entry: VaultEntryMeta;
+  bots: Array<{ id: string; name: string; color: MausColor }>;
+  onEdit: () => void;
+  onChanged: () => void;
+  onError: (m: string) => void;
+}) {
+  const [revealed, setRevealed] = useState<string | null>(null);
+  const allowed = entry.allowedBots.length === 0 ? "Any bot" : bots.filter((b) => entry.allowedBots.includes(b.id)).map((b) => b.name).join(", ") || "specific bots";
+
+  return (
+    <div className="flex items-start gap-3 py-3">
+      <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-inset text-ink-secondary">
+        <KeySquare size={15} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-[14px] font-medium text-ink">
+          {hostOf(entry.origin)}
+          {entry.hasTotp && <span className="rounded bg-inset px-1.5 py-0.5 text-[10px] font-normal text-ink-secondary">2FA</span>}
+        </div>
+        <div className="mt-0.5 text-[12.5px] text-ink-secondary">{entry.username || "no username"}</div>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-ink-secondary">
+          <span className="rounded bg-inset px-1.5 py-0.5">{allowed}</span>
+          {entry.contexts.map((c) => (
+            <span key={c} className="rounded bg-inset px-1.5 py-0.5">
+              {CONTEXT_LABEL[c]}
+            </span>
+          ))}
+          {entry.askEveryFill && <span className="rounded bg-inset px-1.5 py-0.5">asks each time</span>}
+        </div>
+        {revealed !== null && <div className="mt-1.5 rounded-lg bg-inset px-2.5 py-1.5 font-mono text-[12px] text-ink">{revealed}</div>}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          title="Reveal (asks for your fingerprint)"
+          onClick={() =>
+            revealed !== null
+              ? setRevealed(null)
+              : window.ogb!.vault!.reveal(entry.id).then((r) => setRevealed(r.secret)).catch((e) => onError(e instanceof Error ? e.message : String(e)))
+          }
+          className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+        >
+          <Eye size={15} />
+        </button>
+        <button onClick={onEdit} className="rounded-md px-2 py-1.5 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink">
+          Edit
+        </button>
+        <button
+          title="Delete"
+          onClick={() => window.ogb!.vault!.remove(entry.id).then(onChanged).catch((e) => onError(e instanceof Error ? e.message : String(e)))}
+          className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-danger"
+        >
+          <Trash2 size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function VaultForm({
+  entry,
+  bots,
+  onDone,
+}: {
+  entry: VaultEntryMeta | null;
+  bots: Array<{ id: string; name: string; color: MausColor }>;
+  onDone: (changed: boolean) => void;
+}) {
+  const [origin, setOrigin] = useState(entry ? hostOf(entry.origin) : "");
+  const [username, setUsername] = useState(entry?.username ?? "");
+  const [secret, setSecret] = useState("");
+  const [totpSeed, setTotpSeed] = useState("");
+  const [allowedBots, setAllowedBots] = useState<string[]>(entry?.allowedBots ?? []);
+  const [contexts, setContexts] = useState<VaultContext[]>(entry?.contexts ?? ["vm", "box"]);
+  const [askEveryFill, setAskEveryFill] = useState(entry?.askEveryFill ?? true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = <T,>(list: T[], v: T, set: (l: T[]) => void) => set(list.includes(v) ? list.filter((x) => x !== v) : [...list, v]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await window.ogb!.vault!.upsert({
+        id: entry?.id,
+        origin: origin.trim(),
+        username: username.trim(),
+        secret,
+        totpSeed: totpSeed.trim() || undefined,
+        allowedBots,
+        contexts: contexts.length ? contexts : ["vm", "box"],
+        askEveryFill,
+      });
+      onDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-hairline/40 bg-inset/40 p-4">
+      <div className="text-[14px] font-medium text-ink">{entry ? "Edit sign-in" : "New sign-in"}</div>
+      <label className="block">
+        <span className="mb-1 block text-[12px] text-ink-secondary">Site</span>
+        <input className={inputCls} value={origin} onChange={(e) => setOrigin(e.target.value)} placeholder="accounts.google.com" autoFocus />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-[12px] text-ink-secondary">Username / email</span>
+        <input className={inputCls} value={username} onChange={(e) => setUsername(e.target.value)} placeholder="you@gmail.com" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-[12px] text-ink-secondary">Password{entry ? " · leave blank to keep" : ""}</span>
+        <input className={cn(inputCls, "font-mono")} type="password" value={secret} onChange={(e) => setSecret(e.target.value)} placeholder="••••••••" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-[12px] text-ink-secondary">
+          2FA seed <span className="font-normal">· optional, the TOTP secret from the site's authenticator setup</span>
+        </span>
+        <input className={cn(inputCls, "font-mono")} value={totpSeed} onChange={(e) => setTotpSeed(e.target.value)} placeholder="JBSWY3DPEHPK3PXP" />
+      </label>
+
+      <div>
+        <span className="mb-1.5 block text-[12px] text-ink-secondary">Which bots may use it</span>
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            onClick={() => setAllowedBots([])}
+            className={cn("rounded-lg border px-2.5 py-1 text-[12px]", allowedBots.length === 0 ? "border-accent/70 bg-accent/10 text-ink" : "border-hairline/50 text-ink-secondary hover:bg-raised/60")}
+          >
+            Any bot
+          </button>
+          {bots.map((b) => (
+            <button
+              key={b.id}
+              onClick={() => toggle(allowedBots, b.id, setAllowedBots)}
+              className={cn("flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[12px]", allowedBots.includes(b.id) ? "border-accent/70 bg-accent/10 text-ink" : "border-hairline/50 text-ink-secondary hover:bg-raised/60")}
+            >
+              <MausAvatar color={b.color} state="idle" size={16} animated={false} />
+              {b.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <span className="mb-1.5 block text-[12px] text-ink-secondary">Where it may be used</span>
+        <div className="flex gap-1.5">
+          {(["vm", "box"] as VaultContext[]).map((c) => (
+            <button
+              key={c}
+              onClick={() => toggle(contexts, c, setContexts)}
+              className={cn("rounded-lg border px-2.5 py-1 text-[12px]", contexts.includes(c) ? "border-accent/70 bg-accent/10 text-ink" : "border-hairline/50 text-ink-secondary hover:bg-raised/60")}
+            >
+              {CONTEXT_LABEL[c]}
+            </button>
+          ))}
+        </div>
+        <p className="mt-1 text-[11px] text-ink-secondary/70">Never your own browser — only an isolated computer.</p>
+      </div>
+
+      <label className="flex items-center gap-2 text-[12.5px] text-ink-secondary">
+        <input type="checkbox" checked={askEveryFill} onChange={(e) => setAskEveryFill(e.target.checked)} />
+        Ask me to approve every sign-in
+      </label>
+
+      {error && <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button onClick={() => onDone(false)} className="rounded-lg px-3 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink">
+          Cancel
+        </button>
+        <button
+          onClick={() => void save()}
+          disabled={saving || !origin.trim() || (!entry && !secret)}
+          className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"
+        >
+          {saving && <Loader2 size={14} className="animate-spin" />}
+          {entry ? "Save" : "Add"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VaultSection.tsx
+++ b/src/components/VaultSection.tsx
@@ -11,7 +11,7 @@
 //
 // See docs/superpowers/specs/2026-08-19-bot-credential-vault-design.md.
 import { useEffect, useState } from "react";
-import { Eye, KeySquare, Loader2, Plus, ShieldCheck, Trash2 } from "lucide-react";
+import { Eye, KeySquare, Loader2, Plus, ShieldCheck, Trash2, Wand2 } from "lucide-react";
 import { useStore } from "@/state/store";
 import { Card } from "./SettingsPrimitives";
 import { MausAvatar } from "./Avatar";
@@ -125,7 +125,30 @@ function VaultRow({
   onError: (m: string) => void;
 }) {
   const [revealed, setRevealed] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<string | null>(null);
   const allowed = entry.allowedBots.length === 0 ? "Any bot" : bots.filter((b) => entry.allowedBots.includes(b.id)).map((b) => b.name).join(", ") || "specific bots";
+
+  const runTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const r = await window.ogb!.vault!.testFill!(entry.id, "password");
+      setTestResult(
+        r.outcome === "filled"
+          ? `Filled into the focused field on ${r.origin}.`
+          : r.outcome === "no-match"
+            ? `The open page (${r.origin ?? "?"}) doesn't match this entry (${r.entryOrigin ?? entry.origin}).`
+            : r.outcome === "no-origin"
+              ? `Couldn't read the page origin — ${r.reason ?? ""}`
+              : `${r.outcome}${r.reason ? ` — ${r.reason}` : ""}`,
+      );
+    } catch (e) {
+      setTestResult(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTesting(false);
+    }
+  };
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -148,6 +171,7 @@ function VaultRow({
           {entry.askEveryFill && <span className="rounded bg-inset px-1.5 py-0.5">asks each time</span>}
         </div>
         {revealed !== null && <div className="mt-1.5 rounded-lg bg-inset px-2.5 py-1.5 font-mono text-[12px] text-ink">{revealed}</div>}
+        {testResult && <div className="mt-1.5 rounded-lg bg-inset px-2.5 py-1.5 text-[11.5px] text-ink-secondary">{testResult}</div>}
       </div>
       <div className="flex shrink-0 items-center gap-1">
         <button
@@ -160,6 +184,14 @@ function VaultRow({
           className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
         >
           <Eye size={15} />
+        </button>
+        <button
+          title="Test fill into the focused browser field"
+          disabled={testing}
+          onClick={() => void runTest()}
+          className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+        >
+          {testing ? <Loader2 size={15} className="animate-spin" /> : <Wand2 size={15} />}
         </button>
         <button onClick={onEdit} className="rounded-md px-2 py-1.5 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink">
           Edit

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -268,7 +268,8 @@ export type AppSettingsSection =
   | "companion"
   | "voice"
   | "computer"
-  | "usage";
+  | "usage"
+  | "vault";
 
 export interface AppState {
   bots: Bot[];

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -99,6 +99,8 @@ declare global {
         upsert(input: VaultUpsert): Promise<{ id: string }>;
         remove(id: string): Promise<{ removed: boolean }>;
         reveal(id: string): Promise<{ secret: string; totpSeed: string | null }>;
+        /** Diagnostic: run the real fill against the focused browser field. */
+        testFill(id: string, field: "username" | "password" | "totp"): Promise<{ outcome: string; origin?: string; reason?: string; entryOrigin?: string }>;
       };
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(name: "composioApiKey", value: string): Promise<ConfigStatus>;

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -2,6 +2,30 @@
 
 
 declare global {
+  type VaultContext = "vm" | "box";
+  interface VaultEntryMeta {
+    id: string;
+    origin: string;
+    username: string;
+    hasTotp: boolean;
+    allowedBots: string[];
+    contexts: VaultContext[];
+    askEveryFill: boolean;
+    createdAt: number;
+    updatedAt: number;
+    lastUsedAt?: number;
+  }
+  interface VaultUpsert {
+    id?: string;
+    origin: string;
+    username: string;
+    /** empty on an edit keeps the stored secret */
+    secret: string;
+    totpSeed?: string;
+    allowedBots: string[];
+    contexts: VaultContext[];
+    askEveryFill: boolean;
+  }
   type DesktopCapabilities = {
     host: {
       platform: "darwin" | "linux" | "win32" | "other";
@@ -68,6 +92,14 @@ declare global {
       openExternal?(url: string): Promise<boolean>;
       /** Native folder picker; resolves null when the user cancels. */
       pickFolder?(current?: string): Promise<string | null>;
+      /** The credential vault. The renderer only ever sees metadata; the raw
+       * secret never crosses this bridge (reveal is the one gated exception). */
+      vault?: {
+        list(): Promise<VaultEntryMeta[]>;
+        upsert(input: VaultUpsert): Promise<{ id: string }>;
+        remove(id: string): Promise<{ removed: boolean }>;
+        reveal(id: string): Promise<{ secret: string; totpSeed: string | null }>;
+      };
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(name: "composioApiKey", value: string): Promise<ConfigStatus>;
       /** In-app auto-update (packaged app only; dormant in dev). onState


### PR DESCRIPTION
> [!IMPORTANT]
> ## 🧩 This is a feature request — not ready to merge
>
> Tracking issue: **#255**. The **storage + management + trust-boundary** code below is sound and tested and can be reused. **The Phase 1b fill mechanism is blocked and must be redesigned**, so please don't merge as a finished feature — treat this as prior art for whoever picks up #255.
>
> **Why blocked:** the plan was to type the secret into the isolated computer's browser so the model never sees it. But the bot *drives that browser* via CDP — `browser_snapshot`/`execute_javascript` can read `input.value`, and it can screenshot — so it can read any filled secret straight back. "Blind fill into the agent's browser" is not blind. The secret must instead only ever be *used* inside a **broker the bot cannot observe** (see #255 for the two candidate architectures: session-broker vs intent-broker). Keep everything here except the fill-into-the-agent's-browser step.

---

## In plain language

A **Vault** in App Settings where you store the sign-ins a bot may use to reach *your own* accounts (Gmail → Drive/Sheets, and any password site) inside an isolated computer — without wiring up the OAuth plugin.

- *What you can do now:* add a site + username + password (and an optional 2FA seed), scope it to specific bots and to a Local VM / Cloud box, and choose "ask me every time." The list shows only the site and username — never the password. A per-row **reveal** asks for **Touch ID** before showing it back.
- *Where the password lives:* in your **OS keychain** (Keychain on macOS, DPAPI on Windows, libsecret on Linux), encrypted at rest in `vault.bin`. It never touches `~/.openmausbot`, never crosses the app's network surface, and the browser build can't reach it at all.
- *The AI never sees it.* This PR is the storage + management half. The part where a bot actually *signs in* (types the credential into the VM without the model ever seeing it) is **Phase 1b** — see below.

## Why only half

The full design has one hard invariant: **the model never sees the secret.** Delivering that (Phase 1b) requires typing the credential into an isolated VM from Electron main (so it never reaches the harness server), which needs (a) a new server→main bridge that doesn't exist yet, (b) a running CUA VM with a login page to type into, and (c) a decision on how the app reads the page's real origin (anti-phishing). None of that can be verified without a live VM, and building it unverified around a real Google password is exactly what the spec warns against. So this PR lands the solid, tested, at-rest half; 1b is a follow-up done against a real VM.

## Changes

- **`electron/vault.cjs`** — `Vault` over `safeStorage` (`vault.bin`, `0600`, separate from `credentials.bin`). `list()` → metadata only; `reveal()` → OS-auth-gated (Touch ID on macOS); `upsert`/`remove`; **`matchForFill({origin, botId, context})`** scopes by exact origin + allowed bot + context (a lookalike origin never matches — the anti-phishing control). Keystore backend injectable for testing.
- **`electron/main.mjs` / `preload.cjs` / `ogb.d.ts`** — `vault:*` IPC and the `window.ogb.vault` bridge (metadata only; the raw secret crosses only on the gated reveal).
- **`SettingsModal` + `VaultSection.tsx`** — the Vault tab: add/edit/remove, scope to bots + contexts, per-row Touch-ID reveal, "the model never sees these passwords" banner.
- **Spec** — `docs/superpowers/specs/2026-08-19-bot-credential-vault-design.md`: threat model (tricked bot + machine access, both), a `CredentialProvider` port with three adapters (OS keystore now; KDBX/`kdbxweb` next for cross-platform + iOS/Android interop; BYO Bitwarden/1Password/KeePassXC CLIs later), the blind-fill invariant, per-platform matrix (Windows = cloud box until a local VM exists), mobile roles, an MIT-friendly licensing table (spawn GPL over a process boundary, link only MIT), and the phased plan.

## Test plan

- [x] `electron/vault.node-test.mjs` (6, off-Electron via an injected keystore): `normalizeOrigin`; **`list()` never carries the secret or TOTP seed**; `matchForFill` scopes by origin/bot/context and **rejects a lookalike origin**; empty allow-list = any bot; edit keeps the old secret; reveal returns it; survives a reload
- [x] `pnpm typecheck` clean; `pnpm vitest run` green (106 files, 1030 passed); `pnpm check:electron` clean
- [x] Manual in the dev app: added a sign-in, listed as host+username only, Touch-ID reveal showed it, persisted across restart, stored ciphertext in `vault.bin`

Not built here (Phase 1b): the `vault_fill` tool, the server→main bridge, origin detection against the real VM browser, masked frames, the approval card, the audit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure credential vault for managing bot sign-ins.
  * Credentials can be restricted by website, bot, and isolated execution context.
  * Added optional TOTP codes and approval requirements for credential fills.
  * Added vault settings to create, edit, remove, and reveal credentials with OS authentication.
  * Supports secure credential filling without exposing secrets to the AI.
  * Added safeguards against ambiguous, unauthorized, or phishing-like credential matches.
* **Documentation**
  * Added design documentation covering security, storage, auditing, and implementation considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update — Phase 1b infrastructure: the fill trust boundary

The security-critical channel that lets a bot sign in *without the model ever seeing the secret* is now built and tested (only the keystroke into a live VM is still stubbed):

- **`electron/vault-bridge.cjs`** — main starts a loopback (`127.0.0.1`) HTTP endpoint, token + host guarded (mirrors the harness's `/api/internal` guard), and writes `{port, token}` to `userData/vault-bridge.json` (the `cua-connection.json` shared-file pattern, so dev and packaged both find it). `POST /vault/fill`: matches by the **real origin the harness read**; refuses a miss, a **lookalike**, or an **ambiguous** match (never guesses); `askEveryFill` → `needs-approval` with a single-use token and **metadata only**; else fills through a `fillIntoComputer` seam. **A response body can never carry a secret.**
- **`server/vault-client.ts`** — the harness side: read the descriptor, POST a request, get an outcome. No path here can carry a secret. Main is the responder (secret-holder); the server may only request.
- The `fillIntoComputer` seam reports "not yet wired" honestly until the live-VM session.

**Still to wire (needs a running CUA VM):** the `vault_fill` tool the model calls, origin detection via a harness-owned login browser (chosen approach), the approval card + audit chip, and the real `fillIntoComputer`.

**Tests:** `electron/vault-bridge.node-test.mjs` (5): token/loopback/route auth; no-match types nothing; `askEveryFill` needs-approval (metadata only, **no secret in the body**) then the token fills and the **secret reaches only the fill sink**; immediate fill still leaks no secret; **a lookalike origin never matches and ambiguity refuses**. `server/vault-client.test.ts` (3). Full suite green (107 files, 1033).

