### PR TITLE
Release Ubuntu installables for v0.1.25

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -1,0 +1,104 @@
+# Ubuntu packages, built and exercised on the exact distribution we support.
+#
+# This workflow deliberately produces an artifact instead of publishing to the
+# separate public releases repository. That keeps cross-repository credentials
+# out of the source repository while still making every release candidate
+# reproducible from an exact ref. Attach the resulting files to the matching
+# openmausbot-releases release after the smoke test passes.
+name: Package Ubuntu
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit/tag/branch to build (defaults to the branch this is run from)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: DEB + AppImage (Ubuntu 24.04 x64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install package validation and native smoke tools
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools xvfb
+      - run: pnpm install --frozen-lockfile
+      - name: Clean generated output
+        run: pnpm clean
+      - name: Stage the pinned CUA runtime
+        run: pnpm build:cua:linux
+      - name: Package from the verified offline CUA stage
+        run: pnpm package:linux:offline
+      - name: Verify package contents and metadata
+        run: node scripts/verify-linux-package.mjs
+      - name: Configure Chromium sandbox for the unpacked app
+        run: |
+          sudo chown root:root release/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 release/linux-unpacked/chrome-sandbox
+          test "$(stat -c '%U:%G %a' release/linux-unpacked/chrome-sandbox)" = "root:root 4755"
+      - name: Launch packaged app and verify lifecycle
+        env:
+          OMB_KEEP_SMOKE_DIR: "1"
+        run: pnpm smoke:linux-package
+      - name: Prepare release assets
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          appimage="release/OpenMausBot-${version}-x86_64.AppImage"
+          deb="release/OpenMausBot-${version}-amd64.deb"
+          test -f "$appimage"
+          test -f "$deb"
+          cp "$appimage" release/OpenMausBot.AppImage
+          cp "$deb" release/OpenMausBot-amd64.deb
+          chmod 0755 release/OpenMausBot.AppImage
+          (
+            cd release
+            sha256sum \
+              "$(basename "$appimage")" \
+              "$(basename "$deb")" \
+              OpenMausBot.AppImage \
+              OpenMausBot-amd64.deb > SHA256SUMS-ubuntu-x64.txt
+          )
+          echo "artifact-name=openmausbot-ubuntu-${version}-x64" >> "$GITHUB_OUTPUT"
+          echo "version: $version"
+          echo "commit:  $(git rev-parse HEAD)"
+          cat release/SHA256SUMS-ubuntu-x64.txt
+      - name: Upload smoke diagnostics on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: openmausbot-ubuntu-smoke-diagnostics
+          path: |
+            ${{ runner.temp }}/omb-linux-smoke-*
+            ${{ runner.temp }}/omb-linux-smoke-runtime-*
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release.outputs.artifact-name }}
+          path: |
+            release/OpenMausBot-*-amd64.deb
+            release/OpenMausBot-*-x86_64.AppImage
+            release/OpenMausBot-amd64.deb
+            release/OpenMausBot.AppImage
+            release/SHA256SUMS-ubuntu-x64.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,22 @@ pnpm package:linux # Ubuntu x64 .deb + AppImage; no Swift required
 
 For Ubuntu installation and real desktop checks, see [`docs/linux-desktop.md`](docs/linux-desktop.md).
 
