### PR TITLE
Add an extended reaction palette behind a "+" on the reaction bar

### DIFF
--- a/src/components/Reactions.tsx
+++ b/src/components/Reactions.tsx
@@ -1,25 +1,98 @@
 // Emoji reactions — iMessage grammar: a hover bar to give one, small chips
 // under the bubble to show them. `by` is "user" or a member botId; in rooms
 // a bot's own reactions render with its name in the tooltip.
+import { useEffect, useRef, useState } from "react";
+import { Plus, X } from "lucide-react";
 import { useStore, type Bot, type Message } from "@/state/store";
 import { cn } from "@/lib/cn";
 
 export const REACTION_SET = ["👍", "❤️", "😂", "🎉", "👀"] as const;
 
+/** The extended palette behind the "+". Kept to single-grapheme emoji the
+ * API's 8-char cap carries comfortably — no long ZWJ sequences. */
+const EXTENDED_SET = [
+  "👍", "👎", "❤️", "🔥", "🚀", "🧠",
+  "💡", "🫡", "💯", "❓", "‼️", "😂",
+  "🤖", "🎯", "👀", "🤝", "⚡", "💎",
+  "💀", "✨", "🎉", "☕",
+] as const;
+
 export function ReactionBar({ threadId, message }: { threadId: string; message: Message }) {
   const { dispatch } = useStore();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // same dismiss contract as the sidebar menus: outside click, Escape, blur
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!pickerRef.current?.contains(target) && !anchorRef.current?.contains(target)) {
+        setPickerOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setPickerOpen(false);
+    const onBlur = () => setPickerOpen(false);
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [pickerOpen]);
+
   return (
-    <div className="flex items-center gap-0.5 rounded-full border border-hairline/40 bg-panel px-1 py-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-      {REACTION_SET.map((emoji) => (
+    <div className="relative">
+      <div
+        ref={anchorRef}
+        className="flex items-center gap-0.5 rounded-full border border-hairline/40 bg-panel px-1 py-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {REACTION_SET.map((emoji) => (
+          <button
+            key={emoji}
+            onClick={() => dispatch({ type: "toggleReaction", threadId, messageId: message.id, emoji })}
+            aria-label={`React ${emoji}`}
+            className="rounded-full px-1 py-0.5 text-[13px] leading-none hover:bg-raised"
+          >
+            {emoji}
+          </button>
+        ))}
         <button
-          key={emoji}
-          onClick={() => dispatch({ type: "toggleReaction", threadId, messageId: message.id, emoji })}
-          aria-label={`React ${emoji}`}
-          className="rounded-full px-1 py-0.5 text-[13px] leading-none hover:bg-raised"
+          onClick={() => setPickerOpen((o) => !o)}
+          aria-label="More reactions"
+          aria-expanded={pickerOpen}
+          title="More reactions"
+          className="flex size-[22px] items-center justify-center rounded-full text-ink-secondary hover:bg-raised hover:text-ink"
         >
-          {emoji}
+          {pickerOpen ? <X size={12} /> : <Plus size={12} />}
         </button>
-      ))}
+      </div>
+      {pickerOpen && (
+        <div
+          ref={pickerRef}
+          data-reaction-picker
+          className="absolute bottom-full right-0 z-40 mb-1.5 w-[218px] rounded-xl border border-hairline/50 bg-card p-2 shadow-2xl shadow-black/60"
+        >
+          <div className="grid grid-cols-6 gap-0.5">
+            {EXTENDED_SET.map((emoji) => (
+              <button
+                key={emoji}
+                onClick={() => {
+                  dispatch({ type: "toggleReaction", threadId, messageId: message.id, emoji });
+                  setPickerOpen(false);
+                }}
+                aria-label={`React ${emoji}`}
+                className="rounded-lg px-1 py-1 text-[15px] leading-none hover:bg-raised"
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #263.

## What

The reaction bar offered five hardcoded emoji while the store and API (`POST .../reactions`) already accept any string — every other reaction was unreachable from the UI. This keeps the quick strip **byte-for-byte unchanged** (the five emoji, hover bar, and affordance are exactly as before) and adds a **"+"** at its end that opens an anchored popover with a 22-emoji palette in a 6×4 grid.

| | |
|---|---|
| Quick strip | unchanged — 👍 ❤️ 😂 🎉 👀 |
| "+" popover | 👍 👎 ❤️ 🔥 🚀 🧠 💡 🫡 💯 ❓ ‼️ 😂 🤖 🎯 👀 🤝 ⚡ 💎 💀 ✨ 🎉 ☕ |

Selecting toggles through the existing `toggleReaction` dispatch — **no store or server changes, no new dependencies**, one file touched.

## Details

- Popover follows the same dismiss contract as the existing sidebar menus: outside click, `Escape`, window blur (listener cleanup verified)
- Anchored above the bar (`bottom-full right-0`) so it never covers the message it reacts to
- Palette limited to single-grapheme emoji — comfortably inside the API's 8-char cap, no ZWJ sequences
- `aria-expanded` on the toggle, `aria-label` on every emoji button

## Screenshot

The picker open on a message (a 🧠 from the palette already sits as a chip below):

![reaction picker](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-reaction-picker/shots/reaction-picker.png)

## Validation

- `pnpm typecheck` ✓
- `pnpm test` — 112 files, 1,072 passed / 8 skipped ✓
- Manual, in the real app: "+" opens the popover with all 22 emoji; picking 🧠 lands a grouped chip with the "You" tooltip via the normal persistence path; outside click and Escape close it

Palette contents are adapted from a reaction picker I ship in a native macOS multi-agent client — happy to trim or reshape the set to taste.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable reaction picker with an extended emoji palette.
  * Added dismissal options when clicking outside the picker, pressing Escape, or leaving the window.
  * Quick-reaction buttons remain available in the updated reaction bar.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->