### PR TITLE
Fix Codex web search activity completion

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -86,7 +86,9 @@ describe("CodexDriver turns (fake app-server)", () => {
       "turn.started",
       "session.started",
       "item.started", // commandExecution ls -la
+      "item.started", // webSearch OpenMausBot
       "item.completed", // commandExecution done
+      "item.completed", // webSearch done
       "content.delta",
       "item.completed", // assistant_text
       "thread.token-usage.updated",
@@ -101,6 +103,10 @@ describe("CodexDriver turns (fake app-server)", () => {
       input: 7,
       output: 3,
     });
+    expect(recorder.events.filter((event) => event.itemId === "w1")).toMatchObject([
+      { type: "item.started", itemType: "tool", title: "web_search" },
+      { type: "item.completed", itemType: "tool", ok: true },
+    ]);
     // codex reports the THREAD total; the driver turns it into this turn's
     // figure so the harness never sums a running total
     expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true, usage: { input: 7, output: 3 } });

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -347,7 +347,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
                 state.sawStreamDelta = false;
                 emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: item.text });
               }
-            } else if (["commandExecution", "fileChange", "mcpToolCall"].includes(item.type)) {
+            } else if (["commandExecution", "fileChange", "mcpToolCall", "webSearch"].includes(item.type)) {
               emit({
                 ...base(threadId, turnId),
                 type: "item.completed",

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -45,6 +45,7 @@ const dump = () => {
 
 const finishTurn = () => {
   notify("item/completed", { item: { id: "i1", type: "commandExecution", status: "completed" } });
+  notify("item/completed", { item: { id: "w1", type: "webSearch", status: "completed" } });
   if (mode === "stream") {
     // token deltas, then the whole message — the driver must not double-emit
     notify("item/agentMessage/delta", { itemId: "m1", delta: "done from " });
@@ -134,6 +135,7 @@ process.stdin.on("data", (chunk) => {
         }
         out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
         notify("item/started", { item: { id: "i1", type: "commandExecution", command: "ls -la" } });
+        notify("item/started", { item: { id: "w1", type: "webSearch", query: "OpenMausBot" } });
         if (mode === "approval") {
           out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: "rm -rf scratch" } });
           // turn continues from the approval response handler above


### PR DESCRIPTION
## What changed

- Normalize Codex webSearch item/completed notifications as completed tool events.
- Extend the fake Codex app-server with a web search lifecycle.
- Assert that web search activity transitions from started to successful completion.

## Why

Codex web searches emitted an activity-start event, but their matching completion notification was ignored. The persisted activity therefore kept an undefined outcome, so the UI spinner never stopped after the turn finished.

## How it was verified

- pnpm exec vitest run server/drivers/codex.test.ts
- pnpm typecheck
- pnpm test
- pnpm check:electron

The full suite passed with 1381 tests passing and 12 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web searches now correctly report when they start and finish.
  * Search activity is consistently recognized alongside other tool actions during responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->