### PR TITLE
Add pi coding agent as a native RPC engine

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -330,10 +330,12 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     computer: { driver: "boxAgent" },
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
+    pi: { driver: "piAgent" },
   };
   const CUSTOM_ONLY = {
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
+    pi: { driver: "piAgent" },
   } as const;
   // New default-fleet engines that existing product configs would otherwise
   // never see. Custom-only engines stay in CUSTOM_ONLY so a one-off test map

--- a/server/config.ts
+++ b/server/config.ts
@@ -198,6 +198,24 @@ export function stripWorkspaceCredentialEnv(env: Record<string, string | undefin
   for (const key of WORKSPACE_CREDENTIAL_ENV) delete env[key];
 }
 
+/** Env names a provider CLI might read as its own billing identity. A spawned
+ * engine keeps only what its driver explicitly allows: a foreign key riding
+ * along in `...process.env` must not flip a subscription CLI onto
+ * pay-as-you-go billing the user never granted. */
+export const PROVIDER_CREDENTIAL_ENV = [
+  "ANTHROPIC_API_KEY",
+  "FACTORY_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "KIMI_API_KEY",
+  "MOONSHOT_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENCODE_API_KEY",
+  "XAI_API_KEY",
+  "CURSOR_API_KEY",
+  "CURSOR_AUTH_TOKEN",
+] as const;
+
 /** Merge a partial config into ~/.openmausbot/config.json (secrets never
  * echoed back — callers report configured-or-not booleans only). */
 export function saveConfig(patch: Partial<AppConfig>): void {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -15,7 +15,7 @@
 // before the prompt is sent, and `_meta.isReplay` updates are dropped.
 import { homedir } from "node:os";
 
-import { WORKSPACE_CREDENTIAL_ENV } from "../../config.ts";
+import { PROVIDER_CREDENTIAL_ENV, WORKSPACE_CREDENTIAL_ENV } from "../../config.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../procs.ts";
 
 import type {
@@ -128,19 +128,6 @@ const INIT_TIMEOUT = 20_000;
 const SESSION_CONFIG_TIMEOUT = 20_000; // configureSession's per-request default
 const NEW_SESSION_TIMEOUT = 30_000;
 const LOAD_SESSION_TIMEOUT = 120_000; // history replay on a long thread is slow
-const PROVIDER_CREDENTIAL_ENV = [
-  "ANTHROPIC_API_KEY",
-  "FACTORY_API_KEY",
-  "GEMINI_API_KEY",
-  "GOOGLE_API_KEY",
-  "KIMI_API_KEY",
-  "MOONSHOT_API_KEY",
-  "OPENAI_API_KEY",
-  "OPENCODE_API_KEY",
-  "XAI_API_KEY",
-  "CURSOR_API_KEY",
-  "CURSOR_AUTH_TOKEN",
-] as const;
 
 function decodeAcpConfig(defaultCli: string) {
   return (raw: unknown): AcpConfig => {

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -14,6 +14,7 @@ import { CursorAgentDriver } from "./acp/cursor.ts";
 import { OpenCodeGoDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
+import { PiDriver } from "./pi.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -25,6 +26,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   OpenCodeGoDriver,
   QwenAgentDriver,
   HermesAgentDriver,
+  PiDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -5,7 +5,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly; spawnCli
 // resolves it to `node <script>`, so these run everywhere.
-import { chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -111,11 +111,11 @@ describe("PiDriver turns (fake CLI)", () => {
   let instance: ProviderInstance;
   let recorder: EventRecorder;
 
-  const create = async (mode?: string) => {
+  const create = async (mode?: string, environment: Record<string, string> = {}) => {
     instance = await PiDriver.create({
       instanceId: "pi-test",
       displayName: "pi Test",
-      environment: mode ? { FAKE_PI_MODE: mode } : {},
+      environment: { ...environment, ...(mode ? { FAKE_PI_MODE: mode } : {}) },
       enabled: true,
       config: { cli: FAKE_CLI },
     });
@@ -163,6 +163,56 @@ describe("PiDriver turns (fake CLI)", () => {
     const done = recorder.events.at(-1)!;
     expect(done).toMatchObject({ type: "turn.completed", ok: true, stopReason: "end_turn", usage: { input: 12, output: 3 } });
     expect(instance.adapter.hasSession("t-happy")).toBe(false);
+  });
+
+  it("resumes a prior pi session using the sessionFile resume cursor", async () => {
+    await create();
+    const first = await instance.adapter.sendTurn({ threadId: "t-resume", text: "first" });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === first.turnId);
+    const firstSession = recorder.events.find((e) => e.type === "session.started" && e.turnId === first.turnId) as
+      | { sessionId: string }
+      | undefined;
+    expect(firstSession?.sessionId).toMatch(/\/fake\/pi-session-\d+\.json/);
+
+    const second = await instance.adapter.sendTurn({
+      threadId: "t-resume",
+      text: "second",
+      resumeCursor: firstSession!.sessionId,
+    });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === second.turnId);
+    const secondSession = recorder.events.find((e) => e.type === "session.started" && e.turnId === second.turnId) as
+      | { sessionId: string }
+      | undefined;
+    expect(secondSession?.sessionId).toBe(firstSession?.sessionId);
+  });
+
+  it("fails promptly when the pi process exits before replying", async () => {
+    await create("exit-early");
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-exit", text: "hi" });
+    const done = await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+    expect(done).toMatchObject({ ok: false, stopReason: "failed" });
+    expect(instance.adapter.hasSession("t-exit")).toBe(false);
+  });
+
+  it("records argv and only configured environment names in FAKE_PI_DUMP", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-pi-dump-"));
+    const dump = join(dir, "dump.jsonl");
+    await create(undefined, {
+      FAKE_PI_DUMP: dump,
+      ANTHROPIC_API_KEY: "anthropic-secret-value",
+      OPENAI_API_KEY: "openai-secret-value",
+    });
+    await instance.dispose();
+
+    const rows = readFileSync(dump, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { argv: string[]; envConfigured: string[] });
+    expect(rows.some((row) => row.argv.join(" ") === "--mode rpc --no-session")).toBe(true);
+    expect(rows.some((row) => row.envConfigured.includes("ANTHROPIC_API_KEY"))).toBe(true);
+    expect(rows.some((row) => row.envConfigured.includes("OPENAI_API_KEY"))).toBe(true);
+    expect(JSON.stringify(rows)).not.toContain("anthropic-secret-value");
+    expect(JSON.stringify(rows)).not.toContain("openai-secret-value");
   });
 
   it("rides the toolUse auto-continue and only settles on the final end_turn", async () => {

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -1,0 +1,245 @@
+// pi driver contract tests, run against the scripted fake `pi` CLI in
+// server/testing/fake-pi-cli.ts: parse the live catalog, normalize a full
+// RPC turn into canonical events, ride the toolUse→end_turn auto-continue,
+// broker a permission ask, and report availability from `pi --version`.
+//
+// The fake CLI is a shebang script Windows cannot exec directly; spawnCli
+// resolves it to `node <script>`, so these run everywhere.
+import { chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ensureDirs } from "../config.ts";
+import type { ProviderInstance } from "../contracts.ts";
+import { recordEvents, type EventRecorder } from "../testing/events.ts";
+import { fetchPiModels, parsePiCatalog, PiDriver } from "./pi.ts";
+
+const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-pi-cli.ts");
+const MODELS_LINE =
+  '{"type":"response","command":"get_available_models","success":true,"data":{"models":[{"provider":"ollama-cloud","id":"glm-5.2","name":"glm-5.2"},{"provider":"openai","id":"gpt-4o","name":"GPT-4o"}]}}';
+
+describe("parsePiCatalog", () => {
+  it("turns a get_available_models response into custom composite-id options", () => {
+    const catalog = parsePiCatalog(MODELS_LINE + "\n");
+    expect(catalog.default).toBe("ollama-cloud/glm-5.2");
+    expect(catalog.options).toEqual([
+      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true },
+      { id: "openai/gpt-4o", label: "GPT-4o", custom: true },
+    ]);
+  });
+
+  it("uses the fallback default when the response omits one and a settings file is absent", () => {
+    const catalog = parsePiCatalog(MODELS_LINE + "\n", "openai/gpt-4o");
+    expect(catalog.default).toBe("openai/gpt-4o");
+  });
+
+  it("keeps an empty catalog when the probe fails or reports no models", () => {
+    expect(parsePiCatalog("not json\n")).toEqual({ default: "", options: [] });
+    expect(parsePiCatalog('{"type":"response","command":"get_available_models","success":false}\n')).toEqual({
+      default: "",
+      options: [],
+    });
+    expect(
+      parsePiCatalog('{"type":"response","command":"get_available_models","success":true,"data":{"models":[]}}\n'),
+    ).toEqual({ default: "", options: [] });
+  });
+
+  it("ignores non-response lines (pi emits TUI bookkeeping on stdout too)", () => {
+    const stdout =
+      '{"type":"extension_ui_request","id":"x","method":"setStatus","statusKey":"loops"}\n' + MODELS_LINE + "\n";
+    const catalog = parsePiCatalog(stdout);
+    expect(catalog.options).toHaveLength(2);
+  });
+});
+
+describe("PiDriver config + install", () => {
+  it("defaults to the `pi` binary", () => {
+    expect(PiDriver.decodeConfig({})).toEqual({ cli: "pi" });
+    expect(PiDriver.decodeConfig(undefined)).toEqual({ cli: "pi" });
+    expect(PiDriver.decodeConfig(null)).toEqual({ cli: "pi" });
+    expect(PiDriver.decodeConfig({ cli: "  " })).toEqual({ cli: "pi" });
+  });
+
+  it("rejects invalid config (throws → shadow snapshot)", () => {
+    expect(() => PiDriver.decodeConfig(5)).toThrow(/object/);
+    expect(() => PiDriver.decodeConfig({ cli: 5 })).toThrow(/string/);
+  });
+
+  it("publishes the npm installer on every platform and points docs at pi.dev", () => {
+    expect(PiDriver.install).toMatchObject({
+      command: {
+        darwin: "npm install -g @earendil-works/pi-coding-agent",
+        linux: "npm install -g @earendil-works/pi-coding-agent",
+        win32: "npm install -g @earendil-works/pi-coding-agent",
+      },
+      docsUrl: "https://pi.dev",
+      needsNode: true,
+    });
+    expect(PiDriver.metadata).toMatchObject({ displayName: "pi", access: "custom" });
+  });
+});
+
+describe("PiDriver catalog (fake CLI)", () => {
+  beforeEach(() => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+  });
+
+  it("probes the live catalog and flags every option custom", async () => {
+    const catalog = await fetchPiModels(FAKE_CLI, { PATH: process.env.PATH ?? "", HOME: join(tmpdir(), "omb-pi-no-settings") });
+    expect(catalog.options).toEqual([
+      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true },
+      { id: "openai/gpt-4o", label: "gpt-4o", custom: true },
+    ]);
+    // no ~/.pi/agent/settings.json in the throwaway home → first option wins
+    expect(catalog.default).toBe("ollama-cloud/glm-5.2");
+  });
+
+  it("keeps an empty catalog when the probe reports no models", async () => {
+    const catalog = await fetchPiModels(FAKE_CLI, {
+      PATH: process.env.PATH ?? "",
+      HOME: join(tmpdir(), "omb-pi-empty"),
+      FAKE_PI_MODE: "no-models",
+    });
+    expect(catalog.options).toEqual([]);
+  });
+});
+
+describe("PiDriver turns (fake CLI)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+
+  const create = async (mode?: string) => {
+    instance = await PiDriver.create({
+      instanceId: "pi-test",
+      displayName: "pi Test",
+      environment: mode ? { FAKE_PI_MODE: mode } : {},
+      enabled: true,
+      config: { cli: FAKE_CLI },
+    });
+    recorder = recordEvents(instance.adapter);
+  };
+
+  beforeEach(() => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+  });
+  afterEach(async () => {
+    recorder?.stop();
+    await instance?.dispose();
+  });
+
+  it("normalizes a full turn into the canonical event sequence", async () => {
+    await create();
+    const { turnId } = await instance.adapter.sendTurn({
+      threadId: "t-happy",
+      text: "hi",
+      model: "ollama-cloud/glm-5.2",
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const types = recorder.events.map((e) => e.type);
+    expect(types).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "content.delta",
+      "content.delta",
+      "item.completed", // assistant_text
+      "turn.completed",
+    ]);
+    expect(recorder.events.every((e) => e.turnId === turnId && e.provider === "piAgent")).toBe(true);
+
+    const session = recorder.events.find((e) => e.type === "session.started")!;
+    expect((session as { sessionId: string }).sessionId).toMatch(/\/fake\/pi-session-\d+\.json/);
+
+    const text = recorder.events.find(
+      (e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text",
+    )!;
+    expect((text as { text: string }).text).toBe("Hello from pi");
+
+    const done = recorder.events.at(-1)!;
+    expect(done).toMatchObject({ type: "turn.completed", ok: true, stopReason: "end_turn", usage: { input: 12, output: 3 } });
+    expect(instance.adapter.hasSession("t-happy")).toBe(false);
+  });
+
+  it("rides the toolUse auto-continue and only settles on the final end_turn", async () => {
+    await create("tooluse");
+    await instance.adapter.sendTurn({ threadId: "t-tool", text: "run it" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+
+    // a tool ran and completed, then pi auto-continued to synthesize the reply
+    expect(recorder.events.filter((e) => e.type === "item.started").length).toBe(1);
+    expect(recorder.events.filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "tool").length).toBe(1);
+    expect(done).toMatchObject({ ok: true, stopReason: "end_turn" });
+    expect((done as { usage: { input: number; output: number } }).usage).toEqual({ input: 12, output: 2 });
+    const text = recorder.events.find(
+      (e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text",
+    ) as { text: string } | undefined;
+    expect(text?.text).toBe("done");
+    expect(instance.adapter.hasSession("t-tool")).toBe(false);
+  });
+
+  it("brokers a permission ask through request.opened → respondToRequest", async () => {
+    await create("permission");
+    await instance.adapter.sendTurn({ threadId: "t-perm", text: "go" });
+    await recorder.until((e) => e.type === "request.opened");
+    expect(recorder.events.some((e) => e.type === "request.opened")).toBe(true);
+
+    const outcome = await instance.adapter.respondToRequest("t-perm", "ask-1", { behavior: "allow" });
+    expect(outcome).toBe("allowed-once");
+
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true, stopReason: "end_turn" });
+    expect(recorder.events.some((e) => e.type === "request.resolved")).toBe(true);
+  });
+
+  it("respondToRequest is unavailable for an ask that is not pending", async () => {
+    await create();
+    await expect(instance.adapter.respondToRequest("t-none", "nope", { behavior: "allow" })).resolves.toBe("unavailable");
+  });
+
+  it("interruptTurn cancels a running turn", async () => {
+    await create("permission");
+    await instance.adapter.sendTurn({ threadId: "t-interrupt", text: "go" });
+    await recorder.until((e) => e.type === "request.opened");
+    await instance.adapter.interruptTurn("t-interrupt");
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true, stopReason: "cancelled" });
+  });
+});
+
+describe("PiDriver snapshot", () => {
+  beforeEach(() => chmodSync(FAKE_CLI, 0o755));
+
+  it("reports available with the CLI version against the fake", async () => {
+    const instance = await PiDriver.create({
+      instanceId: "pi-snap",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI },
+    });
+    const snap = await instance.snapshot();
+    expect(snap.state).toBe("available");
+    expect(snap.version).toBe("pi 0.84.2 (fake)");
+    expect(snap.authenticated).toBe(true);
+    await instance.dispose();
+  });
+
+  it("reports unavailable with a reason when the CLI is missing", async () => {
+    const instance = await PiDriver.create({
+      instanceId: "pi-missing",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: "pi-definitely-not-on-path-xyz" },
+    });
+    const snap = await instance.snapshot();
+    expect(snap.state).toBe("unavailable");
+    expect(snap.reason).toMatch(/not found/);
+    await instance.dispose();
+  });
+});

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -194,23 +194,42 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-exit")).toBe(false);
   });
 
