### PR TITLE
Release 0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the application version from 0.1.25 to 0.1.26
- prepare a new release containing the macOS updater restart-loop fix from #299

## Validation
- package metadata parses successfully as version 0.1.26
- the Release workflow will rebuild and verify macOS, Windows, and Ubuntu artifacts from the merged commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package to version 0.1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->