### PR TITLE
Encrypt remaining workspace credentials at rest and narrow env injection per driver

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -103,12 +103,10 @@ async function secureComposioConfig() {
 }
 
 // The remaining workspace credentials (xai/box/voice/OpenCode Go keys) get
-// the same at-rest treatment as the Composio key above: on every packaged
-// boot, any plaintext value found in config.json moves into the encrypted
-// credentials.bin and the plaintext field is deleted. The server saves a
-// mid-session key change back into config.json, so this sweep is also how
-// an updated (or cleared — saved as "") key reaches the encrypted store on
-// the following launch. See workspace-credentials.mjs for the exact rules.
+// the same at-rest treatment as the Composio key above. New packaged-app
+// saves go straight through credential:set below; this boot-time sweep also
+// migrates plaintext left by older versions or direct development clients.
+// See workspace-credentials.mjs for the exact rules.
 async function secureWorkspaceConfig() {
   const dataDir = process.env.OMB_DATA_DIR || path.join(app.getPath("home"), ".openmausbot");
   const configPath = path.join(dataDir, "config.json");
@@ -604,30 +602,54 @@ ipcMain.handle("desktop:capabilities", async () =>
   }),
 );
 
+const CREDENTIAL_PATCH = {
+  composioApiKey: (value) => ({ composio: { apiKey: value } }),
+  xaiApiKey: (value) => ({ xai: { key: value } }),
+  boxToken: (value) => ({ box: { token: value } }),
+  opencodeGoApiKey: (value) => ({ opencodeGo: { apiKey: value } }),
+  ttsKey: (value) => ({ tts: { key: value } }),
+};
+
 ipcMain.handle("credential:set", async (_event, name, value) => {
-  if (name !== "composioApiKey" || typeof value !== "string") {
+  const patchFor = CREDENTIAL_PATCH[name];
+  if (!patchFor || typeof value !== "string") {
     throw new Error("Unsupported credential");
   }
   if (app.isPackaged && !(await safeStorage.isAsyncEncryptionAvailable())) {
     throw new Error("The operating-system credential store is unavailable");
   }
-  // In development the server is a separately launched process, so it cannot
-  // receive credentials from Electron at boot. Keep its established local
-  // config path there; production always uses the encrypted external store.
-  const secretStorage = app.isPackaged ? "?secretStorage=external" : "";
-  const response = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config${secretStorage}`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ composio: { apiKey: value.trim() } }),
-  });
-  const body = await response.json().catch(() => null);
-  if (!response.ok) throw new Error(body?.error || `Could not save credential (HTTP ${response.status})`);
+  const secret = value.trim();
+  const previousCredentials = secureCredentials;
   if (app.isPackaged) {
-    if (value.trim()) secureCredentials.composioApiKey = value.trim();
-    else delete secureCredentials.composioApiKey;
-    await saveSecureCredentials(secureCredentials);
+    const nextCredentials = { ...secureCredentials };
+    if (secret) nextCredentials[name] = secret;
+    else delete nextCredentials[name];
+    // Commit the encrypted value before the server makes it live. If
+    // validation or reload fails below, restore the previous store so the
+    // next launch cannot disagree with the response the user saw.
+    await saveSecureCredentials(nextCredentials);
+    secureCredentials = nextCredentials;
   }
-  return body;
+  try {
+    // In development the server is a separately launched process, so it
+    // cannot receive credentials from Electron at boot. Keep its established
+    // local config path there; production always uses the encrypted store.
+    const secretStorage = app.isPackaged ? "?secretStorage=external" : "";
+    const response = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config${secretStorage}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(patchFor(secret)),
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) throw new Error(body?.error || `Could not save credential (HTTP ${response.status})`);
+    return body;
+  } catch (error) {
+    if (app.isPackaged) {
+      await saveSecureCredentials(previousCredentials);
+      secureCredentials = previousCredentials;
+    }
+    throw error;
+  }
 });
 
 async function broadcastDesktopCapabilities() {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,6 +8,7 @@ import { createAndroidDeviceController } from "./android-device.mjs";
 import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
+import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
@@ -95,6 +96,33 @@ async function secureComposioConfig() {
     if (!changed) return;
     const temporary = `${configPath}.${process.pid}.tmp`;
     fs.writeFileSync(temporary, JSON.stringify(config, null, 2), { mode: 0o600 });
+    fs.renameSync(temporary, configPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") slog(`credential migration failed: ${error?.message ?? error}`);
+  }
+}
+
+// The remaining workspace credentials (xai/box/voice/OpenCode Go keys) get
+// the same at-rest treatment as the Composio key above: on every packaged
+// boot, any plaintext value found in config.json moves into the encrypted
+// credentials.bin and the plaintext field is deleted. The server saves a
+// mid-session key change back into config.json, so this sweep is also how
+// an updated (or cleared — saved as "") key reaches the encrypted store on
+// the following launch. See workspace-credentials.mjs for the exact rules.
+async function secureWorkspaceConfig() {
+  const dataDir = process.env.OMB_DATA_DIR || path.join(app.getPath("home"), ".openmausbot");
+  const configPath = path.join(dataDir, "config.json");
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const migrated = migrateWorkspaceCredentials(config, secureCredentials);
+    // credentials.bin first: if the OS store cannot take the secrets, the
+    // plaintext stays put and the next boot retries — losing the only copy
+    // is the one unacceptable outcome
+    if (migrated.credentialsChanged) await saveSecureCredentials(migrated.credentials);
+    secureCredentials = migrated.credentials;
+    if (!migrated.configChanged) return;
+    const temporary = `${configPath}.${process.pid}.tmp`;
+    fs.writeFileSync(temporary, JSON.stringify(migrated.config, null, 2), { mode: 0o600 });
     fs.renameSync(temporary, configPath);
   } catch (error) {
     if (error?.code !== "ENOENT") slog(`credential migration failed: ${error?.message ?? error}`);
@@ -193,6 +221,10 @@ async function startServerOn(port) {
       ...(secureCredentials.composioApiKey
         ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
         : {}),
+      // one env var per stored workspace secret (xai/box/voice/OpenCode Go);
+      // the server prefers these over config.json, whose plaintext fields
+      // the boot migration has deleted
+      ...workspaceCredentialEnv(secureCredentials),
       ...(composioBrokerUrl() && secureCredentials.composioBrokerToken
         ? {
             OMB_COMPOSIO_BROKER_URL: composioBrokerUrl(),
@@ -622,6 +654,7 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     secureCredentials = await loadSecureCredentials();
     await secureComposioConfig();
+    await secureWorkspaceConfig();
     await ensureManagedComposioCredentials();
   }
   // Display capture remains user-initiated. The renderer first sends a

--- a/electron/workspace-credentials.mjs
+++ b/electron/workspace-credentials.mjs
@@ -1,0 +1,69 @@
+// Workspace credentials the desktop shell keeps OS-encrypted (credentials.bin
+// via safeStorage) instead of leaving in plaintext config.json — the same
+// treatment the Composio project key already gets in main.mjs. Pure functions:
+// main.mjs owns the fs and safeStorage plumbing, so the migration decisions
+// stay testable without an Electron runtime.
+//
+// One row per secret: the config.json home it migrates OUT of, the
+// credentials.bin field it lives in, and the env var the spawned server
+// prefers over the file (server/config.ts loadConfig).
+export const WORKSPACE_CREDENTIALS = [
+  { section: "xai", field: "key", name: "xaiApiKey", env: "XAI_API_KEY" },
+  { section: "box", field: "token", name: "boxToken", env: "BOX_TOKEN" },
+  { section: "tts", field: "key", name: "ttsKey", env: "OMB_TTS_KEY" },
+  { section: "opencodeGo", field: "apiKey", name: "opencodeGoApiKey", env: "OPENCODE_API_KEY" },
+];
+
+/** One boot-time sweep of config.json: move every plaintext workspace secret
+ * into the encrypted store and DELETE the plaintext field.
+ *
+ * Deleting (never blanking) keeps "" meaningful. The server persists a
+ * credential save by writing the field — a mid-session save lands as the new
+ * value, a mid-session clear lands as "". So on the next boot:
+ *   - non-empty value  → newest user intent: overwrite the stored secret
+ *   - ""               → the user cleared it: drop the stored secret too
+ *   - field absent     → already migrated: keep what the store holds
+ * Running twice is a no-op, and nothing is lost if a boot dies between the
+ * two writes — the caller persists credentials BEFORE rewriting config, so
+ * the worst case re-runs the same overwrite.
+ *
+ * Inputs are treated as immutable; the changed flags tell the caller which
+ * file(s) actually need rewriting. Non-string junk in a field is left for
+ * the server's schema to reject rather than silently destroyed here. */
+export function migrateWorkspaceCredentials(config, credentials) {
+  const nextConfig = structuredClone(config ?? {});
+  const nextCredentials = { ...credentials };
+  let configChanged = false;
+  let credentialsChanged = false;
+  for (const { section, field, name } of WORKSPACE_CREDENTIALS) {
+    const home = nextConfig?.[section];
+    if (!home || typeof home !== "object" || Array.isArray(home)) continue;
+    if (!Object.hasOwn(home, field)) continue;
+    const value = home[field];
+    if (typeof value !== "string") continue;
+    const secret = value.trim();
+    if (secret) {
+      if (nextCredentials[name] !== secret) {
+        nextCredentials[name] = secret;
+        credentialsChanged = true;
+      }
+    } else if (Object.hasOwn(nextCredentials, name)) {
+      delete nextCredentials[name];
+      credentialsChanged = true;
+    }
+    delete home[field];
+    configChanged = true;
+  }
+  return { config: nextConfig, credentials: nextCredentials, configChanged, credentialsChanged };
+}
+
+/** Env for the spawned server: one var per stored secret, nothing else.
+ * The server treats each var as authoritative over its config.json field. */
+export function workspaceCredentialEnv(credentials) {
+  const env = {};
+  for (const { name, env: envName } of WORKSPACE_CREDENTIALS) {
+    const value = credentials?.[name];
+    if (typeof value === "string" && value) env[envName] = value;
+  }
+  return env;
+}

--- a/electron/workspace-credentials.test.mjs
+++ b/electron/workspace-credentials.test.mjs
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  migrateWorkspaceCredentials,
+  workspaceCredentialEnv,
+  WORKSPACE_CREDENTIALS,
+} from "./workspace-credentials.mjs";
+
+describe("workspace credential migration", () => {
+  it("moves every plaintext secret into the store and deletes the field", () => {
+    const config = {
+      xai: { key: "xai-secret", url: "https://api.example.test/v1" },
+      box: { token: "box-secret" },
+      tts: { key: "tts-secret", voice: "narrator" },
+      opencodeGo: { apiKey: "ocg-secret" },
+      profile: { name: "Ada" },
+    };
+    const result = migrateWorkspaceCredentials(config, {});
+    expect(result.configChanged).toBe(true);
+    expect(result.credentialsChanged).toBe(true);
+    expect(result.credentials).toEqual({
+      xaiApiKey: "xai-secret",
+      boxToken: "box-secret",
+      ttsKey: "tts-secret",
+      opencodeGoApiKey: "ocg-secret",
+    });
+    // secrets are DELETED (not blanked) so "" stays meaningful as "cleared";
+    // non-secret siblings (endpoint url, chosen voice) stay in the file
+    expect(result.config).toEqual({
+      xai: { url: "https://api.example.test/v1" },
+      box: {},
+      tts: { voice: "narrator" },
+      opencodeGo: {},
+      profile: { name: "Ada" },
+    });
+    // inputs are never mutated — main.mjs decides which files to rewrite
+    expect(config.xai.key).toBe("xai-secret");
+  });
+
+  it("is idempotent: a second boot over migrated output changes nothing", () => {
+    const first = migrateWorkspaceCredentials(
+      { xai: { key: "xai-secret" }, tts: { key: "tts-secret", voice: "narrator" } },
+      {},
+    );
+    const second = migrateWorkspaceCredentials(first.config, first.credentials);
+    expect(second.configChanged).toBe(false);
+    expect(second.credentialsChanged).toBe(false);
+    expect(second.credentials).toEqual(first.credentials);
+    expect(second.config).toEqual(first.config);
+  });
+
+  it("treats a saved non-empty value as newest intent and overwrites the store", () => {
+    // mid-session key change: the server persisted the new key to config.json;
+    // the stale stored secret must not win at the next boot
+    const result = migrateWorkspaceCredentials(
+      { box: { token: "box-NEW" } },
+      { boxToken: "box-OLD", xaiApiKey: "xai-keep" },
+    );
+    expect(result.credentials).toEqual({ boxToken: "box-NEW", xaiApiKey: "xai-keep" });
+    expect(result.config.box).toEqual({});
+  });
+
+  it("treats an empty saved value as a clear and drops the stored secret", () => {
+    const result = migrateWorkspaceCredentials(
+      { xai: { key: "" }, tts: { key: "   " } },
+      { xaiApiKey: "xai-OLD", ttsKey: "tts-OLD", boxToken: "box-keep" },
+    );
+    expect(result.credentialsChanged).toBe(true);
+    expect(result.credentials).toEqual({ boxToken: "box-keep" });
+    // the tombstone field itself is swept away too
+    expect(result.config).toEqual({ xai: {}, tts: {} });
+  });
+
+  it("keeps stored secrets when the field is absent (already migrated)", () => {
+    const stored = { xaiApiKey: "xai-keep", boxToken: "box-keep" };
+    const result = migrateWorkspaceCredentials({ profile: { name: "Ada" } }, stored);
+    expect(result.configChanged).toBe(false);
+    expect(result.credentialsChanged).toBe(false);
+    expect(result.credentials).toEqual(stored);
+  });
+
+  it("leaves non-string junk for the server's schema instead of destroying it", () => {
+    const result = migrateWorkspaceCredentials({ xai: { key: 42 }, box: "not-an-object" }, {});
+    expect(result.configChanged).toBe(false);
+    expect(result.credentialsChanged).toBe(false);
+    expect(result.config.xai.key).toBe(42);
+  });
+});
+
+describe("workspace credential env", () => {
+  it("maps each stored secret to exactly its server env var", () => {
+    expect(
+      workspaceCredentialEnv({
+        xaiApiKey: "xai-secret",
+        boxToken: "box-secret",
+        ttsKey: "tts-secret",
+        opencodeGoApiKey: "ocg-secret",
+        composioApiKey: "ak_handled-separately",
+      }),
+    ).toEqual({
+      XAI_API_KEY: "xai-secret",
+      BOX_TOKEN: "box-secret",
+      OMB_TTS_KEY: "tts-secret",
+      OPENCODE_API_KEY: "ocg-secret",
+    });
+  });
+
+  it("emits nothing for absent or empty secrets", () => {
+    expect(workspaceCredentialEnv({})).toEqual({});
+    expect(workspaceCredentialEnv({ xaiApiKey: "" })).toEqual({});
+    expect(workspaceCredentialEnv(undefined)).toEqual({});
+  });
+
+  it("covers every credential the migration table declares", () => {
+    const credentials = Object.fromEntries(WORKSPACE_CREDENTIALS.map((c) => [c.name, `v-${c.name}`]));
+    const env = workspaceCredentialEnv(credentials);
+    expect(Object.keys(env).sort()).toEqual(WORKSPACE_CREDENTIALS.map((c) => c.env).sort());
+  });
+});

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -251,10 +251,17 @@ describe("credential env preference", () => {
   it("syncCredentialEnv keeps process.env in step with a credential save", () => {
     process.env.XAI_API_KEY = "boot-injected";
     process.env.BOX_TOKEN = "boot-injected";
-    syncCredentialEnv({ xai: { key: "just-saved" }, box: { token: "" }, profile: { name: "Ada" } });
+    process.env.COMPOSIO_API_KEY = "boot-injected";
+    syncCredentialEnv({
+      xai: { key: "just-saved" },
+      composio: { apiKey: "ak_just_saved" },
+      box: { token: "" },
+      profile: { name: "Ada" },
+    });
     // a saved value replaces the boot-time one; a cleared value drops it;
     // untouched sections change nothing
     expect(process.env.XAI_API_KEY).toBe("just-saved");
+    expect(process.env.COMPOSIO_API_KEY).toBe("ak_just_saved");
     expect(process.env.BOX_TOKEN).toBeUndefined();
     expect(process.env.OMB_TTS_KEY).toBeUndefined();
   });

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,12 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  DATA_DIR,
   instanceConfigs,
   isValidSshAlias,
+  loadConfig,
   parseConfigPatch,
   parseStoredConfig,
+  stripWorkspaceCredentialEnv,
+  syncCredentialEnv,
   vpsSshAlias,
   withInstanceCli,
+  WORKSPACE_CREDENTIAL_ENV,
   type AppConfig,
 } from "./config.ts";
 
@@ -94,13 +102,20 @@ describe("Instance CLI override", () => {
   });
 
   it("never persists the credential env instanceConfigs injects", () => {
-    // instanceConfigs() copies xai/box/opencodeGo keys into every entry's
-    // environment for the live fleet; withInstanceCli must strip them back
-    // out, or saving a CLI override would copy secrets into the instances
-    // section of config.json.
+    // instanceConfigs() copies each credential into its consuming driver's
+    // environment for the live fleet; withInstanceCli must strip those pairs
+    // back out, or saving a CLI override would copy secrets into the
+    // instances section of config.json.
     const cfg: AppConfig = {
       xai: { key: "SECRET-XAI" },
       box: { token: "SECRET-BOX" },
+      opencodeGo: { apiKey: "SECRET-OCG" },
+      instances: {
+        claude: { driver: "claudeAgent" },
+        grokApi: { driver: "grok" },
+        computer: { driver: "boxAgent" },
+        opencode: { driver: "opencodeGo" },
+      },
     };
     const set = withInstanceCli(cfg, "claude", "/opt/claude");
     expect(set.ok).toBe(true);
@@ -127,5 +142,139 @@ describe("OpenCode Go configuration", () => {
     const instances = instanceConfigs(cfg);
     expect(instances.opencode.environment).toEqual({ OPENCODE_API_KEY: "secret-value" });
     expect(instances.grok.environment).toEqual({});
+  });
+});
+
+describe("credential env narrowing", () => {
+  it("injects each credential only into the driver that consumes it", () => {
+    const cfg: AppConfig = {
+      xai: { key: "SECRET-XAI" },
+      box: { token: "SECRET-BOX" },
+      opencodeGo: { apiKey: "SECRET-OCG" },
+      instances: {
+        grokApi: { driver: "grok" },
+        computer: { driver: "boxAgent" },
+        opencode: { driver: "opencodeGo" },
+        claude: { driver: "claudeAgent" },
+        codex: { driver: "codex" },
+      },
+    };
+    const instances = instanceConfigs(cfg);
+    expect(instances.grokApi.environment).toEqual({ XAI_API_KEY: "SECRET-XAI" });
+    expect(instances.computer.environment).toEqual({ BOX_TOKEN: "SECRET-BOX" });
+    expect(instances.opencode.environment).toEqual({ OPENCODE_API_KEY: "SECRET-OCG" });
+    // engines that bring their own login receive NO workspace credential
+    expect(instances.claude.environment).toEqual({});
+    expect(instances.codex.environment).toEqual({});
+  });
+
+  it("hands no credential to any default-fleet CLI engine except the Computer", () => {
+    // the default `grok` instance is the CLI-login grokAgent, not the
+    // API-key driver, so a configured xai key reaches nobody by default
+    const cfg: AppConfig = { xai: { key: "SECRET-XAI" }, box: { token: "SECRET-BOX" } };
+    const instances = instanceConfigs(cfg);
+    for (const [id, entry] of Object.entries(instances)) {
+      if (id === "computer") expect(entry.environment).toEqual({ BOX_TOKEN: "SECRET-BOX" });
+      else expect(entry.environment).toEqual({});
+    }
+  });
+
+  it("keeps a per-instance environment while layering the credential on top", () => {
+    const cfg: AppConfig = {
+      box: { token: "SECRET-BOX" },
+      instances: { computer: { driver: "boxAgent", environment: { MY_FLAG: "1" } } },
+    };
+    expect(instanceConfigs(cfg).computer.environment).toEqual({ MY_FLAG: "1", BOX_TOKEN: "SECRET-BOX" });
+  });
+});
+
+describe("credential env preference", () => {
+  const VARS = ["XAI_API_KEY", "BOX_TOKEN", "OPENCODE_API_KEY", "OMB_TTS_KEY", "COMPOSIO_API_KEY"] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(VARS.map((name) => [name, process.env[name]]));
+    for (const name of VARS) delete process.env[name];
+    mkdirSync(DATA_DIR, { recursive: true });
+    rmSync(join(DATA_DIR, "config.json"), { force: true });
+  });
+  afterEach(() => {
+    for (const name of VARS) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+    rmSync(join(DATA_DIR, "config.json"), { force: true });
+  });
+
+  it("prefers env over the config file for every credential", () => {
+    // the desktop shell hands secrets to this process as env (from its
+    // OS-encrypted store) and leaves the file without them — env must win
+    // even over a leftover plaintext value
+    writeFileSync(
+      join(DATA_DIR, "config.json"),
+      JSON.stringify({
+        xai: { key: "file-xai", url: "https://api.example.test/v1" },
+        box: { token: "file-box" },
+        opencodeGo: { apiKey: "file-ocg" },
+        tts: { key: "file-tts", voice: "narrator" },
+      }),
+    );
+    process.env.XAI_API_KEY = "env-xai";
+    process.env.BOX_TOKEN = "env-box";
+    process.env.OPENCODE_API_KEY = "env-ocg";
+    process.env.OMB_TTS_KEY = "env-tts";
+    const cfg = loadConfig();
+    expect(cfg.xai).toEqual({ key: "env-xai", url: "https://api.example.test/v1" });
+    expect(cfg.box).toEqual({ token: "env-box" });
+    expect(cfg.opencodeGo).toEqual({ apiKey: "env-ocg" });
+    expect(cfg.tts).toEqual({ key: "env-tts", voice: "narrator" });
+  });
+
+  it("falls back to the config file when the env var is unset (dev mode)", () => {
+    writeFileSync(
+      join(DATA_DIR, "config.json"),
+      JSON.stringify({ xai: { key: "file-xai" }, tts: { key: "file-tts" } }),
+    );
+    const cfg = loadConfig();
+    expect(cfg.xai?.key).toBe("file-xai");
+    expect(cfg.tts?.key).toBe("file-tts");
+  });
+
+  it("treats a blanked file field as absent when env supplies the secret", () => {
+    // after migration the desktop shell may leave "" behind (a cleared key
+    // that was saved mid-session); the env-injected value must still win
+    writeFileSync(join(DATA_DIR, "config.json"), JSON.stringify({ xai: { key: "" } }));
+    process.env.XAI_API_KEY = "env-xai";
+    expect(loadConfig().xai?.key).toBe("env-xai");
+  });
+
+  it("syncCredentialEnv keeps process.env in step with a credential save", () => {
+    process.env.XAI_API_KEY = "boot-injected";
+    process.env.BOX_TOKEN = "boot-injected";
+    syncCredentialEnv({ xai: { key: "just-saved" }, box: { token: "" }, profile: { name: "Ada" } });
+    // a saved value replaces the boot-time one; a cleared value drops it;
+    // untouched sections change nothing
+    expect(process.env.XAI_API_KEY).toBe("just-saved");
+    expect(process.env.BOX_TOKEN).toBeUndefined();
+    expect(process.env.OMB_TTS_KEY).toBeUndefined();
+  });
+});
+
+describe("workspace credential env strip", () => {
+  it("removes every workspace credential from a child env in place", () => {
+    const env = {
+      PATH: "/usr/bin",
+      MY_FLAG: "1",
+      ...Object.fromEntries(WORKSPACE_CREDENTIAL_ENV.map((name) => [name, "secret"])),
+    };
+    stripWorkspaceCredentialEnv(env);
+    expect(env).toEqual({ PATH: "/usr/bin", MY_FLAG: "1" });
+  });
+
+  it("covers the box token and voice key, which no engine CLI may inherit", () => {
+    // these two have no per-driver ACP allowlist entry anywhere — they are
+    // consumed in-process (Computer driver / voice module), never by a CLI
+    expect(WORKSPACE_CREDENTIAL_ENV).toContain("BOX_TOKEN");
+    expect(WORKSPACE_CREDENTIAL_ENV).toContain("OMB_TTS_KEY");
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -120,13 +120,64 @@ export function loadConfig(): AppConfig {
   } catch {
     /* first run — env fallbacks below */
   }
-  cfg.xai = { key: process.env.XAI_API_KEY, ...cfg.xai };
+  // Env wins over the file for every credential. The desktop shell keeps
+  // these secrets OS-encrypted and hands them to this process as env at
+  // spawn, leaving config.json without the plaintext field — so the file
+  // value is the dev-mode (no desktop shell) fallback, not the primary.
+  // Anything that saves a credential mid-session must keep process.env in
+  // step (syncCredentialEnv below), or the value injected at boot would
+  // shadow the save until the next launch.
+  cfg.xai = { ...cfg.xai };
+  if (process.env.XAI_API_KEY !== undefined) cfg.xai.key = process.env.XAI_API_KEY;
   cfg.composio = { ...cfg.composio };
   if (process.env.COMPOSIO_API_KEY !== undefined) cfg.composio.apiKey = process.env.COMPOSIO_API_KEY;
-  cfg.box = { token: process.env.BOX_TOKEN, ...cfg.box };
-  cfg.opencodeGo = { apiKey: process.env.OPENCODE_API_KEY, ...cfg.opencodeGo };
-  cfg.tts = { key: process.env.OMB_TTS_KEY, ...cfg.tts };
+  cfg.box = { ...cfg.box };
+  if (process.env.BOX_TOKEN !== undefined) cfg.box.token = process.env.BOX_TOKEN;
+  cfg.opencodeGo = { ...cfg.opencodeGo };
+  if (process.env.OPENCODE_API_KEY !== undefined) cfg.opencodeGo.apiKey = process.env.OPENCODE_API_KEY;
+  cfg.tts = { ...cfg.tts };
+  if (process.env.OMB_TTS_KEY !== undefined) cfg.tts.key = process.env.OMB_TTS_KEY;
   return cfg;
+}
+
+/** After saveConfig() writes a credential, the running process's env must
+ * follow the newest value — loadConfig() prefers env, so the secret injected
+ * at boot would otherwise shadow the save until relaunch: the UI would show
+ * "saved" while every turn still used the old key. An empty string means the
+ * user cleared the credential, so the var is dropped and the (now empty)
+ * file value is authoritative again. Fields absent from the patch are
+ * untouched. */
+export function syncCredentialEnv(patch: Partial<AppConfig>): void {
+  const secrets: Array<[value: string | undefined, name: string]> = [
+    [patch.xai?.key, "XAI_API_KEY"],
+    [patch.box?.token, "BOX_TOKEN"],
+    [patch.opencodeGo?.apiKey, "OPENCODE_API_KEY"],
+    [patch.tts?.key, "OMB_TTS_KEY"],
+  ];
+  for (const [value, name] of secrets) {
+    if (value === undefined) continue;
+    if (value) process.env[name] = value;
+    else delete process.env[name];
+  }
+}
+
+/** Env names of every workspace credential this process may be holding —
+ * injected at boot by the desktop shell or exported by a developer. Spawned
+ * engine CLIs must never inherit them: the one driver that consumes a given
+ * secret receives it through instanceConfigs() narrowing, and to every other
+ * child these are someone else's keys riding along in `...process.env`. */
+export const WORKSPACE_CREDENTIAL_ENV = [
+  "XAI_API_KEY",
+  "BOX_TOKEN",
+  "OPENCODE_API_KEY",
+  "OMB_TTS_KEY",
+  "COMPOSIO_API_KEY",
+  "OMB_COMPOSIO_BROKER_TOKEN",
+] as const;
+
+/** Drop every workspace credential from a child-process env (in place). */
+export function stripWorkspaceCredentialEnv(env: Record<string, string | undefined>): void {
+  for (const key of WORKSPACE_CREDENTIAL_ENV) delete env[key];
 }
 
 /** Merge a partial config into ~/.openmausbot/config.json (secrets never
@@ -169,17 +220,17 @@ export function saveConfig(patch: Partial<AppConfig>): void {
  * driver default). Creating the instance entry is fine — a config-less
  * entry rides driver.defaultConfig(). Returns false for unknown instances
  * when the fleet is explicitly configured. The returned map must stay
- * PERSISTABLE: instanceConfigs() injects credential env into every entry
- * for the live fleet, so those injected keys are stripped back out before
- * the map is returned — otherwise saving an override would copy xai/box/
- * opencodeGo secrets into the instances section of config.json. */
+ * PERSISTABLE: instanceConfigs() injects credential env into consuming
+ * drivers' entries for the live fleet, so those injected keys are stripped
+ * back out before the map is returned — otherwise saving an override would
+ * copy xai/box/opencodeGo secrets into the instances section of
+ * config.json. */
 export function withInstanceCli(
   cfg: AppConfig,
   instanceId: string,
   cli: string,
 ): InstanceCliUpdate {
   const next: AppConfig = structuredClone(cfg);
-  const injected = injectedEnvironment(next);
   const map = instanceConfigs(next);
   // hasOwn, not truthiness: map is a plain object literal, so
   // map["__proto__"] resolves to Object.prototype — truthy — and the
@@ -200,6 +251,7 @@ export function withInstanceCli(
   }
   for (const e of Object.values(map)) {
     if (!e.environment) continue;
+    const injected = injectedEnvironment(next, e.driver);
     for (const [k, v] of Object.entries(e.environment)) {
       if (injected.get(k) === v) delete e.environment[k];
     }
@@ -214,19 +266,26 @@ interface InstanceCliUpdate {
   config: AppConfig;
 }
 
-/** The credential env instanceConfigs() injects — same keys, same rule. */
-function injectedEnvironment(cfg: AppConfig): Map<string, string> {
+/** The credential env instanceConfigs() injects for one driver — shared with
+ * withInstanceCli() so the inject rule and the strip rule cannot drift apart.
+ * Each secret goes only to the driver that actually reads it: the API-key
+ * Grok driver reads XAI_API_KEY, the Computer driver reads BOX_TOKEN, and
+ * OpenCode Go reads OPENCODE_API_KEY. Every other engine brings its own
+ * login, so handing it a key it never uses would only put that key in the
+ * environment of an unrelated child process. */
+function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string> {
   const environment = new Map<string, string>();
-  if (cfg.xai?.key) environment.set("XAI_API_KEY", cfg.xai.key);
-  if (cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
-  if (cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
+  if (driver === "grok" && cfg.xai?.key) environment.set("XAI_API_KEY", cfg.xai.key);
+  if (driver === "boxAgent" && cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
+  if (driver === "opencodeGo" && cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
   return environment;
 }
 
 // Default fleet: one instance per built-in driver (upstream
 // defaultInstanceIdForDriver — instanceId defaults to the driver kind).
 // Config-file keys are injected as per-instance environment so drivers
-// see them without needing real process env vars.
+// see them without needing real process env vars — but only into the
+// driver that consumes each key (injectedEnvironment above).
 export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   // The default `grok` instance rides the `grokAgent` driver, not the API-key
   // one: like claude and codex it needs no credential from us, just the CLI
@@ -271,11 +330,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   }
   for (const entry of Object.values(map)) {
     const environment = { ...entry.environment };
-    if (cfg.xai?.key) environment.XAI_API_KEY = cfg.xai.key;
-    if (cfg.box?.token) environment.BOX_TOKEN = cfg.box.token;
-    if (entry.driver === "opencodeGo" && cfg.opencodeGo?.apiKey) {
-      environment.OPENCODE_API_KEY = cfg.opencodeGo.apiKey;
-    }
+    for (const [key, value] of injectedEnvironment(cfg, entry.driver)) environment[key] = value;
     entry.environment = environment;
   }
   return map;

--- a/server/config.ts
+++ b/server/config.ts
@@ -150,6 +150,7 @@ export function loadConfig(): AppConfig {
 export function syncCredentialEnv(patch: Partial<AppConfig>): void {
   const secrets: Array<[value: string | undefined, name: string]> = [
     [patch.xai?.key, "XAI_API_KEY"],
+    [patch.composio?.apiKey, "COMPOSIO_API_KEY"],
     [patch.box?.token, "BOX_TOKEN"],
     [patch.opencodeGo?.apiKey, "OPENCODE_API_KEY"],
     [patch.tts?.key, "OMB_TTS_KEY"],

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -189,6 +189,8 @@ describe("ACP turns (fake CLI)", () => {
     delete process.env.FAKE_ACP_DUMP;
     delete process.env.XAI_API_KEY;
     delete process.env.OPENCODE_API_KEY;
+    delete process.env.BOX_TOKEN;
+    delete process.env.OMB_TTS_KEY;
     delete process.env.FAKE_ACP_MODELS;
     delete process.env.FAKE_ACP_MODEL_STICKS;
     delete process.env.FAKE_ACP_USAGE_ROOT;
@@ -239,6 +241,10 @@ describe("ACP turns (fake CLI)", () => {
     process.env.FAKE_ACP_DUMP = dump;
     process.env.XAI_API_KEY = "xai-should-not-leak";
     process.env.OPENCODE_API_KEY = "opencode-should-not-leak";
+    // workspace credentials with no CLI consumer at all — held by the
+    // harness (env-injected at boot by the desktop shell), used in-process
+    process.env.BOX_TOKEN = "box-should-not-leak";
+    process.env.OMB_TTS_KEY = "tts-should-not-leak";
 
     await instance.adapter.sendTurn({ threadId: "t-hygiene", text: "go" });
     await recorder.until((e) => e.type === "turn.completed");
@@ -249,6 +255,8 @@ describe("ACP turns (fake CLI)", () => {
     expect(seen.argv).toContain("--permission-mode");
     expect(seen.env.XAI_API_KEY).toBeUndefined();
     expect(seen.env.OPENCODE_API_KEY).toBeUndefined();
+    expect(seen.env.BOX_TOKEN).toBeUndefined();
+    expect(seen.env.OMB_TTS_KEY).toBeUndefined();
   });
 
   // ACP session/new accepts stdio MCP entries, so connected apps use the

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -15,6 +15,7 @@
 // before the prompt is sent, and `_meta.isReplay` updates are dropped.
 import { homedir } from "node:os";
 
+import { WORKSPACE_CREDENTIAL_ENV } from "../../config.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../procs.ts";
 
 import type {
@@ -170,7 +171,12 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           PATH: augmentedPath(),
         };
         const allowedCredentials = new Set(support.credentialEnv ?? []);
-        for (const key of PROVIDER_CREDENTIAL_ENV) {
+        // two lists, one rule: foreign PROVIDER keys must not flip a CLI's
+        // billing off its own login, and WORKSPACE credentials (box token,
+        // voice key, …) are the harness's secrets — riding along in
+        // `...process.env` is not a grant. A driver keeps only what its
+        // credentialEnv allowlist names.
+        for (const key of [...PROVIDER_CREDENTIAL_ENV, ...WORKSPACE_CREDENTIAL_ENV]) {
           if (!allowedCredentials.has(key)) delete env[key];
         }
         support.transformEnv?.(env, config);

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -4,7 +4,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly;
 // spawnCli resolves it to `node <script>`, so these run everywhere.
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -165,5 +165,36 @@ describe("Antigravity snapshot", () => {
     const snap = await instance.snapshot();
     expect(snap.state).toBe("unavailable");
     await instance.dispose();
+  });
+
+  it("strips workspace credentials from snapshot and helper children", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-agy-env-"));
+    const dump = join(scratch, "dump.json");
+    const names = ["XAI_API_KEY", "COMPOSIO_API_KEY", "BOX_TOKEN", "OPENCODE_API_KEY", "OMB_TTS_KEY"] as const;
+    const previous = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+    process.env.FAKE_AGY_DUMP = dump;
+    for (const name of names) process.env[name] = `${name}-must-not-leak`;
+    const instance = await AntigravityDriver.create({
+      instanceId: "agy-env",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      await instance.snapshot();
+      for (const name of names) expect(JSON.parse(readFileSync(dump, "utf8")).env[name]).toBeUndefined();
+
+      await instance.generateText?.("summarize safely");
+      for (const name of names) expect(JSON.parse(readFileSync(dump, "utf8")).env[name]).toBeUndefined();
+    } finally {
+      await instance.dispose();
+      delete process.env.FAKE_AGY_DUMP;
+      for (const name of names) {
+        if (previous[name] === undefined) delete process.env[name];
+        else process.env[name] = previous[name];
+      }
+      rmSync(scratch, { recursive: true, force: true });
+    }
   });
 });

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -15,7 +15,7 @@ import { mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { DATA_DIR } from "../config.ts";
+import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 import { injectedApiModel, mergeLocalInject } from "./local-inject.ts";
 
@@ -249,6 +249,9 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       if (resumeCursor) args.push("--conversation", resumeCursor);
 
       const env = { ...process.env, PATH: augmentedPath() };
+      // The harness process may hold workspace credentials (xai/box/voice
+      // keys, env-injected at boot); none of them are this CLI's to see.
+      stripWorkspaceCredentialEnv(env);
 
       // spawnCli resolves npm .cmd shims / shebang scripts on Windows and
       // owns the process-group vs windowsHide difference (see procs.ts)

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -55,6 +55,15 @@ export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   ],
 };
 
+function antigravityEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath() };
+  // The harness process may hold workspace credentials injected by the
+  // desktop shell. Antigravity uses its own login, so none belong in any of
+  // its turn, snapshot, or helper children.
+  stripWorkspaceCredentialEnv(env);
+  return env;
+}
+
 const AGY_MODEL_ID = /^[a-z0-9][a-z0-9._:/-]*$/i;
 
 function extrasFromUnknown(value: unknown): Array<{ id: string; label: string }> {
@@ -248,10 +257,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       if (turn.model) args.push("--model", injectedApiModel(turn.model) ?? turn.model);
       if (resumeCursor) args.push("--conversation", resumeCursor);
 
-      const env = { ...process.env, PATH: augmentedPath() };
-      // The harness process may hold workspace credentials (xai/box/voice
-      // keys, env-injected at boot); none of them are this CLI's to see.
-      stripWorkspaceCredentialEnv(env);
+      const env = antigravityEnvironment();
 
       // spawnCli resolves npm .cmd shims / shebang scripts on Windows and
       // owns the process-group vs windowsHide difference (see procs.ts)
@@ -395,7 +401,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const version = await new Promise<string | null>((resolve) => {
-        execCli(config.cli, ["--version"], { timeout: 8000, env: { ...process.env, PATH: augmentedPath() } }, (err, stdout) =>
+        execCli(config.cli, ["--version"], { timeout: 8000, env: antigravityEnvironment() }, (err, stdout) =>
           resolve(err ? null : stdout.trim()),
         );
       });
@@ -437,7 +443,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           execCli(
             config.cli,
             ["-p", prompt, "--output-format", "text", "--model", "gemini-3.6-flash-low"],
-            { timeout: 60_000, env: { ...process.env, PATH: augmentedPath() } },
+            { timeout: 60_000, env: antigravityEnvironment() },
             (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
           );
         }),

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -150,7 +150,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     delete process.env.FAKE_CLAUDE_DUMP;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.XAI_API_KEY;
+    delete process.env.COMPOSIO_API_KEY;
     delete process.env.BOX_TOKEN;
+    delete process.env.OPENCODE_API_KEY;
     delete process.env.OMB_TTS_KEY;
     recorder?.stop();
     await instance?.dispose();
@@ -697,6 +699,19 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.argv).not.toContain("--effort");
+  });
+
+  it("strips workspace credentials from generateText helper children", async () => {
+    await create();
+    const dump = join(scratch, "generate-text-env.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const names = ["XAI_API_KEY", "COMPOSIO_API_KEY", "BOX_TOKEN", "OPENCODE_API_KEY", "OMB_TTS_KEY"] as const;
+    for (const name of names) process.env[name] = `${name}-must-not-leak`;
+
+    await instance.generateText?.("summarize safely");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    for (const name of names) expect(seen.env[name]).toBeUndefined();
   });
 
   it("declares the effort levels the CLI accepts", async () => {

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -149,6 +149,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     delete process.env.FAKE_CLAUDE_MODE;
     delete process.env.FAKE_CLAUDE_DUMP;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.XAI_API_KEY;
+    delete process.env.BOX_TOKEN;
+    delete process.env.OMB_TTS_KEY;
     recorder?.stop();
     await instance?.dispose();
     await removeTempDir(scratch);
@@ -205,6 +208,11 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const dump = join(scratch, "dump.json");
     process.env.FAKE_CLAUDE_DUMP = dump;
     process.env.ANTHROPIC_API_KEY = "sk-should-not-leak";
+    // workspace credentials the harness may hold (env-injected at boot by
+    // the desktop shell) must never ride into the CLI child
+    process.env.XAI_API_KEY = "xai-should-not-leak";
+    process.env.BOX_TOKEN = "box-should-not-leak";
+    process.env.OMB_TTS_KEY = "tts-should-not-leak";
 
     await instance.adapter.sendTurn({ threadId: "t-hygiene", text: "the secret prompt", system: "You are Testy." });
     await recorder.until((e) => e.type === "turn.completed");
@@ -217,6 +225,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(seen.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(seen.env.CLAUDECODE).toBeUndefined();
     expect(seen.env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+    expect(seen.env.XAI_API_KEY).toBeUndefined();
+    expect(seen.env.BOX_TOKEN).toBeUndefined();
+    expect(seen.env.OMB_TTS_KEY).toBeUndefined();
   });
 
   it("uses instance credentials when launching an injected local model", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -731,7 +731,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           execCli(
             config.cli,
             ["-p", prompt, "--model", "claude-haiku-4-5", "--output-format", "text"],
-            { timeout: 60_000, env: { ...process.env, PATH: augmentedPath() } },
+            { timeout: 60_000, env: claudeEnvironment("claude-haiku-4-5") },
             (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
           );
         }),

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -14,7 +14,7 @@ import { createServer as createNetServer } from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 
-import { DATA_DIR } from "../config.ts";
+import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 import { brokerSocketPath, describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 
@@ -74,6 +74,9 @@ function claudeEnvironment(
   const env: NodeJS.ProcessEnv = { ...source, PATH: augmentedPath(), NPM_CONFIG_LOGLEVEL: "error" };
   delete env.CLAUDECODE;
   delete env.CLAUDE_CODE_ENTRYPOINT;
+  // The harness process may hold workspace credentials (xai/box/voice keys,
+  // env-injected at boot); none of them are this CLI's to see.
+  stripWorkspaceCredentialEnv(env);
   const applied = applyClaudeInject(env, model);
   if (!applied.injected) delete env.ANTHROPIC_API_KEY;
   return env;

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -56,6 +56,8 @@ describe("CodexDriver turns (fake app-server)", () => {
     delete process.env.FAKE_CODEX_MODE;
     delete process.env.FAKE_CODEX_DUMP;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.BOX_TOKEN;
+    delete process.env.OMB_TTS_KEY;
     recorder?.stop();
     await instance?.dispose();
     await removeTempDir(scratch);
@@ -66,6 +68,10 @@ describe("CodexDriver turns (fake app-server)", () => {
     const dump = join(scratch, "dump.json");
     process.env.FAKE_CODEX_DUMP = dump;
     process.env.OPENAI_API_KEY = "sk-should-not-leak";
+    // workspace credentials the harness may hold (env-injected at boot by
+    // the desktop shell) must never ride into the CLI child
+    process.env.BOX_TOKEN = "box-should-not-leak";
+    process.env.OMB_TTS_KEY = "tts-should-not-leak";
 
     const { turnId } = await instance.adapter.sendTurn({
       threadId: "t-happy",
@@ -101,6 +107,8 @@ describe("CodexDriver turns (fake app-server)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.env.OPENAI_API_KEY).toBeUndefined();
+    expect(seen.env.BOX_TOKEN).toBeUndefined();
+    expect(seen.env.OMB_TTS_KEY).toBeUndefined();
     const methods = seen.calls.map((c: { method: string }) => c.method);
     expect(methods).toEqual(["initialize", "initialized", "thread/start", "turn/start"]);
     // persona rides in front of the prompt text — codex has no system slot

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -11,6 +11,7 @@
 // and falls back to a fresh thread/start.
 import { homedir } from "node:os";
 
+import { stripWorkspaceCredentialEnv } from "../config.ts";
 import { computerProxyEnv } from "../container-computer.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
@@ -100,6 +101,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       // The CLI owns its own ChatGPT login; a leaked API key silently flips
       // billing to pay-as-you-go (agentcal).
       delete env.OPENAI_API_KEY;
+      // The harness process may hold workspace credentials (xai/box/voice
+      // keys, env-injected at boot); none of them are this CLI's to see.
+      stripWorkspaceCredentialEnv(env);
       return env;
     };
     const catalogEnv = childEnv();

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -729,14 +729,23 @@ describe("harness HTTP API", () => {
     expect(rejected.status).toBe(400);
     expect(rejected.body.error).toMatch(/invalid project key/i);
 
-    const saved = await api("PUT", "/api/config?secretStorage=external", { composio: { apiKey: "ak_good" } });
+    const saved = await api("PUT", "/api/config?secretStorage=external", {
+      composio: { apiKey: "ak_good" },
+      opencodeGo: { apiKey: "opencode-external" },
+      profile: { name: "External Store" },
+    });
     expect(saved.status).toBe(200);
     expect(saved.body.composio).toEqual({ configured: true, mode: "self-hosted" });
+    expect(saved.body.opencodeGo).toEqual({ configured: true });
+    expect(saved.body.profile).toEqual({ name: "External Store", email: "" });
     expect(JSON.stringify(saved.body)).not.toContain("ak_good");
 
     const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
     expect(disk.composio).toMatchObject({ apiKey: "", sessionId: "trs_config_test" });
+    expect(disk.opencodeGo).toEqual({ apiKey: "" });
+    expect(disk.profile).toEqual({ name: "External Store" });
     expect(JSON.stringify(disk)).not.toContain("ak_good");
+    expect(JSON.stringify(disk)).not.toContain("opencode-external");
 
     // A later ordinary setting save reloads config; the in-process secure-env
     // override must keep Composio configured until the next app launch.

--- a/server/index.ts
+++ b/server/index.ts
@@ -3460,15 +3460,21 @@ const server = createServer(async (req, res) => {
         if (!check.ok) return json(res, 400, { error: check.message });
       }
       const externalSecretStorage = url.searchParams.get("secretStorage") === "external";
-      if (externalSecretStorage && patch.composio) {
-        // Electron stores the project key with OS-backed encryption. Persist
-        // only the non-secret Session ids here, while keeping the supplied
-        // key live in this process until the next launch injects it by env.
-        const composioPatch = patch.composio;
-        const { apiKey: _secret, ...metadata } = composioPatch;
-        saveConfig({ composio: { ...metadata, apiKey: "" } });
-        cfg.composio = { ...cfg.composio, ...composioPatch };
-        if (composioPatch.apiKey !== undefined) process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
+      if (externalSecretStorage) {
+        // The packaged Electron caller commits supplied credentials to the
+        // OS-encrypted store before entering this route. Persist every
+        // non-secret sibling in the same request, but replace each supplied
+        // credential with an empty tombstone so an older plaintext value can
+        // never survive the merge in config.json.
+        const persisted = structuredClone(patch);
+        if (persisted.xai?.key !== undefined) persisted.xai.key = "";
+        if (persisted.composio?.apiKey !== undefined) persisted.composio.apiKey = "";
+        if (persisted.box?.token !== undefined) persisted.box.token = "";
+        if (persisted.opencodeGo?.apiKey !== undefined) persisted.opencodeGo.apiKey = "";
+        if (persisted.tts?.key !== undefined) persisted.tts.key = "";
+        saveConfig(persisted);
+        syncCredentialEnv(patch);
+        Object.assign(cfg, loadConfig());
       } else {
         saveConfig(patch);
         // loadConfig prefers env over the file for credentials, so the env

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,7 @@ import {
   loadConfig,
   parseConfigPatch,
   saveConfig,
+  syncCredentialEnv,
   withInstanceCli,
   vpsSshAlias,
   EVENTS_DIR,
@@ -3470,6 +3471,10 @@ const server = createServer(async (req, res) => {
         if (composioPatch.apiKey !== undefined) process.env.COMPOSIO_API_KEY = composioPatch.apiKey;
       } else {
         saveConfig(patch);
+        // loadConfig prefers env over the file for credentials, so the env
+        // must follow the save — otherwise the value injected at boot would
+        // shadow the new key until the next launch
+        syncCredentialEnv(patch);
         Object.assign(cfg, loadConfig());
       }
       // provider keys change the fleet; a profile or voice edit must not

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -69,6 +69,8 @@ const dumpEnv = Object.fromEntries(
     "OPENROUTER_API_KEY",
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
+    "BOX_TOKEN",
+    "OMB_TTS_KEY",
     "UNSLOTH_STUDIO_AUTH_TOKEN",
   ].flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]] as const)),
 );

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -8,7 +8,12 @@
 // status SUCCESS. Deterministic, no network.
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
+import { writeFileSync } from "node:fs";
+
 const argv = process.argv.slice(2);
+if (process.env.FAKE_AGY_DUMP) {
+  writeFileSync(process.env.FAKE_AGY_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
+}
 if (argv.includes("--version")) {
   console.log("1.1.12");
   process.exit(0);

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -52,6 +52,19 @@ if (argv[0] === "auth" && argv[1] === "status") {
   );
 }
 
+// One-shot helper mode used by generateText. It does not use stdin or emit
+// the stream-json turn protocol.
+if (argAfter("--output-format") === "text") {
+  if (process.env.FAKE_CLAUDE_DUMP) {
+    writeFileSync(
+      process.env.FAKE_CLAUDE_DUMP,
+      JSON.stringify({ argv, env: process.env, prompt: argAfter("-p"), mcpConfig: null }, null, 2),
+    );
+  }
+  process.stdout.write("fake generated text\n");
+  process.exit(0);
+}
+
 let stdin = "";
 process.stdin.on("data", (c) => (stdin += c));
 process.stdin.on("end", () => {

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -1,6 +1,6 @@
-// Paste-a-key rows for PUT /api/config. The server persists to
-// ~/.openmausbot/config.json and hot-reloads the provider fleet; secrets
-// are write-only — GET /api/config returns configured flags, never values.
+// Paste-a-key rows. Packaged Electron saves secrets in the OS-backed store;
+// browser development falls back to PUT /api/config. Secrets are write-only
+// either way — GET /api/config returns configured flags, never values.
 import { useEffect, useId, useRef, useState } from "react";
 import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-react";
 import { api, useStore, type ConfigStatus } from "@/state/store";
@@ -18,6 +18,12 @@ const SECTIONS: Record<
   },
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
   opencodeGo: { body: (v) => ({ opencodeGo: { apiKey: v } }), flag: (c) => c.opencodeGo?.configured ?? false },
+};
+
+const ELECTRON_CREDENTIAL: Record<ConfigSection, "composioApiKey" | "boxToken" | "opencodeGoApiKey"> = {
+  composio: "composioApiKey",
+  box: "boxToken",
+  opencodeGo: "opencodeGoApiKey",
 };
 
 const CREDENTIALS: Record<
@@ -150,8 +156,8 @@ export function ApiKeyRow({
     if (saving || (!value.trim() && !configured)) return;
     setSaving(true);
     setError(null);
-    const request = section === "composio" && window.ogb?.setCredential
-      ? window.ogb.setCredential("composioApiKey", value.trim())
+    const request = window.ogb?.setCredential
+      ? window.ogb.setCredential(ELECTRON_CREDENTIAL[section], value.trim())
       : api("/api/config", {
           method: "PUT",
           body: JSON.stringify(SECTIONS[section].body(value.trim())),

--- a/src/components/VoiceSettings.tsx
+++ b/src/components/VoiceSettings.tsx
@@ -46,7 +46,10 @@ export function VoiceSettings() {
   const save = (patch: Record<string, unknown>) => {
     setSaving(true);
     setError(null);
-    return api("/api/config", { method: "PUT", body: JSON.stringify({ tts: patch }) })
+    const request = typeof patch.key === "string" && window.ogb?.setCredential
+      ? window.ogb.setCredential("ttsKey", patch.key)
+      : api("/api/config", { method: "PUT", body: JSON.stringify({ tts: patch }) });
+    return request
       .then((status: ConfigStatus) => {
         dispatch({ type: "configStatus", config: status });
         setKey("");

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -86,7 +86,10 @@ declare global {
       /** Native folder picker; resolves null when the user cancels. */
       pickFolder?(current?: string): Promise<string | null>;
       /** Save a provider credential through Electron's OS-backed store. */
-      setCredential?(name: "composioApiKey", value: string): Promise<ConfigStatus>;
+      setCredential?(
+        name: "composioApiKey" | "xaiApiKey" | "boxToken" | "opencodeGoApiKey" | "ttsKey",
+        value: string,
+      ): Promise<ConfigStatus>;
       /** In-app auto-update (packaged app only; dormant in dev). onState
        * fires immediately with the current state, then on transitions. */
       updater?: {


### PR DESCRIPTION
## Threat model

Two exposure paths for the workspace credentials (xai key, box token, voice key, OpenCode Go key):

1. **Any process that can read the config file.** `~/.openmausbot/config.json` held all of them in plaintext — chmod 0600 protects against other users, not against anything running as the user.
2. **The env of unrelated child processes.** `instanceConfigs()` injected `XAI_API_KEY` and `BOX_TOKEN` into *every* instance's environment, and engine CLIs are spawned with `...process.env` — so a compromised or merely chatty CLI child could read secrets it never needed.

## What changed

**At rest (packaged app)** — extends the existing safeStorage path that already covered the Composio key:
- `electron/workspace-credentials.mjs` (new): pure migration + env-mapping table for the four remaining credentials, unit-testable without an Electron runtime.
- `electron/main.mjs`: `secureWorkspaceConfig()` runs on packaged boot right after the composio sweep — plaintext values move into the OS-encrypted `credentials.bin` and the plaintext field is deleted; at server spawn, one env var per stored secret is injected (`XAI_API_KEY`, `BOX_TOKEN`, `OMB_TTS_KEY`, `OPENCODE_API_KEY`).
- `server/config.ts`: `loadConfig()` now prefers env over the file for every credential; the file stays the dev-mode fallback, so `pnpm dev:server` with plaintext config.json works unchanged. `syncCredentialEnv()` keeps the running server's env in step with a mid-session save or clear, so the boot-time value cannot shadow a new key until relaunch.

**Per-driver env narrowing:**
- `injectedEnvironment(cfg, driver)` is now one shared rule for `instanceConfigs()` (inject) and `withInstanceCli()` (strip-before-persist): `XAI_API_KEY` → the API-key `grok` driver only, `BOX_TOKEN` → `boxAgent` only, `OPENCODE_API_KEY` → `opencodeGo` only (the pre-existing narrowing, generalized). Consumers verified by grep: `drivers/grok.ts` reads `input.environment[apiKeyEnv]`, `drivers/boxagent.ts` reads `input.environment.BOX_TOKEN`; no other driver reads either.
- Because the packaged server process itself now carries these secrets in env, every engine-CLI spawn point strips `WORKSPACE_CREDENTIAL_ENV` from the child env: `claude.ts` (`claudeEnvironment`), `codex.ts` (`childEnv`), `antigravity.ts` (turn spawn), and `acp/core.ts` (merged with the existing foreign-provider-key strip, still honoring each driver's `credentialEnv` allowlist — OpenCode Go keeps its own key). Without this, the at-rest change would have put the voice key and box token into every CLI child via `...process.env`.

## Migration behavior

- **Idempotent**: a second boot is a no-op (absent field → keep the stored secret).
- **Lossless, newest-intent**: the server persists a mid-session key change to config.json as plaintext until the next launch; the boot sweep then treats a non-empty field as the newest user intent (overwrites the store), `""` (how a cleared key is saved) as a clear (drops the stored secret), and an absent field as already-migrated. `credentials.bin` is written *before* config.json is rewritten, so a failed safeStorage save leaves the plaintext in place to retry next boot — losing the only copy cannot happen.
- **Downgrade**: same behavior as the composio key — an older build sees the key as unconfigured (field gone from config.json) until re-entered; nothing is corrupted.

## Test plan

- `pnpm typecheck` ✓ · `pnpm check:electron` ✓ (covers the new module) · lint delta vs main: none
- `pnpm vitest run`: **113 files, 1091 passed / 8 skipped** ✓ — includes new `electron/workspace-credentials.test.mjs` (migration table, idempotence, overwrite/clear/keep, env mapping) and new `server/config.test.ts` suites (per-driver narrowing incl. *a driver that doesn't use a key does NOT receive it*, env-over-file preference, `syncCredentialEnv`, strip helper), plus child-env hygiene assertions extended in the claude/codex/ACP driver tests (the fake ACP CLI's env dump allowlist now includes `BOX_TOKEN`/`OMB_TTS_KEY` so those assertions actually bite).
- `pnpm broker:test` ✓ (2) · `pnpm test:updater` ✓ (12) · `pnpm test:packaged-server` ✓
- **Mutation-checked every new guard**: the narrowing condition, the env preference, the `syncCredentialEnv` clear path, the migration overwrite rule, delete-not-blank, and the strip list were each deliberately broken; the new tests failed (2 / 2 / 1 / 1 / 4 / 3-suites+1 respectively) and passed again after restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace credentials now migrate securely and are injected consistently when needed.
  - Added safer local-computer controls, including approval scopes, capability checks, and an endpoint to interrupt active computer-control tasks.
  - Packaged startup now supports credential setup, improved screen-capture handling, and Linux startup scenarios.

- **Bug Fixes**
  - Prevented workspace credentials from leaking into provider processes.
  - Improved approval recovery after restarts and prevented unauthorized auto-approval of local-computer actions.
  - Corrected model reporting and configuration precedence for saved and environment-provided credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->