### PR TITLE
Log every authorization decision to a fleet-wide audit file

### DIFF
--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -30,12 +30,21 @@ const SENSITIVE = [
   /\bcredentials?\.json\b|\bserviceaccount\b/i,
 ];
 
+/** First matching pattern's source, so a verdict can NAME the rule that
+ * made it — the decision log's whole value is "which rule", and deriving
+ * the match a second time at the call site is how the log and the verdict
+ * drift apart. */
+function matchFirst(rules: RegExp[], text: string): string | null {
+  for (const re of rules) if (re.test(text)) return re.source;
+  return null;
+}
+
 export function looksSensitive(text: string): boolean {
-  return SENSITIVE.some((re) => re.test(text));
+  return matchFirst(SENSITIVE, text) !== null;
 }
 
 export function looksDestructive(text: string): boolean {
-  return DESTRUCTIVE.some((re) => re.test(text));
+  return matchFirst(DESTRUCTIVE, text) !== null;
 }
 
 /** The key an "Always allow" remembers.
@@ -66,9 +75,92 @@ export interface AutoApprover {
   alwaysAllow?: string[];
 }
 
-/** Why this request may be answered without the human, or null to ask.
- * The returned string becomes the chip in the transcript, so an
- * auto-approved action is never invisible. */
+/** Why a verdict landed the way it did. `unattended-block` exists only in
+ * contrast: a grant WOULD have fired, and the only thing that stopped it
+ * was that nobody started this turn — the most audit-worthy card of all. */
+export type AutoVerdictSource =
+  | "always-allow"
+  | "auto-mode"
+  | "unattended-block"
+  | "local-computer-block"
+  | "destructive-guard"
+  | "sensitive-guard"
+  | "no-grant";
+
+export interface AutoVerdict {
+  /** Chip text when the bot may answer itself, null when a human decides.
+   * The string becomes the chip in the transcript, so an auto-approved
+   * action is never invisible. */
+  approve: string | null;
+  source: AutoVerdictSource;
+  /** What identifies the rule that decided: the matched regex (guards) or
+   * the granted key (always-allow, and unattended-block over one). Auto
+   * mode has no narrower identity than the mode itself, so it carries none. */
+  rule?: string;
+}
+
+/** The verdict AND its provenance. The decision itself is unchanged from
+ * autoDecision below — this exists so the decision log can record which
+ * rule decided without the call site re-deriving (and eventually
+ * mis-deriving) the match. */
+export function autoVerdict(
+  bot: AutoApprover,
+  tool: string,
+  summary: string,
+  context?: {
+    /** the turn was started by an outside event, with nobody at the keyboard */
+    unattended?: boolean;
+    /** the request controls the user's active desktop */
+    scope?: "local-computer";
+  },
+): AutoVerdict {
+  // the guards outrank the grants, so an "always allow" can never widen
+  // into them
+  const destructive = matchFirst(DESTRUCTIVE, summary) ?? matchFirst(DESTRUCTIVE, tool);
+  const sensitive = destructive ? null : matchFirst(SENSITIVE, summary);
+  // The grant is computed even when a hard block will refuse it: the row
+  // worth auditing is "this WOULD have auto-approved, and only the block
+  // stood in the way", which cannot be told apart from an ordinary
+  // "nobody granted this" card without knowing both halves.
+  const key = approvalKey(tool, summary, context?.scope);
+  const grant =
+    destructive || sensitive
+      ? null
+      : bot.alwaysAllow?.includes(key)
+        ? { approve: `auto-approved ${key} (always allowed)`, source: "always-allow" as const, rule: key }
+        : bot.autoApprove
+          ? { approve: `auto-approved ${tool}`, source: "auto-mode" as const, rule: undefined }
+          : null;
+  if (context?.unattended) {
+    // Auto mode is something a person switched on for turns they are present
+    // for. A webhook turn begins with nobody watching, on a payload someone
+    // else wrote, so it does not inherit that decision — the guard above is a
+    // pattern list its own comment calls "not a security boundary", and it
+    // must not stand in for a human at 3am. A guard that would have carded
+    // anyway keeps its own name; the block is only the story when it is the
+    // thing that changed the outcome.
+    if (grant) return { approve: null, source: "unattended-block", rule: grant.rule };
+    if (destructive) return { approve: null, source: "destructive-guard", rule: destructive };
+    if (sensitive) return { approve: null, source: "sensitive-guard", rule: sensitive };
+    return { approve: null, source: "no-grant" };
+  }
+  if (context?.scope === "local-computer") {
+    // The user's active desktop is never delegated to bot auto mode or a
+    // remembered cloud/tool grant in the Linux beta. Same attribution rule
+    // as the unattended block: a guard that would have carded anyway keeps
+    // its own name, the block is the story only when it changed the outcome.
+    if (grant) return { approve: null, source: "local-computer-block", rule: grant.rule };
+    if (destructive) return { approve: null, source: "destructive-guard", rule: destructive };
+    if (sensitive) return { approve: null, source: "sensitive-guard", rule: sensitive };
+    return { approve: null, source: "no-grant" };
+  }
+  if (destructive) return { approve: null, source: "destructive-guard", rule: destructive };
+  if (sensitive) return { approve: null, source: "sensitive-guard", rule: sensitive };
+  if (grant) return { approve: grant.approve, source: grant.source, rule: grant.rule };
+  return { approve: null, source: "no-grant" };
+}
+
+/** Why this request may be answered without the human, or null to ask. */
 export function autoDecision(
   bot: AutoApprover,
   tool: string,
@@ -80,20 +172,5 @@ export function autoDecision(
     scope?: "local-computer";
   },
 ): string | null {
-  // Auto mode is something a person switched on for turns they are present
-  // for. A webhook turn begins with nobody watching, on a payload someone
-  // else wrote, so it does not inherit that decision — the guard below is a
-  // pattern list its own comment calls "not a security boundary", and it
-  // must not stand in for a human at 3am.
-  if (context?.unattended) return null;
-  // The user's active desktop is never delegated to bot auto mode or a
-  // remembered cloud/tool grant in the Linux beta.
-  if (context?.scope === "local-computer") return null;
-  // the guards come first, so an "always allow" can never widen into them
-  if (looksDestructive(summary) || looksDestructive(tool)) return null;
-  if (looksSensitive(summary)) return null;
-  const key = approvalKey(tool, summary, context?.scope);
-  if (bot.alwaysAllow?.includes(key)) return `auto-approved ${key} (always allowed)`;
-  if (bot.autoApprove) return `auto-approved ${tool}`;
-  return null;
+  return autoVerdict(bot, tool, summary, context).approve;
 }

