### PR TITLE
fix(codex): preserve full shell commands

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -127,18 +127,22 @@ describe("CodexDriver turns (fake app-server)", () => {
   it("keeps the full command when a Windows interpreter prefix is long", async () => {
     await create({ mode: "windows-command" });
     await instance.adapter.sendTurn({ threadId: "t-windows-command", text: "read notes" });
-    await recorder.until((event) => event.type === "turn.completed");
 
     const command = [
       "\"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"",
       "-Command",
-      "\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\research\\NOTES.md'\"",
+      `\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\${"very-long-folder\\".repeat(8)}NOTES.md'\"`,
     ].join(" ");
-    expect(command.length).toBeGreaterThan(80);
+    expect(command.length).toBeGreaterThan(200);
+    const opened = await recorder.until((event) => event.type === "request.opened");
     expect(recorder.events.find((event) => event.type === "item.started")).toMatchObject({
       type: "item.started",
       title: command,
     });
+    expect(opened).toMatchObject({ requestType: "permission", summary: command });
+
+    await instance.adapter.respondToRequest("t-windows-command", opened.requestId!, { behavior: "allow" });
+    await recorder.until((event) => event.type === "turn.completed");
   });
 
   it("uses the instance environment for the Codex process", async () => {

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -124,6 +124,23 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(threadStart.params).toMatchObject({ model: "gpt-5.6-sol", modelProvider: "openai" });
   });
 
+  it("keeps the full command when a Windows interpreter prefix is long", async () => {
+    await create({ mode: "windows-command" });
+    await instance.adapter.sendTurn({ threadId: "t-windows-command", text: "read notes" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const command = [
+      "\"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"",
+      "-Command",
+      "\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\research\\NOTES.md'\"",
+    ].join(" ");
+    expect(command.length).toBeGreaterThan(80);
+    expect(recorder.events.find((event) => event.type === "item.started")).toMatchObject({
+      type: "item.started",
+      title: command,
+    });
+  });
+
   it("uses the instance environment for the Codex process", async () => {
     const codexHome = join(scratch, "custom-codex-home");
     await create({ environment: { CODEX_HOME: codexHome } });

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -258,7 +258,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         const requestId = newId();
         const summary =
           typeof params.command === "string"
-            ? params.command.slice(0, 200)
+            ? params.command
             : Array.isArray(params.questions)
               ? params.questions.map((q: any) => q.question ?? q.header).filter(Boolean).join(" · ")
               : typeof params.reason === "string"
@@ -325,7 +325,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             const item = p.item ?? {};
             const title =
               item.type === "commandExecution"
-                ? String(item.command ?? "shell").slice(0, 80)
+                ? String(item.command ?? "shell")
                 : item.type === "fileChange"
                   ? "edit"
                   : item.type === "mcpToolCall"

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -121,7 +121,7 @@ process.stdin.on("data", (chunk) => {
       case "thread/start":
         out({ jsonrpc: "2.0", id: msg.id, result: { thread: { id: "codex-thread-1" }, model: "fake-codex-model" } });
         break;
-      case "turn/start":
+      case "turn/start": {
         if (mode === "unauthorized") {
           out({
             jsonrpc: "2.0",
@@ -138,18 +138,20 @@ process.stdin.on("data", (chunk) => {
           ? [
               "\"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"",
               "-Command",
-              "\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\research\\NOTES.md'\"",
+              `\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\${"very-long-folder\\".repeat(8)}NOTES.md'\"`,
             ].join(" ")
           : "ls -la";
         notify("item/started", { item: { id: "i1", type: "commandExecution", command } });
         notify("item/started", { item: { id: "w1", type: "webSearch", query: "OpenMausBot" } });
-        if (mode === "approval") {
-          out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: "rm -rf scratch" } });
+        if (mode === "approval" || mode === "windows-command") {
+          const approvalCommand = mode === "windows-command" ? command : "rm -rf scratch";
+          out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: approvalCommand } });
           // turn continues from the approval response handler above
         } else {
           finishTurn();
         }
         break;
+      }
       default:
         if (msg.id !== undefined) out({ jsonrpc: "2.0", id: msg.id, result: {} });
     }

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -4,7 +4,7 @@
 // initialize/thread/turn handshake, then plays a scripted turn. Like the
 // real app-server, it never exits on its own — the driver kills it.
 //
-//   FAKE_CODEX_MODE   happy (default) | approval | resume | stream |
+//   FAKE_CODEX_MODE   happy (default) | approval | resume | stream | windows-command |
 //                     logged-in-stdout | logged-out | unauthorized
 //   FAKE_CODEX_DUMP   path to write {argv, env, calls, decision} as JSON
 //
@@ -134,7 +134,14 @@ process.stdin.on("data", (chunk) => {
           break;
         }
         out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
-        notify("item/started", { item: { id: "i1", type: "commandExecution", command: "ls -la" } });
+        const command = mode === "windows-command"
+          ? [
+              "\"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"",
+              "-Command",
+              "\"Get-Content -Raw -LiteralPath 'C:\\Users\\Ada\\workspaces\\research\\NOTES.md'\"",
+            ].join(" ")
+          : "ls -la";
+        notify("item/started", { item: { id: "i1", type: "commandExecution", command } });
         notify("item/started", { item: { id: "w1", type: "webSearch", query: "OpenMausBot" } });
         if (mode === "approval") {
           out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: "rm -rf scratch" } });


### PR DESCRIPTION
Codex was truncating shell commands at the driver boundary, so Windows PowerShell prefixes consumed nearly the entire persisted command and made approvals/history unauditable.

This keeps the full command in both tool activity and approval events; the existing UI remains responsible for visual wrapping/clipping. A Windows-shaped integration case guards commands longer than 80 characters.

Validated with typechecking, 1,394 counted tests, broker/updater/viewer tests, and the packaged-server smoke test.

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Full command text is now preserved in approval requests and command execution titles.
  * Long Windows PowerShell commands and file paths are no longer truncated in activity updates.
  * Web search activities now report completion correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->