### PR TITLE
feat: add a Multica driver — a workspace's agents as contacts

### DIFF
--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -17,6 +17,7 @@ import { HermesAgentDriver } from "./acp/hermes.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
 import { PiDriver } from "./pi.ts";
 import { MinimaxDriver } from "./minimax.ts";
+import { MulticaAgentDriver } from "./multica.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -35,4 +36,5 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   AntigravityDriver,
   BoxAgentDriver,
   MinimaxDriver,
+  MulticaAgentDriver,
 ];

--- a/server/drivers/multica.test.ts
+++ b/server/drivers/multica.test.ts
@@ -33,6 +33,20 @@ describe("issueTitleFromText / issueDescriptionFromText", () => {
   it("falls back to a default title for empty input", () => {
     expect(issueTitleFromText("   ")).toBe("OpenMausBot task");
   });
+
+  it("keeps the whole request when one long line has to be truncated", () => {
+    // Regression: the title caps at 200 and the brief is "the lines after the
+    // first", so a single long line used to lose everything past character
+    // 200 — the agent received a cut-off sentence and nothing else.
+    const long = `Baue die Startseite um: ${"x".repeat(250)} und dann noch der Rest`;
+    expect(issueTitleFromText(long)).toHaveLength(200);
+    expect(issueDescriptionFromText(long)).toBe(long);
+    expect(issueDescriptionFromText(long)).toContain("und dann noch der Rest");
+  });
+
+  it("still puts only the tail in the brief when the title fits", () => {
+    expect(issueDescriptionFromText("Kurzer Titel\nDetails hier")).toBe("Details hier");
+  });
 });
 
 describe("issueIdFromCursor", () => {

--- a/server/drivers/multica.test.ts
+++ b/server/drivers/multica.test.ts
@@ -1,0 +1,99 @@
+// Pure mapping functions of the multicaAgent driver: text → ticket fields,
+// run status → canonical outcome, run message → canonical runtime event.
+// These are the only parts worth unit-testing without a live factory.
+import { describe, expect, it } from "vitest";
+
+import {
+  issueDescriptionFromText,
+  issueIdFromCursor,
+  issueTitleFromText,
+  messageToEvents,
+  runSettled,
+} from "./multica.ts";
+
+const base = {
+  eventId: "ev-1",
+  provider: "multicaAgent",
+  threadId: "t1",
+  turnId: "turn-1",
+  createdAt: "2026-08-15T00:00:00Z",
+};
+
+describe("issueTitleFromText / issueDescriptionFromText", () => {
+  it("takes the first line as title and the rest as the brief", () => {
+    expect(issueTitleFromText("Landingpage X\nHero modernisieren\nCTA schärfen")).toBe("Landingpage X");
+    expect(issueDescriptionFromText("Landingpage X\nHero modernisieren\nCTA schärfen")).toBe("Hero modernisieren\nCTA schärfen");
+  });
+
+  it("single-line text has no description", () => {
+    expect(issueTitleFromText("Nur ein Titel")).toBe("Nur ein Titel");
+    expect(issueDescriptionFromText("Nur ein Titel")).toBeUndefined();
+  });
+
+  it("falls back to a default title for empty input", () => {
+    expect(issueTitleFromText("   ")).toBe("OpenMausBot task");
+  });
+});
+
+describe("issueIdFromCursor", () => {
+  // The harness hands back session.started's sessionId verbatim, so the
+  // cursor is a bare ticket id. Reading it as an envelope made every
+  // follow-up turn open a new ticket instead of commenting on the open one.
+  it("reads the bare ticket id the harness stores", () => {
+    expect(issueIdFromCursor("349bb483-1c2d-4e5f-9a8b-7c6d5e4f3a2b")).toBe("349bb483-1c2d-4e5f-9a8b-7c6d5e4f3a2b");
+  });
+
+  it("opens a new ticket when there is no cursor yet", () => {
+    expect(issueIdFromCursor(undefined)).toBeUndefined();
+    expect(issueIdFromCursor(null)).toBeUndefined();
+    expect(issueIdFromCursor("   ")).toBeUndefined();
+  });
+
+  it("still accepts an envelope, so a stored cursor keeps working", () => {
+    expect(issueIdFromCursor({ issueId: "issue-7" })).toBe("issue-7");
+    expect(issueIdFromCursor({})).toBeUndefined();
+    expect(issueIdFromCursor({ issueId: 42 })).toBeUndefined();
+  });
+});
+
+describe("runSettled", () => {
+  it("returns null while the run is still going", () => {
+    expect(runSettled({ id: "r1", status: "running" })).toBeNull();
+    expect(runSettled({ id: "r1", status: "queued" })).toBeNull();
+  });
+
+  it("maps terminal success states", () => {
+    expect(runSettled({ id: "r1", status: "completed" })).toEqual({ ok: true, stopReason: "completed" });
+    expect(runSettled({ id: "r1", status: "succeeded" })).toEqual({ ok: true, stopReason: "succeeded" });
+  });
+
+  it("maps terminal failure states", () => {
+    expect(runSettled({ id: "r1", status: "failed" })).toEqual({ ok: false, stopReason: "failed" });
+    expect(runSettled({ id: "r1", status: "cancelled" })).toEqual({ ok: false, stopReason: "cancelled" });
+  });
+});
+
+describe("messageToEvents", () => {
+  it("streams text messages as content.delta", () => {
+    const events = messageToEvents(base, { seq: 1, type: "text", content: "Ich baue die Hero-Sektion." });
+    expect(events).toEqual([
+      { ...base, type: "content.delta", streamKind: "assistant_text", delta: "Ich baue die Hero-Sektion." },
+    ]);
+  });
+
+  it("surfaces tool_use as item.started and tool_result as item.completed", () => {
+    const started = messageToEvents(base, { seq: 2, type: "tool_use", tool: "Bash" });
+    expect(started).toEqual([{ ...base, type: "item.started", itemType: "tool", itemId: "m2", title: "Bash" }]);
+    const done = messageToEvents(base, { seq: 3, type: "tool_result", tool: "Bash", output: "ok" });
+    expect(done).toEqual([{ ...base, type: "item.completed", itemType: "tool", itemId: "m3", ok: true }]);
+  });
+
+  it("maps error messages to runtime.error", () => {
+    const events = messageToEvents(base, { seq: 4, type: "error", content: "build failed" });
+    expect(events).toEqual([{ ...base, type: "runtime.error", message: "build failed" }]);
+  });
+
+  it("ignores unknown message types", () => {
+    expect(messageToEvents(base, { seq: 5, type: "heartbeat" })).toEqual([]);
+  });
+});

--- a/server/drivers/multica.ts
+++ b/server/drivers/multica.ts
@@ -49,22 +49,34 @@ function decodeConfig(raw: unknown): MulticaAgentConfig {
   return {
     profile: typeof o.profile === "string" ? o.profile : undefined,
     workspaceId: typeof o.workspaceId === "string" ? o.workspaceId : undefined,
-    pollMs: typeof o.pollMs === "number" ? o.pollMs : 3000,
+    // Clamped: a config with 0 or a negative value would spin the poll loop
+    // with no pause, two HTTP requests per iteration, against someone else's
+    // server.
+    pollMs:
+      typeof o.pollMs === "number" && Number.isFinite(o.pollMs) ? Math.max(500, o.pollMs) : 3000,
   };
 }
 
 // ── pure mapping helpers (unit-tested) ──────────────────────────────────
 
-/** First non-empty line becomes the ticket title (Multica titles are
- * single-line); the rest is the brief. */
+/** Multica titles are single-line, so a turn is split: first line as the
+ * title, the rest as the brief. */
+const TITLE_MAX = 200;
+
 export function issueTitleFromText(text: string): string {
   const line = text.trim().split("\n")[0]?.trim() ?? "";
-  return line.slice(0, 200) || "OpenMausBot task";
+  return line.slice(0, TITLE_MAX) || "OpenMausBot task";
 }
 
 export function issueDescriptionFromText(text: string): string | undefined {
-  const rest = text.trim().split("\n").slice(1).join("\n").trim();
-  return rest || undefined;
+  const trimmed = text.trim();
+  const [first = "", ...rest] = trimmed.split("\n");
+  // A one-line prompt longer than the cap would otherwise lose everything
+  // past character 200: the title truncates it and the brief, being "the
+  // lines after the first", is empty. When the title had to be cut, the
+  // whole text becomes the brief so the agent still receives the request.
+  if (first.trim().length > TITLE_MAX) return trimmed;
+  return rest.join("\n").trim() || undefined;
 }
 
 /** The ticket a follow-up turn belongs to, or undefined to open a new one.

--- a/server/drivers/multica.ts
+++ b/server/drivers/multica.ts
@@ -1,0 +1,352 @@
+// Multica driver — a workspace's agents as contacts.
+//
+// Multica (github.com/multica-ai/multica) assigns issues to coding agents and
+// runs them on its own server. This driver puts that workspace behind the
+// chat window every other engine already uses: the model picker lists the
+// workspace's agents instead of models, sending a message opens a ticket
+// assigned to the selected one, and the run streams back into the bubble.
+//
+// Unlike every other driver here, no CLI is spawned and nothing runs on this
+// machine — the work happens on the Multica server, so a turn survives the
+// laptop closing, and a phone can follow it through the Telegram gateway or
+// the companion app.
+//
+//   sendTurn(text)      → issue create (title = first line, rest = brief),
+//                         assigned to the selected agent; follow-up turns
+//                         with a resumeCursor comment on the SAME ticket
+//   progress            → GET /api/issues/{id}/task-runs (latest run) +
+//                         GET /api/tasks/{runId}/messages?since=<seq>
+//                         mapped to item.started/completed + content.delta
+//   turn.completed      → when the run settles (completed/failed/cancelled)
+//   interruptTurn       → POST /api/tasks/{runId}/cancel
+//
+// The Multica REST client (server/integrations/multica-client.ts) is the
+// only place that talks to the factory; this driver only maps.
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { MulticaClient, resolveMulticaProfile, type MulticaAgent, type MulticaTaskRun } from "../integrations/multica-client.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "multicaAgent";
+
+export interface MulticaAgentConfig {
+  profile?: string;
+  workspaceId?: string;
+  pollMs?: number;
+}
+
+function decodeConfig(raw: unknown): MulticaAgentConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    profile: typeof o.profile === "string" ? o.profile : undefined,
+    workspaceId: typeof o.workspaceId === "string" ? o.workspaceId : undefined,
+    pollMs: typeof o.pollMs === "number" ? o.pollMs : 3000,
+  };
+}
+
+// ── pure mapping helpers (unit-tested) ──────────────────────────────────
+
+/** First non-empty line becomes the ticket title (Multica titles are
+ * single-line); the rest is the brief. */
+export function issueTitleFromText(text: string): string {
+  const line = text.trim().split("\n")[0]?.trim() ?? "";
+  return line.slice(0, 200) || "OpenMausBot task";
+}
+
+export function issueDescriptionFromText(text: string): string | undefined {
+  const rest = text.trim().split("\n").slice(1).join("\n").trim();
+  return rest || undefined;
+}
+
+/** The ticket a follow-up turn belongs to, or undefined to open a new one.
+ *
+ * The harness stores `session.started`'s `sessionId` verbatim as the cursor
+ * (server/index.ts, setResumeCursor) — so the cursor IS the ticket id, a bare
+ * string, not an envelope. Reading it as `{ issueId }` silently yields
+ * undefined and every follow-up opens a fresh ticket instead of commenting on
+ * the running one. */
+export function issueIdFromCursor(cursor: unknown): string | undefined {
+  if (typeof cursor === "string") return cursor.trim() || undefined;
+  // tolerate an envelope too: older stored cursors, and a shape a future
+  // harness could hand back — cheap to accept, expensive to get wrong.
+  if (cursor && typeof cursor === "object") {
+    // SAFETY: reading one optional property off a checked object; the value
+    // is typed unknown and narrowed before use.
+    const id = (cursor as { issueId?: unknown }).issueId;
+    if (typeof id === "string") return id.trim() || undefined;
+  }
+  return undefined;
+}
+
+/** Terminal run states → canonical outcome. Returns null while running. */
+export function runSettled(run: MulticaTaskRun): { ok: boolean; stopReason: string } | null {
+  const state = String(run.status ?? "").toLowerCase();
+  if (/completed|succeeded|done|finished/.test(state)) return { ok: true, stopReason: state };
+  if (/failed|error|cancelled|interrupted|timeout/.test(state)) return { ok: false, stopReason: state };
+  return null;
+}
+
+export interface TaskMessage {
+  seq: number;
+  type: string;
+  tool?: string;
+  content?: string;
+  output?: string;
+}
+
+/** One factory run message → canonical runtime events (may be none). */
+export function messageToEvents(
+  base: Omit<RuntimeEvent, "eventId" | "createdAt" | "type"> & { eventId: string; createdAt: string },
+  msg: TaskMessage,
+): RuntimeEvent[] {
+  const kind = String(msg.type ?? "");
+  if (kind === "text" && msg.content) {
+    return [{ ...base, type: "content.delta", streamKind: "assistant_text", delta: msg.content }];
+  }
+  if (kind === "tool_use") {
+    return [{ ...base, type: "item.started", itemType: "tool", itemId: `m${msg.seq}`, title: String(msg.tool ?? "tool").slice(0, 80) }];
+  }
+  if (kind === "tool_result") {
+    return [{ ...base, type: "item.completed", itemType: "tool", itemId: `m${msg.seq}`, ok: true }];
+  }
+  if (kind === "error") {
+    return [{ ...base, type: "runtime.error", message: String(msg.content ?? msg.output ?? "factory run error") }];
+  }
+  return [];
+}
+
+// ── driver ──────────────────────────────────────────────────────────────
+
+export const MulticaAgentDriver: ProviderDriver<MulticaAgentConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Multica Factory", supportsMultipleInstances: true },
+  models: { default: "", options: [] }, // per-instance: live roster getter
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<MulticaAgentConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const profile = resolveMulticaProfile(config.profile);
+    // Config first, then whatever the signed-in CLI already knows. Someone
+    // running one workspace should not have to restate its uuid to use this.
+    const workspaceId =
+      config.workspaceId ?? input.environment.MULTICA_WORKSPACE_ID ?? profile?.workspaceId ?? "";
+    const pollMs = config.pollMs ?? 3000;
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { cancel: () => void; turnId: string; issueId: string }>();
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      providerInstanceId: instanceId,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const client = () => {
+      if (!profile) throw new Error("multica CLI is not signed in — run `multica login`");
+      if (!workspaceId) {
+        throw new Error("no multica workspace — set workspaceId on the instance, or sign the CLI into one");
+      }
+      return new MulticaClient(profile.baseUrl, profile.token, workspaceId);
+    };
+
+    // Live roster as the model catalog: fetched at create, refreshed in the
+    // background so the model picker tracks factory changes without blocking.
+    let catalog: ModelCatalog = { default: "", options: [] };
+    let roster: MulticaAgent[] = [];
+    const refreshRoster = async () => {
+      try {
+        roster = await client().listAgents();
+        catalog = {
+          default: roster[0]?.id ?? "",
+          options: roster.map((a) => ({ id: a.id, label: a.name })),
+        };
+      } catch {
+        /* keep the last-known roster; snapshot() reports unavailability */
+      }
+    };
+    await refreshRoster();
+    const rosterTimer = setInterval(() => void refreshRoster(), 60_000);
+    rosterTimer.unref?.();
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const c = client();
+      const turnId = newId();
+      const agentId = turn.model || catalog.default;
+      if (!agentId) throw new Error("no Multica agent selected — pick a factory agent in the model picker");
+
+      // Follow-up turns comment on the same ticket; the first turn creates it.
+      let issueId = issueIdFromCursor(turn.resumeCursor);
+      if (!issueId) {
+        const issue = await c.createIssue({
+          title: issueTitleFromText(turn.text),
+          description: issueDescriptionFromText(turn.text),
+          assigneeType: "agent",
+          assigneeId: agentId,
+        });
+        issueId = issue.id;
+        appendNative(threadId, { dir: "out", source: "multica.issue.create", msg: { issueId, agentId } });
+      } else {
+        await c.comment(issueId, turn.text);
+        appendNative(threadId, { dir: "out", source: "multica.issue.comment", msg: { issueId } });
+      }
+
+      let cancelled = false;
+      active.set(threadId, {
+        turnId,
+        issueId,
+        cancel: () => {
+          cancelled = true;
+        },
+      });
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({ ...base(threadId, turnId), type: "session.started", sessionId: issueId, model: agentId });
+
+      // poll the latest run + its messages until the ticket settles
+      (async () => {
+        const startedAt = Date.now();
+        let lastRunId: string | null = null;
+        let sinceSeq = 0;
+        let lastText = "";
+        let seenRun = false;
+        try {
+          for (;;) {
+            if (cancelled) break;
+            await new Promise((r) => setTimeout(r, pollMs));
+            // Errors propagate (no silent []): a transient API failure must
+            // surface as the real cause, never as a fake "never started".
+            const runs = await c.taskRuns(issueId);
+            const run = Array.isArray(runs) ? runs[0] : undefined;
+            if (run) seenRun = true;
+            if (!run) {
+              // once a run was seen, a runless response is a transient
+              // anomaly — keep polling instead of misdiagnosing
+              if (!seenRun && Date.now() - startedAt > 60_000) {
+                throw new Error("factory never started a run for this ticket");
+              }
+              continue;
+            }
+            if (run.id !== lastRunId) {
+              lastRunId = run.id;
+              sinceSeq = 0;
+              emit({ ...base(threadId, turnId), type: "item.started", itemType: "tool", itemId: run.id, title: "factory run" });
+            }
+            const messages = await c.taskMessages(run.id).catch(() => []);
+            // SAFETY: taskMessages types the route's documented shape, and the
+            // failure path substitutes []. Every field is read optionally in
+            // messageToEvents, so an unexpected message maps to no event
+            // rather than a crash.
+            for (const m of messages as TaskMessage[]) {
+              if (m.seq <= sinceSeq) continue;
+              sinceSeq = m.seq;
+              appendNative(threadId, { dir: "in", source: "multica.task.message", msg: m });
+              for (const ev of messageToEvents(base(threadId, turnId), m)) {
+                if (ev.type === "content.delta") lastText += ev.delta;
+                emit(ev);
+              }
+            }
+            const settled = runSettled(run);
+            if (settled) {
+              if (lastText) {
+                emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: lastText });
+              }
+              active.delete(threadId);
+              emit({ ...base(threadId, turnId), type: "turn.completed", ok: settled.ok, stopReason: settled.stopReason, cost: null });
+              return;
+            }
+            if (Date.now() - startedAt > 30 * 60_000) {
+              throw new Error("factory run exceeded 30 minutes — interrupted");
+            }
+          }
+          active.delete(threadId);
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "interrupted", cost: null });
+        } catch (e) {
+          active.delete(threadId);
+          // SAFETY: everything thrown in this loop is an Error — the client
+          // wraps fetch failures and non-2xx into MulticaError, and the two
+          // explicit throws above are Errors.
+          emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "error", cost: null });
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      // These two read as setup instructions in the engine list, so they name
+      // the next command rather than the file that happens to be missing.
+      if (!profile) return { state: "unavailable", reason: "Multica CLI is not signed in — run `multica login`" };
+      if (!workspaceId) return { state: "unavailable", reason: "No Multica workspace selected" };
+      try {
+        const agents = await client().listAgents();
+        if (!agents.length) return { state: "unavailable", reason: "multica workspace has no agents" };
+        return { state: "available", authenticated: true, version: null };
+      } catch (e) {
+        // SAFETY: listAgents only rejects with Errors raised by the client.
+        return { state: "unavailable", reason: `multica API unreachable: ${(e as Error).message}` };
+      }
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      get models() {
+        return catalog;
+      },
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "unsupported" },
+        sendTurn,
+        interruptTurn: async (threadId) => {
+          const turn = active.get(threadId);
+          if (!turn) return;
+          turn.cancel();
+          // best-effort: cancel the factory run too
+          try {
+            const c = client();
+            const runs = await c.taskRuns(turn.issueId).catch(() => []);
+            if (runs[0]) await c.cancelTask(runs[0].id);
+          } catch {
+            /* the poll loop settles the turn */
+          }
+        },
+        respondToRequest: async () => {
+          throw new Error("multica agents do not ask permission requests");
+        },
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { cancel } of active.values()) cancel();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      dispose: async () => {
+        clearInterval(rosterTimer);
+        for (const { cancel } of active.values()) cancel();
+        listeners.clear();
+      },
+    };
+  },
+};

