### PR TITLE
ci: fail the run when suspiciously few tests were counted

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:desktop": "electron .",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
-    "test": "vitest run && pnpm broker:test && pnpm test:updater && pnpm test:packaged-server",
+    "test": "node scripts/test-floor.mjs && pnpm broker:test && pnpm test:updater && pnpm test:packaged-server",
     "test:updater": "node --test electron/updater-coordinator.node-test.mjs",
     "bench:observation": "node --experimental-strip-types scripts/bench-observation.ts",
     "test:watch": "vitest",

--- a/scripts/test-floor.mjs
+++ b/scripts/test-floor.mjs
@@ -21,12 +21,36 @@ import { pathToFileURL } from "node:url";
 
 // The FLOOR, not an exact count. An exact count would catch the failure mode
 // too, but it would need editing on every PR that adds or removes a test —
-// so it is set to roughly 90% of the suite's size when this gate landed
-// (1081 tests, 2026-08). Ordinary churn never touches it; losing a whole
-// file's worth of tests does. If the suite legitimately shrinks below this,
+// so this keeps a small buffer below the most recently verified full run
+// (1091 registered tests, 2026-08). Adding tests never touches it; removing
+// a meaningful slice does. If the suite legitimately shrinks below this,
 // lower the number here in the same PR that removes the tests, so the change
 // is a visible, reviewed decision rather than a silent one.
