### PR TITLE
test: handle duplicate starter names in team imports

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -541,10 +541,19 @@ describe("harness HTTP API", () => {
       const imported = await api("POST", "/api/teams/import", exported.body);
       expect(imported.status).toBe(201);
       // the originals still exist, so every member arrives visibly numbered
-      // rather than wearing a name that already resolves to another bot
-      expect(imported.body.bots.map((bot: { name: string }) => bot.name)).toEqual(
-        visibleNames.map((name: string) => `${name} 2`),
-      );
+      // rather than wearing a name that already resolves to another bot. The
+      // starter name is intentionally random, so it can duplicate a member
+      // name and advance that member to the next available suffix.
+      const importedNames = imported.body.bots.map((bot: { name: string }) => bot.name);
+      const namesBefore = new Set(stateBefore.bots.map((bot: { name: string }) => bot.name.toLowerCase()));
+      expect(importedNames).toHaveLength(visibleNames.length);
+      expect(new Set(importedNames.map((name: string) => name.toLowerCase())).size).toBe(importedNames.length);
+      for (const [index, name] of importedNames.entries()) {
+        const base = visibleNames[index]!;
+        expect(name.startsWith(`${base} `)).toBe(true);
+        expect(Number(name.slice(base.length + 1))).toBeGreaterThanOrEqual(2);
+        expect(namesBefore.has(name.toLowerCase())).toBe(false);
+      }
       expect(imported.body.bots.every((bot: { id: string }) => ![first.id, second.id].includes(bot.id))).toBe(true);
       expect(imported.body.bots[0]).not.toHaveProperty("alwaysAllow");
       // imported bots arrive quiet and without reach: no seeded greeting


### PR DESCRIPTION
## Why

The integration test assumed every imported name would end in `2`. The starter bot name is randomly selected and can already match an exported member, correctly advancing the duplicate to `3` and making Ubuntu CI fail deterministically for that seed.

## Change

Assert the actual contract—numbered, unique, non-colliding names—without assuming the starter never shares a member name.

## Verification

- `pnpm exec vitest run server/index.test.ts` (67 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved team-import validation to support multiple duplicate-name suffixes.
  * Added coverage for starter-name collisions.
  * Confirmed imported names remain unique, derived from source names, and distinct from existing names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->