### PR TITLE
Close the approvals a cancelled turn can no longer answer

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -75,6 +75,16 @@ beforeAll(async () => {
         dm: true,
       },
       {
+        id: "test-cancel-room",
+        threadId: "test-cancel-room-thread",
+        name: "Cancel room",
+        memberIds: ["test-bot-a"],
+        defaultResponder: { kind: "member", botId: "test-bot-a" },
+        bulletin: "",
+        unread: false,
+        createdAt: 4,
+      },
+      {
         id: "test-pinned-room",
         threadId: "test-pinned-room-thread",
         name: "Pinned room",
@@ -86,6 +96,33 @@ beforeAll(async () => {
         pinnedCwd: null,
       },
     ]),
+  );
+
+  // A room holding an approval nobody has answered yet, so "Cancel turn"
+  // has something open to close.
+  writeFileSync(
+    join(home, ".openmausbot", "messages-test-cancel-room-thread.json"),
+    JSON.stringify({
+      activeLeafId: "cancel-card",
+      messages: [
+        {
+          id: "cancel-card",
+          at: 4,
+          parentId: null,
+          role: "bot",
+          kind: "options",
+          card: {
+            title: "Approval needed",
+            subtitle: "rm -rf /tmp/scratch",
+            options: ["Allow", "Deny"],
+            requestId: "cancel-request",
+            tool: "Bash",
+            allowKey: "Bash:rm",
+          },
+          from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+      ],
+    }),
   );
 
   boxStub = createServer(async (req, res) => {
@@ -525,6 +562,21 @@ describe("harness HTTP API", () => {
     const reread = (await api("GET", "/api/bots")).body.bots.find((candidate: { id: string }) => candidate.id === bot.id);
     expect(reread.messages.at(-1).tool).toMatchObject({ ok: false });
     expect(reread.messages.at(-1).tool.name).toContain("request is no longer open");
+  });
+
+  it("closes the approvals a cancelled turn can no longer answer", async () => {
+    // "Cancel turn" is a button ON the approval card, and a pending approval
+    // owns the composer. Stopping the turn without closing its card leaves the
+    // room blocked by a question whose asker is already gone.
+    const stopped = await api("POST", "/api/groups/test-cancel-room/interrupt");
+    expect(stopped.status).toBe(200);
+
+    const room = (await api("GET", "/api/bots")).body.groups.find(
+      (group: { id: string }) => group.id === "test-cancel-room",
+    );
+    const card = room.messages.find((message: { id: string }) => message.id === "cancel-card").card;
+    expect(card.dismissed).toBe(true);
+    expect(card.answered).toBe("unavailable");
   });
 
   it("rejects an empty message and explains an unavailable provider", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -429,6 +429,19 @@ async function answerRequest(
   return outcome;
 }
 
+/** Close every approval still open on a thread. Interrupting a turn kills the
+ * process that raised its questions, so those cards can never be answered —
+ * and a pending approval owns the composer, so one left open blocks the
+ * conversation behind a question with nobody left to hear the answer. */
+function closeOpenApprovals(threadId: string): void {
+  for (const message of store.messagesFor(threadId)) {
+    const card = message.card;
+    if (!card?.requestId || card.answered || card.dismissed) continue;
+    store.patchMessage(threadId, message.id, { card: { ...card, answered: "unavailable", dismissed: true } });
+    askMessageByRequest.delete(`${threadId}:${card.requestId}`);
+  }
+}
+
 function requestBehavior(value: unknown): "allow" | "deny" | "answer" | null {
   return value === "allow" || value === "deny" || value === "answer" ? value : null;
 }
@@ -2768,6 +2781,7 @@ const server = createServer(async (req, res) => {
       const busy = group.busyBotId ? store.bot(group.busyBotId) : undefined;
       const instance = busy ? registry.get(busy.modelSelection.instanceId) : undefined;
       await instance?.adapter.interruptTurn(group.threadId).catch(() => {});
+      closeOpenApprovals(group.threadId);
       return json(res, 200, { ok: true });
     }
 
@@ -3127,8 +3141,12 @@ const server = createServer(async (req, res) => {
       // a bot busy in a ROOM is running on the room's thread — stopping it
       // from its own chat must reach that turn, not just the 1:1 thread
       const busyGroup = store.groups.find((g) => g.busyBotId === bot.id);
-      if (busyGroup) await instance?.adapter.interruptTurn(busyGroup.threadId).catch(() => {});
+      if (busyGroup) {
+        await instance?.adapter.interruptTurn(busyGroup.threadId).catch(() => {});
+        closeOpenApprovals(busyGroup.threadId);
+      }
       await instance?.adapter.interruptTurn(bot.threadId);
+      closeOpenApprovals(bot.threadId);
       return json(res, 200, { ok: true });
     }
 


### PR DESCRIPTION
## What happens

Press **Cancel turn** on an approval card and the card stays. The composer stays blocked behind it, and the button that was supposed to be the way out has quietly made things worse.

## Why

`Cancel turn` lives on the approval card itself, and `Composer.tsx` is explicit about what a pending approval does:

```
{/* An approval takes over the composer: you answer it before you
    can type again, so a waiting bot is impossible to miss. */}
```

The interrupt routes stop the turn but never touch the card the turn had raised. `pendingApprovals` decides what is open from the card alone:

```ts
.filter((m) => m.kind === "options" && m.card?.requestId && m.card.tool && !m.card.answered && !m.card.dismissed)
```

Nothing there knows whether a turn is running, so the card survives the interrupt. The process that asked the question is dead, so it can never be answered — and since the interrupt also clears `busyBotId`, the room ends up in exactly the stranded state where the card's own buttons have no speaker to resolve against. Pressing the escape hatch is what springs the trap.

The only place that closes an approval today is `answerRequest`'s `unavailable` branch. Interrupts had no equivalent.

## The change

A small `closeOpenApprovals(threadId)` that marks every still-open approval on a thread `answered: "unavailable"` + `dismissed`, the same way `answerRequest` marks one it cannot deliver, and drops its `askMessageByRequest` entry. Called from both interrupt routes — including the room thread a bot is busy on when it is stopped from its own 1:1 chat, which the route already reaches for the interrupt itself.

Server-only; no UI changes, no new dependencies.

## Testing

New API test seeds a room holding an unanswered approval, calls `POST /api/groups/:id/interrupt`, and asserts the card is closed. It fails on `main` with `expected undefined to be true`.

- `pnpm typecheck` clean
- `pnpm test`: 1073 passed. `server/drivers/codex-catalog.test.ts` fails identically on `main` on this machine (it reads the locally installed `codex` model catalog) — unrelated.
- `pnpm test:packaged-server` passes; `oxlint server/index.ts` reports the same rule counts before and after.

## Related

- #274 fixes the other half: answering a card whose speaker is already gone. The two are independent — this one stops the state being created by a button press, that one lets you out of it once you are in. Neither depends on the other.
- #289 covers a third way in, the flat 5-minute room ceiling, which is a behaviour question rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupting a room or direct bot conversation now automatically closes unresolved approval requests.
  * Open approvals are marked as unavailable and dismissed when an active turn is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->