### PR TITLE
feat: four switchable skins, and the token that makes them possible

### DIFF
--- a/scripts/check-skin-contrast.mjs
+++ b/scripts/check-skin-contrast.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Reads the skin blocks out of src/styles.css and measures every text/surface
+// pair the components actually produce. Run it after touching a palette:
+//
+//   node scripts/check-skin-contrast.mjs
+//
+// It parses the CSS rather than taking a second copy of the values, so the
+// check can never pass against a palette that is no longer the shipped one.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const css = readFileSync(join(root, "src/styles.css"), "utf8");
+
+function declarations(body) {
+  const tokens = {};
+  for (const [, name, value] of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    tokens[name] = value.trim();
+  }
+  return tokens;
+}
+
+/** The tokens every skin starts from: the `@theme` defaults plus the bare
+ * `:root` block. A skin that does not redefine one of these still SHIPS it,
+ * so the check has to measure it — otherwise a token upstream adds is
+ * inherited untested by every skin, and the run stays green while a light
+ * skin wears a dark skin's focus ring. That is exactly what happened when
+ * upstream introduced --color-focus. */
+function parseBase(source) {
+  const base = {};
+  for (const [, body] of source.matchAll(/(?:@theme|:root)\s*\{([^}]*)\}/g)) {
+    Object.assign(base, declarations(body));
+  }
+  return base;
+}
+
+/** Every `[data-skin="x"] { … }` block, as id → {token: value}, over the
+ * inherited base so a skin is measured as it actually renders. */
+function parseSkins(source) {
+  const base = parseBase(source);
+  const skins = new Map();
+  for (const [, id, body] of source.matchAll(/\[data-skin="([a-z-]+)"\]\s*\{([^}]*)\}/g)) {
+    skins.set(id, { ...base, ...declarations(body) });
+  }
+  return skins;
+}
+
+function parseHex(hex) {
+  const h = hex.replace("#", "").trim();
+  const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h;
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+    a: full.length === 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1,
+  };
+}
+
+/** Foreground alpha composited over an opaque background. */
+function flatten(fg, bg) {
+  if (fg.a === 1) return fg;
+  return {
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+    a: 1,
+  };
+}
+
+function luminance({ r, g, b }) {
+  const channel = (v) => {
+    const s = v / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(fgHex, bgHex) {
+  const bg = parseHex(bgHex);
+  const fg = flatten(parseHex(fgHex), bg);
+  const [hi, lo] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Pairs taken from what the components render, not from what looks plausible:
+// body copy sits on all five surfaces, the filled accent/danger buttons carry
+// their own ink token, and the status colours are used as text on cards.
+const SURFACES = ["--color-app", "--color-panel", "--color-raised", "--color-raised-hover", "--color-card", "--color-inset"];
+const PAIRS = [
+  ...SURFACES.map((s) => ["--color-ink", s, 4.5]),
+  ...SURFACES.map((s) => ["--color-ink-secondary", s, 4.5]),
+  ["--color-ink", "--color-bubble-user", 4.5],
+  ["--color-accent-ink", "--color-accent", 4.5],
+  ["--color-danger-ink", "--color-danger", 4.5],
+  ["--color-accent-text", "--color-app", 4.5],
+  ["--color-accent-text", "--color-panel", 4.5],
+  ["--color-accent-text", "--color-card", 4.5],
+  ["--color-danger", "--color-card", 4.5],
+  ["--color-success", "--color-card", 4.5],
+  ["--color-warning", "--color-card", 4.5],
+  // borders and dots are UI components, not text — AA asks 3:1 of them
+  ["--color-hairline", "--color-app", 1.5],
+  ["--color-accent", "--color-app", 3],
+  ["--color-scrollbar", "--color-app", 1.5],
+  // The focus ring sits outside the control (outline-offset: 2px), so it
+  // lands on whatever surface is behind it — a skin that inherits another
+  // skin's ring keeps a colour that was never checked against its ground.
+  // WCAG 1.4.11 asks 3:1 of a non-text indicator.
+  ["--color-focus", "--color-app", 3],
+  ["--color-focus", "--color-panel", 3],
+  ["--color-focus", "--color-card", 3],
+];
+
+const skins = parseSkins(css);
+// Midnight is shipped as a faithful copy of upstream, contrast gaps included;
+// it is reported but not allowed to fail the run.
+const ADVISORY = new Set(["midnight"]);
+
+let failed = false;
+for (const [id, tokens] of skins) {
+  const problems = [];
+  const missing = [];
+  let measured = 0;
+  for (const [fg, bg, min] of PAIRS) {
+    // A pair we cannot measure is reported, never silently skipped: an
+    // unmeasured pair used to be counted as a passing one.
+    if (!tokens[fg] || !tokens[bg]) {
+      missing.push(!tokens[fg] ? fg : bg);
+      continue;
+    }
+    measured++;
+    const ratio = contrast(tokens[fg], tokens[bg]);
+    if (ratio < min) problems.push({ fg, bg, ratio, min });
+  }
+  const advisory = ADVISORY.has(id);
+  if (missing.length) {
+    console.log(`✗ ${id} — undefined token(s): ${[...new Set(missing)].join(", ")}`);
+    if (!advisory) failed = true;
+  }
+  if (problems.length === 0) {
+    if (!missing.length) console.log(`✓ ${id} — ${measured} pairs, none below target`);
+    continue;
+  }
+  console.log(`${advisory ? "~" : "✗"} ${id}${advisory ? " (advisory — upstream copy)" : ""}`);
+  for (const { fg, bg, ratio, min } of problems) {
+    console.log(`    ${fg} on ${bg}: ${ratio.toFixed(2)}:1 (needs ${min}:1)`);
+  }
+  if (!advisory) failed = true;
+}
+
+process.exit(failed ? 1 : 0);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import { CompanionSection } from "./CompanionSection";
 import { Card } from "./SettingsPrimitives";
 import { UsageSection } from "./UsageSection";
 import { VoiceSettings } from "./VoiceSettings";
+import { SkinPicker } from "./SkinPicker";
 import { cn } from "@/lib/cn";
 
 const SECTIONS: Array<{ id: AppSettingsSection; label: string; icon: typeof User }> = [
@@ -201,6 +202,9 @@ export function SettingsModal() {
               <>
                 <Card title="Profile" subtitle="Shown in the sidebar. Saved as you go.">
                   <ProfileFields />
+                </Card>
+                <Card title="Skin" subtitle="Applies instantly and is remembered on this machine.">
+                  <SkinPicker />
                 </Card>
                 <UpdatesRow />
               </>

--- a/src/components/SkinPicker.tsx
+++ b/src/components/SkinPicker.tsx
@@ -1,0 +1,113 @@
+// Choosing a skin is a visual decision, so the options are shown visually: each
+// card carries a working miniature of the app rendered in that skin, not a row
+// of paint chips. That works because the skin blocks in styles.css are keyed on
+// `[data-skin]` rather than `:root[data-skin]` — any element can open a skin
+// context for its own subtree, so the miniature styles itself and can never
+// drift from what picking it actually does.
+import { useState } from "react";
+import { Check } from "lucide-react";
+import { SKINS, applySkin, readSkin, type SkinId } from "@/lib/skins";
+import { cn } from "@/lib/cn";
+
+/**
+ * The app's own layout at roughly 1/14 scale: rail, sidebar with a selected
+ * row, thread, composer. The selected row and the send button are drawn in the
+ * accent on purpose — a skin is mostly judged by where its colour lands, and a
+ * single dot was too small to judge.
+ */
+function Miniature({ skin }: { skin: SkinId }) {
+  return (
+    <div
+      data-skin={skin}
+      aria-hidden="true"
+      className="flex h-[78px] w-full overflow-hidden rounded-lg bg-app"
+    >
+      {/* rail */}
+      <div className="flex w-[11px] shrink-0 flex-col items-center gap-[3px] bg-panel pt-[5px]">
+        <span className="size-[5px] rounded-full bg-accent" />
+        <span className="size-[5px] rounded-full bg-ink-secondary/40" />
+        <span className="size-[5px] rounded-full bg-ink-secondary/40" />
+      </div>
+      {/* sidebar — the top row is the selected conversation */}
+      <div className="flex w-[30px] shrink-0 flex-col gap-[3px] border-r border-hairline bg-panel p-[4px]">
+        <span className="flex h-[9px] w-full items-center gap-[2px] rounded-sm bg-raised px-[2px]">
+          <span className="size-[4px] shrink-0 rounded-full bg-accent" />
+          <span className="h-[2px] flex-1 rounded-full bg-ink/50" />
+        </span>
+        <span className="h-[3px] w-[80%] rounded-full bg-ink-secondary/30" />
+        <span className="h-[3px] w-[62%] rounded-full bg-ink-secondary/30" />
+        <span className="h-[3px] w-[74%] rounded-full bg-ink-secondary/30" />
+      </div>
+      {/* thread */}
+      <div className="flex min-w-0 flex-1 flex-col gap-[4px] p-[6px]">
+        <span className="h-[13px] w-[62%] self-end rounded-md bg-bubble-user" />
+        <div className="flex w-[88%] flex-col gap-[3px] rounded-md bg-card p-[4px]">
+          <span className="h-[2px] w-full rounded-full bg-ink/45" />
+          <span className="h-[2px] w-[85%] rounded-full bg-ink/45" />
+          <span className="h-[2px] w-[60%] rounded-full bg-ink-secondary/40" />
+        </div>
+        <div className="mt-auto flex items-center gap-[4px]">
+          <span className="h-[11px] flex-1 rounded-full bg-inset ring-1 ring-hairline" />
+          {/* filled accent with its own ink — Foundry's inversion reads right
+              here: bright brass carrying a dark mark, where the others carry
+              a light one */}
+          <span className="flex size-[11px] items-center justify-center rounded-full bg-accent">
+            <span
+              className="h-[1.5px] w-[5px] rounded-full"
+              style={{ background: "var(--color-accent-ink)" }}
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SkinPicker() {
+  // The document is the source of truth, not storage: main.tsx has already
+  // stamped it, and reading it back keeps the checkmark honest even if the
+  // skin was set some other way.
+  // SAFETY: main.tsx writes this attribute from applySkin() before the first
+  // paint, and readSkin() covers the case where it is absent or unreadable.
+  const [active, setActive] = useState<SkinId>(
+    () => (document.documentElement.dataset.skin as SkinId) || readSkin(),
+  );
+
+  return (
+    // One row, so the whole set is visible without scrolling the modal —
+    // 2x2 pushed the second row below the fold of its 560px frame.
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {SKINS.map((skin) => {
+        const selected = skin.id === active;
+        return (
+          <button
+            key={skin.id}
+            type="button"
+            onClick={() => {
+              applySkin(skin.id);
+              setActive(skin.id);
+            }}
+            aria-pressed={selected}
+            className={cn(
+              "flex flex-col gap-2 rounded-xl border p-2 text-left transition-colors",
+              selected
+                ? "border-accent-border bg-raised"
+                : "border-hairline/60 hover:border-hairline hover:bg-raised/50",
+            )}
+          >
+            <Miniature skin={skin.id} />
+            <div className="flex items-start gap-1.5 px-0.5 pb-0.5">
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-medium text-ink">{skin.name}</div>
+                <div className="mt-0.5 text-[11px] leading-snug text-ink-secondary">
+                  {skin.tagline}
+                </div>
+              </div>
+              {selected && <Check size={13} className="mt-0.5 shrink-0 text-accent-text" />}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/skins.test.ts
+++ b/src/lib/skins.test.ts
@@ -1,0 +1,49 @@
+// The registry and the stylesheet are two halves of one contract: a skin listed
+// here without a matching CSS block renders as whatever was active before, with
+// no error anywhere. That failure is silent, so it gets a test.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SKINS, SKIN_IDS, DEFAULT_SKIN } from "./skins";
+
+const css = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../styles.css"),
+  "utf8",
+);
+
+const blocks = new Set(
+  [...css.matchAll(/\[data-skin="([a-z-]+)"\]/g)].map(([, id]) => id),
+);
+
+describe("skins", () => {
+  it("gives every registered skin a stylesheet block", () => {
+    for (const id of SKIN_IDS) expect(blocks).toContain(id);
+  });
+
+  it("registers every stylesheet block", () => {
+    // SAFETY: the assertion only fits toContain()'s parameter type — the
+    // assertion IS the check, and an unregistered block fails the test.
+    for (const id of blocks) expect(SKIN_IDS).toContain(id as (typeof SKIN_IDS)[number]);
+  });
+
+  it("defines the same tokens in every skin", () => {
+    const tokensOf = (id: string) => {
+      const body = css.match(new RegExp(`\\[data-skin="${id}"\\]\\s*\\{([^}]*)\\}`))?.[1] ?? "";
+      return new Set([...body.matchAll(/(--[\w-]+)\s*:/g)].map(([, name]) => name));
+    };
+    const reference = tokensOf(DEFAULT_SKIN);
+    expect(reference.size).toBeGreaterThan(15);
+    for (const id of SKIN_IDS) {
+      expect([...reference].filter((t) => !tokensOf(id).has(t))).toEqual([]);
+    }
+  });
+
+  it("describes each skin exactly once", () => {
+    expect(SKINS.map((s) => s.id).sort()).toEqual([...SKIN_IDS].sort());
+    for (const skin of SKINS) {
+      expect(skin.name.length).toBeGreaterThan(0);
+      expect(skin.tagline.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/skins.ts
+++ b/src/lib/skins.ts
@@ -1,0 +1,70 @@
+// Skins are pure CSS. Every one of them is a block of custom properties in
+// styles.css, selected by a `data-skin` attribute; this module only decides
+// which one is active and remembers the choice. Nothing here knows a colour —
+// that keeps the two halves from drifting apart, and it means adding a skin is
+// one CSS block plus one line in SKINS.
+
+export const SKIN_IDS = ["midnight", "atelier", "foundry", "lagoon"] as const;
+export type SkinId = (typeof SKIN_IDS)[number];
+
+export type Skin = {
+  id: SkinId;
+  name: string;
+  /** One line, shown under the name in the picker. */
+  tagline: string;
+};
+
+export const SKINS: readonly Skin[] = [
+  { id: "midnight", name: "Midnight", tagline: "The original. Cool and dark." },
+  { id: "atelier", name: "Atelier", tagline: "Daylight on paper, warm and quiet." },
+  { id: "foundry", name: "Foundry", tagline: "Night shift. Dark, warm, lit in brass." },
+  { id: "lagoon", name: "Lagoon", tagline: "Cool daylight. Porcelain and deep teal." },
+];
+
+export const DEFAULT_SKIN: SkinId = "midnight";
+
+const KEY = "omb-skin";
+
+// The input is whatever localStorage handed back — a string this app wrote
+// on an earlier run, a value edited by hand, or a leftover from a renamed
+// skin. The list is the schema.
+function isSkinId(value: unknown): value is SkinId {
+  // SAFETY: the assertion only satisfies includes()' parameter type; the
+  // check itself is what decides, and a non-member returns false.
+  return SKIN_IDS.includes(value as SkinId);
+}
+
+// Reaching for localStorage is itself a failure point: on an origin with
+// storage blocked the getter throws, and `typeof` alone doesn't shield it.
+function getStore(): Storage | undefined {
+  try {
+    // A bare feature test, not a narrowing of parsed input: in a renderer
+    // without storage the identifier is simply not defined.
+    return typeof localStorage === "undefined" ? undefined : localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readSkin(): SkinId {
+  try {
+    const stored = getStore()?.getItem(KEY);
+    return isSkinId(stored) ? stored : DEFAULT_SKIN;
+  } catch {
+    return DEFAULT_SKIN;
+  }
+}
+
+/**
+ * Point the document at a skin and remember it. Called once before the first
+ * paint (main.tsx) and again on every change from the picker — a stamped
+ * attribute rather than a class so it can never collide with Tailwind.
+ */
+export function applySkin(id: SkinId): void {
+  document.documentElement.dataset.skin = id;
+  try {
+    getStore()?.setItem(KEY, id);
+  } catch {
+    /* quota / private mode — the skin still applies for this session */
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { applySkin, readSkin } from "./lib/skins";
 import "./styles.css";
+
+// Before the first paint, not inside a component: stamping the skin during
+// render would show one frame of the default palette first.
+applySkin(readSkin());
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,26 @@
 @import "tailwindcss";
 
-/* Grok Bot dark palette (pixel-sampled from the real app) */
+/* ─────────────────────────────────────────────────────────────────────────
+   SKINS
+
+   A skin is nothing but a block of custom properties. `@theme` declares the
+   tokens (and gives them the Midnight values, so the app renders correctly
+   even before any skin is applied); every block below re-declares the same
+   tokens under a `[data-skin]` selector.
+
+   Two consequences worth knowing:
+
+   1. The selector is `[data-skin=…]`, not `:root[data-skin=…]`. That means any
+      element can open a skin context for its subtree — which is how the skin
+      picker renders a live miniature of each skin instead of a painted mockup.
+   2. These blocks sit outside `@layer`, so they win against Tailwind's theme
+      layer regardless of specificity.
+
+   Contrast is a design constraint here, not an afterthought: every text/surface
+   pair in Atelier and Foundry clears WCAG AA (4.5:1), verified by measuring the
+   rendered values rather than reading the hex. `scripts/check-skin-contrast.mjs`
+   re-runs that check.
+   ───────────────────────────────────────────────────────────────────────── */
 @theme {
   --animate-panel-in: panel-in 0.24s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-pop-in: pop-in 0.2s cubic-bezier(0.22, 1, 0.36, 1);
@@ -8,6 +28,7 @@
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-shimmer: shimmer 2s linear infinite;
 
+  /* Defaults = Midnight. Kept here so the app is never unstyled. */
   --color-app: #070707;
   --color-panel: #111111;
   --color-raised: #2f2f2f;
@@ -22,6 +43,7 @@
   /* the ring a keyboard user follows; sits on the accent so focus reads as
      "the app is talking to you", not as a browser default */
   --color-focus: #459ffe;
+  --color-accent-text: #7fc0ff;
   --color-bubble-user: #5a5a5a;
   --color-success: #38d591;
   --color-danger: #ff5667;
@@ -29,9 +51,201 @@
 
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text",
     "Segoe UI", system-ui, sans-serif;
+}
 
+/* Tokens that no utility generates — declared outside `@theme` so Tailwind
+   can't tree-shake them away, and so a skin can redefine them freely. */
+:root {
+  /* ink carried by a filled accent / danger surface (see the rule at the
+     bottom of this file, which is what makes them take effect) */
+  --color-accent-ink: #ffffff;
+  --color-danger-ink: #ffffff;
+  --color-scrollbar: #3d3d3d;
+  /* second speed line of the mascot — contrasts against the app ground */
+  --color-maus-line: #fcfcfc;
+}
+
+/* ── Midnight ──────────────────────────────────────────────────────────────
+   The upstream palette, pixel-sampled from the real Grok app. Repeated here
+   (rather than relying on the `@theme` defaults) so that a `[data-skin]`
+   subtree can switch *back* to it — the picker needs that.
+
+   Two upstream contrast gaps are preserved deliberately, because this skin's
+   job is to be the original: white on the accent fill measures 3.65:1 and
+   white on the danger fill 3.32:1, both short of AA for the 13–15px labels
+   they carry. Atelier and Foundry fix this via --color-accent-ink.
+   ───────────────────────────────────────────────────────────────────────── */
+[data-skin="midnight"] {
+  --color-app: #070707;
+  --color-panel: #111111;
+  --color-raised: #2f2f2f;
+  --color-raised-hover: #3d3d3d;
+  --color-card: #262626;
+  --color-inset: #191919;
+  --color-hairline: #333333;
+  --color-ink: #fcfcfc;
+  --color-ink-secondary: #fcfcfc99;
+  --color-accent: #1084fe;
+  --color-accent-border: #459ffe;
+  --color-accent-text: #7fc0ff;
+  --color-accent-ink: #ffffff;
+  --color-bubble-user: #5a5a5a;
+  --color-success: #38d591;
+  --color-danger: #ff5667;
+  --color-danger-ink: #ffffff;
+  --color-warning: #ff9800;
+  --color-scrollbar: #3d3d3d;
+  --color-maus-line: #fcfcfc;
+
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Segoe UI", system-ui, sans-serif;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+}
+
+/* ── Atelier ───────────────────────────────────────────────────────────────
+   Daylight on paper, and the inverse of Midnight in every axis. Its one
+   structural idea: surfaces get BRIGHTER as they rise — rail, sidebar,
+   content — so the ground closest to the work is the lightest, the opposite
+   of a dark skin where raised means lighter-grey.
+
+   Four tones were darkened from the first draft to clear AA; the original
+   value is named next to each, so the drift stays auditable.
+   ───────────────────────────────────────────────────────────────────────── */
+[data-skin="atelier"] {
+  --color-app: #f5f1eb;           /* outermost ground */
+  --color-panel: #fbf8f2;         /* sidebar */
+  --color-raised: #ffffff;        /* content — raised means lighter here */
+  --color-raised-hover: #f2e9dc;  /* warm beige doubles as the hover fill */
+  --color-card: #ffffff;
+  --color-inset: #f5f1eb;         /* inset surfaces pick the rail tone back up */
+  --color-hairline: #c8bda8;      /* #ece7dd was 1.11:1 on the rail → 1.65:1 */
+
+  --color-ink: #1a1a18;           /* 17.4:1 on white */
+  --color-ink-secondary: #6b6559; /* #8b8578 was 3.67:1 → 5.78:1 */
+
+  /* Two accent tones: the fill carries white, the text stands on white. */
+  --color-accent: #a05f25;        /* #b06a2c darkened → 5.05:1 */
+  --color-accent-border: #b06a2c; /* the original tone lives on as the border */
+  --color-accent-text: #96551f;   /* for links on a light ground — 5.81:1 */
+  --color-focus: #96551f;         /* the ring rides the accent, not Grok blue */
+  --color-accent-ink: #ffffff;
+  --color-bubble-user: #f2e9dc;   /* your own messages in the badge beige */
+
+  --color-success: #3f6b47;
+  --color-danger: #a33a32;
+  --color-danger-ink: #ffffff;
+  --color-warning: #7a5f31;       /* darkened → 4.98:1 */
+  --color-scrollbar: #c9c0ae;
+  --color-maus-line: #6b6559;
+
+  /* System faces rather than Inter: paper reads as the platform's own. */
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
   --radius-lg: 6px;
   --radius-xl: 10px;
+}
+
+/* ── Foundry ───────────────────────────────────────────────────────────────
+   Night shift. The third corner of the grid: Midnight is dark and cool,
+   Atelier light and warm — this one is dark and warm, which is the register
+   most of this app's actual use falls into.
+
+   Its one structural idea, and the thing that makes it read as metal rather
+   than as "Atelier with the lights off": the accent is the brightest thing on
+   screen, not a darker patch of it. Brass at #d99a3e glows against the ground
+   at 7.9:1 and carries near-black lettering at 7.4:1 — so filled buttons read
+   as lit, not as painted. That inversion is only possible because
+   --color-accent-ink exists; with hardcoded white text the accent would have
+   to stay dark and the skin would lose its point.
+
+   Surfaces warm up as they rise (#100e0b → #262019), the way material does as
+   it comes closer to the lamp. Corners are tighter than Atelier's — 4px and
+   8px — because sheet metal doesn't round the way paper does.
+   ───────────────────────────────────────────────────────────────────────── */
+[data-skin="foundry"] {
+  --color-app: #100e0b;           /* deepest ground, warm black */
+  --color-panel: #171410;         /* sidebar */
+  --color-raised: #262019;        /* raised means warmer, not just lighter */
+  --color-raised-hover: #322b21;
+  --color-card: #1e1a14;
+  --color-inset: #0b0a08;         /* inset sinks below the ground */
+  --color-hairline: #3d3529;      /* visible on purpose — this UI has edges */
+
+  --color-ink: #f4efe4;           /* warm off-white, never pure #fff */
+  --color-ink-secondary: #b0a696; /* 6.7:1 on raised, 5.9:1 on hover */
+
+  /* Brass. Bright fill, dark lettering — the inversion described above. */
+  --color-accent: #d99a3e;
+  --color-accent-border: #e8b25e;
+  --color-accent-text: #e0a44c;   /* 8.6:1 on the ground, for links */
+  --color-focus: #e0a44c;         /* the ring rides the accent, not Grok blue */
+  --color-accent-ink: #1c150c;    /* 7.4:1 on the brass fill */
+  --color-bubble-user: #2a2318;   /* your own messages, one step out of the card */
+
+  --color-success: #57b078;
+  --color-danger: #e0685e;        /* a lamp, not a paint chip */
+  --color-danger-ink: #1c0d0b;
+  --color-warning: #dfa441;
+  --color-scrollbar: #3d3529;
+  --color-maus-line: #b0a696;
+
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Segoe UI", system-ui, sans-serif;
+  --radius-lg: 4px;
+  --radius-xl: 8px;
+}
+
+/* ── Lagoon ────────────────────────────────────────────────────────────────
+   Cool daylight — the fourth corner, and the one the grid was missing:
+   Midnight is dark and cool, Atelier light and warm, Foundry dark and warm.
+
+   Where Atelier is paper, this is glazed ceramic. The neutrals carry a green-
+   blue cast rather than a cream one (#eef2f2, not #f5f1eb), so the whole
+   surface reads cool without a single saturated pixel, and the deep teal
+   accent belongs to the ground instead of sitting on top of it. Even the ink
+   is a very dark petrol rather than a neutral black — on a tinted ground a
+   truly neutral black reads as a foreign object.
+
+   Corners are the most generous of the four (8px / 14px): glass and ceramic
+   round more than paper does, and far more than sheet metal.
+   ───────────────────────────────────────────────────────────────────────── */
+[data-skin="lagoon"] {
+  /* The tint is the point, so it is carried by the surfaces, not by a button:
+     the ground sits 13 points of green-blue above its red channel, roughly
+     three times Atelier's cream cast, which is what makes the skin read as
+     teal at a glance. Raised surfaces stay pure white as the contrast anchor —
+     tinting those too turns the whole thing to soup. */
+  --color-app: #dfeceb;
+  --color-panel: #ecf4f3;
+  --color-raised: #ffffff;
+  --color-raised-hover: #cfe4e1;
+  --color-card: #ffffff;
+  --color-inset: #d5e8e5;
+  --color-hairline: #aebfbd;      /* 1.60:1 — level with the other three */
+
+  --color-ink: #14201f;           /* dark petrol; a neutral black would read
+                                     as a foreign object on a tinted ground */
+  --color-ink-secondary: #4d5c5b; /* 7.0:1 on white, 5.8:1 on the ground */
+
+  --color-accent: #11736d;        /* deep teal, carries white at 5.68:1 */
+  --color-accent-border: #14807a;
+  --color-accent-text: #0d5f5a;   /* 7.5:1 on a card */
+  --color-focus: #0d5f5a;         /* the ring rides the accent, not Grok blue */
+  --color-accent-ink: #ffffff;
+  --color-bubble-user: #cfe4e1;
+
+  --color-success: #2f6b4f;
+  --color-danger: #a8382f;
+  --color-danger-ink: #ffffff;
+  --color-warning: #7a5a2a;
+  --color-scrollbar: #a6b8b6;
+  --color-maus-line: #4d5c5b;
+
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  --radius-lg: 8px;
+  --radius-xl: 14px;
 }
 
 html,
@@ -73,7 +287,7 @@ body {
   height: 8px;
 }
 ::-webkit-scrollbar-thumb {
-  background: #3d3d3d;
+  background: var(--color-scrollbar);
   border-radius: 4px;
 }
 /* the thumb was inert — it never acknowledged the pointer */
@@ -204,7 +418,9 @@ body {
 }
 
 .maus-speed-line--two {
-  stroke: #fcfcfc;
+  /* the mascot's own --maus-color is set per motion; this line reads against
+     the app ground instead, so it follows the skin */
+  stroke: var(--color-maus-line);
   stroke-width: 2.5px;
 }
 
@@ -607,4 +823,34 @@ body {
   .animate-spin {
     animation: reduced-loader-pulse 1.6s ease-in-out infinite !important;
   }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Filled accent / danger surfaces
+
+   Components hardcode `text-white` on these fills (~20 call sites). That works
+   only as long as every skin's accent is dark enough to carry white — which
+   rules out any skin whose accent is meant to glow. Rather than edit twenty
+   components, the ink is taken from a token here; `text-white` and this rule
+   have equal specificity, and this file is loaded after Tailwind's utilities.
+   Midnight sets the token to #ffffff, so its rendering is unchanged.
+   ───────────────────────────────────────────────────────────────────────── */
+.bg-accent {
+  color: var(--color-accent-ink);
+}
+.bg-danger {
+  color: var(--color-danger-ink);
+}
+
+/* Disabled buttons.
+   Upstream fades them with `disabled:opacity-40`. On a dark ground that holds:
+   the button stays darker than the page and the white label survives. On a
+   light ground it inverts — Atelier's #a05f25 at 40% over white lands on
+   #d9bfa8, where white lettering measures 1.75:1 and effectively disappears.
+   So the disabled state gets its own colours instead of transparency. */
+button:disabled.bg-accent,
+button:disabled.bg-danger {
+  background-color: var(--color-raised-hover);
+  color: var(--color-ink-secondary);
+  opacity: 1;
 }


### PR DESCRIPTION
Midnight (the current palette, **unchanged**) plus three alternatives, switchable in Settings → General and remembered per machine. They fill a grid:

|  | cool | warm |
|---|---|---|
| **light** | Lagoon — ceramic, teal | Atelier — paper, daylight |
| **dark** | **Midnight** — the original | Foundry — night shift, brass |

### Why this is mostly a CSS change

Because of a property this codebase already has: **916 token classes against 8 hardcoded hex values and no Tailwind greys.** A skin is therefore one block of custom properties — Lagoon cost 51 lines. That token discipline is what made this worth trying at all.

The selector is `[data-skin=…]` rather than `:root[data-skin=…]`, so any element can open a skin context for its subtree. That is how the picker renders a live miniature of each skin instead of a painted mockup.

### One token does real work beyond theming

`--color-accent-ink` — the ink carried by a filled accent or danger surface. Components hardcode `text-white` on those fills at ~20 sites, which holds only while every accent is dark enough to carry white.

That constraint is measurable, and the numbers are worth having on their own: white on the current accent is **3.65:1** and on danger **3.10:1**, both short of the 4.5:1 that AA asks of the 12–14px labels they carry. (Measured in more detail in #249, which stands alone.)

Midnight sets the token to `#ffffff`, so **its rendering is byte-identical**. But Foundry can invert the relationship — brass fill, near-black lettering, 7.4:1 — which is what lets it read as lit metal rather than a dark paint chip. With hardcoded white, every accent would have to stay dark and the skin would lose its point.

Same story for the disabled state: `disabled:opacity-40` works on a dark ground and inverts on a light one, where Atelier's accent at 40% over white lands on `#d9bfa8` and white lettering measures 1.75:1. Disabled buttons get their own colours instead of transparency.

### Contrast is measured, not asserted

`scripts/check-skin-contrast.mjs` parses the stylesheet, reads `@theme` and `:root` as the **inherited base** — so a token a skin does *not* set is still measured as it actually ships — and fails on an undefined token rather than skipping it. 27 pairs per skin, all three new ones clear. Midnight is advisory, since its job is to be the original, gaps included.

That inheritance detail is not theoretical: while rebasing this onto v0.1.24 the new `--color-focus` landed, no skin overrode it, and all three would have silently worn Midnight's blue — 2.27:1 on Lagoon. The check now catches that class of regression.

Fully understand if a four-way skin picker is not where you want this app to go — the `--color-accent-ink` and disabled-state parts stand on their own if you would rather take only those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)