### PR TITLE
Fix Gemini authentication detection

### DIFF
--- a/server/drivers/acp/gemini-auth.test.ts
+++ b/server/drivers/acp/gemini-auth.test.ts
@@ -1,0 +1,76 @@
+// #28: the Gemini driver's credential detection after the 2026-06-18
+// consumer OAuth shutdown. The shared setup already points HOME at a
+// throwaway directory, so these tests write ~/.gemini/oauth_creds.json
+// there and assert what the exported check reports for each shape.
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { geminiIsAuthenticated } from "./gemini.ts";
+
+const geminiDir = join(homedir(), ".gemini");
+const credsPath = join(geminiDir, "oauth_creds.json");
+
+const writeCreds = (creds: unknown) => {
+  mkdirSync(geminiDir, { recursive: true });
+  writeFileSync(credsPath, JSON.stringify(creds));
+};
+
+describe("gemini auth detection (#28)", () => {
+  afterEach(() => {
+    rmSync(geminiDir, { recursive: true, force: true });
+  });
+
+  it("counts an API key with no oauth file present", () => {
+    expect(geminiIsAuthenticated({ GEMINI_API_KEY: "AIza..." })).toBe(true);
+    expect(geminiIsAuthenticated({ GOOGLE_API_KEY: "AIza..." })).toBe(true);
+  });
+
+  it("rejects blank API keys", () => {
+    expect(geminiIsAuthenticated({ GEMINI_API_KEY: "  ", GOOGLE_API_KEY: "\t" })).toBe(false);
+  });
+
+  it("reads as signed out with no key and no credential file", () => {
+    expect(geminiIsAuthenticated({})).toBe(false);
+  });
+
+  it("counts an unexpired access token", () => {
+    writeCreds({ access_token: "at", expiry_date: Date.now() + 60_000 });
+    expect(geminiIsAuthenticated({})).toBe(true);
+  });
+
+  it("keeps an expired token alive only when a refresh token exists (enterprise path)", () => {
+    writeCreds({ access_token: "at", expiry_date: Date.now() - 60_000 });
+    expect(geminiIsAuthenticated({})).toBe(false);
+    writeCreds({ access_token: "at", refresh_token: "rt", expiry_date: Date.now() - 60_000 });
+    expect(geminiIsAuthenticated({})).toBe(true);
+  });
+
+  it("reads the common post-shutdown consumer shape — expired, no refresh — as signed out", () => {
+    writeCreds({ access_token: "at", expiry_date: Date.now() - 86_400_000 });
+    expect(geminiIsAuthenticated({})).toBe(false);
+  });
+
+  it("treats a corrupt or unreadable credential file as signed out, not a crash", () => {
+    mkdirSync(geminiDir, { recursive: true });
+    writeFileSync(credsPath, "{not json");
+    expect(geminiIsAuthenticated({})).toBe(false);
+  });
+
+  it("counts a credential with no recorded expiry", () => {
+    writeCreds({ access_token: "at" });
+    expect(geminiIsAuthenticated({})).toBe(true);
+  });
+
+  it("rejects blank token strings and an invalid expiry", () => {
+    writeCreds({ access_token: "  ", expiry_date: Date.now() + 60_000 });
+    expect(geminiIsAuthenticated({})).toBe(false);
+    writeCreds({ access_token: "at", refresh_token: " \t", expiry_date: Date.now() - 60_000 });
+    expect(geminiIsAuthenticated({})).toBe(false);
+    writeCreds({ access_token: "at", expiry_date: "soon" });
+    expect(geminiIsAuthenticated({})).toBe(false);
+    writeCreds({ access_token: "at", expiry_date: Number.POSITIVE_INFINITY });
+    expect(geminiIsAuthenticated({})).toBe(false);
+  });
+});

--- a/server/drivers/acp/gemini.ts
+++ b/server/drivers/acp/gemini.ts
@@ -7,16 +7,25 @@
 // on an enterprise licence. Kept registered for exactly that case — add
 // {"instances": {"gemini": {"driver": "geminiAgent"}}} to config.json.
 //
