### PR TITLE
feat(rooms): add rename action

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -335,6 +335,26 @@ describe("harness HTTP API", () => {
     expect((await api("DELETE", "/api/groups/test-pinned-room")).status).toBe(200);
   });
 
+  it("renames rooms through a bounded non-empty name", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const room = (await api("POST", "/api/groups", { name: "Old room", memberIds: [bot.id] })).body.group;
+    try {
+      const renamed = await api("PATCH", `/api/groups/${room.id}`, { name: "  Project Atlas  " });
+      expect(renamed.status).toBe(200);
+      expect(renamed.body.group.name).toBe("Project Atlas");
+
+      for (const name of ["", "   ", 42, "x".repeat(101)]) {
+        expect((await api("PATCH", `/api/groups/${room.id}`, { name })).status).toBe(400);
+      }
+
+      const state = (await api("GET", "/api/bots")).body;
+      expect(state.groups.find((group: { id: string }) => group.id === room.id).name).toBe("Project Atlas");
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("describes the configured fleet, shadows included", async () => {
     const { status, body } = await api("GET", "/api/instances");
     expect(status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -3108,7 +3108,14 @@ const server = createServer(async (req, res) => {
       const existing = store.group(m[1]);
       if (!existing) return json(res, 404, { error: "no such room" });
       const patch: Record<string, unknown> = {};
-      for (const key of ["name", "bulletin", "unread"] as const) {
+      if (body.name !== undefined) {
+        if (typeof body.name !== "string") return json(res, 400, { error: "room name must be a string" });
+        const name = body.name.trim();
+        if (!name) return json(res, 400, { error: "room name must not be empty" });
+        if (name.length > 100) return json(res, 400, { error: "room name must be at most 100 characters" });
+        patch.name = name;
+      }
+      for (const key of ["bulletin", "unread"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
       }
       if (Array.isArray(body.memberIds)) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ import { BotAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
+import { nextRename } from "@/lib/rename";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { MIN_QUERY, SearchResults } from "./SearchResults";
@@ -254,6 +255,8 @@ function RoomContextMenu({
 }) {
   const { state, dispatch } = useStore();
   const group = state.groups.find((g) => g.id === menu.groupId);
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState(group?.name ?? "");
 
   useEffect(() => {
     const onDown = (e: MouseEvent) => {
@@ -271,6 +274,11 @@ function RoomContextMenu({
   }, [onClose]);
 
   if (!group) return null;
+  const saveRename = () => {
+    const name = nextRename(group.name, draft);
+    if (name) dispatch({ type: "patchGroup", groupId: group.id, patch: { name } });
+    onClose();
+  };
   const top = Math.min(menu.y, window.innerHeight - 164);
   const left = Math.min(menu.x, window.innerWidth - 240);
   return createPortal(
@@ -279,6 +287,58 @@ function RoomContextMenu({
       style={{ top, left }}
       className="fixed z-40 w-[228px] overflow-hidden rounded-xl border border-hairline/50 bg-card py-1.5 shadow-2xl shadow-black/60"
     >
+      {renaming ? (
+        <div className="flex items-center gap-1 px-2 py-1">
+          <input
+            autoFocus
+            value={draft}
+            maxLength={100}
+            aria-label={`Rename ${group.name}`}
+            onFocus={(event) => event.currentTarget.select()}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+                event.preventDefault();
+                saveRename();
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+              }
+            }}
+            className="min-w-0 flex-1 rounded-lg bg-raised px-2 py-1.5 text-[14px] text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+          <button
+            type="button"
+            onClick={saveRename}
+            aria-label="Save room name"
+            title="Save"
+            className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
+          >
+            <Check size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cancel room rename"
+            title="Cancel"
+            className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
+          >
+            <X size={15} />
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => {
+            setDraft(group.name);
+            setRenaming(true);
+          }}
+          className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+        >
+          <Pencil size={16} className="text-ink-secondary" />
+          Rename Room
+        </button>
+      )}
       <button
         onClick={() => {
           void navigator.clipboard?.writeText(group.threadId);
@@ -1415,6 +1475,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       )}
       {roomMenu && (
         <RoomContextMenu
+          key={roomMenu.groupId}
           menu={roomMenu}
           onClose={() => setRoomMenu(null)}
         />


### PR DESCRIPTION
## Summary

- add a Rename Room action to the existing sidebar context menu
- edit the room name in place with save and cancel controls plus Enter and Escape keyboard support
- trim and validate renamed room names at the server boundary
- add API regression coverage for valid and invalid names

## Testing

- pnpm build
- pnpm exec vitest run server/index.test.ts (73 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to rename rooms directly from the sidebar context menu.
  * Added controls to edit, save, or cancel room name changes.

* **Bug Fixes**
  * Room names are now trimmed and validated before saving.
  * Invalid names, including empty, whitespace-only, non-text, and overly long names, are rejected.
  * Valid room name changes persist correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->