### PR TITLE
Enable Codex peer-agent communication

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -150,6 +150,40 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(seen.env.OMB_COMMS_TOKEN).toBe("per-boot-token");
   });
 
+  it("mounts peer-agent comms without placing the comms token in argv", async () => {
+    await create();
+    const dump = join(scratch, "agents.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-agents",
+      text: "ask the researcher",
+      integrations: {
+        agents: {
+          command: process.execPath,
+          args: ["/tmp/agents-proxy.js"],
+          env: {
+            ELECTRON_RUN_AS_NODE: "1",
+            OMB_HARNESS_URL: "http://127.0.0.1:8799",
+            OMB_BOT_ID: "captain",
+            OMB_THREAD_ID: "t-agents",
+            OMB_COMMS_TOKEN: "peer-comms-secret",
+            OMB_TURN_DEPTH: "0",
+          },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv.join(" ")).toContain("mcp_servers.agents.command");
+    expect(seen.argv.join(" ")).toContain("/tmp/agents-proxy.js");
+    expect(seen.argv.join(" ")).toContain("OMB_COMMS_TOKEN");
+    expect(seen.argv.join(" ")).not.toContain("peer-comms-secret");
+    expect(seen.env.OMB_COMMS_TOKEN).toBe("peer-comms-secret");
+    expect(instance.adapter.capabilities.agentsMcp).toBe(true);
+  });
+
   it("mounts the Local VM computer MCP server without placing credentials in argv", async () => {
     await create();
     const dump = join(scratch, "local-computer.json");

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -142,6 +142,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       if (turn.integrations?.composio) {
         mountMcpServer(appServerArgs, env, "openmausbot_connectors", turn.integrations.composio);
       }
+      if (turn.integrations?.agents) {
+        mountMcpServer(appServerArgs, env, "agents", turn.integrations.agents);
+      }
       if (turn.integrations?.computer) {
         const proxyEnv = computerProxyEnv(turn.integrations.computer);
         mountMcpServer(appServerArgs, env, "computer", {
@@ -532,6 +535,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           sessionModelSwitch: "unsupported",
           computerMcp: true,
           composioMcp: true,
+          agentsMcp: true,
           phoneMcp: true,
           effortLevels: ["low", "medium", "high", "xhigh", "max"],
         },


### PR DESCRIPTION
## What changed

- Mount the existing peer-agent stdio MCP integration on Codex turns.
- Advertise `agentsMcp` support so the harness supplies Codex bots with the agents integration.
- Add a Codex driver contract test covering MCP configuration, capability reporting, and comms-token hygiene.

## Why

Codex already supports generic stdio MCP configuration, but its driver did not mount the agents integration or advertise the corresponding capability. As a result, a Codex-backed Chief of Staff could not use the existing `list_bots`, `ask_bot`, and `delegate_bot` tools.

This keeps depth limits, approval gates, authentication, and delegation execution in the existing harness and agents proxy.

## How it was verified

- `pnpm typecheck`
- `pnpm test`
  - 1,073 main tests passed; 8 skipped
  - 2 broker tests passed
  - 12 updater tests passed
  - Packaged-server smoke test passed
- Full Codex driver contract suite: 22 tests passed
- Peer-agent orchestration suites: 62 tests passed
- Independent read-only review: no findings

## Screenshots (UI changes)

Not applicable. This change has no UI impact.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Codex now supports connecting to the agents integration through MCP.
  - Communication credentials are securely passed through the environment rather than exposed in command-line arguments.
  - Codex capability reporting now includes agents MCP support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->