### PR TITLE
Fix macOS release blockmap regeneration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,9 @@ jobs:
           rm -f "release/OpenMausBot-$v-arm64.zip" "release/OpenMausBot-$v-x64.zip"
           ditto -c -k --sequesterRsrc --keepParent release/mac-arm64/OpenMausBot.app "release/OpenMausBot-$v-arm64.zip"
           ditto -c -k --sequesterRsrc --keepParent release/mac/OpenMausBot.app "release/OpenMausBot-$v-x64.zip"
-          AB=$(node -p "require('app-builder-bin').appBuilderPath")
-          for f in "release/OpenMausBot-$v-arm64.zip" "release/OpenMausBot-$v-x64.zip" \
-                   "release/OpenMausBot-$v-arm64.dmg" "release/OpenMausBot-$v-x64.dmg"; do
-            "$AB" blockmap -i "$f" -o "$f.blockmap" > /dev/null
-          done
+          node scripts/regenerate-blockmaps.mjs \
+            "release/OpenMausBot-$v-arm64.zip" "release/OpenMausBot-$v-x64.zip" \
+            "release/OpenMausBot-$v-arm64.dmg" "release/OpenMausBot-$v-x64.dmg"
           # refreshes every hash from the post-staple bytes and refuses to
           # finish unless the feed matches the files on disk
           node scripts/regenerate-mac-feed.mjs

--- a/scripts/regenerate-blockmaps.mjs
+++ b/scripts/regenerate-blockmaps.mjs
@@ -1,0 +1,27 @@
+// Regenerate external electron-updater blockmaps after release artifacts have
+// been stapled or rebuilt. electron-builder 26 generates blockmaps in
+// app-builder-lib; the former app-builder-bin package is no longer installed.
+import { access, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const electronBuilderPackage = require.resolve("electron-builder/package.json");
+const requireFromElectronBuilder = createRequire(electronBuilderPackage);
+const { buildBlockMap } = requireFromElectronBuilder(
+  "app-builder-lib/out/targets/blockmap/blockmap.js",
+);
+
+const inputs = process.argv.slice(2);
+if (inputs.length === 0) {
+  throw new Error("usage: node scripts/regenerate-blockmaps.mjs <artifact> [...artifact]");
+}
+
+for (const input of inputs) {
+  const artifact = resolve(input);
+  await access(artifact);
+  const blockmap = `${artifact}.blockmap`;
+  await buildBlockMap(artifact, "gzip", blockmap);
+  const { size } = await stat(blockmap);
+  console.log(`blockmap: ${blockmap} (${size} bytes)`);
+}

--- a/scripts/regenerate-mac-feed.mjs
+++ b/scripts/regenerate-mac-feed.mjs
@@ -12,8 +12,8 @@
 // top-level path/sha512 is the legacy fallback taken from the first entry —
 // and only recomputes sha512 + size from the bytes on disk right now.
 //
-// Blockmaps are NOT handled here: regenerate them separately (app-builder
-// blockmap) after stapling, for the same staleness reason.
+// Blockmaps are NOT handled here: regenerate them separately with
+// scripts/regenerate-blockmaps.mjs after stapling, for the same staleness reason.
 import { createHash } from "node:crypto";
 import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";


### PR DESCRIPTION
## Summary
- replace the removed `app-builder-bin` lookup with electron-builder 26’s current blockmap generator
- add a reusable blockmap regeneration script for post-staple artifacts
- keep the feed regeneration documentation aligned with the release command

## Why
The 0.1.26 release successfully signed, notarized, and stapled all four macOS artifacts, then failed because `app-builder-bin` is no longer installed by electron-builder 26.15.3.

## Validation
- generated a gzip-compressed blockmap v2 from a test artifact
- validated the new script with Node syntax checking
- validated release workflow YAML
- verified staged diff integrity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release processing to reliably generate blockmaps for ZIP and DMG artifacts.
  * Added validation and reporting for generated blockmap files.
* **Documentation**
  * Updated release guidance to reference the current blockmap generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->