### PR TITLE
Give the Local VM panel a way to actually drive it

### DIFF
--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -181,7 +181,9 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       api("/api/local-computer")
         .then((status) => {
           if (!alive) return;
-          if (typeof status.viewer_url === "string") setVmViewerUrl(status.viewer_url);
+          // parse at the boundary: our own status endpoint sends a string or nothing
+          const viewerUrl = String(status.viewer_url ?? "");
+          if (viewerUrl.startsWith("http")) setVmViewerUrl(viewerUrl);
           if (status.ready) setPhase("vm");
           else {
             setError(`${status.problem ?? "The Local VM is not ready"}. Open App Settings → Local VM.`);

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -97,6 +97,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   const [boxState, setBoxState] = useState<string | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [vmFrame, setVmFrame] = useState<string | null>(null);
+  // The Local VM's interactive noVNC viewer (passworded, autoconnect). The
+  // preview below is a periodic screenshot that swallows clicks — this URL is
+  // the only way a person can actually drive the VM.
+  const [vmViewerUrl, setVmViewerUrl] = useState<string | null>(null);
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<"join" | "sleep" | "provision" | null>(null);
   const [controlPending, setControlPending] = useState(false);
@@ -177,6 +181,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       api("/api/local-computer")
         .then((status) => {
           if (!alive) return;
+          if (typeof status.viewer_url === "string") setVmViewerUrl(status.viewer_url);
           if (status.ready) setPhase("vm");
           else {
             setError(`${status.problem ?? "The Local VM is not ready"}. Open App Settings → Local VM.`);
@@ -556,7 +561,12 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         </div>
         <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
           {frameSrc ? (
-            <img src={frameSrc} alt={`${bot.name}'s screen`} className="h-full w-full object-contain" />
+            <img
+              src={frameSrc}
+              alt={`${bot.name}'s screen`}
+              className="h-full w-full object-contain"
+              title={phase === "vm" ? "Watch-only preview — use Open desktop to click and type" : undefined}
+            />
           ) : (
             <div className="flex flex-col items-center gap-2 px-6 text-center text-ink-secondary">
               {phase === "checking" || phase === "starting" || phase === "vm" || (phase === "local" && !isLinux) ? (
@@ -677,6 +687,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             <div className="text-[13px] leading-relaxed text-ink">
               You have the wheel — the bot's clicks and keystrokes are refused until you hand it back.
               {phase === "ready" && cloudBackend === "box" && " Use Open desktop to drive."}
+              {phase === "vm" && " Use Open desktop to drive — the preview here is watch-only."}
             </div>
             <button
               onClick={() => controlAction("release")}
@@ -687,6 +698,21 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               Hand control back
             </button>
           </div>
+        )}
+        {phase === "vm" && vmViewerUrl && (
+          <button
+            onClick={() => {
+              // Electron opens the viewer in the system browser; the plain-web
+              // fallback opens a tab. Same URL Settings links as Watch screen.
+              if (window.ogb?.openExternal) void window.ogb.openExternal(vmViewerUrl);
+              else window.open(vmViewerUrl, "_blank", "noopener");
+            }}
+            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover"
+            title="Open the Local VM's interactive desktop — click and type there"
+          >
+            <ExternalLink size={14} />
+            Open desktop
+          </button>
         )}
         {phase === "vm" && !control.held && !control.helpReason && (
           <button


### PR DESCRIPTION
Field report from X (Ubuntu/KDE): *"it's not possible to control the Cua VM computer — I can't click in and I can't type anything."*

They were right, and **KDE was a red herring** — nothing about this depends on the desktop environment.

## What was actually happening

- The Local VM preview in the computer panel is a **screenshot refreshed every 4 seconds**. It has no input path at all — clicking and typing on it silently does nothing, while looking exactly like a live surface.
- **Take control** made it worse: it paused the bot's hands, announced *"You have the wheel"*, and offered nothing to drive with — the *"Use Open desktop to drive"* hint **and** the Open desktop button were both gated to `cloudBackend === "box"`.
- The interactive answer already existed end to end: the container runs a passworded noVNC viewer, `container-computer.ts` computes its autoconnect URL into `status.viewer_url`, and App Settings even links it as *Watch screen*. The panel fetched that status and threw the field away.

## The fix (panel-only)

- keep `viewer_url` from `/api/local-computer`
- **Open desktop** button in the VM phase (Electron `openExternal`, tab fallback)
- the held-wheel message for the VM now says where to drive
- the preview image says it is watch-only on hover

`typeof` narrowing replaced with boundary parsing per the anti-slop rule; the file's 3 remaining hits pre-date this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open desktop” action for launching the interactive VM viewer externally.
  * Added clearer guidance to use the interactive viewer when desktop control is available.

* **UI Improvements**
  * VM previews are now clearly identified as watch-only.
  * Viewer links are validated before being made available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->