### PR TITLE
Fix Codex model discovery and computer use

### DIFF
--- a/server/drivers/codex-catalog.test.ts
+++ b/server/drivers/codex-catalog.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CodexDriver } from "./codex.ts";
@@ -13,6 +14,7 @@ import {
 } from "./codex-catalog.ts";
 
 const scratchDirs: string[] = [];
+const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
 
 afterEach(() => {
   for (const dir of scratchDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
@@ -39,6 +41,13 @@ describe("decodeCodexSelection", () => {
     });
   });
 
+  it("forces newly discovered bare ids onto the ChatGPT provider too", () => {
+    expect(decodeCodexSelection("gpt-future-codex")).toEqual({
+      model: "gpt-future-codex",
+      modelProvider: OFFICIAL_CODEX_PROVIDER,
+    });
+  });
+
   it("splits provider-encoded custom ids", () => {
     expect(decodeCodexSelection("omlx::Qwen3.6-35B-A3B-bf16:qwen3-5-6-n-r-reasoning")).toEqual({
       model: "Qwen3.6-35B-A3B-bf16:qwen3-5-6-n-r-reasoning",
@@ -48,10 +57,27 @@ describe("decodeCodexSelection", () => {
 });
 
 describe("readCodexModelCatalog", () => {
-  it("returns the static cloud trio when there is no config", async () => {
+  it("returns the static cloud fallback when there is no config or CLI probe", async () => {
     expect(await readCodexModelCatalog({ HOME: join(tmpdir(), "omb-codex-missing-home") })).toEqual(
       STATIC_CODEX_MODELS,
     );
+  });
+
+  it("uses every visible page from the installed Codex app-server catalog", async () => {
+    chmodSync(FAKE_CLI, 0o755);
+    const catalog = await readCodexModelCatalog(
+      { HOME: join(tmpdir(), "omb-codex-app-server-models"), PATH: process.env.PATH },
+      fetch,
+      FAKE_CLI,
+    );
+
+    expect(catalog).toEqual({
+      default: "gpt-fake-default",
+      options: [
+        { id: "gpt-fake-default", label: "GPT Fake Default" },
+        { id: "gpt-page-two", label: "GPT Page Two" },
+      ],
+    });
   });
 
   it("appends the configured local model and cached catalog slugs as custom", async () => {
@@ -78,7 +104,7 @@ model = "GLM-5.2-mxfp4"
     });
 
     expect(catalog.default).toBe(encodeCodexSelection("omlx", "Qwen3.6-35B-A3B-bf16:qwen3-5-6-n-r-reasoning"));
-    expect(catalog.options.slice(0, 3)).toEqual(STATIC_CODEX_MODELS.options);
+    expect(catalog.options.slice(0, STATIC_CODEX_MODELS.options.length)).toEqual(STATIC_CODEX_MODELS.options);
     expect(catalog.options.filter((option) => option.custom).map((option) => option.id)).toEqual([
       encodeCodexSelection("omlx", "Qwen3.6-35B-A3B-bf16:qwen3-5-6-n-r-reasoning"),
       encodeCodexSelection("omlx", "GLM-5.2-mxfp4"),
@@ -167,6 +193,7 @@ name = "oMLX"
 
 describe("CodexDriver catalog", () => {
   it("loads the config catalog when the instance is created", async () => {
+    chmodSync(FAKE_CLI, 0o755);
     const home = scratchHome({
       "config.toml": `
 model_provider = "omlx"
@@ -181,7 +208,7 @@ name = "oMLX"
       displayName: "Codex",
       environment: { HOME: home },
       enabled: true,
-      config: CodexDriver.defaultConfig(),
+      config: { ...CodexDriver.defaultConfig(), cli: FAKE_CLI },
     });
     try {
       expect(instance.models.options.some((option) => option.id === "omlx::MiniMax-M3-4bit" && option.custom)).toBe(true);

--- a/server/drivers/codex-catalog.ts
+++ b/server/drivers/codex-catalog.ts
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
 import type { ModelCatalog } from "../contracts.ts";
+import { killCliTree, spawnCli } from "../procs.ts";
 import { mergeLocalInject } from "./local-inject.ts";
 
 export const STATIC_CODEX_MODELS: ModelCatalog = {
@@ -15,7 +16,11 @@ export const STATIC_CODEX_MODELS: ModelCatalog = {
   options: [
     { id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
     { id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+    { id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
+    { id: "gpt-5.5", label: "GPT-5.5" },
     { id: "gpt-5.4", label: "GPT-5.4" },
+    { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+    { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
   ],
 };
 
@@ -36,14 +41,134 @@ export function decodeCodexSelection(id: string | null | undefined): {
   modelProvider: string | null;
 } {
   if (!id) return { model: null, modelProvider: null };
-  if (STATIC_CODEX_MODELS.options.some((option) => option.id === id)) {
-    return { model: id, modelProvider: OFFICIAL_CODEX_PROVIDER };
-  }
   const sep = id.indexOf(SEP);
   if (sep > 0) {
     return { model: id.slice(sep + SEP.length), modelProvider: id.slice(0, sep) };
   }
-  return { model: id, modelProvider: null };
+  // Every official app-server picker row has a bare id. Custom providers are
+  // always provider-qualified above, so a newly released cloud model must not
+  // silently fall through to the user's configured local provider.
+  return { model: id, modelProvider: MODEL_ID.test(id) ? OFFICIAL_CODEX_PROVIDER : null };
+}
+
+interface CodexAppServerModel {
+  id?: unknown;
+  displayName?: unknown;
+  hidden?: unknown;
+  isDefault?: unknown;
+}
+
+/** Ask the installed Codex CLI for the ChatGPT model catalog it can actually
+ * use. This is the authoritative subscription catalog and changes more often
+ * than OpenMausBot releases, so consume every page instead of hard-coding the
+ * current set forever. */
+export function readCodexAppServerModelCatalog(
+  cli: string,
+  env: Record<string, string | undefined>,
+  timeoutMs = 8_000,
+): Promise<ModelCatalog | null> {
+  return new Promise((resolve) => {
+    const child = spawnCli(cli, ["app-server"], {
+      cwd: homedir(),
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let settled = false;
+    let buffer = "";
+    let nextId = 1;
+    const models: CodexAppServerModel[] = [];
+    const cursors = new Set<string>();
+    const pending = new Map<number, "initialize" | "models">();
+
+    const finish = (catalog: ModelCatalog | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      killCliTree(child);
+      resolve(catalog);
+    };
+    const request = (method: string, params: unknown, kind: "initialize" | "models") => {
+      const id = nextId++;
+      pending.set(id, kind);
+      try {
+        child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+      } catch {
+        finish(null);
+      }
+    };
+    const requestModels = (cursor: string | null) => {
+      request("model/list", { cursor, limit: 100 }, "models");
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    timer.unref?.();
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk;
+      let newline;
+      while ((newline = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line.trim()) continue;
+        let message: any;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const kind = pending.get(message.id);
+        if (!kind) continue;
+        pending.delete(message.id);
+        if (message.error) {
+          finish(null);
+          return;
+        }
+        if (kind === "initialize") {
+          try {
+            child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "initialized", params: {} })}\n`);
+          } catch {
+            finish(null);
+            return;
+          }
+          requestModels(null);
+          continue;
+        }
+
+        const page = message.result;
+        if (Array.isArray(page?.data)) models.push(...page.data);
+        const cursor = typeof page?.nextCursor === "string" && page.nextCursor ? page.nextCursor : null;
+        if (cursor && !cursors.has(cursor)) {
+          cursors.add(cursor);
+          requestModels(cursor);
+          continue;
+        }
+
+        const options: ModelCatalog["options"] = [];
+        const seen = new Set<string>();
+        let defaultModel: string | null = null;
+        for (const row of models) {
+          if (row.hidden === true || typeof row.id !== "string" || !MODEL_ID.test(row.id) || seen.has(row.id)) continue;
+          seen.add(row.id);
+          options.push({
+            id: row.id,
+            label: typeof row.displayName === "string" && row.displayName.trim() ? row.displayName : row.id,
+          });
+          if (row.isDefault === true) defaultModel = row.id;
+        }
+        if (!options.length) {
+          finish(null);
+          return;
+        }
+        finish({
+          default: defaultModel && seen.has(defaultModel) ? defaultModel : options[0].id,
+          options,
+        });
+      }
+    });
+    child.on("error", () => finish(null));
+    child.on("close", () => finish(null));
+    request("initialize", { clientInfo: { name: "openmausbot", version: "1" } }, "initialize");
+  });
 }
 
 export function codexHome(env: Record<string, string | undefined>): string {
@@ -232,10 +357,12 @@ async function probeProviderModels(
 export async function readCodexModelCatalog(
   env: Record<string, string | undefined> = process.env,
   fetchImpl: typeof fetch = fetch,
+  cli?: string,
 ): Promise<ModelCatalog> {
+  const official = (cli ? await readCodexAppServerModelCatalog(cli, env) : null) ?? STATIC_CODEX_MODELS;
   const home = codexHome(env);
   const mainText = readText(join(home, "config.toml"));
-  if (!mainText) return STATIC_CODEX_MODELS;
+  if (!mainText) return mergeLocalInject(official, env, fetchImpl);
 
   const main = parseCodexToml(mainText);
   const known = new Map(main.providers.map((provider) => [provider.id, provider]));
@@ -250,7 +377,7 @@ export async function readCodexModelCatalog(
     // default would decode the bare slug back to the OpenAI provider.
     if (
       provider === OFFICIAL_CODEX_PROVIDER &&
-      STATIC_CODEX_MODELS.options.some((option) => option.id === model)
+      official.options.some((option) => option.id === model)
     ) return;
     extras.push({ provider, model });
   };
@@ -279,7 +406,7 @@ export async function readCodexModelCatalog(
   );
   for (const row of live.flat()) remember(row.provider, row.model);
 
-  const options = STATIC_CODEX_MODELS.options.map((option) => ({ ...option }));
+  const options = official.options.map((option) => ({ ...option }));
   const seen = new Set(options.map((option) => option.id));
   for (const extra of extras) {
     const id = encodeCodexSelection(extra.provider, extra.model);
@@ -294,7 +421,7 @@ export async function readCodexModelCatalog(
 
   const configured = main.model && main.modelProvider
     ? main.modelProvider === OFFICIAL_CODEX_PROVIDER &&
-      STATIC_CODEX_MODELS.options.some((option) => option.id === main.model)
+      official.options.some((option) => option.id === main.model)
       ? main.model
       : encodeCodexSelection(main.modelProvider, main.model)
     : main.model && seen.has(main.model)
@@ -303,7 +430,7 @@ export async function readCodexModelCatalog(
 
   return mergeLocalInject(
     {
-      default: configured && seen.has(configured) ? configured : STATIC_CODEX_MODELS.default,
+      default: configured && seen.has(configured) ? configured : official.default,
       options,
     },
     env,

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -150,6 +150,56 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(seen.env.OMB_COMMS_TOKEN).toBe("per-boot-token");
   });
 
+  it("mounts the Local VM computer MCP server without placing credentials in argv", async () => {
+    await create();
+    const dump = join(scratch, "local-computer.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+    expect(instance.adapter.capabilities.computerMcp).toBe(true);
+
+    await instance.adapter.sendTurn({
+      threadId: "t-local-computer",
+      text: "open the browser",
+      integrations: {
+        localComputer: {
+          command: process.execPath,
+          args: ["/tmp/container-mcp.js", "podman", "openmausbot-computer", "/run/cua.sock"],
+          env: { ELECTRON_RUN_AS_NODE: "1", OMB_VM_TOKEN: "vm-secret" },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv.join(" ")).toContain("mcp_servers.computer.command");
+    expect(seen.argv.join(" ")).toContain("/tmp/container-mcp.js");
+    expect(seen.argv.join(" ")).toContain("OMB_VM_TOKEN");
+    expect(seen.argv.join(" ")).not.toContain("vm-secret");
+    expect(seen.env.OMB_VM_TOKEN).toBe("vm-secret");
+  });
+
+  it("mounts the remote computer proxy without placing its token in argv", async () => {
+    await create();
+    const dump = join(scratch, "remote-computer.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-remote-computer",
+      text: "take a screenshot",
+      integrations: {
+        computer: { boxId: "box-123", token: "remote-secret" },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv.join(" ")).toContain("mcp_servers.computer.command");
+    expect(seen.argv.join(" ")).toContain("computer-proxy");
+    expect(seen.argv.join(" ")).toContain("OGB_BOX_TOKEN");
+    expect(seen.argv.join(" ")).not.toContain("remote-secret");
+    expect(seen.env.OGB_BOX_ID).toBe("box-123");
+    expect(seen.env.OGB_BOX_TOKEN).toBe("remote-secret");
+  });
+
   it("sends the local provider when the picker id is custom-encoded", async () => {
     await create({ environment: { UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-secret" } });
     const dump = join(scratch, "dump.json");

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -11,7 +11,9 @@
 // and falls back to a fresh thread/start.
 import { homedir } from "node:os";
 
+import { computerProxyEnv } from "../container-computer.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
+import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 
 import type {
   DriverCreateInput,
@@ -49,6 +51,26 @@ const QUESTION_TIMEOUT_NOTE = "No answer was given — use your best judgment.";
 const DENY_TIMEOUT_NOTE =
   "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
 
+type StdioMcpServer = { command: string; args: string[]; env: Record<string, string> };
+
+function mountMcpServer(
+  appServerArgs: string[],
+  env: Record<string, string | undefined>,
+  name: string,
+  server: StdioMcpServer,
+): void {
+  Object.assign(env, server.env);
+  const prefix = `mcp_servers.${name}`;
+  appServerArgs.push(
+    "-c", `${prefix}.command=${JSON.stringify(server.command)}`,
+    "-c", `${prefix}.args=${JSON.stringify(server.args)}`,
+    // Values stay in the child environment; argv contains names only so
+    // credentials never appear in process listings or diagnostics.
+    "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(server.env))}`,
+    "-c", `${prefix}.default_tools_approval_mode="auto"`,
+  );
+}
+
 export const CodexDriver: ProviderDriver<CodexConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Codex", supportsMultipleInstances: true },
@@ -84,7 +106,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
     let models = STATIC_CODEX_MODELS;
     const refreshModels = async () => {
       try {
-        const resolved = await readCodexModelCatalog(catalogEnv);
+        const resolved = await readCodexModelCatalog(catalogEnv, fetch, config.cli);
         if (resolved.options.length) models = resolved;
       } catch {
         // Keep the last usable catalog when a local provider is down.
@@ -118,15 +140,23 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       const env = childEnv();
       const appServerArgs = ["app-server", ...codexLocalProviderArgs(env, turn.model)];
       if (turn.integrations?.composio) {
-        const bridge = turn.integrations.composio;
-        Object.assign(env, bridge.env);
-        const prefix = "mcp_servers.openmausbot_connectors";
-        appServerArgs.push(
-          "-c", `${prefix}.command=${JSON.stringify(bridge.command)}`,
-          "-c", `${prefix}.args=${JSON.stringify(bridge.args)}`,
-          "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(bridge.env))}`,
-          "-c", `${prefix}.default_tools_approval_mode="auto"`,
-        );
+        mountMcpServer(appServerArgs, env, "openmausbot_connectors", turn.integrations.composio);
+      }
+      if (turn.integrations?.computer) {
+        const proxyEnv = computerProxyEnv(turn.integrations.computer);
+        mountMcpServer(appServerArgs, env, "computer", {
+          command: process.execPath,
+          args: [SPAWNED_PROXIES.computer],
+          env: {
+            ELECTRON_RUN_AS_NODE: "1",
+            OGB_BOX_ID: proxyEnv.OGB_BOX_ID ?? "",
+            OGB_BOX_TOKEN: proxyEnv.OGB_BOX_TOKEN ?? "",
+          },
+        });
+      } else if (turn.integrations?.localComputer) {
+        // The host daemon and isolated Local VM both arrive as a direct Cua
+        // Driver stdio MCP server. Codex sees the same computer tool surface.
+        mountMcpServer(appServerArgs, env, "computer", turn.integrations.localComputer);
       }
       if (turn.integrations?.phone) {
         const bridge = turn.integrations.phone;
@@ -500,6 +530,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         provider: DRIVER_KIND,
         capabilities: {
           sessionModelSwitch: "unsupported",
+          computerMcp: true,
           composioMcp: true,
           phoneMcp: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -84,6 +84,32 @@ process.stdin.on("data", (chunk) => {
       case "initialize":
         out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
         break;
+      case "model/list":
+        if (msg.params?.cursor === "page-2") {
+          out({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {
+              data: [
+                { id: "gpt-hidden", displayName: "Hidden", hidden: true, isDefault: false },
+                { id: "gpt-page-two", displayName: "GPT Page Two", hidden: false, isDefault: false },
+              ],
+              nextCursor: null,
+            },
+          });
+        } else {
+          out({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {
+              data: [
+                { id: "gpt-fake-default", displayName: "GPT Fake Default", hidden: false, isDefault: true },
+              ],
+              nextCursor: "page-2",
+            },
+          });
+        }
+        break;
       case "thread/resume":
         if (mode === "resume") {
           out({ jsonrpc: "2.0", id: msg.id, result: { thread: { id: msg.params?.threadId } } });


### PR DESCRIPTION
## What changed

- Discover the visible Codex subscription model catalog from the installed `codex app-server`, including every pagination page.
- Keep a current seven-model fallback catalog for offline or older CLI failure cases.
- Bind all bare cloud model selections to the official OpenAI provider so newly released models cannot be routed to a configured local provider.
- Mount both the isolated Local VM Cua MCP server and the remote computer proxy in Codex turns.
- Keep computer credentials in the child environment rather than process arguments.

## Why

OpenMausBot only exposed three hard-coded Codex models even though the installed CLI currently exposes seven. The Codex adapter also declared no computer MCP capability, so Local VM routing rejected Codex before a turn could start.

## Impact

Codex users see the complete model list supported by their installed CLI and can use host/Local VM or remote computer tools like the other MCP-capable engines.

## Validation

- `pnpm exec vitest run server/drivers/codex-catalog.test.ts server/drivers/codex.test.ts` — 31 passed
- `pnpm typecheck`
- `pnpm build:server`
- Live catalog probe against `codex-cli 0.147.0` returned all seven visible models


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live discovery of available Codex models, including support for paginated catalogs.
  - Added support for additional Codex models and local configuration.
  - Added computer and Local VM integrations through MCP.
  - Added support for connecting Codex to remote computer tools.
- **Bug Fixes**
  - Improved model selection and fallback behavior when live discovery is unavailable.
  - Credentials are now passed securely through the process environment instead of command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->