### PR TITLE
Keep a room's approval answerable after its turn ends

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -75,6 +75,16 @@ beforeAll(async () => {
         dm: true,
       },
       {
+        id: "test-stranded-room",
+        threadId: "test-stranded-room-thread",
+        name: "Stranded room",
+        memberIds: ["test-bot-a"],
+        defaultResponder: { kind: "member", botId: "test-bot-a" },
+        bulletin: "",
+        unread: false,
+        createdAt: 3,
+      },
+      {
         id: "test-pinned-room",
         threadId: "test-pinned-room-thread",
         name: "Pinned room",
@@ -86,6 +96,33 @@ beforeAll(async () => {
         pinnedCwd: null,
       },
     ]),
+  );
+
+  // A room transcript carrying an approval that outlived its turn: the card
+  // is durable, but busyBotId is in-memory only and never survives a restart.
+  writeFileSync(
+    join(home, ".openmausbot", "messages-test-stranded-room-thread.json"),
+    JSON.stringify({
+      activeLeafId: "stranded-card",
+      messages: [
+        {
+          id: "stranded-card",
+          at: 3,
+          parentId: null,
+          role: "bot",
+          kind: "options",
+          card: {
+            title: "Approval needed",
+            subtitle: "rm -rf /tmp/scratch",
+            options: ["Allow", "Deny"],
+            requestId: "stranded-request",
+            tool: "Bash",
+            allowKey: "Bash:rm",
+          },
+          from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+      ],
+    }),
   );
 
   boxStub = createServer(async (req, res) => {
@@ -525,6 +562,32 @@ describe("harness HTTP API", () => {
     const reread = (await api("GET", "/api/bots")).body.bots.find((candidate: { id: string }) => candidate.id === bot.id);
     expect(reread.messages.at(-1).tool).toMatchObject({ ok: false });
     expect(reread.messages.at(-1).tool.name).toContain("request is no longer open");
+  });
+
+  it("answers a room approval whose turn is already over instead of stranding the room", async () => {
+    // busyBotId lives in memory only, so a card that outlives its turn (or the
+    // process) has no speaker. The room must still be answerable: a pending
+    // approval takes over the composer, so a dead end locks the room for good.
+    const answered = await api("POST", "/api/threads/test-stranded-room-thread/respond", {
+      requestId: "stranded-request",
+      behavior: "allow",
+    });
+    expect(answered.status).toBe(200);
+    expect(answered.body).toEqual({ ok: true, outcome: "unavailable" });
+
+    const room = (await api("GET", "/api/bots")).body.groups.find(
+      (group: { id: string }) => group.id === "test-stranded-room",
+    );
+    const card = room.messages.find((message: { id: string }) => message.id === "stranded-card").card;
+    expect(card.dismissed).toBe(true);
+    expect(card.answered).toBe("unavailable");
+
+    // a room with nothing pending still reports that plainly
+    const nothing = await api("POST", "/api/threads/test-pinned-room-thread/respond", {
+      requestId: "never-existed",
+      behavior: "allow",
+    });
+    expect(nothing.status).toBe(404);
   });
 
   it("rejects an empty message and explains an unavailable provider", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -414,8 +414,14 @@ async function answerRequest(
     }
   }
   if (outcome === "unavailable") {
+    // The in-flight map is memory-only. After a restart the card is still on
+    // the thread, so fall back to the request it carries — otherwise an
+    // unreachable approval is never closed and keeps owning the composer.
     const messageId = askMessageByRequest.get(`${threadId}:${requestId}`);
-    const existing = messageId ? store.messagesFor(threadId).find((m) => m.id === messageId) : undefined;
+    const thread = store.messagesFor(threadId);
+    const existing = messageId
+      ? thread.find((m) => m.id === messageId)
+      : thread.find((m) => m.card?.requestId === requestId);
     if (existing?.card && !existing.card.answered) {
       store.patchMessage(threadId, existing.id, { card: { ...existing.card, answered: "unavailable", dismissed: true } });
     }
@@ -3104,14 +3110,26 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const behavior = requestBehavior(body.behavior);
       if (!behavior) return json(res, 400, { error: "behavior must be allow, deny, or answer" });
-      const group = store.groupByThread(threadId);
-      const owner = group ? (group.busyBotId ? store.bot(group.busyBotId) : undefined) : store.botByThread(threadId);
-      if (!owner) return json(res, 404, { error: "nothing is waiting on an answer in this conversation" });
-      // peer-approval intercept (see /api/bots/:id/respond above).
-      if (resolvePeerComms(approvalBus, String(body.requestId), behavior)) {
+      const requestId = String(body.requestId);
+      // peer-approval intercept (see /api/bots/:id/respond above). A peer card
+      // belongs to the bus rather than to a speaker, so resolve it before we go
+      // looking for one — a room between turns has no speaker to find.
+      if (resolvePeerComms(approvalBus, requestId, behavior)) {
         return json(res, 200, { ok: true, outcome: behavior === "allow" ? "allowed-once" : "rejected" });
       }
-      const outcome = await answerRequest(threadId, owner.modelSelection.instanceId, String(body.requestId), behavior, body.message);
+      const group = store.groupByThread(threadId);
+      // busyBotId is in-memory only, so an approval that outlives its turn — or
+      // the process — leaves a durable card with no speaker behind it. Fall back
+      // to the member that raised it, and answer even when that member is gone:
+      // answerRequest closes an unreachable card, and a pending approval owns
+      // the composer, so a dead end here locks the room for good.
+      const pending = store.messagesFor(threadId).find((message) => message.card?.requestId === requestId);
+      const owner = group
+        ? (group.busyBotId ? store.bot(group.busyBotId) : undefined) ??
+          (pending?.from ? store.bot(pending.from.botId) : undefined)
+        : store.botByThread(threadId);
+      if (!owner && !pending) return json(res, 404, { error: "nothing is waiting on an answer in this conversation" });
+      const outcome = await answerRequest(threadId, owner?.modelSelection.instanceId ?? "", requestId, behavior, body.message);
       return json(res, 200, { ok: true, outcome });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)\/interrupt$/);


### PR DESCRIPTION
## What happens

A room approval card that outlives its turn locks the room permanently. Every button on the card fails, and because a pending approval takes over the composer, there is no way to type past it either. Restarting the app does not help — the card is durable, so it comes back.

I hit this in a room with a real pending `Bash` approval: after quitting and reopening the app, Allow / Always allow / Deny / Cancel turn all did nothing, and the room could not be used again.

```
POST /api/threads/<room-thread>/respond {"requestId":"…","behavior":"allow"}
→ 404 {"error":"nothing is waiting on an answer in this conversation"}
```

## Why

A room resolves the bot behind an approval through `group.busyBotId`. That field is deliberately in-memory only — `saveGroups` strips it on write and load sets it to `null`:

```ts
writeFileAtomic(GROUPS_FILE, JSON.stringify(this.groups.map(({ busyBotId, ...g }) => g), null, 2));
```

The card, though, is persisted. So any approval that outlives its turn — a finished turn, or a restart — leaves a durable card whose speaker is gone, and `/api/threads/:id/respond` 404s on the `!owner` gate.

A 1:1 does not have this problem: it resolves through `store.botByThread()`, a structural lookup that always succeeds. That asymmetry is the bug.

Two things compound it:

1. The `!owner` gate sits *above* the peer-approval intercept, so peer cards — which belong to the bus and need no speaker at all — are unreachable in a room too.
2. `answerRequest` already knows how to close an approval it cannot deliver (marks the card `unavailable` + dismissed and says so in the transcript), but it finds the card only through `askMessageByRequest`, which is memory-only. After a restart it appends the notice **without dismissing the card**, so the composer stays blocked even once the route is reachable.

## The change

- Resolve the peer-approval intercept before the owner lookup.
- When `busyBotId` is gone, fall back to the member named by the card's `from`.
- When no owner resolves at all, still call `answerRequest` so the card is closed out rather than stranding the room. A thread with nothing pending still gets the 404.
- `answerRequest` falls back to finding the card by the request it carries when the in-flight map has been lost.

Server-only; no UI changes, no new dependencies.

## Testing

New API test seeds a room whose transcript holds a pending approval with no `busyBotId` — the restart case — and asserts the answer lands, the card is dismissed, and a room with nothing pending still 404s. It fails on `main` with `expected 404 to be 200`.

- `pnpm typecheck` clean
- `pnpm test`: 1073 passed. `server/drivers/codex-catalog.test.ts` fails identically on `main` on this machine (it reads the locally installed `codex` model catalog) — unrelated to this change.
- `oxlint server/index.ts` reports the same rule counts before and after.

## Follow-up (not in this PR)

`POST /api/groups/:id/interrupt` has the same root cause in its own way — with `busyBotId` null, `instance` is `undefined`, so `instance?.adapter.interruptTurn(...)` is a no-op while the route still returns `200 {ok:true}`. That is why "Cancel turn" fails *silently* where the others at least surface an error. Kept out to keep this PR to one concern; happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requests can now be recovered after a restart or temporary connection loss.
  * Stale or unreachable approvals are dismissed and shown as unavailable instead of blocking message composition.
  * Improved handling when responding to rooms without an active pending request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->