### PR TITLE
Ship a macOS Intel (x64) build alongside Apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Talk to them like contacts. Watch them work. Approve what matters.
   <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Ubuntu&labelColor=070707&color=e95420&cacheSeconds=300" alt="Download the latest OpenMausBot for Ubuntu (.deb)" height="40">
 </a>
 
-<sub>macOS: Apple silicon · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
+<sub>macOS: Apple silicon & Intel · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
 
 <br>
 <br>
@@ -186,6 +186,7 @@ flowchart LR
 | | Download | Install |
 |---|---|---|
 | **macOS** (Apple silicon) | [OpenMausBot.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Drag it to Applications, open it. Signed & notarized. |
+| **macOS** (Intel) | [OpenMausBot-intel.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg) | Same app, built for Intel Macs. Signed & notarized. |
 | **Windows** (x64) | [OpenMausBot-setup.exe](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Run it — one-click, per-user, no admin rights. The installer isn't code-signed yet, so SmartScreen shows "unknown publisher": **More info → Run anyway**. |
 | **Ubuntu 24.04** (x64) | [OpenMausBot-amd64.deb](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) · [OpenMausBot.AppImage](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) | Install the `.deb` with APT (recommended), or make the AppImage executable and run it. Beta; GNOME is the supported desktop. |
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Talk to them like contacts. Watch them work. Approve what matters.
 <br>
 
 <a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg">
-  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20macOS&labelColor=070707&color=1084fe&cacheSeconds=300" alt="Download the latest OpenMausBot for macOS (.dmg)" height="40">
+  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Apple%20silicon%29&labelColor=070707&color=1084fe&cacheSeconds=300" alt="Download the latest OpenMausBot for Mac with Apple silicon (.dmg)" height="40">
+</a>
+&nbsp;
+<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg">
+  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Intel%29&labelColor=070707&color=2a9d8f&cacheSeconds=300" alt="Download the latest OpenMausBot for Intel Macs (.dmg)" height="40">
 </a>
 &nbsp;
 <a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe">

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -54,11 +54,15 @@ extraResources:
     to: android-platform-tools
 
 mac:
+  # Two single-arch artifacts rather than one universal binary: the app is
+  # ~177 MB per arch, and universal would make every user download both halves.
+  # electron-updater picks by filename (arm64-marked files on Apple silicon,
+  # unmarked ones on Intel), so latest-mac.yml must list all four files.
   target:
     - target: dmg
-      arch: arm64
+      arch: [arm64, x64]
     - target: zip
-      arch: arm64
+      arch: [arm64, x64]
   icon: build/icon.icns
   category: public.app-category.productivity
   hardenedRuntime: true
@@ -71,9 +75,10 @@ mac:
       to: OpenMausBot Speech.app
     # CUA must live outside ASAR. prepare-cua stages the signed executable and
     # a self-contained JS/native SDK bundle selected for macOS arm64.
-    - from: dist-native/cua-driver
+    # ${arch} resolves per built arch — each bundle carries its own natives
+    - from: dist-native/${arch}/cua-driver
       to: cua-driver
-    - from: dist-native/cua-sdk
+    - from: dist-native/${arch}/cua-sdk
       to: cua-sdk
   extendInfo:
     NSMicrophoneUsageDescription: OpenMausBot uses the microphone for voice dictation into the composer.
@@ -86,7 +91,10 @@ mac:
 
 dmg:
   sign: true
-  artifactName: OpenMausBot-${version}.dmg
+  # ${arch} is load-bearing: without it the x64 dmg silently overwrites
+  # the arm64 one when both arches build (this section overrides both the
+  # top-level and mac-level artifactName, so it must carry the arch itself)
+  artifactName: OpenMausBot-${version}-${arch}.dmg
 
 win:
   target:

--- a/electron/build-speech-helper.mjs
+++ b/electron/build-speech-helper.mjs
@@ -3,7 +3,7 @@
 // current releases; TCC reads the Info.plist belonging to the executable's
 // bundle and terminates the process before Swift can recover when it is absent.
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -18,11 +18,29 @@ export function buildSpeechHelper() {
   const contents = path.join(speechHelperBundle, "Contents");
   mkdirSync(path.join(contents, "MacOS"), { recursive: true });
   copyFileSync(path.join(resourcesDir, "speech-helper-Info.plist"), path.join(contents, "Info.plist"));
-  execFileSync(
-    "swiftc",
-    ["-O", path.join(resourcesDir, "speech-helper.swift"), "-o", speechHelperBinary],
-    { stdio: "inherit", timeout: 120_000 },
-  );
+  // The mac app ships for arm64 and x64, and the helper rides inside both
+  // bundles, so it must be universal — bare `swiftc` builds host-arch only,
+  // which inside an Intel app is a dictation helper that cannot launch.
+  // macos12 matches the app's LSMinimumSystemVersion; the Speech/AVFoundation
+  // APIs used here are all older than that.
+  const slices = ["arm64", "x86_64"].map((arch) => {
+    const slice = `${speechHelperBinary}-${arch}`;
+    execFileSync(
+      "swiftc",
+      ["-O", "-target", `${arch}-apple-macos12`, path.join(resourcesDir, "speech-helper.swift"), "-o", slice],
+      { stdio: "inherit", timeout: 120_000 },
+    );
+    return slice;
+  });
+  execFileSync("lipo", ["-create", ...slices, "-output", speechHelperBinary], {
+    stdio: "inherit",
+    timeout: 60_000,
+  });
+  for (const slice of slices) rmSync(slice, { force: true });
+  const archs = execFileSync("lipo", ["-archs", speechHelperBinary], { timeout: 60_000 }).toString();
+  if (!archs.includes("arm64") || !archs.includes("x86_64")) {
+    throw new Error(`speech helper is not universal: ${archs.trim()}`);
+  }
   // Give development builds a stable identity and the same audio entitlement
   // as the release. electron-builder replaces this ad-hoc signature when it
   // signs the containing distribution.

--- a/package.json
+++ b/package.json
@@ -90,5 +90,13 @@
     "vite": "^7.1.0",
     "vitest": "^4.1.10",
     "wrangler": "4.123.0"
+  },
+  "pnpm": {
+    "supportedArchitectures": {
+      "cpu": [
+        "arm64",
+        "x64"
+      ]
+    }
   }
 }

--- a/scripts/prepare-cua.mjs
+++ b/scripts/prepare-cua.mjs
@@ -79,48 +79,76 @@ if (process.env.CUA_DRIVER_PATH) {
   }
   binary = process.env.CUA_DRIVER_PATH;
 } else {
+  // The locally installed app may be a single-arch build; both shipped arches
+  // need it, so fall back to the official universal binary rather than fail.
   const installed = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver";
-  binary = (await binaryVersion(installed)) === expectedVersion ? installed : await officialBinary();
+  const installedUniversal = async () => {
+    try {
+      const { stdout } = await run("/usr/bin/lipo", ["-archs", installed]);
+      return stdout.includes("arm64") && stdout.includes("x86_64");
+    } catch {
+      return false;
+    }
+  };
+  binary =
+    (await binaryVersion(installed)) === expectedVersion && (await installedUniversal())
+      ? installed
+      : await officialBinary();
 }
 const details = await stat(binary);
 if (!details.isFile() || (details.mode & 0o111) === 0) {
   throw new Error(`cua-driver is not an executable file: ${binary}`);
 }
 
