### PR TITLE
Add image attachments: paste a screenshot into the composer (roadmap item 3.5)

### DIFF
--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -1,0 +1,81 @@
+// attachments.ts: save + read-back, the mime allowlist, size ceiling, and
+// the name-lock that keeps the serving route inside the attachments dir.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The module reads DATA_DIR at import time, so the env var must be set
+// before the import is evaluated.
+const DATA_ROOT = mkdtempSync(join(tmpdir(), "omb-attachments-"));
+process.env.OMB_DATA_DIR = join(DATA_ROOT, "data");
+
+const { ATTACHMENTS_DIR, IMAGE_MAX_BYTES, extensionForMime, readAttachment, saveImage } = await import("./attachments.ts");
+
+describe("extensionForMime", () => {
+  it("maps the accepted image mimes to extensions", () => {
+    expect(extensionForMime("image/png")).toBe(".png");
+    expect(extensionForMime("image/jpeg")).toBe(".jpg");
+    expect(extensionForMime("image/gif")).toBe(".gif");
+    expect(extensionForMime("image/webp")).toBe(".webp");
+  });
+
+  it("tolerates parameters and casing", () => {
+    expect(extensionForMime("Image/PNG; charset=binary")).toBe(".png");
+    expect(extensionForMime("  image/webp  ")).toBe(".webp");
+  });
+
+  it("refuses everything else — including svg, which executes script", () => {
+    expect(extensionForMime("image/svg+xml")).toBeNull();
+    expect(extensionForMime("text/plain")).toBeNull();
+    expect(extensionForMime(undefined)).toBeNull();
+  });
+});
+
+describe("saveImage", () => {
+  beforeEach(() => {
+    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+  });
+  afterEach(() => {
+    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+  });
+
+  it("persists bytes under the attachments dir with a generated name", () => {
+    const saved = saveImage(Buffer.from("png-bytes"), "image/png");
+    expect(saved.path.startsWith(ATTACHMENTS_DIR)).toBe(true);
+    expect(saved.path.endsWith(".png")).toBe(true);
+    expect(saved.bytes).toBe(9);
+    expect(saved.mime).toBe("image/png");
+  });
+
+  it("round-trips through readAttachment with the right mime", () => {
+    const saved = saveImage(Buffer.from("gif!"), "image/gif");
+    const name = saved.path.split(/[\\/]/).pop()!;
+    const back = readAttachment(name);
+    expect(back?.bytes.toString()).toBe("gif!");
+    expect(back?.mime).toBe("image/gif");
+  });
+
+  it("rejects unsupported mimes, empty bodies, and oversize bodies", () => {
+    expect(() => saveImage(Buffer.from("x"), "image/svg+xml")).toThrow(/unsupported image type/);
+    expect(() => saveImage(Buffer.alloc(0), "image/png")).toThrow(/empty/);
+    expect(() => saveImage(Buffer.alloc(IMAGE_MAX_BYTES + 1), "image/png")).toThrow(/exceeds/);
+  });
+});
+
+describe("readAttachment name lock", () => {
+  beforeEach(() => {
+    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+  });
+  afterEach(() => {
+    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+  });
+
+  it("refuses traversal, dotfiles, and names the saver never writes", () => {
+    expect(readAttachment("..%2F..%2Fconfig.json")).toBeNull();
+    expect(readAttachment(".env")).toBeNull();
+    expect(readAttachment("a/b.png")).toBeNull();
+    expect(readAttachment("no-extension")).toBeNull();
+    expect(readAttachment("uuid.jpeg")).toBeNull(); // saved as .jpg
+  });
+});

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -1,0 +1,83 @@
+// Image attachments: pasted/dropped images become files under
+// ~/.openmausbot/attachments so every CLI engine can open them by path —
+// the app never ships image bytes through the prompt itself.
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import { DATA_DIR } from "./config.ts";
+
+export const ATTACHMENTS_DIR = join(DATA_DIR, "attachments");
+
+/** The spec's ceiling: a screenshot bigger than this is rejected before it
+ * is ever buffered, matching the composer's existing size discipline. */
+export const IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Mimes the endpoint accepts, mapped to the extension stored on disk.
+ * Sniffing is not attempted — a lie here only changes the filename. */
+const IMAGE_MIMES: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+
+export function extensionForMime(mime: string | undefined): string | null {
+  if (!mime) return null;
+  return IMAGE_MIMES[mime.split(";")[0]!.trim().toLowerCase()] ?? null;
+}
+
+export function ensureAttachmentsDir(): void {
+  mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+}
+
+export interface SavedAttachment {
+  path: string;
+  mime: string;
+  bytes: number;
+}
+
+/** Persist one image and return its path. The UUID filename means the name
+ * is never attacker-controlled and never collides; the extension preserves
+ * the format the sender claimed. */
+export function saveImage(bytes: Buffer, mime: string): SavedAttachment {
+  const ext = extensionForMime(mime);
+  if (!ext) throw Object.assign(new Error("unsupported image type"), { status: 400 });
+  if (bytes.byteLength === 0) throw Object.assign(new Error("empty image"), { status: 400 });
+  if (bytes.byteLength > IMAGE_MAX_BYTES) {
+    throw Object.assign(new Error(`image exceeds ${IMAGE_MAX_BYTES} bytes`), { status: 413 });
+  }
+  ensureAttachmentsDir();
+  const name = `${randomUUID()}${ext}`;
+  const path = join(ATTACHMENTS_DIR, name);
+  writeFileSync(path, bytes);
+  return { path, mime: mime.split(";")[0]!.trim().toLowerCase(), bytes: bytes.byteLength };
+}
+
+/** Read an attachment back for serving. Only names that are exactly a bare
+ * filename (no separators, no dotfiles) inside ATTACHMENTS_DIR resolve —
+ * the route must never become a general file server for the data dir. */
+export function readAttachment(name: string): { bytes: Buffer; mime: string } | null {
+  if (!/^[A-Za-z0-9-]+\.(png|jpg|jpeg|gif|webp)$/.test(name)) return null;
+  const path = join(ATTACHMENTS_DIR, name);
+  if (extname(path) === ".jpeg") return null; // saved as .jpg; .jpeg is not a name we write
+  try {
+    return { bytes: readFileSync(path), mime: mimeForExt(extname(path)) };
+  } catch {
+    return null;
+  }
+}
+
+function mimeForExt(ext: string): string {
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -193,6 +193,11 @@ export interface ProviderAdapter {
     composioMcp?: boolean;
     /** True when the driver can mount the first-party physical-phone MCP. */
     phoneMcp?: boolean;
+    /** True when this engine accepts images in the prompt — gates image
+     * paste in the composer. Same rule as computerMcp: never offer an
+     * attachment an engine cannot open (a bot told it has an image it
+     * cannot read burns the turn). */
+    images?: boolean;
     /** Effort levels this driver can pass to its CLI, ascending. Absent =
      * the driver cannot set effort, so the app never offers the control —
      * same rule as computerMcp: never show a knob the driver cannot turn. */

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -674,6 +674,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             agentsMcp: true,
             computerMcp: true,
             composioMcp: true,
+            images: true,
             effortLevels: support.effortLevels,
           },
           sendTurn,

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -415,7 +415,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       snapshot,
       adapter: {
         provider: DRIVER_KIND,
-        capabilities: { sessionModelSwitch: "in-session" },
+        capabilities: { sessionModelSwitch: "in-session", images: true },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async () => "unavailable" as const, // this engine has no asks to answer

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -690,6 +690,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           computerMcp: true,
           composioMcp: true,
           phoneMcp: true,
+          images: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
         },
         sendTurn,

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -533,6 +533,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           computerMcp: true,
           composioMcp: true,
           phoneMcp: true,
+          images: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
         },
         sendTurn,

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -171,6 +171,7 @@ export class ProviderRegistry {
             agentsMcp: inst.adapter.capabilities.agentsMcp === true,
             composioMcp: inst.adapter.capabilities.composioMcp === true,
             phoneMcp: inst.adapter.capabilities.phoneMcp === true,
+            images: inst.adapter.capabilities.images === true,
             effortLevels: inst.adapter.capabilities.effortLevels,
           },
           access: driver?.metadata.access ?? "subscription",

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { openSse } from "./testing/sse.ts";
+import { IMAGE_MAX_BYTES } from "./attachments.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
@@ -357,6 +358,13 @@ describe("harness HTTP API", () => {
     expect(traversal.status).toBe(404);
     const unknown = await fetch(`${BASE}/api/attachments/00000000-0000-0000-0000-000000000000.png`);
     expect(unknown.status).toBe(404);
+
+    const tooBig = await fetch(`${BASE}/api/attachments`, {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body: Buffer.alloc(IMAGE_MAX_BYTES + 1),
+    });
+    expect(tooBig.status).toBe(413);
   });
 
   it("exports every visible bot and imports the team without creating a room", async () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -321,6 +321,44 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
+  it("saves, serves, and guards image attachments", async () => {
+    // a real 1x1 PNG so the bytes round-trip intact
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+
+    const wrongType = await fetch(`${BASE}/api/attachments`, {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: "not an image",
+    });
+    expect(wrongType.status).toBe(400);
+
+    const saved = await fetch(`${BASE}/api/attachments`, {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body: new Uint8Array(png),
+    });
+    expect(saved.status).toBe(201);
+    const { path: savedPath, mime, bytes } = (await saved.json()) as { path: string; mime: string; bytes: number };
+    expect(mime).toBe("image/png");
+    expect(bytes).toBe(png.byteLength);
+    expect(savedPath).toContain("attachments");
+
+    const name = savedPath.split(/[\\/]/).pop();
+    const served = await fetch(`${BASE}/api/attachments/${name}`);
+    expect(served.status).toBe(200);
+    expect(served.headers.get("content-type")).toBe("image/png");
+    expect(Buffer.from(await served.arrayBuffer()).equals(png)).toBe(true);
+
+    // the serving route is name-locked to the attachments dir
+    const traversal = await fetch(`${BASE}/api/attachments/..%2F..%2Fconfig.json`);
+    expect(traversal.status).toBe(404);
+    const unknown = await fetch(`${BASE}/api/attachments/00000000-0000-0000-0000-000000000000.png`);
+    expect(unknown.status).toBe(404);
+  });
+
   it("exports every visible bot and imports the team without creating a room", async () => {
     const first = (await api("POST", "/api/bots")).body.bot;
     const second = (await api("POST", "/api/bots")).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -2513,9 +2513,6 @@ const server = createServer(async (req, res) => {
         const fail = (status: number, msg: string) => {
           if (settled) return;
           settled = true;
-          req.removeAllListeners("data");
-          req.removeAllListeners("end");
-          req.destroy();
           reject(Object.assign(new Error(msg), { status }));
         };
         req.on("data", (chunk: Buffer) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { approvalKey, autoDecision } from "./auto-approve.ts";
 import { validateBotCwd } from "./bot-cwd.ts";
+import { extensionForMime, IMAGE_MAX_BYTES, readAttachment, saveImage, type SavedAttachment } from "./attachments.ts";
 import { groupTurnCwd } from "./room-cwd.ts";
 import * as box from "./box.ts";
 import { cloudBackendChangeError, vpsAliasChangeError } from "./cloud-backend.ts";
@@ -2492,6 +2493,63 @@ const server = createServer(async (req, res) => {
         "cache-control": "private, max-age=31536000, immutable",
       });
       return res.end(bytes);
+    }
+
+    // ── image attachments ────────────────────────────────────────────────
+    // Pasted/dropped images are stored as files and referenced by path in
+    // the prompt (<attached-image path="…"/>); this pair of routes is the
+    // save + serve. The POST takes raw bytes (base64 JSON would double the
+    // payload), so it needs its own reader rather than readBody.
+    if (method === "POST" && path === "/api/attachments") {
+      const rawType = Array.isArray(req.headers["content-type"]) ? req.headers["content-type"][0] : req.headers["content-type"];
+      const mime = rawType?.split(";")[0]?.trim().toLowerCase();
+      if (!mime || !extensionForMime(mime)) {
+        return json(res, 400, { error: "content-type must be an image type" });
+      }
+      const saved = await new Promise<SavedAttachment>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let received = 0;
+        let settled = false;
+        const fail = (status: number, msg: string) => {
+          if (settled) return;
+          settled = true;
+          req.removeAllListeners("data");
+          req.removeAllListeners("end");
+          req.destroy();
+          reject(Object.assign(new Error(msg), { status }));
+        };
+        req.on("data", (chunk: Buffer) => {
+          if (settled) return;
+          received += chunk.byteLength;
+          if (received > IMAGE_MAX_BYTES) return fail(413, `image exceeds ${IMAGE_MAX_BYTES} bytes`);
+          chunks.push(chunk);
+        });
+        req.on("end", () => {
+          if (settled) return;
+          settled = true;
+          try {
+            resolve(saveImage(Buffer.concat(chunks), mime));
+          } catch (e) {
+            reject(Object.assign(e instanceof Error ? e : new Error(String(e)), { status: 400 }));
+          }
+        });
+        req.on("error", (e) => fail(400, e instanceof Error ? e.message : String(e)));
+      });
+      return json(res, 201, saved);
+    }
+
+    // serving is name-locked to the attachments dir — readAttachment
+    // refuses anything that is not a bare generated filename
+    m = path.match(/^\/api\/attachments\/([\w.-]+)$/);
+    if (m && method === "GET") {
+      const attachment = readAttachment(m[1]!);
+      if (!attachment) return json(res, 404, { error: "no such attachment" });
+      res.writeHead(200, {
+        "content-type": attachment.mime,
+        "content-length": String(attachment.bytes.byteLength),
+        "cache-control": "private, max-age=31536000, immutable",
+      });
+      return res.end(attachment.bytes);
     }
 
     // ── search across every transcript ──────────────────────────────────

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -49,6 +49,7 @@ import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
 import { useFocusMessage } from "@/lib/focus-message";
 import { webhookMessageView } from "@/lib/webhook-message";
+import { attachmentBasename, splitAttachedImages } from "@/lib/composer-attachments";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 import {
   TRANSCRIPT_WINDOW_SIZE,
@@ -287,7 +288,8 @@ function Bubble({
   const [expanded, setExpanded] = useState(false);
   const text = message.text ?? "";
   const webhookView = user ? webhookMessageView(text) : null;
-  const visibleText = webhookView?.task ?? text;
+  const attachedImages = user && !webhookView ? splitAttachedImages(text) : null;
+  const visibleText = webhookView?.task ?? attachedImages?.display ?? text;
   const collapsible =
     user && !webhookView && !expanded && (visibleText.length > USER_COLLAPSE_CHARS || visibleText.split("\n").length > USER_COLLAPSE_LINES);
 
@@ -350,10 +352,31 @@ function Bubble({
             </div>
           ) : user ? (
             <>
+              {attachedImages && attachedImages.images.length > 0 && (
+                <div className="mb-2 flex flex-wrap justify-end gap-2">
+                  {attachedImages.images.map((path) => (
+                    <a
+                      key={path}
+                      href={`/api/attachments/${encodeURIComponent(attachmentBasename(path))}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="block max-w-[260px] overflow-hidden rounded-lg border border-hairline/40"
+                      title={path}
+                    >
+                      <img
+                        src={`/api/attachments/${encodeURIComponent(attachmentBasename(path))}`}
+                        alt="Attached image"
+                        loading="lazy"
+                        className="block max-h-[220px] w-full object-cover"
+                      />
+                    </a>
+                  ))}
+                </div>
+              )}
               <div
                 className={cn(collapsible && "max-h-40 overflow-hidden [mask-image:linear-gradient(to_bottom,black_60%,transparent)]")}
               >
-                {text}
+                {visibleText}
               </div>
               {collapsible && (
                 <button onClick={() => setExpanded(true)} className="mt-1 text-[12.5px] text-ink-secondary hover:text-ink">

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -15,7 +15,7 @@ import {
   type Attachment,
 } from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
-import { groupComposerHint } from "@/lib/group-routing";
+import { groupComposerHint, roomRespondersForComposer } from "@/lib/group-routing";
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 
@@ -85,12 +85,19 @@ export function Composer({
   // what was typed before the mic went on — partials append after it
   const baseText = useRef("");
 
-  // image paste is offered only when the active engine can open one; in a
-  // room the answering bot is whichever member is currently running, so
-  // the gate is the bot's own engine for 1:1 and any member for rooms
-  const engineSupportsImages = group
-    ? Boolean(members?.some((m) => state.instances.find((i) => i.instanceId === m.modelSelection.instanceId)?.capabilities?.images))
-    : Boolean(state.instances.find((i) => i.instanceId === bot?.modelSelection.instanceId)?.capabilities?.images);
+  // image paste is offered only when every bot that will actually answer
+  // can open one. sendGroup routes to mentions, else the room default —
+  // `members.some` would let a mixed room send <attached-image> to Grok.
+  const engineSupportsImages = (() => {
+    const supports = (candidate?: Bot) =>
+      Boolean(
+        candidate &&
+          state.instances.find((i) => i.instanceId === candidate.modelSelection.instanceId)?.capabilities?.images,
+      );
+    if (!group) return supports(bot);
+    const responders = roomRespondersForComposer(text, members ?? [], group);
+    return responders.length > 0 && responders.every(supports);
+  })();
 
   // ── @mention picker (tag another bot; the agent reaches it via ask_bot) ──
   const mention = mentionQueryAt(text, caret);
@@ -292,6 +299,7 @@ export function Composer({
           items={attachments}
           onAdd={addAttachments}
           onRemove={removeAttachment}
+          allowImages={engineSupportsImages}
         />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
         <textarea

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -8,6 +8,8 @@ import { MausAvatar } from "./Avatar";
 import { ComposerAttachments } from "./ComposerAttachments";
 import {
   composeMessage,
+  imageAttachmentFromFile,
+  isImageFile,
   isLongPaste,
   pasteAttachment,
   type Attachment,
@@ -82,6 +84,13 @@ export function Composer({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // what was typed before the mic went on — partials append after it
   const baseText = useRef("");
+
+  // image paste is offered only when the active engine can open one; in a
+  // room the answering bot is whichever member is currently running, so
+  // the gate is the bot's own engine for 1:1 and any member for rooms
+  const engineSupportsImages = group
+    ? Boolean(members?.some((m) => state.instances.find((i) => i.instanceId === m.modelSelection.instanceId)?.capabilities?.images))
+    : Boolean(state.instances.find((i) => i.instanceId === bot?.modelSelection.instanceId)?.capabilities?.images);
 
   // ── @mention picker (tag another bot; the agent reaches it via ask_bot) ──
   const mention = mentionQueryAt(text, caret);
@@ -295,6 +304,27 @@ export function Composer({
             setDismissedAt(null);
           }}
           onPaste={(e) => {
+            // an image from the clipboard becomes an uploaded attachment —
+            // but only for engines that can open one; a grok bot politely
+            // refuses instead of receiving a path it cannot read
+            const imageFiles = Array.from(e.clipboardData.files).filter(isImageFile);
+            if (imageFiles.length && engineSupportsImages) {
+              e.preventDefault();
+              void (async () => {
+                for (const file of imageFiles) {
+                  try {
+                    const attachment = await imageAttachmentFromFile(file);
+                    if (attachment) setAttachments((prev) => [...prev, attachment]);
+                  } catch (err) {
+                    dispatch({
+                      type: "error",
+                      message: err instanceof Error ? err.message : "image upload failed",
+                    });
+                  }
+                }
+              })();
+              return;
+            }
             // a wall of text becomes a chip instead of burying the input
             const pasted = e.clipboardData.getData("text/plain");
             if (!isLongPaste(pasted)) return;

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -3,11 +3,13 @@
 // first lines instead of flooding the composer; a file dropped anywhere
 // on the window attaches by path.
 import { useEffect, useRef, useState } from "react";
-import { ClipboardPaste, File as FileIcon, X } from "lucide-react";
+import { ClipboardPaste, File as FileIcon, Image as ImageIcon, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 import {
   attachmentsFromDroppedFiles,
   formatSize,
+  imageAttachmentFromFile,
+  isImageFile,
   pasteSummary,
   type Attachment,
 } from "@/lib/composer-attachments";
@@ -57,13 +59,29 @@ export function ComposerAttachments({
       depth.current = 0;
       setDragging(false);
       const files = Array.from(e.dataTransfer?.files ?? []);
-      const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(files, pathForFile);
+      const images = files.filter(isImageFile);
+      const rest = files.filter((f) => !isImageFile(f));
+      const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(rest, pathForFile);
+      const uploaded: Attachment[] = [];
+      const imageErrors: string[] = [];
+      for (const file of images) {
+        try {
+          const attachment = await imageAttachmentFromFile(file);
+          if (attachment) uploaded.push(attachment);
+        } catch (err) {
+          imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
+        }
+      }
       if (!active) return;
-      if (attachments.length) onAdd(attachments);
+      if (attachments.length || uploaded.length) onAdd([...attachments, ...uploaded]);
       setNotice(
-        rejectedNames.length
-          ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder.`
-          : null,
+        rejectedNames.length && imageErrors.length
+          ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder. (${imageErrors.join("; ")})`
+          : rejectedNames.length
+            ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder.`
+            : imageErrors.length
+              ? imageErrors.join("; ")
+              : null,
       );
     };
 
@@ -121,6 +139,18 @@ export function ComposerAttachments({
                 </div>
                 <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(a)}</div>
               </Chip>
+            ) : a.kind === "image" ? (
+              <Chip key={a.id} label="IMAGE" title={a.path} onRemove={() => onRemove(a.id)}>
+                <div className="flex h-[76px] items-center justify-center overflow-hidden rounded-lg bg-inset">
+                  <img
+                    src={`/api/attachments/${encodeURIComponent(a.path.split("/").pop() ?? "")}`}
+                    alt={a.name}
+                    loading="lazy"
+                    className="max-h-[76px] max-w-full object-contain"
+                  />
+                </div>
+                <div className="mt-1 truncate text-[10.5px] text-ink-secondary/70">{formatSize(a.size)}</div>
+              </Chip>
             ) : (
               <Chip key={a.id} label="FILE" title={a.path} onRemove={() => onRemove(a.id)}>
                 <div className="flex h-[76px] items-center gap-2">
@@ -146,11 +176,11 @@ function Chip({
   onRemove,
 }: {
   children: React.ReactNode;
-  label: "PASTED" | "FILE";
+  label: "PASTED" | "FILE" | "IMAGE";
   title: string;
   onRemove: () => void;
 }) {
-  const Icon = label === "PASTED" ? ClipboardPaste : FileIcon;
+  const Icon = label === "PASTED" ? ClipboardPaste : label === "IMAGE" ? ImageIcon : FileIcon;
   return (
     <div
       title={title}

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { ClipboardPaste, File as FileIcon, Image as ImageIcon, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 import {
+  attachmentBasename,
   attachmentsFromDroppedFiles,
   formatSize,
   imageAttachmentFromFile,
@@ -23,10 +24,12 @@ export function ComposerAttachments({
   items,
   onAdd,
   onRemove,
+  allowImages = true,
 }: {
   items: Attachment[];
   onAdd: (attachments: Attachment[]) => void;
   onRemove: (id: string) => void;
+  allowImages?: boolean;
 }) {
   const [dragging, setDragging] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -59,7 +62,7 @@ export function ComposerAttachments({
       depth.current = 0;
       setDragging(false);
       const files = Array.from(e.dataTransfer?.files ?? []);
-      const images = files.filter(isImageFile);
+      const images = allowImages ? files.filter(isImageFile) : [];
       const rest = files.filter((f) => !isImageFile(f));
       const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(rest, pathForFile);
       const uploaded: Attachment[] = [];
@@ -96,7 +99,7 @@ export function ComposerAttachments({
       window.removeEventListener("dragover", onOver);
       window.removeEventListener("drop", onDrop);
     };
-  }, [onAdd]);
+  }, [onAdd, allowImages]);
 
   return (
     <>
@@ -143,7 +146,7 @@ export function ComposerAttachments({
               <Chip key={a.id} label="IMAGE" title={a.path} onRemove={() => onRemove(a.id)}>
                 <div className="flex h-[76px] items-center justify-center overflow-hidden rounded-lg bg-inset">
                   <img
-                    src={`/api/attachments/${encodeURIComponent(a.path.split("/").pop() ?? "")}`}
+                    src={`/api/attachments/${encodeURIComponent(attachmentBasename(a.path))}`}
                     alt={a.name}
                     loading="lazy"
                     className="max-h-[76px] max-w-full object-contain"

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -1,0 +1,77 @@
+// composeMessage with images, the image tag round-trip through
+// splitAttachedImages, and the mime gate the composer pastes through.
+import { describe, expect, it } from "vitest";
+
+import {
+  attachmentBasename,
+  composeMessage,
+  isImageFile,
+  splitAttachedImages,
+  type ImageAttachment,
+} from "./composer-attachments";
+
+const image = (path: string): ImageAttachment => ({
+  kind: "image",
+  id: "i1",
+  path,
+  name: "shot.png",
+  size: 1234,
+  mime: "image/png",
+});
+
+describe("composeMessage with images", () => {
+  it("emits an attached-image tag carrying the server path", () => {
+    const prompt = composeMessage("what is this?", [image("/home/u/.openmausbot/attachments/abc.png")]);
+    expect(prompt).toBe(
+      'what is this?\n\n<attached-image path="/home/u/.openmausbot/attachments/abc.png" />',
+    );
+  });
+
+  it("escapes a hostile path the same way file paths are escaped", () => {
+    const prompt = composeMessage("", [image('/x/")} onload="evil()')]);
+    // every quote is entity-encoded, so the payload can never break out of
+    // the attribute — the tag stays one well-formed element
+    expect(prompt).toMatch(/<attached-image path="[^"]*" \/>/);
+    expect(prompt).toContain("&quot;");
+  });
+});
+
+describe("splitAttachedImages", () => {
+  it("splits tags out of a stored message and returns the paths", () => {
+    const stored =
+      'look at this\n\n<attached-image path="/a/b/one.png" />\n\n<attached-image path="/a/b/two.jpg" />';
+    const { display, images } = splitAttachedImages(stored);
+    expect(display).toBe("look at this");
+    expect(images).toEqual(["/a/b/one.png", "/a/b/two.jpg"]);
+  });
+
+  it("unescapes attribute entities so the path round-trips", () => {
+    const stored = '<attached-image path="/a/b/&amp;x.png" />';
+    const { images } = splitAttachedImages(stored);
+    expect(images).toEqual(["/a/b/&x.png"]);
+  });
+
+  it("leaves plain text and other tags untouched", () => {
+    const stored = '<pasted-text index="1">\nhi\n</pasted-text>';
+    const { display, images } = splitAttachedImages(stored);
+    expect(display).toBe(stored);
+    expect(images).toEqual([]);
+  });
+});
+
+describe("attachmentBasename", () => {
+  it("takes the final path segment on POSIX and Windows separators", () => {
+    expect(attachmentBasename("/a/b/c.png")).toBe("c.png");
+    expect(attachmentBasename("C:\\a\\b\\c.png")).toBe("c.png");
+  });
+});
+
+describe("isImageFile", () => {
+  it("accepts the served image mimes and rejects others", () => {
+    expect(isImageFile({ type: "image/png", size: 10 })).toBe(true);
+    expect(isImageFile({ type: "image/jpeg", size: 10 })).toBe(true);
+    expect(isImageFile({ type: "image/webp", size: 10 })).toBe(true);
+    expect(isImageFile({ type: "image/svg+xml", size: 10 })).toBe(false);
+    expect(isImageFile({ type: "text/plain", size: 10 })).toBe(false);
+  });
+});

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -17,7 +17,16 @@ export type FileAttachment = {
   size: number;
 };
 
-export type Attachment = PasteAttachment | FileAttachment;
+export type ImageAttachment = {
+  kind: "image";
+  id: string;
+  path: string;
+  name: string;
+  size: number;
+  mime: string;
+};
+
+export type Attachment = PasteAttachment | FileAttachment | ImageAttachment;
 
 export function isAttachment(value: unknown): value is Attachment {
   if (!value || typeof value !== "object") return false;
@@ -36,6 +45,15 @@ export function isAttachment(value: unknown): value is Attachment {
       typeof attachment.path === "string" &&
       attachment.path.length > 0 &&
       typeof attachment.name === "string"
+    );
+  }
+  if (attachment.kind === "image") {
+    return (
+      typeof attachment.path === "string" &&
+      attachment.path.length > 0 &&
+      typeof attachment.name === "string" &&
+      typeof attachment.mime === "string" &&
+      attachment.mime.startsWith("image/")
     );
   }
   return false;
@@ -64,6 +82,37 @@ function newId(): string {
 
 export function fileAttachment(name: string, path: string, size: number): FileAttachment {
   return { kind: "file", id: newId(), path, name, size };
+}
+
+/** Matches the server's IMAGE_MAX_BYTES — checked client-side so an
+ * oversized paste is refused before the upload starts, not mid-stream. */
+export const IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+export function isImageFile(file: { type: string; size: number }): boolean {
+  return (
+    file.type.startsWith("image/") &&
+    ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(file.type.split(";")[0]!.trim().toLowerCase())
+  );
+}
+
+/** Persist a pasted image server-side and return the attachment chip data.
+ * The server writes ~/.openmausbot/attachments/<uuid>.<ext> and answers
+ * with the path; the prompt references that path so every CLI can open it. */
+export async function imageAttachmentFromFile(file: File): Promise<ImageAttachment | null> {
+  if (!isImageFile(file)) return null;
+  if (file.size > IMAGE_MAX_BYTES) throw Object.assign(new Error(`${file.name} exceeds 10 MB`), { status: 413 });
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const response = await fetch("/api/attachments", {
+    method: "POST",
+    headers: { "content-type": file.type },
+    body: bytes,
+  });
+  if (!response.ok) {
+    const detail = (await response.json().catch(() => ({ error: response.statusText }))) as { error?: string };
+    throw Object.assign(new Error(detail.error ?? "upload failed"), { status: response.status });
+  }
+  const saved = (await response.json()) as { path: string; mime: string; bytes: number };
+  return { kind: "image", id: newId(), path: saved.path, name: file.name || "pasted image", size: saved.bytes, mime: saved.mime };
 }
 
 export function pasteAttachment(text: string): PasteAttachment {
@@ -145,6 +194,8 @@ export function composeMessage(text: string, attachments: Attachment[]): string 
   attachments.forEach((a, i) => {
     if (a.kind === "paste") {
       parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
+    } else if (a.kind === "image") {
+      parts.push(`<attached-image path="${escapeAttribute(a.path)}" />`);
     } else {
       parts.push(`<attached-file path="${escapeAttribute(a.path)}" />`);
     }
@@ -163,4 +214,27 @@ export function escapeAttribute(value: string): string {
     .replaceAll("\t", "&#9;")
     .replaceAll("\r", "&#13;")
     .replaceAll("\n", "&#10;");
+}
+
+/** Split a stored user message into its display text and the images it
+ * attached, for transcript rendering. The tag never shows in the bubble. */
+export function splitAttachedImages(text: string): { display: string; images: string[] } {
+  const images: string[] = [];
+  const display = text.replace(/<attached-image\s+path="([^"]*)"\s*\/?>(?:\s*\n)?/g, (_match, raw: string) => {
+    const path = raw
+      .replaceAll("&quot;", '"')
+      .replaceAll("&lt;", "<")
+      .replaceAll("&gt;", ">")
+      .replaceAll("&amp;", "&");
+    if (path) images.push(path);
+    return "";
+  });
+  return { display: display.trim(), images };
+}
+
+/** The bare filename a saved attachment path ends in — what the serving
+ * route expects. Works for POSIX and Windows separators. */
+export function attachmentBasename(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] ?? "";
 }

--- a/src/lib/group-routing.test.ts
+++ b/src/lib/group-routing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { roomRespondersForComposer } from "./group-routing";
+
+describe("roomRespondersForComposer", () => {
+  const members = [
+    { id: "atlas", name: "Atlas" },
+    { id: "milind", name: "Milind" },
+  ];
+
+  it("routes an unmentioned message to the configured lead", () => {
+    expect(
+      roomRespondersForComposer("hello there", members, { defaultResponder: { kind: "member", botId: "atlas" } }),
+    ).toEqual([members[0]]);
+  });
+
+  it("lets explicit mentions override the configured lead", () => {
+    expect(
+      roomRespondersForComposer("@Milind take this", members, { defaultResponder: { kind: "member", botId: "atlas" } }),
+    ).toEqual([members[1]]);
+  });
+
+  it("supports everyone and mentions-only room policies", () => {
+    expect(roomRespondersForComposer("hello", members, { defaultResponder: { kind: "everyone" } })).toEqual(members);
+    expect(roomRespondersForComposer("hello", members, { defaultResponder: { kind: "mentions" } })).toEqual([]);
+    expect(roomRespondersForComposer("@everyone hello", members, { defaultResponder: { kind: "mentions" } })).toEqual(
+      members,
+    );
+  });
+});

--- a/src/lib/group-routing.ts
+++ b/src/lib/group-routing.ts
@@ -2,7 +2,10 @@ import type { Bot, Group, GroupDefaultResponder } from "@/state/store";
 
 /** Be defensive around rooms loaded while an older server is still running,
  * and around a lead removed by another client before the group patch arrives. */
-export function effectiveDefaultResponder(group: Group, members: Bot[]): GroupDefaultResponder {
+export function effectiveDefaultResponder(
+  group: Pick<Group, "defaultResponder">,
+  members: Array<{ id: string }>,
+): GroupDefaultResponder {
   const value = group.defaultResponder;
   if (value?.kind === "everyone" || value?.kind === "mentions") return value;
   if (value?.kind === "member" && members.some((member) => member.id === value.botId)) return value;
@@ -30,4 +33,46 @@ export function groupComposerHint(group: Group, members: Bot[]): string {
   if (value.kind === "everyone") return "everyone responds";
   if (value.kind === "mentions") return "@ to bring a bot in";
   return `${defaultResponderName(group, members) ?? "Lead"} responds`;
+}
+
+/** Same routing sendGroup uses: explicit @mentions win, otherwise the
+ * room's default responder. Keep this aligned with server/store.ts
+ * `roomResponders` / `mentionedBots`. */
+export function roomRespondersForComposer<T extends { id: string; name: string; hidden?: boolean }>(
+  text: string,
+  members: T[],
+  group: Pick<Group, "defaultResponder">,
+): T[] {
+  const available = members.filter((member) => !member.hidden);
+  if (/(?:^|\s)@everyone\b/i.test(text)) return available;
+  const mentioned = mentionedMembers(text, available);
+  if (mentioned.length) return mentioned;
+  const fallback = effectiveDefaultResponder(group, available);
+  if (fallback.kind === "everyone") return available;
+  if (fallback.kind === "member") {
+    const lead = available.find((member) => member.id === fallback.botId);
+    return lead ? [lead] : [];
+  }
+  return [];
+}
+
+function mentionedMembers<T extends { name: string; hidden?: boolean }>(text: string, peers: T[]): T[] {
+  const candidates = peers
+    .filter((p) => !p.hidden && p.name.trim())
+    .sort((a, b) => b.name.length - a.name.length);
+  const lower = text.toLowerCase();
+  const found: T[] = [];
+  let at = -1;
+  while ((at = lower.indexOf("@", at + 1)) !== -1) {
+    if (at > 0 && !/\s/.test(text[at - 1])) continue;
+    const rest = lower.slice(at + 1);
+    const hit = candidates.find((p) => {
+      const name = p.name.toLowerCase();
+      if (!rest.startsWith(name)) return false;
+      const after = rest[name.length];
+      return after === undefined || !/[a-z0-9]/i.test(after);
+    });
+    if (hit && !found.includes(hit)) found.push(hit);
+  }
+  return found;
 }

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -250,6 +250,7 @@ export interface InstanceInfo {
     computerMcp?: boolean;
     agentsMcp?: boolean;
     composioMcp?: boolean;
+    images?: boolean;
     effortLevels?: readonly EffortLevel[];
   };
   /** `custom` agents sit below the rail divider — no subscription catalog. */


### PR DESCRIPTION
Closes #260. Implements **item 3.5 from `docs/plans/agent-harness-upgrades-v2.md`** — the image path on top of the existing paste/file/drop layer in `src/lib/composer-attachments.ts`.

## Design (as specified in the plan)

The server owns the bytes; the prompt only ever carries a path. `POST /api/attachments` accepts image mimes (`png/jpeg/gif/webp`, ≤10 MB, raw body — not base64 JSON) and writes `~/.openmausbot/attachments/<uuid>.<ext>`. `composeMessage` emits `<attached-image path="…"/>`, exactly like the existing `<attached-file>` tag — every CLI engine opens the file natively, so there is no per-driver encoding and no `SendTurnInput.images` yet (that waits for a second API driver, per the plan).

## What's in the diff

- **`server/attachments.ts`** (new) — save + read-back, mime allowlist (`image/svg+xml` deliberately refused: it executes script), size ceiling, and a name lock: the serving route only resolves bare generated filenames, never a path
- **Routes** — `POST /api/attachments`, `GET /api/attachments/:name` (immutable cache header, same posture as the message-image route)
- **`capabilities.images`** in `contracts.ts` + registry `describe()` — gates paste per engine: `claude`/`codex`/`acp`/`antigravity` true; `grok`/`boxAgent` absent, so their composers never offer the paste
- **Composer** — clipboard images and dropped image files upload through the new endpoint; a thumbnail chip previews from the served route; rooms gate on any member's engine
- **Transcript** — `splitAttachedImages` parses the tag back out of stored messages; the bubble renders the thumbnail above the text and the raw tag never displays. Survives reload by construction: the message persists the path, the file persists on disk
- **Tests** — 7 unit tests for the storage module (mime allowlist, size ceiling, traversal/dotfile name-lock refusals), API smoke coverage (save/serve round-trip with byte equality, wrong-type 400, traversal 404), and client lib tests (tag emission with hostile-path escaping, tag split/un-escape round-trip, basename, mime gate)

## Screenshots

Pasted image in the composer (chip with live thumbnail):

![composer chip](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-image-attachments/shots/composer-chip.png)

Transcript rendering (tag hidden, thumbnail above the caption):

![transcript](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-image-attachments/shots/transcript-render.png)

*(Hosted on a branch of my fork to keep this PR's diff clean.)*

## Validation

- `pnpm typecheck` ✓
- `pnpm test` — 114 files, 1,087 passed / 8 platform-skipped ✓
- Manual: paste → upload → chip; stored message → transcript thumbnail; unsupported type refused; oversized refused server-side (413 mid-stream, socket drained)
- The plan's "done when": pasted screenshot reaches a Claude bot as a file path ✓ · renders in transcript ✓ · survives reload ✓ · a grok bot is never offered the paste (capability gate) ✓

## Out of scope (deliberately)

- `SendTurnInput.images` for API drivers — the plan holds it for a second API driver
- Attachment management/GC of `~/.openmausbot/attachments` — files are small, UUID-named, and user-inspectable; worth a follow-up if the dir ever grows

Prior art note: I ship media attachments in a native macOS multi-agent client I maintain; the paste→upload→thumbnail UX here is that pattern adapted to this codebase's conventions per the plan spec.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image attachments to messages via paste, drag-and-drop, and file selection.
  * Added image previews, thumbnails, and linked display in conversations.
  * Added secure image upload and retrieval with size, type, and filename validation.
  * Providers now indicate whether they support image input.
  * Improved room routing for hidden members, mentions, and default responders.

* **Bug Fixes**
  * Prevented unsafe attachment paths, unsupported formats, empty files, and oversized images.

* **Tests**
  * Added coverage for image uploads, validation, persistence, retrieval, rendering, routing, and security protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->