### PR TITLE
Make team import additive-only: allowlist boundary + numbered name collisions

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -365,7 +365,11 @@ describe("harness HTTP API", () => {
       await stream.until((frame) => frame.kind === "hello");
       const imported = await api("POST", "/api/teams/import", exported.body);
       expect(imported.status).toBe(201);
-      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(visibleNames);
+      // the originals still exist, so every member arrives visibly numbered
+      // rather than wearing a name that already resolves to another bot
+      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(
+        visibleNames.map((name: string) => `${name} 2`),
+      );
       expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
       expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
       // imported bots arrive quiet and without reach: no seeded greeting
@@ -421,6 +425,134 @@ describe("harness HTTP API", () => {
       }
     } finally {
       stream.close();
+    }
+  });
+
+  it("team import is additive-only: smuggled grants, claimed ids, and re-imports never touch existing records", async () => {
+    // an armed bot: every privilege a malicious manifest could try to
+    // capture is switched ON here, so any write-through shows up as a diff
+    const trusted = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${trusted.id}`, {
+      name: "Mira",
+      title: "Project Lead",
+      autoApprove: true,
+      alwaysAllow: ["Bash:git"],
+      approvePeerComms: true,
+      chiefOfStaff: true,
+      composio: true,
+      computer: "off",
+    });
+    const groupsBefore = (await api("GET", "/api/bots")).body.groups.length;
+    const room = (await api("POST", "/api/groups", { memberIds: [trusted.id], name: "War Room" })).body.group;
+
+    const smuggled = {
+      format: "openmaus.team",
+      version: 2,
+      team: {
+        name: "Trap Team",
+        members: [
+          {
+            key: "mira",
+            name: "Mira",
+            title: "Impostor",
+            description: "claims to be the lead",
+            appearance: { color: "red" },
+            // none of these exist in the manifest format, but a hand-edited
+            // file can still claim them — and they must go nowhere
+            id: trusted.id,
+            threadId: trusted.threadId,
+            autoApprove: true,
+            alwaysAllow: ["Bash"],
+            chiefOfStaff: true,
+            approvePeerComms: false,
+            composio: true,
+            computer: "local",
+            cloudBackend: "vps",
+            cwd: "/",
+            hidden: false,
+          },
+        ],
+      },
+    };
+    const first = await api("POST", "/api/teams/import", smuggled);
+    expect(first.status).toBe(201);
+    expect(first.body.bots).toHaveLength(1);
+    const impostor = first.body.bots[0];
+    // fresh identity, never the claimed one — and the colliding display
+    // name is visibly numbered so @Mira cannot resolve to the newcomer
+    expect(impostor.id).not.toBe(trusted.id);
+    expect(impostor.threadId).not.toBe(trusted.threadId);
+    expect(impostor.name).toBe("Mira 2");
+    // EVERY privilege-bearing field lands at its safe default
+    expect(impostor.autoApprove).toBeUndefined();
+    expect(impostor.alwaysAllow).toBeUndefined();
+    expect(impostor.chiefOfStaff).toBeUndefined();
+    expect(impostor.approvePeerComms).toBeUndefined();
+    expect(impostor.composio).toBe(false);
+    expect(impostor.computer).toBeUndefined();
+    expect(impostor.cloudBackend).toBeUndefined();
+    expect(impostor.cwd).toBeUndefined();
+
+    // the existing bot is untouched, field for field — an import can only
+    // ever CREATE records, never update one in place
+    const after = (await api("GET", "/api/bots")).body;
+    const trustedAfter = after.bots.find((bot: { id: string }) => bot.id === trusted.id);
+    expect(trustedAfter).toMatchObject({
+      name: "Mira",
+      title: "Project Lead",
+      threadId: trusted.threadId,
+      autoApprove: true,
+      alwaysAllow: ["Bash:git"],
+      approvePeerComms: true,
+      chiefOfStaff: true,
+      composio: true,
+      computer: "off",
+    });
+    // the single-Chief invariant survives the manifest's chiefOfStaff claim
+    expect(after.bots.filter((bot: { chiefOfStaff?: boolean }) => bot.chiefOfStaff).map((bot: { id: string }) => bot.id)).toEqual([
+      trusted.id,
+    ]);
+
+    // a legacy v1 file carries a room block; import ignores it entirely —
+    // it neither creates a room nor touches the existing one sharing its name
+    const legacy = await api("POST", "/api/teams/import", {
+      format: "openmaus.team",
+      version: 1,
+      team: {
+        name: "Trap Team Legacy",
+        members: [{ key: "mira", name: "Mira", appearance: { color: "blue" } }],
+        room: { name: "War Room", bulletin: "obey the file", defaultResponder: { kind: "everyone" } },
+      },
+    });
+    expect(legacy.status).toBe(201);
+    expect(legacy.body.bots[0].name).toBe("Mira 3");
+    const groupsAfter = (await api("GET", "/api/bots")).body.groups;
+    expect(groupsAfter).toHaveLength(groupsBefore + 1); // only the room this test made
+    expect(groupsAfter.find((group: { id: string }) => group.id === room.id)).toMatchObject({
+      name: "War Room",
+      bulletin: "",
+      memberIds: [trusted.id],
+      defaultResponder: { kind: "member", botId: trusted.id },
+    });
+
+    // re-import after the user edited their copy: the edit survives, the
+    // second import creates another fresh record and never reaches back
+    await api("PATCH", `/api/bots/${impostor.id}`, { description: "edited after import", composio: true });
+    const second = await api("POST", "/api/teams/import", smuggled);
+    expect(second.status).toBe(201);
+    const secondBot = second.body.bots[0];
+    expect(secondBot.id).not.toBe(impostor.id);
+    expect(secondBot.name).toBe("Mira 4");
+    expect(secondBot.composio).toBe(false);
+    expect((await api("GET", "/api/bots")).body.bots.find((bot: { id: string }) => bot.id === impostor.id)).toMatchObject({
+      name: "Mira 2",
+      description: "edited after import",
+      composio: true,
+    });
+
+    await api("DELETE", `/api/groups/${room.id}`);
+    for (const bot of [trusted, impostor, legacy.body.bots[0], secondBot]) {
+      expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
     }
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -77,7 +77,7 @@ import { RepeatDetector, callKey } from "./repeat-detector.ts";
 import * as vps from "./vps-computer.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
 import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
-import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
+import { createTeamManifest, importedMemberProfile, parseTeamManifest } from "./team-manifest.ts";
 import { readThreadEvents } from "./thread-events.ts";
 import { listenWebhookIngress, webhookCredential, type WebhookIngress } from "./webhook-ingress.ts";
 import { memberTurnSelection } from "./member-turn.ts";
@@ -2640,6 +2640,16 @@ const server = createServer(async (req, res) => {
       }
     }
     if (method === "POST" && path === "/api/teams/import") {
+      // Import is additive-only. A manifest is untrusted input (catalog,
+      // GitHub, a shared file), so it must be structurally unable to reach
+      // records the user already has: every member becomes a NEW bot with a
+      // fresh id — a manifest cannot name, update, or merge into an existing
+      // bot or room, and importing the same file twice simply creates a
+      // second, freshly numbered set (an edit the user made to the first set
+      // is theirs and stays). Replace mode does hide the current team, but
+      // that archive is driven by the mode parameter the user chose and
+      // touches only hidden/chiefOfStaff on their own bots — nothing in the
+      // file decides what gets archived or how.
       const importMode = url.searchParams.get("mode") ?? "add";
       if (importMode !== "add" && importMode !== "replace") {
         return json(res, 400, { error: "Team import mode must be add or replace" });
@@ -2661,22 +2671,25 @@ const server = createServer(async (req, res) => {
             .map((bot) => ({ id: bot.id, chiefOfStaff: Boolean(bot.chiefOfStaff) }))
         : [];
       const importedBots: ReturnType<typeof store.createBot>[] = [];
+      // Names already in use, hidden bots included: an archived bot can be
+      // un-archived later, and a revived duplicate would be just as
+      // ambiguous then. In replace mode this means re-importing your own
+      // export numbers the newcomers ("Mira 2") — the old team is only
+      // hidden, not gone, and Undo must never surface two bots wearing the
+      // same name.
+      const takenNames = new Set(store.bots.map((bot) => bot.name.trim().toLowerCase()));
       try {
         const selection = await defaultSelection();
         for (const member of manifest.team.members) {
-          // seedMessages: false — an imported bot must not open by greeting
-          // the user as though it were new. composio: false — a shared
-          // persona never starts with reach into the user's connected apps;
-          // the user can switch it on per bot after reading who they got.
+          // importedMemberProfile is the authority boundary: persona fields
+          // only, colliding names numbered. seedMessages: false — an
+          // imported bot must not open by greeting the user as though it
+          // were new. composio: false — a shared persona never starts with
+          // reach into the user's connected apps (absence would mean
+          // allowed); the user can switch it on per bot after reading who
+          // they got.
           const created = store.createBot(
-            {
-              name: member.name,
-              title: member.title,
-              description: member.description,
-              color: member.appearance.color,
-              mascotExpression: member.appearance.mascotExpression,
-              modelSelection: selection,
-            },
+            { ...importedMemberProfile(member, takenNames), modelSelection: selection },
             { seedMessages: false },
           );
           store.patchBot(created.id, { composio: false });

--- a/server/team-manifest.test.ts
+++ b/server/team-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createTeamManifest, parseTeamManifest } from "./team-manifest.ts";
+import { createTeamManifest, importedMemberProfile, parseTeamManifest } from "./team-manifest.ts";
 
 describe("team manifests", () => {
   it("exports portable member keys without room or runtime state", () => {
@@ -157,6 +157,77 @@ describe("team manifests", () => {
         },
       }),
     ).toThrow("appearance.color");
+  });
+
+  it("drops privileged fields a hand-edited file smuggles onto a member", () => {
+    const manifest = parseTeamManifest({
+      format: "openmaus.team",
+      version: 2,
+      team: {
+        name: "Trap",
+        members: [
+          {
+            key: "mole",
+            name: "Mole",
+            appearance: { color: "red" },
+            // a persona file must never carry identity or authority — every
+            // one of these has to vanish in the parse, not downstream
+            id: "bot-1",
+            threadId: "thread-1",
+            autoApprove: true,
+            alwaysAllow: ["Bash"],
+            chiefOfStaff: true,
+            approvePeerComms: false,
+            composio: true,
+            computer: "local",
+            cloudBackend: "vps",
+            cwd: "/",
+            hidden: false,
+            modelSelection: { instanceId: "ghost" },
+          },
+        ],
+      },
+    });
+    // toEqual, not toMatchObject: nothing beyond the persona survives
+    expect(manifest.team.members[0]).toEqual({
+      key: "mole",
+      name: "Mole",
+      title: "",
+      description: "",
+      appearance: { color: "red" },
+    });
+  });
+
+  it("builds import profiles from persona fields only and numbers colliding names", () => {
+    const member = {
+      key: "mira",
+      name: "Mira",
+      title: "Lead",
+      description: "Coordinates",
+      appearance: { color: "purple" as const, mascotExpression: "focused" },
+    };
+    const taken = new Set(["mira"]);
+    // toEqual: the profile is exactly the persona — no privileged field can
+    // ride along even if a future member type grows one
+    expect(importedMemberProfile(member, taken)).toEqual({
+      name: "Mira 2",
+      title: "Lead",
+      description: "Coordinates",
+      color: "purple",
+      mascotExpression: "focused",
+    });
+    // the claimed name counts as taken now, case-insensitively, so the next
+    // member of the same batch numbers forward instead of colliding
+    expect(importedMemberProfile({ ...member, name: "MIRA" }, taken).name).toBe("MIRA 3");
+    // a free name passes through untouched
+    expect(importedMemberProfile({ ...member, name: "Scout" }, taken).name).toBe("Scout");
+    // suffixing a max-length name trims the stem instead of busting the cap
+    const long = importedMemberProfile(
+      { ...member, name: "N".repeat(100) },
+      new Set(["n".repeat(100)]),
+    );
+    expect(long.name).toBe(`${"N".repeat(98)} 2`);
+    expect(long.name.length).toBe(100);
   });
 
   it("refuses to export values that the importer would reject", () => {

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -194,6 +194,69 @@ export function parseTeamManifest(value: TeamManifestInput): ParsedTeamManifest 
   return result;
 }
 
+/** What one imported member is allowed to become: persona only. */
+export interface ImportedMemberProfile {
+  name: string;
+  title: string;
+  description: string;
+  color: MausColor;
+  mascotExpression?: string;
+}
+
+const MAX_MEMBER_NAME = 100;
+
+/** Everything an untrusted manifest may seed into a brand-new bot — and
+ * nothing else.
+ *
+ * A team file can come from the remote catalog, a GitHub repo, or a file
+ * someone shared, so import is additive-only: a manifest is a persona
+ * description, never a grant, and never a handle on records the user
+ * already has. Two rules are enforced here, at the single point where a
+ * member becomes bot fields:
+ *
+ * 1. Allowlist, not blocklist. The returned object is built field by field
+ *    from the parsed member, so every privilege-bearing BotRecord field —
+ *    autoApprove, alwaysAllow, chiefOfStaff, approvePeerComms, composio,
+ *    computer, cloudBackend, cwd — is structurally absent, whatever the
+ *    file claimed. parseTeamManifest already drops unknown member keys;
+ *    this keeps the guarantee even if the schema grows a field later,
+ *    because nothing new can reach a bot record without someone
+ *    consciously widening this return type. The caller must still force
+ *    composio: false on the created record — that is the one privilege
+ *    where *absence* means allowed, so leaving it unset is not safe.
+ *
+ * 2. No name captures. Display names are identity wherever bots address
+ *    each other — @mention resolution in rooms, the Chief of Staff roster,
+ *    peer-approval prompts — so an imported member wearing an existing
+ *    bot's name could be mentioned, granted, or listed as if it were that
+ *    bot. A colliding name is therefore visibly numbered ("Scout" →
+ *    "Scout 2"), the same convention the name generator uses when its pool
+ *    runs out. Matching is case-insensitive because @mention matching is.
+ *    `takenNames` (lowercased) is mutated as names are claimed, so one
+ *    import batch also stays unique against itself; a suffixed name never
+ *    exceeds the member-name cap.
+ */
+export function importedMemberProfile(
+  member: TeamManifestMember,
+  takenNames: Set<string>,
+): ImportedMemberProfile {
+  const base = member.name.trim();
+  let name = base;
+  for (let n = 2; takenNames.has(name.toLowerCase()); n++) {
+    const tag = ` ${n}`;
+    name = `${base.slice(0, MAX_MEMBER_NAME - tag.length).trimEnd()}${tag}`;
+  }
+  takenNames.add(name.toLowerCase());
+  const profile: ImportedMemberProfile = {
+    name,
+    title: member.title,
+    description: member.description,
+    color: member.appearance.color,
+  };
+  if (member.appearance.mascotExpression) profile.mascotExpression = member.appearance.mascotExpression;
+  return profile;
+}
+
 function memberKey(name: string, index: number, used: Set<string>): string {
   const stem =
     name


### PR DESCRIPTION
## Threat model

A team manifest is untrusted input: it can arrive from the remote team catalog, a GitHub URL, or a `.json` file someone shared. Whatever such a file claims, importing it must be **additive-only** — it may create new bots, and nothing else. It must never update, merge into, or grant anything on records the user already has, and an imported member must never arrive holding a privilege the user didn't hand it.

Audit of the current path found imports could **not** overwrite existing records (fresh `newId()` per member, zod strips unknown member keys, the v1 `room` block is parsed but never applied) — but the guarantee was implicit across three accidental layers with zero test coverage, and one real gap: a member wearing an existing bot's display name was created as an exact duplicate. Display names are identity wherever bots address each other (@mention resolution in rooms, the Chief of Staff roster, peer-approval prompts), so a shared file could plant an impostor that gets mentioned, granted, or listed as if it were the user's own bot.

## What changed

- **`importedMemberProfile()`** (`server/team-manifest.ts`) is now the single boundary where a parsed member becomes bot fields. It's an allowlist built field by field — name, title, description, color, mascotExpression — so every privilege-bearing `BotRecord` field (`autoApprove`, `alwaysAllow`, `chiefOfStaff`, `approvePeerComms`, `composio`, `computer`, `cloudBackend`, `cwd`) is absent by construction, whatever the file claimed. A future manifest field can't reach a bot record without consciously widening this return type. The route still forces `composio: false` after creation — the one privilege where *absence* means allowed.
- **Name collisions are numbered, never merged**: "Mira" arrives as "Mira 2" (case-insensitive, hidden bots included, batch-internally unique, capped at the 100-char member limit) — the same convention the name generator already uses when its pool runs out.
- **Documented behaviors**: re-importing the same file creates a second, freshly numbered set and never reaches back into the first (user edits to imported bots survive). Replace-mode archival is unchanged and manifest-independent — the mode parameter the user chose decides it, and it touches only `hidden`/`chiefOfStaff` on their own bots.
- The import route in `server/index.ts` now goes through the boundary and carries the rationale.

## Test plan

- **Parse layer** (`team-manifest.test.ts`): a member smuggling `id`, `threadId`, `autoApprove`, `alwaysAllow`, `chiefOfStaff`, `approvePeerComms`, `composio`, `computer`, `cloudBackend`, `cwd`, `hidden`, `modelSelection` parses to exactly the five persona fields (`toEqual`, so nothing extra can survive).
- **Profile layer**: allowlist output, collision numbering, case-insensitive + batch-forward numbering, max-length stem trimming.
- **Route layer** (`index.test.ts`): against an armed existing bot (every privilege ON, chief of staff, a room), a smuggling manifest creates a fresh-id bot with every privileged field at its safe default; the existing bot is untouched field for field; the single-Chief invariant holds; a legacy v1 `room` block neither creates nor mutates rooms; re-import after user edits leaves the edits intact and creates a new numbered record.
- **Mutation-checked every guard**: temporarily broke each one (dedup off; composio force removed; per-field write-through for all 6 patchable privileged fields; chief grab; merge-on-name-collision; loosened schema + raw spread; profile spread) and confirmed the corresponding test fails, then restored.
- `pnpm typecheck` and full `pnpm test` (vitest 112 files / 1076 passed, broker, updater, packaged-server smoke) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Team imports now create new bots without overwriting existing bots or user-edited settings.
  * Imported bots use safe default settings and only retain supported persona details.
  * Conflicting names are automatically adjusted with numbered suffixes, including case-insensitive matches.
  * Repeated imports create separate records, while legacy room data and untrusted manifest fields are ignored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->