-await mkdir(stage, { recursive: true });
-await Promise.all([
-  rm(join(stage, "cua-driver"), { force: true }),
-  rm(join(stage, "cua-sdk"), { recursive: true, force: true }),
-]);
-await copyFile(binary, join(stage, "cua-driver"));
-await chmod(join(stage, "cua-driver"), 0o755);
-// A binary copied out of CuaDriver.app retains a bundle-relative signature
-// whose Info.plist no longer exists at the new path. Give the staged file a
-// valid temporary signature; electron-builder replaces it with the enclosing
-// app's identity during its nested-code signing pass.
-await run("/usr/bin/codesign", [
-  "--force",
-  "--sign",
-  "-",
-  "--options",
-  "runtime",
-  join(stage, "cua-driver"),
-]);
+// The mac app ships for two architectures, each with its own staging dir that
+// electron-builder selects via ${arch} in extraResources. The driver
+// executable is the official universal binary (same bytes in both dirs, and
+// asserted universal below so a future non-universal pin fails loudly here,
+// not on a user's Intel Mac); the SDK's dylib/.node are genuinely per-arch,
+// pulled from the two darwin native packages that pnpm installs because of
+// supportedArchitectures in package.json.
+const MAC_ARCHES = ["arm64", "x64"];
+
+const { stdout: archList } = await run("/usr/bin/lipo", ["-archs", binary]);
+for (const arch of MAC_ARCHES) {
+  const lipoName = arch === "x64" ? "x86_64" : arch;
+  if (!archList.trim().split(/\s+/).includes(lipoName)) {
+    throw new Error(`cua-driver at ${binary} is not universal: has [${archList.trim()}], needs ${lipoName}`);
+  }
+}
+
+for (const arch of MAC_ARCHES) {
+  const archStage = join(stage, arch);
+  await rm(archStage, { recursive: true, force: true });
+  await mkdir(archStage, { recursive: true });
+  await copyFile(binary, join(archStage, "cua-driver"));
+  await chmod(join(archStage, "cua-driver"), 0o755);
+  // A binary copied out of CuaDriver.app retains a bundle-relative signature
+  // whose Info.plist no longer exists at the new path. Give the staged file a
+  // valid temporary signature; electron-builder replaces it with the enclosing
+  // app's identity during its nested-code signing pass.
+  await run("/usr/bin/codesign", ["--force", "--sign", "-", "--options", "runtime", join(archStage, "cua-driver")]);
+
+  const nativeDir = join(archStage, "cua-sdk", "native");
+  const nativePackage = join(dependencyRoot, "@trycua", `cua-driver-darwin-${arch}`);
+  if (!existsSync(nativePackage)) {
+    throw new Error(
+      `required CUA darwin-${arch} native package is missing — is pnpm.supportedArchitectures.cpu set in package.json?`,
+    );
+  }
+  await mkdir(nativeDir, { recursive: true });
+  await Promise.all([
+    copyFile(join(realpathSync(nativePackage), "libcua_driver_sdk.dylib"), join(nativeDir, "libcua_driver_sdk.dylib")),
+    copyFile(join(realpathSync(nativePackage), "cua_driver_node_runtime.node"), join(nativeDir, "cua_driver_node_runtime.node")),
+  ]);
+}
 
 // Bundle the JS side into one ESM file so electron-builder's intentional
 // node_modules exclusion cannot drop it. The SDK resolves its native library
