### PR TITLE
Add one pinned message per thread, shown as a banner above the transcript

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -281,6 +281,19 @@ describe("harness HTTP API", () => {
     expect((await api("GET", `/api/threads/${bot.threadId}/export?format=pdf`)).status).toBe(400);
     expect((await api("GET", "/api/threads/nope/export")).status).toBe(404);
 
+    // one pinned message per thread: pin, round-trip, replace, clear; the
+    // id is stored verbatim — resolution is the UI's job
+    const pin = await api("PATCH", `/api/bots/${bot.id}`, { pinnedMessageId: "msg-abc_123" });
+    expect(pin.status).toBe(200);
+    expect(pin.body.bot).toMatchObject({ pinnedMessageId: "msg-abc_123" });
+    const repin = await api("PATCH", `/api/bots/${bot.id}`, { pinnedMessageId: "msg-second" });
+    expect(repin.body.bot).toMatchObject({ pinnedMessageId: "msg-second" });
+    expect((await api("PATCH", `/api/bots/${bot.id}`, { pinnedMessageId: "not an id!" })).status).toBe(400);
+    expect((await api("PATCH", `/api/bots/${bot.id}`, { pinnedMessageId: 42 })).status).toBe(400);
+    const unpinned = await api("PATCH", `/api/bots/${bot.id}`, { pinnedMessageId: null });
+    expect(unpinned.status).toBe(200);
+    expect(unpinned.body.bot).not.toHaveProperty("pinnedMessageId");
+
     // deleted conversations drop out of search rather than 404ing it
     await api("DELETE", `/api/bots/${bot.id}`);
     const after = await api("GET", "/api/search?q=nice%20to%20meet");

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -294,6 +294,18 @@ describe("harness HTTP API", () => {
     expect(unpinned.status).toBe(200);
     expect(unpinned.body.bot).not.toHaveProperty("pinnedMessageId");
 
+    const room = (await api("POST", "/api/groups", { name: "Pins", memberIds: [bot.id] })).body.group;
+    const roomPin = await api("PATCH", `/api/groups/${room.id}`, { pinnedMessageId: "msg-room_1" });
+    expect(roomPin.status).toBe(200);
+    expect(roomPin.body.group).toMatchObject({ pinnedMessageId: "msg-room_1" });
+    const roomRepin = await api("PATCH", `/api/groups/${room.id}`, { pinnedMessageId: "msg-room_2" });
+    expect(roomRepin.body.group).toMatchObject({ pinnedMessageId: "msg-room_2" });
+    expect((await api("PATCH", `/api/groups/${room.id}`, { pinnedMessageId: "not an id!" })).status).toBe(400);
+    expect((await api("PATCH", `/api/groups/${room.id}`, { pinnedMessageId: 42 })).status).toBe(400);
+    const roomCleared = await api("PATCH", `/api/groups/${room.id}`, { pinnedMessageId: "" });
+    expect(roomCleared.status).toBe(200);
+    expect(roomCleared.body.group).not.toHaveProperty("pinnedMessageId");
+
     // deleted conversations drop out of search rather than 404ing it
     await api("DELETE", `/api/bots/${bot.id}`);
     const after = await api("GET", "/api/search?q=nice%20to%20meet");

--- a/server/index.ts
+++ b/server/index.ts
@@ -2729,6 +2729,15 @@ const server = createServer(async (req, res) => {
         if (!checked.ok) return json(res, 400, { error: checked.error });
         patch.cwd = checked.cwd ?? undefined;
       }
+      // one pinned message per room; null/"" clears. The id is not
+      // validated against the transcript here — a pin whose message was
+      // edited away or deleted simply resolves to nothing in the UI.
+      if (body.pinnedMessageId !== undefined) {
+        if (body.pinnedMessageId === null || body.pinnedMessageId === "") patch.pinnedMessageId = undefined;
+        else if (typeof body.pinnedMessageId === "string" && /^[\w-]+$/.test(body.pinnedMessageId)) {
+          patch.pinnedMessageId = body.pinnedMessageId;
+        } else return json(res, 400, { error: "pinnedMessageId must be a message id" });
+      }
       const group = store.patchGroup(m[1], patch);
       if (!group) return json(res, 404, { error: "no such room" });
       return json(res, 200, { group });
@@ -2869,6 +2878,15 @@ const server = createServer(async (req, res) => {
       const patch: Record<string, unknown> = {};
       for (const key of ["name", "title", "description", "notifications", "modelSelection", "unread", "computer", "cloudBackend", "color", "mascotExpression", "pinned", "hidden", "speakReplies", "voice"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
+      }
+      // one pinned message per thread; null/"" clears. The id is not
+      // validated against the transcript here — a pin whose message was
+      // edited to another branch or deleted simply resolves to nothing.
+      if (body.pinnedMessageId !== undefined) {
+        if (body.pinnedMessageId === null || body.pinnedMessageId === "") patch.pinnedMessageId = undefined;
+        else if (typeof body.pinnedMessageId === "string" && /^[\w-]+$/.test(body.pinnedMessageId)) {
+          patch.pinnedMessageId = body.pinnedMessageId;
+        } else return json(res, 400, { error: "pinnedMessageId must be a message id" });
       }
       // per-bot gate on the workspace's connected apps (Composio)
       if (body.composio !== undefined) {

--- a/server/store.ts
+++ b/server/store.ts
@@ -129,6 +129,9 @@ export interface GroupRecord {
    * turn that dispatches. null = each member's own default; absent = not
    * pinned yet. See pinGroupCwd for why it never moves. */
   pinnedCwd?: string | null;
+  /** the one message pinned to the top of this room's transcript. A pin id
+   * that no longer resolves (edited away, deleted) simply renders nothing. */
+  pinnedMessageId?: string;
 }
 
 /** One task = one conversation with its own context.
@@ -271,6 +274,9 @@ export interface BotRecord {
   rewound?: boolean;
   pinned?: boolean;
   hidden?: boolean;
+  /** the one message pinned to the top of this bot's active thread; a pin
+   * that no longer resolves (branch switched away, deleted) renders nothing */
+  pinnedMessageId?: string;
   /** The single workspace-wide coordinator. The store enforces that at
    * most one bot owns this role, even if an older/corrupt file says more. */
   chiefOfStaff?: boolean;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -15,6 +15,8 @@ import {
   Loader2,
   Monitor,
   Pencil,
+  Pin,
+  PinOff,
   RefreshCw,
   Square,
   Webhook,
@@ -323,6 +325,24 @@ function Bubble({
         )}
         {user && message.kind === "text" && <ReactionBar threadId={bot.threadId} message={message} />}
         {user && <CopyButton text={visibleText} />}
+        <button
+          onClick={() =>
+            dispatch({
+              type: "updateBot",
+              botId: bot.id,
+              patch: { pinnedMessageId: bot.pinnedMessageId === message.id ? "" : message.id },
+            })
+          }
+          aria-label={bot.pinnedMessageId === message.id ? "Unpin message" : "Pin message"}
+          className="rounded-md p-1.5 text-ink-secondary opacity-0 transition-opacity hover:bg-raised hover:text-ink focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+          title={
+            bot.pinnedMessageId === message.id
+              ? "Unpin this message"
+              : "Pin this message to the top of the thread"
+          }
+        >
+          {bot.pinnedMessageId === message.id ? <PinOff size={14} /> : <Pin size={14} />}
+        </button>
         <div
           className={cn(
             "max-w-[70%] rounded-2xl text-[15px] leading-relaxed",
@@ -624,6 +644,53 @@ const MessagesList = memo(function MessagesList({
   );
 });
 
+/** The one pinned message, above the transcript: sender, one line, click to
+ * jump, X to unpin. Resolves the pin id against the full message list; a
+ * pin that no longer resolves renders nothing (edited away or deleted). */
+function PinnedBanner({
+  bot,
+  pinnedId,
+  messages,
+  onJump,
+  onUnpin,
+}: {
+  bot: Bot;
+  pinnedId?: string;
+  messages: Message[];
+  onJump: (messageId: string) => void;
+  onUnpin: () => void;
+}) {
+  const pinned = messages.find((m) => m.id === pinnedId);
+  if (!pinned || pinned.kind !== "text") return null;
+  const sender =
+    pinned.role === "user" ? "You" : (pinned.from?.name ?? bot.name);
+  const text = (pinned.text ?? "").replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  return (
+    <div className="mx-auto w-full max-w-[900px] px-5">
+      <div className="mb-2 flex items-center gap-2 rounded-lg border border-accent/25 bg-accent/[0.07] px-3 py-1.5">
+        <Pin size={12} className="shrink-0 text-accent" />
+        <button
+          onClick={() => onJump(pinned.id)}
+          className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
+          title="Jump to the pinned message"
+        >
+          <span className="shrink-0 text-[11.5px] font-medium text-accent">{sender}</span>
+          <span className="truncate text-[12.5px] text-ink-secondary">{text}</span>
+        </button>
+        <button
+          onClick={onUnpin}
+          aria-label="Unpin message"
+          title="Unpin"
+          className="shrink-0 rounded p-0.5 text-ink-secondary hover:bg-raised hover:text-ink"
+        >
+          <X size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function ChatView({ bot }: { bot: Bot }) {
   const { state, dispatch } = useStore();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -886,6 +953,19 @@ export function ChatView({ bot }: { bot: Bot }) {
           </div>
         </div>
       )}
+
+      {/* Pinned message banner */}
+      <PinnedBanner
+        bot={bot}
+        pinnedId={bot.pinnedMessageId}
+        messages={messages}
+        onJump={(messageId) =>
+          dispatch({ type: "focusMessage", threadId: bot.threadId, messageId })
+        }
+        onUnpin={() =>
+          dispatch({ type: "updateBot", botId: bot.id, patch: { pinnedMessageId: "" } })
+        }
+      />
 
       {/* Messages */}
       <div

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ChevronDown, Folder, FolderOpen, Pin } from "lucide-react";
+import { ArrowDown, ChevronDown, Folder, FolderOpen, Pin, PinOff, X } from "lucide-react";
 import {
   api,
   useStore,
@@ -64,6 +64,28 @@ function ClusterLabel({ bot, name, color }: { bot?: Bot; name: string; color: st
   );
 }
 
+/** Pin toggle for one room message — one pin per room, patchGroup path. */
+function PinToggle({ group, message }: { group: Group; message: Message }) {
+  const { dispatch } = useStore();
+  const pinned = group.pinnedMessageId === message.id;
+  return (
+    <button
+      onClick={() =>
+        dispatch({
+          type: "patchGroup",
+          groupId: group.id,
+          patch: { pinnedMessageId: pinned ? "" : message.id },
+        })
+      }
+      aria-label={pinned ? "Unpin message" : "Pin message"}
+      className="rounded-md p-1.5 text-ink-secondary opacity-0 transition-opacity hover:bg-raised hover:text-ink focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+      title={pinned ? "Unpin this message" : "Pin this message to the top of the room"}
+    >
+      {pinned ? <PinOff size={14} /> : <Pin size={14} />}
+    </button>
+  );
+}
+
 const Transcript = memo(function Transcript({
   group,
   members,
@@ -110,6 +132,7 @@ const Transcript = memo(function Transcript({
             <div className={cn("group flex w-full flex-col", user ? "items-end" : "items-start")}>
               <div className={cn("flex w-full items-end gap-1.5", user ? "justify-end" : "justify-start")}>
                 {user && <ReactionBar threadId={group.threadId} message={m} />}
+                <PinToggle group={group} message={m} />
                 <div
                   className={cn(
                     "max-w-[70%] rounded-2xl px-4 py-2.5 text-[15px] leading-relaxed",
@@ -529,6 +552,37 @@ export function GroupView({ group }: { group: Group }) {
           </div>
         </div>
       )}
+
+      {/* Pinned message banner — resolves against the room's full transcript */}
+      {(() => {
+        const pinned = group.messages.find((m) => m.id === group.pinnedMessageId && m.kind === "text");
+        const text = pinned ? (pinned.text ?? "").replace(/\s+/g, " ").trim() : "";
+        if (!pinned || !text) return null;
+        const sender = pinned.role === "user" ? "You" : (pinned.from?.name ?? "A bot");
+        return (
+          <div className="mx-auto w-full max-w-[900px] px-5">
+            <div className="mb-2 flex items-center gap-2 rounded-lg border border-accent/25 bg-accent/[0.07] px-3 py-1.5">
+              <Pin size={12} className="shrink-0 text-accent" />
+              <button
+                onClick={() => dispatch({ type: "focusMessage", threadId: group.threadId, messageId: pinned.id })}
+                className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
+                title="Jump to the pinned message"
+              >
+                <span className="shrink-0 text-[11.5px] font-medium text-accent">{sender}</span>
+                <span className="truncate text-[12.5px] text-ink-secondary">{text}</span>
+              </button>
+              <button
+                onClick={() => dispatch({ type: "patchGroup", groupId: group.id, patch: { pinnedMessageId: "" } })}
+                aria-label="Unpin message"
+                title="Unpin"
+                className="shrink-0 rounded p-0.5 text-ink-secondary hover:bg-raised hover:text-ink"
+              >
+                <X size={13} />
+              </button>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Transcript */}
       <div

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -104,6 +104,8 @@ export interface Group {
   /** folder the room's turns actually run in, pinned on the first turn;
    * null = each member's own default; absent = not pinned yet */
   pinnedCwd?: string | null;
+  /** the one message pinned to the top of this room's transcript */
+  pinnedMessageId?: string;
   messages: Message[];
 }
 
@@ -167,6 +169,8 @@ export interface Bot {
   voice?: string;
   pinned?: boolean;
   hidden?: boolean;
+  /** the one message pinned to the top of this bot's active thread */
+  pinnedMessageId?: string;
   /** The workspace's one primary coordinator. */
   chiefOfStaff?: boolean;
   /** When this bot wants to talk to another bot (ask_bot/delegate_bot),
@@ -335,7 +339,7 @@ export type Action =
   | {
       type: "patchGroup";
       groupId: string;
-      patch: Partial<Pick<Group, "name" | "bulletin" | "memberIds" | "defaultResponder">>;
+      patch: Partial<Pick<Group, "name" | "bulletin" | "memberIds" | "defaultResponder" | "pinnedMessageId">>;
     }
   | { type: "deleteGroup"; groupId: string }
   | { type: "toggleReaction"; threadId: string; messageId: string; emoji: string }
@@ -405,6 +409,7 @@ export type Action =
           | "voice"
           | "pinned"
           | "hidden"
+          | "pinnedMessageId"
           | "chiefOfStaff"
           | "approvePeerComms"
           | "composio"


### PR DESCRIPTION
Closes #268.

## What

A pin button joins the message hover actions (next to copy/edit/reactions). The one pinned message renders as a compact banner between the header and the transcript: sender name, one-line truncated text, **click to jump** to the message, **X to unpin**. Works in 1:1 threads and rooms; rooms attribute the sender (`You` or the member bot's name).

One pin per thread — pinning another message replaces the pin, matching iMessage/Messenger mental models and keeping the data model to a single field.

## Design

- `pinnedMessageId?: string` on `BotRecord` and `GroupRecord`, through the existing PATCH allowlists (validated as a message-id shape; `null`/`""` clears so the key drops off the record)
- The id is stored verbatim and **resolved against the transcript at render** — a pin whose message was edited to another branch or deleted simply renders nothing. No cross-record integrity to maintain, no migration edge cases
- Clearing sends `""` from the client (the debounced PATCH's `JSON.stringify` drops `undefined`), which the server normalizes to unset — same convention the codebase uses for `cwd`
- Banner jump reuses the existing `focusMessage` action (opens a transcript window around the target and scrolls to it) — no new scroll machinery

## Screenshot

Banner live on a real thread (sender + one line, between header and transcript):

![pinned banner](https://raw.githubusercontent.com/willsigmon/OpenMausBot/screenshots/pr-pin/shots/pinned-banner.png)

## Validation

- `pnpm typecheck` ✓
- `pnpm vitest run src` — 94/94 ✓ · `server/store.test.ts` — 47/47 ✓
- New API assertions: pin / round-trip / replace / reject bad shape (`"not an id!"`, `42`) / clear via null
- Manual in the real app: pin via hover button → banner appears with sender + text; the bubble's pin flips to Unpin; X and Unpin both clear it; jump scrolls to the message
- Same honest note as #267: the spawn-dependent slice of `pnpm test` currently times out on this machine **identically on clean `main`** (verified by stash-and-rerun); unit + client suites are green and CI is authoritative

Prior art: the same pattern (sender-attributed one-line banner, click-to-jump, X-to-unpin) ships in a native macOS multi-agent client I maintain.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to pin one message in group rooms and bot conversations.
  * Added banners showing pinned messages, including sender and message text.
  * Select a pinned-message banner to jump to the message, or remove the pin.
  * Pins can be cleared when no longer needed.

* **Bug Fixes**
  * Added validation to reject invalid pinned-message identifiers with a clear error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->