### PR TITLE
Render ~~double-tilde~~ spans in bot replies as tap-to-reveal spoilers

### DIFF
--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -11,6 +11,7 @@ import { memo, useEffect, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/cn";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed and capped. Streamed partials may land here
@@ -109,6 +110,31 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
   );
 }
 
+// Spoiler spans: GFM parses ~~text~~ to <del>; in bot messages that content
+// is usually a spoiler (answers, plot points, surprises), not a deletion —
+// hide it behind a tap-to-reveal chip instead of striking it through.
+// Display only: the stored markdown, exports, and the model's own context
+// all keep the raw ~~text~~.
+function Spoiler({ children }: { children?: ReactNode }) {
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => setRevealed((r) => !r)}
+      aria-pressed={revealed}
+      title={revealed ? "Hide spoiler" : "Reveal spoiler"}
+      className={cn(
+        "mx-px rounded px-1 py-px text-[13px] leading-relaxed transition-colors",
+        revealed
+          ? "border-0 bg-transparent text-ink underline decoration-dotted decoration-hairline underline-offset-2"
+          : "bg-raised text-transparent select-none [&_*]:!text-transparent [&_a]:!no-underline",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 function ChatMarkdownComponent({ text, streaming = false }: { text: string; streaming?: boolean }) {
   return (
     <div className="chat-md min-w-0 [&>*+*]:mt-2">
@@ -197,6 +223,9 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
             return (
               <blockquote className="border-l-2 border-hairline pl-3 text-ink-secondary">{children}</blockquote>
             );
+          },
+          del({ children }: { children?: ReactNode }) {
+            return <Spoiler>{children}</Spoiler>;
           },
           hr() {
             return <hr className="border-hairline/40" />;

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -11,7 +11,6 @@ import { memo, useEffect, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Check, Copy } from "lucide-react";
-import { cn } from "@/lib/cn";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed and capped. Streamed partials may land here
@@ -117,21 +116,38 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
 // all keep the raw ~~text~~.
 function Spoiler({ children }: { children?: ReactNode }) {
   const [revealed, setRevealed] = useState(false);
+  if (!revealed) {
+    return (
+      <span className="relative mx-px inline-block rounded px-1 py-px">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none select-none bg-raised text-transparent [&_*]:!text-transparent [&_a]:!no-underline"
+        >
+          {children}
+        </span>
+        <button
+          type="button"
+          aria-label="Reveal spoiler"
+          title="Reveal spoiler"
+          onClick={() => setRevealed(true)}
+          className="absolute inset-0 rounded bg-raised/90"
+        />
+      </span>
+    );
+  }
   return (
-    <button
-      type="button"
-      onClick={() => setRevealed((r) => !r)}
-      aria-pressed={revealed}
-      title={revealed ? "Hide spoiler" : "Reveal spoiler"}
-      className={cn(
-        "mx-px rounded px-1 py-px text-[13px] leading-relaxed transition-colors",
-        revealed
-          ? "border-0 bg-transparent text-ink underline decoration-dotted decoration-hairline underline-offset-2"
-          : "bg-raised text-transparent select-none [&_*]:!text-transparent [&_a]:!no-underline",
-      )}
-    >
+    <span className="mx-px inline rounded px-1 py-px text-[13px] leading-relaxed text-ink underline decoration-dotted decoration-hairline underline-offset-2">
       {children}
-    </button>
+      <button
+        type="button"
+        aria-label="Hide spoiler"
+        title="Hide spoiler"
+        onClick={() => setRevealed(false)}
+        className="ml-1 rounded px-0.5 text-[11px] text-ink-secondary hover:text-ink"
+      >
+        Hide
+      </button>
+    </span>
   );
 }
 


### PR DESCRIPTION
Closes #265.

## What

GFM already parses `~~text~~` into `<del>`, which renders as strikethrough — spoiling content that agents frequently deliver hidden: puzzle solutions, plot points, quiz answers, surprise plans. This adds a `del` override in `ChatMarkdown.tsx` that renders those spans as a **tap-to-reveal chip**: hidden behind a flat fill, click to reveal, click again to re-hide.

One file, +29 lines, display only. The stored markdown, exports, and the model's own context all keep the raw `~~text~~`.

## Details

- The chip is a real `<button>` with `aria-pressed` — keyboard-reachable, Enter/Space work natively, tooltip names the action ("Reveal spoiler" / "Hide spoiler")
- Hidden state uses `text-transparent` over `bg-raised` with `select-none`, and neutralizes nested elements (`[&_*]:!text-transparent`, `[&_a]:!no-underline`) so a link or code span inside a spoiler can't leak its own colors through
- Revealed state keeps a dotted underline as the "this is a spoiler, click to re-hide" affordance
- **User bubbles are untouched** — they render as plain pre-wrapped text and never pass through ChatMarkdown
- No server, store, or dependency changes

## Screenshots

Hidden — chips carry no visible text:

![hidden](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-spoiler/shots/spoiler-hidden.png)

Revealed after two clicks:

![revealed](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-spoiler/shots/spoiler-revealed.png)

## Validation

- `pnpm typecheck` ✓
- `pnpm vitest run src` — 94/94 ✓ (my change's surface is client-only)
- Manual, in the real app: both chips render hidden, click reveals, click re-hides, reload keeps hidden
- ⚠️ Honest note on the full suite: `pnpm test` currently fails **81 spawn-dependent tests on this machine, identically on clean `main`** — verified by stashing my change and re-running. Server-spawning tests (proxy/API smoke) time out here regardless of code; pure unit tests and all client tests pass. CI on the PR will be the authoritative green/red.

Prior art: the same double-tilde grammar and tap-to-reveal interaction ships in a native macOS multi-agent client I maintain (`SpoilerTextView`); the chip styling here is OpenMausBot's own flat idiom.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for spoiler text in Markdown content.
  * Strikethrough text can now be toggled between hidden and revealed states.
  * Hidden spoiler content is covered and non-interactive until revealed.
  * Separate controls let you reveal or hide spoiler content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->