### PR TITLE
Fix macOS updater restart loop

### DIFF
--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -1,13 +1,28 @@
 export function createUpdaterCoordinator(updater, setState) {
   let checkOperation = null;
   let downloadOperation = null;
+  let installOperation = null;
+  const routedErrors = new WeakSet();
 
-  function handleRejectedOperation(manual, error) {
+  const routeError = (manual, error) => {
+    if (error instanceof Error) routedErrors.add(error);
+    if (downloadOperation) downloadOperation.failed = true;
+    if (checkOperation) checkOperation.failed = true;
+    if (installOperation) {
+      installOperation.failed = true;
+      clearTimeout(installOperation.timer);
+      installOperation = null;
+    }
     if (!manual) {
       setState({ status: "idle" });
       return;
     }
     setState({ status: "error", message: String(error?.message ?? error) });
+  };
+
+  function handleRejectedOperation(manual, error) {
+    if (error instanceof Error && routedErrors.has(error)) return;
+    routeError(manual, error);
   }
 
   function checkOwnsState() {
@@ -25,12 +40,27 @@ export function createUpdaterCoordinator(updater, setState) {
   updater.on("update-not-available", () => {
     if (checkOwnsState()) setState({ status: "idle" });
   });
+  // downloadUpdate/checkForUpdates reject after most updater errors, but the
+  // macOS native staging pass used by quitAndInstall is event-only. Without
+  // this listener a Squirrel.Mac failure leaves the renderer on "Restarting"
+  // forever because quitAndInstall itself returns void.
+  updater.on("error", (error) => {
+    const manual = Boolean(installOperation || downloadOperation || checkOperation?.manual);
+    routeError(manual, error);
+  });
   updater.on("download-progress", (progress) =>
     setState({ status: "downloading", percent: Math.round(progress?.percent ?? 0) }),
   );
-  updater.on("update-downloaded", (info) =>
-    setState({ status: "downloaded", version: info?.version }),
-  );
+  updater.on("update-downloaded", (info) => {
+    // On macOS electron-updater emits this before Squirrel.Mac has finished
+    // staging the ZIP. Keep the UI in downloading until downloadUpdate's
+    // promise resolves, which is the point the native updater is ready.
+    if (downloadOperation) {
+      downloadOperation.downloadedInfo = info;
+      return;
+    }
+    setState({ status: "downloaded", version: info?.version });
+  });
 
   function check(manual = false) {
     if (checkOperation) {
@@ -39,7 +69,7 @@ export function createUpdaterCoordinator(updater, setState) {
       return checkOperation.promise;
     }
 
-    const operation = { manual, supersededByDownload: Boolean(downloadOperation), promise: null };
+    const operation = { manual, supersededByDownload: Boolean(downloadOperation), failed: false, promise: null };
     checkOperation = operation;
     try {
       operation.promise = Promise.resolve(updater.checkForUpdates())
@@ -61,7 +91,7 @@ export function createUpdaterCoordinator(updater, setState) {
     if (checkOperation) checkOperation.supersededByDownload = true;
     if (downloadOperation) return downloadOperation.promise;
 
-    const operation = { promise: null };
+    const operation = { downloadedInfo: null, failed: false, promise: null };
     downloadOperation = operation;
     // Own the state before the request goes out: the first "download-progress"
     // can be seconds away (connection setup, redirects), and until then the
@@ -70,6 +100,12 @@ export function createUpdaterCoordinator(updater, setState) {
     setState({ status: "downloading" });
     try {
       operation.promise = Promise.resolve(updater.downloadUpdate())
+        .then((result) => {
+          if (!operation.failed && operation.downloadedInfo) {
+            setState({ status: "downloaded", version: operation.downloadedInfo?.version });
+          }
+          return result;
+        })
         .catch((error) => handleRejectedOperation(true, error))
         .finally(() => {
           if (downloadOperation === operation) downloadOperation = null;
@@ -82,5 +118,28 @@ export function createUpdaterCoordinator(updater, setState) {
     return operation.promise;
   }
 
-  return { check, download };
+  function install() {
+    if (installOperation) return;
+    const operation = { failed: false, timer: null };
+    installOperation = operation;
+    setState({ status: "installing" });
+    try {
+      updater.quitAndInstall(true, true);
+    } catch (error) {
+      routeError(true, error);
+      return;
+    }
+    // quitAndInstall is void. If neither a quit nor an updater error arrives,
+    // recover the UI instead of spinning for the lifetime of the process.
+    if (installOperation === operation) {
+      operation.timer = setTimeout(() => {
+        if (installOperation !== operation) return;
+        installOperation = null;
+        setState({ status: "error", message: "The update could not be staged. Quit the app and try again." });
+      }, 2 * 60 * 1000);
+      operation.timer.unref?.();
+    }
+  }
+
+  return { check, download, install };
 }

--- a/electron/updater-coordinator.node-test.mjs
+++ b/electron/updater-coordinator.node-test.mjs
@@ -132,6 +132,42 @@ test("download reports downloading before the first progress event", async () =>
   await download;
 });
 
+test("downloaded waits for native staging to finish before becoming actionable", async () => {
+  const { updater, coordinator, getState } = harness();
+  const pending = deferred();
+  updater.downloadUpdate = () => pending.promise;
+
+  const download = coordinator.download();
+  updater.emit("update-downloaded", { version: "2.0.0" });
+  assert.deepEqual(getState(), { status: "downloading" });
+
+  pending.resolve(["update.zip"]);
+  await download;
+  assert.deepEqual(getState(), { status: "downloaded", version: "2.0.0" });
+});
+
+test("an asynchronous native install error escapes the restarting spinner", () => {
+  const { updater, coordinator, getState, states } = harness();
+  const error = new Error("native staging failed");
+  updater.quitAndInstall = () => updater.emit("error", error);
+
+  coordinator.install();
+
+  assert.deepEqual(getState(), { status: "error", message: "native staging failed" });
+  assert.equal(errorStates(states).length, 1);
+});
+
+test("a synchronous install failure becomes a user-visible error", () => {
+  const { updater, coordinator, getState } = harness();
+  updater.quitAndInstall = () => {
+    throw new Error("install threw");
+  };
+
+  coordinator.install();
+
+  assert.deepEqual(getState(), { status: "error", message: "install threw" });
+});
+
 test("an active download state survives a later background check failure", async () => {
   const { updater, coordinator, getState } = harness();
   const downloadPending = deferred();

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -1,14 +1,15 @@
-// In-app auto-updater (electron-updater), manual/button-driven — the same
-// shape t3code's desktop app uses: autoDownload off, quitAndInstall on the
-// user's "Restart to update" click. One state object is broadcast to the
-// renderer on every transition; the renderer just renders it.
+// In-app auto-updater (electron-updater). Downloads are user-driven; macOS
+// stages the downloaded ZIP immediately and the explicit restart applies it.
+// One state object is broadcast on every transition.
 //
 // Only runs in the packaged, signed+notarized app (mac auto-update requires
 // signing). In dev it's a no-op so the browser/dev shell is unaffected.
 // electron-updater is vendored (electron/vendor/electron-updater.cjs) because
 // the packaged app ships no node_modules.
 import { app, ipcMain } from "electron";
+import { appendFileSync, mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
 
 const require = createRequire(import.meta.url);
@@ -18,6 +19,23 @@ let win = null;
 // status: idle | checking | available | downloading | downloaded | installing | error
 let state = { status: "idle" };
 let updaterCoordinator = null;
+
+function updaterLogger() {
+  const directory = app.getPath("logs");
+  const file = join(directory, "updater.log");
+  const write = (level, values) => {
+    try {
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      const message = values
+        .map((value) => (value instanceof Error ? value.stack ?? value.message : String(value)))
+        .join(" ");
+      appendFileSync(file, `[${new Date().toISOString()}] [${level}] ${message}\n`, { mode: 0o600 });
+    } catch {
+      // Logging must never make updating unavailable.
+    }
+  };
+  return Object.fromEntries(["debug", "info", "warn", "error"].map((level) => [level, (...values) => write(level, values)]));
+}
 
 function setState(patch) {
   state = { ...state, ...patch };
@@ -32,18 +50,7 @@ export function registerUpdaterIpc() {
   ipcMain.handle("update:get-state", () => state);
   ipcMain.handle("update:check", () => updaterCoordinator?.check(true));
   ipcMain.handle("update:download", () => updaterCoordinator?.download());
-  ipcMain.handle("update:install", () => {
-    if (!autoUpdater) return;
-    // Tearing down the window and relaunching takes a beat; announce it so the
-    // button greys out instead of looking like the click was swallowed.
-    setState({ status: "installing" });
-    // isSilent, isForceRunAfter — relaunch straight into the new version
-    try {
-      autoUpdater.quitAndInstall(true, true);
-    } catch (e) {
-      setState({ status: "error", message: String(e?.message ?? e) });
-    }
-  });
+  ipcMain.handle("update:install", () => updaterCoordinator?.install());
 }
 
 export function startUpdater(mainWindow) {
@@ -62,8 +69,11 @@ export function startUpdater(mainWindow) {
     return;
   }
   autoUpdater.autoDownload = false; // button-driven download
-  autoUpdater.autoInstallOnAppQuit = false; // button-driven install
-  autoUpdater.logger = null;
+  // Squirrel.Mac has a second, native staging pass after the ZIP download.
+  // Start it immediately so "Restart to update" never has to begin that slow
+  // pass and wait indefinitely. Windows keeps the explicit installer click.
+  autoUpdater.autoInstallOnAppQuit = process.platform === "darwin";
+  autoUpdater.logger = updaterLogger();
 
   updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState);
 


### PR DESCRIPTION
## Summary
- stage macOS updates through Squirrel before presenting Restart
- surface native updater errors and prevent the UI from spinning indefinitely
- add a bounded install timeout and private updater diagnostics
- cover staging, asynchronous errors, and synchronous install failures with tests

## Verification
- `pnpm test` (1327 passed, 12 skipped)
- `pnpm test:updater` (15 passed)
- `pnpm typecheck`
- `pnpm check:electron`
- changed-file Oxlint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing updates through the updater flow.
  * Added updater activity logging to help monitor update operations.
  * macOS updates can now install automatically when the app quits.

* **Bug Fixes**
  * Improved handling of download and installation failures.
  * Prevented duplicate error notifications and incorrect download status updates.
  * Added timeout handling for stalled installations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->