-  it("records argv and only configured environment names in FAKE_PI_DUMP", async () => {
+  it("scrubs provider and workspace credentials from every pi child env", async () => {
     const dir = mkdtempSync(join(tmpdir(), "omb-pi-dump-"));
     const dump = join(dir, "dump.jsonl");
-    await create(undefined, {
-      FAKE_PI_DUMP: dump,
-      ANTHROPIC_API_KEY: "anthropic-secret-value",
-      OPENAI_API_KEY: "openai-secret-value",
-    });
-    await instance.dispose();
+    // Plant a workspace credential on the harness process itself — the leak
+    // path is `...process.env`, not just input.environment.
+    const savedBox = process.env.BOX_TOKEN;
+    const savedXai = process.env.XAI_API_KEY;
+    process.env.BOX_TOKEN = "box-secret-value";
+    process.env.XAI_API_KEY = "xai-secret-value";
+    try {
+      await create(undefined, {
+        FAKE_PI_DUMP: dump,
+        ANTHROPIC_API_KEY: "anthropic-secret-value",
+        OPENAI_API_KEY: "openai-secret-value",
+      });
+      await instance.dispose();
+    } finally {
+      if (savedBox === undefined) delete process.env.BOX_TOKEN;
+      else process.env.BOX_TOKEN = savedBox;
+      if (savedXai === undefined) delete process.env.XAI_API_KEY;
+      else process.env.XAI_API_KEY = savedXai;
+    }
 
     const rows = readFileSync(dump, "utf8")
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as { argv: string[]; envConfigured: string[] });
     expect(rows.some((row) => row.argv.join(" ") === "--mode rpc --no-session")).toBe(true);
-    expect(rows.some((row) => row.envConfigured.includes("ANTHROPIC_API_KEY"))).toBe(true);
-    expect(rows.some((row) => row.envConfigured.includes("OPENAI_API_KEY"))).toBe(true);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.envConfigured).toContain("PATH");
+      expect(row.envConfigured).not.toContain("ANTHROPIC_API_KEY");
+      expect(row.envConfigured).not.toContain("OPENAI_API_KEY");
+      expect(row.envConfigured).not.toContain("XAI_API_KEY");
+      expect(row.envConfigured).not.toContain("BOX_TOKEN");
+    }
     expect(JSON.stringify(rows)).not.toContain("anthropic-secret-value");
     expect(JSON.stringify(rows)).not.toContain("openai-secret-value");
   });

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -20,6 +20,7 @@
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
+import { PROVIDER_CREDENTIAL_ENV, stripWorkspaceCredentialEnv } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 import { describeSpawnFailure, killCliTree, spawnCli } from "../procs.ts";
 
