### PR TITLE
See real OpenCode logins, and list Gemini 3.7 for Antigravity

### DIFF
--- a/server/drivers/acp/opencode-go.test.ts
+++ b/server/drivers/acp/opencode-go.test.ts
@@ -104,6 +104,60 @@ describe("OpenCode Go catalog", () => {
     }
   });
 
+  it("finds the CLI's login at ~/.local/share on every platform, macOS included", async () => {
+    // `opencode auth list` prints ~/.local/share/opencode/auth.json on macOS —
+    // the CLI is xdg-flavoured everywhere. Looking only in Library/Application
+    // Support is the bug that told signed-in users to sign in. No XDG override
+    // here on purpose: this is the exact real-world shape.
+    const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-home-"));
+    const authDir = join(scratch, ".local", "share", "opencode");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), JSON.stringify({
+      "opencode-go": { type: "api", key: "stored-secret" },
+    }));
+    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const instance = await driver.create({
+      instanceId: "opencode-home-auth",
+      displayName: "OpenCode Go",
+      environment: { HOME: scratch, USERPROFILE: scratch, XDG_DATA_HOME: "", OPENCODE_API_KEY: "" },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      await removeTempDir(scratch);
+    }
+  });
+
+  it("accepts a browser (oauth) sign-in stored under the plain 'opencode' id", async () => {
+    // `opencode auth login` -> OpenCode writes {type:"oauth", access, refresh}
+    // under "opencode", not an api `key` under "opencode-go". Both unlock the
+    // Go models; demanding `key` under "opencode-go" rejected every real
+    // browser login.
+    const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-oauth-"));
+    const authDir = join(scratch, "opencode");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), JSON.stringify({
+      opencode: { type: "oauth", access: "acc-token", refresh: "ref-token" },
+    }));
+    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const instance = await driver.create({
+      instanceId: "opencode-oauth-auth",
+      displayName: "OpenCode Go",
+      environment: { XDG_DATA_HOME: scratch, OPENCODE_API_KEY: "" },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      await removeTempDir(scratch);
+    }
+  });
+
   it("classifies ACP's standard authentication error", () => {
     expect(classifyOpenCodeGoError({ code: -32000 })).toBe("invalid_credentials");
   });

--- a/server/drivers/acp/opencode-go.ts
+++ b/server/drivers/acp/opencode-go.ts
@@ -147,30 +147,56 @@ export function ensureOpenCodeInjectModel(
   return native;
 }
 