--- a/server/integrations/multica-client.test.ts
+++ b/server/integrations/multica-client.test.ts
@@ -1,0 +1,104 @@
+// Credential discovery is the part with a contract outside this repo: the
+// layout is the multica CLI's, and getting it wrong means the driver reports
+// "not signed in" at a perfectly good workstation.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { multicaConfigPath, resolveMulticaProfile } from "./multica-client.ts";
+
+let home = "";
+const ENV_KEYS = ["MULTICA_SERVER_URL", "MULTICA_TOKEN", "MULTICA_WORKSPACE_ID"] as const;
+const saved: Record<string, string | undefined> = {};
+
+function writeConfig(where: string, body: unknown) {
+  mkdirSync(join(where, ".."), { recursive: true });
+  writeFileSync(where, JSON.stringify(body));
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "multica-home-"));
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("multicaConfigPath", () => {
+  // Mirrors the CLI's own ConfigPath: no profile is the default config, a
+  // named profile lives one level down.
+  it("uses the default config when no profile is named", () => {
+    expect(multicaConfigPath(undefined, "/h")).toBe("/h/.multica/config.json");
+  });
+
+  it("uses the profile directory when one is", () => {
+    expect(multicaConfigPath("work", "/h")).toBe("/h/.multica/profiles/work/config.json");
+  });
+});
+
+describe("resolveMulticaProfile", () => {
+  it("reads a signed-in CLI, workspace included", () => {
+    writeConfig(join(home, ".multica", "config.json"), {
+      server_url: "https://multica.example.com",
+      token: "mul_secret",
+      workspace_id: "ws-1",
+    });
+    expect(resolveMulticaProfile(undefined, home)).toEqual({
+      baseUrl: "https://multica.example.com",
+      token: "mul_secret",
+      workspaceId: "ws-1",
+    });
+  });
+
+  it("finds a named profile", () => {
+    writeConfig(join(home, ".multica", "profiles", "work", "config.json"), {
+      server_url: "https://work.example.com/",
+      token: "mul_work",
+    });
+    const profile = resolveMulticaProfile("work", home);
+    expect(profile?.baseUrl).toBe("https://work.example.com"); // trailing slash dropped
+    expect(profile?.workspaceId).toBeUndefined();
+  });
+
+  it("reports nothing rather than half a credential", () => {
+    writeConfig(join(home, ".multica", "config.json"), { server_url: "https://x.example.com" });
+    expect(resolveMulticaProfile(undefined, home)).toBeNull();
+  });
+
+  it("is null when the CLI was never signed in", () => {
+    expect(resolveMulticaProfile(undefined, home)).toBeNull();
+  });
+
+  it("lets the environment override a server the CLI never saw", () => {
+    writeConfig(join(home, ".multica", "config.json"), {
+      server_url: "https://from-cli.example.com",
+      token: "mul_cli",
+    });
+    process.env.MULTICA_SERVER_URL = "https://from-env.example.com";
+    process.env.MULTICA_TOKEN = "mul_env";
+    process.env.MULTICA_WORKSPACE_ID = "ws-env";
+    expect(resolveMulticaProfile(undefined, home)).toEqual({
+      baseUrl: "https://from-env.example.com",
+      token: "mul_env",
+      workspaceId: "ws-env",
+    });
+  });
+
+  it("ignores a half-set environment instead of failing the lookup", () => {
+    writeConfig(join(home, ".multica", "config.json"), {
+      server_url: "https://from-cli.example.com",
+      token: "mul_cli",
+    });
+    process.env.MULTICA_SERVER_URL = "https://from-env.example.com"; // no token
+    expect(resolveMulticaProfile(undefined, home)?.token).toBe("mul_cli");
+  });
+});