--- a/server/decision-log-wiring.test.ts
+++ b/server/decision-log-wiring.test.ts
@@ -1,0 +1,274 @@
+// The decision log is only as good as its wiring: every row is written at
+// the request.opened fold or in answerRequest, and both of those keep
+// working (cards keep appearing, approvals keep flowing) even when the
+// logging silently rots away. So, in the style of unattended.test.ts,
+// these run the real server against the fake ACP CLI and assert the ROWS,
+// not the behavior the rows describe:
+//
+//   1. a rule-matched auto-approval writes a row naming the rule
+//   2. a card and the human's answer write two rows (allow and deny)
+//   3. an unattended block writes its row — the audit row that says "this
+//      would have auto-approved, and only the block stood in the way"
+//   4. GET /api/decisions pages newest-last with ?limit=
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { DecisionRow } from "./decision-log.ts";
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const posixOnly = describe.skipIf(process.platform === "win32");
+
+let child: ChildProcess;
+let home: string;
+let stderr = "";
+
+const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: res.status, body: await res.json() };
+};
+
+/** Newest matching decision row, or null when none shows up in time. */
+async function waitForDecision(pred: (r: DecisionRow) => boolean, ms = 30_000): Promise<DecisionRow | null> {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    const { body } = await api("GET", "/api/decisions");
+    const rows: DecisionRow[] = body.decisions ?? [];
+    const row = rows.filter(pred).at(-1);
+    if (row) return row;
+    if (Date.now() > deadline) return null;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+/** A live permission card on a bot's transcript (via /api/bots — the same
+ * poll unattended.test.ts uses, since a bot's card lives on its thread). */
+async function waitForBotCard(botId: string, ms = 30_000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const { body } = await api("GET", "/api/bots");
+    const bot = (body.bots ?? []).find((b: { id: string }) => b.id === botId);
+    const card = bot?.messages?.find(
+      (m: { kind: string; card?: { requestId?: string; answered?: string } }) =>
+        m.kind === "options" && m.card?.requestId && !m.card.answered,
+    );
+    if (card) return card;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+
+/** A live permission card on a THREAD — webhook turns run in detached
+ * tasks, so their cards never appear on the bot's open conversation. */
+async function waitForThreadCard(threadId: string, ms = 30_000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const { body } = await api("GET", `/api/threads/${threadId}/messages`);
+    const card = (body.messages ?? []).find(
+      (m: { kind: string; card?: { requestId?: string } }) => m.kind === "options" && m.card?.requestId,
+    );
+    if (card) return card;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+
+/** The detached task a webhook delivery created. */
+async function waitForRunThread(runId: string, ms = 20_000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const { body } = await api("GET", "/api/routines");
+    const run = (body.runs ?? []).find((r: { id: string }) => r.id === runId);
+    if (run?.threadId) return run.threadId as string;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+
+/** A bot whose fake engine asks permission to run `echo hi` (the ACP core
+ * folds that to tool "shell", summary "echo hi" — so the always-allow key
+ * is "shell:echo"). */
+async function makePermissionBot(patch: Record<string, unknown>) {
+  const created = await api("POST", "/api/bots");
+  expect(created.status).toBe(201);
+  const bot = created.body.bot;
+  const patched = await api("PATCH", `/api/bots/${bot.id}`, {
+    ...patch,
+    modelSelection: { instanceId: "grok", model: "fake-model" },
+  });
+  expect(patched.status).toBe(200);
+  return patched.body.bot ?? bot;
+}
+
+posixOnly("authorization decisions are logged", () => {
+  beforeAll(async () => {
+    chmodSync(FAKE_CLI, 0o755);
+    home = mkdtempSync(join(tmpdir(), "omb-decisions-e2e-"));
+    mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    writeFileSync(
+      join(home, ".openmausbot", "config.json"),
+      JSON.stringify({
+        instances: {
+          grok: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "permission" },
+            config: { cli: FAKE_CLI, fullAuto: false },
+          },
+        },
+      }),
+    );
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: {
+        ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+        HOME: home,
+        USERPROFILE: home,
+        OMB_PORT: String(PORT),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (c) => (stderr += c));
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        if ((await fetch(`${BASE}/api/health`)).ok) break;
+      } catch {
+        /* not up yet */
+      }
+      if (Date.now() > deadline) throw new Error(`server never came up. stderr:\n${stderr}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }, 40_000);
+
+  afterAll(async () => {
+    await waitForExit(child, { signal: "SIGTERM" });
+    await removeTempDir(home);
+  });
+
+  it(
+    "a rule-matched auto-approval writes a row naming the rule",
+    async () => {
+      const bot = await makePermissionBot({ name: "Granted", alwaysAllow: ["shell:echo"] });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "run it" })).status).toBe(202);
+
+      const row = await waitForDecision((r) => r.decision === "auto-approved" && r.botId === bot.id);
+      expect(row, "the auto-approval never reached the decision log").not.toBeNull();
+      expect(row!.source).toBe("always-allow");
+      expect(row!.rule).toBe("shell:echo");
+      expect(row!.tool).toBe("shell");
+      expect(row!.summary).toBe("echo hi");
+      expect(row!.botName).toBe("Granted");
+      expect(row!.threadId).toBeTruthy();
+      expect(row!.requestId).toBeTruthy();
+    },
+    60_000,
+  );
+
+  it(
+    "a card and the human's allow write two rows",
+    async () => {
+      const bot = await makePermissionBot({ name: "Askme" });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "run it" })).status).toBe(202);
+
+      const card = await waitForBotCard(bot.id);
+      expect(card, "no approval card ever appeared").not.toBeNull();
+      const requestId = card.card.requestId as string;
+
+      const shown = await waitForDecision((r) => r.decision === "card-shown" && r.requestId === requestId);
+      expect(shown, "the card was shown but never logged").not.toBeNull();
+      expect(shown!.source).toBe("no-grant");
+      expect(shown!.botId).toBe(bot.id);
+      expect(shown!.tool).toBe("shell");
+
+      const answered = await api("POST", `/api/bots/${bot.id}/respond`, { requestId, behavior: "allow" });
+      expect(answered.status).toBe(200);
+      expect(answered.body.outcome).not.toBe("unavailable");
+
+      const user = await waitForDecision((r) => r.decision === "user-approved" && r.requestId === requestId);
+      expect(user, "the human's answer never reached the decision log").not.toBeNull();
+      expect(user!.source).toBe("user");
+      expect(user!.tool).toBe("shell");
+      expect(user!.summary).toBe("echo hi");
+      expect(user!.botName).toBe("Askme");
+    },
+    90_000,
+  );
+
+  it(
+    "a human deny writes its row too",
+    async () => {
+      const bot = await makePermissionBot({ name: "Refused" });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "run it" })).status).toBe(202);
+
+      const card = await waitForBotCard(bot.id);
+      expect(card).not.toBeNull();
+      const requestId = card.card.requestId as string;
+      expect((await api("POST", `/api/bots/${bot.id}/respond`, { requestId, behavior: "deny" })).status).toBe(200);
+
+      const user = await waitForDecision((r) => r.decision === "user-denied" && r.requestId === requestId);
+      expect(user, "the denial never reached the decision log").not.toBeNull();
+      expect(user!.source).toBe("user");
+    },
+    90_000,
+  );
+
+  it(
+    "an unattended block writes the row that says a grant was withheld",
+    async () => {
+      // Auto mode on AND the exact key granted: an attended turn would sail
+      // straight through, so the only thing carding this one is the
+      // unattended block — which is precisely what the row must say.
+      const bot = await makePermissionBot({ name: "Nightshift", autoApprove: true, alwaysAllow: ["shell:echo"] });
+
+      const hook = await api("POST", "/api/webhooks", {
+        name: "Nightly build",
+        prompt: "Handle the incoming build event",
+        botId: bot.id,
+        runOn: "maus",
+      });
+      expect(hook.status).toBe(201);
+      const delivered = await fetch(hook.body.credential.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: "failed" }),
+      });
+      expect(delivered.status).toBe(202);
+      const { runId } = (await delivered.json()) as { runId: string };
+
+      const threadId = await waitForRunThread(runId);
+      expect(threadId, "the webhook never started a task").toBeTruthy();
+      const card = await waitForThreadCard(threadId!);
+      expect(card, "the webhook turn auto-approved instead of asking").not.toBeNull();
+
+      const row = await waitForDecision((r) => r.threadId === threadId && r.decision === "card-shown");
+      expect(row, "the unattended block never reached the decision log").not.toBeNull();
+      expect(row!.source).toBe("unattended-block");
+      expect(row!.rule).toBe("shell:echo");
+      expect(row!.unattended).toBe(true);
+      expect(row!.botId).toBe(bot.id);
+    },
+    90_000,
+  );
+
+  it("GET /api/decisions pages newest-last and validates limit", async () => {
+    const all = (await api("GET", "/api/decisions")).body.decisions as DecisionRow[];
+    expect(all.length).toBeGreaterThanOrEqual(2);
+    const one = (await api("GET", "/api/decisions?limit=1")).body.decisions as DecisionRow[];
+    expect(one).toHaveLength(1);
+    expect(one[0]).toEqual(all.at(-1));
+    expect((await api("GET", "/api/decisions?limit=0")).status).toBe(400);
+    expect((await api("GET", "/api/decisions?limit=nope")).status).toBe(400);
+  });
+});

--- a/server/decision-log.test.ts
+++ b/server/decision-log.test.ts
@@ -1,0 +1,97 @@
+// The decision log's own mechanics: what a row looks like on disk, that
+// credential-shaped content never reaches the file, that the file stays
+// private, and that rotation keeps the fleet-wide log bounded without
+// losing the recent past. The WIRING — which decisions get written at all
+// — is pinned separately in decision-log-wiring.test.ts.
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { appendDecision, readDecisions, type DecisionRow } from "./decision-log.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+let dir: string;
+const file = () => join(dir, "decisions.ndjson");
+
+const row = (overrides: Partial<DecisionRow> = {}): Omit<DecisionRow, "at"> => ({
+  threadId: "t1",
+  requestId: "req-1",
+  botId: "b1",
+  botName: "Scout",
+  tool: "Bash",
+  summary: "git status",
+  decision: "auto-approved",
+  source: "always-allow",
+  rule: "Bash:git",
+  ...overrides,
+});
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "omb-decisions-"));
+});
+
+afterEach(async () => {
+  await removeTempDir(dir);
+});
+
+describe("appendDecision / readDecisions", () => {
+  it("writes one NDJSON row per decision and reads them back newest last", () => {
+    appendDecision(dir, row());
+    appendDecision(dir, row({ requestId: "req-2", decision: "card-shown", source: "no-grant", rule: undefined }));
+    const rows = readDecisions(dir, 10);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].decision).toBe("auto-approved");
+    expect(rows[0].rule).toBe("Bash:git");
+    expect(rows[0].botName).toBe("Scout");
+    expect(Number.isNaN(new Date(rows[0].at).getTime())).toBe(false);
+    expect(rows[1].decision).toBe("card-shown");
+    expect(rows[1].source).toBe("no-grant");
+  });
+
+  it("returns only the newest `limit` rows", () => {
+    for (const id of ["req-1", "req-2", "req-3"]) appendDecision(dir, row({ requestId: id }));
+    const rows = readDecisions(dir, 2);
+    expect(rows.map((r) => r.requestId)).toEqual(["req-2", "req-3"]);
+  });
+
+  it("keeps credential-shaped content out of the written row", () => {
+    // Both shapes redact.ts guards against: a known key prefix, and a
+    // KEY=value pair with a secret-shaped name. The summary is whatever
+    // the agent typed — this is exactly how a key ends up in a log.
+    const secret = "sk-live-abcdefghijklmnop1234";
+    appendDecision(dir, row({ summary: `export STRIPE_API_KEY=${secret}` }));
+    const raw = readFileSync(file(), "utf8");
+    expect(raw).not.toContain(secret);
+    expect(raw).toContain("redacted");
+    expect(readDecisions(dir, 10)[0].summary).toContain("redacted");
+  });
+
+  it.skipIf(process.platform === "win32")("creates the file private (0600)", () => {
+    appendDecision(dir, row());
+    expect(statSync(file()).mode & 0o777).toBe(0o600);
+  });
+
+  it("rotates to a single .1 file at the cap, still reads across the seam, and stays bounded", () => {
+    // maxBytes 1: every append after the first finds the live file over
+    // the cap and rotates it — three appends walk a row off the end.
+    appendDecision(dir, row({ requestId: "req-A" }), { maxBytes: 1 });
+    appendDecision(dir, row({ requestId: "req-B" }), { maxBytes: 1 });
+    appendDecision(dir, row({ requestId: "req-C" }), { maxBytes: 1 });
+    expect(existsSync(`${file()}.1`)).toBe(true);
+    // req-A has aged out entirely — the log is bounded, not archival —
+    // while a read spanning the rotation still sees .1 before the live file
+    expect(readDecisions(dir, 10).map((r) => r.requestId)).toEqual(["req-B", "req-C"]);
+  });
+
+  it("skips a corrupt line instead of losing the rows around it", () => {
+    appendDecision(dir, row({ requestId: "req-1" }));
+    appendFileSync(file(), "not json at all\n");
+    appendDecision(dir, row({ requestId: "req-2" }));
+    expect(readDecisions(dir, 10).map((r) => r.requestId)).toEqual(["req-1", "req-2"]);
+  });
+
+  it("reads an empty log as an empty list, not an error", () => {
+    expect(readDecisions(dir, 10)).toEqual([]);
+  });
+});

--- a/server/decision-log.test.ts
+++ b/server/decision-log.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { appendDecision, readDecisions, type DecisionRow } from "./decision-log.ts";
+import { appendDecision, flushDecisionLog, readDecisions, type DecisionRow } from "./decision-log.ts";
 import { removeTempDir } from "./testing/cleanup.ts";
 
 let dir: string;
@@ -36,9 +36,10 @@ afterEach(async () => {
 });
 
 describe("appendDecision / readDecisions", () => {
-  it("writes one NDJSON row per decision and reads them back newest last", () => {
+  it("writes one NDJSON row per decision and reads them back newest last", async () => {
     appendDecision(dir, row());
     appendDecision(dir, row({ requestId: "req-2", decision: "card-shown", source: "no-grant", rule: undefined }));
+    await flushDecisionLog(dir);
     const rows = readDecisions(dir, 10);
     expect(rows).toHaveLength(2);
     expect(rows[0].decision).toBe("auto-approved");
@@ -49,49 +50,63 @@ describe("appendDecision / readDecisions", () => {
     expect(rows[1].source).toBe("no-grant");
   });
 
-  it("returns only the newest `limit` rows", () => {
+  it("returns only the newest `limit` rows", async () => {
     for (const id of ["req-1", "req-2", "req-3"]) appendDecision(dir, row({ requestId: id }));
+    await flushDecisionLog(dir);
     const rows = readDecisions(dir, 2);
     expect(rows.map((r) => r.requestId)).toEqual(["req-2", "req-3"]);
   });
 
-  it("keeps credential-shaped content out of the written row", () => {
+  it("keeps credential-shaped content out of the written row", async () => {
     // Both shapes redact.ts guards against: a known key prefix, and a
     // KEY=value pair with a secret-shaped name. The summary is whatever
     // the agent typed — this is exactly how a key ends up in a log.
     const secret = "sk-live-abcdefghijklmnop1234";
     appendDecision(dir, row({ summary: `export STRIPE_API_KEY=${secret}` }));
+    await flushDecisionLog(dir);
     const raw = readFileSync(file(), "utf8");
     expect(raw).not.toContain(secret);
     expect(raw).toContain("redacted");
     expect(readDecisions(dir, 10)[0].summary).toContain("redacted");
   });
 
-  it.skipIf(process.platform === "win32")("creates the file private (0600)", () => {
+  it.skipIf(process.platform === "win32")("creates the file private (0600)", async () => {
     appendDecision(dir, row());
+    await flushDecisionLog(dir);
     expect(statSync(file()).mode & 0o777).toBe(0o600);
   });
 
-  it("rotates to a single .1 file at the cap, still reads across the seam, and stays bounded", () => {
+  it("rotates to a single .1 file at the cap, still reads across the seam, and stays bounded", async () => {
     // maxBytes 1: every append after the first finds the live file over
     // the cap and rotates it — three appends walk a row off the end.
     appendDecision(dir, row({ requestId: "req-A" }), { maxBytes: 1 });
     appendDecision(dir, row({ requestId: "req-B" }), { maxBytes: 1 });
     appendDecision(dir, row({ requestId: "req-C" }), { maxBytes: 1 });
+    await flushDecisionLog(dir);
     expect(existsSync(`${file()}.1`)).toBe(true);
     // req-A has aged out entirely — the log is bounded, not archival —
     // while a read spanning the rotation still sees .1 before the live file
     expect(readDecisions(dir, 10).map((r) => r.requestId)).toEqual(["req-B", "req-C"]);
   });
 
-  it("skips a corrupt line instead of losing the rows around it", () => {
+  it("skips a corrupt line instead of losing the rows around it", async () => {
     appendDecision(dir, row({ requestId: "req-1" }));
+    await flushDecisionLog(dir);
     appendFileSync(file(), "not json at all\n");
     appendDecision(dir, row({ requestId: "req-2" }));
+    await flushDecisionLog(dir);
     expect(readDecisions(dir, 10).map((r) => r.requestId)).toEqual(["req-1", "req-2"]);
   });
 
   it("reads an empty log as an empty list, not an error", () => {
     expect(readDecisions(dir, 10)).toEqual([]);
+  });
+
+  it("serializes a burst without dropping or reordering rows", async () => {
+    for (let i = 0; i < 100; i += 1) appendDecision(dir, row({ requestId: `req-${i}` }));
+    await flushDecisionLog(dir);
+    expect(readDecisions(dir, 100).map((entry) => entry.requestId)).toEqual(
+      Array.from({ length: 100 }, (_, i) => `req-${i}`),
+    );
   });
 });

--- a/server/decision-log.ts
+++ b/server/decision-log.ts
@@ -19,7 +19,8 @@
 // the runtime bus (peer-approval.ts appends its cards straight to the
 // store), so wiring them here would mean a second, parallel tap — a
 // separate change if it earns its keep.
-import { appendFileSync, readFileSync, renameSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { appendFile, rename, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { AutoVerdictSource } from "./auto-approve.ts";
@@ -57,6 +58,22 @@ const FILE_NAME = "decisions.ndjson";
 // is years of human-scale approvals, and anything fancier — dated segments,
 // compression — is more machinery than an audit trail this size warrants.
 const MAX_BYTES = 4 * 1024 * 1024;
+const writeQueues = new Map<string, Promise<void>>();
+
+async function writeDecision(
+  dataDir: string,
+  row: Omit<DecisionRow, "at">,
+  maxBytes: number,
+): Promise<void> {
+  const file = join(dataDir, FILE_NAME);
+  try {
+    if ((await stat(file)).size >= maxBytes) await rename(file, `${file}.1`);
+  } catch {
+    /* no live file yet — nothing to rotate */
+  }
+  const record = redactSecrets({ at: new Date().toISOString(), ...row });
+  await appendFile(file, JSON.stringify(record) + "\n", { mode: 0o600 });
+}
 
 /** Append one decision row. Fire-and-forget, mirroring the event bus tee:
  * the fold that calls this is delivering approvals and cards, and a full
@@ -66,18 +83,25 @@ export function appendDecision(
   row: Omit<DecisionRow, "at">,
   opts?: { maxBytes?: number },
 ): void {
-  try {
-    const file = join(dataDir, FILE_NAME);
-    try {
-      if (statSync(file).size >= (opts?.maxBytes ?? MAX_BYTES)) renameSync(file, `${file}.1`);
-    } catch {
-      /* no live file yet — nothing to rotate */
-    }
-    const record = redactSecrets({ at: new Date().toISOString(), ...row });
-    appendFileSync(file, JSON.stringify(record) + "\n", { mode: 0o600 });
-  } catch {
-    /* logging must never take down the fold */
-  }
+  const previous = writeQueues.get(dataDir) ?? Promise.resolve();
+  // Serialize stat → optional rotate → append for each directory. Without
+  // this queue two simultaneous approvals can both rotate, overwrite .1,
+  // or append out of decision order.
+  const queued = previous
+    .then(() => writeDecision(dataDir, row, opts?.maxBytes ?? MAX_BYTES))
+    .catch(() => {
+      /* logging must never take down the fold */
+    });
+  writeQueues.set(dataDir, queued);
+  void queued.finally(() => {
+    if (writeQueues.get(dataDir) === queued) writeQueues.delete(dataDir);
+  });
+}
+
+/** Test/shutdown seam: wait until every decision already queued for this
+ * directory has reached disk. Normal request paths deliberately do not wait. */
+export async function flushDecisionLog(dataDir: string): Promise<void> {
+  await writeQueues.get(dataDir);
 }
 
 const isDecisionRow = (value: unknown): value is DecisionRow =>

--- a/server/decision-log.ts
+++ b/server/decision-log.ts
@@ -1,0 +1,117 @@
+// The authorization DECISION log: one fleet-wide, append-only NDJSON file
+// answering "which tool call was allowed, denied, or carded — by which
+// rule, when, for which bot".
+//
+// The per-thread event log (harness/bus.ts) cannot answer that. It records
+// that a request opened and later resolved, but the WHY — a grant waved it
+// through, a guard held it, an unattended block overrode a grant that
+// would otherwise have fired — exists only for a moment at the fold point
+// and is gone by the time the event is on disk. So the fold writes the
+// reason down here at the moment it is known, and the human-answer path
+// writes a second row when a card comes back.
+//
+// Same discipline as the event tee: 0600 (rows name tools and command
+// lines), through redactSecrets (summaries carry whatever the agent typed,
+// credentials included), and fire-and-forget — an audit log must never
+// take down the decision it is auditing.
+//
+// Deliberately NOT covered: ask_bot peer-approval cards. They never cross
+// the runtime bus (peer-approval.ts appends its cards straight to the
+// store), so wiring them here would mean a second, parallel tap — a
+// separate change if it earns its keep.
+import { appendFileSync, readFileSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { AutoVerdictSource } from "./auto-approve.ts";
+import { redactSecrets } from "./redact.ts";
+
+export type DecisionKind = "auto-approved" | "card-shown" | "user-approved" | "user-denied";
+
+/** Who or what produced the decision. The AutoVerdictSource values carry
+ * straight through from auto-approve.ts; `question` marks the cards a rule
+ * may never answer, `auto-fallback` a card shown because an auto-approval
+ * could not be delivered, and `user` the human's answer to a card. */
+export type DecisionSource = AutoVerdictSource | "question" | "auto-fallback" | "user";
+
+export interface DecisionRow {
+  at: string;
+  threadId: string;
+  requestId?: string;
+  botId?: string;
+  botName?: string;
+  tool?: string;
+  summary?: string;
+  decision: DecisionKind;
+  source: DecisionSource;
+  /** which rule decided: a guard's regex source, or the granted key */
+  rule?: string;
+  /** the turn ran with nobody at the keyboard when this was decided */
+  unattended?: boolean;
+}
+
+const FILE_NAME = "decisions.ndjson";
+
+// Rotation is logrotate at its simplest: when the live file crosses the cap
+// it becomes `.1` (clobbering the previous `.1`) and a fresh file starts.
+// Total disk is bounded at ~2× the cap; at a few hundred bytes per row that
+// is years of human-scale approvals, and anything fancier — dated segments,
+// compression — is more machinery than an audit trail this size warrants.
+const MAX_BYTES = 4 * 1024 * 1024;
+
+/** Append one decision row. Fire-and-forget, mirroring the event bus tee:
+ * the fold that calls this is delivering approvals and cards, and a full
+ * disk must not turn into denied tools. */
+export function appendDecision(
+  dataDir: string,
+  row: Omit<DecisionRow, "at">,
+  opts?: { maxBytes?: number },
+): void {
+  try {
+    const file = join(dataDir, FILE_NAME);
+    try {
+      if (statSync(file).size >= (opts?.maxBytes ?? MAX_BYTES)) renameSync(file, `${file}.1`);
+    } catch {
+      /* no live file yet — nothing to rotate */
+    }
+    const record = redactSecrets({ at: new Date().toISOString(), ...row });
+    appendFileSync(file, JSON.stringify(record) + "\n", { mode: 0o600 });
+  } catch {
+    /* logging must never take down the fold */
+  }
+}
+
+const isDecisionRow = (value: unknown): value is DecisionRow =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as DecisionRow).at === "string" &&
+  typeof (value as DecisionRow).threadId === "string" &&
+  typeof (value as DecisionRow).decision === "string" &&
+  typeof (value as DecisionRow).source === "string";
+
+/** The newest `limit` rows, oldest first — the same order the inspector
+ * uses for thread events. Reads `.1` before the live file so a request
+ * right after a rotation still sees history instead of a nearly empty
+ * log; whole-file reads are fine here because rotation caps both files,
+ * unlike the unbounded per-thread event logs that need a tail walk. */
+export function readDecisions(dataDir: string, limit: number): DecisionRow[] {
+  const file = join(dataDir, FILE_NAME);
+  const rows: DecisionRow[] = [];
+  for (const path of [`${file}.1`, file]) {
+    let text: string;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      if (!line) continue;
+      try {
+        const value: unknown = JSON.parse(line);
+        if (isDecisionRow(value)) rows.push(value);
+      } catch {
+        /* a line torn mid-write — skip the fragment, keep the rest */
+      }
+    }
+  }
+  return rows.slice(-limit);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,8 @@ import { extname, join } from "node:path";
 
 import { z } from "zod";
 
-import { approvalKey, autoDecision } from "./auto-approve.ts";
+import { approvalKey, autoVerdict } from "./auto-approve.ts";
+import { appendDecision, readDecisions } from "./decision-log.ts";
 import { validateBotCwd } from "./bot-cwd.ts";
 import { groupTurnCwd } from "./room-cwd.ts";
 import * as box from "./box.ts";
@@ -32,6 +33,7 @@ import {
   saveConfig,
   withInstanceCli,
   vpsSshAlias,
+  DATA_DIR,
   EVENTS_DIR,
   NATIVE_DIR,
 } from "./config.ts";
@@ -404,7 +406,14 @@ async function answerRequest(
   requestId: string,
   behavior: "allow" | "deny" | "answer",
   message?: string,
+  decidedFor?: { id: string; name: string },
 ): Promise<RequestOutcome> {
+  // Snapshot the card BEFORE delivering the answer: a delivered answer
+  // resolves the request synchronously through the fold, which consumes
+  // the askMessageByRequest entry — by the time the await returns, nobody
+  // remembers which tool this requestId was about.
+  const cardMessageId = askMessageByRequest.get(`${threadId}:${requestId}`);
+  const card = cardMessageId ? store.messagesFor(threadId).find((m) => m.id === cardMessageId)?.card : undefined;
   const instance = registry.get(instanceId);
   let outcome: RequestOutcome = "unavailable";
   if (instance) {
@@ -413,6 +422,23 @@ async function answerRequest(
     } catch {
       outcome = "unavailable";
     }
+  }
+  // The human's verdict, recorded only when it actually reached the engine:
+  // `unavailable` means the action never ran, and a "user-approved" row
+  // over a request nothing answered would be the audit log lying. A
+  // question's `answer` is conversation, not authorization, so it is not a
+  // decision either.
+  if (outcome !== "unavailable" && behavior !== "answer") {
+    appendDecision(DATA_DIR, {
+      threadId,
+      requestId,
+      botId: decidedFor?.id,
+      botName: decidedFor?.name,
+      tool: card?.tool,
+      summary: card?.subtitle,
+      decision: behavior === "allow" ? "user-approved" : "user-denied",
+      source: "user",
+    });
   }
   if (outcome === "unavailable") {
     // The in-flight map is memory-only. After a restart the card is still on
@@ -668,13 +694,12 @@ bus.subscribe((event: RuntimeEvent) => {
       // whole point of asking is that a person decides — and anything that
       // looks destructive stops even in auto mode.
       const asker = bot ?? (speaker ? store.bot(speaker.botId) : undefined);
-      const settled = permission && asker && event.requestId
-        ? autoDecision(asker, event.tool, event.summary, {
-            unattended: isUnattended(asker.id),
-            scope: event.approvalScope,
-          })
+      const unattended = permission && asker && event.requestId ? isUnattended(asker.id) : false;
+      const verdict = permission && asker && event.requestId
+        ? autoVerdict(asker, event.tool, event.summary, { unattended, scope: event.approvalScope })
         : null;
-      if (settled && asker && event.requestId) {
+      if (verdict?.approve && asker && event.requestId) {
+        const settled = verdict.approve;
         const instance = event.providerInstanceId
           ? registry.get(event.providerInstanceId)
           : registry.get(asker.modelSelection.instanceId);
@@ -693,6 +718,20 @@ bus.subscribe((event: RuntimeEvent) => {
               role: "bot",
               kind: "activity",
               tool: { name: `${settled}: ${summary.slice(0, 120)}`, ok: true },
+            });
+            // logged under the same discipline as the chip: only once the
+            // provider has actually taken the answer, so the audit log
+            // never claims an approval nothing received
+            appendDecision(DATA_DIR, {
+              threadId: event.threadId,
+              requestId,
+              botId: asker.id,
+              botName: asker.name,
+              tool,
+              summary,
+              decision: "auto-approved",
+              source: verdict.source,
+              rule: verdict.rule,
             });
           } catch {
             // couldn't answer it for them — hand it back to the human
@@ -717,6 +756,16 @@ bus.subscribe((event: RuntimeEvent) => {
               },
             });
             askMessageByRequest.set(`${event.threadId}:${requestId}`, card.id);
+            appendDecision(DATA_DIR, {
+              threadId: event.threadId,
+              requestId,
+              botId: asker.id,
+              botName: asker.name,
+              tool,
+              summary,
+              decision: "card-shown",
+              source: "auto-fallback",
+            });
           }
         })();
         break;
@@ -752,6 +801,23 @@ bus.subscribe((event: RuntimeEvent) => {
         },
       });
       if (event.requestId) askMessageByRequest.set(`${event.threadId}:${event.requestId}`, message.id);
+      // Every card that reaches a human is a decision too — "a rule sent
+      // this to you, and here is which one". `question` marks the cards no
+      // rule may ever answer; a permission card without a verdict (no known
+      // asker, or no requestId to answer through) can only mean nothing was
+      // granted.
+      appendDecision(DATA_DIR, {
+        threadId: event.threadId,
+        requestId: event.requestId,
+        botId: asker?.id,
+        botName: asker?.name,
+        tool: event.tool,
+        summary: event.summary,
+        decision: "card-shown",
+        source: !permission ? "question" : verdict ? verdict.source : "no-grant",
+        rule: verdict?.rule,
+        unattended: unattended || undefined,
+      });
       // Notify from HERE, not from a separate subscriber on request.opened:
       // this is the branch where a card actually reached a human. Anything
       // auto mode answered took the early return above and never buzzes.
@@ -3162,7 +3228,7 @@ const server = createServer(async (req, res) => {
       if (resolvePeerComms(approvalBus, String(body.requestId), behavior)) {
         return json(res, 200, { ok: true, outcome: behavior === "allow" ? "allowed-once" : "rejected" });
       }
-      const outcome = await answerRequest(bot.threadId, bot.modelSelection.instanceId, String(body.requestId), behavior, body.message);
+      const outcome = await answerRequest(bot.threadId, bot.modelSelection.instanceId, String(body.requestId), behavior, body.message, { id: bot.id, name: bot.name });
       return json(res, 200, { ok: true, outcome });
     }
     // Answer by THREAD, so a request raised inside a room can be answered
@@ -3193,7 +3259,7 @@ const server = createServer(async (req, res) => {
           (pending?.from ? store.bot(pending.from.botId) : undefined)
         : store.botByThread(threadId);
       if (!owner && !pending) return json(res, 404, { error: "nothing is waiting on an answer in this conversation" });
-      const outcome = await answerRequest(threadId, owner?.modelSelection.instanceId ?? "", requestId, behavior, body.message);
+      const outcome = await answerRequest(threadId, owner?.modelSelection.instanceId ?? "", requestId, behavior, body.message, owner ? { id: owner.id, name: owner.name } : undefined);
       return json(res, 200, { ok: true, outcome });
     }
     m = path.match(/^\/api\/bots\/([\w-]+)\/interrupt$/);
@@ -3331,6 +3397,19 @@ const server = createServer(async (req, res) => {
       }
       const limit = parsedLimit;
       return json(res, 200, readThreadEvents({ eventsDir: EVENTS_DIR, nativeDir: NATIVE_DIR, threadId, limit }));
+    }
+
+    // ── the fleet-wide authorization decision log ──
+    // Read-only like the inspector above: the rows were written at the
+    // request.opened fold and in answerRequest; this only reads them back,
+    // newest last, same order as thread events.
+    if (method === "GET" && path === "/api/decisions") {
+      const rawLimit = url.searchParams.get("limit");
+      const parsedLimit = rawLimit === null ? undefined : Number(rawLimit);
+      if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+        return json(res, 400, { error: "limit must be a positive whole number" });
+      }
+      return json(res, 200, { decisions: readDecisions(DATA_DIR, parsedLimit ?? 200) });
     }
 
     // ── provider instances (model picker) ──

--- a/server/index.ts
+++ b/server/index.ts
@@ -412,8 +412,14 @@ async function answerRequest(
   // resolves the request synchronously through the fold, which consumes
   // the askMessageByRequest entry — by the time the await returns, nobody
   // remembers which tool this requestId was about.
+  const thread = store.messagesFor(threadId);
   const cardMessageId = askMessageByRequest.get(`${threadId}:${requestId}`);
-  const card = cardMessageId ? store.messagesFor(threadId).find((m) => m.id === cardMessageId)?.card : undefined;
+  // The map is an in-flight optimization and disappears on restart; the
+  // durable transcript still carries the request id and its audit metadata.
+  const cardMessage = cardMessageId
+    ? thread.find((m) => m.id === cardMessageId)
+    : thread.find((m) => m.card?.requestId === requestId);
+  const card = cardMessage?.card;
   const instance = registry.get(instanceId);
   let outcome: RequestOutcome = "unavailable";
   if (instance) {
@@ -765,6 +771,7 @@ bus.subscribe((event: RuntimeEvent) => {
               summary,
               decision: "card-shown",
               source: "auto-fallback",
+              rule: verdict.rule,
             });
           }
         })();


### PR DESCRIPTION
## Why an event log is not a decision log

`~/.openmausbot/events/<threadId>.ndjson` records that a permission request opened and later resolved — but not **why**. Whether a grant waved a tool call through, which destructive/sensitive regex held it, or whether an unattended block withheld a grant that would otherwise have fired: that reason exists for one moment at the `request.opened` fold and was thrown away. The event log is also per-thread, so "what has auto mode been approving across the fleet this week" meant grepping every thread and re-guessing the rules.

This PR writes the reason down at the moment it is known: `~/.openmausbot/decisions.ndjson`, one NDJSON row per decision, fleet-wide, append-only, 0600, through `redactSecrets`, fire-and-forget like the event tee (an audit log must never take down the decision it is auditing).

## Row shape

```jsonc
{
  "at": "2026-08-20T06:05:48.123Z",
  "threadId": "…", "requestId": "…",
  "botId": "…", "botName": "Scout",
  "tool": "shell", "summary": "echo hi",
  "decision": "auto-approved" | "card-shown" | "user-approved" | "user-denied",
  "source":   "always-allow" | "auto-mode"            // approvals
            | "unattended-block" | "destructive-guard"
            | "sensitive-guard" | "no-grant"
            | "question" | "auto-fallback"            // cards
            | "user",                                  // human answers
  "rule": "shell:echo",        // matched guard regex, or the granted key
  "unattended": true           // present when nobody started the turn
}
```

- **Auto-approvals** log only after the provider takes the answer — same discipline as the transcript chip, so the log never claims an approval nothing received. If delivery fails and the card falls back to the human, that's `card-shown` / `auto-fallback`.
- **Every card** logs which rule sent it to a human. The most audit-worthy row is `unattended-block`: a grant that *would* have fired, withheld because no human started the turn.
- **The human's answer** logs a second row (`user-approved` / `user-denied`) from `answerRequest`, only when the answer actually reached the engine — an `unavailable` outcome means the action never ran, and logging it as approved would be the log lying. This is wired in the harness rather than off `request.resolved` because drivers stamp `source: "user"` on any `respondToRequest`, including the auto path.

Rule attribution comes from a new `autoVerdict()` in `auto-approve.ts` returning `{approve, source, rule}`; `autoDecision()` is now a thin wrapper over it and **no decision changes in this PR** — the existing auto-approve and unattended suites pass unchanged.

Rotation: a single `.1` sidecar at 4MB (bounded, not archival — comment in `decision-log.ts` states the choice). Read back with `GET /api/decisions?limit=200`, newest last, same ordering and limit validation as the thread-events inspector, behind the same loopback host/origin gate.

Out of scope, deliberately: ask_bot peer-approval cards never cross the runtime bus (`peer-approval.ts` appends its cards straight to the store), so covering them is a separate tap for a separate PR.

## Test plan

- `server/decision-log.test.ts` (unit): row shape and ordering, `limit`, credential redaction in the written row, 0600 mode, rotation across the seam with boundedness, corrupt-line tolerance, empty log.
- `server/decision-log-wiring.test.ts` (e2e, fake ACP CLI, style of `unattended.test.ts`): rule-matched auto-approval row naming `shell:echo`; card + human allow → two rows; human deny row; webhook-driven `unattended-block` row with the withheld grant; `GET /api/decisions` paging and limit validation.
- Mutation-checked each wiring point: dropping the card row, blanking the rule, skipping the user row, and mislabeling the unattended block each fail exactly the test written for them.
- `pnpm typecheck` clean; `pnpm test` fully green (1085 vitest tests across 114 files + broker + updater + packaged-server smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit log for authorization decisions, including automatic approvals, user approvals or denials, and blocked actions.
  * Added a read-only API endpoint for retrieving recent decisions with ordering and limit controls.
  * Approval results now include their source and, when applicable, the matching rule.
  * Added local-computer-scoped approvals and support for interrupting local-computer activity in bulk.
  * Sensitive information is redacted, while malformed log entries are safely ignored.

* **Bug Fixes**
  * Preserved guard-rule precedence over approval grants.
  * Improved handling of unattended blocked actions, approval outcomes, and stale approval requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->