### PR TITLE
feat: scout a project folder into a suggested team

### DIFF
--- a/server/bot-directory.test.ts
+++ b/server/bot-directory.test.ts
@@ -64,6 +64,34 @@ describe("fetchBotDirectory", () => {
     const down = vi.fn(async () => new Response("nope", { status: 503 }));
     await expect(fetchBotDirectory(down as unknown as typeof fetch)).rejects.toThrow("HTTP 503");
   });
+
+  it("rejects an oversized response while reading, not after buffering it whole", async () => {
+    // no content-length header on purpose: the announced-size shortcut must
+    // not be the only guard. The stream never ends on its own — the fetch
+    // has to bail the moment the cap is crossed, or this test times out.
+    const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
+    let sent = 0;
+    let cancelled = false;
+    const endless = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        sent += chunk.byteLength;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const big = vi.fn(async () => new Response(endless));
+    await expect(fetchBotDirectory(big as unknown as typeof fetch)).rejects.toThrow("too large");
+    expect(cancelled).toBe(true);
+    // barely past the 1 MB cap — nowhere near what an unbounded read would take
+    expect(sent).toBeLessThan(2_000_000);
+
+    const announced = vi.fn(async () =>
+      new Response("{}", { headers: { "content-length": String(50_000_000) } }),
+    );
+    await expect(fetchBotDirectory(announced as unknown as typeof fetch)).rejects.toThrow("too large");
+  });
 });
 
 describe("matchDirectoryBots", () => {
@@ -88,5 +116,11 @@ describe("matchDirectoryBots", () => {
 
   it("honors the limit", () => {
     expect(matchDirectoryBots(profile, bots, 1)).toHaveLength(1);
+  });
+
+  it("ignores stack names too short to mean anything as substrings", () => {
+    const goProfile: ProjectProfile = { name: "svc", summary: "", stacks: ["Go"], signals: [] };
+    const google = { ...entry(), slug: "google-helper", name: "Google Helper", category: "Ops", integrations: [] } as DirectoryBot;
+    expect(matchDirectoryBots(goProfile, [google])).toEqual([]);
   });
 });

--- a/server/bot-directory.test.ts
+++ b/server/bot-directory.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BOT_DIRECTORY_API_URL,
+  fetchBotDirectory,
+  matchDirectoryBots,
+  parseBotDirectory,
+  type DirectoryBot,
+} from "./bot-directory.ts";
+import type { ProjectProfile } from "./project-scout.ts";
+
+const entry = (over: Partial<Record<string, unknown>> = {}) => ({
+  slug: "release-scribe",
+  name: "Release Scribe",
+  category: "Docs",
+  integrations: ["GitHub"],
+  prompt: "Set up a bot that drafts release notes.",
+  detailUrl: "https://botdirectory.ai/bots/release-scribe/",
+  ...over,
+});
+
+describe("parseBotDirectory", () => {
+  it("accepts the published shape and keeps only the fields we use", () => {
+    const bots = parseBotDirectory({ version: 1, bots: [entry({ contributor: "someone", addedAt: "2026" })] });
+    expect(bots).toEqual([
+      {
+        slug: "release-scribe",
+        name: "Release Scribe",
+        category: "Docs",
+        integrations: ["GitHub"],
+        prompt: "Set up a bot that drafts release notes.",
+        detailUrl: "https://botdirectory.ai/bots/release-scribe/",
+      },
+    ]);
+  });
+
+  it("drops malformed entries instead of failing the whole directory", () => {
+    const bots = parseBotDirectory({
+      version: 1,
+      bots: [
+        entry(),
+        entry({ slug: "UPPER CASE" }),
+        entry({ slug: "no-prompt", prompt: "" }),
+        entry({ slug: "elsewhere", detailUrl: "https://evil.example/bots/x/" }),
+        entry(), // duplicate slug
+        "not an object",
+      ],
+    });
+    expect(bots.map((bot) => bot.slug)).toEqual(["release-scribe"]);
+  });
+
+  it("rejects a response that is not the directory", () => {
+    expect(() => parseBotDirectory({ version: 2, bots: [] })).toThrow("not supported");
+    expect(() => parseBotDirectory([])).toThrow("not supported");
+  });
+});
+
+describe("fetchBotDirectory", () => {
+  it("fetches, validates, and passes errors through", async () => {
+    const ok = vi.fn(async () => new Response(JSON.stringify({ version: 1, bots: [entry()] })));
+    await expect(fetchBotDirectory(ok as unknown as typeof fetch)).resolves.toHaveLength(1);
+    expect(ok).toHaveBeenCalledWith(BOT_DIRECTORY_API_URL, expect.objectContaining({ redirect: "error" }));
+
+    const down = vi.fn(async () => new Response("nope", { status: 503 }));
+    await expect(fetchBotDirectory(down as unknown as typeof fetch)).rejects.toThrow("HTTP 503");
+  });
+});
+
+describe("matchDirectoryBots", () => {
+  const profile: ProjectProfile = {
+    name: "Shop",
+    summary: "A storefront with payments.",
+    stacks: ["TypeScript", "React"],
+    signals: [{ role: "frontend", evidence: ["react"] }],
+  };
+  const bots: DirectoryBot[] = [
+    { ...entry(), slug: "react-reviewer", name: "React Reviewer", category: "Engineering", integrations: ["GitHub"] } as DirectoryBot,
+    { ...entry(), slug: "payments-auditor", name: "Payments Auditor", category: "Finance", integrations: ["Stripe"] } as DirectoryBot,
+    { ...entry(), slug: "gig-closer", name: "Gig Closer", category: "Ops", integrations: ["QuickBooks"] } as DirectoryBot,
+  ];
+
+  it("returns only bots that overlap the profile, best match first, with the matched terms", () => {
+    const matched = matchDirectoryBots(profile, bots);
+    expect(matched.map((bot) => bot.slug)).toEqual(["react-reviewer", "payments-auditor"]);
+    expect(matched[0]!.matched).toContain("react");
+    expect(matched[1]!.matched).toContain("payments");
+  });
+
+  it("honors the limit", () => {
+    expect(matchDirectoryBots(profile, bots, 1)).toHaveLength(1);
+  });
+});

--- a/server/bot-directory.ts
+++ b/server/bot-directory.ts
@@ -1,0 +1,120 @@
+import { parseJson } from "./schema.ts";
+import type { ProjectProfile } from "./project-scout.ts";
+
+export const BOT_DIRECTORY_URL = "https://botdirectory.ai";
+export const BOT_DIRECTORY_API_URL = "https://api.botdirectory.ai/api/bots";
+
+const MAX_DIRECTORY_BYTES = 1_000_000;
+const MAX_DIRECTORY_BOTS = 200;
+
+export interface DirectoryBot {
+  slug: string;
+  name: string;
+  category: string;
+  integrations: string[];
+  /** the community-written setup prompt — shown to the human, and only ever
+   * imported as a bot description through the same persona-only boundary as
+   * any shared team file */
+  prompt: string;
+  detailUrl: string;
+}
+
+export interface MatchedDirectoryBot extends DirectoryBot {
+  /** the profile terms this bot matched on, for the human reviewing it */
+  matched: string[];
+}
+
+type Fetcher = typeof fetch;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+function text(value: unknown, max: number): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const normalized = value.trim();
+  return normalized.length > max ? null : normalized;
+}
+
+/** Validate the community-maintained index before any of it reaches the
+ * renderer. Entries that do not parse are dropped, not fatal — one bad
+ * community submission must not blank the whole directory. */
+export function parseBotDirectory(value: unknown): DirectoryBot[] {
+  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.bots)) {
+    throw new Error("The bot directory response is not supported");
+  }
+  const bots: DirectoryBot[] = [];
+  const seen = new Set<string>();
+  for (const raw of value.bots.slice(0, MAX_DIRECTORY_BOTS)) {
+    if (!isRecord(raw)) continue;
+    const slug = text(raw.slug, 100);
+    if (!slug || !/^[a-z0-9][a-z0-9-]*$/.test(slug) || seen.has(slug)) continue;
+    const name = text(raw.name, 100);
+    const prompt = text(raw.prompt, 4_000);
+    if (!name || !prompt) continue;
+    const detailUrl = text(raw.detailUrl, 300);
+    if (!detailUrl || !detailUrl.startsWith(`${BOT_DIRECTORY_URL}/`)) continue;
+    seen.add(slug);
+    bots.push({
+      slug,
+      name,
+      category: text(raw.category, 80) ?? "",
+      integrations: Array.isArray(raw.integrations)
+        ? raw.integrations.flatMap((item) => text(item, 80) ?? []).slice(0, 20)
+        : [],
+      prompt,
+      detailUrl,
+    });
+  }
+  return bots;
+}
+
+export async function fetchBotDirectory(fetcher: Fetcher = fetch): Promise<DirectoryBot[]> {
+  const response = await fetcher(BOT_DIRECTORY_API_URL, {
+    headers: { accept: "application/json" },
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) throw new Error(`The bot directory returned HTTP ${response.status}`);
+  const raw = await response.text();
+  if (Buffer.byteLength(raw) > MAX_DIRECTORY_BYTES) throw new Error("The bot directory response is too large");
+  return parseBotDirectory(parseJson(raw));
+}
+
+/** Rank directory bots against a scouted project: overlap between the
+ * project's stacks/summary words and a bot's name, category and
+ * integrations. Purely lexical on purpose — deterministic, explainable,
+ * and honest about being a hint rather than a verdict. */
+// Words that appear in nearly every project blurb and would match nearly
+// every directory entry. A match on one of these is noise, not affinity —
+// measured live: "Your own team of AI bots" matched a home-value tracker
+// purely on "your".
+const STOPWORDS = new Set([
+  "your", "with", "that", "this", "from", "have", "what", "when", "where", "will",
+  "them", "then", "than", "only", "also", "into", "over", "about", "after", "before",
+  "every", "some", "most", "much", "many", "very", "just", "like", "each", "other",
+  "their", "there", "these", "those", "using", "based", "open", "free", "fast",
+  "simple", "easy", "apps", "tool", "tools", "project", "team", "chat", "bots",
+]);
+
+export function matchDirectoryBots(
+  profile: ProjectProfile,
+  bots: DirectoryBot[],
+  limit = 5,
+): MatchedDirectoryBot[] {
+  const terms = new Set<string>();
+  for (const stack of profile.stacks) terms.add(stack.toLowerCase());
+  for (const signal of profile.signals) terms.add(signal.role);
+  // "." and "#" stay word-internal for the likes of next.js and C#, but a
+  // sentence-final "payments." must still match "Payments"
+  for (const raw of `${profile.name} ${profile.summary}`.toLowerCase().split(/[^a-z0-9+.#-]+/)) {
+    const word = raw.replace(/^[.#+-]+|[.#+-]+$/g, "");
+    if (word.length >= 4 && !STOPWORDS.has(word)) terms.add(word);
+  }
+
+  const scored = bots.flatMap((bot) => {
+    const haystackParts = [bot.name, bot.category, ...bot.integrations].map((part) => part.toLowerCase());
+    const matched = [...terms].filter((term) => haystackParts.some((part) => part.includes(term)));
+    return matched.length > 0 ? [{ ...bot, matched }] : [];
+  });
+  return scored.sort((a, b) => b.matched.length - a.matched.length).slice(0, limit);
+}

--- a/server/bot-directory.ts
+++ b/server/bot-directory.ts
@@ -68,6 +68,33 @@ export function parseBotDirectory(value: unknown): DirectoryBot[] {
   return bots;
 }
 
+/** Read the body in bounded chunks: an oversized or endless response is
+ * rejected the moment it crosses the cap, never buffered whole first. */
+async function readBounded(response: Response, maxBytes: number): Promise<string> {
+  const oversized = () => new Error("The bot directory response is too large");
+  const announced = Number(response.headers.get("content-length") ?? 0);
+  if (announced > maxBytes) throw oversized();
+  if (!response.body) {
+    const raw = await response.text();
+    if (Buffer.byteLength(raw) > maxBytes) throw oversized();
+    return raw;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw oversized();
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 export async function fetchBotDirectory(fetcher: Fetcher = fetch): Promise<DirectoryBot[]> {
   const response = await fetcher(BOT_DIRECTORY_API_URL, {
     headers: { accept: "application/json" },
@@ -75,9 +102,7 @@ export async function fetchBotDirectory(fetcher: Fetcher = fetch): Promise<Direc
     signal: AbortSignal.timeout(10_000),
   });
   if (!response.ok) throw new Error(`The bot directory returned HTTP ${response.status}`);
-  const raw = await response.text();
-  if (Buffer.byteLength(raw) > MAX_DIRECTORY_BYTES) throw new Error("The bot directory response is too large");
-  return parseBotDirectory(parseJson(raw));
+  return parseBotDirectory(parseJson(await readBounded(response, MAX_DIRECTORY_BYTES)));
 }
 
 /** Rank directory bots against a scouted project: overlap between the
@@ -102,7 +127,12 @@ export function matchDirectoryBots(
   limit = 5,
 ): MatchedDirectoryBot[] {
   const terms = new Set<string>();
-  for (const stack of profile.stacks) terms.add(stack.toLowerCase());
+  for (const stack of profile.stacks) {
+    const term = stack.toLowerCase();
+    // a two- or three-letter stack ("go", "php") substring-matches half the
+    // directory — "google", "django", "logo" are not Go affinity
+    if (term.length >= 4) terms.add(term);
+  }
   for (const signal of profile.signals) terms.add(signal.role);
   // "." and "#" stay word-internal for the likes of next.js and C#, but a
   // sentence-final "payments." must still match "Payments"

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -799,6 +799,7 @@ describe("harness HTTP API", () => {
 
     expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
     for (const bot of imported.body.bots) await api("DELETE", `/api/bots/${bot.id}`);
+    rmSync(folder, { recursive: true, force: true });
   });
 
   it("team import is additive-only: smuggled grants, claimed ids, and re-imports never touch existing records", async () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -760,6 +760,47 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("the scout reads a folder, proposes an importable team, and creates nothing until the human imports", async () => {
+    const folder = mkdtempSync(join(tmpdir(), "omb-scout-"));
+    writeFileSync(join(folder, "README.md"), "# Demo Shop\n\nA storefront demo.\n");
+    writeFileSync(
+      join(folder, "package.json"),
+      JSON.stringify({ dependencies: { react: "^19" }, devDependencies: { vitest: "^3" } }),
+    );
+
+    const before = (await api("GET", "/api/bots")).body;
+
+    expect((await api("GET", "/api/teams/scout")).status).toBe(400);
+    expect((await api("GET", `/api/teams/scout?cwd=${encodeURIComponent(join(folder, "nope"))}`)).status).toBe(400);
+
+    const scouted = await api("GET", `/api/teams/scout?cwd=${encodeURIComponent(folder)}`);
+    expect(scouted.status).toBe(200);
+    expect(scouted.body.profile).toMatchObject({ name: "Demo Shop", summary: "A storefront demo." });
+    expect(scouted.body.profile.stacks).toContain("React");
+    expect(scouted.body.suggestion.roomName).toBe("Demo Shop");
+    const keys = scouted.body.suggestion.manifest.team.members.map((member: { key: string }) => member.key);
+    expect(keys).toEqual(["lead", "frontend", "testing"]);
+    expect(Object.keys(scouted.body.suggestion.reasons).sort()).toEqual(keys.slice().sort());
+
+    // scouting is read-only: no bot and no room exists until the import
+    const after = (await api("GET", "/api/bots")).body;
+    expect(after.bots).toHaveLength(before.bots.length);
+    expect(after.groups).toHaveLength(before.groups.length);
+
+    // and the suggestion goes through the real importer verbatim
+    const imported = await api(
+      "POST",
+      `/api/teams/import?mode=project&cwd=${encodeURIComponent(folder)}&room=${encodeURIComponent(scouted.body.suggestion.roomName)}`,
+      scouted.body.suggestion.manifest,
+    );
+    expect(imported.status).toBe(201);
+    expect(imported.body.group).toMatchObject({ name: "Demo Shop", cwd: folder });
+    expect(imported.body.bots).toHaveLength(3);
+
+    expect((await api("DELETE", `/api/groups/${imported.body.group.id}`)).status).toBe(200);
+    for (const bot of imported.body.bots) await api("DELETE", `/api/bots/${bot.id}`);
+  });
+
   it("team import is additive-only: smuggled grants, claimed ids, and re-imports never touch existing records", async () => {
     // an armed bot: every privilege a malicious manifest could try to
     // capture is switched ON here, so any write-through shows up as a diff

--- a/server/index.ts
+++ b/server/index.ts
@@ -3026,8 +3026,10 @@ const server = createServer(async (req, res) => {
       let directory: MatchedDirectoryBot[] = [];
       try {
         directory = matchDirectoryBots(scoutProject(validated.cwd), await fetchBotDirectory());
-      } catch {
-        // an unreachable directory is a fact of life, not an error
+      } catch (error) {
+        // an unreachable directory is a fact of life, not an error — but an
+        // empty section should still be diagnosable from the server log
+        console.warn("bot directory lookup failed:", error instanceof Error ? error.message : String(error));
       }
       return json(res, 200, { directory });
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -98,6 +98,8 @@ import { LocalVmLease, LocalVmLeasePool } from "./local-vm-lease.ts";
 import { RepeatDetector, callKey } from "./repeat-detector.ts";
 import * as vps from "./vps-computer.ts";
 import { RoutineManager, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
+import { fetchBotDirectory, matchDirectoryBots, type MatchedDirectoryBot } from "./bot-directory.ts";
+import { scoutProject, suggestTeam } from "./project-scout.ts";
 import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
 import { createTeamManifest, importedMemberProfile, parseTeamManifest } from "./team-manifest.ts";
 import { readThreadEvents } from "./thread-events.ts";
@@ -2998,6 +3000,36 @@ const server = createServer(async (req, res) => {
         const status = (error as { status?: number }).status === 404 ? 404 : 400;
         return json(res, status, { error: error instanceof Error ? error.message : "The GitHub team could not be loaded" });
       }
+    }
+    if (method === "GET" && path === "/api/teams/scout") {
+      // The scout reads a folder and answers with a suggestion — it creates
+      // nothing. Bots and the room come into being only when the human sends
+      // the suggested manifest through /api/teams/import, so "the agent
+      // proposes, the person imports" is enforced by the route split itself.
+      // The folder is whatever validateBotCwd accepts: the same local-user
+      // trust boundary as pointing any bot's working folder at a path.
+      // Deliberately offline — the community directory lives on its own
+      // route below, so a slow network can never delay the suggestion.
+      const validated = validateBotCwd(url.searchParams.get("cwd"));
+      if (!validated.ok) return json(res, 400, { error: validated.error });
+      if (!validated.cwd) return json(res, 400, { error: "scout needs a folder to read" });
+      const profile = scoutProject(validated.cwd);
+      return json(res, 200, { profile, suggestion: suggestTeam(profile) });
+    }
+    if (method === "GET" && path === "/api/teams/scout/directory") {
+      // Community bots that fit the scouted folder — a separate, lazy call
+      // so an unreachable directory degrades to "no extra candidates", never
+      // to a broken scout.
+      const validated = validateBotCwd(url.searchParams.get("cwd"));
+      if (!validated.ok) return json(res, 400, { error: validated.error });
+      if (!validated.cwd) return json(res, 400, { error: "scout needs a folder to read" });
+      let directory: MatchedDirectoryBot[] = [];
+      try {
+        directory = matchDirectoryBots(scoutProject(validated.cwd), await fetchBotDirectory());
+      } catch {
+        // an unreachable directory is a fact of life, not an error
+      }
+      return json(res, 200, { directory });
     }
     if (method === "POST" && path === "/api/teams/import") {
       // Import is additive-only. A manifest is untrusted input (catalog,

--- a/server/project-scout.test.ts
+++ b/server/project-scout.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { parseTeamManifest } from "./team-manifest.ts";
@@ -39,7 +39,7 @@ describe("scoutProject", () => {
     const fromPkg = scoutProject(project({ "package.json": JSON.stringify({ name: "pkg-name" }) }));
     expect(fromPkg.name).toBe("pkg-name");
     const bare = project({});
-    expect(scoutProject(bare).name).toBe(bare.split("/").at(-1));
+    expect(scoutProject(bare).name).toBe(basename(bare));
   });
 
   it("detects roles from dependencies and folders, with evidence", () => {

--- a/server/project-scout.test.ts
+++ b/server/project-scout.test.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseTeamManifest } from "./team-manifest.ts";
+import { scoutProject, suggestTeam, type ProjectProfile } from "./project-scout.ts";
+
+let dirs: string[] = [];
+
+function project(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "omb-scout-"));
+  dirs.push(dir);
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(dir, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  dirs = [];
+});
+
+describe("scoutProject", () => {
+  it("names the project from the README and summarizes its first paragraph", () => {
+    const dir = project({
+      "README.md": "[![ci](x)](y)\n# Maus Tracker\n\nTracks every maus in the house.\n\nMore prose.",
+      "package.json": JSON.stringify({ name: "not-this", description: "not this either" }),
+    });
+    const profile = scoutProject(dir);
+    expect(profile.name).toBe("Maus Tracker");
+    expect(profile.summary).toBe("Tracks every maus in the house.");
+  });
+
+  it("falls back to package name, then folder name", () => {
+    const fromPkg = scoutProject(project({ "package.json": JSON.stringify({ name: "pkg-name" }) }));
+    expect(fromPkg.name).toBe("pkg-name");
+    const bare = project({});
+    expect(scoutProject(bare).name).toBe(bare.split("/").at(-1));
+  });
+
+  it("detects roles from dependencies and folders, with evidence", () => {
+    const dir = project({
+      "package.json": JSON.stringify({
+        dependencies: { react: "^19", express: "^5" },
+        devDependencies: { vitest: "^3", typescript: "^5" },
+      }),
+      "tsconfig.json": "{}",
+      "Dockerfile": "FROM node",
+      "docs/guide.md": "# Guide",
+      "server/index.ts": "",
+    });
+    const profile = scoutProject(dir);
+    const roles = profile.signals.map((signal) => signal.role);
+    expect(roles).toEqual(["frontend", "backend", "testing", "infra", "docs"]);
+    const backend = profile.signals.find((signal) => signal.role === "backend")!;
+    expect(backend.evidence).toContain("express");
+    expect(backend.evidence).toContain("server/");
+    expect(profile.stacks).toEqual(expect.arrayContaining(["TypeScript", "React", "Node", "Docker"]));
+  });
+
+  it("does not call an empty docs folder a docs project", () => {
+    const dir = project({ "docs/image.png": "" });
+    expect(scoutProject(dir).signals.find((signal) => signal.role === "docs")).toBeUndefined();
+  });
+
+  it("reads python projects without a package.json", () => {
+    const dir = project({
+      "requirements.txt": "fastapi==0.116\npytest==8.0",
+      "pyproject.toml": "[project]\nname='svc'",
+    });
+    const profile = scoutProject(dir);
+    expect(profile.signals.map((signal) => signal.role)).toEqual(["backend", "testing"]);
+    expect(profile.stacks).toContain("Python");
+  });
+
+  it("survives an unreadable folder and malformed files", () => {
+    const dir = project({ "package.json": "{not json" });
+    expect(scoutProject(dir).signals).toEqual([]);
+    expect(scoutProject(join(dir, "does-not-exist")).stacks).toEqual([]);
+  });
+});
+
+describe("suggestTeam", () => {
+  const profile: ProjectProfile = {
+    name: "Maus Tracker",
+    summary: "Tracks every maus in the house.",
+    stacks: ["TypeScript", "React"],
+    signals: [
+      { role: "frontend", evidence: ["react", "vite"] },
+      { role: "testing", evidence: ["vitest"] },
+    ],
+  };
+
+  it("always leads with a lead, then one member per signal, each with a reason", () => {
+    const suggestion = suggestTeam(profile);
+    expect(suggestion.roomName).toBe("Maus Tracker");
+    expect(suggestion.manifest.team.members.map((member) => member.key)).toEqual(["lead", "frontend", "testing"]);
+    expect(suggestion.reasons.frontend).toContain("react");
+    expect(suggestion.manifest.team.description).toBe(profile.summary);
+    const frontend = suggestion.manifest.team.members[1]!;
+    expect(frontend.description).toContain("Maus Tracker");
+    expect(frontend.description).toContain("react, vite");
+  });
+
+  it("adds a generalist when nothing was detected", () => {
+    const suggestion = suggestTeam({ name: "Mystery", summary: "", stacks: [], signals: [] });
+    expect(suggestion.manifest.team.members.map((member) => member.key)).toEqual(["lead", "builder"]);
+  });
+
+  it("caps the lineup at a lead plus five specialists", () => {
+    const wide: ProjectProfile = {
+      ...profile,
+      signals: (["frontend", "backend", "mobile", "data", "testing", "infra", "docs"] as const).map((role) => ({
+        role,
+        evidence: ["x"],
+      })),
+    };
+    expect(suggestTeam(wide).manifest.team.members).toHaveLength(6);
+  });
+
+  it("emits a manifest the importer accepts verbatim", () => {
+    const suggestion = suggestTeam(profile);
+    // the round-trip through the real parser is the contract: a suggestion
+    // is exactly as importable as a shared team file
+    expect(() => parseTeamManifest(JSON.parse(JSON.stringify(suggestion.manifest)))).not.toThrow();
+  });
+});

--- a/server/project-scout.ts
+++ b/server/project-scout.ts
@@ -23,8 +23,9 @@ export type ScoutRole =
 
 export interface ProjectSignal {
   role: ScoutRole;
-  /** the files and dependencies that argued for this role, for the human
-   * reviewing the suggestion — never shown to a model */
+  /** the files and dependencies that argued for this role: shown to the
+   * human reviewing the suggestion, and quoted in the suggested member's
+   * description — which becomes persona text and reaches the provider */
   evidence: string[];
 }
 

--- a/server/project-scout.ts
+++ b/server/project-scout.ts
@@ -1,0 +1,370 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import {
+  parseTeamManifest,
+  TEAM_MANIFEST_FORMAT,
+  TEAM_MANIFEST_VERSION,
+  type TeamManifestMember,
+  type TeamManifestV2,
+} from "./team-manifest.ts";
+import type { MausColor } from "./store.ts";
+
+/** What the scout can recognize a project needing. One role becomes one
+ * suggested team member; the lead is always added on top. */
+export type ScoutRole =
+  | "frontend"
+  | "backend"
+  | "mobile"
+  | "data"
+  | "testing"
+  | "infra"
+  | "docs";
+
+export interface ProjectSignal {
+  role: ScoutRole;
+  /** the files and dependencies that argued for this role, for the human
+   * reviewing the suggestion — never shown to a model */
+  evidence: string[];
+}
+
+export interface ProjectProfile {
+  /** README h1 > package name > folder name */
+  name: string;
+  /** README first paragraph > package description > "" */
+  summary: string;
+  /** display chips: languages, frameworks, notable tooling */
+  stacks: string[];
+  signals: ProjectSignal[];
+}
+
+export interface TeamSuggestion {
+  roomName: string;
+  manifest: TeamManifestV2;
+  /** member key → the one-line reason it was suggested */
+  reasons: Record<string, string>;
+}
+
+// The scout reads, it never writes — and it reads bounded: a handful of
+// well-known files by name, top-level directory listings, and nothing
+// recursive. A folder full of surprises must cost milliseconds, not minutes.
+const MAX_FILE_BYTES = 256_000;
+const MAX_DIR_ENTRIES = 400;
+
+function readText(path: string): string | null {
+  try {
+    if (statSync(path).size > MAX_FILE_BYTES) return null;
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function listNames(dir: string): string[] {
+  try {
+    return readdirSync(dir).slice(0, MAX_DIR_ENTRIES);
+  } catch {
+    return [];
+  }
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function packageJson(cwd: string): { name?: string; description?: string; deps: Set<string> } {
+  const raw = readText(join(cwd, "package.json"));
+  if (!raw) return { deps: new Set() };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { deps: new Set() };
+    const pkg = parsed as Record<string, unknown>;
+    const deps = new Set<string>();
+    for (const field of ["dependencies", "devDependencies"]) {
+      const block = pkg[field];
+      if (block && typeof block === "object" && !Array.isArray(block)) {
+        for (const dep of Object.keys(block)) deps.add(dep);
+      }
+    }
+    return {
+      name: typeof pkg.name === "string" ? pkg.name : undefined,
+      description: typeof pkg.description === "string" ? pkg.description : undefined,
+      deps,
+    };
+  } catch {
+    return { deps: new Set() };
+  }
+}
+
+/** README h1 and the first prose paragraph after it. Badge rows and heading
+ * lines are skipped so the summary reads like a sentence, not markup. */
+function readme(cwd: string): { title?: string; summary?: string } {
+  const raw =
+    readText(join(cwd, "README.md")) ?? readText(join(cwd, "readme.md")) ?? readText(join(cwd, "README"));
+  if (!raw) return {};
+  let title: string | undefined;
+  let summary: string | undefined;
+  for (const line of raw.slice(0, 64_000).split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("#")) {
+      if (!title) title = trimmed.replace(/^#+\s*/, "").trim() || undefined;
+      continue;
+    }
+    // badge rows, raw HTML, and blockquote callouts (warnings, notices) are
+    // not the sentence that says what the project is
+    if (trimmed.startsWith("[![") || trimmed.startsWith("![") || trimmed.startsWith("<") || trimmed.startsWith(">")) continue;
+    // the summary is rendered as plain text; markdown emphasis would show
+    // its asterisks
+    summary = trimmed.replace(/[*_`]/g, "").slice(0, 1_000);
+    break;
+  }
+  return { title, summary };
+}
+
+interface Detector {
+  role: ScoutRole;
+  deps: string[];
+  paths: string[];
+}
+
+// Order is priority: when a suggestion has to be trimmed, the roles that
+// define the project's shape survive over the ones that polish it.
+const DETECTORS: Detector[] = [
+  {
+    role: "frontend",
+    deps: ["react", "vue", "svelte", "next", "nuxt", "astro", "vite", "@angular/core", "solid-js"],
+    paths: ["index.html", "vite.config.ts", "vite.config.js", "next.config.js", "next.config.ts"],
+  },
+  {
+    role: "backend",
+    deps: ["express", "fastify", "koa", "hono", "@nestjs/core", "django", "flask", "fastapi"],
+    paths: ["server", "api", "go.mod"],
+  },
+  {
+    role: "mobile",
+    deps: ["react-native", "expo"],
+    paths: ["ios", "android", "pubspec.yaml"],
+  },
+  {
+    role: "data",
+    deps: ["prisma", "drizzle-orm", "knex", "sequelize", "typeorm", "mongoose", "pg", "mysql2", "better-sqlite3", "sqlalchemy"],
+    paths: ["prisma", "migrations"],
+  },
+  {
+    role: "testing",
+    deps: ["vitest", "jest", "mocha", "@playwright/test", "cypress", "pytest"],
+    paths: ["test", "tests", "__tests__", "e2e"],
+  },
+  {
+    role: "infra",
+    deps: [],
+    paths: ["Dockerfile", "docker-compose.yml", "docker-compose.yaml", "compose.yaml", ".github/workflows", "terraform", "helm"],
+  },
+  {
+    role: "docs",
+    deps: [],
+    paths: ["docs", "mkdocs.yml"],
+  },
+];
+
+const STACK_MARKERS: Array<{ stack: string; deps?: string[]; paths?: string[] }> = [
+  { stack: "TypeScript", deps: ["typescript"], paths: ["tsconfig.json"] },
+  { stack: "React", deps: ["react"] },
+  { stack: "Vue", deps: ["vue"] },
+  { stack: "Svelte", deps: ["svelte"] },
+  { stack: "Next.js", deps: ["next"] },
+  { stack: "Vite", deps: ["vite"] },
+  { stack: "Node", paths: ["package.json"] },
+  { stack: "Python", paths: ["pyproject.toml", "requirements.txt", "setup.py"] },
+  { stack: "Rust", paths: ["Cargo.toml"] },
+  { stack: "Go", paths: ["go.mod"] },
+  { stack: "Ruby", paths: ["Gemfile"] },
+  { stack: "PHP", paths: ["composer.json"] },
+  { stack: "Java", paths: ["pom.xml", "build.gradle", "build.gradle.kts"] },
+  { stack: "Docker", paths: ["Dockerfile", "docker-compose.yml", "compose.yaml"] },
+];
+
+/** Read a folder and describe the project in it: name, one-line summary,
+ * stack chips, and which team roles the contents argue for. Deterministic
+ * and offline — the same folder always scouts to the same profile. */
+export function scoutProject(cwd: string): ProjectProfile {
+  const pkg = packageJson(cwd);
+  const md = readme(cwd);
+  const entries = new Set(listNames(cwd));
+
+  // Python deps live in files, not a lockfile-adjacent field; a cheap
+  // substring scan of the two conventional files covers the common cases.
+  const pythonDeps = `${readText(join(cwd, "requirements.txt")) ?? ""}\n${readText(join(cwd, "pyproject.toml")) ?? ""}`.toLowerCase();
+  const hasDep = (dep: string) => pkg.deps.has(dep) || (pythonDeps.length > 1 && pythonDeps.includes(dep));
+
+  const pathEvidence = (path: string): string | null => {
+    if (path.includes("/")) return isDir(join(cwd, path)) && listNames(join(cwd, path)).length > 0 ? `${path}/` : null;
+    if (entries.has(path)) return isDir(join(cwd, path)) ? `${path}/` : path;
+    return null;
+  };
+
+  const signals: ProjectSignal[] = [];
+  for (const detector of DETECTORS) {
+    const evidence: string[] = [];
+    for (const dep of detector.deps) if (hasDep(dep)) evidence.push(dep);
+    for (const path of detector.paths) {
+      const found = pathEvidence(path);
+      if (found) evidence.push(found);
+    }
+    // docs need substance: a folder with no markdown in it is not a docs site
+    if (detector.role === "docs" && evidence.length > 0) {
+      const hasMkdocs = evidence.includes("mkdocs.yml");
+      const hasMarkdown = listNames(join(cwd, "docs")).some((name) => name.endsWith(".md"));
+      if (!hasMkdocs && !hasMarkdown) continue;
+    }
+    if (evidence.length > 0) signals.push({ role: detector.role, evidence: evidence.slice(0, 6) });
+  }
+
+  const stacks: string[] = [];
+  for (const marker of STACK_MARKERS) {
+    const byDep = marker.deps?.some((dep) => hasDep(dep)) ?? false;
+    const byPath = marker.paths?.some((path) => entries.has(path)) ?? false;
+    if (byDep || byPath) stacks.push(marker.stack);
+  }
+
+  return {
+    name: (md.title ?? pkg.name ?? basename(cwd)).slice(0, 100),
+    summary: (md.summary ?? pkg.description ?? "").slice(0, 1_000),
+    stacks,
+    signals,
+  };
+}
+
+interface RoleTemplate {
+  name: string;
+  title: string;
+  color: MausColor;
+  describe: (profile: ProjectProfile, evidence: string[]) => string;
+}
+
+const stackLine = (profile: ProjectProfile) =>
+  profile.stacks.length > 0 ? ` The stack: ${profile.stacks.join(", ")}.` : "";
+
+const ROLE_TEMPLATES: Record<ScoutRole, RoleTemplate> = {
+  frontend: {
+    name: "Pixel",
+    title: "Frontend Builder",
+    color: "pink",
+    describe: (profile, evidence) =>
+      `You build and refine the user interface of ${profile.name}.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. Keep changes small, match the existing component patterns, and check what you built actually renders before calling it done.`,
+  },
+  backend: {
+    name: "Forge",
+    title: "Backend Builder",
+    color: "blue",
+    describe: (profile, evidence) =>
+      `You own the server side of ${profile.name}: endpoints, business logic, and the contracts the frontend relies on.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. Change behavior only alongside the tests that prove it.`,
+  },
+  mobile: {
+    name: "Pocket",
+    title: "Mobile Builder",
+    color: "coral",
+    describe: (profile, evidence) =>
+      `You keep ${profile.name} working on phones: screens, navigation, and platform quirks.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. Test on both platforms before declaring victory.`,
+  },
+  data: {
+    name: "Schema",
+    title: "Data Engineer",
+    color: "teal",
+    describe: (profile, evidence) =>
+      `You own the data layer of ${profile.name}: models, migrations, and query performance.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. Every migration ships with its rollback story.`,
+  },
+  testing: {
+    name: "Probe",
+    title: "Test Engineer",
+    color: "green",
+    describe: (profile, evidence) =>
+      `You guard ${profile.name} with tests: you reproduce bugs before they are fixed and extend coverage where changes land.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. A red test you wrote is worth more than a green suite nobody trusts.`,
+  },
+  infra: {
+    name: "Anchor",
+    title: "Infra & CI",
+    color: "orange",
+    describe: (profile, evidence) =>
+      `You keep ${profile.name} buildable, shippable, and observable: CI, containers, and deploy paths.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. Prefer boring, reproducible steps over clever ones.`,
+  },
+  docs: {
+    name: "Quill",
+    title: "Docs Writer",
+    color: "purple",
+    describe: (profile, evidence) =>
+      `You keep the documentation of ${profile.name} truthful and current.${stackLine(profile)} Your turf shows up as ${evidence.join(", ")}. When code and docs disagree, you chase down which one is lying.`,
+  },
+};
+
+const LEAD: RoleTemplate = {
+  name: "Compass",
+  title: "Project Lead",
+  color: "yellow",
+  describe: (profile) =>
+    `You coordinate work on ${profile.name}: break briefs into tasks for the team, keep the room's bulletin current, and review results before they count as done.${stackLine(profile)}${profile.summary ? ` The project, in its own words: ${profile.summary}` : ""}`,
+};
+
+/** at most the lead plus this many specialists — a suggestion is a starting
+ * lineup, not a payroll */
+const MAX_SUGGESTED_SPECIALISTS = 5;
+
+/** Turn a scouted profile into an importable team: a lead plus one member
+ * per detected role, as a regular v2 manifest. Suggesting is all this does —
+ * creating bots and the room stays behind the existing import endpoint and
+ * its human click. */
+export function suggestTeam(profile: ProjectProfile): TeamSuggestion {
+  const reasons: Record<string, string> = {
+    lead: "Every project room needs one member who briefs, splits, and reviews.",
+  };
+  const members: TeamManifestMember[] = [
+    {
+      key: "lead",
+      name: LEAD.name,
+      title: LEAD.title,
+      description: LEAD.describe(profile, []),
+      appearance: { color: LEAD.color },
+    },
+  ];
+  for (const signal of profile.signals.slice(0, MAX_SUGGESTED_SPECIALISTS)) {
+    const template = ROLE_TEMPLATES[signal.role];
+    members.push({
+      key: signal.role,
+      name: template.name,
+      title: template.title,
+      description: template.describe(profile, signal.evidence),
+      appearance: { color: template.color },
+    });
+    reasons[signal.role] = `Detected via ${signal.evidence.join(", ")}.`;
+  }
+  // no signals at all → the room still gets a working pair of hands
+  if (members.length === 1) {
+    members.push({
+      key: "builder",
+      name: "Wrench",
+      title: "Builder",
+      description: `You do the hands-on work in ${profile.name}: read the folder, make the change, show the result.${stackLine(profile)}`,
+      appearance: { color: "blue" },
+    });
+    reasons.builder = "No specific stack detected — a generalist covers the ground.";
+  }
+
+  const manifest: TeamManifestV2 = {
+    format: TEAM_MANIFEST_FORMAT,
+    version: TEAM_MANIFEST_VERSION,
+    team: {
+      name: `${profile.name} team`.slice(0, 100),
+      members,
+    },
+  };
+  if (profile.summary) manifest.team.description = profile.summary.slice(0, 2_000);
+
+  // Lockstep with import: a suggestion must be exactly as valid as a file
+  // someone shared — same parser, same limits, same normalization.
+  return { roomName: profile.name, manifest: parseTeamManifest(manifest), reasons };
+}

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -1,11 +1,13 @@
 import { track } from "@/lib/analytics";
 import { cn } from "@/lib/cn";
 import { teamImportPreview, type PendingTeamImport } from "@/lib/team-import";
-import { api, useStore, type Bot } from "@/state/store";
+import { api, useStore, type Bot, type Group } from "@/state/store";
 import {
   ArrowLeft,
   Check,
+  Compass,
   ExternalLink,
+  FolderOpen,
   Github,
   Loader2,
   Search,
@@ -49,8 +51,34 @@ export interface TeamImportResult {
 }
 
 type ImportSource = "library" | "file" | "github";
-type TeamTab = "explore" | "import";
+type TeamTab = "explore" | "import" | "scout";
 type ImportMode = "replace" | "add";
+
+/** the scout endpoint's answer, as far as this panel renders it — the
+ * manifest itself stays opaque and goes back to the server verbatim */
+interface ScoutResult {
+  profile: { name: string; summary: string; stacks: string[] };
+  suggestion: {
+    roomName: string;
+    manifest: {
+      team: { members: Array<{ key: string; name: string; title: string; description: string; appearance: { color: string } }> };
+    };
+    reasons: Record<string, string>;
+  };
+}
+
+interface DirectoryCandidate {
+  slug: string;
+  name: string;
+  category: string;
+  integrations: string[];
+  prompt: string;
+  detailUrl: string;
+  matched: string[];
+}
+
+/** appearance colors for community bots folded into a scouted team */
+const DIRECTORY_COLORS = ["cyan", "red", "purple", "green", "orange"] as const;
 
 const TEAM_GLYPHS = [
   "bg-purple-500/15 text-purple-300",
@@ -102,6 +130,14 @@ export function TeamLibraryPanel({
   const [importMode, setImportMode] = useState<ImportMode>("replace");
   const [search, setSearch] = useState("");
   const [error, setError] = useState("");
+  const [scoutFolder, setScoutFolder] = useState("");
+  const [scouting, setScouting] = useState(false);
+  const [scouted, setScouted] = useState<ScoutResult | null>(null);
+  // null = not asked yet or still loading; [] = asked, nothing (or offline)
+  const [directory, setDirectory] = useState<DirectoryCandidate[] | null>(null);
+  const [pickedDirectory, setPickedDirectory] = useState<Set<string>>(new Set());
+  const [roomName, setRoomName] = useState("");
+  const [creating, setCreating] = useState(false);
 
   const currentBotCount = state.bots.filter((bot) => !bot.hidden).length;
 
@@ -231,6 +267,90 @@ export function TeamLibraryPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setImporting(false);
+    }
+  };
+
+  const scoutTarget = scoutFolder.trim();
+
+  const runScout = async (folder: string) => {
+    setScouting(true);
+    setError("");
+    setScouted(null);
+    setDirectory(null);
+    setPickedDirectory(new Set());
+    try {
+      // SAFETY: this endpoint is owned by the app and returns ScoutResult.
+      const result = (await api(`/api/teams/scout?cwd=${encodeURIComponent(folder)}`)) as ScoutResult;
+      setScouted(result);
+      setRoomName(result.suggestion.roomName);
+      track("team_scouted", { signals: result.suggestion.manifest.team.members.length - 1 });
+      // community candidates arrive lazily; an unreachable directory just
+      // leaves this section empty
+      void api(`/api/teams/scout/directory?cwd=${encodeURIComponent(folder)}`)
+        // SAFETY: this endpoint is owned by the app and returns candidates.
+        .then((extra) => setDirectory((extra as { directory: DirectoryCandidate[] }).directory))
+        .catch(() => setDirectory([]));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setScouting(false);
+    }
+  };
+
+  const pickScoutFolder = async () => {
+    const chosen = await window.ogb?.pickFolder?.(scoutTarget || undefined);
+    if (!chosen) return;
+    setScoutFolder(chosen);
+    await runScout(chosen);
+  };
+
+  const createProject = async () => {
+    if (!scouted || creating) return;
+    setCreating(true);
+    setError("");
+    try {
+      // the confirmed suggestion, plus any community bots the user ticked —
+      // folded in as ordinary manifest members so the import boundary
+      // (persona only, no grants) applies to them like to everything else
+      const extras = (directory ?? [])
+        .filter((candidate) => pickedDirectory.has(candidate.slug))
+        .map((candidate, index) => ({
+          key: `dir-${candidate.slug}`,
+          name: candidate.name,
+          title: candidate.category || "Community bot",
+          description: candidate.prompt,
+          appearance: { color: DIRECTORY_COLORS[index % DIRECTORY_COLORS.length] },
+        }));
+      const manifest = {
+        ...scouted.suggestion.manifest,
+        team: {
+          ...scouted.suggestion.manifest.team,
+          members: [...scouted.suggestion.manifest.team.members, ...extras],
+        },
+      };
+      const room = roomName.trim() || scouted.suggestion.roomName;
+      // SAFETY: this endpoint is owned by the app and returns imported bots.
+      const response = (await api(
+        `/api/teams/import?mode=project&cwd=${encodeURIComponent(scoutTarget)}&room=${encodeURIComponent(room)}`,
+        { method: "POST", body: JSON.stringify(manifest) },
+      )) as { bots: Bot[]; group?: Group };
+      for (const bot of response.bots) dispatch({ type: "botAdded", bot });
+      if (response.group) {
+        // upsert now instead of waiting for the SSE frame, then land in the room
+        dispatch({ type: "groupPatched", group: { ...response.group, messages: [] } });
+        dispatch({ type: "select", id: response.group.id });
+      }
+      track("team_imported", { members: response.bots.length, source: "scout", mode: "project" });
+      onImported({
+        name: room,
+        members: response.bots.length,
+        importedBotIds: response.bots.map((bot) => bot.id),
+        archived: [],
+      });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -398,6 +518,20 @@ export function TeamLibraryPanel({
                 >
                   Import
                 </button>
+                <button
+                  role="tab"
+                  aria-selected={tab === "scout"}
+                  onClick={() => {
+                    setTab("scout");
+                    setError("");
+                  }}
+                  className={cn(
+                    "rounded-lg px-4 py-2 text-[13.5px] transition-colors",
+                    tab === "scout" ? "bg-card text-ink shadow-sm" : "text-ink-secondary hover:text-ink",
+                  )}
+                >
+                  From a folder
+                </button>
               </div>
               {tab === "explore" && (
                 <label className="flex h-11 w-full items-center gap-2.5 rounded-xl bg-raised/70 px-3.5 sm:w-[320px]">
@@ -525,6 +659,148 @@ export function TeamLibraryPanel({
                       </div>
                     </div>
                   </div>
+                  {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+                </div>
+              )}
+
+              {tab === "scout" && (
+                <div>
+                  <div className="mb-3 text-[12px] font-medium text-ink-secondary">Start from a project folder</div>
+                  <p className="max-w-2xl text-[12.5px] leading-relaxed text-ink-secondary">
+                    Point the scout at a folder. It reads what&apos;s in there — README, dependencies, layout — and
+                    suggests a team for it. Nothing is created until you say so.
+                  </p>
+                  <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                    <input
+                      value={scoutFolder}
+                      onChange={(event) => setScoutFolder(event.target.value)}
+                      onKeyDown={(event) => event.key === "Enter" && scoutTarget && void runScout(scoutTarget)}
+                      placeholder="/path/to/your/project"
+                      aria-label="Project folder to scout"
+                      className="min-w-0 flex-1 rounded-xl bg-raised/80 px-3 py-2.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
+                    />
+                    {Boolean(window.ogb?.pickFolder) && (
+                      <button
+                        onClick={() => void pickScoutFolder()}
+                        disabled={scouting}
+                        className="flex items-center justify-center gap-1.5 rounded-full bg-raised px-4 py-2.5 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-40"
+                      >
+                        <FolderOpen size={14} />
+                        Browse
+                      </button>
+                    )}
+                    <button
+                      onClick={() => void runScout(scoutTarget)}
+                      disabled={!scoutTarget || scouting}
+                      className="flex items-center justify-center gap-1.5 rounded-full bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:bg-accent/90 disabled:opacity-40"
+                    >
+                      {scouting ? <Loader2 size={14} className="animate-spin" /> : <Compass size={14} />}
+                      {scouting ? "Scouting…" : "Scout"}
+                    </button>
+                  </div>
+
+                  {scouted && (
+                    <div className="mt-6">
+                      <div className="rounded-2xl bg-raised/25 px-5 py-4">
+                        <div className="text-[15px] font-semibold text-ink">{scouted.profile.name}</div>
+                        {scouted.profile.summary && (
+                          <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">{scouted.profile.summary}</p>
+                        )}
+                        {scouted.profile.stacks.length > 0 && (
+                          <div className="mt-2.5 flex flex-wrap gap-1.5">
+                            {scouted.profile.stacks.map((stack) => (
+                              <span key={stack} className="rounded-full bg-raised px-2.5 py-1 text-[11.5px] text-ink-secondary">
+                                {stack}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="mt-5 text-[12px] font-medium text-ink-secondary">Suggested team</div>
+                      <div className="mt-1 grid grid-cols-1 gap-x-10 md:grid-cols-2">
+                        {scouted.suggestion.manifest.team.members.map((member, index) => (
+                          <div key={member.key} className="flex min-h-[64px] items-center gap-3 border-b border-hairline/35 px-1 py-3">
+                            <div className={cn("flex size-9 shrink-0 items-center justify-center rounded-lg text-[13px] font-semibold", TEAM_GLYPHS[index % TEAM_GLYPHS.length])}>
+                              {member.name.slice(0, 1).toUpperCase()}
+                            </div>
+                            <div className="min-w-0">
+                              <div className="truncate text-[14px] font-medium text-ink">
+                                {member.name} <span className="font-normal text-ink-secondary">· {member.title}</span>
+                              </div>
+                              <div className="mt-0.5 truncate text-[12px] text-ink-secondary">
+                                {scouted.suggestion.reasons[member.key] ?? ""}
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      {directory && directory.length > 0 && (
+                        <>
+                          <div className="mt-5 text-[12px] font-medium text-ink-secondary">From the community directory — tick to add</div>
+                          <div className="mt-1 flex flex-col">
+                            {directory.map((candidate) => (
+                              <label key={candidate.slug} className="flex cursor-pointer items-center gap-3 border-b border-hairline/35 px-1 py-3">
+                                <input
+                                  type="checkbox"
+                                  checked={pickedDirectory.has(candidate.slug)}
+                                  onChange={() =>
+                                    setPickedDirectory((prev) => {
+                                      const next = new Set(prev);
+                                      if (next.has(candidate.slug)) next.delete(candidate.slug);
+                                      else next.add(candidate.slug);
+                                      return next;
+                                    })
+                                  }
+                                  className="size-4 accent-accent"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="truncate text-[13.5px] font-medium text-ink">
+                                    {candidate.name}
+                                    {candidate.category && <span className="font-normal text-ink-secondary"> · {candidate.category}</span>}
+                                  </div>
+                                  <div className="mt-0.5 truncate text-[12px] text-ink-secondary">
+                                    Matches {candidate.matched.join(", ")}
+                                  </div>
+                                </div>
+                                <button
+                                  onClick={(event) => {
+                                    event.preventDefault();
+                                    void openExternal(candidate.detailUrl);
+                                  }}
+                                  className="rounded-lg p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+                                  title="Read this bot's page before adding it"
+                                >
+                                  <ExternalLink size={14} />
+                                </button>
+                              </label>
+                            ))}
+                          </div>
+                        </>
+                      )}
+
+                      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+                        <input
+                          value={roomName}
+                          onChange={(event) => setRoomName(event.target.value)}
+                          aria-label="Project room name"
+                          className="min-w-0 flex-1 rounded-xl bg-raised/80 px-3 py-2.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
+                        />
+                        <button
+                          onClick={() => void createProject()}
+                          disabled={creating}
+                          className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-accent px-5 py-2.5 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
+                        >
+                          {creating && <Loader2 size={15} className="animate-spin" />}
+                          {creating ? "Creating…" : "Create project room"}
+                        </button>
+                      </div>
+                      <p className="mt-2 text-[12px] text-ink-secondary">
+                        Creates the team as new bots, opens a room for them, and points the room at this folder.
+                      </p>
+                    </div>
+                  )}
                   {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
                 </div>
               )}

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -133,11 +133,18 @@ export function TeamLibraryPanel({
   const [scoutFolder, setScoutFolder] = useState("");
   const [scouting, setScouting] = useState(false);
   const [scouted, setScouted] = useState<ScoutResult | null>(null);
+  // the folder the current `scouted` result was actually read from — the
+  // import must pin the room to THIS, not to whatever the input says now
+  const [scoutedFolder, setScoutedFolder] = useState("");
   // null = not asked yet or still loading; [] = asked, nothing (or offline)
   const [directory, setDirectory] = useState<DirectoryCandidate[] | null>(null);
   const [pickedDirectory, setPickedDirectory] = useState<Set<string>>(new Set());
   const [roomName, setRoomName] = useState("");
   const [creating, setCreating] = useState(false);
+  // monotonically increasing scout token: a late response from an older
+  // scout (including its lazy directory call) must never overwrite state
+  // that belongs to a newer one
+  const scoutRequest = useRef(0);
 
   const currentBotCount = state.bots.filter((bot) => !bot.hidden).length;
 
@@ -273,6 +280,7 @@ export function TeamLibraryPanel({
   const scoutTarget = scoutFolder.trim();
 
   const runScout = async (folder: string) => {
+    const request = ++scoutRequest.current;
     setScouting(true);
     setError("");
     setScouted(null);
@@ -281,19 +289,26 @@ export function TeamLibraryPanel({
     try {
       // SAFETY: this endpoint is owned by the app and returns ScoutResult.
       const result = (await api(`/api/teams/scout?cwd=${encodeURIComponent(folder)}`)) as ScoutResult;
+      if (request !== scoutRequest.current) return;
       setScouted(result);
+      setScoutedFolder(folder);
       setRoomName(result.suggestion.roomName);
       track("team_scouted", { signals: result.suggestion.manifest.team.members.length - 1 });
       // community candidates arrive lazily; an unreachable directory just
       // leaves this section empty
       void api(`/api/teams/scout/directory?cwd=${encodeURIComponent(folder)}`)
         // SAFETY: this endpoint is owned by the app and returns candidates.
-        .then((extra) => setDirectory((extra as { directory: DirectoryCandidate[] }).directory))
-        .catch(() => setDirectory([]));
+        .then((extra) => {
+          if (request === scoutRequest.current) setDirectory((extra as { directory: DirectoryCandidate[] }).directory);
+        })
+        .catch(() => {
+          if (request === scoutRequest.current) setDirectory([]);
+        });
     } catch (cause) {
+      if (request !== scoutRequest.current) return;
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
-      setScouting(false);
+      if (request === scoutRequest.current) setScouting(false);
     }
   };
 
@@ -331,7 +346,7 @@ export function TeamLibraryPanel({
       const room = roomName.trim() || scouted.suggestion.roomName;
       // SAFETY: this endpoint is owned by the app and returns imported bots.
       const response = (await api(
-        `/api/teams/import?mode=project&cwd=${encodeURIComponent(scoutTarget)}&room=${encodeURIComponent(room)}`,
+        `/api/teams/import?mode=project&cwd=${encodeURIComponent(scoutedFolder)}&room=${encodeURIComponent(room)}`,
         { method: "POST", body: JSON.stringify(manifest) },
       )) as { bots: Bot[]; group?: Group };
       for (const bot of response.bots) dispatch({ type: "botAdded", bot });
@@ -741,40 +756,40 @@ export function TeamLibraryPanel({
                           <div className="mt-5 text-[12px] font-medium text-ink-secondary">From the community directory — tick to add</div>
                           <div className="mt-1 flex flex-col">
                             {directory.map((candidate) => (
-                              <label key={candidate.slug} className="flex cursor-pointer items-center gap-3 border-b border-hairline/35 px-1 py-3">
-                                <input
-                                  type="checkbox"
-                                  checked={pickedDirectory.has(candidate.slug)}
-                                  onChange={() =>
-                                    setPickedDirectory((prev) => {
-                                      const next = new Set(prev);
-                                      if (next.has(candidate.slug)) next.delete(candidate.slug);
-                                      else next.add(candidate.slug);
-                                      return next;
-                                    })
-                                  }
-                                  className="size-4 accent-accent"
-                                />
-                                <div className="min-w-0 flex-1">
-                                  <div className="truncate text-[13.5px] font-medium text-ink">
-                                    {candidate.name}
-                                    {candidate.category && <span className="font-normal text-ink-secondary"> · {candidate.category}</span>}
+                              <div key={candidate.slug} className="flex items-center gap-3 border-b border-hairline/35 px-1 py-3">
+                                <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                                  <input
+                                    type="checkbox"
+                                    checked={pickedDirectory.has(candidate.slug)}
+                                    onChange={() =>
+                                      setPickedDirectory((prev) => {
+                                        const next = new Set(prev);
+                                        if (next.has(candidate.slug)) next.delete(candidate.slug);
+                                        else next.add(candidate.slug);
+                                        return next;
+                                      })
+                                    }
+                                    className="size-4 accent-accent"
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <div className="truncate text-[13.5px] font-medium text-ink">
+                                      {candidate.name}
+                                      {candidate.category && <span className="font-normal text-ink-secondary"> · {candidate.category}</span>}
+                                    </div>
+                                    <div className="mt-0.5 truncate text-[12px] text-ink-secondary">
+                                      Matches {candidate.matched.join(", ")}
+                                    </div>
                                   </div>
-                                  <div className="mt-0.5 truncate text-[12px] text-ink-secondary">
-                                    Matches {candidate.matched.join(", ")}
-                                  </div>
-                                </div>
+                                </label>
                                 <button
-                                  onClick={(event) => {
-                                    event.preventDefault();
-                                    void openExternal(candidate.detailUrl);
-                                  }}
-                                  className="rounded-lg p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+                                  onClick={() => void openExternal(candidate.detailUrl)}
+                                  aria-label={`Open ${candidate.name} on botdirectory.ai`}
                                   title="Read this bot's page before adding it"
+                                  className="rounded-lg p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
                                 >
                                   <ExternalLink size={14} />
                                 </button>
-                              </label>
+                              </div>
                             ))}
                           </div>
                         </>


### PR DESCRIPTION
## What

#316 built the door — this PR walks through it. The Teams panel gets a third way in: **From a folder**. Point the scout at a project folder and it reads what's in there — README, dependencies, layout — and proposes a team for it: a lead plus one member per detected role (frontend, backend, mobile, data, testing, infra, docs), each row carrying the evidence that argued for it ("Detected via react, vite, index.html"). One click sends the suggestion through the existing project import: the bots are created, a room opens on the folder, the lead responds by default.

## How it holds the trust line

- **The scout only suggests.** `GET /api/teams/scout?cwd=…` is read-only and deterministic — nothing exists until the human clicks import. "The agent proposes, the person imports" is enforced by the route split itself.
- **The suggestion is an ordinary v2 manifest**, round-tripped through `parseTeamManifest` before it leaves the server, so it is exactly as importable — and exactly as bounded — as any shared team file. The persona-only import boundary from #316 applies untouched.
- **Offline by design.** Folder analysis is local; the [botdirectory.ai](https://botdirectory.ai) candidates live on a separate lazy route (`/api/teams/scout/directory`) with the same fetch hardening as the team library (https-only, size cap, timeout, schema validation, malformed entries dropped). Directory bots the user ticks are folded in as ordinary manifest members — same boundary again. An unreachable directory degrades to "no extra candidates", never to a broken scout.
- **Bounded reads.** The scout reads a handful of well-known files by name and top-level listings only — no recursion, size caps on everything.

## Testing

- `server/project-scout.test.ts` — README title/summary extraction (badges, blockquote callouts and markdown emphasis skipped), role detection with evidence across JS/TS and Python fixtures, docs-folder substance check, malformed-input survival, lineup cap, and the manifest round-trip through the real parser.
- `server/bot-directory.test.ts` — directory parsing (bad entries dropped, not fatal), fetch error paths, lexical matching with a stopword guard (measured live: "Your own team…" matched a home-value tracker purely on "your" before the guard).
- `server/index.test.ts` — end to end: scout a fixture folder, assert read-only (no bots, no rooms created), then send the suggestion verbatim through `POST /api/teams/import?mode=project` and get the room on the folder.
- Manually smoked against this very repo: scouts to TypeScript/React/Vite/Node with frontend, backend, mobile, testing and infra members; Create project room produced the 6 bots and the room on the folder in one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “From a folder” scouting to suggest teams based on a project’s technologies and structure.
  * Added optional matching with community directory bots.
  * Added customization of room names and selected bots before creating a project room.
  * Added read-only scouting with safe handling for invalid folders or unavailable directory data.
* **Bug Fixes**
  * Improved validation and protection for project and directory data.
  * Reduced false matches for short technology names and rejected oversized directory responses safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->