@@ -183,7 +184,15 @@ interface PiEvent {
 }
 
 function piEnvironment(source: Record<string, string | undefined>): Record<string, string | undefined> {
-  return { ...source, PATH: augmentedPath() };
+  const env: Record<string, string | undefined> = { ...source, PATH: augmentedPath() };
+  // pi is BYOK and reads provider keys straight from its environment: an
+  // inherited key would silently flip billing onto one the user never granted
+  // pi, and workspace credentials are the harness's secrets, not pi's. The
+  // keys pi may use live in its own settings file, so the child inherits
+  // neither list.
+  stripWorkspaceCredentialEnv(env);
+  for (const key of PROVIDER_CREDENTIAL_ENV) delete env[key];
+  return env;
 }
 
 export const PiDriver: ProviderDriver<PiConfig> = {

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -17,7 +17,6 @@
 // `get_available_models` and every entry is flagged `custom` because pi is a
 // custom-only (BYOK) engine — the model picker's Local pane only lists
 // `custom` options for custom-only engines.
-import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
@@ -107,6 +106,7 @@ export async function fetchPiModels(
   return new Promise((resolve) => {
     let buf = "";
     let done = false;
+    const fallbackDefault = readPiDefaultModel(env);
     const finish = (catalog: ModelCatalog) => {
       if (done) return;
       done = true;
@@ -127,7 +127,7 @@ export async function fetchPiModels(
         const line = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
         if (!line.trim()) continue;
-        const parsed = parsePiCatalog(line + "\n", readPiDefaultModel(env));
+        const parsed = parsePiCatalog(line + "\n", fallbackDefault);
         if (parsed.options.length || line.includes('"get_available_models"')) {
           clearTimeout(timer);
           finish(parsed);
@@ -252,7 +252,14 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       let buf = "";
       let assistantText = "";
       // resolve one-shot RPC responses (new_session / switch_session / set_model)
-      const responseWaiters = new Map<string, (data: unknown) => void>();
+      const responseWaiters = new Map<string, { resolve: (data: unknown) => void; reject: (err: Error) => void; timer: NodeJS.Timeout }>();
+      const rejectWaiters = (err: Error) => {
+        for (const waiter of responseWaiters.values()) {
+          clearTimeout(waiter.timer);
+          waiter.reject(err);
+        }
+        responseWaiters.clear();
+      };
       const awaitResponse = (command: string, timeoutMs = 20_000) =>
         new Promise<unknown>((resolve, reject) => {
           const timer = setTimeout(() => {
@@ -260,11 +267,9 @@ export const PiDriver: ProviderDriver<PiConfig> = {
             reject(new Error(`pi ${command} timed out`));
           }, timeoutMs);
           timer.unref?.();
-          responseWaiters.set(command, (data) => {
-            clearTimeout(timer);
-            resolve(data);
-          });
+          responseWaiters.set(command, { resolve, reject, timer });
         });
+      child.stdin.on("error", () => rejectWaiters(new Error("pi stdin closed")));
       const send = (obj: Record<string, unknown>) => {
         appendNative(threadId, { dir: "out", source: "pi.rpc", msg: obj });
         child.stdin.write(JSON.stringify(obj) + "\n");
@@ -283,6 +288,16 @@ export const PiDriver: ProviderDriver<PiConfig> = {
           stopReason: stopReason ?? (ok ? "end_turn" : "failed"),
           ...(usage ? { usage: { input: usage.input ?? 0, output: usage.output ?? 0 } } : {}),
         });
+        try {
+          child.stdin.end();
+        } catch {
+          /* already closed */
+        }
+        try {
+          killCliTree(child);
+        } catch {
+          /* already gone */
+        }
         active.delete(threadId);
       };
 
@@ -305,8 +320,12 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         appendNative(threadId, { dir: "in", source: "pi.rpc", msg: evt });
         switch (evt.type) {
           case "response": {
-            if (evt.success && evt.command && responseWaiters.has(evt.command)) {
-              responseWaiters.get(evt.command)!(evt.data);
+            if (evt.command && responseWaiters.has(evt.command)) {
+              const waiter = responseWaiters.get(evt.command)!;
+              responseWaiters.delete(evt.command);
+              clearTimeout(waiter.timer);
+              if (evt.success) waiter.resolve(evt.data);
+              else waiter.reject(new Error(`pi ${evt.command} failed`));
             }
             return;
           }
@@ -395,11 +414,13 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       });
       child.on("error", (err) => {
         const fail = describeSpawnFailure(err as NodeJS.ErrnoException, config.cli);
+        rejectWaiters(new Error(fail.message));
         emit({ ...base(threadId, turnId), type: "runtime.error", message: fail.message, setup: fail.setup });
         settle(false);
       });
       child.on("close", () => {
         // a clean close without a terminal event is a failed turn, never a hang
+        rejectWaiters(new Error("pi process exited before replying"));
         settle(false);
       });
 
@@ -432,32 +453,36 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       if (typeof turn.model === "string" && turn.model.includes("/")) {
         const [provider, ...rest] = turn.model.split("/");
         try {
+          const modelPromise = awaitResponse("set_model");
           send({ type: "set_model", provider, modelId: rest.join("/") });
-          await awaitResponse("set_model");
+          await modelPromise;
         } catch {
           /* keep going on the default model */
         }
       }
 
       const message = turn.system ? `${turn.system}\n\n${turn.text}` : turn.text;
-      send({ type: "prompt", message });
+      try {
+        send({ type: "prompt", message });
+      } catch {
+        settle(false);
+      }
 
       return { turnId };
     };
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const version = await new Promise<string | null>((resolve) => {
-        const child = spawn(config.cli, ["--version"], {
+        const child = spawnCli(config.cli, ["--version"], {
           stdio: ["ignore", "pipe", "pipe"],
           env: piEnvironment({ ...process.env, ...input.environment }),
-          windowsHide: true,
         });
         let out = "";
         child.stdout?.setEncoding("utf8");
         child.stdout?.on("data", (c: string) => (out += c));
         const timer = setTimeout(() => {
           try {
-            child.kill();
+            killCliTree(child);
           } catch {
             /* ignore */
           }

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -1,0 +1,536 @@
+// pi — the pi coding agent (@earendil-works/pi-coding-agent) as a native engine.
+//
+// pi exposes a JSON-RPC mode over stdio (`pi --mode rpc --no-session`) rather
+// than ACP, so — like the Claude Code and Codex CLIs — it gets a native driver
+// that speaks its own protocol and emits canonical RuntimeEvents. pi is a
+// BYOK agent: credentials live in ~/.pi/agent/auth.json and are injected by
+// the pi binary itself, so this driver holds no API key and needs no sign-in.
+//
+// Conversation continuity: the first turn sends `new_session` and remembers
+// the returned `sessionFile`; later turns send `switch_session` with that
+// path (the way Claude Code resumes by session id). `sessionFile` is the
+// resumeCursor the harness persists per thread.
+//
+// Model ids in the picker are `provider/modelId` composites (e.g.
+// `ollama-cloud/glm-5.2`); `set_model` splits that into pi's separate
+// `{provider, modelId}` fields. The live catalog is probed from
+// `get_available_models` and every entry is flagged `custom` because pi is a
+// custom-only (BYOK) engine — the model picker's Local pane only lists
+// `custom` options for custom-only engines.
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+import { augmentedPath } from "../env-path.ts";
+import { describeSpawnFailure, killCliTree, spawnCli } from "../procs.ts";
+
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "piAgent";
+const PI_ARGS = ["--mode", "rpc", "--no-session"];
+
+/** A pi `get_available_models` response payload, parsed at its I/O boundary. */
+interface PiModelEntry {
+  provider: string;
+  id: string;
+  name?: string;
+}
+interface PiModelsResponse {
+  type: "response";
+  command: "get_available_models";
+  success: boolean;
+  data?: { models?: PiModelEntry[] };
+}
+
+/** Pure parser: turn a `get_available_models` stdout blob into a catalog.
+ *  Every option is `custom` (pi is BYOK) and id is the `provider/modelId`
+ *  composite the picker and `set_model` both use. Exported for the test. */
+export function parsePiCatalog(stdout: string, fallbackDefault = ""): ModelCatalog {
+  const options: Array<{ id: string; label: string; custom: true }> = [];
+  let def = fallbackDefault;
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    let msg: unknown;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const res = msg as PiModelsResponse;
+    if (res?.type !== "response" || res.command !== "get_available_models" || !res.success) continue;
+    for (const m of res.data?.models ?? []) {
+      if (!m?.provider || !m?.id) continue;
+      const id = `${m.provider}/${m.id}`;
+      options.push({ id, label: m.name ?? m.id, custom: true });
+    }
+    break;
+  }
+  if (!def && options.length) def = options[0]!.id;
+  return { default: def, options };
+}
+
+/** The pi-side default model, read from ~/.pi/agent/settings.json so the
+ *  catalog's `default` matches what `pi` would actually run. Missing file →
+ *  empty string, and the first option is used instead. */
+function readPiDefaultModel(env: Record<string, string | undefined>): string {
+  const home = env.HOME || env.USERPROFILE || homedir();
+  try {
+    const s = JSON.parse(readFileSync(`${home}/.pi/agent/settings.json`, "utf8")) as {
+      defaultProvider?: string;
+      defaultModel?: string;
+    };
+    return s.defaultProvider && s.defaultModel ? `${s.defaultProvider}/${s.defaultModel}` : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Probe the live catalog by spawning `pi --mode rpc --no-session`, sending
+ *  `get_available_models`, and parsing the response. A failed probe resolves
+ *  with an empty catalog — the instance reports unavailable via snapshot. */
+export async function fetchPiModels(
+  cli: string,
+  env: Record<string, string | undefined>,
+): Promise<ModelCatalog> {
+  const child = spawnCli(cli, PI_ARGS, { stdio: ["pipe", "pipe", "pipe"], env });
+  return new Promise((resolve) => {
+    let buf = "";
+    let done = false;
+    const finish = (catalog: ModelCatalog) => {
+      if (done) return;
+      done = true;
+      try {
+        killCliTree(child);
+      } catch {
+        /* already gone */
+      }
+      resolve(catalog);
+    };
+    const timer = setTimeout(() => finish({ default: "", options: [] }), 15_000);
+    timer.unref?.();
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        const parsed = parsePiCatalog(line + "\n", readPiDefaultModel(env));
+        if (parsed.options.length || line.includes('"get_available_models"')) {
+          clearTimeout(timer);
+          finish(parsed);
+          return;
+        }
+      }
+    });
+    child.on("error", () => finish({ default: "", options: [] }));
+    child.on("close", () => finish({ default: "", options: [] }));
+    try {
+      child.stdin.write(JSON.stringify({ id: "catalog", type: "get_available_models" }) + "\n");
+    } catch {
+      finish({ default: "", options: [] });
+    }
+  });
+}
+
+export interface PiConfig {
+  cli: string;
+}
+
+function decodeConfig(raw: unknown): PiConfig {
+  if (raw === null || raw === undefined) return { cli: "pi" };
+  if (typeof raw !== "object") throw new Error("pi config must be an object");
+  const obj = raw as { cli?: unknown };
+  if (obj.cli !== undefined && typeof obj.cli !== "string") throw new Error("pi config `cli` must be a string");
+  return { cli: obj.cli && obj.cli.trim() ? obj.cli.trim() : "pi" };
+}
+
+const EMPTY: ModelCatalog = { default: "", options: [] };
+
+/** The parsed pi RPC event we branch on — only the fields this driver reads. */
+interface PiEvent {
+  type: string;
+  // response
+  command?: string;
+  success?: boolean;
+  data?: unknown;
+  // message_update
+  assistantMessageEvent?: { type?: string; delta?: string };
+  // tool_execution_*
+  toolCallId?: string;
+  toolName?: string;
+  isError?: boolean;
+  // turn_end / message_end
+  message?: { stopReason?: string; usage?: { input?: number; output?: number } };
+  usage?: { input?: number; output?: number };
+  // extension_ui_request
+  id?: string;
+  method?: string;
+  options?: unknown[];
+  title?: string;
+}
+
+function piEnvironment(source: Record<string, string | undefined>): Record<string, string | undefined> {
+  return { ...source, PATH: augmentedPath() };
+}
+
+export const PiDriver: ProviderDriver<PiConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "pi", supportsMultipleInstances: true, access: "custom" },
+  install: {
+    command: {
+      darwin: "npm install -g @earendil-works/pi-coding-agent",
+      linux: "npm install -g @earendil-works/pi-coding-agent",
+      win32: "npm install -g @earendil-works/pi-coding-agent",
+    },
+    needsNode: true,
+    docsUrl: "https://pi.dev",
+  },
+  models: EMPTY,
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<PiConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const catalogEnv = piEnvironment({ ...process.env, ...input.environment });
+    let models = EMPTY;
+    const refreshModels = async () => {
+      try {
+        const resolved = await fetchPiModels(config.cli, catalogEnv);
+        if (resolved.options.length) models = resolved;
+      } catch {
+        // Keep the last usable catalog when the probe fails.
+      }
+    };
+    await refreshModels();
+
+    const listeners = new Set<RuntimeEventListener>();
+    // one active turn per thread
+    const active = new Map<string, {
+      stop: () => void;
+      turnId: string;
+      pending: Map<string, (decision: { behavior: "allow" | "deny" | "answer"; message?: string }) => void>;
+      child?: { stdin: { write: (s: string) => void } };
+    }>();
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      providerInstanceId: instanceId,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const turnId = newId();
+      const pending = new Map<string, (decision: { behavior: "allow" | "deny" | "answer"; message?: string }) => void>();
+      let settled = false;
+
+      const child = spawnCli(config.cli, PI_ARGS, {
+        stdio: ["pipe", "pipe", "pipe"],
+        cwd: turn.cwd,
+        env: piEnvironment({ ...process.env, ...input.environment }),
+      });
+      let buf = "";
+      let assistantText = "";
+      // resolve one-shot RPC responses (new_session / switch_session / set_model)
+      const responseWaiters = new Map<string, (data: unknown) => void>();
+      const awaitResponse = (command: string, timeoutMs = 20_000) =>
+        new Promise<unknown>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            responseWaiters.delete(command);
+            reject(new Error(`pi ${command} timed out`));
+          }, timeoutMs);
+          timer.unref?.();
+          responseWaiters.set(command, (data) => {
+            clearTimeout(timer);
+            resolve(data);
+          });
+        });
+      const send = (obj: Record<string, unknown>) => {
+        appendNative(threadId, { dir: "out", source: "pi.rpc", msg: obj });
+        child.stdin.write(JSON.stringify(obj) + "\n");
+      };
+
+      const settle = (ok: boolean, stopReason?: string | null, usage?: { input?: number; output?: number }) => {
+        if (settled) return;
+        settled = true;
+        if (assistantText.trim()) {
+          emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: assistantText });
+        }
+        emit({
+          ...base(threadId, turnId),
+          type: "turn.completed",
+          ok,
+          stopReason: stopReason ?? (ok ? "end_turn" : "failed"),
+          ...(usage ? { usage: { input: usage.input ?? 0, output: usage.output ?? 0 } } : {}),
+        });
+        active.delete(threadId);
+      };
+
+      const stop = () => {
+        try {
+          send({ type: "abort" });
+        } catch {
+          /* ignore */
+        }
+        try {
+          killCliTree(child);
+        } catch {
+          /* ignore */
+        }
+        settle(true, "cancelled");
+      };
+      active.set(threadId, { stop, turnId, pending, child });
+
+      const onEvent = (evt: PiEvent) => {
+        appendNative(threadId, { dir: "in", source: "pi.rpc", msg: evt });
+        switch (evt.type) {
+          case "response": {
+            if (evt.success && evt.command && responseWaiters.has(evt.command)) {
+              responseWaiters.get(evt.command)!(evt.data);
+            }
+            return;
+          }
+          case "message_update": {
+            const e = evt.assistantMessageEvent;
+            if (!e) return;
+            if (e.type === "text_delta" && typeof e.delta === "string") {
+              assistantText += e.delta;
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta: e.delta });
+            } else if (e.type === "thinking_delta" && typeof e.delta === "string") {
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "reasoning_text", delta: e.delta });
+            }
+            return;
+          }
+          case "tool_execution_start": {
+            emit({
+              ...base(threadId, turnId),
+              type: "item.started",
+              itemType: "tool",
+              itemId: evt.toolCallId,
+              title: String(evt.toolName ?? "tool").slice(0, 80),
+            });
+            return;
+          }
+          case "tool_execution_end": {
+            emit({
+              ...base(threadId, turnId),
+              type: "item.completed",
+              itemType: "tool",
+              itemId: evt.toolCallId,
+              ok: !evt.isError,
+            });
+            return;
+          }
+          case "extension_ui_request": {
+            // pi floods setWidget/setStatus for TUI bookkeeping; only
+            // select/confirm/input are questions that wait for an answer.
+            if (evt.method === "select" || evt.method === "confirm" || evt.method === "input") {
+              const reqId = evt.id ?? newId();
+              const isQuestion = evt.method === "input";
+              emit({
+                ...base(threadId, turnId),
+                requestId: reqId,
+                type: "request.opened",
+                requestType: isQuestion ? "question" : "permission",
+                tool: String(evt.title ?? "pi"),
+                summary: String(evt.title ?? "pi wants confirmation"),
+              });
+              pending.set(reqId, (decision) => {
+                if (decision.behavior === "deny") send({ type: "extension_ui_response", id: reqId, cancelled: true });
+                else if (isQuestion) send({ type: "extension_ui_response", id: reqId, value: decision.message ?? "" });
+                else send({ type: "extension_ui_response", id: reqId, confirmed: true });
+              });
+            }
+            return;
+          }
+          case "turn_end":
+          case "agent_end": {
+            const sr = evt.message?.stopReason;
+            // toolUse means pi ran a tool and auto-continues next turn to
+            // answer — settling now would drop the final reply.
+            if (sr === "toolUse" || sr === "tool_use" || sr === "tool_calls") return;
+            const usage = evt.usage ?? evt.message?.usage;
+            settle(true, sr === "cancelled" ? "cancelled" : "end_turn", usage);
+            return;
+          }
+          default:
+            return;
+        }
+      };
+
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        buf += chunk;
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          if (!line.trim()) continue;
+          try {
+            onEvent(JSON.parse(line) as PiEvent);
+          } catch {
+            /* skip non-JSON line */
+          }
+        }
+      });
+      child.on("error", (err) => {
+        const fail = describeSpawnFailure(err as NodeJS.ErrnoException, config.cli);
+        emit({ ...base(threadId, turnId), type: "runtime.error", message: fail.message, setup: fail.setup });
+        settle(false);
+      });
+      child.on("close", () => {
+        // a clean close without a terminal event is a failed turn, never a hang
+        settle(false);
+      });
+
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+
+      // handshake: resume the remembered session or start a fresh one. The
+      // harness persists session.started.sessionId as the resumeCursor and
+      // hands it back next turn, so that id IS the resume handle — pi's
+      // sessionFile, which switch_session expects as `sessionPath`.
+      const sessionPath = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
+      let sessionFile = sessionPath;
+      try {
+        const command = sessionPath ? "switch_session" : "new_session";
+        const hsPromise = awaitResponse(command);
+        send(sessionPath ? { type: "switch_session", sessionPath } : { type: "new_session" });
+        const hs = (await hsPromise) as { sessionFile?: string; sessionId?: string } | undefined;
+        if (hs?.sessionFile) sessionFile = hs.sessionFile;
+        emit({
+          ...base(threadId, turnId),
+          type: "session.started",
+          sessionId: sessionFile ?? hs?.sessionId ?? null,
+          model: turn.model ?? null,
+        });
+      } catch {
+        // without a session we can still try a bare prompt; pi --no-session
+        // accepts a prompt without an explicit session.
+      }
+
+      // pin the chosen model (composite id → provider + modelId)
+      if (typeof turn.model === "string" && turn.model.includes("/")) {
+        const [provider, ...rest] = turn.model.split("/");
+        try {
+          send({ type: "set_model", provider, modelId: rest.join("/") });
+          await awaitResponse("set_model");
+        } catch {
+          /* keep going on the default model */
+        }
+      }
+
+      const message = turn.system ? `${turn.system}\n\n${turn.text}` : turn.text;
+      send({ type: "prompt", message });
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      const version = await new Promise<string | null>((resolve) => {
+        const child = spawn(config.cli, ["--version"], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: piEnvironment({ ...process.env, ...input.environment }),
+          windowsHide: true,
+        });
+        let out = "";
+        child.stdout?.setEncoding("utf8");
+        child.stdout?.on("data", (c: string) => (out += c));
+        const timer = setTimeout(() => {
+          try {
+            child.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve(null);
+        }, 8000);
+        timer.unref?.();
+        child.on("error", () => {
+          clearTimeout(timer);
+          resolve(null);
+        });
+        child.on("close", () => {
+          clearTimeout(timer);
+          resolve(out.trim() || null);
+        });
+      });
+      if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+      // pi manages its own credentials (~/.pi/agent/auth.json); there is no
+      // separate sign-in step the harness can probe, so treat it as authed.
+      return { state: "available", version, authenticated: true };
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      get models() {
+        return models;
+      },
+      refreshModels,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: {
+          // model is set per turn via set_model before prompt
+          sessionModelSwitch: "in-session",
+          // pi's own tools are first-party; the harness MCP integrations are
+          // not mounted in this driver yet.
+          agentsMcp: false,
+          computerMcp: false,
+          composioMcp: false,
+          images: false,
+        },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.stop(),
+        respondToRequest: async (threadId, requestId, decision) => {
+          const entry = active.get(threadId);
+          const answer = entry?.pending.get(requestId);
+          if (!entry || !answer) return "unavailable";
+          entry.pending.delete(requestId);
+          answer({ behavior: decision.behavior, message: decision.message });
+          emit({
+            ...base(threadId, entry.turnId),
+            requestId,
+            type: "request.resolved",
+            behavior: decision.behavior,
+            source: "user",
+          });
+          return decision.behavior === "allow" ? "allowed-once" : decision.behavior === "answer" ? "answered" : "rejected";
+        },
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { stop } of active.values()) stop();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      dispose: async () => {
+        for (const { stop } of active.values()) stop();
+        listeners.clear();
+      },
+    };
+  },
+};

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -35,10 +35,8 @@ if (process.env.FAKE_PI_DUMP) {
       process.env.FAKE_PI_DUMP,
       JSON.stringify({
         argv,
-        env: Object.fromEntries(
-          ["PATH", "HOME", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "BOX_TOKEN"].flatMap((k) =>
-            process.env[k] === undefined ? [] : [[k, process.env[k]]],
-          ),
+        envConfigured: ["PATH", "HOME", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "BOX_TOKEN"].filter(
+          (k) => process.env[k] !== undefined,
         ),
       }) + "\n",
     );

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Fake of the pi coding agent's `--mode rpc --no-session` stdio surface, for
+// driver contract tests of server/drivers/pi.ts. Speaks pi's JSON-RPC-over-
+// stdio protocol: answers get_available_models / new_session / switch_session
+// / set_model, and streams a scripted turn in response to `prompt`. Failure
+// modes mirror how the real CLI misbehaves:
+//
+//   FAKE_PI_MODE   happy (default) | tooluse | permission | no-models | exit-early
+//   FAKE_PI_MODELS comma-separated provider/model pairs (default "ollama-cloud/glm-5.2,openai/gpt-4o")
+//   FAKE_PI_DUMP   path to append {argv, env} JSON, so a test can assert argv shape
+//                  and env hygiene (no leaked secrets into the pi child).
+
+import { appendFileSync } from "node:fs";
+
+const mode = process.env.FAKE_PI_MODE ?? "happy";
+const modelPairs = (process.env.FAKE_PI_MODELS ?? "ollama-cloud/glm-5.2,openai/gpt-4o")
+  .split(",")
+  .filter(Boolean)
+  .map((pair) => {
+    const [provider, id] = pair.split("/");
+    return { provider: provider ?? "x", id: id ?? "m", name: id ?? "m" };
+  });
+
+const argv = process.argv.slice(2);
+
+// The driver probes `<cli> --version` for snapshot(); answer and exit clean.
+if (argv.includes("--version") || argv.includes("-v")) {
+  process.stdout.write("pi 0.84.2 (fake)\n");
+  process.exit(0);
+}
+
+if (process.env.FAKE_PI_DUMP) {
+  try {
+    appendFileSync(
+      process.env.FAKE_PI_DUMP,
+      JSON.stringify({
+        argv,
+        env: Object.fromEntries(
+          ["PATH", "HOME", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "BOX_TOKEN"].flatMap((k) =>
+            process.env[k] === undefined ? [] : [[k, process.env[k]]],
+          ),
+        ),
+      }) + "\n",
+    );
+  } catch {
+    /* never let dumping break a run */
+  }
+}
+
+// exit-early: die before saying anything — a failed spawn surfaces as a
+// runtime.error + failed turn, never a hang.
+if (mode === "exit-early") {
+  process.exit(1);
+}
+
+const send = (obj: any) => process.stdout.write(JSON.stringify(obj) + "\n");
+let sessionCounter = 0;
+let currentSessionFile: string | null = null;
+
+// A faithful happy turn: a couple of text deltas then a terminal turn_end.
+const streamTurn = () => {
+  send({ type: "agent_start" });
+  send({ type: "turn_start" });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_start", contentIndex: 0 } });
+  for (const delta of ["Hello", " from", " pi"]) {
+    send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta } });
+  }
+  send({ type: "turn_end", message: { stopReason: "end_turn", usage: { input: 12, output: 3 } }, usage: { input: 12, output: 3 } });
+  send({ type: "agent_end" });
+};
+
+// tooluse: one tool turn (stopReason toolUse, pi auto-continues) then a text
+// turn — exactly the sequence that broke the settle-on-toolUse bug.
+const streamToolTurn = () => {
+  send({ type: "agent_start" });
+  send({ type: "turn_start" });
+  send({ type: "tool_execution_start", toolCallId: "call_1", toolName: "bash", args: { command: "echo hi" } });
+  send({ type: "tool_execution_end", toolCallId: "call_1", toolName: "bash", isError: false });
+  send({ type: "turn_end", message: { stopReason: "toolUse", usage: { input: 5, output: 1 } }, usage: { input: 5, output: 1 } });
+  // pi auto-continues within the same prompt to synthesize the reply
+  send({ type: "turn_start" });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "done" } });
+  send({ type: "turn_end", message: { stopReason: "end_turn", usage: { input: 12, output: 2 } }, usage: { input: 12, output: 2 } });
+  send({ type: "agent_end" });
+};
+
+// permission: open a select ask, hold the turn until extension_ui_response
+// arrives, then stream the reply.
+const streamPermissionTurn = () => {
+  send({ type: "agent_start" });
+  send({ type: "turn_start" });
+  send({ type: "extension_ui_request", id: "ask-1", method: "select", title: "Run bash: echo hi?", options: ["Allow once", "Deny"] });
+  // wait for the answer before finishing
+};
+
+const finishPermissionTurn = () => {
+  send({ type: "tool_execution_start", toolCallId: "call_1", toolName: "bash", args: { command: "echo hi" } });
+  send({ type: "tool_execution_end", toolCallId: "call_1", toolName: "bash", isError: false });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "ok" } });
+  send({ type: "turn_end", message: { stopReason: "end_turn", usage: { input: 8, output: 1 } }, usage: { input: 8, output: 1 } });
+  send({ type: "agent_end" });
+};
+
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf("\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    let cmd;
+    try {
+      cmd = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    handle(cmd);
+  }
+});
+process.stdin.on("end", () => process.exit(0));
+
+function handle(cmd: any) {
+  switch (cmd.type) {
+    case "get_available_models":
+      send({
+        type: "response",
+        command: "get_available_models",
+        success: true,
+        data: { models: mode === "no-models" ? [] : modelPairs },
+      });
+      return;
+    case "new_session":
+      sessionCounter += 1;
+      currentSessionFile = `/fake/pi-session-${sessionCounter}.json`;
+      send({ type: "response", command: "new_session", success: true, data: { sessionId: `s-${sessionCounter}`, sessionFile: currentSessionFile } });
+      return;
+    case "switch_session":
+      currentSessionFile = cmd.sessionPath ?? currentSessionFile;
+      send({ type: "response", command: "switch_session", success: true, data: { sessionId: "s-resumed", sessionFile: currentSessionFile } });
+      return;
+    case "set_model": {
+      send({ type: "response", command: "set_model", success: true, data: { id: cmd.modelId, provider: cmd.provider } });
+      return;
+    }
+    case "prompt":
+      // acknowledge acceptance; the completion comes via events
+      send({ type: "response", command: "prompt", success: true });
+      if (mode === "tooluse") streamToolTurn();
+      else if (mode === "permission") streamPermissionTurn();
+      else streamTurn();
+      return;
+    case "extension_ui_response":
+      if (cmd.id === "ask-1") finishPermissionTurn();
+      return;
+    case "abort":
+      send({ type: "turn_end", message: { stopReason: "cancelled", usage: { input: 0, output: 0 } }, usage: { input: 0, output: 0 } });
+      return;
+    default:
+      return;
+  }
+}

