### PR TITLE
chore(release): bump version to 0.1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Release

Bumps the desktop/updater version to **0.1.27** after merging Cursor ACP support and the computer join-tab fix.

The existing 0.1.26 artifact remains an unpublished draft and will not be exposed to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->