-export const TEST_COUNT_FLOOR = 970;
+export const TEST_COUNT_FLOOR = 1070;
+
+const TARGET_FLAGS = ["--changed", "--related", "--shard", "--exclude", "--testNamePattern", "-t", "--project"];
+
+/** A path/name/project filter intentionally collects only part of the suite,
+ * so applying the global floor would make Vitest's normal targeted-run
+ * workflow unusable. CI invokes the wrapper without arguments and therefore
+ * always keeps the floor. */
+export function isTargetedRun(args) {
+  return args.some((arg) => {
+    if (!arg.startsWith("-")) return true;
+    return TARGET_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`));
+  });
+}
+
+export function vitestArguments(vitestBin, summaryFile, cliArgs) {
+  return [
+    vitestBin,
+    "run",
+    ...cliArgs,
+    "--reporter=default",
+    "--reporter=json",
+    `--outputFile.json=${summaryFile}`,
+  ];
+}
 
 // Registered tests, not executed tests, on purpose: POSIX-only process tests
 // self-skip on Windows, and a skipped test still proves its file was imported
@@ -63,7 +87,7 @@ export function evaluateRun({ exitCode, summary }, floor = TEST_COUNT_FLOOR) {
     };
   }
 
-  if (counted < floor) {
+  if (floor !== null && counted < floor) {
     return {
       ok: false,
       message:
@@ -77,11 +101,13 @@ export function evaluateRun({ exitCode, summary }, floor = TEST_COUNT_FLOOR) {
 
   return {
     ok: true,
-    message: `test-floor: ${counted} tests counted, floor is ${floor} ✓`,
+    message: floor === null
+      ? `test-floor: ${counted} targeted tests counted (global floor intentionally skipped) ✓`
+      : `test-floor: ${counted} tests counted, floor is ${floor} ✓`,
   };
 }
 
-async function main() {
+async function main(cliArgs = process.argv.slice(2)) {
   // Resolve vitest's CLI entry and run it under this same Node binary instead
   // of shelling out to `pnpm exec` — spawning package-manager shims is the
   // classic Windows CI papercut (.cmd resolution), and this script runs on
@@ -102,13 +128,7 @@ async function main() {
   const exitCode = await new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
-      [
-        vitestBin,
-        "run",
-        "--reporter=default",
-        "--reporter=json",
-        `--outputFile.json=${summaryFile}`,
-      ],
+      vitestArguments(vitestBin, summaryFile, cliArgs),
       { stdio: "inherit" },
     );
     child.on("error", reject);
@@ -129,7 +149,7 @@ async function main() {
     // Scratch cleanup must never decide the verdict.
   }
 
-  const result = evaluateRun({ exitCode, summary });
+  const result = evaluateRun({ exitCode, summary }, isTargetedRun(cliArgs) ? null : TEST_COUNT_FLOOR);
   console[result.ok ? "log" : "error"](result.message);
   process.exit(result.ok ? 0 : (exitCode ?? 1) || 1);
 }

--- a/scripts/test-floor.mjs
+++ b/scripts/test-floor.mjs
@@ -1,0 +1,141 @@
+// Fail CI when suspiciously few tests were counted — even if all of them passed.
+//
+// The failure mode this guards against: a test file that never registers its
+// tests still lets the run go green. A rename that slips out of the include
+// globs, a directory dropped from the vitest config, an import-time throw that
+// gets swallowed as an empty collection — in each case the surviving files all
+// pass and CI reports success with a chunk of the suite silently missing. A
+// green run only means "everything that ran passed"; this script adds the
+// missing half of the claim: "and roughly everything we expected to run, ran."
+//
+// It wraps `vitest run` with a machine-readable reporter, counts the tests the
+// run REGISTERED, and refuses to pass if that count is below the floor — or if
+// the count cannot be determined at all. An uncountable run must never report
+// success: that is exactly the shape a collection failure has.
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// The FLOOR, not an exact count. An exact count would catch the failure mode
+// too, but it would need editing on every PR that adds or removes a test —
+// so it is set to roughly 90% of the suite's size when this gate landed
+// (1081 tests, 2026-08). Ordinary churn never touches it; losing a whole
+// file's worth of tests does. If the suite legitimately shrinks below this,
+// lower the number here in the same PR that removes the tests, so the change
+// is a visible, reviewed decision rather than a silent one.
+export const TEST_COUNT_FLOOR = 970;
+
+// Registered tests, not executed tests, on purpose: POSIX-only process tests
+// self-skip on Windows, and a skipped test still proves its file was imported
+// and collected — which is the thing that silently disappears in the failure
+// mode above. Counting registrations keeps one floor valid across the whole
+// 3-OS CI matrix instead of needing a per-platform allowance for skips.
+export function evaluateRun({ exitCode, summary }, floor = TEST_COUNT_FLOOR) {
+  // Anything that is not a finite number — absent summary, absent field, NaN,
+  // a stringified count — collapses to "uncountable" here, at the boundary.
+  const counted = Number.isFinite(summary?.numTotalTests) ? summary.numTotalTests : null;
+
+  if (counted === null) {
+    return {
+      ok: false,
+      message:
+        "test-floor: could not determine how many tests ran (no usable JSON summary). " +
+        "Refusing to report a pass on a run that cannot be counted.",
+    };
+  }
+
+  if (exitCode !== 0) {
+    return {
+      ok: false,
+      message: `test-floor: vitest exited with ${exitCode === null ? "a signal" : `code ${exitCode}`} (${counted} tests counted). See the report above.`,
+    };
+  }
+
+  // Belt and braces: a reporter bug or partial write could hand us exit 0
+  // alongside a summary that says the run failed. Trust the pessimistic one.
+  if (summary.success === false) {
+    return {
+      ok: false,
+      message: `test-floor: vitest exited 0 but its own summary reports failure (${counted} tests counted).`,
+    };
+  }
+
+  if (counted < floor) {
+    return {
+      ok: false,
+      message:
+        `test-floor: only ${counted} tests were counted, below the floor of ${floor}. ` +
+        "Every test that ran passed — but a chunk of the suite did not run at all. " +
+        "Likely causes: a test file failing at import/collection time, or include " +
+        "globs no longer matching it. If the suite genuinely shrank, lower " +
+        "TEST_COUNT_FLOOR in scripts/test-floor.mjs in the same PR.",
+    };
+  }
+
+  return {
+    ok: true,
+    message: `test-floor: ${counted} tests counted, floor is ${floor} ✓`,
+  };
+}
+
+async function main() {
+  // Resolve vitest's CLI entry and run it under this same Node binary instead
+  // of shelling out to `pnpm exec` — spawning package-manager shims is the
+  // classic Windows CI papercut (.cmd resolution), and this script runs on
+  // all three matrix platforms.
+  const require = createRequire(import.meta.url);
+  const vitestPkgPath = require.resolve("vitest/package.json");
+  const vitestPkg = JSON.parse(readFileSync(vitestPkgPath, "utf8"));
+  // npm allows `bin` as either a name→path map or a bare path string.
+  const binRel = vitestPkg.bin?.vitest ?? vitestPkg.bin;
+  const vitestBin = join(dirname(vitestPkgPath), binRel);
+
+  // The JSON summary goes to a scratch file, not stdout: the default reporter
+  // owns stdout so humans still get the live report, and a file cannot be
+  // corrupted by interleaved test output the way a piped stream can.
+  const scratch = mkdtempSync(join(tmpdir(), "omb-test-floor-"));
+  const summaryFile = join(scratch, "vitest-summary.json");
+
+  const exitCode = await new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        vitestBin,
+        "run",
+        "--reporter=default",
+        "--reporter=json",
+        `--outputFile.json=${summaryFile}`,
+      ],
+      { stdio: "inherit" },
+    );
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code));
+  });
+
+  let summary = null;
+  try {
+    summary = JSON.parse(readFileSync(summaryFile, "utf8"));
+  } catch {
+    // Missing or unparsable summary — evaluateRun treats that as uncountable
+    // and fails; it must not be masked into a pass here.
+  }
+
+  try {
+    rmSync(scratch, { recursive: true, force: true });
+  } catch {
+    // Scratch cleanup must never decide the verdict.
+  }
+
+  const result = evaluateRun({ exitCode, summary });
+  console[result.ok ? "log" : "error"](result.message);
+  process.exit(result.ok ? 0 : (exitCode ?? 1) || 1);
+}
+
+// Only act as a CLI when invoked directly; the unit test imports evaluateRun
+// without wanting a full suite run as a side effect.
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main();
+}

--- a/scripts/test-floor.test.mjs
+++ b/scripts/test-floor.test.mjs
@@ -4,7 +4,7 @@
 // down here; the process-spawning half of test-floor.mjs stays a thin shell
 // around it.
 import { describe, expect, it } from "vitest";
-import { evaluateRun, TEST_COUNT_FLOOR } from "./test-floor.mjs";
+import { evaluateRun, isTargetedRun, TEST_COUNT_FLOOR, vitestArguments } from "./test-floor.mjs";
 
 const summary = (overrides = {}) => ({
   numTotalTests: 1000,
@@ -60,5 +60,38 @@ describe("evaluateRun", () => {
     const belowFloor = summary({ numTotalTests: TEST_COUNT_FLOOR - 1 });
     expect(evaluateRun({ exitCode: 0, summary: atFloor }).ok).toBe(true);
     expect(evaluateRun({ exitCode: 0, summary: belowFloor }).ok).toBe(false);
+  });
+
+  it("allows an intentional targeted run without weakening its exit checks", () => {
+    expect(evaluateRun({ exitCode: 0, summary: summary({ numTotalTests: 1 }) }, null)).toMatchObject({ ok: true });
+    expect(evaluateRun({ exitCode: 1, summary: summary({ numTotalTests: 1 }) }, null)).toMatchObject({ ok: false });
+  });
+});
+
+describe("isTargetedRun", () => {
+  it("recognizes positional file filters and Vitest collection filters", () => {
+    expect(isTargetedRun(["server/config.test.ts"])).toBe(true);
+    expect(isTargetedRun(["--testNamePattern", "credential"])).toBe(true);
+    expect(isTargetedRun(["--changed=origin/main"])).toBe(true);
+    expect(isTargetedRun(["--project", "unit"])).toBe(true);
+  });
+
+  it("keeps the floor for an unfiltered run with execution-only options", () => {
+    expect(isTargetedRun([])).toBe(false);
+    expect(isTargetedRun(["--coverage", "--pool=threads"])).toBe(false);
+  });
+
+  it("forwards the caller's filters to Vitest", () => {
+    expect(vitestArguments("/vitest.mjs", "/summary.json", ["server/config.test.ts", "-t", "env"]))
+      .toEqual([
+        "/vitest.mjs",
+        "run",
+        "server/config.test.ts",
+        "-t",
+        "env",
+        "--reporter=default",
+        "--reporter=json",
+        "--outputFile.json=/summary.json",
+      ]);
   });
 });

--- a/scripts/test-floor.test.mjs
+++ b/scripts/test-floor.test.mjs
@@ -1,0 +1,64 @@
+// The floor gate's whole job is to distrust green runs, so its decision logic
+// must be provably right without spawning a nested suite. evaluateRun is a
+// pure function over (exit code, JSON summary) precisely so it can be pinned
+// down here; the process-spawning half of test-floor.mjs stays a thin shell
+// around it.
+import { describe, expect, it } from "vitest";
+import { evaluateRun, TEST_COUNT_FLOOR } from "./test-floor.mjs";
+
+const summary = (overrides = {}) => ({
+  numTotalTests: 1000,
+  success: true,
+  ...overrides,
+});
+
+describe("evaluateRun", () => {
+  it("passes a green run at or above the floor", () => {
+    expect(evaluateRun({ exitCode: 0, summary: summary() }, 1000).ok).toBe(true);
+    expect(evaluateRun({ exitCode: 0, summary: summary() }, 999).ok).toBe(true);
+  });
+
+  it("fails a green run below the floor — the failure mode this gate exists for", () => {
+    const result = evaluateRun({ exitCode: 0, summary: summary({ numTotalTests: 999 }) }, 1000);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("999");
+    expect(result.message).toContain("1000");
+    // the message must point at the real culprit, not just say "too few"
+    expect(result.message).toMatch(/import|collection/);
+  });
+
+  it("refuses to pass when the count cannot be determined", () => {
+    // A run that cannot be counted has exactly the shape of a collection
+    // failure, so "unknown" must never be promoted to "fine".
+    for (const broken of [
+      null,
+      undefined,
+      {},
+      summary({ numTotalTests: undefined }),
+      summary({ numTotalTests: NaN }),
+      summary({ numTotalTests: "1000" }),
+    ]) {
+      const result = evaluateRun({ exitCode: 0, summary: broken }, 1);
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("cannot be counted");
+    }
+  });
+
+  it("propagates a vitest failure even when the count clears the floor", () => {
+    expect(evaluateRun({ exitCode: 1, summary: summary() }, 1).ok).toBe(false);
+    // killed by a signal: exit code is null, still a failure
+    expect(evaluateRun({ exitCode: null, summary: summary() }, 1).ok).toBe(false);
+  });
+
+  it("trusts the summary's own failure flag over a zero exit code", () => {
+    const result = evaluateRun({ exitCode: 0, summary: summary({ success: false }) }, 1);
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses TEST_COUNT_FLOOR as the default floor", () => {
+    const atFloor = summary({ numTotalTests: TEST_COUNT_FLOOR });
+    const belowFloor = summary({ numTotalTests: TEST_COUNT_FLOOR - 1 });
+    expect(evaluateRun({ exitCode: 0, summary: atFloor }).ok).toBe(true);
+    expect(evaluateRun({ exitCode: 0, summary: belowFloor }).ok).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "electron/**/*.test.mjs",
       "src/**/*.test.ts",
       "companion/**/*.test.ts",
+      "scripts/**/*.test.mjs",
     ],
     setupFiles: ["server/testing/setup.ts"],
     // the suite spawns fake provider CLIs and a real harness server;


### PR DESCRIPTION
## What

CI now fails when suspiciously few tests were counted, even if every one of them passed. `pnpm test`'s leading `vitest run` is replaced by `node scripts/test-floor.mjs`, which runs the exact same suite with a machine-readable JSON reporter alongside the normal console reporter, counts the tests the run registered, and fails below a floor of **970** (roughly 90% of the 1081 tests in the suite today). It also refuses to report a pass when the count cannot be determined at all — a run that cannot be counted has exactly the shape of a collection failure.

## Why

A green test run only proves "everything that ran passed". It says nothing about whether everything that *should* have run, ran. A test file that never registers its tests — a rename that slips out of the include globs, a directory dropped from the vitest config, an import-time throw swallowed as an empty collection — leaves the remaining files passing and CI green with a chunk of the suite silently missing. The floor adds the other half of the claim: "and roughly everything we expected to run, ran."

Design choices, all commented in `scripts/test-floor.mjs`:

- **A floor, not an exact count** — an exact count would need editing on every PR that adds or removes a test. 970 leaves room for ordinary churn while still tripping if a whole file's worth of tests disappears. If the suite ever legitimately shrinks below it, lowering `TEST_COUNT_FLOOR` becomes a visible, reviewed decision in that same PR.
- **Registered tests, not executed tests** — POSIX-only process tests self-skip on Windows, and a skipped test still proves its file imported and collected. Counting registrations keeps one floor valid across the whole 3-OS matrix.
- **Wiring via the `test` script chain** — least invasive option: ci.yml is untouched, CI still runs `pnpm test`, and the other legs (`broker:test`, `test:updater`, `test:packaged-server`) run exactly as before. Local `pnpm test` gets the same protection for free; `test:watch` stays plain vitest.
- **The pass/fail decision is a pure function** (`evaluateRun`) so it can be unit-tested without spawning a nested suite; `scripts/test-floor.test.mjs` pins down every branch (below floor, uncountable summary, nonzero exit, signal death, `success: false` with exit 0). Those tests run inside the counted suite via a new `scripts/**/*.test.mjs` include glob.

## Test plan

- `pnpm typecheck` — clean.
- Full `pnpm test` (floor gate + broker + updater + packaged-server) — green; the floor leg counts 1087 tests against the 970 floor.
- Unit tests for the decision logic: 6 tests in `scripts/test-floor.test.mjs`, all passing.
- Mutation check: with the floor temporarily set to 99999, `node scripts/test-floor.mjs` exits 1 with `only 1087 tests were counted, below the floor of 99999` — the gate demonstrably fires end-to-end, not just in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added safeguards to ensure the automated test suite runs successfully and maintains a minimum test count.
  * Test failures, incomplete test collection, and interrupted runs are now reported clearly.
  * Added coverage for the new test validation behavior.
  * Included script-based tests in the test runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->