+## Ubuntu release checklist
+
+Ubuntu release packages must come from the manual **Package Ubuntu** workflow on an exact release commit or tag,
+not from a developer workstation. The Ubuntu 24.04 runner builds and verifies both formats, launches the unpacked
+app and AppImage, exercises the bundled Cua lifecycle, and produces one release artifact containing:
+
+- the versioned `.deb` and AppImage;
+- stable `OpenMausBot-amd64.deb` and `OpenMausBot.AppImage` copies used by the latest-download links;
+- `SHA256SUMS-ubuntu-x64.txt` covering both versioned and stable names.
+
+Before publishing, confirm that `package.json` has the release version and dispatch the workflow against the same
+commit used for the other platforms. Attach all five Ubuntu files to the matching release in the separate
+[`openmausbot-releases`](https://github.com/milind-soni/openmausbot-releases) repository. Then verify the checksum
+file and install the `.deb` plus launch the AppImage in a clean Ubuntu 24.04 x86_64 GNOME environment. Never combine
+packages built from different commits under one version.
+
 ## Repo map
 
 | Path | What lives there |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Talk to them like contacts. Watch them work. Approve what matters.
 <a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe">
   <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Windows&labelColor=070707&color=4cc2ff&cacheSeconds=300" alt="Download the latest OpenMausBot for Windows (.exe)" height="40">
 </a>
+&nbsp;
+<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb">
+  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Ubuntu&labelColor=070707&color=e95420&cacheSeconds=300" alt="Download the latest OpenMausBot for Ubuntu (.deb)" height="40">
+</a>
 
-<sub>macOS: Apple silicon · signed & notarized · one-click .dmg &nbsp;·&nbsp; Windows: 64-bit · one-click installer, no admin rights &nbsp;·&nbsp; both always the latest · [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
+<sub>macOS: Apple silicon · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
 
 <br>
 <br>
@@ -177,16 +181,15 @@ flowchart LR
 
 ## Quick start
 
-**Released builds:** the harness server is embedded, so macOS and Windows need no separate server setup.
+**Released builds:** the harness server is embedded, so no separate server setup is required.
 
 | | Download | Install |
 |---|---|---|
 | **macOS** (Apple silicon) | [OpenMausBot.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Drag it to Applications, open it. Signed & notarized. |
 | **Windows** (x64) | [OpenMausBot-setup.exe](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Run it — one-click, per-user, no admin rights. The installer isn't code-signed yet, so SmartScreen shows "unknown publisher": **More info → Run anyway**. |
+| **Ubuntu 24.04** (x64) | [OpenMausBot-amd64.deb](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) · [OpenMausBot.AppImage](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) | Install the `.deb` with APT (recommended), or make the AppImage executable and run it. Beta; GNOME is the supported desktop. |
 
-**Ubuntu Desktop beta:** build the `.deb` or AppImage from source using the commands below. Release downloads
-will be linked here once Linux publishing is enabled. See [the Ubuntu Desktop guide](docs/linux-desktop.md) for
-installation, capabilities, and troubleshooting.
+See the [Ubuntu Desktop guide](docs/linux-desktop.md) for installation, capabilities, and troubleshooting.
 
 **From source:**
 
@@ -274,7 +277,7 @@ dedicated receiver through a hosted relay or a tool such as Tailscale Funnel.
 ## Status
 
 Early but real — the loop works end to end: message → agent → streamed reply → tools → approvals →
-computer use. macOS and Windows have released builds; Ubuntu 24.04 x64 packages are in beta with the
+computer use. macOS, Windows, and Ubuntu 24.04 x64 have released builds; Ubuntu remains a beta with the
 capability limits above. Rough edges to expect: hosted/mobile connectivity is still being built, and webhook
 triggers currently use the local receiver rather than an always-on hosted relay.
 Voice needs an ElevenLabs key, and calls are macOS-only for now (they ride the same on-device dictation as

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -23,6 +23,17 @@ CUA supply-chain work is tracked in [issue #113](https://github.com/milind-soni/
 [issue #79](https://github.com/milind-soni/OpenMausBot/issues/79), and guarded GNOME/Wayland support in
 [issue #109](https://github.com/milind-soni/OpenMausBot/issues/109).
 
+## Download packages
+
+Choose one Ubuntu 24.04 x86_64 package from the latest release:
+
+- [Debian package (`OpenMausBot-amd64.deb`)](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) — recommended; APT installs its desktop dependencies.
+- [Portable AppImage (`OpenMausBot.AppImage`)](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) — does not install system files.
+- [SHA-256 checksums](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/SHA256SUMS-ubuntu-x64.txt)
+
+Versioned packages and previous releases remain available on the
+[releases page](https://github.com/milind-soni/openmausbot-releases/releases).
+
 ## Build packages
 
 Requirements for building from source:
@@ -48,10 +59,10 @@ The AppImage uses a static runtime and does not require the legacy `libfuse2` pa
 
 ## Install and run
 
-Install the Debian package with APT so its desktop dependencies are resolved:
+Install a downloaded Debian package with APT so its desktop dependencies are resolved:
 
 ```sh
-sudo apt install ./release/OpenMausBot-*-amd64.deb
+sudo apt install ./OpenMausBot-amd64.deb
 ```
 
 Then open **OpenMausBot** from the GNOME application launcher. To remove it:
@@ -66,6 +77,8 @@ The portable AppImage does not install system files:
 chmod +x release/OpenMausBot-*-x86_64.AppImage
 ./release/OpenMausBot-*-x86_64.AppImage
 ```
+
+For a downloaded release AppImage, use `OpenMausBot.AppImage` in place of the versioned path above.
 
 Application data remains local in `~/.openmausbot`. Electron browser data and window state use the normal XDG
 configuration directory (`~/.config/openmausbot` unless the environment overrides it).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- add a manual Ubuntu 24.04 x64 release workflow that builds and smoke-tests the bundled-CUA `.deb` and AppImage
- produce versioned assets, stable latest-download aliases, and SHA-256 checksums
- publish Ubuntu download links and the maintainer release checklist
- bump the application version to 0.1.25

This is the release-layer follow-up to merged Ubuntu PRs #111 and #116.

## Validation

- `pnpm typecheck`
- `pnpm check:electron`
- 122 Vitest files / 1,184 tests passed, plus broker, updater, and packaged-server smoke tests before the release-only commit
- workflow YAML parsed successfully
- `git diff --check`

The Ubuntu package and lifecycle lane will run on GitHub’s Ubuntu 24.04 x64 runner before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ubuntu 24.04 x64 release packages in DEB and AppImage formats.
  * Added downloadable SHA-256 checksums for Linux releases.
  * Added verified installation and smoke testing for packaged builds.

* **Documentation**
  * Updated Ubuntu quick-start, download, and installation instructions.
  * Added an Ubuntu release checklist for maintainers.

* **Chores**
  * Updated the application version to 0.1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->