### PR TITLE
feat(ios): add multi-account connected-app parity

### DIFF
--- a/ios/App/ConnectedAppsView.swift
+++ b/ios/App/ConnectedAppsView.swift
@@ -165,6 +165,4 @@ private extension ConnectorAccount {
         let value = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
         return value?.isEmpty == false ? value : nil
     }
-
-    var isActive: Bool { status.lowercased().contains("active") }
 }

--- a/ios/App/ConnectedAppsView.swift
+++ b/ios/App/ConnectedAppsView.swift
@@ -1,0 +1,170 @@
+import CompanionCore
+import SwiftUI
+import UIKit
+
+/// Account-aware Composio inventory for a paired phone.
+///
+/// The companion may list accounts and start authorization, but revocation
+/// deliberately remains on the Mac. That keeps a lost phone from removing a
+/// workspace integration while still giving mobile users explicit Work,
+/// Personal, and client-account choices.
+struct ConnectedAppsView: View {
+    @EnvironmentObject private var session: Session
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var catalog: ConnectorCatalog?
+    @State private var statuses: [String: ConnectorStatus] = [:]
+    @State private var query = ""
+    @State private var aliasCard: ConnectorCard?
+    @State private var alias = ""
+    @State private var loading = true
+    @State private var refreshing = false
+
+    private var cards: [ConnectorCard] {
+        let values = catalog?.cards ?? []
+        guard !query.isEmpty else { return values }
+        return values.filter {
+            $0.label.localizedCaseInsensitiveContains(query) ||
+                $0.slug.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    var body: some View {
+        List {
+            if catalog?.configured == false {
+                Section {
+                    ContentUnavailableView(
+                        "Connected apps need setup",
+                        systemImage: "link.badge.plus",
+                        description: Text("Configure Composio on your computer first. Provider credentials are never returned to this phone.")
+                    )
+                }
+            }
+
+            ForEach(cards) { card in
+                connectorSection(card)
+            }
+        }
+        .navigationTitle("Connected Apps")
+        .searchable(text: $query, prompt: "Search apps")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Refresh", systemImage: "arrow.clockwise") {
+                    Task { await refreshStatuses(showProgress: true) }
+                }
+                .disabled(refreshing)
+            }
+        }
+        .overlay { if loading { ProgressView() } }
+        .task { await load() }
+        .refreshable { await refreshStatuses() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { Task { await refreshStatuses() } }
+        }
+        .alert("Account alias", isPresented: Binding(
+            get: { aliasCard != nil },
+            set: { if !$0 { aliasCard = nil } }
+        )) {
+            TextField("Work, Personal, Client…", text: $alias)
+                .textInputAutocapitalization(.words)
+            Button("Cancel", role: .cancel) { aliasCard = nil }
+            Button("Continue") {
+                guard let card = aliasCard else { return }
+                let value = String(alias.trimmingCharacters(in: .whitespacesAndNewlines).prefix(64))
+                aliasCard = nil
+                Task { await authorize(card, alias: value) }
+            }
+            .disabled(alias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        } message: {
+            Text("An alias makes the account explicit when an agent uses more than one \(aliasCard?.label ?? "app") account.")
+        }
+    }
+
+    @ViewBuilder
+    private func connectorSection(_ card: ConnectorCard) -> some View {
+        let status = statuses[card.slug]
+        let accounts = status?.accounts ?? []
+        let isConnected = status?.connected == true
+        let isPending = status?.pending == true
+
+        Section {
+            if accounts.isEmpty, !isConnected, !isPending {
+                Button("Connect \(card.label)", systemImage: "plus.circle") {
+                    Task { await authorize(card, alias: nil) }
+                }
+                .disabled(catalog?.configured != true)
+            } else if accounts.isEmpty {
+                let statusLabel = isPending ? "Connecting…" : "Connected"
+                let statusSymbol = isPending ? "clock" : "checkmark.circle.fill"
+                Label(statusLabel, systemImage: statusSymbol)
+                    .foregroundStyle(isPending ? Color.secondary : Color.green)
+                Text("Account details are unavailable from this provider. Refresh after authorization finishes.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(accounts) { account in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(account.nonemptyAlias ?? "Primary account")
+                            Text(account.status.replacingOccurrences(of: "_", with: " ").capitalized)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(account.id)
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                                .textSelection(.enabled)
+                        }
+                        Spacer()
+                        Image(systemName: account.isActive ? "checkmark.circle.fill" : "clock")
+                            .foregroundStyle(account.isActive ? .green : .secondary)
+                    }
+                }
+
+                Button("Add another account", systemImage: "person.crop.circle.badge.plus") {
+                    alias = ""
+                    aliasCard = card
+                }
+                .disabled(accounts.count >= 5)
+            }
+        } header: {
+            HStack {
+                Text(card.label)
+                Spacer()
+                if isPending { Text("Connecting…") }
+            }
+        } footer: {
+            Text(card.blurb)
+        }
+    }
+
+    private func load() async {
+        loading = true
+        defer { loading = false }
+        catalog = await session.loadConnectorCatalog()
+        await refreshStatuses()
+    }
+
+    private func refreshStatuses(showProgress: Bool = false) async {
+        if showProgress { refreshing = true }
+        defer { if showProgress { refreshing = false } }
+        guard let response = await session.loadAllConnectorStatuses() else { return }
+        statuses = response.services
+    }
+
+    private func authorize(_ card: ConnectorCard, alias: String?) async {
+        guard let url = await session.authorizeConnector(card.slug, alias: alias) else { return }
+        guard await UIApplication.shared.open(url) else {
+            session.actionError = "The authorization page could not be opened. Try again after checking your browser restrictions."
+            return
+        }
+    }
+}
+
+private extension ConnectorAccount {
+    var nonemptyAlias: String? {
+        let value = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
+    }
+
+    var isActive: Bool { status.lowercased().contains("active") }
+}

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -872,6 +872,26 @@ final class Session: ObservableObject {
         }
     }
 