-function storedAuthPath(env: Record<string, string | undefined>) {
+/** Every path the OpenCode CLI may keep auth.json at.
+ *
+ * The CLI is xdg-flavoured on EVERY platform — `opencode auth list` on macOS
+ * prints `~/.local/share/opencode/auth.json`, and that is where real logins
+ * land. The platform-conventional locations are kept as fallbacks in case a
+ * future CLI moves there, but the xdg path must come first: checking only
+ * Library/Application Support on macOS is exactly the bug that made the app
+ * demand a sign-in from users who were already signed in. */
+function storedAuthPaths(env: Record<string, string | undefined>): string[] {
   const home = env.HOME || env.USERPROFILE || homedir();
-  const dataRoot = env.XDG_DATA_HOME
-    || (process.platform === "darwin"
+  const roots = [
+    env.XDG_DATA_HOME || join(home, ".local", "share"),
+    process.platform === "darwin"
       ? join(home, "Library", "Application Support")
       : process.platform === "win32"
         ? env.LOCALAPPDATA || join(home, "AppData", "Local")
-        : join(home, ".local", "share"));
-  return join(dataRoot, "opencode", "auth.json");
+        : "",
+  ].filter(Boolean);
+  return [...new Set(roots)].map((root) => join(root, "opencode", "auth.json"));
+}
+
+/** True when an auth.json entry looks like a usable OpenCode login.
+ *
+ * The CLI writes `{type:"api", key}` for pasted keys and
+ * `{type:"oauth", access, refresh}` for browser sign-ins — demanding `key`
+ * alone rejects every OAuth login. The entry id is `"opencode"` for the
+ * standard Zen sign-in and `"opencode-go"` for the Go product; both unlock
+ * the Go models, so both count. */
+function usableAuthEntry(parsed: Record<string, unknown>): boolean {
+  return ["opencode-go", "opencode"].some((id) => {
+    const auth = parsed[id];
+    if (!auth || typeof auth !== "object") return false;
+    const entry = auth as { key?: unknown; access?: unknown; refresh?: unknown };
+    return Boolean(entry.key || entry.access || entry.refresh);
+  });
 }
 
 function hasStoredOpenCodeGoAuth(env: Record<string, string | undefined>) {
   const candidates: string[] = [];
   if (env.OPENCODE_AUTH_CONTENT) candidates.push(env.OPENCODE_AUTH_CONTENT);
-  try {
-    candidates.push(readFileSync(storedAuthPath(env), "utf8"));
-  } catch {
-    // A missing or unreadable file simply means there is no ambient login.
+  for (const path of storedAuthPaths(env)) {
+    try {
+      candidates.push(readFileSync(path, "utf8"));
+    } catch {
+      // A missing or unreadable file simply means there is no ambient login.
+    }
   }
   return candidates.some((raw) => {
     try {
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const auth = parsed["opencode-go"];
-      return Boolean(auth && typeof auth === "object" && (auth as { key?: unknown }).key);
+      return usableAuthEntry(JSON.parse(raw) as Record<string, unknown>);
     } catch {
       return false;
     }
@@ -183,7 +209,8 @@ const support = (fetcher: typeof fetch): AcpSupport => ({
   models: STATIC_MODELS,
   defaultCli: "opencode",
   nativeSource: "opencode-go.acp",
-  loginNote: "OpenCode Go is not configured — add an OPENCODE_API_KEY in OpenMausBot settings",
+  loginNote:
+    "OpenCode is not signed in — run `opencode auth login` and pick OpenCode, or add an OPENCODE_API_KEY in OpenMausBot settings",
   install: {
     command: {
       darwin: "npm install -g opencode-ai",

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -46,6 +46,10 @@ export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   options: [
     { id: "gemini-3.1-pro-high", label: "Gemini 3.1 Pro (High)" },
     { id: "gemini-3.1-pro-low", label: "Gemini 3.1 Pro (Low)" },
+    // 3.7 ids confirmed against the agy 1.1.12 binary's own model table
+    { id: "gemini-3.7-flash-high", label: "Gemini 3.7 Flash (High)" },
+    { id: "gemini-3.7-flash-medium", label: "Gemini 3.7 Flash (Medium)" },
+    { id: "gemini-3.7-flash-low", label: "Gemini 3.7 Flash (Low)" },
     { id: "gemini-3.6-flash-high", label: "Gemini 3.6 Flash (High)" },
     { id: "gemini-3.6-flash-medium", label: "Gemini 3.6 Flash (Medium)" },
     { id: "gemini-3.6-flash-low", label: "Gemini 3.6 Flash (Low)" },


### PR DESCRIPTION
Two user reports, one cause each — the app refused to see sign-ins that were really there, and hid models that really exist.

## OpenCode: "signed up but it still asks me to sign in"

Diagnosed against the installed CLI (1.18.18), not assumptions:

- `opencode auth list` prints its own storage location: `~/.local/share/opencode/auth.json` — **the CLI is xdg-flavoured on every platform, macOS included**. Our detection looked in `Library/Application Support` on darwin, so real logins were invisible.
- Browser sign-ins write `{type:"oauth", access, refresh}` under the plain `"opencode"` id; we demanded an `"opencode-go"` entry carrying `key`. Both ids appear in the CLI binary's own string table; both unlock the Go models. Every OAuth login was rejected.

Detection now checks the xdg path first (platform-conventional dir kept as fallback) and accepts either entry id with `key` **or** oauth tokens. The sign-in hint now names `opencode auth login` rather than only the API-key path. The free-model catalog itself was already fine — `https://opencode.ai/zen/go/v1/models` lists them and the fetch works — it was the auth gate in front of it that was wrong.

## Antigravity: "login doesn't show gemini 3.7"

The static catalog was transcribed from an older `agy models` run and stops at 3.6. The `agy` 1.1.12 binary's own model table contains `gemini-3.7-flash-{high,medium,low}` — added, default unchanged. (Truly live discovery via `agy models` needs a signed-in fixture to parse against; left for a follow-up.)

## Verification

- both new regression tests reproduce the real-world shapes (a login at `~/.local/share` with no XDG override; an oauth entry under `"opencode"`) and **fail on the previous code** — mutation-checked
- full suite: 1329 passed / 12 skipped across 134 files; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting OpenCode credentials from platform-specific authentication file locations.
  - Recognized both API-key and OAuth credentials for OpenCode authentication.
  - Added high, medium, and low variants of the Gemini 3.7 Flash model.

- **Bug Fixes**
  - Improved OpenCode login guidance, including supported authentication commands and API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->