-// Auth is intentionally lenient (authFailure "continue"): the Gemini CLI
-// commonly runs off an ambient login — an OAuth session from a prior
-// `gemini` run (~/.gemini/oauth_creds.json) or GEMINI_API_KEY in the env —
-// so we attempt the advertised authenticate method but never hard-fail the
-// turn on it, unlike Grok's subscription-bound cached_token.
+// Auth reality since 2026-06-18 (#28): consumer "Login with Google" no
+// longer serves the Gemini CLI — consumer tiers route through Antigravity,
+// and the login that produced ~/.gemini/oauth_creds.json stopped working
+// for them. The remaining paths are a GEMINI_API_KEY, Vertex, or an
+// enterprise Code Assist licence (whose OAuth refresh still works). The
+// driver cannot tell a consumer from an enterprise file locally, so the
+// file check only counts a *live-looking* credential (unexpired access
+// token, or a refresh token the CLI may still be able to use) and the
+// login note names the three real paths instead of the retired login.
+//
+// Auth is intentionally lenient (authFailure "continue"): the CLI may run
+// off an ambient login, so we attempt the advertised authenticate method
+// but never hard-fail the turn on it, unlike Grok's subscription-bound
+// cached_token.
 //
 // NOTE: untested against a live `gemini` CLI on this machine (not installed);
 // the ACP flag + auth method ids follow the published Gemini CLI ACP contract
 // and should be re-verified end-to-end once the CLI is present.
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -25,6 +34,44 @@ import { createAcpDriver, type AcpSupport } from "./core.ts";
 // Prefer an explicit key method, then personal OAuth, then Vertex — but fall
 // back to whatever the CLI advertises so a new method id still works.
 const AUTH_PREFERENCE = ["gemini-api-key", "oauth-personal", "vertex-ai"];
+
+/** A stored oauth_creds.json only counts when it looks alive: the access
+ * token has not passed its expiry_date, or a refresh token is present that
+ * an enterprise licence may still redeem. A stale consumer credential —
+ * the common case since 2026-06-18 — reads as not signed in, which is the
+ * truthful answer for an engine that would fail its first turn anyway. */
+function liveOauthCredential(): boolean {
+  try {
+    const creds = JSON.parse(readFileSync(join(homedir(), ".gemini", "oauth_creds.json"), "utf8")) as {
+      access_token?: unknown;
+      refresh_token?: unknown;
+      expiry_date?: unknown;
+    };
+    if (typeof creds.access_token !== "string" || creds.access_token.trim().length === 0) return false;
+    const hasRefresh = typeof creds.refresh_token === "string" && creds.refresh_token.trim().length > 0;
+    if (creds.expiry_date !== undefined) {
+      if (typeof creds.expiry_date !== "number" || !Number.isFinite(creds.expiry_date)) return false;
+      return Date.now() < creds.expiry_date || hasRefresh;
+    }
+    // no recorded expiry — treat possession of the credential as the signal
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const nonBlank = (value: string | undefined): boolean => Boolean(value?.trim());
+
+/** The credential check as a named function, so the support entry and the
+ * exported test surface are the same implementation, not a self-call.
+ * Config is unused — kept to match the AcpSupport signature. */
+export function geminiIsAuthenticated(env: Record<string, string | undefined>): boolean {
+  return (
+    nonBlank(env.GEMINI_API_KEY) ||
+    nonBlank(env.GOOGLE_API_KEY) ||
+    (existsSync(join(homedir(), ".gemini", "oauth_creds.json")) && liveOauthCredential())
+  );
+}
 
 const support: AcpSupport = {
   driverKind: "geminiAgent",
@@ -38,7 +85,8 @@ const support: AcpSupport = {
   },
   defaultCli: "gemini",
   nativeSource: "gemini.acp",
-  loginNote: "Gemini CLI is not signed in — run `gemini` once to log in, or set GEMINI_API_KEY",
+  loginNote:
+    "Gemini CLI needs a GEMINI_API_KEY, a Vertex AI setup, or an enterprise Code Assist login — consumer Google logins stopped working on 2026-06-18 (use the Antigravity engine for those accounts)",
 
   spawnArgs: (_config, turn) => ["--experimental-acp", ...(turn.model ? ["-m", turn.model] : [])],
   credentialEnv: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
@@ -50,9 +98,7 @@ const support: AcpSupport = {
   },
   authFailure: "continue",
 
-  isAuthenticated: (env) =>
-    Boolean(env.GEMINI_API_KEY || env.GOOGLE_API_KEY) ||
-    existsSync(join(homedir(), ".gemini", "oauth_creds.json")),
+  isAuthenticated: geminiIsAuthenticated,
 
   buildPromptText: (turn) => (turn.system ? `${turn.system}\n\n${turn.text}` : turn.text),
 };


### PR DESCRIPTION
Supersedes #262 with the reviewed fixes applied on current main.

Adds strict token/expiry validation, rejects blank API keys, and covers the remaining whitespace-token review case. Original implementation retained with contributor co-authorship.

Closes #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini authentication detection to reject expired, malformed, blank, or unreadable credentials.
  * Recognizes valid API keys and active or refreshable OAuth credentials.
  * Updated login guidance with supported authentication options and account-specific directions.

* **Tests**
  * Added comprehensive coverage for Gemini credential and expiration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->