+    // MARK: - Connected apps
+
+    func loadConnectorCatalog() async -> ConnectorCatalog? {
+        guard let client else { return nil }
+        do { return try await client.connectorCatalog() }
+        catch { actionError = error.localizedDescription; return nil }
+    }
+
+    func loadAllConnectorStatuses() async -> ConnectorStatuses? {
+        guard let client else { return nil }
+        do { return try await client.allConnectorStatuses() }
+        catch { actionError = error.localizedDescription; return nil }
+    }
+
+    func authorizeConnector(_ slug: String, alias: String?) async -> URL? {
+        guard let client else { return nil }
+        do { return try await client.authorizeConnector(slug: slug, alias: alias) }
+        catch { actionError = error.localizedDescription; return nil }
+    }
+
     func refreshNotificationAuthorization() async {
         notificationAuthorization = await NotificationCoordinator.shared.authorizationStatus()
     }

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -1,8 +1,8 @@
 // Paired-device settings and safe workspace feature entry points.
 //
 // Credentials, revocation, Local VM and execution policy still live only on
-// the computer. The phone can manage renderer-neutral routines without
-// widening that boundary.
+// the computer. The phone can manage renderer-neutral routines and connected-
+// account inventory/authorization without widening that boundary.
 import SwiftUI
 import CompanionCore
 
@@ -49,10 +49,15 @@ struct SettingsView: View {
                 } label: {
                     Label("Tasks & Routines", systemImage: "calendar.badge.clock")
                 }
