### PR TITLE
fix(computer): pre-open the join tab so pop-up blockers don't eat the join URL

### DIFF
--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -443,13 +443,17 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       if (joinTab) joinTab.opener = null;
     }
     api(`/api/bots/${bot.id}/computer/${kind}`, { method: "POST" })
-      .then((result) => {
+      .then(async (result) => {
         // the join URL's stream token rotates — always freshly minted, never cached
         if (kind === "join") {
-          if (!result.joinUrl) joinTab?.close();
-          else if (joinTab) joinTab.location.replace(result.joinUrl);
-          else if (window.ogb?.openExternal) void window.ogb.openExternal(result.joinUrl);
-          else window.open(result.joinUrl, "_blank", "noopener");
+          if (!result.joinUrl) throw new Error("The computer did not return a join link");
+          if (joinTab) joinTab.location.replace(result.joinUrl);
+          else if (window.ogb?.openExternal) {
+            const opened = await window.ogb.openExternal(result.joinUrl);
+            if (!opened) throw new Error("OpenMausBot could not open the computer join link");
+          } else if (!window.open(result.joinUrl, "_blank", "noopener")) {
+            throw new Error("Your browser blocked the computer join tab");
+          }
         }
         if (kind === "provision") {
           setBoxState(result.container ?? null);

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -434,10 +434,23 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const run = (kind: "join" | "sleep" | "provision") => {
     setPending(kind);
     setError(null);
+    // Pop-up blockers only allow windows opened synchronously inside the click,
+    // so pre-open the tab before the request and point it at the join URL once
+    // minted (same pattern as ConnectorCard); Electron keeps using openExternal.
+    let joinTab: Window | null = null;
+    if (kind === "join" && !window.ogb?.openExternal) {
+      joinTab = window.open("", "_blank");
+      if (joinTab) joinTab.opener = null;
+    }
     api(`/api/bots/${bot.id}/computer/${kind}`, { method: "POST" })
       .then((result) => {
         // the join URL's stream token rotates — always freshly minted, never cached
-        if (kind === "join" && result.joinUrl) window.open(result.joinUrl, "_blank", "noopener");
+        if (kind === "join") {
+          if (!result.joinUrl) joinTab?.close();
+          else if (joinTab) joinTab.location.replace(result.joinUrl);
+          else if (window.ogb?.openExternal) void window.ogb.openExternal(result.joinUrl);
+          else window.open(result.joinUrl, "_blank", "noopener");
+        }
         if (kind === "provision") {
           setBoxState(result.container ?? null);
           if (result.ready) setPhase("ready");
@@ -451,7 +464,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
           if (cloudBackend === "vps") setPhase("vps-stopped");
         }
       })
-      .catch((e) => setError(e.message))
+      .catch((e) => {
+        joinTab?.close();
+        setError(e.message);
+      })
       .finally(() => setPending(null));
   };
 


### PR DESCRIPTION
## What

`ComputerPanel`'s **Open desktop / join** button calls `window.open(result.joinUrl, …)` inside the `.then()` of the `/api/bots/:id/computer/join` request. In a plain browser that runs outside the user-gesture window, so pop-up blockers (Chrome/Safari defaults) silently swallow the tab — the click appears to do nothing, with no error surfaced. We hit this class of bug while hosting the web UI behind a proxy on Cloudflare Workers: every "open a URL we just fetched" flow died silently until the open was moved into the click's synchronous window.

## Fix

Pre-open a blank tab synchronously in the click handler and point it at the join URL once it's minted — the exact pattern `ConnectorCard.openConnectionPage` and `PluginsPanel` already use — and close the placeholder tab if the request fails or returns no `joinUrl`. Electron behavior is unchanged (`ogb.openExternal` still takes priority, and no placeholder tab is opened there).

This also preserves the existing guarantee in the comment above the call: the URL is always the freshly minted one, never cached.

## Checks

- `pnpm typecheck` ✅
- `pnpm test` ✅ (full suite)
- No new dependencies; UI-only, no visual change (screenshots N/A — the change is that the tab now actually opens in browsers with default pop-up settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join error handling when a join link is unavailable, cannot be opened in the desktop app, or is blocked by the browser.
  * Ensured temporary join windows are closed after unsuccessful attempts.
  * Join links now open reliably in the available window when the operation succeeds.
  * Added clearer error handling for failed join attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->