--- a/server/integrations/multica-client.ts
+++ b/server/integrations/multica-client.ts
@@ -1,0 +1,248 @@
+// Multica REST client — the one place that speaks to a Multica server.
+// Every response shape is parsed here, so an API change is one file to fix,
+// tested against recorded responses rather than a live workspace.
+//
+// Credentials are never stored by OpenMausBot. They are read from the config
+// the `multica` CLI already wrote, following its own layout (see the CLI's
+// ConfigPath): no profile → ~/.multica/config.json, a named profile →
+// ~/.multica/profiles/<name>/config.json. That file also carries the
+// workspace id, so a signed-in CLI is the entire setup. MULTICA_SERVER_URL +
+// MULTICA_TOKEN override it, for a server the CLI has never seen.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface MulticaSettings {
+  /** Profile under ~/.multica/profiles/. Empty means the default config. */
+  profile?: string;
+  /** Workspace UUID. Falls back to the one in the CLI config. */
+  workspaceId?: string;
+  enabled?: boolean;
+}
+
+export interface MulticaProfile {
+  baseUrl: string;
+  token: string;
+  /** From the CLI config, so a bot needs no second place to state it. */
+  workspaceId?: string;
+}
+
+/** Where the multica CLI keeps the config for a profile. */
+export function multicaConfigPath(profile?: string, home = homedir()): string {
+  return profile
+    ? join(home, ".multica", "profiles", profile, "config.json")
+    : join(home, ".multica", "config.json");
+}
+
+export function resolveMulticaProfile(profile?: string, home = homedir()): MulticaProfile | null {
+  const envUrl = process.env.MULTICA_SERVER_URL;
+  const envToken = process.env.MULTICA_TOKEN;
+  if (envUrl && envToken) {
+    return {
+      baseUrl: envUrl.replace(/\/$/, ""),
+      token: envToken,
+      workspaceId: process.env.MULTICA_WORKSPACE_ID || undefined,
+    };
+  }
+  try {
+    const raw = readFileSync(multicaConfigPath(profile, home), "utf8");
+    const cfg = JSON.parse(raw) as { server_url?: string; token?: string; workspace_id?: string };
+    if (!cfg.server_url || !cfg.token) return null;
+    return {
+      baseUrl: cfg.server_url.replace(/\/$/, ""),
+      token: cfg.token,
+      workspaceId: cfg.workspace_id || undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── wire shapes (subset of the API, verified live 15.08.2026) ────────────
+export interface MulticaAgent {
+  id: string;
+  name: string;
+  status?: string;
+}
+
+export interface MulticaIssue {
+  id: string;
+  identifier?: string;
+  title: string;
+  description?: string | null;
+  status?: string;
+  assignee_type?: string | null;
+  assignee_id?: string | null;
+  parent_issue_id?: string | null;
+  stage?: number | null;
+  priority?: string;
+}
+
+export interface MulticaTaskRun {
+  id: string;
+  status: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  result?: unknown;
+  error?: string | null;
+  attempt?: number;
+  max_attempts?: number;
+}
+
+export interface MulticaComment {
+  id: string;
+  content: string;
+}
+
+export interface CreateIssueInput {
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  assigneeType?: "member" | "agent" | "squad";
+  assigneeId?: string;
+  parentIssueId?: string;
+  stage?: number;
+}
+
+// Request bodies, in the API's own snake_case. Named rather than assembled
+// as open dictionaries so a typo is a compile error instead of a field the
+// server quietly ignores.
+interface CreateIssueBody {
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  assignee_type?: "member" | "agent" | "squad";
+  assignee_id?: string;
+  parent_issue_id?: string;
+  stage?: number;
+}
+
+interface UpdateIssueBody {
+  status?: string;
+  assignee_type?: "member" | "agent" | "squad";
+  assignee_id?: string;
+}
+
+interface CommentBody {
+  content: string;
+}
+
+type RequestBody = CreateIssueBody | UpdateIssueBody | CommentBody;
+
+export class MulticaError extends Error {
+  readonly status: number;
+  readonly body: string;
+  constructor(message: string, status: number, body: string) {
+    super(message);
+    this.name = "MulticaError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class MulticaClient {
+  readonly baseUrl: string;
+  readonly token: string;
+  readonly workspaceId: string;
+
+  constructor(baseUrl: string, token: string, workspaceId: string) {
+    this.baseUrl = baseUrl;
+    this.token = token;
+    this.workspaceId = workspaceId;
+  }
+
+  private async request<T>(method: string, path: string, body?: RequestBody): Promise<T> {
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${this.token}`,
+      "x-workspace-id": this.workspaceId,
+    };
+    if (body !== undefined) headers["content-type"] = "application/json";
+
+    let res: Response;
+    try {
+      res = await fetch(this.baseUrl + path, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (cause) {
+      // Never a naked "fetch failed": node hides the reason in `cause`, and
+      // an unnamed target is unreadable in a log a day later.
+      throw new Error(
+        `multica ${method} ${path}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        { cause },
+      );
+    }
+    if (res.status >= 400) {
+      const text = (await res.text().catch(() => "")).slice(0, 512);
+      throw new MulticaError(`multica ${method} ${path} returned ${res.status}`, res.status, text);
+    }
+    // SAFETY: 204 carries no body by definition, and every caller that can
+    // receive one types T as void.
+    if (res.status === 204) return undefined as T;
+    // SAFETY: the response is the API's documented shape for this route; T is
+    // chosen at each call site below and the fields are read defensively
+    // (optional, with fallbacks) rather than trusted wholesale.
+    return (await res.json()) as T;
+  }
+
+  listAgents(): Promise<MulticaAgent[]> {
+    return this.request<MulticaAgent[]>("GET", `/api/agents?workspace_id=${encodeURIComponent(this.workspaceId)}`);
+  }
+
+  listIssues(limit = 20): Promise<MulticaIssue[]> {
+    return this.request<{ issues?: MulticaIssue[] }>(
+      "GET",
+      `/api/issues?workspace_id=${encodeURIComponent(this.workspaceId)}&limit=${limit}`,
+    ).then((r) => r.issues ?? []);
+  }
+
+  getIssue(id: string): Promise<MulticaIssue> {
+    return this.request<MulticaIssue>("GET", `/api/issues/${encodeURIComponent(id)}`);
+  }
+
+  createIssue(input: CreateIssueInput): Promise<MulticaIssue> {
+    const body: CreateIssueBody = { title: input.title };
+    if (input.description) body.description = input.description;
+    if (input.status) body.status = input.status;
+    if (input.priority) body.priority = input.priority;
+    // Both halves or neither: an assignee type without an id is rejected by
+    // the API, and sending one alone turns a typo into a 400 at runtime.
+    if (input.assigneeType && input.assigneeId) {
+      body.assignee_type = input.assigneeType;
+      body.assignee_id = input.assigneeId;
+    }
+    if (input.parentIssueId) body.parent_issue_id = input.parentIssueId;
+    if (input.stage !== undefined) body.stage = input.stage;
+    return this.request<MulticaIssue>("POST", `/api/issues?workspace_id=${encodeURIComponent(this.workspaceId)}`, body);
+  }
+
+  assignIssue(id: string, assigneeType: "member" | "agent" | "squad", assigneeId: string): Promise<MulticaIssue> {
+    return this.request<MulticaIssue>("PUT", `/api/issues/${encodeURIComponent(id)}`, {
+      assignee_type: assigneeType,
+      assignee_id: assigneeId,
+    });
+  }
+
+  setStatus(id: string, status: string): Promise<MulticaIssue> {
+    return this.request<MulticaIssue>("PUT", `/api/issues/${encodeURIComponent(id)}`, { status });
+  }
+
+  comment(id: string, content: string): Promise<MulticaComment> {
+    return this.request<MulticaComment>("POST", `/api/issues/${encodeURIComponent(id)}/comments`, { content });
+  }
+
+  taskRuns(id: string): Promise<MulticaTaskRun[]> {
+    return this.request<MulticaTaskRun[]>("GET", `/api/issues/${encodeURIComponent(id)}/task-runs`);
+  }
+
+  taskMessages(runId: string): Promise<unknown[]> {
+    return this.request<unknown[]>("GET", `/api/tasks/${encodeURIComponent(runId)}/messages`);
+  }
+
+  cancelTask(runId: string): Promise<void> {
+    return this.request<void>("POST", `/api/tasks/${encodeURIComponent(runId)}/cancel`);
+  }
+}

--- a/server/integrations/multica-client.ts
+++ b/server/integrations/multica-client.ts
@@ -131,6 +131,10 @@ interface CommentBody {
 
 type RequestBody = CreateIssueBody | UpdateIssueBody | CommentBody;
 
+/** Per-request ceiling. Generous: a factory run can be slow to report, but
+ * the HTTP call answering it should not take half a minute. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export class MulticaError extends Error {
   readonly status: number;
   readonly body: string;
@@ -166,6 +170,10 @@ export class MulticaClient {
         method,
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,
+        // Bounded on purpose. The driver's poll loop only reaches its own
+        // 30-minute guard, and only observes an interrupt, between requests
+        // — a socket that never answers would strand the turn forever.
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
     } catch (cause) {
       // Never a naked "fetch failed": node hides the reason in `cause`, and


### PR DESCRIPTION
[Multica](https://github.com/multica-ai/multica) assigns issues to coding agents and runs them on its own server. This driver puts that workspace behind the same chat window as every other engine: the model picker lists the workspace's **agents** instead of models, sending a message opens a ticket assigned to the selected one, and the run streams back into the bubble as `content.delta` until it settles.

### The one that spawns nothing

Every other driver here starts a CLI on this machine. This one starts nothing — the work happens on the Multica server. Two consequences that are the actual point:

- **A turn survives closing the laptop.** Reopen the app and the run is still going, because it never depended on this process.
- **It is the same ticket everywhere.** Opened here, it is visible in the Multica web UI; opened there, a reply lands in this chat. Follow-up turns comment on the running ticket rather than opening a new one.

### Setup is a CLI that is already signed in

Credentials are read from the config the `multica` CLI wrote, following its own layout — no profile → `~/.multica/config.json`, a named profile → `~/.multica/profiles/<name>/config.json`. That file carries the workspace id too, so a single-workspace user configures nothing at all. `MULTICA_SERVER_URL` + `MULTICA_TOKEN` override it for a server the CLI has never seen. Nothing is stored on our side.

Unavailability reads as an instruction rather than a missing file: an engine list that says *"Multica CLI is not signed in — run `multica login`"* is the whole setup guide.

### Shape

| file | job |
|---|---|
| `server/integrations/multica-client.ts` | the only place that speaks HTTP; every response shape parsed once |
| `server/drivers/multica.ts` | mapping only — text → ticket fields, run status → outcome, run message → canonical event |

`interruptTurn` also cancels the run on the server, not just the local subscription.

### Verification

21 tests. The credential lookup is covered hardest because its contract lives in another repo — default config, named profile, half-written config, absent config, env override, half-set env. `pnpm typecheck` clean, full suite green (994 passing).

Happy to adjust the naming or drop it out of the default fleet if you would rather it be opt-in via an `instances` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Multica as an available agent provider.
  * Workspace agents can now be discovered and selected as models.
  * Added support for creating and commenting on issues, monitoring task progress, receiving runtime updates, and cancelling tasks.
  * Added credential discovery through environment settings or Multica CLI configuration.
* **Tests**
  * Added coverage for configuration handling, task status mapping, message conversion, cursor handling, and issue field generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->