### PR TITLE
Drop the inset blue focus ring on text fields

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -55,12 +55,14 @@ body {
   outline-offset: 2px;
 }
 
-/* Chromium intentionally matches :focus-visible on text controls after a
-   pointer click too. Make that behavior explicit: every focused editor has
-   a clear inset ring, while retaining each control's own border radius. */
-:is(input, textarea, select):focus {
-  outline: 2px solid var(--color-focus);
-  outline-offset: -2px;
+/* Text fields already sit in a bordered card (the composer pill especially).
+   Chromium treats a pointer click as :focus-visible on inputs, so the
+   global ring above becomes a sharp blue rectangle inside the rounded
+   chrome. Fields keep their own focus:border-*; buttons still use the
+   :focus-visible ring. */
+:is(input, textarea, select):focus,
+:is(input, textarea, select):focus-visible {
+  outline: none;
 }
 
 ::selection {


### PR DESCRIPTION
## What changed

Stop painting a sharp blue rectangle inside the composer (and other text fields) on click.

Chromium treats a pointer click on `input` / `textarea` / `select` as `:focus-visible`, so the global accent outline sat inset inside the rounded composer card. Those fields already have their own `focus:border-*`. Buttons still keep the keyboard `:focus-visible` ring.

## Why

Clicking the composer drew a 2px accent rectangle with square corners inside the pill. It looked like a broken focus state, not a keyboard affordance.

## How it was verified

Clicked the composer, settings fields, and model-picker search on macOS. No inset blue rectangle; Tab to a button still shows the accent ring.

## Screenshots (UI changes)

Server/UI CSS only. The before state is a blue rectangle inside the composer pill on click; after, the pill border is unchanged.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated focus styling for inputs, textareas, and select fields.
  * Removed the blue inset focus ring and outline offset from these form controls.
  * Preserved existing focus-visible behavior for buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->