+                NavigationLink {
+                    ConnectedAppsView()
+                } label: {
+                    Label("Connected Apps", systemImage: "link")
+                }
             } header: {
                 Text("Workspace")
             } footer: {
-                Text("Routine schedules are safe to manage here. Provider keys, webhook secrets, pairing, revocation, Local VM, and agent execution policy stay on your computer.")
+                Text("Manage routine schedules, view connected accounts, and add Work, Personal, or client aliases here. Provider keys, webhook secrets, account revocation, pairing, Local VM, and agent execution policy stay on your computer.")
             }
 
             Section {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -409,6 +409,19 @@ public struct CompanionClient: Sendable {
         try await send(try makeRequest("GET", "/api/config"), as: ConfigStatus.self)
     }
 
+    public func connectorCatalog() async throws -> ConnectorCatalog {
+        try await send(try makeRequest("GET", "/api/connectors/catalog"), as: ConnectorCatalog.self)
+    }
+
+    /// Complete account-aware status in one request. This is the inventory
+    /// source for the phone; a catalog page is not an account list.
+    public func allConnectorStatuses() async throws -> ConnectorStatuses {
+        try await send(
+            try makeRequest("GET", "/api/connectors/connected"),
+            as: ConnectorStatuses.self
+        )
+    }
+
     /// The pixels of one screen message.
     public func image(threadId: String, messageId: String) async throws -> Data {
         let imageRequest = try makeRequest("GET", "/api/threads/\(threadId)/messages/\(messageId)/image")
@@ -591,6 +604,32 @@ public struct CompanionClient: Sendable {
     /// the key and puts it on the card; the phone never derives its own.
     public func alwaysAllow(botId: String, key: String) async throws {
         try await send(try makeRequest("POST", "/api/bots/\(botId)/always-allow", body: ["allowKey": key]))
+    }
+
+    /// Starts one more account authorization for a toolkit. Revocation is
+    /// intentionally absent: the paired-device boundary keeps that on the Mac.
+    public func authorizeConnector(slug: String, alias: String?) async throws -> URL {
+        guard Self.validConnectorSlug(slug) else { throw APIError.badURL }
+        let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = trimmed.map { ["alias": $0] }
+        let response = try await send(
+            try makeRequest("POST", "/api/connectors/\(slug)/authorize", body: body),
+            as: ConnectorAuthorizationResponse.self
+        )
+        guard let url = URL(string: response.url),
+              url.scheme == "https",
+              url.host != nil
+        else { throw APIError.badURL }
+        return url
+    }
+
+    /// Matches the companion's `[\w-]+` toolkit route component. JavaScript
+    /// `\w` is ASCII here; Unicode letters must not become a confusing 404.
+    private static func validConnectorSlug(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0) ||
+                (97...122).contains($0) || $0 == 95 || $0 == 45
+        }
     }
 
     public func toggleReaction(threadId: String, messageId: String, emoji: String) async throws -> Message {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -611,7 +611,12 @@ public struct CompanionClient: Sendable {
     public func authorizeConnector(slug: String, alias: String?) async throws -> URL {
         guard Self.validConnectorSlug(slug) else { throw APIError.badURL }
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let body = trimmed.map { ["alias": $0] }
+        let body: [String: String]?
+        if let trimmed, !trimmed.isEmpty {
+            body = ["alias": trimmed]
+        } else {
+            body = nil
+        }
         let response = try await send(
             try makeRequest("POST", "/api/connectors/\(slug)/authorize", body: body),
             as: ConnectorAuthorizationResponse.self

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -643,6 +643,42 @@ public struct NotificationTarget: Equatable, Sendable {
     }
 }
 
+// MARK: - Connected apps
+
+public struct ConnectorCard: Codable, Hashable, Identifiable, Sendable {
+    public var slug: String
+    public var label: String
+    public var blurb: String
+    public var logo: String?
+    public var domain: String?
+    public var id: String { slug }
+}
+
+public struct ConnectorAccount: Codable, Hashable, Identifiable, Sendable {
+    public var id: String
+    public var alias: String?
+    public var status: String
+}
+
+public struct ConnectorStatus: Codable, Hashable, Sendable {
+    public var connected: Bool
+    public var pending: Bool?
+    public var status: String?
+    public var accounts: [ConnectorAccount]?
+}
+
+public struct ConnectorCatalog: Codable, Sendable {
+    public var configured: Bool
+    public var mode: String?
+    public var source: String?
+    public var cards: [ConnectorCard]
+}
+
+public struct ConnectorStatuses: Codable, Sendable {
+    public var configured: Bool
+    public var services: [String: ConnectorStatus]
+}
+
 /// The harness's error body. Every non-2xx response carries one.
 public struct APIErrorBody: Codable, Sendable {
     public var error: String
@@ -688,7 +724,6 @@ struct ActiveBranchResponse: Codable, Sendable {
 struct BotResponse: Codable, Sendable {
     var bot: Bot
 }
-
 struct VoiceListResponse: Codable, Sendable {
     var voices: [Voice]
     var error: String?
@@ -712,3 +747,7 @@ struct RoutinesResponse: Codable, Sendable {
 
 struct RoutineResponse: Codable, Sendable { var routine: Routine }
 struct RoutineRunResponse: Codable, Sendable { var run: RoutineRun }
+
+struct ConnectorAuthorizationResponse: Codable, Sendable {
+    var url: String
+}

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -658,6 +658,12 @@ public struct ConnectorAccount: Codable, Hashable, Identifiable, Sendable {
     public var id: String
     public var alias: String?
     public var status: String
+
+    /// Composio lifecycle values include both `ACTIVE` and `INACTIVE`; an
+    /// exact normalized comparison avoids rendering the latter as connected.
+    public var isActive: Bool {
+        status.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() == "ACTIVE"
+    }
 }
 
 public struct ConnectorStatus: Codable, Hashable, Sendable {

--- a/ios/Tests/CompanionCoreTests/ConnectedAppsClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectedAppsClientTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class ConnectorRequestStub: URLProtocol {
+    static var responseBody = Data()
+    static var statusCode = 200
+    static var capturedRequest: URLRequest?
+    static var capturedBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequest = request
+        Self.capturedBody = Self.readBody(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+final class ConnectedAppsClientTests: XCTestCase {
+    private var session: URLSession!
+    private var client: CompanionClient!
+
+    override func setUp() {
+        super.setUp()
+        ConnectorRequestStub.responseBody = Data()
+        ConnectorRequestStub.statusCode = 200
+        ConnectorRequestStub.capturedRequest = nil
+        ConnectorRequestStub.capturedBody = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ConnectorRequestStub.self]
+        session = URLSession(configuration: configuration)
+        client = CompanionClient(
+            connection: Connection(name: "Test", host: "127.0.0.1", port: 8810),
+            token: "paired-token",
+            session: session
+        )
+    }
+
+    override func tearDown() {
+        session?.invalidateAndCancel()
+        session = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testLoadsCompleteAccountInventoryRatherThanInferringItFromTheCatalog() async throws {
+        ConnectorRequestStub.responseBody = Data(#"{"configured":true,"services":{"slack":{"connected":true,"accounts":[{"id":"ca_work","alias":"Work","status":"ACTIVE"},{"id":"ca_client","alias":"Client","status":"ACTIVE"}]}}}"#.utf8)
+
+        let statuses = try await client.allConnectorStatuses()
+
+        XCTAssertEqual(ConnectorRequestStub.capturedRequest?.url?.path, "/api/connectors/connected")
+        XCTAssertEqual(statuses.services["slack"]?.accounts?.map(\.alias), ["Work", "Client"])
+        XCTAssertEqual(
+            ConnectorRequestStub.capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer paired-token"
+        )
+    }
+
+    func testAuthorizesAnotherAccountWithAnExplicitAlias() async throws {
+        ConnectorRequestStub.responseBody = Data(#"{"url":"https://auth.example/connect"}"#.utf8)
+
+        let url = try await client.authorizeConnector(slug: "google-calendar", alias: "  Personal  ")
+
+        XCTAssertEqual(url.absoluteString, "https://auth.example/connect")
+        XCTAssertEqual(ConnectorRequestStub.capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(ConnectorRequestStub.capturedRequest?.url?.path, "/api/connectors/google-calendar/authorize")
+        let body = try XCTUnwrap(ConnectorRequestStub.capturedBody)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(object, ["alias": "Personal"])
+    }
+
+    func testRejectsUnsafeToolkitComponentsAndAuthorizationURLsLocally() async {
+        await assertBadURL { _ = try await self.client.authorizeConnector(slug: "café", alias: nil) }
+        await assertBadURL { _ = try await self.client.authorizeConnector(slug: "bad/slash", alias: nil) }
+        XCTAssertNil(ConnectorRequestStub.capturedRequest)
+
+        ConnectorRequestStub.responseBody = Data(#"{"url":"http://auth.example/connect"}"#.utf8)
+        await assertBadURL { _ = try await self.client.authorizeConnector(slug: "gmail", alias: nil) }
+    }
+
+    private func assertBadURL(
+        _ operation: () async throws -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await operation()
+            XCTFail("expected badURL", file: file, line: line)
+        } catch APIError.badURL {
+            // Expected: reject before sending paired credentials or opening it.
+        } catch {
+            XCTFail("unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ConnectedAppsClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectedAppsClientTests.swift
@@ -97,6 +97,14 @@ final class ConnectedAppsClientTests: XCTestCase {
         XCTAssertEqual(object, ["alias": "Personal"])
     }
 
+    func testOmitsAWhitespaceOnlyAlias() async throws {
+        ConnectorRequestStub.responseBody = Data(#"{"url":"https://auth.example/connect"}"#.utf8)
+
+        _ = try await client.authorizeConnector(slug: "gmail", alias: "   \n  ")
+
+        XCTAssertNil(ConnectorRequestStub.capturedBody)
+    }
+
     func testRejectsUnsafeToolkitComponentsAndAuthorizationURLsLocally() async {
         await assertBadURL { _ = try await self.client.authorizeConnector(slug: "café", alias: nil) }
         await assertBadURL { _ = try await self.client.authorizeConnector(slug: "bad/slash", alias: nil) }

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -150,6 +150,10 @@ final class DecodingTests: XCTestCase {
               "pending": false,
               "status": "ACTIVE",
               "accounts": []
+            },
+            "slack": {
+              "connected": false,
+              "pending": true
             }
           }
         }
@@ -165,6 +169,10 @@ final class DecodingTests: XCTestCase {
         let noAuth = try XCTUnwrap(statuses.services["weather"])
         XCTAssertTrue(noAuth.connected)
         XCTAssertEqual(noAuth.accounts?.isEmpty, true)
+
+        let pending = try XCTUnwrap(statuses.services["slack"])
+        XCTAssertEqual(pending.pending, true)
+        XCTAssertNil(pending.accounts)
     }
 
     func testOneMalformedBotDoesNotHideTheRestOfTheFleet() throws {

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -131,6 +131,40 @@ final class DecodingTests: XCTestCase {
         XCTAssertNil(fleet.bots.last?.cloudBackend)
     }
 
+    func testDecodesMultipleConnectedAccountsAndNoAuthToolkit() throws {
+        let payload = #"""
+        {
+          "configured": true,
+          "services": {
+            "gmail": {
+              "connected": true,
+              "pending": false,
+              "status": "ACTIVE",
+              "accounts": [
+                {"id": "ca_work", "alias": "Work", "status": "ACTIVE"},
+                {"id": "ca_personal", "status": "ACTIVE"}
+              ]
+            },
+            "weather": {
+              "connected": true,
+              "pending": false,
+              "status": "ACTIVE",
+              "accounts": []
+            }
+          }
+        }
+        """#
+        let statuses = try JSONDecoder().decode(ConnectorStatuses.self, from: Data(payload.utf8))
+        let gmail = try XCTUnwrap(statuses.services["gmail"])
+        XCTAssertEqual(gmail.accounts?.map(\.id), ["ca_work", "ca_personal"])
+        XCTAssertEqual(gmail.accounts?.first?.alias, "Work")
+        XCTAssertNil(gmail.accounts?.last?.alias)
+
+        let noAuth = try XCTUnwrap(statuses.services["weather"])
+        XCTAssertTrue(noAuth.connected)
+        XCTAssertEqual(noAuth.accounts?.isEmpty, true)
+    }
+
     func testOneMalformedBotDoesNotHideTheRestOfTheFleet() throws {
         let json = """
         {

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -142,7 +142,7 @@ final class DecodingTests: XCTestCase {
               "status": "ACTIVE",
               "accounts": [
                 {"id": "ca_work", "alias": "Work", "status": "ACTIVE"},
-                {"id": "ca_personal", "status": "ACTIVE"}
+                {"id": "ca_personal", "status": "INACTIVE"}
               ]
             },
             "weather": {
@@ -159,6 +159,8 @@ final class DecodingTests: XCTestCase {
         XCTAssertEqual(gmail.accounts?.map(\.id), ["ca_work", "ca_personal"])
         XCTAssertEqual(gmail.accounts?.first?.alias, "Work")
         XCTAssertNil(gmail.accounts?.last?.alias)
+        XCTAssertTrue(try XCTUnwrap(gmail.accounts?.first).isActive)
+        XCTAssertFalse(try XCTUnwrap(gmail.accounts?.last).isActive)
 
         let noAuth = try XCTUnwrap(statuses.services["weather"])
         XCTAssertTrue(noAuth.connected)


### PR DESCRIPTION
## Summary

Follow-up iOS parity for the multi-account Composio work merged in #330.

- adds **Settings → Connected Apps** on iOS alongside the merged **Tasks & Routines** entry
- shows every account returned for Slack, Gmail/Google, and other toolkits, including explicit Work/Personal/client aliases
- starts another account authorization from the phone and opens only an authenticated HTTPS authorization URL
- refreshes account inventory on pull-to-refresh, toolbar refresh, and return from the browser
- handles providers that report connected/pending without exposing an account row

## Paired-device boundary

This deliberately matches the sidecar policy merged in #330:

- provider keys never leave the computer
- iOS may list account IDs/aliases and start authorization
- **disconnect/revocation remains Mac-only**; this PR exposes no DELETE client method or swipe-to-delete UI
- toolkit route components are validated against the companion's exact ASCII contract before paired credentials are sent

## Why a follow-up PR

The maintainer review for #330 merged the web/server/broker feature and intentionally removed the iOS view from that branch so the mobile UI could land as a separately reviewable parity slice. This PR is rebased directly on current `main` after #327–#329 merged and contains only the iOS client, models, view, navigation, and tests.

## Duplicate audit

Checked current open PRs and issues before submission. No open PR implements iOS multi-account Connected Apps. #330 is the merged backend/web prerequisite; issue #297 was the original multi-account request.

## Verification

- `xcrun swift test` — **124 tests passed**
- `xcodegen generate`
- unsigned generic iOS Simulator build — **BUILD SUCCEEDED**
- `git diff --check`

## Data and security notes

No real OAuth URLs, provider credentials, or private account data are committed. Tests use stub account IDs and `auth.example`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Connected Apps workspace in Settings to browse and search available integrations.
  * View connection statuses, linked accounts, active or inactive states, and optional account aliases.
  * Authorize additional accounts directly from the app with secure browser handoff and clear error reporting.
  * Refresh connected-app information manually or when returning to the app.
* **Documentation**
  * Clarified which connected-account management features are available on mobile versus computer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->