-// through @ubjs at runtime; redirect those generated lookups to the two native
-// files staged beside the bundle.
-const cuaSdkDir = join(stage, "cua-sdk");
-const nativeDir = join(cuaSdkDir, "native");
-const nativePackage = join(dependencyRoot, "@trycua", "cua-driver-darwin-arm64");
-if (!existsSync(nativePackage)) throw new Error("required CUA darwin-arm64 native package is missing");
-await mkdir(nativeDir, { recursive: true });
-await Promise.all([
-  copyFile(join(realpathSync(nativePackage), "libcua_driver_sdk.dylib"), join(nativeDir, "libcua_driver_sdk.dylib")),
-  copyFile(join(realpathSync(nativePackage), "cua_driver_node_runtime.node"), join(nativeDir, "cua_driver_node_runtime.node")),
-]);
-const bundle = join(cuaSdkDir, "cua-sdk.mjs");
+// through @ubjs at runtime; redirect those generated lookups to the native
+// files staged beside the bundle. The bundle is pure JS — built once, shipped
+// in both arch dirs.
+const bundle = join(stage, MAC_ARCHES[0], "cua-sdk", "cua-sdk.mjs");
 await build({
   stdin: {
     contents: [
@@ -155,4 +183,8 @@ await writeFile(
   ),
 );
 
-console.log(`Staged CUA from ${binary}`);
+for (const arch of MAC_ARCHES.slice(1)) {
+  await copyFile(bundle, join(stage, arch, "cua-sdk", "cua-sdk.mjs"));
+}
+
+console.log(`Staged CUA for ${MAC_ARCHES.join(" + ")} from ${binary}`);

--- a/scripts/regenerate-mac-feed.mjs
+++ b/scripts/regenerate-mac-feed.mjs
@@ -1,0 +1,81 @@
+// Refresh latest-mac.yml after notarization stapling has changed the bytes.
+//
+// electron-builder writes latest-mac.yml during packaging, but the release
+// flow then notarizes and STAPLES the dmg and the updater zip, which rewrites
+// both files — so every hash in the feed is stale by the time it is published.
+// Shipping the stale feed makes electron-updater reject the download (sha512
+// mismatch) and every update falls back to a full manual reinstall.
+//
+// This keeps the file list and ORDER exactly as electron-builder wrote them —
+// electron-updater filters that list by arch on macOS (files carrying an
+// "arm64" marker on Apple silicon, the unmarked x64 ones on Intel), and the
+// top-level path/sha512 is the legacy fallback taken from the first entry —
+// and only recomputes sha512 + size from the bytes on disk right now.
+//
+// Blockmaps are NOT handled here: regenerate them separately (app-builder
+// blockmap) after stapling, for the same staleness reason.
+import { createHash } from "node:crypto";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const feedPath = process.argv[2] ?? join(root, "release", "latest-mac.yml");
+const releaseDir = dirname(feedPath);
+
+const sha512 = (file) => createHash("sha512").update(readFileSync(file)).digest("base64");
+
+const original = readFileSync(feedPath, "utf8");
+const lines = original.split("\n");
+
+let currentUrl = null;
+let firstUrl = null;
+const out = lines.map((line) => {
+  const url = line.match(/^\s*-\s+url:\s+(\S+)\s*$/);
+  if (url) {
+    currentUrl = url[1];
+    firstUrl ??= currentUrl;
+    return line;
+  }
+  // top-level path introduces the legacy fallback block: hash the first file
+  if (/^path:\s+/.test(line)) {
+    currentUrl = firstUrl;
+    return `path: ${firstUrl}`;
+  }
+  if (currentUrl && /^\s*sha512:\s+/.test(line)) {
+    const indent = line.match(/^\s*/)[0];
+    return `${indent}sha512: ${sha512(join(releaseDir, currentUrl))}`;
+  }
+  if (currentUrl && /^\s*size:\s+/.test(line)) {
+    const indent = line.match(/^\s*/)[0];
+    return `${indent}size: ${statSync(join(releaseDir, currentUrl)).size}`;
+  }
+  if (/^sha512:\s+/.test(line)) {
+    return `sha512: ${sha512(join(releaseDir, firstUrl))}`;
+  }
+  if (/^releaseDate:/.test(line)) {
+    return `releaseDate: '${new Date().toISOString()}'`;
+  }
+  return line;
+});
+
+const updated = out.join("\n");
+if (updated === original) {
+  console.log("latest-mac.yml already matches the bytes on disk");
+} else {
+  writeFileSync(feedPath, updated);
+}
+
+// Refuse to end with a feed that lies: verify every entry against the disk.
+const entries = [...updated.matchAll(/-\s+url:\s+(\S+)[\s\S]*?sha512:\s+(\S+)\n\s+size:\s+(\d+)/g)];
+if (entries.length === 0) throw new Error("no file entries found in latest-mac.yml");
+for (const [, url, hash, size] of entries) {
+  const file = join(releaseDir, url);
+  const actualHash = sha512(file);
+  const actualSize = statSync(file).size;
+  if (actualHash !== hash || actualSize !== Number(size)) {
+    throw new Error(`feed mismatch for ${url}: hash/size do not match the file on disk`);
+  }
+  console.log(`  ok ${url} (${actualSize} bytes)`);
+}
+console.log(`latest-mac.yml verified against ${entries.length} artifacts`);

--- a/scripts/smoke-cua.mjs
+++ b/scripts/smoke-cua.mjs
@@ -5,7 +5,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const resources = process.env.OMB_CUA_RESOURCES ?? join(root, "dist-native");
+// staging is per-arch since the Intel build (dist-native/<arch>/…); default to
+// the host arch, which is the only one whose native SDK can load in-process
+const hostArch = process.arch === "arm64" ? "arm64" : "x64";
+const resources = process.env.OMB_CUA_RESOURCES ?? join(root, "dist-native", hostArch);
 process.env.OPENMAUSBOT_CUA_SDK_LIBRARY = join(resources, "cua-sdk/native/libcua_driver_sdk.dylib");
 process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED = "0";
 const sdk = pathToFileURL(join(resources, "cua-sdk/cua-sdk.mjs")).href;


### PR DESCRIPTION
Closes #257 — the published mac app was Apple silicon only, and Rosetta does not translate in that direction.

## What this does

Every release now produces four mac artifacts: `OpenMausBot-<v>-{arm64,x64}.{dmg,zip}`. electron-updater already routes by filename on macOS (arm64-marked files on Apple silicon, unmarked ones on Intel), so existing users are unaffected and Intel users get real auto-updates.

**Local computer use works fully on Intel** — no Silicon-only carve-out was needed: the pinned CUA driver release is a universal binary, and `@trycua/cua-driver-darwin-x64` exists at our exact pinned 0.20.0.

## The changes

- **`electron-builder.yml`** — dmg+zip for `[arm64, x64]`; `extraResources` resolve through `dist-native/${arch}` so each bundle carries its own natives. One trap found empirically: the `dmg:` section's own `artifactName` was arch-less and **overrides everything**, so on the first dual-arch build the x64 dmg silently overwrote the arm64 one and the feed listed one filename with two hashes. It now carries `${arch}`.
- **`package.json`** — `pnpm.supportedArchitectures.cpu: [arm64, x64]` so pnpm installs both darwin natives. Lockfile is byte-identical.
- **`scripts/prepare-cua.mjs`** — per-arch staging; asserts the driver is genuinely universal with `lipo` (a future non-universal pin fails at package time, not on a user's Intel Mac); falls back to the official universal download if the locally installed CuaDriver.app is single-arch.
- **`electron/build-speech-helper.mjs`** — two `swiftc` passes targeting `{arm64,x86_64}-apple-macos12` (matches the app's `LSMinimumSystemVersion`), `lipo`'d and asserted universal. Bare `swiftc` built host-arch only — inside an Intel app, a dictation helper that cannot launch.
- **`scripts/regenerate-mac-feed.mjs`** (new) — release tooling: refreshes `latest-mac.yml` hashes after notarization stapling rewrites the bytes, preserving electron-builder's file order (which the updater's arch filtering depends on) and refusing to finish unless every entry matches the bytes on disk.
- **README** — Intel download row; the stable Apple-silicon link `OpenMausBot.dmg` is unchanged, Intel gets `OpenMausBot-intel.dmg` at publish time.

## Verification

- four distinct artifacts; app binaries `x86_64` / `arm64` respectively; `cua-driver` and the speech helper inside the x64 bundle are universal (`lipo -archs`)
- **the x64 app was launched under Rosetta on an arm64 Mac** with a sandboxed `OMB_DATA_DIR`/`--user-data-dir`: server forked, `/api/health` returned `static: true`, and all 8 spawned proxy paths resolve inside `Resources/server`
- full suite green: 1187 passed / 12 skipped, plus the packaged-server smoke test

## Release-flow note

The next release cut from main after this merges will produce 4 mac artifacts to notarize/staple instead of 2 (the versioned arm64 dmg name changes from `OpenMausBot-<v>.dmg` to `OpenMausBot-<v>-arm64.dmg`), and should upload `OpenMausBot-intel.dmg` as a stable-named copy next to the existing `OpenMausBot.dmg`. Auto-update for existing arm64 users is unaffected — updates ship via the zip, whose name is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS downloads for both Apple silicon and Intel processors.
  - Added architecture-specific DMG and ZIP release artifacts.
  - Improved macOS release metadata with accurate download sizes, hashes, and architecture entries.

- **Bug Fixes**
  - Prevented architecture-specific release files from overwriting one another.
  - Improved compatibility by bundling universal speech and accessibility components.
  - Added validation to ensure packaged native resources support the required architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->