### PR TITLE
fix(ios): follow active tasks and approval choices

### DIFF
--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -875,7 +875,12 @@ struct CardView: View {
                             answering = true
                             Task {
                                 await session.alwaysAllow(bot: bot, card: card)
-                                await session.answer(chat: chat, card: card, choice: allow)
+                                await session.answer(
+                                    chat: chat,
+                                    card: card,
+                                    choice: allow,
+                                    rememberingPermission: false
+                                )
                                 answering = false
                             }
                         }

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -37,10 +37,6 @@ struct ChatView: View {
     /// one per chat and it has no message id to borrow.
     static let liveBubbleId = "companion.live"
 
-    private var messages: [Message] {
-        session.state.visibleTranscript(forThread: chat.threadId)
-    }
-
     /// The live chat record, so busy/unread stay current as frames land.
     private var current: Chat {
         switch chat {
@@ -48,6 +44,15 @@ struct ChatView: View {
         case let .room(room):
             return session.state.rooms.first { $0.id == room.id }.map(Chat.room) ?? chat
         }
+    }
+
+    /// A bot receives a new thread when its task changes. Navigation keeps
+    /// the original Chat value, so every transcript lookup must follow the
+    /// live record instead of the snapshot that opened this screen.
+    private var threadId: String { current.threadId }
+
+    private var messages: [Message] {
+        session.state.visibleTranscript(forThread: threadId)
     }
 
     /// Unread elsewhere — what the back pill's badge counts, like Messages.
@@ -81,14 +86,14 @@ struct ChatView: View {
                         // room for the floating face when scrolled to the top
                         Color.clear.frame(height: 72)
 
-                        if session.state.hasMore[chat.threadId] == true {
+                        if session.state.hasMore[threadId] == true {
                             Button("Load earlier messages") {
                                 // keep the reader where they were: after older
                                 // messages are prepended, sit back on the one
                                 // that used to be at the top
                                 let anchor = transcript.first?.id
                                 Task {
-                                    await session.loadOlder(threadId: chat.threadId)
+                                    await session.loadOlder(threadId: threadId)
                                     if let anchor { proxy.scrollTo(anchor, anchor: .top) }
                                 }
                             }
@@ -123,10 +128,10 @@ struct ChatView: View {
                         // one arrives — the store clears it on the same frame
                         // that appends the message, so there is never a beat
                         // where both are on screen.
-                        if let live = session.state.streaming[chat.threadId], !live.isEmpty {
+                        if let live = session.state.streaming[threadId], !live.isEmpty {
                             StreamingBubble(text: live, reasoning: nil, color: current.color)
                                 .id(Self.liveBubbleId)
-                        } else if let thinking = session.state.reasoning[chat.threadId], !thinking.isEmpty {
+                        } else if let thinking = session.state.reasoning[threadId], !thinking.isEmpty {
                             // Only while there is no answer yet. Once tokens
                             // of the reply exist, the reasoning is behind us
                             // and showing both is just noise.
@@ -196,7 +201,7 @@ struct ChatView: View {
                 // the string so this fires once per delta batch, and without
                 // animation — animating every token turns a smooth stream
                 // into a stutter, because each scroll interrupts the last.
-                .onChange(of: session.state.streaming[chat.threadId]?.count ?? 0) { _, length in
+                .onChange(of: session.state.streaming[threadId]?.count ?? 0) { _, length in
                     guard length > 0 else { return }
                     proxy.scrollTo(Self.liveBubbleId, anchor: .bottom)
                 }
@@ -215,6 +220,7 @@ struct ChatView: View {
                     session.consumeFocus(messageId)
                 }
             }
+            .id(threadId)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             composer
@@ -226,7 +232,7 @@ struct ChatView: View {
         .navigationDestination(isPresented: $showingComputer) {
             if case let .bot(bot) = current { ComputerView(bot: bot) }
         }
-        .task {
+        .task(id: threadId) {
             // opening a chat is what marks it read, exactly as on the desktop
             if current.unread { await session.markRead(current) }
 #if DEBUG
@@ -804,9 +810,7 @@ struct CardView: View {
 
     /// One definition of "the refusal", shared by the button tint and the
     /// choice above so the two cannot drift apart.
-    private static func isRefusal(_ option: String) -> Bool {
-        option.caseInsensitiveCompare("Deny") == .orderedSame
-    }
+    private static func isRefusal(_ option: String) -> Bool { OptionCard.isRefusal(option) }
 
     private var tint: Color { MausPalette.color(chat.color) }
 
@@ -842,7 +846,7 @@ struct CardView: View {
                             Button {
                                 answering = true
                                 Task {
-                                    await session.answer(threadId: chat.threadId, card: card, choice: option)
+                                    await session.answer(chat: chat, card: card, choice: option)
                                     answering = false
                                 }
                             } label: {
@@ -871,7 +875,7 @@ struct CardView: View {
                             answering = true
                             Task {
                                 await session.alwaysAllow(bot: bot, card: card)
-                                await session.answer(threadId: chat.threadId, card: card, choice: allow)
+                                await session.answer(chat: chat, card: card, choice: allow)
                                 answering = false
                             }
                         }

--- a/ios/App/Island.swift
+++ b/ios/App/Island.swift
@@ -113,7 +113,7 @@ struct NeedsYouIsland: View {
                                     Button {
                                         answering = true
                                         Task {
-                                            await session.answer(threadId: shown.chat.threadId, card: card, choice: option)
+                                            await session.answer(chat: shown.chat, card: card, choice: option)
                                             answering = false
                                             dismiss()
                                         }

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -439,9 +439,17 @@ final class Session: ObservableObject {
         }
     }
 
-    func answer(threadId: String, card: OptionCard, choice: String) async {
+    func answer(chat: Chat, card: OptionCard, choice: String) async {
         guard let requestId = card.requestId else { return }
-        await answer(threadId: threadId, requestId: requestId, choice: choice, isPermission: card.isPermission)
+        if card.shouldRememberPermission(for: choice), case let .bot(bot) = chat {
+            await alwaysAllow(bot: bot, card: card)
+        }
+        await answer(
+            threadId: chat.threadId,
+            requestId: requestId,
+            choice: choice,
+            isPermission: card.isPermission
+        )
     }
 
     /// The same answer, from something that only has the ids — the Live
@@ -450,11 +458,12 @@ final class Session: ObservableObject {
         await perform {
             // Permission cards answer allow/deny; a question answers with
             // the chosen text. The harness tells them apart by `behavior`.
-            if isPermission {
+            let behavior = OptionCard.responseBehavior(for: choice, isPermission: isPermission)
+            if behavior != "answer" {
                 try await $0.respond(
                     threadId: threadId,
                     requestId: requestId,
-                    behavior: choice.lowercased() == "allow" ? "allow" : "deny"
+                    behavior: behavior
                 )
             } else {
                 try await $0.respond(threadId: threadId, requestId: requestId, behavior: "answer", message: choice)

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -439,9 +439,9 @@ final class Session: ObservableObject {
         }
     }
 
-    func answer(chat: Chat, card: OptionCard, choice: String) async {
+    func answer(chat: Chat, card: OptionCard, choice: String, rememberingPermission: Bool = true) async {
         guard let requestId = card.requestId else { return }
-        if card.shouldRememberPermission(for: choice), case let .bot(bot) = chat {
+        if rememberingPermission, card.shouldRememberPermission(for: choice), case let .bot(bot) = chat {
             await alwaysAllow(bot: bot, card: card)
         }
         await answer(

--- a/ios/App/UpdatesSheet.swift
+++ b/ios/App/UpdatesSheet.swift
@@ -98,7 +98,7 @@ private struct UpdateRow: View {
                                 Button {
                                     answering = true
                                     Task {
-                                        await session.answer(threadId: update.chat.threadId, card: card, choice: option)
+                                        await session.answer(chat: update.chat, card: card, choice: option)
                                         answering = false
                                     }
                                 } label: {
@@ -152,6 +152,6 @@ private struct UpdateRow: View {
 /// are drawn as buttons, so the tints cannot drift apart.
 enum CardStyle {
     static func isRefusal(_ option: String) -> Bool {
-        option.caseInsensitiveCompare("Deny") == .orderedSame
+        OptionCard.isRefusal(option)
     }
 }

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -36,6 +36,35 @@ public struct OptionCard: Codable, Hashable, Sendable {
 
     /// Permission cards carry a tool; questions do not.
     public var isPermission: Bool { tool != nil }
+
+    /// The wire API accepts an approval behavior rather than the button's
+    /// display text. Treat the one refusal as deny and every other offered
+    /// permission choice as allow: providers may say "Approve", "Yes", or
+    /// "Always allow", and none of those should accidentally become a deny.
+    public func responseBehavior(for choice: String) -> String {
+        Self.responseBehavior(for: choice, isPermission: isPermission)
+    }
+
+    /// The ID-only form is used by Live Activity buttons, which carry the
+    /// card kind but not the full card payload.
+    public static func responseBehavior(for choice: String, isPermission: Bool) -> String {
+        guard isPermission else { return "answer" }
+        return isRefusal(choice) ? "deny" : "allow"
+    }
+
+    /// Shared by all of the app's card surfaces and by Live Activities.
+    public static func isRefusal(_ choice: String) -> Bool {
+        choice.trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare("Deny") == .orderedSame
+    }
+
+    /// A provider may include the standing grant as an option of its own.
+    /// Only remember it when the server supplied the narrow grant key.
+    public func shouldRememberPermission(for choice: String) -> Bool {
+        guard isPermission, allowKey != nil else { return false }
+        let normalized = choice.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.caseInsensitiveCompare("Always allow") == .orderedSame
+    }
 }
 
 public struct ToolActivity: Codable, Hashable, Sendable {

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -151,6 +151,12 @@ final class DecodingTests: XCTestCase {
         XCTAssertTrue(card.isPending)
         XCTAssertTrue(card.isPermission)
         XCTAssertEqual(card.allowKey, "Bash:rm")
+        XCTAssertEqual(card.responseBehavior(for: "Allow"), "allow")
+        XCTAssertEqual(card.responseBehavior(for: "Approve"), "allow")
+        XCTAssertEqual(card.responseBehavior(for: "Always allow"), "allow")
+        XCTAssertEqual(card.responseBehavior(for: "Deny"), "deny")
+        XCTAssertTrue(card.shouldRememberPermission(for: "Always allow"))
+        XCTAssertFalse(card.shouldRememberPermission(for: "Allow"))
 
         var answered = card
         answered.answered = "Allow"
@@ -159,6 +165,14 @@ final class DecodingTests: XCTestCase {
         var dismissed = card
         dismissed.dismissed = true
         XCTAssertFalse(dismissed.isPending)
+    }
+
+    func testAQuestionSendsItsChoiceAsAnAnswer() throws {
+        let message = try decode(Message.self, "options-card")
+        let card = try XCTUnwrap(message.card)
+        XCTAssertFalse(card.isPermission)
+        XCTAssertEqual(card.responseBehavior(for: "Anything"), "answer")
+        XCTAssertFalse(card.shouldRememberPermission(for: "Always allow"))
     }
 
     func testDecodesAMessageThatGainedAFieldWeDoNotKnow() throws {

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -153,10 +153,13 @@ final class DecodingTests: XCTestCase {
         XCTAssertEqual(card.allowKey, "Bash:rm")
         XCTAssertEqual(card.responseBehavior(for: "Allow"), "allow")
         XCTAssertEqual(card.responseBehavior(for: "Approve"), "allow")
+        XCTAssertEqual(card.responseBehavior(for: "Yes"), "allow")
         XCTAssertEqual(card.responseBehavior(for: "Always allow"), "allow")
         XCTAssertEqual(card.responseBehavior(for: "Deny"), "deny")
+        XCTAssertEqual(card.responseBehavior(for: " deny "), "deny")
         XCTAssertTrue(card.shouldRememberPermission(for: "Always allow"))
         XCTAssertFalse(card.shouldRememberPermission(for: "Allow"))
+        XCTAssertFalse(card.shouldRememberPermission(for: " deny "))
 
         var answered = card
         answered.answered = "Allow"


### PR DESCRIPTION
Fixes two companion regressions found during issue triage:

- follow a bot’s live thread after switching tasks instead of keeping the navigation snapshot
- map every non-deny permission choice to allow across chat, updates, island, and Live Activities
- persist the narrow standing grant when a provider offers Always allow directly
- cover approval semantics with CompanionCore tests

Validated with 109 Swift package tests and a full unsigned iOS simulator build.

Closes #312
Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat updates, message loading, and scrolling when conversations change or receive live responses.
  - Fixed answer actions to consistently use the active conversation.
  - Improved refusal and permission-choice handling.
- **New Features**
  - “Always allow” choices can now be remembered when applicable.
  - Permission responses are handled consistently, including allow, deny, and standard answer options.
- **Tests**
  - Added coverage for permission decisions and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->