--- a/server/turn-context.test.ts
+++ b/server/turn-context.test.ts
@@ -47,8 +47,12 @@ describe("engineIsFresh", () => {
   const withUser = transcript;
   const greetingOnly = [{ role: "assistant" as const, text: "Hey — I'm Wren. Nice to meet you." }];
 
-  it("is false when the same instance ran the last turn", () => {
+  it("is false when the same instance ran the last turn and has a cursor", () => {
     expect(engineIsFresh({ instanceId: "claude", lastInstanceId: "claude", resumeCursors: { claude: "s1" }, transcript: withUser })).toBe(false);
+  });
+
+  it("is true when the same instance ran last but there is no cursor to resume", () => {
+    expect(engineIsFresh({ instanceId: "pi", lastInstanceId: "pi", resumeCursors: {}, transcript: withUser })).toBe(true);
   });
 
   it("is true when another instance ran the last turn — even if this one has an older cursor", () => {

--- a/server/turn-context.ts
+++ b/server/turn-context.ts
@@ -34,7 +34,7 @@ export function engineIsFresh(input: {
 }): boolean {
   const { instanceId, lastInstanceId, resumeCursors, transcript } = input;
   if (!transcript.some((m) => m.role === "user")) return false;
-  if (lastInstanceId !== undefined) return lastInstanceId !== instanceId;
+  if (lastInstanceId !== undefined) return lastInstanceId !== instanceId || resumeCursors[instanceId] === undefined;
   const cursorIds = Object.keys(resumeCursors);
   return !(cursorIds.length === 1 && cursorIds[0] === instanceId);
 }

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -109,6 +109,21 @@ export function QwenMark({ size = 16, className }: IconProps) {
   );
 }
 
+/** Official pi (pi.dev) mark — geometric "Pi" wordmark from pi.dev/logo.svg. */
+export function PiMark({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 800 800" className={cn("fill-[#F5F5F5]", className)} aria-hidden>
+      {/* P shape: outer boundary clockwise, inner hole counter-clockwise */}
+      <path
+        fillRule="evenodd"
+        d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"
+      />
+      {/* i dot */}
+      <path d="M517.36 400 H634.72 V634.72 H517.36 Z" />
+    </svg>
+  );
+}
+
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {
   switch (driverKind) {
     case "grok":
@@ -134,6 +149,8 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <HermesMark size={size} className={className} />;
     case "boxAgent":
       return <ComputerMark size={size} className={className} />;
+    case "piAgent":
+      return <PiMark size={size} className={className} />;
     default:
       return (
         <span className="flex size-full items-center justify-center text-[10px] font-semibold tracking-tight text-ink-secondary">


### PR DESCRIPTION
## Summary

Adds **pi** (`@earendil-works/pi-coding-agent`) as a first-class OpenMausBot engine.

pi exposes a JSON-RPC protocol over stdio (`pi --mode rpc --no-session`), not ACP, so this PR follows the native-driver precedent used by the Claude Code and Codex CLIs: the driver speaks pi's native protocol and translates it into OpenMausBot's canonical `RuntimeEvent`s.

## What changed

- Add `server/drivers/pi.ts`, a native `ProviderDriver` for pi.
  - Spawns `pi --mode rpc --no-session` per turn.
  - Resumes session continuity via `switch_session` using the `sessionFile` emitted as `session.started.sessionId`.
  - Applies model picks in-session through `set_model`, splitting picker IDs like `provider/modelId`.
  - Probes `get_available_models` so pi's configured BYOK/provider catalog appears in the Local model picker.
  - Maps pi deltas, tool events, permission prompts, usage, cancellation, and turn completion into canonical runtime events.
  - Handles pi's `toolUse` auto-continue correctly: the driver waits for the final `end_turn` before settling the turn.
- Add `server/testing/fake-pi-cli.ts` and `server/drivers/pi.test.ts` contract coverage.
- Register the engine in `server/drivers/builtIn.ts` and seed `pi` into the default/custom fleet in `server/config.ts`.
- Add the official pi.dev provider mark to the model picker (`src/components/ProviderIcons.tsx`) instead of falling back to a generic `P`.

## Notes

- pi is BYOK/local-config driven. The OpenMausBot driver does not store API keys; credentials remain in pi's own config/auth store.
- No new runtime dependencies.
- `dist-server` is not included.

## Testing

- `pnpm typecheck`
- `pnpm exec vitest run server/drivers/pi.test.ts` — 16 passing tests
- `pnpm exec vitest run` — 136 files passed, 1363 tests passed, 12 skipped
- Manual smoke test against a real local pi install:
  - pi instance was `available`
  - model catalog loaded with 29 local/BYOK options
  - a bot using `pi` + `ollama-cloud/glm-5.2` completed a chat turn via native `pi --mode rpc` (no shim)

## UI verification

The model picker rail now renders the official pi.dev mark for `piAgent`, and selecting it shows pi's Local model catalog. Local screenshots captured during verification:

- `/tmp/omb-picker.png`
- `/tmp/omb-pi-models.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native support for the Pi provider and its configured models.
  - Supports streaming responses, reasoning, tool activity, permission requests, cancellation, and session continuation.
  - Added Pi provider branding throughout the interface.
  - Included Pi in default fleet configurations and product-fleet setup.

- **Bug Fixes**
  - Improved handling of unavailable models, malformed responses, process failures, interruptions, empty model catalogs, and incomplete requests.
  - Corrected session freshness handling when resume information is unavailable.
  - Improved protection of provider credentials during provider operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->