### PR TITLE
fix(linux): harden Ubuntu upgrades and Xorg local control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
           deb=(release/*.deb)
           test "${#deb[@]}" -eq 1
           sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
+      - name: Match a normal Ubuntu package parent on the ephemeral runner
+        run: |
+          test ! -L /opt
+          test "$(stat -c '%F %U:%G' /opt)" = "directory root:root"
+          case "$(stat -c '%a' /opt)" in
+            755) ;;
+            775|777) sudo chmod 0755 /opt ;;
+            *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
+          esac
+          test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Package from the verified offline CUA stage
         run: pnpm package:linux:offline
       - run: node scripts/verify-linux-package.mjs
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox
@@ -70,7 +75,11 @@ jobs:
       - name: Launch packaged app and verify lifecycle
         env:
           OMB_KEEP_SMOKE_DIR: "1"
+          OMB_SMOKE_INSTALLED_DEB: "1"
         run: pnpm smoke:linux-package
+      - name: Remove the installed upgrade fixture
+        if: always()
+        run: sudo dpkg --purge openmausbot || true
       - name: Upload smoke diagnostics on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
         with:
           name: openmausbot-ubuntu-smoke-diagnostics
           path: |
-            ${{ runner.temp }}/omb-linux-smoke-*
-            ${{ runner.temp }}/omb-linux-smoke-runtime-*
+            /tmp/omb-linux-smoke-*
+            /tmp/omb-linux-smoke-runtime-*
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,12 @@ jobs:
       - name: Install package validation and native smoke tools
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools xvfb
+          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools x11-utils xdotool xvfb
       - run: pnpm install --frozen-lockfile
       - name: Stage the pinned CUA runtime
         run: pnpm build:cua:linux
+      - name: Prove overlay-free X11 input routing
+        run: dbus-run-session -- xvfb-run -a pnpm smoke:cua-x11-input
       - name: Package from the verified offline CUA stage
         run: pnpm package:linux:offline
       - run: node scripts/verify-linux-package.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,6 @@ jobs:
       - name: Package from the verified offline CUA stage
         run: pnpm package:linux:offline
       - run: node scripts/verify-linux-package.mjs
-      - name: Reproduce and verify an in-place DEB upgrade
-        run: |
-          deb=(release/*.deb)
-          test "${#deb[@]}" -eq 1
-          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Match a normal Ubuntu package parent on the ephemeral runner
         run: |
           test ! -L /opt
@@ -79,6 +74,11 @@ jobs:
             *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
           esac
           test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -48,11 +48,6 @@ jobs:
         run: pnpm package:linux:offline
       - name: Verify package contents and metadata
         run: node scripts/verify-linux-package.mjs
-      - name: Reproduce and verify an in-place DEB upgrade
-        run: |
-          deb=(release/*.deb)
-          test "${#deb[@]}" -eq 1
-          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Match a normal Ubuntu package parent on the ephemeral runner
         run: |
           test ! -L /opt
@@ -63,6 +58,11 @@ jobs:
             *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
           esac
           test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -97,8 +97,8 @@ jobs:
         with:
           name: openmausbot-ubuntu-smoke-diagnostics
           path: |
-            ${{ runner.temp }}/omb-linux-smoke-*
-            ${{ runner.temp }}/omb-linux-smoke-runtime-*
+            /tmp/omb-linux-smoke-*
+            /tmp/omb-linux-smoke-runtime-*
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -46,6 +46,11 @@ jobs:
         run: pnpm package:linux:offline
       - name: Verify package contents and metadata
         run: node scripts/verify-linux-package.mjs
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox
@@ -54,7 +59,11 @@ jobs:
       - name: Launch packaged app and verify lifecycle
         env:
           OMB_KEEP_SMOKE_DIR: "1"
+          OMB_SMOKE_INSTALLED_DEB: "1"
         run: pnpm smoke:linux-package
+      - name: Remove the installed upgrade fixture
+        if: always()
+        run: sudo dpkg --purge openmausbot || true
       - name: Prepare release assets
         id: release
         shell: bash

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -53,6 +53,16 @@ jobs:
           deb=(release/*.deb)
           test "${#deb[@]}" -eq 1
           sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
+      - name: Match a normal Ubuntu package parent on the ephemeral runner
+        run: |
+          test ! -L /opt
+          test "$(stat -c '%F %U:%G' /opt)" = "directory root:root"
+          case "$(stat -c '%a' /opt)" in
+            755) ;;
+            775|777) sudo chmod 0755 /opt ;;
+            *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
+          esac
+          test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -36,12 +36,14 @@ jobs:
       - name: Install package validation and native smoke tools
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools xvfb
+          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools x11-utils xdotool xvfb
       - run: pnpm install --frozen-lockfile
       - name: Clean generated output
         run: pnpm clean
       - name: Stage the pinned CUA runtime
         run: pnpm build:cua:linux
+      - name: Prove overlay-free X11 input routing
+        run: dbus-run-session -- xvfb-run -a pnpm smoke:cua-x11-input
       - name: Package from the verified offline CUA stage
         run: pnpm package:linux:offline
       - name: Verify package contents and metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,11 +273,6 @@ jobs:
       - run: pnpm package:linux
       - name: Verify package contents and metadata
         run: node scripts/verify-linux-package.mjs
-      - name: Reproduce and verify an in-place DEB upgrade
-        run: |
-          deb=(release/*.deb)
-          test "${#deb[@]}" -eq 1
-          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Match a normal Ubuntu package parent on the ephemeral runner
         run: |
           test ! -L /opt
@@ -288,6 +283,11 @@ jobs:
             *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
           esac
           test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,12 +262,14 @@ jobs:
       - name: Install package validation and native smoke tools
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools xvfb
+          at-spi2-core dbus-x11 desktop-file-utils libxi6 libxkbcommon0 squashfs-tools x11-utils xdotool xvfb
       - run: pnpm install --frozen-lockfile
       - name: Clean generated output
         run: pnpm clean
       - name: Stage the pinned CUA runtime
         run: pnpm build:cua:linux
+      - name: Prove overlay-free X11 input routing
+        run: dbus-run-session -- xvfb-run -a pnpm smoke:cua-x11-input
       - run: pnpm package:linux
       - name: Verify package contents and metadata
         run: node scripts/verify-linux-package.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,13 @@ jobs:
       - name: Stage the pinned CUA runtime
         run: pnpm build:cua:linux
       - run: pnpm package:linux
+      - name: Verify package contents and metadata
+        run: node scripts/verify-linux-package.mjs
+      - name: Reproduce and verify an in-place DEB upgrade
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox
@@ -277,7 +284,11 @@ jobs:
       - name: Smoke the packages
         env:
           OMB_KEEP_SMOKE_DIR: "1"
+          OMB_SMOKE_INSTALLED_DEB: "1"
         run: pnpm smoke:linux-package
+      - name: Remove the installed upgrade fixture
+        if: always()
+        run: sudo dpkg --purge openmausbot || true
       - name: Stable-named copies and checksums
         run: |
           v=$(node -p "require('./package.json').version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,6 +278,16 @@ jobs:
           deb=(release/*.deb)
           test "${#deb[@]}" -eq 1
           sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
+      - name: Match a normal Ubuntu package parent on the ephemeral runner
+        run: |
+          test ! -L /opt
+          test "$(stat -c '%F %U:%G' /opt)" = "directory root:root"
+          case "$(stat -c '%a' /opt)" in
+            755) ;;
+            775|777) sudo chmod 0755 /opt ;;
+            *) echo "Unexpected /opt mode: $(stat -c '%a' /opt)" >&2; exit 1 ;;
+          esac
+          test "$(stat -c '%U:%G %a' /opt)" = "root:root 755"
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ For Ubuntu installation and real desktop checks, see [`docs/linux-desktop.md`](d
 
 Ubuntu release packages must come from the manual **Package Ubuntu** workflow on an exact release commit or tag,
 not from a developer workstation. The Ubuntu 24.04 runner builds and verifies both formats, launches the unpacked
-app and AppImage, exercises the bundled Cua lifecycle, and produces one release artifact containing:
+app and AppImage, exercises the overlay-free bundled Cua lifecycle on Xorg and the fail-closed Wayland CUA smoke,
+and produces one release artifact containing:
 
 - the versioned `.deb` and AppImage;
 - stable `OpenMausBot-amd64.deb` and `OpenMausBot.AppImage` copies used by the latest-download links;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,12 @@ The SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately small. A
   independent capabilities.
 - Test Ubuntu platform claims on a real GNOME session. Xvfb proves packaging and fake-driver orchestration, not
   Wayland portal behavior or real CUA inspection/input delivery.
-- Linux local control must remain explicit: global opt-in plus per-bot **This computer**. Linux Auto, provider
-  full-auto/bypass modes, remembered grants, and cloud approvals must never authorize the user's desktop.
+- Linux local control currently has a release safety hold from #345: packaged and development desktop launches
+  must not start Cua, must clear a legacy durable opt-in, and must report `linux-seat-safety-blocked`. Do not add an
+  environment bypass. Re-enabling it requires real GNOME/Xorg and GNOME/Wayland evidence that an unrelated app
+  remains clickable/typeable before any approved action. After re-enablement, global opt-in plus per-bot
+  **This computer** remains mandatory; Linux Auto, full-auto/bypass modes, remembered grants, and cloud approvals
+  must never authorize the user's desktop.
 - Keep CUA discovery shell-free and pin accepted archive, inner-file, manifest, and driver contracts. Packaged Linux
   builds must prefer their reviewed outside-ASAR runtime and fail closed instead of executing ambient PATH code;
   source/dev builds may use the validated explicit/user-local paths. Never add a runtime downloader/self-updater or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ For Ubuntu installation and real desktop checks, see [`docs/linux-desktop.md`](d
 
 Ubuntu release packages must come from the manual **Package Ubuntu** workflow on an exact release commit or tag,
 not from a developer workstation. The Ubuntu 24.04 runner builds and verifies both formats, launches the unpacked
-app and AppImage, exercises the overlay-free bundled Cua lifecycle on Xorg and the fail-closed Wayland CUA smoke,
+app and AppImage, routes `click` and `type_text` through the overlay-free bundled Cua runtime on Xorg, runs the
+fail-closed Wayland CUA smoke,
 and produces one release artifact containing:
 
 - the versioned `.deb` and AppImage;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,12 @@ The SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately small. A
   independent capabilities.
 - Test Ubuntu platform claims on a real GNOME session. Xvfb proves packaging and fake-driver orchestration, not
   Wayland portal behavior or real CUA inspection/input delivery.
-- Linux local control currently has a release safety hold from #345: packaged and development desktop launches
-  must not start Cua, must clear a legacy durable opt-in, and must report `linux-seat-safety-blocked`. Do not add an
-  environment bypass. Re-enabling it requires real GNOME/Xorg and GNOME/Wayland evidence that an unrelated app
-  remains clickable/typeable before any approved action. After re-enablement, global opt-in plus per-bot
+- Linux local control is enabled only on GNOME/Xorg after explicit opt-in. The owned daemon must start with
+  `--no-overlay`: the decorative full-screen Cua cursor surface is not part of the product contract and must never
+  sit between the person and their desktop. GNOME/Wayland must clear a legacy durable opt-in, report
+  `linux-wayland-seat-safety-blocked`, and never start Cua until it independently passes the real-seat matrix in
+  #345. Xvfb proves the overlay-free arguments, lifecycle, and input routing; it does not waive real-seat evidence.
+  An unrelated app must remain clickable/typeable before any approved action. Global opt-in plus per-bot
   **This computer** remains mandatory; Linux Auto, full-auto/bypass modes, remembered grants, and cloud approvals
   must never authorize the user's desktop.
 - Keep CUA discovery shell-free and pin accepted archive, inner-file, manifest, and driver contracts. Packaged Linux

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ already have:
   custom CLI binary (a versioned build or wrapper) in **Settings → Engines**.
 - **Local first.** One small harness server on `127.0.0.1` owns every agent process. Transcripts, keys, and
   events live in `~/.openmausbot`, not a cloud.
-- **Agents with hands.** Each bot can use a cloud Linux desktop, an isolated Local VM, or your own computer,
-  plus 500+ apps through Composio. Host control is available on macOS and as an explicit Ubuntu GNOME beta.
+- **Agents with hands.** Each bot can use a cloud Linux desktop, an isolated Local VM, or—where the platform
+  safety boundary is currently certified—your own computer, plus 500+ apps through Composio. Host control is
+  available on macOS; Ubuntu host control is temporarily disabled while issue #345 is resolved.
 
 ## Features
 
@@ -201,7 +202,7 @@ flowchart LR
 | API | `server/index.ts` | Bots, turns, approvals, model catalog, computer lifecycle, connectors, config — HTTP + SSE. |
 | Voice | `server/tts/` | ElevenLabs, bring your own key. Runs on the harness so the key never reaches the UI; markdown is rewritten into something worth hearing before it is spoken. |
 | App | `src/` | The chat shell. Server-backed store, one reducer, zero client-side transports. |
-| Desktop | `electron/` | macOS, Windows, and Ubuntu shells with an embedded harness and platform capabilities; Apple speech stays macOS-only, while a release-pinned bundled CUA runtime enables guarded Ubuntu GNOME local control. |
+| Desktop | `electron/` | macOS, Windows, and Ubuntu shells with an embedded harness and platform capabilities; Apple speech stays macOS-only, and Ubuntu local control currently fails closed while its real-seat safety blocker is resolved. |
 
 ## Quick start
 
@@ -246,17 +247,16 @@ pnpm package:linux    # Ubuntu x64: .deb + AppImage + verified CUA runtime
 | Packaged app, embedded harness, local agent CLIs | Supported | Beta | Beta |
 | Composio and Box/cloud computers | Supported | Beta | Beta |
 | Explicit preview-only local screen capture | Supported | Beta | Beta |
-| Bot control of this computer | Supported | Beta: opt-in, bundled Cua 0.19.3 | Beta: GNOME only, opt-in, bundled Cua 0.19.3; separately installed WinRects v8 helper |
+| Bot control of this computer | Supported | Temporarily disabled: input-safety hold | Temporarily disabled: input-safety hold |
 | Native on-device dictation | Supported | Planned | Planned |
 
-The Linux preview is user-initiated and never enables local bot control or Auto routing. Packaged Linux builds ship
-the exact Cua Driver 0.19.3 runtime outside ASAR; control still requires explicit app opt-in and an explicit per-bot
-**This computer** selection, and every local action asks for approval. GNOME/Wayland additionally requires the
-versioned WinRects v8 helper and a
-passing prompt-free AT-SPI/capture/portal health report. Other Wayland compositors fail closed without blocking
-chat or cloud features. See the [Ubuntu Desktop guide](docs/linux-desktop.md) and
-tracking issues [#29](https://github.com/milind-soni/OpenMausBot/issues/29) and
-[#79](https://github.com/milind-soni/OpenMausBot/issues/79) / [#109](https://github.com/milind-soni/OpenMausBot/issues/109) / [#113](https://github.com/milind-soni/OpenMausBot/issues/113).
+The Linux preview is user-initiated and never enables local bot control or Auto routing. Packaged Linux builds still
+contain the reviewed Cua Driver 0.19.3 runtime, but the app does not start it and clears legacy opt-ins while the
+real-seat input-safety blocker is unresolved. Chat, preview, Cloud, and Local VM remain available. Do not bypass the
+hold by starting the bundled driver manually. See the [Ubuntu Desktop guide](docs/linux-desktop.md) and tracking
+issues [#29](https://github.com/milind-soni/OpenMausBot/issues/29),
+[#345](https://github.com/milind-soni/OpenMausBot/issues/345), and
+[#113](https://github.com/milind-soni/OpenMausBot/issues/113).
 
 The Linux packager downloads only the tag-pinned upstream archive during the build, verifies its size, SHA-256,
 complete member allowlist, and inner executable hashes, then packages only the CLI and cursor-theme sidecar. The

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ already have:
   events live in `~/.openmausbot`, not a cloud.
 - **Agents with hands.** Each bot can use a cloud Linux desktop, an isolated Local VM, or—where the platform
   safety boundary is currently certified—your own computer, plus 500+ apps through Composio. Host control is
-  available on macOS; Ubuntu host control is temporarily disabled while issue #345 is resolved.
+  available on macOS and Ubuntu Xorg after explicit opt-in. Ubuntu Wayland host control remains disabled while
+  issue #345 is resolved.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ flowchart LR
 | API | `server/index.ts` | Bots, turns, approvals, model catalog, computer lifecycle, connectors, config — HTTP + SSE. |
 | Voice | `server/tts/` | ElevenLabs, bring your own key. Runs on the harness so the key never reaches the UI; markdown is rewritten into something worth hearing before it is spoken. |
 | App | `src/` | The chat shell. Server-backed store, one reducer, zero client-side transports. |
-| Desktop | `electron/` | macOS, Windows, and Ubuntu shells with an embedded harness and platform capabilities; Apple speech stays macOS-only, and Ubuntu local control currently fails closed while its real-seat safety blocker is resolved. |
+| Desktop | `electron/` | macOS, Windows, and Ubuntu shells with an embedded harness and platform capabilities; Apple speech stays macOS-only, Ubuntu Xorg has opt-in local control, and Wayland remains fail-closed. |
 
 ## Quick start
 
@@ -247,13 +247,13 @@ pnpm package:linux    # Ubuntu x64: .deb + AppImage + verified CUA runtime
 | Packaged app, embedded harness, local agent CLIs | Supported | Beta | Beta |
 | Composio and Box/cloud computers | Supported | Beta | Beta |
 | Explicit preview-only local screen capture | Supported | Beta | Beta |
-| Bot control of this computer | Supported | Temporarily disabled: input-safety hold | Temporarily disabled: input-safety hold |
+| Bot control of this computer | Supported | Beta, explicit opt-in | Disabled: Wayland safety gate |
 | Native on-device dictation | Supported | Planned | Planned |
 
-The Linux preview is user-initiated and never enables local bot control or Auto routing. Packaged Linux builds still
-contain the reviewed Cua Driver 0.19.3 runtime, but the app does not start it and clears legacy opt-ins while the
-real-seat input-safety blocker is unresolved. Chat, preview, Cloud, and Local VM remain available. Do not bypass the
-hold by starting the bundled driver manually. See the [Ubuntu Desktop guide](docs/linux-desktop.md) and tracking
+The Linux preview is user-initiated and never enables local bot control or Auto routing. On Xorg, the reviewed Cua
+Driver 0.19.3 runtime starts only after explicit opt-in and without its full-screen cursor overlay. On Wayland the
+app never starts it and clears legacy opt-ins while that real-seat safety gate remains unresolved. Chat, preview,
+Cloud, and Local VM remain available on both sessions. See the [Ubuntu Desktop guide](docs/linux-desktop.md) and tracking
 issues [#29](https://github.com/milind-soni/OpenMausBot/issues/29),
 [#345](https://github.com/milind-soni/OpenMausBot/issues/345), and
 [#113](https://github.com/milind-soni/OpenMausBot/issues/113).

--- a/apps/docs/content/docs/computers/local-computer.mdx
+++ b/apps/docs/content/docs/computers/local-computer.mdx
@@ -12,7 +12,7 @@ The packaged app can request Accessibility and Screen Recording permission. Afte
 
 ## Ubuntu
 
-Ubuntu 24.04 GNOME local control is beta. Packaged builds include a pinned CUA runtime. Xorg is supported with explicit opt-in; guarded Wayland support also requires its validated GNOME helper and health checks.
+Ubuntu 24.04 GNOME host control is temporarily disabled while the real-seat input-safety blocker in issue #345 is resolved. Packaged builds retain the pinned runtime for reproducible review, but OpenMausBot does not start it and clears legacy opt-ins. Chat, screen preview, Cloud, and Local VM remain available. Do not start the bundled driver manually as a workaround.
 
 ## Safety model
 

--- a/apps/docs/content/docs/features/index.mdx
+++ b/apps/docs/content/docs/features/index.mdx
@@ -19,7 +19,7 @@ OpenMausBot turns agent CLIs into a messaging-style workspace. The harness norma
 
 ## Computers and tools
 
-- Local computer control with explicit opt-in and approval boundaries
+- Local computer control with explicit opt-in and approval boundaries on supported hosts; Ubuntu currently fails closed under an input-safety hold
 - Isolated Local VM desktops through Docker or Podman
 - Hosted Box cloud computers
 - A self-hosted Linux VPS backend over Docker's SSH transport
@@ -48,5 +48,5 @@ OpenMausBot turns agent CLIs into a messaging-style workspace. The harness norma
 - Automatic updates on macOS and Windows
 
 <Callout type="info" title="Platform differences are intentional">
-  macOS has the broadest native integration. Ubuntu local control is a guarded beta, Windows installers are not yet signed, and the iOS companion keeps sensitive workspace configuration on the computer.
+  macOS has the broadest native integration. Ubuntu chat, preview, Cloud, and Local VM are available, while host control is temporarily disabled under an input-safety hold. Windows installers are not yet signed, and the iOS companion keeps sensitive workspace configuration on the computer.
 </Callout>

--- a/build/linux-after-install.sh
+++ b/build/linux-after-install.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+# dpkg preserves an existing directory's mode during an in-place upgrade.
+# OpenMausBot 0.1.7 installed the application ancestors as 0775, which makes
+# the bundled Cua Driver correctly reject its own executable path. Repair only
+# the exact package-owned chain; never weaken the runtime validator and never
+# ask an end user to run chmod manually.
+if [ -n "${OPENMAUSBOT_POSTINSTALL_TEST_ROOT:-}" ]; then
+  TEST_ROOT="$(realpath -e -- "$OPENMAUSBOT_POSTINSTALL_TEST_ROOT")"
+  case "$TEST_ROOT" in
+    /tmp/*) APP_ROOT=$TEST_ROOT ;;
+    *)
+      echo "OpenMausBot test install root must stay under /tmp" >&2
+      exit 1
+      ;;
+  esac
+  EXPECTED_OWNER="$(id -un):$(id -gn)"
+  TEST_MODE=1
+else
+  APP_ROOT=/opt/OpenMausBot
+  EXPECTED_OWNER=root:root
+  TEST_MODE=0
+fi
+
+repair_directory() {
+  target=$1
+  if [ -L "$target" ] || [ ! -d "$target" ]; then
+    echo "OpenMausBot package directory is missing or unsafe: $target" >&2
+    exit 1
+  fi
+  if [ "$TEST_MODE" -eq 0 ]; then chown root:root -- "$target"; fi
+  chmod 0755 -- "$target"
+  actual="$(stat -c '%U:%G:%a' -- "$target")"
+  if [ "$actual" != "$EXPECTED_OWNER:755" ]; then
+    echo "OpenMausBot could not secure package directory: $target ($actual)" >&2
+    exit 1
+  fi
+}
+
+repair_executable() {
+  target=$1
+  if [ -L "$target" ] || [ ! -f "$target" ]; then
+    echo "OpenMausBot package executable is missing or unsafe: $target" >&2
+    exit 1
+  fi
+  if [ "$TEST_MODE" -eq 0 ]; then chown root:root -- "$target"; fi
+  chmod 0755 -- "$target"
+  actual="$(stat -c '%U:%G:%a' -- "$target")"
+  if [ "$actual" != "$EXPECTED_OWNER:755" ]; then
+    echo "OpenMausBot could not secure package executable: $target ($actual)" >&2
+    exit 1
+  fi
+}
+
+CUA_ROOT=$APP_ROOT/resources/cua-linux-x64
+repair_directory "$APP_ROOT"
+repair_directory "$APP_ROOT/resources"
+repair_directory "$CUA_ROOT"
+repair_executable "$CUA_ROOT/cua-driver"
+repair_executable "$CUA_ROOT/cua-cursor-theme"

--- a/build/linux-after-install.sh
+++ b/build/linux-after-install.sh
@@ -3,8 +3,9 @@ set -eu
 
 # dpkg preserves an existing directory's mode during an in-place upgrade.
 # OpenMausBot 0.1.7 installed the application ancestors as 0775, which makes
-# the bundled Cua Driver correctly reject its own executable path. Repair only
-# the exact package-owned chain; never weaken the runtime validator and never
+# the bundled Cua Driver correctly reject its own executable path. A configured
+# DEB also needs Electron's Chromium sandbox to be root-owned and setuid. Repair
+# only the exact package-owned paths; never weaken a runtime validator and never
 # ask an end user to run chmod manually.
 if [ -n "${OPENMAUSBOT_POSTINSTALL_TEST_ROOT:-}" ]; then
   TEST_ROOT="$(realpath -e -- "$OPENMAUSBOT_POSTINSTALL_TEST_ROOT")"
@@ -53,9 +54,25 @@ repair_executable() {
   fi
 }
 
+repair_chromium_sandbox() {
+  target=$1
+  if [ -L "$target" ] || [ ! -f "$target" ]; then
+    echo "OpenMausBot Chromium sandbox is missing or unsafe: $target" >&2
+    exit 1
+  fi
+  if [ "$TEST_MODE" -eq 0 ]; then chown root:root -- "$target"; fi
+  chmod 4755 -- "$target"
+  actual="$(stat -c '%U:%G:%a' -- "$target")"
+  if [ "$actual" != "$EXPECTED_OWNER:4755" ]; then
+    echo "OpenMausBot could not secure Chromium sandbox: $target ($actual)" >&2
+    exit 1
+  fi
+}
+
 CUA_ROOT=$APP_ROOT/resources/cua-linux-x64
 repair_directory "$APP_ROOT"
 repair_directory "$APP_ROOT/resources"
 repair_directory "$CUA_ROOT"
 repair_executable "$CUA_ROOT/cua-driver"
 repair_executable "$CUA_ROOT/cua-cursor-theme"
+repair_chromium_sandbox "$APP_ROOT/chrome-sandbox"

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -13,11 +13,15 @@ of Linux desktop on your own server instead of this machine, see [byo-vps.md](by
 - External documentation and OAuth links in the default browser.
 - An explicit, view-only local screen preview on GNOME Xorg and GNOME Wayland. The Wayland path uses the
   native portal chooser and keeps the selected PipeWire stream open until the user stops sharing.
-- A fail-closed Linux local-control state while the real-seat input-safety blocker in issue #345 is resolved.
+- Explicit opt-in local computer control on GNOME Xorg using the bundled, pinned Cua Driver without its
+  decorative full-screen cursor overlay.
+- A fail-closed local-control state on GNOME Wayland while its separate real-seat input-safety gate in issue #345
+  is resolved.
 
-The local preview does **not** give the bot control of this computer by itself. Linux local control is temporarily
-disabled and legacy opt-ins are cleared automatically; do not start the bundled driver manually as a workaround.
-Automatic Wayland helper installation, Linux dictation, and ARM64 remain unavailable and fail closed; follow their
+The local preview does **not** give the bot control of this computer by itself. On Xorg, local control requires both
+the global **Enable local control** choice and assigning a bot to **This computer**; every action still enters the
+approval flow. On Wayland, local control is disabled and legacy opt-ins are cleared automatically. Automatic Wayland
+helper installation, Linux dictation, and ARM64 remain unavailable and fail closed; follow their
 progress in [issue #29](https://github.com/milind-soni/OpenMausBot/issues/29) and the safety hold in
 [issue #345](https://github.com/milind-soni/OpenMausBot/issues/345). Bundled
 CUA supply-chain work is tracked in [issue #113](https://github.com/milind-soni/OpenMausBot/issues/113). Xorg is tracked in
@@ -142,20 +146,22 @@ Cancelling or ending Wayland sharing returns to a calm **Try again** state and n
 automatically. OpenMausBot does not capture screen audio, remember the selected monitor after restart, or
 offer an **Open Settings** action on Linux.
 
-Local computer control is independent from preview and currently fails closed on both sessions. The app never
-starts Cua from a legacy preference. XWayland's `DISPLAY` never bypasses this release safety hold.
+Local computer control is independent from preview. It is available after explicit opt-in on Xorg and remains
+fail-closed on Wayland. XWayland's `DISPLAY` never bypasses the Wayland safety gate.
 
-## Local control safety hold
+## Enable local control
 
 Installed `.deb` and AppImage builds include the certified **Cua Driver 0.19.3** CLI and cursor-theme sidecar.
-The app deliberately does not start that runtime while #345 is open: real GNOME/Xorg validation found that merely
-starting it could capture the physical pointer and keyboard before an approved action. Xvfb readiness, a successful
-handshake, and driver diagnostics do not prove that human-input boundary safe. The UI reports the safety hold,
-**This computer** remains unavailable, and an older persisted opt-in is reset to off with private file permissions.
+On GNOME Xorg, open Settings, choose **Enable local control (Beta)**, wait for **Ready**, then explicitly assign a bot
+to **This computer**. No driver download, terminal command, `chmod`, or daemon setup is required. The owned daemon
+starts with `--no-overlay`, so Cua's decorative full-screen X11 cursor surface is never created. OpenMausBot also
+uses Electron software rendering on Linux to avoid the reproduced NVIDIA/libGLES GPU-process failure that could
+leave an invisible focused app window receiving input.
 
-There is no supported manual enable flow during this hold. Continue using Chat, preview-only capture, Cloud, or
-Local VM. Re-enablement requires evidence on real GNOME/Xorg and GNOME/Wayland seats; it will not be controlled by
-an environment override.
+On GNOME Wayland, **This computer** remains unavailable and an older persisted opt-in is reset to off with private
+file permissions. Sign out and choose **Ubuntu on Xorg** from the login-screen session menu, or continue using Chat,
+preview-only capture, Cloud, or Local VM. Wayland re-enablement requires its own real-seat evidence and will not be
+controlled by an environment override.
 
 The upstream release has no signature or GitHub artifact attestation and is not immutable, so the build uses an
 explicit reviewed digest as its trust anchor:
@@ -174,16 +180,16 @@ requires glibc 2.30 or newer plus the standard Ubuntu X11/XInput/xkbcommon libra
 Ubuntu 24.04 desktop; the package verifier executes the exact binary from every artifact layout.
 
 AppImage's pinned SquashFS toolchain can emit root-owned directories as `0755` or `0775`; the package verifier
-requires one of those modes consistently across the reviewed resource tree. The dormant runtime retains a private
-`0700` staging design for a future re-enabled AppImage, while the current release hold prevents copying or executing
-either binary. DEB upgrades repair their exact package-owned path to `root:root 0755` automatically.
+requires one of those modes consistently across the reviewed resource tree. Before execution, AppImage copies only
+the pinned binaries into a private `0700` stage and verifies their hashes again. DEB upgrades repair their exact
+package-owned path to `root:root 0755` automatically.
 
-The packaged runtime remains outside ASAR only for deterministic provenance and future validation. Neither a
-`CUA_DRIVER_PATH` value nor an ambient PATH candidate bypasses the current release hold.
+The packaged runtime remains outside ASAR for deterministic provenance and validation. In packaged builds neither a
+`CUA_DRIVER_PATH` value nor an ambient PATH candidate can replace it; on Wayland neither can bypass the safety gate.
 
-The dormant runtime code retains private sockets, standard permission mode, per-action OpenMausBot approvals,
-telemetry/update-check suppression, strict driver identity, and lifecycle cleanup tests. Those defenses remain
-necessary, but none substitutes for the real-seat acceptance evidence required to remove the safety hold. Linux
+The Xorg runtime uses private sockets, standard permission mode, per-action OpenMausBot approvals,
+telemetry/update-check suppression, strict driver identity, overlay-free startup, and lifecycle cleanup tests. Those
+defenses remain necessary, but none substitutes for the real-seat acceptance evidence required to enable Wayland. Linux
 **Auto** never routes to the user's desktop, and no Cloud or Local VM approval can authorize it.
 
 ## Validate a package change
@@ -193,6 +199,7 @@ pnpm typecheck
 pnpm test
 pnpm check:electron
 pnpm build:cua:linux          # networked, checksum-pinned staging
+dbus-run-session -- xvfb-run -a pnpm smoke:cua-x11-input
 pnpm package:linux:offline    # CUA staging is offline; builder caches must already be available
 node scripts/verify-linux-package.mjs
 pnpm smoke:linux-package
@@ -217,13 +224,13 @@ considered for automatic discovery.
 ### A bot needs computer tools
 
 Choose **Cloud box** and add a Box token in App Settings, or use Local VM. Linux **This computer** remains disabled
-under the input-safety hold; it has no supported manual workaround.
+on Wayland. On Xorg, enable it from the **Local control** card first.
 
 ### Local control is not ready
 
-The in-app card should say that Linux local control is temporarily unavailable. If it instead offers **Enable local
-control**, close the app and report the package version on #345; do not click it or run the bundled driver manually.
-An upgraded DEB repairs its own package directory modes automatically—no user `chmod` is required.
+On Xorg, press **Try again** and use the reason shown in the card. The bundled package requires no manual driver
+installation or `chmod`; an upgraded DEB repairs its exact package-owned directory modes automatically. On Wayland,
+the card directs you to Ubuntu on Xorg and intentionally offers no enable button.
 
 ### Screen preview does not start
 

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -158,6 +158,10 @@ starts with `--no-overlay`, so Cua's decorative full-screen X11 cursor surface i
 uses Electron software rendering on Linux to avoid the reproduced NVIDIA/libGLES GPU-process failure that could
 leave an invisible focused app window receiving input.
 
+Cua actions use a private logical cursor. With the decorative overlay disabled, `move_cursor` does not move the
+user's physical pointer; approved click and typing actions still target the requested window, while the user's own
+mouse remains under their control.
+
 On GNOME Wayland, **This computer** remains unavailable and an older persisted opt-in is reset to off with private
 file permissions. Sign out and choose **Ubuntu on Xorg** from the login-screen session menu, or continue using Chat,
 preview-only capture, Cloud, or Local VM. Wayland re-enablement requires its own real-seat evidence and will not be

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -13,12 +13,13 @@ of Linux desktop on your own server instead of this machine, see [byo-vps.md](by
 - External documentation and OAuth links in the default browser.
 - An explicit, view-only local screen preview on GNOME Xorg and GNOME Wayland. The Wayland path uses the
   native portal chooser and keeps the selected PipeWire stream open until the user stops sharing.
-- An explicit local-computer control beta on GNOME/Xorg and guarded GNOME/Wayland with bundled Cua Driver
-  0.19.3 and an approval-capable Claude or ACP provider.
+- A fail-closed Linux local-control state while the real-seat input-safety blocker in issue #345 is resolved.
 
-The local preview does **not** give the bot control of this computer by itself. Local control is a separate,
-off-by-default beta. Automatic Wayland helper installation, Linux dictation, and ARM64 remain unavailable and
-fail closed; follow their progress in [issue #29](https://github.com/milind-soni/OpenMausBot/issues/29). Bundled
+The local preview does **not** give the bot control of this computer by itself. Linux local control is temporarily
+disabled and legacy opt-ins are cleared automatically; do not start the bundled driver manually as a workaround.
+Automatic Wayland helper installation, Linux dictation, and ARM64 remain unavailable and fail closed; follow their
+progress in [issue #29](https://github.com/milind-soni/OpenMausBot/issues/29) and the safety hold in
+[issue #345](https://github.com/milind-soni/OpenMausBot/issues/345). Bundled
 CUA supply-chain work is tracked in [issue #113](https://github.com/milind-soni/OpenMausBot/issues/113). Xorg is tracked in
 [issue #79](https://github.com/milind-soni/OpenMausBot/issues/79), and guarded GNOME/Wayland support in
 [issue #109](https://github.com/milind-soni/OpenMausBot/issues/109).
@@ -141,16 +142,20 @@ Cancelling or ending Wayland sharing returns to a calm **Try again** state and n
 automatically. OpenMausBot does not capture screen audio, remember the selected monitor after restart, or
 offer an **Open Settings** action on Linux.
 
-Local computer control is a separate opt-in. On Wayland, OpenMausBot recognizes only GNOME/Mutter and requires
-the certified Cua health report to pass AT-SPI, portal capture, and the portal/libei input backend with verified
-WinRects target activation. Other Wayland compositors remain unavailable. XWayland's `DISPLAY` never bypasses
-these checks.
+Local computer control is independent from preview and currently fails closed on both sessions. The app never
+starts Cua from a legacy preference. XWayland's `DISPLAY` never bypasses this release safety hold.
 
-## Enable local control
+## Local control safety hold
 
 Installed `.deb` and AppImage builds include the certified **Cua Driver 0.19.3** CLI and cursor-theme sidecar.
-You do not need to install Cua separately for GNOME/Xorg. OpenMausBot starts its own private daemon only after
-you enable the beta; it never starts, updates, or stops a global Cua daemon.
+The app deliberately does not start that runtime while #345 is open: real GNOME/Xorg validation found that merely
+starting it could capture the physical pointer and keyboard before an approved action. Xvfb readiness, a successful
+handshake, and driver diagnostics do not prove that human-input boundary safe. The UI reports the safety hold,
+**This computer** remains unavailable, and an older persisted opt-in is reset to off with private file permissions.
+
+There is no supported manual enable flow during this hold. Continue using Chat, preview-only capture, Cloud, or
+Local VM. Re-enablement requires evidence on real GNOME/Xorg and GNOME/Wayland seats; it will not be controlled by
+an environment override.
 
 The upstream release has no signature or GitHub artifact attestation and is not immutable, so the build uses an
 explicit reviewed digest as its trust anchor:
@@ -169,72 +174,17 @@ requires glibc 2.30 or newer plus the standard Ubuntu X11/XInput/xkbcommon libra
 Ubuntu 24.04 desktop; the package verifier executes the exact binary from every artifact layout.
 
 AppImage's pinned SquashFS toolchain can emit root-owned directories as `0755` or `0775`; the package verifier
-requires one of those modes consistently across the reviewed resource tree. Because `0775` is correctly rejected by
-the normal executable-path policy, AppImage launch always copies only the two pinned files into a fresh private
-`0700` temporary directory, verifies both hashes after the copy, executes from there, and removes that directory on
-quit. DEB and unpacked builds keep their package path at `0755` and execute directly. This exception does not relax
-validation for an explicit override, `PATH`, or any other group-writable location.
+requires one of those modes consistently across the reviewed resource tree. The dormant runtime retains a private
+`0700` staging design for a future re-enabled AppImage, while the current release hold prevents copying or executing
+either binary. DEB upgrades repair their exact package-owned path to `root:root 0755` automatically.
 
-An explicit absolute `CUA_DRIVER_PATH` remains an advanced override for development and incident response. A
-packaged app otherwise uses only its bundled driver and fails closed if it is missing, unsafe, changed, or
-incompatible—it never silently executes `~/.local/bin/cua-driver` or a PATH candidate. Source/dev runs retain the
-validated user-local discovery described by the [official Cua installation guide](https://cua.ai/docs/how-to-guides/driver/install).
+The packaged runtime remains outside ASAR only for deterministic provenance and future validation. Neither a
+`CUA_DRIVER_PATH` value nor an ambient PATH candidate bypasses the current release hold.
 
-GNOME/Wayland still needs the privileged WinRects v8 Shell helper. OpenMausBot does not install or enable a Shell
-extension silently. If it is not already active, download the same pinned archive, verify it, extract only the helper,
-review its installer, and run it explicitly:
-
-```sh
-version="0.19.3"
-asset="cua-driver-rs-${version}-linux-x86_64-binary.tar.gz"
-download_dir="$(mktemp -d)"
-curl --fail --location --proto '=https' --tlsv1.2 \
-  --output "$download_dir/$asset" \
-  "https://github.com/trycua/cua/releases/download/cua-driver-rs-v${version}/$asset"
-printf '%s  %s\n' \
-  '3db9d4257d84bacaf7eb104d225f85613ce67edbb20d6eeb83c1384b6d8a5b10' \
-  "$download_dir/$asset" | sha256sum --check --strict
-tar --extract --gzip --no-same-owner --no-same-permissions \
-  --file "$download_dir/$asset" --directory "$download_dir" wayland-helper
-sed -n '1,240p' "$download_dir/wayland-helper/install.sh"
-"$download_dir/wayland-helper/install.sh"
-```
-
-Sign out and back in once, then verify that GNOME loaded exactly the expected helper:
-
-```sh
-gnome-extensions info winrects@cua
-```
-
-The output must include `Version: 8`, `Enabled: Yes`, and `State: ACTIVE`. OpenMausBot never installs or enables
-this GNOME extension silently. The helper exposes window identity, geometry, capture, cursor, and verified target
-activation to Cua; foreground pointer or keyboard delivery remains scoped by GNOME's Remote Desktop portal and
-may ask for session consent.
-
-Then:
-
-1. Open a bot's **Computer** panel.
-2. In **Local control**, choose **Enable local control (Beta)** and review the warning.
-3. Wait until the card shows **Ready**, including the verified driver path and version.
-4. Select **This computer** for that bot. Enabling the global capability never assigns a bot automatically.
-
-Linux **Auto** never falls back to the user's desktop. **This computer** is available only when the current
-provider advertises an interactive approval channel. Claude `bypassPermissions`, ACP full-auto, Codex's current
-app-server adapter, non-GNOME/headless sessions, missing diagnostics, and stale/crashed runtimes fail closed.
-
-OpenMausBot starts one private embedded daemon with a private socket for its own app generation. It never touches
-Cua's default/global daemon. On GNOME/Wayland, the app also rechecks the prompt-free health contract while the
-runtime is active and revokes readiness if the helper or backend disappears. Disabling local control or quitting
-stops the owned daemon and active proxies.
-
-The driver uses Cua's `standard` permission mode. Cua routine actions are promptless at the driver layer, while
-OpenMausBot requires its own **Allow** or **Deny** decision before every local action. Bot Auto mode, persistent
-**Always allow** grants, and cloud-computer approvals cannot authorize the local desktop in this beta.
-
-Cua Driver has content-free telemetry and an update check enabled by default. OpenMausBot disables both for every
-Cua process it owns and does not change any separately installed Cua preferences. Driver updates arrive only with an
-OpenMausBot application release; rolling back the app rolls back the paired driver. Review the upstream behavior in
-the [official telemetry documentation](https://cua.ai/docs/reference/cua-driver/telemetry).
+The dormant runtime code retains private sockets, standard permission mode, per-action OpenMausBot approvals,
+telemetry/update-check suppression, strict driver identity, and lifecycle cleanup tests. Those defenses remain
+necessary, but none substitutes for the real-seat acceptance evidence required to remove the safety hold. Linux
+**Auto** never routes to the user's desktop, and no Cloud or Local VM approval can authorize it.
 
 ## Validate a package change
 
@@ -248,17 +198,13 @@ node scripts/verify-linux-package.mjs
 pnpm smoke:linux-package
 ```
 
-The verifier checks `.deb` metadata, desktop identity, the exact Cua resource tree and provenance, SquashFS/DEB
-directory modes, runtime path policy, and matching binary hashes across all artifacts. The smoke test launches the
-unpacked production app and AppImage without `--no-sandbox` and validates the renderer/preload, embedded health
-endpoint, packaged bundled-driver resolution, strict MCP environment, and process cleanup. It starts the real
-bundled driver under Xvfb/D-Bus to prove packaged launch, private-daemon readiness, and cleanup, then uses a fake
-explicit override to prove diagnostics,
-private-daemon readiness, crash invalidation, explicit retry, and clean shutdown in separate Xorg and simulated
-GNOME/Wayland contract lanes. The Wayland lane also requires the opt-in environment and certified health report.
-Its wrapper isolates the temporary D-Bus/AT-SPI runtime so it cannot replace the live desktop session's
-accessibility socket. Real inspection, input actions, and portal behavior still require evidence from real GNOME
-Xorg and GNOME Wayland sessions; the CI lanes are not a substitute for that evidence.
+The verifier checks `.deb` metadata, desktop identity, the exact dormant Cua resource tree and provenance,
+SquashFS/DEB directory modes, runtime path policy, and matching binary hashes across all artifacts. The local smoke
+launches the unpacked app and AppImage without `--no-sandbox`; CI first reproduces a `0.1.7` in-place DEB upgrade and
+then runs the same smoke against `/opt/OpenMausBot/openmausbot`. These lanes prove the embedded server and UI are
+usable while an optional Composio broker stalls, verify that an old local-control opt-in is cleared, and assert that
+no Cua executable starts on Xorg or simulated Wayland. Low-level runtime tests retain the future private-daemon
+contract without activating it in a packaged app. Only a real-seat acceptance matrix can authorize re-enablement.
 
 ## Troubleshooting
 
@@ -270,48 +216,14 @@ considered for automatic discovery.
 
 ### A bot needs computer tools
 
-Choose **Cloud box** and add a Box token in App Settings, or complete the local-control opt-in above on a supported
-GNOME session. A missing driver/helper, unsupported compositor or provider keeps **This computer** disabled with
-an explanation.
+Choose **Cloud box** and add a Box token in App Settings, or use Local VM. Linux **This computer** remains disabled
+under the input-safety hold; it has no supported manual workaround.
 
 ### Local control is not ready
 
-The in-app card is the primary diagnostic because packaged builds do not add Cua Driver to `PATH`. For a DEB
-installation, run the bundled executable directly in a terminal launched inside the same GNOME session:
-
-```sh
-echo "$XDG_SESSION_TYPE"  # x11 or wayland
-driver=/opt/OpenMausBot/resources/cua-linux-x64/cua-driver
-export CUA_DRIVER_RS_UPDATE_CHECK=false
-export CUA_DRIVER_RS_TELEMETRY_ENABLED=false
-"$driver" --version      # must be 0.19.3 for this beta
-"$driver" doctor --json
-```
-
-For an AppImage, prefer the in-app diagnostic; its verified read-only mount path exists only while the app is
-running. Maintainers testing an unpacked build can use
-`release/linux-unpacked/resources/cua-linux-x64/cua-driver`.
-
-On Wayland, also run:
-
-```sh
-echo "$XDG_CURRENT_DESKTOP"  # must include GNOME
-gnome-extensions info winrects@cua
-CUA_DRIVER_RS_UPDATE_CHECK=false \
-CUA_DRIVER_RS_TELEMETRY_ENABLED=false \
-CUA_DRIVER_RS_ENABLE_WAYLAND=1 \
-  /opt/OpenMausBot/resources/cua-linux-x64/cua-driver doctor --json
-```
-
-If the helper is installed but not `ACTIVE`, sign out and back in once. If the app reports a portal error, confirm
-that `xdg-desktop-portal` and `xdg-desktop-portal-gnome` are running in the user session. OpenMausBot's readiness
-probe never opens a consent prompt; GNOME may prompt when the first approved foreground input action starts.
-
-Repair any display, session bus, or AT-SPI diagnostic before choosing **Try again**. If the path shown in the app
-is unexpected, close OpenMausBot and launch it with an absolute `CUA_DRIVER_PATH`. An invalid explicit override
-fails without silently selecting another executable. For `unsafe-driver-permissions`, use the bounded
-permission-hardening commands in **Enable local control**; do not make the driver executable or its
-directories world-writable.
+The in-app card should say that Linux local control is temporarily unavailable. If it instead offers **Enable local
+control**, close the app and report the package version on #345; do not click it or run the bundled driver manually.
+An upgraded DEB repairs its own package directory modes automatically—no user `chmod` is required.
 
 ### Screen preview does not start
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -167,6 +167,9 @@ linux:
 deb:
   packageCategory: utils
   priority: optional
+  # dpkg can preserve legacy directory modes during an upgrade. This
+  # idempotent hook repairs only the exact package-owned CUA path.
+  afterInstall: build/linux-after-install.sh
 
 # Static AppImage runtime: Ubuntu 24.04 can launch it without legacy FUSE 2.
 toolsets:

--- a/electron/capabilities.cjs
+++ b/electron/capabilities.cjs
@@ -28,6 +28,34 @@ function linuxSession(platform, env) {
   return "headless";
 }
 
+function linuxLocalControlSupport(platform, env) {
+  if (platform !== "linux") {
+    return Object.freeze({
+      available: false,
+      session: "unknown",
+      reasonCode: "unsupported-platform",
+      message: "Local control is not available on this platform.",
+    });
+  }
+  const session = linuxSession(platform, env);
+  if (session === "x11") return Object.freeze({ available: true, session });
+  if (session === "wayland") {
+    return Object.freeze({
+      available: false,
+      session,
+      reasonCode: "linux-wayland-seat-safety-blocked",
+      message:
+        "Local control is not available on Wayland yet. Sign out and choose Ubuntu on Xorg to use This computer.",
+    });
+  }
+  return Object.freeze({
+    available: false,
+    session,
+    reasonCode: "headless-session",
+    message: "Local control needs an active Ubuntu Xorg desktop session.",
+  });
+}
+
 function localComputerReady(platform, connection) {
   if (platform === "darwin") {
     return connection?.mode === "embedded" || connection?.mode === "standalone";
@@ -44,11 +72,7 @@ function localComputerReady(platform, connection) {
   if (connection.mode === "linux-x11-supervised") {
     return connection.session === "x11";
   }
-  return (
-    connection.mode === "linux-wayland-gnome-supervised" &&
-    connection.session === "wayland" &&
-    connection.compositor === "gnome-mutter"
-  );
+  return false;
 }
 
 function desktopCapabilities({
@@ -149,6 +173,7 @@ function connectionEnabled(platform, connection) {
 module.exports = {
   connectionEnabled,
   desktopCapabilities,
+  linuxLocalControlSupport,
   linuxSession,
   localComputerReady,
   nativeDesktopActions,

--- a/electron/capabilities.test.mjs
+++ b/electron/capabilities.test.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 const require = createRequire(import.meta.url);
 const {
   desktopCapabilities,
+  linuxLocalControlSupport,
   linuxSession,
   localComputerReady,
   nativeDesktopActions,
@@ -95,6 +96,28 @@ describe("desktop capabilities", () => {
     expect(linuxSession("linux", {})).toBe("headless");
   });
 
+  it("re-enables local control only on X11 and keeps Wayland/headless fail-closed", () => {
+    expect(
+      linuxLocalControlSupport("linux", { XDG_SESSION_TYPE: "x11", DISPLAY: ":0" }),
+    ).toEqual({ available: true, session: "x11" });
+    expect(
+      linuxLocalControlSupport("linux", {
+        XDG_SESSION_TYPE: "wayland",
+        WAYLAND_DISPLAY: "wayland-0",
+        DISPLAY: ":0",
+      }),
+    ).toMatchObject({
+      available: false,
+      session: "wayland",
+      reasonCode: "linux-wayland-seat-safety-blocked",
+    });
+    expect(linuxLocalControlSupport("linux", {})).toMatchObject({
+      available: false,
+      session: "headless",
+      reasonCode: "headless-session",
+    });
+  });
+
   it("never treats an embedded-looking Linux connection as local control", () => {
     expect(localComputerReady("linux", { mode: "embedded" })).toBe(false);
     expect(localComputerReady("darwin", { mode: "unavailable" })).toBe(false);
@@ -134,7 +157,7 @@ describe("desktop capabilities", () => {
     expect(localComputerReady("linux", { ...connection, schemaVersion: 2 })).toBe(false);
   });
 
-  it("enables GNOME Wayland control only for the exact supervised contract", () => {
+  it("rejects even a forged ready Wayland contract until its real-seat gate is lifted", () => {
     const connection = {
       schemaVersion: 1,
       mode: "linux-wayland-gnome-supervised",
@@ -144,7 +167,7 @@ describe("desktop capabilities", () => {
       enabled: true,
       status: "ready",
     };
-    expect(localComputerReady("linux", connection)).toBe(true);
+    expect(localComputerReady("linux", connection)).toBe(false);
     expect(localComputerReady("linux", { ...connection, compositor: undefined })).toBe(false);
     expect(localComputerReady("linux", { ...connection, session: "x11" })).toBe(false);
     expect(
@@ -154,8 +177,8 @@ describe("desktop capabilities", () => {
         localConnection: connection,
       }).localComputer,
     ).toMatchObject({
-      available: true,
-      support: "limited",
+      available: false,
+      support: "unsupported",
       session: "wayland",
       compositor: "gnome-mutter",
     });

--- a/electron/cua-linux-bundle.cjs
+++ b/electron/cua-linux-bundle.cjs
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const STAGE_PREFIX = "openmausbot-cua-linux-x64-";
+const LEGACY_STAGE_GRACE_MS = 10 * 60 * 1000;
 const FILES = Object.freeze({
   "cua-driver": "ed5844fadf07b9b72c4a3b3802e1c47233c166d66d6198608d5991f807aab4ac",
   "cua-cursor-theme": "e589b2b7521bbfeaf9e2bfce668a38e80ed1b9790b1327b13d374fc331d8312a",
@@ -13,17 +14,150 @@ function sha256(file, fileSystem = fs) {
   return createHash("sha256").update(fileSystem.readFileSync(file)).digest("hex");
 }
 
+function processIsAlive(processId) {
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function processReferencesDirectory(directory, {
+  fileSystem = fs,
+  procRoot = "/proc",
+} = {}) {
+  let processes;
+  try {
+    processes = fileSystem.readdirSync(procRoot);
+  } catch {
+    // If process discovery is unavailable, retain the candidate. Cleanup is
+    // optional; deleting a stage that might still be in use is not.
+    return true;
+  }
+  for (const processName of processes) {
+    if (!/^\d+$/.test(processName)) continue;
+    for (const linkName of ["exe", "cwd"]) {
+      let target;
+      try {
+        target = fileSystem.readlinkSync(path.join(procRoot, processName, linkName));
+      } catch {
+        continue;
+      }
+      const liveTarget = target.endsWith(" (deleted)") ? target.slice(0, -10) : target;
+      if (liveTarget === directory || liveTarget.startsWith(`${directory}${path.sep}`)) return true;
+    }
+  }
+  return false;
+}
+
+function safeStageContents(directory, {
+  currentUid = process.getuid?.(),
+  fileSystem = fs,
+  files = FILES,
+} = {}) {
+  let entries;
+  try {
+    entries = fileSystem.readdirSync(directory);
+  } catch {
+    return false;
+  }
+  for (const name of entries) {
+    const expectedHash = files[name];
+    if (!expectedHash) return false;
+    const candidate = path.join(directory, name);
+    let details;
+    try {
+      details = fileSystem.lstatSync(candidate);
+      if (
+        !details.isFile() ||
+        details.isSymbolicLink() ||
+        details.uid !== currentUid ||
+        (details.mode & 0o777) !== 0o755 ||
+        sha256(candidate, fileSystem) !== expectedHash
+      ) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function reapStaleAppImageCuaBundles({
+  temporaryRoot = os.tmpdir(),
+  currentUid = process.getuid?.(),
+  fileSystem = fs,
+  files = FILES,
+  isDirectoryActive = (directory) => processReferencesDirectory(directory, { fileSystem }),
+  isProcessAlive = processIsAlive,
+  legacyGraceMs = LEGACY_STAGE_GRACE_MS,
+  now = Date.now(),
+} = {}) {
+  if (!path.isAbsolute(temporaryRoot) || !Number.isInteger(currentUid)) return [];
+  let names;
+  try {
+    names = fileSystem.readdirSync(temporaryRoot);
+  } catch {
+    return [];
+  }
+  const removed = [];
+  const escapedPrefix = STAGE_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const candidatePattern = new RegExp(`^${escapedPrefix}(?:(\\d+)-)?[A-Za-z0-9]{6}$`);
+  for (const name of names) {
+    const match = candidatePattern.exec(name);
+    if (!match) continue;
+    const directory = path.join(temporaryRoot, name);
+    let details;
+    try {
+      details = fileSystem.lstatSync(directory);
+    } catch {
+      continue;
+    }
+    if (
+      !details.isDirectory() ||
+      details.isSymbolicLink() ||
+      details.uid !== currentUid ||
+      (details.mode & 0o777) !== 0o700
+    ) {
+      continue;
+    }
+    const ownerPid = match[1] ? Number(match[1]) : null;
+    if (ownerPid !== null && isProcessAlive(ownerPid)) continue;
+    if (ownerPid === null && now - details.mtimeMs < legacyGraceMs) continue;
+    if (isDirectoryActive(directory)) continue;
+    if (!safeStageContents(directory, { currentUid, fileSystem, files })) continue;
+    try {
+      fileSystem.rmSync(directory, { recursive: true, force: false });
+      removed.push(directory);
+    } catch {
+      // A concurrent process may have replaced or started using the stage.
+      // Retaining it is always safer than broadening cleanup.
+    }
+  }
+  return removed;
+}
+
 function stageAppImageCuaBundle({
   resourcesPath,
   temporaryRoot = os.tmpdir(),
   fileSystem = fs,
   files = FILES,
+  processId = process.pid,
 } = {}) {
-  if (!path.isAbsolute(resourcesPath) || !path.isAbsolute(temporaryRoot)) {
+  if (
+    !path.isAbsolute(resourcesPath) ||
+    !path.isAbsolute(temporaryRoot) ||
+    !Number.isSafeInteger(processId) ||
+    processId <= 0
+  ) {
     throw new Error("AppImage CUA staging paths must be absolute");
   }
   const sourceRoot = path.join(resourcesPath, "cua-linux-x64");
-  const stageDirectory = fileSystem.mkdtempSync(path.join(temporaryRoot, STAGE_PREFIX));
+  const stageDirectory = fileSystem.mkdtempSync(
+    path.join(temporaryRoot, `${STAGE_PREFIX}${processId}-`),
+  );
   fileSystem.chmodSync(stageDirectory, 0o700);
   try {
     for (const [name, expectedHash] of Object.entries(files)) {
@@ -77,7 +211,9 @@ function cleanupAppImageCuaBundle(stage, {
 
 module.exports = {
   FILES,
+  LEGACY_STAGE_GRACE_MS,
   STAGE_PREFIX,
   cleanupAppImageCuaBundle,
+  reapStaleAppImageCuaBundles,
   stageAppImageCuaBundle,
 };

--- a/electron/cua-linux-bundle.test.mjs
+++ b/electron/cua-linux-bundle.test.mjs
@@ -8,7 +8,9 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const {
   FILES,
+  LEGACY_STAGE_GRACE_MS,
   cleanupAppImageCuaBundle,
+  reapStaleAppImageCuaBundles,
   stageAppImageCuaBundle,
 } = require("./cua-linux-bundle.cjs");
 
@@ -40,7 +42,13 @@ describe.skipIf(process.platform === "win32")("AppImage CUA private staging", ()
       fs.writeFileSync(path.join(source, name), bytes);
       files[name] = createHash("sha256").update(bytes).digest("hex");
     }
-    const stage = stageAppImageCuaBundle({ resourcesPath, temporaryRoot: root, files });
+    const stage = stageAppImageCuaBundle({
+      resourcesPath,
+      temporaryRoot: root,
+      files,
+      processId: 4242,
+    });
+    expect(path.basename(stage.directory)).toMatch(/^openmausbot-cua-linux-x64-4242-/);
     expect(fs.lstatSync(stage.directory).mode & 0o777).toBe(0o700);
     expect(fs.lstatSync(stage.driverPath).mode & 0o777).toBe(0o755);
     cleanupAppImageCuaBundle(stage, { temporaryRoot: root });
@@ -62,5 +70,89 @@ describe.skipIf(process.platform === "win32")("AppImage CUA private staging", ()
     expect(() =>
       cleanupAppImageCuaBundle({ directory: root }, { temporaryRoot: path.dirname(root) }),
     ).toThrow("unexpected AppImage CUA stage");
+  });
+
+  it("reaps only dead process-owned stages with exact private contents", () => {
+    const { root, resourcesPath, source } = fixture();
+    const files = {};
+    for (const [name, bytes] of [
+      ["cua-driver", Buffer.from("driver")],
+      ["cua-cursor-theme", Buffer.from("theme")],
+    ]) {
+      fs.writeFileSync(path.join(source, name), bytes);
+      files[name] = createHash("sha256").update(bytes).digest("hex");
+    }
+    const dead = stageAppImageCuaBundle({
+      resourcesPath,
+      temporaryRoot: root,
+      files,
+      processId: 1111,
+    });
+    const live = stageAppImageCuaBundle({
+      resourcesPath,
+      temporaryRoot: root,
+      files,
+      processId: 2222,
+    });
+    const tampered = stageAppImageCuaBundle({
+      resourcesPath,
+      temporaryRoot: root,
+      files,
+      processId: 3333,
+    });
+    fs.writeFileSync(path.join(tampered.directory, "unexpected"), "keep me");
+
+    const removed = reapStaleAppImageCuaBundles({
+      temporaryRoot: root,
+      files,
+      isDirectoryActive: () => false,
+      isProcessAlive: (processId) => processId === 2222,
+    });
+
+    expect(removed).toEqual([dead.directory]);
+    expect(fs.existsSync(dead.directory)).toBe(false);
+    expect(fs.existsSync(live.directory)).toBe(true);
+    expect(fs.existsSync(tampered.directory)).toBe(true);
+  });
+
+  it("gives legacy stages a race-safe grace period and retains active ones", () => {
+    const { root, source } = fixture();
+    const files = {};
+    for (const [name, bytes] of [
+      ["cua-driver", Buffer.from("driver")],
+      ["cua-cursor-theme", Buffer.from("theme")],
+    ]) {
+      fs.writeFileSync(path.join(source, name), bytes);
+      files[name] = createHash("sha256").update(bytes).digest("hex");
+    }
+    const createLegacy = (suffix) => {
+      const directory = path.join(root, `openmausbot-cua-linux-x64-${suffix}`);
+      fs.mkdirSync(directory, { mode: 0o700 });
+      for (const name of Object.keys(files)) {
+        fs.copyFileSync(path.join(source, name), path.join(directory, name));
+        fs.chmodSync(path.join(directory, name), 0o755);
+      }
+      return directory;
+    };
+    const recent = createLegacy("ABC123");
+    const active = createLegacy("DEF456");
+    const stale = createLegacy("GHI789");
+    const now = Date.now();
+    const old = new Date(now - LEGACY_STAGE_GRACE_MS - 1);
+    fs.utimesSync(active, old, old);
+    fs.utimesSync(stale, old, old);
+
+    const removed = reapStaleAppImageCuaBundles({
+      temporaryRoot: root,
+      files,
+      now,
+      isDirectoryActive: (directory) => directory === active,
+      isProcessAlive: () => false,
+    });
+
+    expect(removed).toEqual([stale]);
+    expect(fs.existsSync(recent)).toBe(true);
+    expect(fs.existsSync(active)).toBe(true);
+    expect(fs.existsSync(stale)).toBe(false);
   });
 });

--- a/electron/cua-linux-runtime.cjs
+++ b/electron/cua-linux-runtime.cjs
@@ -697,6 +697,10 @@ function createLinuxCuaRuntime({
       const args = [
         "serve",
         "--embedded",
+        // The driver's visual cursor is a full-screen X11 overlay. It is not
+        // needed for inspection or input delivery, and a compositor/renderer
+        // failure must never leave that surface between the user and desktop.
+        "--no-overlay",
         "--socket",
         socketPath,
         "--pid-file",

--- a/electron/cua-linux-runtime.cjs
+++ b/electron/cua-linux-runtime.cjs
@@ -14,7 +14,10 @@ const {
 } = require("./cua-linux.cjs");
 
 const CONNECTION_SCHEMA_VERSION = 1;
-const SETTINGS_SCHEMA_VERSION = 1;
+// Schema 2 is intentionally incompatible with early Linux desktop builds.
+// Those builds could start Cua without the Xorg seat-safety flags; keeping the
+// opt-in versioned makes a newer build unable to arm an older installed copy.
+const SETTINGS_SCHEMA_VERSION = 2;
 const HOST_BUNDLE_ID = "com.openmausbot.app";
 const CERTIFIED_CONTRACT_VERSION = "0.6.0";
 const CERTIFIED_TOOLS_LIST_SCHEMA_VERSION = "1";

--- a/electron/cua-linux-runtime.cjs
+++ b/electron/cua-linux-runtime.cjs
@@ -439,11 +439,20 @@ function publicRuntimeStatus(connection) {
 
 function createUnavailableLinuxRuntime({
   connectionStore,
+  preferenceStore,
+  clearPreference = false,
   onChange = () => {},
   processId = process.pid,
   reasonCode = "bundled-driver-invalid",
   message = "The bundled Cua Driver failed integrity validation.",
 } = {}) {
+  if (clearPreference) {
+    try {
+      preferenceStore?.write(false);
+    } catch (error) {
+      console.error("[cua] Failed to clear unsafe Linux local-control preference:", error);
+    }
+  }
   const connection = {
     schemaVersion: CONNECTION_SCHEMA_VERSION,
     mode: "unavailable",

--- a/electron/cua-linux-runtime.test.mjs
+++ b/electron/cua-linux-runtime.test.mjs
@@ -238,24 +238,24 @@ describe("unavailable Linux CUA runtime", () => {
     });
   });
 
-  it("clears a durable opt-in when a release safety gate blocks startup", async () => {
+  it("clears a durable opt-in when the Wayland safety gate blocks startup", async () => {
     const preferenceStore = { write: vi.fn() };
     const runtime = createUnavailableLinuxRuntime({
       connectionStore: { persist: (connection) => connection },
       preferenceStore,
       clearPreference: true,
-      reasonCode: "linux-seat-safety-blocked",
-      message: "Local control is temporarily unavailable on Linux.",
+      reasonCode: "linux-wayland-seat-safety-blocked",
+      message: "Local control is not available on Wayland yet.",
     });
 
     await expect(runtime.initialize()).resolves.toMatchObject({
       enabled: false,
       status: "unavailable",
-      reasonCode: "linux-seat-safety-blocked",
+      reasonCode: "linux-wayland-seat-safety-blocked",
     });
     await expect(runtime.enable()).resolves.toMatchObject({
       enabled: false,
-      reasonCode: "linux-seat-safety-blocked",
+      reasonCode: "linux-wayland-seat-safety-blocked",
     });
     expect(preferenceStore.write).toHaveBeenCalledOnce();
     expect(preferenceStore.write).toHaveBeenCalledWith(false);
@@ -346,9 +346,18 @@ describe.skipIf(process.platform === "win32")("Linux CUA opt-in and lifecycle", 
     expect(context.spawnProcess).toHaveBeenCalledTimes(1);
     expect(context.spawnProcess).toHaveBeenCalledWith(
       context.binary,
-      expect.arrayContaining(["serve", "--embedded", "--socket", "--permission-mode", "standard"]),
+      expect.arrayContaining([
+        "serve",
+        "--embedded",
+        "--no-overlay",
+        "--socket",
+        "--permission-mode",
+        "standard",
+      ]),
       expect.objectContaining({ shell: false, stdio: ["pipe", "ignore", "pipe"] }),
     );
+    const daemonArgs = context.spawnProcess.mock.calls[0][1];
+    expect(daemonArgs.filter((argument) => argument === "--no-overlay")).toHaveLength(1);
     const spawnOptions = context.spawnProcess.mock.calls[0][2];
     expect(spawnOptions.env).toMatchObject({
       CUA_DRIVER_EMBEDDED: "1",

--- a/electron/cua-linux-runtime.test.mjs
+++ b/electron/cua-linux-runtime.test.mjs
@@ -579,7 +579,15 @@ describe.skipIf(process.platform === "win32")("Linux CUA private data", () => {
     const file = path.join(userData, "cua-local-control.json");
     expect(store.read()).toBe(true);
     expect(fs.statSync(file).mode & 0o777).toBe(0o600);
-    fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, linuxLocalControlEnabled: true, extra: true }), {
+    expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({
+      schemaVersion: 2,
+      linuxLocalControlEnabled: true,
+    });
+    fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, linuxLocalControlEnabled: true }), {
+      mode: 0o600,
+    });
+    expect(store.read()).toBe(false);
+    fs.writeFileSync(file, JSON.stringify({ schemaVersion: 2, linuxLocalControlEnabled: true, extra: true }), {
       mode: 0o600,
     });
     expect(store.read()).toBe(false);

--- a/electron/cua-linux-runtime.test.mjs
+++ b/electron/cua-linux-runtime.test.mjs
@@ -237,6 +237,29 @@ describe("unavailable Linux CUA runtime", () => {
       reasonCode: "bundled-driver-invalid",
     });
   });
+
+  it("clears a durable opt-in when a release safety gate blocks startup", async () => {
+    const preferenceStore = { write: vi.fn() };
+    const runtime = createUnavailableLinuxRuntime({
+      connectionStore: { persist: (connection) => connection },
+      preferenceStore,
+      clearPreference: true,
+      reasonCode: "linux-seat-safety-blocked",
+      message: "Local control is temporarily unavailable on Linux.",
+    });
+
+    await expect(runtime.initialize()).resolves.toMatchObject({
+      enabled: false,
+      status: "unavailable",
+      reasonCode: "linux-seat-safety-blocked",
+    });
+    await expect(runtime.enable()).resolves.toMatchObject({
+      enabled: false,
+      reasonCode: "linux-seat-safety-blocked",
+    });
+    expect(preferenceStore.write).toHaveBeenCalledOnce();
+    expect(preferenceStore.write).toHaveBeenCalledWith(false);
+  });
 });
 
 // Windows does not provide the POSIX executable and Unix-socket semantics this

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -29,7 +29,11 @@ const {
   createLinuxCuaRuntime,
   createUnavailableLinuxRuntime,
 } = require("./cua-linux-runtime.cjs");
-const { cleanupAppImageCuaBundle, stageAppImageCuaBundle } = require("./cua-linux-bundle.cjs");
+const {
+  cleanupAppImageCuaBundle,
+  reapStaleAppImageCuaBundles,
+  stageAppImageCuaBundle,
+} = require("./cua-linux-bundle.cjs");
 const { linuxLocalControlSupport } = require("./capabilities.cjs");
 
 const INSTALLED_DRIVER = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver";
@@ -74,6 +78,7 @@ function ensureLinuxRuntime() {
         // process-owned directory and verify their hashes after the copy, so
         // every AppImage follows the same execution invariant.
         if (process.env.APPIMAGE) {
+          reapStaleAppImageCuaBundles();
           linuxBundleStage ??= stageAppImageCuaBundle({ resourcesPath: process.resourcesPath });
           bundledDriverPath = linuxBundleStage.driverPath;
         }

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -30,6 +30,7 @@ const {
   createUnavailableLinuxRuntime,
 } = require("./cua-linux-runtime.cjs");
 const { cleanupAppImageCuaBundle, stageAppImageCuaBundle } = require("./cua-linux-bundle.cjs");
+const { linuxLocalControlSupport } = require("./capabilities.cjs");
 
 const INSTALLED_DRIVER = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver";
 const STANDALONE_SOCKET = path.join(
@@ -48,26 +49,18 @@ const connectionStore = createCuaConnectionStore({
   getUserData: () => app.getPath("userData"),
 });
 
-// Real GNOME/Xorg validation found that merely starting Cua Driver 0.19.3
-// can capture the user's physical pointer and keyboard before any approved
-// tool action. Simulated/Xvfb readiness cannot prove that boundary safe.
-// Keep Linux fail-closed until a pinned driver passes the real-seat matrix in
-// #345. This is deliberately a source constant, not an environment flag a
-// packaged application could accidentally inherit.
-const LINUX_LOCAL_CONTROL_RELEASE_BLOCKED = true;
-
 function ensureLinuxRuntime() {
   if (!linuxRuntime) {
-    if (LINUX_LOCAL_CONTROL_RELEASE_BLOCKED) {
+    const support = linuxLocalControlSupport(process.platform, process.env);
+    if (!support.available) {
       linuxRuntime = createUnavailableLinuxRuntime({
         connectionStore,
         preferenceStore: createLinuxCuaPreferenceStore({
           getUserData: () => app.getPath("userData"),
         }),
         clearPreference: true,
-        reasonCode: "linux-seat-safety-blocked",
-        message:
-          "Local control is temporarily unavailable on Linux while an input-safety issue is fixed.",
+        reasonCode: support.reasonCode,
+        message: support.message,
         onChange: (connection) => stateListener(connection),
       });
       return linuxRuntime;

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -25,6 +25,7 @@ import { pathToFileURL } from "node:url";
 const require = createRequire(import.meta.url);
 const { createCuaConnectionStore } = require("./cua-connection.cjs");
 const {
+  createLinuxCuaPreferenceStore,
   createLinuxCuaRuntime,
   createUnavailableLinuxRuntime,
 } = require("./cua-linux-runtime.cjs");
@@ -47,8 +48,30 @@ const connectionStore = createCuaConnectionStore({
   getUserData: () => app.getPath("userData"),
 });
 
+// Real GNOME/Xorg validation found that merely starting Cua Driver 0.19.3
+// can capture the user's physical pointer and keyboard before any approved
+// tool action. Simulated/Xvfb readiness cannot prove that boundary safe.
+// Keep Linux fail-closed until a pinned driver passes the real-seat matrix in
+// #345. This is deliberately a source constant, not an environment flag a
+// packaged application could accidentally inherit.
+const LINUX_LOCAL_CONTROL_RELEASE_BLOCKED = true;
+
 function ensureLinuxRuntime() {
   if (!linuxRuntime) {
+    if (LINUX_LOCAL_CONTROL_RELEASE_BLOCKED) {
+      linuxRuntime = createUnavailableLinuxRuntime({
+        connectionStore,
+        preferenceStore: createLinuxCuaPreferenceStore({
+          getUserData: () => app.getPath("userData"),
+        }),
+        clearPreference: true,
+        reasonCode: "linux-seat-safety-blocked",
+        message:
+          "Local control is temporarily unavailable on Linux while an input-safety issue is fixed.",
+        onChange: (connection) => stateListener(connection),
+      });
+      return linuxRuntime;
+    }
     try {
       let bundledDriverPath;
       if (app.isPackaged && !process.env.CUA_DRIVER_PATH) {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -22,6 +22,8 @@ import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-lin
 import {
   ensureManagedComposioCredentials,
   managedComposioAccess,
+  managedComposioChildEnvironment,
+  normalizeManagedComposioBrokerUrl,
 } from "./managed-composio.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
@@ -267,7 +269,9 @@ async function secureWorkspaceConfig() {
 
 function composioBrokerUrl() {
   const configured = process.env.OMB_COMPOSIO_BROKER_URL?.trim();
-  return configured || (app.isPackaged ? DEFAULT_COMPOSIO_BROKER_URL : "");
+  return normalizeManagedComposioBrokerUrl(
+    configured || (app.isPackaged ? DEFAULT_COMPOSIO_BROKER_URL : ""),
+  );
 }
 
 // The packaged app has no terminal: everything about the server child's life
@@ -349,29 +353,24 @@ async function gatherDiagnostics() {
 
 async function startServerOn(port) {
   const entry = path.join(process.resourcesPath, "server", "index.js");
+  const childEnv = managedComposioChildEnvironment(composioBrokerUrl(), secureCredentials, {
+    ...process.env,
+    OMB_STATIC_DIR: path.join(process.resourcesPath, "ui"),
+    OMB_RESOURCES_PATH: process.resourcesPath,
+    OMB_SKILLS_DIR: path.join(process.resourcesPath, "skills"),
+    OMB_PORT: String(port),
+    OMB_USER_DATA: app.getPath("userData"),
+    ...(secureCredentials.composioApiKey
+      ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
+      : {}),
+    // one env var per stored workspace secret (xai/box/voice/OpenCode Go);
+    // the server prefers these over config.json, whose plaintext fields
+    // the boot migration has deleted
+    ...workspaceCredentialEnv(secureCredentials),
+  });
   slog(`fork ${entry} port=${port}`);
   const proc = utilityProcess.fork(entry, [], {
-    env: {
-      ...process.env,
-      OMB_STATIC_DIR: path.join(process.resourcesPath, "ui"),
-      OMB_RESOURCES_PATH: process.resourcesPath,
-      OMB_SKILLS_DIR: path.join(process.resourcesPath, "skills"),
-      OMB_PORT: String(port),
-      OMB_USER_DATA: app.getPath("userData"),
-      ...(secureCredentials.composioApiKey
-        ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
-        : {}),
-      // one env var per stored workspace secret (xai/box/voice/OpenCode);
-      // the server prefers these over config.json, whose plaintext fields
-      // the boot migration has deleted
-      ...workspaceCredentialEnv(secureCredentials),
-      ...(composioBrokerUrl() && secureCredentials.composioBrokerToken
-        ? {
-            OMB_COMPOSIO_BROKER_URL: composioBrokerUrl(),
-            OMB_COMPOSIO_BROKER_TOKEN: secureCredentials.composioBrokerToken,
-          }
-        : {}),
-    },
+    env: childEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
   proc.stdout?.on("data", (d) => slog(`[out] ${String(d).trimEnd()}`));

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -116,8 +116,14 @@ function applyUnreadBadge(win = mainWindow) {
 }
 
 // GNOME groups the window with its installed desktop entry only when both
-// identities match. This must run before Electron becomes ready.
-if (process.platform === "linux") app.setDesktopName("com.openmausbot.app.desktop");
+// identities match. This must run before Electron becomes ready. Ubuntu also
+// uses Chromium's software renderer: the supported machine reproduced two
+// NVIDIA/libGLES GPU-process crashes that left an invisible focused window
+// intercepting input. This app is not graphics-heavy, so reliability wins.
+if (process.platform === "linux") {
+  app.disableHardwareAcceleration();
+  app.setDesktopName("com.openmausbot.app.desktop");
+}
 
 // One instance per user: without this lock a second launch forks a second
 // harness server on a fallback port and splits data dirs in two. The loser
@@ -731,6 +737,7 @@ function createWindow() {
             mcpEnv: connection?.mcp?.env,
           };
         }
+        result.hardwareAccelerationEnabled = app.isHardwareAccelerationEnabled();
         result.displayMediaRequests = displayMediaRequestCount;
         console.log(`[smoke] renderer-ready ${JSON.stringify(result)}`);
       } catch (error) {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -19,6 +19,10 @@ import { buildDiagnosticsReport, decodeLogTail, diagnosticsFileName } from "./di
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow } from "./single-instance.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
+import {
+  ensureManagedComposioCredentials,
+  managedComposioAccess,
+} from "./managed-composio.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
@@ -260,49 +264,6 @@ function composioBrokerUrl() {
   return configured || (app.isPackaged ? DEFAULT_COMPOSIO_BROKER_URL : "");
 }
 
-async function ensureManagedComposioCredentials() {
-  const brokerUrl = composioBrokerUrl();
-  if (!brokerUrl) return;
-  if (/^[0-9a-f]{64}$/.test(secureCredentials.composioBrokerToken ?? "")) {
-    try {
-      const check = await fetch(`${brokerUrl}/v1/me`, {
-        headers: { authorization: `Bearer ${secureCredentials.composioBrokerToken}` },
-        signal: AbortSignal.timeout(8_000),
-      });
-      if (check.ok) return;
-      // Only a definitive auth failure rotates the credential. A transient
-      // outage keeps the existing identity so reconnecting cannot strand
-      // the user's already-authorized accounts under a new installation.
-      if (check.status !== 401) return;
-      delete secureCredentials.composioBrokerToken;
-      delete secureCredentials.composioInstallationId;
-    } catch {
-      return;
-    }
-  }
-  try {
-    const response = await fetch(`${brokerUrl}/v1/installations`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "{}",
-      signal: AbortSignal.timeout(15_000),
-    });
-    const body = await response.json().catch(() => null);
-    if (!response.ok) throw new Error(body?.error || `HTTP ${response.status}`);
-    if (!/^[0-9a-f]{64}$/.test(body?.token ?? "") || typeof body?.installationId !== "string") {
-      throw new Error("the connected-apps service returned invalid credentials");
-    }
-    secureCredentials.composioBrokerToken = body.token;
-    secureCredentials.composioInstallationId = body.installationId;
-    await saveSecureCredentials(secureCredentials);
-    slog("connected-apps installation registered");
-  } catch (error) {
-    // Never block app startup on a hosted integration. A user running their
-    // own Composio project key still has the local fallback below.
-    slog(`connected-apps registration failed: ${error?.message ?? error}`);
-  }
-}
-
 // The packaged app has no terminal: everything about the server child's life
 // goes to server.log in the OS log dir (~/Library/Logs/OpenMausBot on macOS,
 // Console.app-visible; %APPDATA%\OpenMausBot\logs on Windows), which is also
@@ -454,6 +415,18 @@ async function startServerPackaged() {
     await new Promise((r) => setTimeout(r, 2500));
   }
   return false;
+}
+
+function syncManagedComposioCredentials() {
+  if (!serverProc) return;
+  try {
+    serverProc.postMessage({
+      type: "openmausbot:managed-composio",
+      access: managedComposioAccess(composioBrokerUrl(), secureCredentials),
+    });
+  } catch (error) {
+    slog(`connected-apps credential sync failed: ${error?.message ?? error}`);
+  }
 }
 
 const ERROR_PAGE =
@@ -1082,7 +1055,6 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     await secureComposioConfig();
     await secureWorkspaceConfig();
-    await ensureManagedComposioCredentials();
   }
   // Display capture remains user-initiated. The renderer first sends a
   // short-lived one-shot intent, then calls getDisplayMedia in the same click.
@@ -1158,6 +1130,17 @@ app.whenReady().then(async () => {
     void startCompanion({ resourcesPath: process.resourcesPath, harnessPort: SERVER_PORT, log: slog });
   }
   const win = createWindow();
+  // Registration is optional network work. Start it only after the local
+  // server and first window are usable, then update the server child over its
+  // private parent port so Connected Apps becomes available without restart.
+  if (app.isPackaged && composioBrokerUrl()) {
+    void ensureManagedComposioCredentials({
+      brokerUrl: composioBrokerUrl(),
+      credentials: secureCredentials,
+      saveCredentials: saveSecureCredentials,
+      log: slog,
+    }).finally(syncManagedComposioCredentials);
+  }
   // in-app auto-update (packaged only) — checks GitHub releases, downloads on
   // the user's click, installs on "Restart to update"
   startUpdater(win);

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1164,6 +1164,22 @@ app.on("window-all-closed", () => {
 // Cap the defer so a wedged daemon cannot keep the app alive forever.
 const CUA_STOP_TIMEOUT_MS = 2500;
 let cuaCleanedUp = false;
+let signalQuitRequested = false;
+
+// Package managers, desktop watchdogs, and terminal launchers commonly stop
+// Linux apps with SIGTERM/SIGINT. Convert the first signal into Electron's
+// normal quit path so the embedded server, Cua descriptor/socket, and private
+// AppImage stage receive the same bounded cleanup as a window close. A second
+// signal keeps Node's default force-quit behavior because these are `once`
+// listeners.
+const requestSignalQuit = () => {
+  if (signalQuitRequested) return;
+  signalQuitRequested = true;
+  app.quit();
+};
+process.once("SIGINT", requestSignalQuit);
+process.once("SIGTERM", requestSignalQuit);
+
 app.on("before-quit", (e) => {
   if (cuaCleanedUp) return;
   e.preventDefault();

--- a/electron/managed-composio.mjs
+++ b/electron/managed-composio.mjs
@@ -1,0 +1,60 @@
+const TOKEN = /^[0-9a-f]{64}$/;
+
+export function managedComposioAccess(brokerUrl, credentials) {
+  const url = typeof brokerUrl === "string" ? brokerUrl.trim().replace(/\/$/, "") : "";
+  const token = credentials?.composioBrokerToken;
+  if (!url || !TOKEN.test(token ?? "")) return null;
+  return { url, token };
+}
+
+export async function ensureManagedComposioCredentials({
+  brokerUrl,
+  credentials,
+  fetchImpl = globalThis.fetch,
+  saveCredentials,
+  log = () => {},
+  timeoutSignal = (milliseconds) => AbortSignal.timeout(milliseconds),
+  existingCredentialTimeoutMs = 8_000,
+  registrationTimeoutMs = 15_000,
+}) {
+  if (!brokerUrl) return credentials;
+  if (TOKEN.test(credentials.composioBrokerToken ?? "")) {
+    try {
+      const check = await fetchImpl(`${brokerUrl}/v1/me`, {
+        headers: { authorization: `Bearer ${credentials.composioBrokerToken}` },
+        signal: timeoutSignal(existingCredentialTimeoutMs),
+      });
+      if (check.ok) return credentials;
+      // Only a definitive auth failure rotates the credential. A transient
+      // outage keeps the existing identity so reconnecting cannot strand the
+      // user's already-authorized accounts under a new installation.
+      if (check.status !== 401) return credentials;
+      delete credentials.composioBrokerToken;
+      delete credentials.composioInstallationId;
+    } catch {
+      return credentials;
+    }
+  }
+  try {
+    const response = await fetchImpl(`${brokerUrl}/v1/installations`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+      signal: timeoutSignal(registrationTimeoutMs),
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) throw new Error(body?.error || `HTTP ${response.status}`);
+    if (!TOKEN.test(body?.token ?? "") || typeof body?.installationId !== "string") {
+      throw new Error("the connected-apps service returned invalid credentials");
+    }
+    credentials.composioBrokerToken = body.token;
+    credentials.composioInstallationId = body.installationId;
+    await saveCredentials(credentials);
+    log("connected-apps installation registered");
+  } catch (error) {
+    // This operation always settles locally. The caller runs it after first
+    // paint, so an optional hosted integration cannot delay desktop readiness.
+    log(`connected-apps registration failed: ${error?.message ?? error}`);
+  }
+  return credentials;
+}

--- a/electron/managed-composio.mjs
+++ b/electron/managed-composio.mjs
@@ -1,10 +1,36 @@
 const TOKEN = /^[0-9a-f]{64}$/;
 
+export function normalizeManagedComposioBrokerUrl(value) {
+  if (typeof value !== "string" || !value.trim()) return "";
+  let parsed;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    return "";
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) return "";
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback)) return "";
+  return `${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}`;
+}
+
 export function managedComposioAccess(brokerUrl, credentials) {
-  const url = typeof brokerUrl === "string" ? brokerUrl.trim().replace(/\/$/, "") : "";
+  const url = normalizeManagedComposioBrokerUrl(brokerUrl);
   const token = credentials?.composioBrokerToken;
   if (!url || !TOKEN.test(token ?? "")) return null;
   return { url, token };
+}
+
+export function managedComposioChildEnvironment(brokerUrl, credentials, environment) {
+  const next = { ...environment };
+  delete next.OMB_COMPOSIO_BROKER_URL;
+  delete next.OMB_COMPOSIO_BROKER_TOKEN;
+  const access = managedComposioAccess(brokerUrl, credentials);
+  if (access) {
+    next.OMB_COMPOSIO_BROKER_URL = access.url;
+    next.OMB_COMPOSIO_BROKER_TOKEN = access.token;
+  }
+  return next;
 }
 
 export async function ensureManagedComposioCredentials({
@@ -17,11 +43,16 @@ export async function ensureManagedComposioCredentials({
   existingCredentialTimeoutMs = 8_000,
   registrationTimeoutMs = 15_000,
 }) {
-  if (!brokerUrl) return credentials;
+  const url = normalizeManagedComposioBrokerUrl(brokerUrl);
+  if (!url) {
+    if (brokerUrl) log("connected-apps broker URL rejected: HTTPS or a loopback HTTP URL is required");
+    return credentials;
+  }
   if (TOKEN.test(credentials.composioBrokerToken ?? "")) {
     try {
-      const check = await fetchImpl(`${brokerUrl}/v1/me`, {
+      const check = await fetchImpl(`${url}/v1/me`, {
         headers: { authorization: `Bearer ${credentials.composioBrokerToken}` },
+        redirect: "error",
         signal: timeoutSignal(existingCredentialTimeoutMs),
       });
       if (check.ok) return credentials;
@@ -36,10 +67,11 @@ export async function ensureManagedComposioCredentials({
     }
   }
   try {
-    const response = await fetchImpl(`${brokerUrl}/v1/installations`, {
+    const response = await fetchImpl(`${url}/v1/installations`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: "{}",
+      redirect: "error",
       signal: timeoutSignal(registrationTimeoutMs),
     });
     const body = await response.json().catch(() => null);

--- a/electron/managed-composio.test.mjs
+++ b/electron/managed-composio.test.mjs
@@ -28,6 +28,9 @@ describe("managed Composio desktop registration", () => {
     expect(normalizeManagedComposioBrokerUrl("http://localhost:8787")).toBe(
       "http://localhost:8787",
     );
+    expect(normalizeManagedComposioBrokerUrl("http://[::1]:8787/")).toBe(
+      "http://[::1]:8787",
+    );
     expect(normalizeManagedComposioBrokerUrl("http://broker.example")).toBe("");
     expect(normalizeManagedComposioBrokerUrl("https://user:secret@broker.example")).toBe("");
     expect(normalizeManagedComposioBrokerUrl("https://broker.example?redirect=evil")).toBe("");
@@ -49,6 +52,13 @@ describe("managed Composio desktop registration", () => {
         OMB_COMPOSIO_BROKER_TOKEN: "attacker-controlled",
       }),
     ).toEqual({ PATH: "/usr/bin" });
+    expect(
+      managedComposioChildEnvironment("http://[::1]:8787", credentials, { PATH: "/usr/bin" }),
+    ).toEqual({
+      PATH: "/usr/bin",
+      OMB_COMPOSIO_BROKER_URL: "http://[::1]:8787",
+      OMB_COMPOSIO_BROKER_TOKEN: TOKEN,
+    });
   });
 
   it("registers a new installation and persists it", async () => {

--- a/electron/managed-composio.test.mjs
+++ b/electron/managed-composio.test.mjs
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ensureManagedComposioCredentials,
+  managedComposioAccess,
+} from "./managed-composio.mjs";
+
+const TOKEN = "a".repeat(64);
+
+describe("managed Composio desktop registration", () => {
+  it("publishes only a complete broker credential", () => {
+    expect(managedComposioAccess("https://broker.example/", { composioBrokerToken: TOKEN })).toEqual({
+      url: "https://broker.example",
+      token: TOKEN,
+    });
+    expect(managedComposioAccess("https://broker.example", {})).toBeNull();
+    expect(managedComposioAccess("", { composioBrokerToken: TOKEN })).toBeNull();
+  });
+
+  it("registers a new installation and persists it", async () => {
+    const credentials = {};
+    const saveCredentials = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ token: TOKEN, installationId: "installation-test" }),
+    }));
+
+    await ensureManagedComposioCredentials({
+      brokerUrl: "https://broker.example",
+      credentials,
+      fetchImpl,
+      saveCredentials,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://broker.example/v1/installations",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(credentials).toEqual({
+      composioBrokerToken: TOKEN,
+      composioInstallationId: "installation-test",
+    });
+    expect(saveCredentials).toHaveBeenCalledWith(credentials);
+  });
+
+  it("settles a stalled optional registration without storing partial credentials", async () => {
+    vi.useFakeTimers();
+    try {
+      const credentials = {};
+      const saveCredentials = vi.fn(async () => {});
+      const log = vi.fn();
+      const fetchImpl = vi.fn(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+          }),
+      );
+      const operation = ensureManagedComposioCredentials({
+        brokerUrl: "https://broker.example",
+        credentials,
+        fetchImpl,
+        saveCredentials,
+        log,
+        registrationTimeoutMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(operation).resolves.toBe(credentials);
+      expect(credentials).toEqual({});
+      expect(saveCredentials).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("registration failed"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a valid installation identity during a transient broker outage", async () => {
+    const credentials = {
+      composioBrokerToken: TOKEN,
+      composioInstallationId: "installation-test",
+    };
+    const saveCredentials = vi.fn(async () => {});
+
+    await ensureManagedComposioCredentials({
+      brokerUrl: "https://broker.example",
+      credentials,
+      fetchImpl: vi.fn(async () => {
+        throw new Error("offline");
+      }),
+      saveCredentials,
+    });
+
+    expect(credentials).toEqual({
+      composioBrokerToken: TOKEN,
+      composioInstallationId: "installation-test",
+    });
+    expect(saveCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/electron/managed-composio.test.mjs
+++ b/electron/managed-composio.test.mjs
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ensureManagedComposioCredentials,
   managedComposioAccess,
+  managedComposioChildEnvironment,
+  normalizeManagedComposioBrokerUrl,
 } from "./managed-composio.mjs";
 
 const TOKEN = "a".repeat(64);
@@ -14,6 +16,39 @@ describe("managed Composio desktop registration", () => {
     });
     expect(managedComposioAccess("https://broker.example", {})).toBeNull();
     expect(managedComposioAccess("", { composioBrokerToken: TOKEN })).toBeNull();
+  });
+
+  it("accepts HTTPS and loopback development brokers but rejects insecure remote URLs", async () => {
+    expect(normalizeManagedComposioBrokerUrl("https://broker.example/root/")).toBe(
+      "https://broker.example/root",
+    );
+    expect(normalizeManagedComposioBrokerUrl("http://127.0.0.1:8787/")).toBe(
+      "http://127.0.0.1:8787",
+    );
+    expect(normalizeManagedComposioBrokerUrl("http://localhost:8787")).toBe(
+      "http://localhost:8787",
+    );
+    expect(normalizeManagedComposioBrokerUrl("http://broker.example")).toBe("");
+    expect(normalizeManagedComposioBrokerUrl("https://user:secret@broker.example")).toBe("");
+    expect(normalizeManagedComposioBrokerUrl("https://broker.example?redirect=evil")).toBe("");
+
+    const fetchImpl = vi.fn();
+    const credentials = { composioBrokerToken: TOKEN };
+    await ensureManagedComposioCredentials({
+      brokerUrl: "http://broker.example",
+      credentials,
+      fetchImpl,
+      saveCredentials: vi.fn(),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(managedComposioAccess("http://broker.example", credentials)).toBeNull();
+    expect(
+      managedComposioChildEnvironment("http://broker.example", credentials, {
+        PATH: "/usr/bin",
+        OMB_COMPOSIO_BROKER_URL: "http://attacker.example",
+        OMB_COMPOSIO_BROKER_TOKEN: "attacker-controlled",
+      }),
+    ).toEqual({ PATH: "/usr/bin" });
   });
 
   it("registers a new installation and persists it", async () => {
@@ -33,7 +68,7 @@ describe("managed Composio desktop registration", () => {
 
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://broker.example/v1/installations",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({ method: "POST", redirect: "error" }),
     );
     expect(credentials).toEqual({
       composioBrokerToken: TOKEN,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",
+    "smoke:cua-x11-input": "node scripts/smoke-cua-x11-input.mjs",
     "package:linux:dir": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux dir --x64 --publish never",
     "package": "pnpm package:mac",
     "test:packaged-server": "pnpm build:server && node scripts/smoke-packaged-server.mjs",

--- a/scripts/linux-after-install.test.mjs
+++ b/scripts/linux-after-install.test.mjs
@@ -20,7 +20,10 @@ function fixture() {
     fs.writeFileSync(path.join(cuaRoot, executable), "fixture", { mode: 0o664 });
     fs.chmodSync(path.join(cuaRoot, executable), 0o664);
   }
-  return { appRoot, resources, cuaRoot };
+  const chromiumSandbox = path.join(appRoot, "chrome-sandbox");
+  fs.writeFileSync(chromiumSandbox, "fixture", { mode: 0o664 });
+  fs.chmodSync(chromiumSandbox, 0o664);
+  return { appRoot, resources, cuaRoot, chromiumSandbox };
 }
 
 function runHook(appRoot) {
@@ -38,7 +41,7 @@ afterEach(() => {
 
 describe.skipIf(process.platform !== "linux")("Linux DEB upgrade hook", () => {
   it("repairs legacy directory and executable modes idempotently", () => {
-    const { appRoot, resources, cuaRoot } = fixture();
+    const { appRoot, resources, cuaRoot, chromiumSandbox } = fixture();
 
     for (let pass = 0; pass < 2; pass += 1) {
       const result = runHook(appRoot);
@@ -49,6 +52,7 @@ describe.skipIf(process.platform !== "linux")("Linux DEB upgrade hook", () => {
       for (const executable of ["cua-driver", "cua-cursor-theme"]) {
         expect(fs.lstatSync(path.join(cuaRoot, executable)).mode & 0o777).toBe(0o755);
       }
+      expect(fs.lstatSync(chromiumSandbox).mode & 0o7777).toBe(0o4755);
     }
   });
 
@@ -73,6 +77,18 @@ describe.skipIf(process.platform !== "linux")("Linux DEB upgrade hook", () => {
     const result = runHook(appRoot);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("package executable is missing or unsafe");
+  });
+
+  it("fails the install when the Chromium sandbox is replaced by a symlink", () => {
+    const { appRoot, chromiumSandbox } = fixture();
+    const external = path.join(appRoot, "external-sandbox");
+    fs.writeFileSync(external, "fixture", { mode: 0o755 });
+    fs.unlinkSync(chromiumSandbox);
+    fs.symlinkSync(external, chromiumSandbox, "file");
+
+    const result = runHook(appRoot);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Chromium sandbox is missing or unsafe");
   });
 
   it("rejects a test override outside the private temporary root", () => {

--- a/scripts/linux-after-install.test.mjs
+++ b/scripts/linux-after-install.test.mjs
@@ -36,7 +36,7 @@ afterEach(() => {
   }
 });
 
-describe.skipIf(process.platform === "win32")("Linux DEB upgrade hook", () => {
+describe.skipIf(process.platform !== "linux")("Linux DEB upgrade hook", () => {
   it("repairs legacy directory and executable modes idempotently", () => {
     const { appRoot, resources, cuaRoot } = fixture();
 
@@ -76,7 +76,7 @@ describe.skipIf(process.platform === "win32")("Linux DEB upgrade hook", () => {
   });
 
   it("rejects a test override outside the private temporary root", () => {
-    const result = runHook("/opt/OpenMausBot");
+    const result = runHook(root);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("must stay under /tmp");
   });

--- a/scripts/linux-after-install.test.mjs
+++ b/scripts/linux-after-install.test.mjs
@@ -1,0 +1,90 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const hook = path.join(root, "build", "linux-after-install.sh");
+const temporaryDirectories = [];
+
+function fixture() {
+  const appRoot = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "omb-deb-upgrade-"));
+  temporaryDirectories.push(appRoot);
+  const resources = path.join(appRoot, "resources");
+  const cuaRoot = path.join(resources, "cua-linux-x64");
+  fs.mkdirSync(cuaRoot, { recursive: true, mode: 0o775 });
+  for (const directory of [appRoot, resources, cuaRoot]) fs.chmodSync(directory, 0o775);
+  for (const executable of ["cua-driver", "cua-cursor-theme"]) {
+    fs.writeFileSync(path.join(cuaRoot, executable), "fixture", { mode: 0o664 });
+    fs.chmodSync(path.join(cuaRoot, executable), 0o664);
+  }
+  return { appRoot, resources, cuaRoot };
+}
+
+function runHook(appRoot) {
+  return spawnSync("/bin/sh", [hook], {
+    encoding: "utf8",
+    env: { ...process.env, OPENMAUSBOT_POSTINSTALL_TEST_ROOT: appRoot },
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform === "win32")("Linux DEB upgrade hook", () => {
+  it("repairs legacy directory and executable modes idempotently", () => {
+    const { appRoot, resources, cuaRoot } = fixture();
+
+    for (let pass = 0; pass < 2; pass += 1) {
+      const result = runHook(appRoot);
+      expect(result.status, result.stderr).toBe(0);
+      for (const directory of [appRoot, resources, cuaRoot]) {
+        expect(fs.lstatSync(directory).mode & 0o777).toBe(0o755);
+      }
+      for (const executable of ["cua-driver", "cua-cursor-theme"]) {
+        expect(fs.lstatSync(path.join(cuaRoot, executable)).mode & 0o777).toBe(0o755);
+      }
+    }
+  });
+
+  it("refuses to follow a replaced package directory symlink", () => {
+    const { appRoot, resources } = fixture();
+    const external = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "omb-deb-external-"));
+    temporaryDirectories.push(external);
+    fs.chmodSync(external, 0o777);
+    fs.rmSync(resources, { recursive: true });
+    fs.symlinkSync(external, resources, "dir");
+
+    const result = runHook(appRoot);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("missing or unsafe");
+    expect(fs.lstatSync(external).mode & 0o777).toBe(0o777);
+  });
+
+  it("fails the install when a bundled executable is missing", () => {
+    const { appRoot, cuaRoot } = fixture();
+    fs.unlinkSync(path.join(cuaRoot, "cua-driver"));
+
+    const result = runHook(appRoot);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("package executable is missing or unsafe");
+  });
+
+  it("rejects a test override outside the private temporary root", () => {
+    const result = runHook("/opt/OpenMausBot");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must stay under /tmp");
+  });
+
+  it("resolves the test root before applying the temporary-directory boundary", () => {
+    const escaped = path.join(fs.realpathSync(os.tmpdir()), "..", path.relative("/", root));
+    const result = runHook(escaped);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must stay under /tmp");
+  });
+});

--- a/scripts/run-linux-package-smoke.mjs
+++ b/scripts/run-linux-package-smoke.mjs
@@ -62,6 +62,36 @@ for (const executable of executables) {
   await cleanupRuntime(runtimeDirectory);
 }
 
+// A desktop watchdog or package manager sends SIGTERM to Electron itself,
+// not a synthetic window close. Exercise that path against the real bundled
+// AppImage and require the same descriptor/runtime cleanup.
+if (process.exitCode === undefined) {
+  const runtimeDirectory = mkdtempSync(path.join(tmpdir(), prefixName));
+  chmodSync(runtimeDirectory, 0o700);
+  const signalShutdown = spawnSync(
+    "dbus-run-session",
+    ["--", "xvfb-run", "-a", process.execPath, path.join(root, "scripts", "smoke-linux-package.mjs")],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        XDG_RUNTIME_DIR: runtimeDirectory,
+        OMB_SMOKE_BUNDLED_CUA: "1",
+        OMB_SMOKE_SIGNAL_SHUTDOWN: "1",
+        OMB_SMOKE_EXECUTABLE: path.join(root, "release", appImage),
+      },
+      stdio: "inherit",
+    },
+  );
+  if (signalShutdown.error) throw signalShutdown.error;
+  if (signalShutdown.status !== 0) {
+    console.error(`[run-linux-package-smoke] SIGTERM runtime kept at ${runtimeDirectory}`);
+    process.exitCode = signalShutdown.status ?? 1;
+  } else {
+    await cleanupRuntime(runtimeDirectory);
+  }
+}
+
 if (process.exitCode === undefined) for (const lane of [
   { name: "x11-overlay-free-crash-retry", wayland: false, blocked: false },
   { name: "wayland-safety-block", wayland: true, blocked: true },

--- a/scripts/run-linux-package-smoke.mjs
+++ b/scripts/run-linux-package-smoke.mjs
@@ -47,7 +47,7 @@ for (const executable of executables) {
       env: {
         ...process.env,
         XDG_RUNTIME_DIR: runtimeDirectory,
-        OMB_SMOKE_LINUX_CUA_BLOCKED: "1",
+        OMB_SMOKE_BUNDLED_CUA: "1",
         OMB_SMOKE_EXECUTABLE: executable,
       },
       stdio: "inherit",
@@ -63,7 +63,8 @@ for (const executable of executables) {
 }
 
 if (process.exitCode === undefined) for (const lane of [
-  { name: "wayland-safety-block", wayland: true },
+  { name: "x11-overlay-free-crash-retry", wayland: false, blocked: false },
+  { name: "wayland-safety-block", wayland: true, blocked: true },
 ]) {
   const runtimeDirectory = mkdtempSync(path.join(tmpdir(), prefixName));
   if (
@@ -83,7 +84,7 @@ if (process.exitCode === undefined) for (const lane of [
         ...process.env,
         XDG_RUNTIME_DIR: runtimeDirectory,
         OMB_SMOKE_WAYLAND: lane.wayland ? "1" : "0",
-        OMB_SMOKE_LINUX_CUA_BLOCKED: "1",
+        OMB_SMOKE_LINUX_CUA_BLOCKED: lane.blocked ? "1" : "0",
       },
       stdio: "inherit",
     },

--- a/scripts/run-linux-package-smoke.mjs
+++ b/scripts/run-linux-package-smoke.mjs
@@ -28,10 +28,15 @@ if (appImages.length !== 1) {
 }
 const [appImage] = appImages;
 
-for (const executable of [
+const executables = [
   path.join(root, "release", "linux-unpacked", "openmausbot"),
   path.join(root, "release", appImage),
-]) {
+];
+if (process.env.OMB_SMOKE_INSTALLED_DEB === "1") {
+  executables.push("/opt/OpenMausBot/openmausbot");
+}
+
+for (const executable of executables) {
   const runtimeDirectory = mkdtempSync(path.join(tmpdir(), prefixName));
   chmodSync(runtimeDirectory, 0o700);
   const bundled = spawnSync(
@@ -42,7 +47,7 @@ for (const executable of [
       env: {
         ...process.env,
         XDG_RUNTIME_DIR: runtimeDirectory,
-        OMB_SMOKE_BUNDLED_CUA: "1",
+        OMB_SMOKE_LINUX_CUA_BLOCKED: "1",
         OMB_SMOKE_EXECUTABLE: executable,
       },
       stdio: "inherit",
@@ -58,9 +63,7 @@ for (const executable of [
 }
 
 if (process.exitCode === undefined) for (const lane of [
-  { name: "x11", wayland: false, hardDeath: false },
-  { name: "wayland", wayland: true, hardDeath: false },
-  { name: "x11-hard-death", wayland: false, hardDeath: true },
+  { name: "wayland-safety-block", wayland: true },
 ]) {
   const runtimeDirectory = mkdtempSync(path.join(tmpdir(), prefixName));
   if (
@@ -80,7 +83,7 @@ if (process.exitCode === undefined) for (const lane of [
         ...process.env,
         XDG_RUNTIME_DIR: runtimeDirectory,
         OMB_SMOKE_WAYLAND: lane.wayland ? "1" : "0",
-        OMB_SMOKE_HARD_DEATH: lane.hardDeath ? "1" : "0",
+        OMB_SMOKE_LINUX_CUA_BLOCKED: "1",
       },
       stdio: "inherit",
     },

--- a/scripts/smoke-cua-x11-input.mjs
+++ b/scripts/smoke-cua-x11-input.mjs
@@ -73,6 +73,8 @@ driverProcess.stderr.setEncoding("utf8");
 driverProcess.stderr.on("data", (chunk) => {
   driverError += chunk;
 });
+let proxy;
+let proxyError = "";
 
 const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 async function until(probe, description, timeout = 10_000) {
@@ -109,6 +111,63 @@ function driverRequest(method) {
     });
     client.once("error", reject);
   });
+}
+
+function createMcpClient() {
+  proxy = spawn(driver, ["mcp", "--socket", socketPath], {
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_RUNTIME_DIR: runtime,
+      XDG_SESSION_TYPE: "x11",
+      CUA_DRIVER_EMBEDDED: "1",
+      CUA_DRIVER_RS_TELEMETRY_ENABLED: "false",
+      CUA_DRIVER_RS_UPDATE_CHECK: "false",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const pending = new Map();
+  let buffer = "";
+  let nextId = 1;
+  proxy.stderr.setEncoding("utf8");
+  proxy.stderr.on("data", (chunk) => {
+    proxyError += chunk;
+  });
+  proxy.stdout.setEncoding("utf8");
+  proxy.stdout.on("data", (chunk) => {
+    buffer += chunk;
+    let newline;
+    while ((newline = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line.trim()) continue;
+      const message = JSON.parse(line);
+      const settle = pending.get(message.id);
+      if (settle) {
+        pending.delete(message.id);
+        settle(message);
+      }
+    }
+  });
+  return (method, params = {}) =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`${method} timed out${proxyError ? `: ${proxyError.trim()}` : ""}`));
+      }, 20_000);
+      pending.set(id, (message) => {
+        clearTimeout(timer);
+        if (message.error) reject(new Error(message.error.message));
+        else resolve(message.result);
+      });
+      proxy.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    });
+}
+
+function assertToolResult(result, name) {
+  if (result?.isError) throw new Error(result.content?.[0]?.text || `${name} failed`);
+  return result;
 }
 
 async function stop(child) {
@@ -153,29 +212,54 @@ try {
     throw new Error("Cua created its full-screen cursor overlay despite --no-overlay");
   }
 
+  const rpc = createMcpClient();
+  await rpc("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "openmausbot-x11-input-smoke", version: "1" },
+  });
+  proxy.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`);
+  const listed = await rpc("tools/list");
+  const toolNames = new Set(listed.tools.map(({ name }) => name));
+  for (const required of ["start_session", "click", "type_text"]) {
+    if (!toolNames.has(required)) throw new Error(`Cua MCP did not expose ${required}`);
+  }
+
+  const session = `openmausbot-x11-smoke-${process.pid}`;
+  assertToolResult(
+    await rpc("tools/call", {
+      name: "start_session",
+      arguments: { session, capture_scope: "window" },
+    }),
+    "start_session",
+  );
   xevOutput = "";
-  await execFileAsync("xdotool", [
-    "windowfocus",
-    windowId,
-    "mousemove",
-    "--window",
-    windowId,
-    "80",
-    "80",
+  const target = {
+    session,
+    pid: xev.pid,
+    window_id: Number(windowId),
+    x: 80,
+    y: 80,
+    scope: "window",
+    delivery_mode: "foreground",
+  };
+  assertToolResult(
+    await rpc("tools/call", { name: "click", arguments: target }),
     "click",
-    "1",
-    "key",
-    "--clearmodifiers",
-    "a",
-  ]);
+  );
+  assertToolResult(
+    await rpc("tools/call", { name: "type_text", arguments: { ...target, text: "a" } }),
+    "type_text",
+  );
   await until(
     async () => /ButtonPress event/.test(xevOutput) && /KeyPress event/.test(xevOutput),
     "an unrelated X11 window to receive pointer and keyboard input",
   );
   console.log(
-    "[smoke-cua-x11-input] OK: no full-screen Cua overlay; unrelated window received click and keyboard input",
+    "[smoke-cua-x11-input] OK: no full-screen Cua overlay; Cua click and type_text reached an unrelated window",
   );
 } finally {
+  if (proxy) await stop(proxy);
   await stop(driverProcess);
   if (xev.exitCode === null && xev.signalCode === null) xev.kill("SIGTERM");
   rmSync(sandbox, { recursive: true, force: true });

--- a/scripts/smoke-cua-x11-input.mjs
+++ b/scripts/smoke-cua-x11-input.mjs
@@ -1,0 +1,182 @@
+import { execFile, spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const driver = path.join(root, "dist-native", "cua-linux-x64", "cua-driver");
+if (process.platform !== "linux") throw new Error("the X11 input smoke is Linux-only");
+if (!process.env.DISPLAY) throw new Error("the X11 input smoke needs an active DISPLAY");
+if (!existsSync(driver)) throw new Error(`missing staged Cua Driver: ${driver}`);
+
+const prefix = "omb-cua-x11-input-";
+const sandbox = mkdtempSync(path.join(tmpdir(), prefix));
+if (path.dirname(sandbox) !== path.resolve(tmpdir()) || !path.basename(sandbox).startsWith(prefix)) {
+  throw new Error(`unexpected smoke directory: ${sandbox}`);
+}
+const runtime = path.join(sandbox, "runtime");
+const home = path.join(sandbox, "home");
+const socketPath = path.join(runtime, "driver.sock");
+const pidFile = path.join(runtime, "driver.pid");
+mkdirSync(runtime, { mode: 0o700 });
+mkdirSync(home, { mode: 0o700 });
+chmodSync(runtime, 0o700);
+chmodSync(home, 0o700);
+
+const title = `OpenMausBot CUA input safety ${process.pid}`;
+const xev = spawn(
+  "xev",
+  ["-name", title, "-geometry", "320x180+40+40"],
+  { env: process.env, stdio: ["ignore", "pipe", "pipe"] },
+);
+let xevOutput = "";
+for (const stream of [xev.stdout, xev.stderr]) {
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    xevOutput += chunk;
+  });
+}
+
+const driverProcess = spawn(
+  driver,
+  [
+    "serve",
+    "--embedded",
+    "--no-overlay",
+    "--socket",
+    socketPath,
+    "--pid-file",
+    pidFile,
+    "--permission-mode",
+    "standard",
+  ],
+  {
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_RUNTIME_DIR: runtime,
+      XDG_SESSION_TYPE: "x11",
+      CUA_DRIVER_EMBEDDED: "1",
+      CUA_DRIVER_PARENT_LIVENESS_STDIN: "1",
+      CUA_DRIVER_RS_TELEMETRY_ENABLED: "false",
+      CUA_DRIVER_RS_UPDATE_CHECK: "false",
+    },
+    stdio: ["pipe", "ignore", "pipe"],
+  },
+);
+let driverError = "";
+driverProcess.stderr.setEncoding("utf8");
+driverProcess.stderr.on("data", (chunk) => {
+  driverError += chunk;
+});
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+async function until(probe, description, timeout = 10_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const value = await probe().catch(() => null);
+    if (value) return value;
+    if (driverProcess.exitCode !== null || driverProcess.signalCode !== null) {
+      throw new Error(
+        `Cua Driver exited before ${description}: ${driverProcess.exitCode ?? driverProcess.signalCode}\n${driverError}`,
+      );
+    }
+    await delay(25);
+  }
+  throw new Error(`timed out waiting for ${description}\n${driverError}\n${xevOutput}`);
+}
+
+function driverRequest(method) {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection(socketPath);
+    let response = "";
+    client.setEncoding("utf8");
+    client.once("connect", () => client.write(`${JSON.stringify({ method })}\n`));
+    client.on("data", (chunk) => {
+      response += chunk;
+      const newline = response.indexOf("\n");
+      if (newline === -1) return;
+      client.end();
+      try {
+        resolve(JSON.parse(response.slice(0, newline)));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    client.once("error", reject);
+  });
+}
+
+async function stop(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.stdin?.end();
+  const deadline = Date.now() + 2_000;
+  while (child.exitCode === null && child.signalCode === null && Date.now() < deadline) {
+    await delay(25);
+  }
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+}
+
+try {
+  const windowId = await until(async () => {
+    if (xev.exitCode !== null || xev.signalCode !== null) {
+      throw new Error(`xev exited before its test window appeared:\n${xevOutput}`);
+    }
+    const { stdout } = await execFileAsync("xdotool", [
+      "search",
+      "--onlyvisible",
+      "--name",
+      `^${title}$`,
+    ]);
+    return stdout.trim().split(/\s+/)[0] || null;
+  }, "the unrelated X11 test window");
+  if (!windowId) throw new Error("xev test window did not appear");
+
+  const metadata = await until(
+    async () => {
+      if (!existsSync(socketPath)) return null;
+      const response = await driverRequest("metadata");
+      return response?.ok === true ? response.result : null;
+    },
+    "the overlay-free driver handshake",
+  );
+  if (metadata.driver_version !== "0.19.3" || metadata.embedded !== true) {
+    throw new Error(`unexpected driver metadata: ${JSON.stringify(metadata)}`);
+  }
+
+  const { stdout: tree } = await execFileAsync("xwininfo", ["-root", "-tree"]);
+  if (tree.includes("Cua.AgentCursorOverlay")) {
+    throw new Error("Cua created its full-screen cursor overlay despite --no-overlay");
+  }
+
+  xevOutput = "";
+  await execFileAsync("xdotool", [
+    "windowfocus",
+    windowId,
+    "mousemove",
+    "--window",
+    windowId,
+    "80",
+    "80",
+    "click",
+    "1",
+    "key",
+    "--clearmodifiers",
+    "a",
+  ]);
+  await until(
+    async () => /ButtonPress event/.test(xevOutput) && /KeyPress event/.test(xevOutput),
+    "an unrelated X11 window to receive pointer and keyboard input",
+  );
+  console.log(
+    "[smoke-cua-x11-input] OK: no full-screen Cua overlay; unrelated window received click and keyboard input",
+  );
+} finally {
+  await stop(driverProcess);
+  if (xev.exitCode === null && xev.signalCode === null) xev.kill("SIGTERM");
+  rmSync(sandbox, { recursive: true, force: true });
+}

--- a/scripts/smoke-deb-upgrade.mjs
+++ b/scripts/smoke-deb-upgrade.mjs
@@ -88,6 +88,18 @@ try {
       fail(`upgraded executable is not root:root 0755: ${file}`);
     }
   }
+  const chromiumSandbox = "/opt/OpenMausBot/chrome-sandbox";
+  const sandboxDetails = fs.lstatSync(chromiumSandbox);
+  if (!sandboxDetails.isFile() || sandboxDetails.isSymbolicLink()) {
+    fail(`unsafe upgraded Chromium sandbox: ${chromiumSandbox}`);
+  }
+  if (
+    sandboxDetails.uid !== 0 ||
+    sandboxDetails.gid !== 0 ||
+    (sandboxDetails.mode & 0o7777) !== 0o4755
+  ) {
+    fail(`upgraded Chromium sandbox is not root:root 4755: ${chromiumSandbox}`);
+  }
   const installedVersion = execFileSync("dpkg-query", ["-W", "-f=${Version}", "openmausbot"], {
     encoding: "utf8",
   }).trim();

--- a/scripts/smoke-deb-upgrade.mjs
+++ b/scripts/smoke-deb-upgrade.mjs
@@ -62,7 +62,13 @@ try {
     if (mode !== 0o775) fail(`legacy fixture did not reproduce 0775 at ${directory}`);
   }
 
-  execFileSync("dpkg", ["--install", candidate], { stdio: "inherit" });
+  // apt configures the real artifact and resolves its declared desktop
+  // dependencies. Calling dpkg directly can leave the package unconfigured on
+  // the intentionally minimal runner before its post-install hook is tested.
+  execFileSync("apt-get", ["install", "-y", "--no-install-recommends", candidate], {
+    env: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
+    stdio: "inherit",
+  });
   for (const directory of [
     "/opt/OpenMausBot",
     "/opt/OpenMausBot/resources",

--- a/scripts/smoke-deb-upgrade.mjs
+++ b/scripts/smoke-deb-upgrade.mjs
@@ -1,0 +1,93 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  throw new Error(`[smoke-deb-upgrade] ${message}`);
+}
+
+if (process.platform !== "linux" || process.env.CI !== "true" || process.getuid?.() !== 0) {
+  fail("this system-package test runs only as root on an ephemeral Linux CI runner");
+}
+const runnerTemp = process.env.RUNNER_TEMP;
+if (!runnerTemp || !path.isAbsolute(runnerTemp) || !fs.existsSync(runnerTemp)) {
+  fail("RUNNER_TEMP must be an existing absolute CI path");
+}
+const candidate = path.resolve(process.argv[2] ?? "");
+if (!candidate.endsWith(".deb") || !fs.existsSync(candidate)) fail("pass the newly built DEB path");
+
+try {
+  const status = execFileSync("dpkg-query", ["-W", "-f=${db:Status-Abbrev}", "openmausbot"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (status.startsWith("ii")) fail("refusing to replace a pre-existing OpenMausBot installation");
+} catch (error) {
+  if (String(error?.message ?? error).includes("refusing to replace")) throw error;
+}
+
+const temporary = fs.mkdtempSync(path.join(path.resolve(runnerTemp), "omb-deb-upgrade-"));
+if (path.dirname(temporary) !== path.resolve(runnerTemp)) fail("temporary fixture escaped RUNNER_TEMP");
+const legacyRoot = path.join(temporary, "legacy-package");
+const controlRoot = path.join(legacyRoot, "DEBIAN");
+const legacyApp = path.join(legacyRoot, "opt", "OpenMausBot");
+const legacyResources = path.join(legacyApp, "resources");
+const legacyDeb = path.join(temporary, "openmausbot_0.1.7_amd64.deb");
+
+try {
+  fs.mkdirSync(controlRoot, { recursive: true, mode: 0o755 });
+  fs.mkdirSync(legacyResources, { recursive: true, mode: 0o775 });
+  fs.chmodSync(legacyApp, 0o775);
+  fs.chmodSync(legacyResources, 0o775);
+  fs.writeFileSync(
+    path.join(controlRoot, "control"),
+    [
+      "Package: openmausbot",
+      "Version: 0.1.7",
+      "Architecture: amd64",
+      "Maintainer: OpenMausBot CI <ci@openmausbot.invalid>",
+      "Description: Legacy OpenMausBot directory-mode upgrade fixture",
+      "",
+    ].join("\n"),
+    { mode: 0o644 },
+  );
+  fs.writeFileSync(path.join(legacyResources, "legacy-upgrade-fixture"), "0.1.7\n", { mode: 0o644 });
+
+  execFileSync("dpkg-deb", ["--build", "--root-owner-group", legacyRoot, legacyDeb], {
+    stdio: "inherit",
+  });
+  execFileSync("dpkg", ["--install", legacyDeb], { stdio: "inherit" });
+  for (const directory of ["/opt/OpenMausBot", "/opt/OpenMausBot/resources"]) {
+    const mode = fs.lstatSync(directory).mode & 0o777;
+    if (mode !== 0o775) fail(`legacy fixture did not reproduce 0775 at ${directory}`);
+  }
+
+  execFileSync("dpkg", ["--install", candidate], { stdio: "inherit" });
+  for (const directory of [
+    "/opt/OpenMausBot",
+    "/opt/OpenMausBot/resources",
+    "/opt/OpenMausBot/resources/cua-linux-x64",
+  ]) {
+    const details = fs.lstatSync(directory);
+    if (!details.isDirectory() || details.isSymbolicLink()) fail(`unsafe upgraded directory: ${directory}`);
+    if (details.uid !== 0 || details.gid !== 0 || (details.mode & 0o777) !== 0o755) {
+      fail(`upgraded directory is not root:root 0755: ${directory}`);
+    }
+  }
+  for (const executable of ["cua-driver", "cua-cursor-theme"]) {
+    const file = path.join("/opt/OpenMausBot/resources/cua-linux-x64", executable);
+    const details = fs.lstatSync(file);
+    if (!details.isFile() || details.isSymbolicLink()) fail(`unsafe upgraded executable: ${file}`);
+    if (details.uid !== 0 || details.gid !== 0 || (details.mode & 0o777) !== 0o755) {
+      fail(`upgraded executable is not root:root 0755: ${file}`);
+    }
+  }
+  const installedVersion = execFileSync("dpkg-query", ["-W", "-f=${Version}", "openmausbot"], {
+    encoding: "utf8",
+  }).trim();
+  console.log(
+    `[smoke-deb-upgrade] OK: 0.1.7 legacy modes repaired by ${installedVersion} without weakening the runtime path`,
+  );
+} finally {
+  fs.rmSync(temporary, { recursive: true, force: true });
+}

--- a/scripts/smoke-linux-package.mjs
+++ b/scripts/smoke-linux-package.mjs
@@ -18,8 +18,12 @@ const wayland = process.env.OMB_SMOKE_WAYLAND === "1";
 const hardDeath = process.env.OMB_SMOKE_HARD_DEATH === "1";
 const bundled = process.env.OMB_SMOKE_BUNDLED_CUA === "1";
 const sessionBlocked = process.env.OMB_SMOKE_LINUX_CUA_BLOCKED === "1";
+const signalShutdown = process.env.OMB_SMOKE_SIGNAL_SHUTDOWN === "1";
 if ([hardDeath, bundled, sessionBlocked].filter(Boolean).length > 1) {
   throw new Error("hard-death, bundled, and release-safety smoke modes are mutually exclusive");
+}
+if (signalShutdown && !bundled) {
+  throw new Error("signal-shutdown smoke requires the bundled runtime mode");
 }
 const executable = path.resolve(
   process.env.OMB_SMOKE_EXECUTABLE ?? path.join(root, "release", "linux-unpacked", "openmausbot"),
@@ -193,8 +197,8 @@ const desktopEnv = {
   OMB_SMOKE_TEST: "1",
   OMB_SMOKE_CUA: hardDeath || bundled || sessionBlocked ? "0" : "1",
   OMB_SMOKE_BUNDLED_CUA: bundled ? "1" : "0",
-  ...(hardDeath ? { OMB_SMOKE_KEEP_OPEN: "1" } : {}),
 };
+if (hardDeath || signalShutdown) desktopEnv.OMB_SMOKE_KEEP_OPEN = "1";
 if (bundled) delete desktopEnv.CUA_DRIVER_PATH;
 if (wayland) desktopEnv.WAYLAND_DISPLAY = "wayland-smoke";
 else delete desktopEnv.WAYLAND_DISPLAY;
@@ -341,6 +345,7 @@ try {
       `[smoke-linux-package] OK (${wayland ? "GNOME/Wayland" : path.basename(executable)}): slow optional broker did not block first paint and Wayland CUA failed closed`,
     );
   } else if (bundled) {
+    if (signalShutdown) child.kill("SIGTERM");
     await waitForExit();
     const staleHealth = await fetch(new URL("/api/health", location)).catch(() => null);
     if (staleHealth?.ok) throw new Error("embedded harness remained reachable after Electron quit");
@@ -373,6 +378,28 @@ try {
     if (existsSync(marker)) {
       throw new Error(`packaged app invoked the ambient driver:\n${readFileSync(marker, "utf8")}`);
     }
+    const userData = ["openmausbot", "OpenMausBot"]
+      .map((name) => path.join(xdgConfig, name))
+      .find((directory) => existsSync(path.join(directory, "cua-connection.json")));
+    if (!userData) throw new Error("bundled smoke could not locate the CUA descriptor");
+    const persistedConnection = JSON.parse(
+      readFileSync(path.join(userData, "cua-connection.json"), "utf8"),
+    );
+    if (
+      persistedConnection.mode !== "unavailable" ||
+      persistedConnection.status !== "stopped" ||
+      persistedConnection.reasonCode !== "app-stopped"
+    ) {
+      throw new Error(
+        `packaged CUA descriptor did not record a clean shutdown: ${JSON.stringify(persistedConnection)}`,
+      );
+    }
+    const { readCuaConnection } = await import(
+      new URL("../dist-server/local-computer.js", import.meta.url)
+    );
+    if (readCuaConnection({ platform: "linux", userData }) !== null) {
+      throw new Error("packaged CUA descriptor remained usable after shutdown");
+    }
     try {
       process.kill(cuaRuntime.daemonPid, 0);
       throw new Error(`packaged CUA daemon remained alive after quit: ${cuaRuntime.daemonPid}`);
@@ -380,7 +407,7 @@ try {
       if (error?.code !== "ESRCH") throw error;
     }
     console.log(
-      `[smoke-linux-package] OK (bundled ${path.basename(executable)}): packaged resolver, descriptor, harness, and cleanup`,
+      `[smoke-linux-package] OK (bundled ${path.basename(executable)}${signalShutdown ? " SIGTERM" : ""}): packaged resolver, descriptor, harness, and cleanup`,
     );
   } else {
     const invocations = readFileSync(marker, "utf8")

--- a/scripts/smoke-linux-package.mjs
+++ b/scripts/smoke-linux-package.mjs
@@ -306,7 +306,11 @@ try {
       );
     }
   } else {
-    if (!initialCapabilities.localComputer.available) throw new Error("initial Linux CUA runtime was not ready");
+    if (!initialCapabilities.localComputer.available) {
+      throw new Error(
+        `initial Linux CUA runtime was not ready: ${JSON.stringify(initialCapabilities.localComputer)}`,
+      );
+    }
     if (initialCapabilities.localComputer.support !== "limited") throw new Error("Linux CUA was not marked beta/limited");
     if (wayland && (
       initialCapabilities.localComputer.session !== "wayland" ||

--- a/scripts/smoke-linux-package.mjs
+++ b/scripts/smoke-linux-package.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
 import {
   chmodSync,
   existsSync,
@@ -16,7 +17,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const wayland = process.env.OMB_SMOKE_WAYLAND === "1";
 const hardDeath = process.env.OMB_SMOKE_HARD_DEATH === "1";
 const bundled = process.env.OMB_SMOKE_BUNDLED_CUA === "1";
-if (hardDeath && bundled) throw new Error("hard-death and bundled smoke modes are mutually exclusive");
+const releaseBlocked = process.env.OMB_SMOKE_LINUX_CUA_BLOCKED === "1";
+if ([hardDeath, bundled, releaseBlocked].filter(Boolean).length > 1) {
+  throw new Error("hard-death, bundled, and release-safety smoke modes are mutually exclusive");
+}
 const executable = path.resolve(
   process.env.OMB_SMOKE_EXECUTABLE ?? path.join(root, "release", "linux-unpacked", "openmausbot"),
 );
@@ -154,6 +158,27 @@ process.on("SIGTERM", shutdown);
 );
 chmodSync(sentinel, 0o755);
 
+// Accept the optional managed-Composio request but never answer it. The
+// renderer must still become ready and close normally while this request is
+// pending, proving hosted integration latency is outside first paint.
+let brokerRequests = 0;
+const brokerSockets = new Set();
+const slowBroker = createServer(() => {
+  brokerRequests += 1;
+});
+slowBroker.on("connection", (socket) => {
+  brokerSockets.add(socket);
+  socket.once("close", () => brokerSockets.delete(socket));
+});
+await new Promise((resolve, reject) => {
+  slowBroker.once("error", reject);
+  slowBroker.listen(0, "127.0.0.1", resolve);
+});
+const brokerAddress = slowBroker.address();
+if (!brokerAddress || typeof brokerAddress === "string") {
+  throw new Error("could not start the deterministic slow Composio broker");
+}
+
 const desktopEnv = {
   ...process.env,
   HOME: home,
@@ -162,8 +187,9 @@ const desktopEnv = {
   XDG_SESSION_TYPE: wayland ? "wayland" : "x11",
   XDG_CURRENT_DESKTOP: "GNOME",
   CUA_DRIVER_PATH: sentinel,
+  OMB_COMPOSIO_BROKER_URL: `http://127.0.0.1:${brokerAddress.port}`,
   OMB_SMOKE_TEST: "1",
-  OMB_SMOKE_CUA: hardDeath || bundled ? "0" : "1",
+  OMB_SMOKE_CUA: hardDeath || bundled || releaseBlocked ? "0" : "1",
   OMB_SMOKE_BUNDLED_CUA: bundled ? "1" : "0",
   ...(hardDeath ? { OMB_SMOKE_KEEP_OPEN: "1" } : {}),
 };
@@ -263,24 +289,53 @@ try {
     throw new Error(`${wayland ? "Wayland" : "X11"} screen preview capability was not available`);
   }
   if (capabilities.dictation.available) throw new Error("dictation must be unavailable on Linux");
-  if (!initialCapabilities.localComputer.available) throw new Error("initial Linux CUA runtime was not ready");
-  if (initialCapabilities.localComputer.support !== "limited") throw new Error("Linux CUA was not marked beta/limited");
-  if (wayland && (
-    initialCapabilities.localComputer.session !== "wayland" ||
-    initialCapabilities.localComputer.compositor !== "gnome-mutter"
-  )) {
-    throw new Error("initial Linux CUA runtime did not publish the guarded GNOME Wayland contract");
-  }
-  if (!bundled && !hardDeath) {
-    if (cuaCrashReason !== "daemon-exited") {
-      throw new Error("daemon crash did not invalidate local control");
+  if (releaseBlocked) {
+    if (
+      initialCapabilities.localComputer.available ||
+      initialCapabilities.localComputer.enabled ||
+      initialCapabilities.localComputer.reasonCode !== "linux-seat-safety-blocked"
+    ) {
+      throw new Error(
+        `Linux release did not fail closed: ${JSON.stringify(initialCapabilities.localComputer)}`,
+      );
     }
-    if (cuaRetryStatus?.status !== "ready" || !capabilities.localComputer.available) {
-      throw new Error("explicit CUA retry did not create a ready generation");
+  } else {
+    if (!initialCapabilities.localComputer.available) throw new Error("initial Linux CUA runtime was not ready");
+    if (initialCapabilities.localComputer.support !== "limited") throw new Error("Linux CUA was not marked beta/limited");
+    if (wayland && (
+      initialCapabilities.localComputer.session !== "wayland" ||
+      initialCapabilities.localComputer.compositor !== "gnome-mutter"
+    )) {
+      throw new Error("initial Linux CUA runtime did not publish the guarded GNOME Wayland contract");
+    }
+    if (!bundled && !hardDeath) {
+      if (cuaCrashReason !== "daemon-exited") {
+        throw new Error("daemon crash did not invalidate local control");
+      }
+      if (cuaRetryStatus?.status !== "ready" || !capabilities.localComputer.available) {
+        throw new Error("explicit CUA retry did not create a ready generation");
+      }
     }
   }
   if (displayMediaRequests !== 0) throw new Error("launch triggered display capture without user intent");
-  if (bundled) {
+  await until(async () => brokerRequests > 0, "the optional slow-broker request");
+  if (releaseBlocked) {
+    await waitForExit();
+    if (existsSync(marker)) throw new Error("release safety block still invoked a CUA executable");
+    const activeUserData = ["openmausbot", "OpenMausBot"]
+      .map((name) => path.join(xdgConfig, name))
+      .find((directory) => existsSync(path.join(directory, "cua-connection.json")));
+    if (!activeUserData) throw new Error("release safety smoke could not locate the CUA descriptor");
+    const preference = JSON.parse(
+      readFileSync(path.join(activeUserData, "cua-local-control.json"), "utf8"),
+    );
+    if (preference.linuxLocalControlEnabled !== false) {
+      throw new Error("release safety block did not clear the durable Linux opt-in");
+    }
+    console.log(
+      `[smoke-linux-package] OK (${wayland ? "GNOME/Wayland" : path.basename(executable)}): slow optional broker did not block first paint and Linux CUA failed closed`,
+    );
+  } else if (bundled) {
     await waitForExit();
     const staleHealth = await fetch(new URL("/api/health", location)).catch(() => null);
     if (staleHealth?.ok) throw new Error("embedded harness remained reachable after Electron quit");
@@ -498,6 +553,8 @@ try {
   }
 } finally {
   await stopProcess();
+  for (const socket of brokerSockets) socket.destroy();
+  await new Promise((resolve) => slowBroker.close(resolve));
   if (process.env.OMB_KEEP_SMOKE_DIR !== "1") rmSync(sandbox, { recursive: true, force: true });
   else console.log(`[smoke-linux-package] kept ${sandbox}`);
 }

--- a/scripts/smoke-linux-package.mjs
+++ b/scripts/smoke-linux-package.mjs
@@ -17,8 +17,8 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const wayland = process.env.OMB_SMOKE_WAYLAND === "1";
 const hardDeath = process.env.OMB_SMOKE_HARD_DEATH === "1";
 const bundled = process.env.OMB_SMOKE_BUNDLED_CUA === "1";
-const releaseBlocked = process.env.OMB_SMOKE_LINUX_CUA_BLOCKED === "1";
-if ([hardDeath, bundled, releaseBlocked].filter(Boolean).length > 1) {
+const sessionBlocked = process.env.OMB_SMOKE_LINUX_CUA_BLOCKED === "1";
+if ([hardDeath, bundled, sessionBlocked].filter(Boolean).length > 1) {
   throw new Error("hard-death, bundled, and release-safety smoke modes are mutually exclusive");
 }
 const executable = path.resolve(
@@ -96,7 +96,7 @@ if (args[0] === "doctor" && args.includes("--json")) {
 if (args[0] !== "serve") process.exit(64);
 const socketPath = after("--socket");
 const pidFile = after("--pid-file");
-if (!socketPath || !pidFile || !args.includes("--embedded") || after("--permission-mode") !== "standard") {
+if (!socketPath || !pidFile || !args.includes("--embedded") || !args.includes("--no-overlay") || after("--permission-mode") !== "standard") {
   process.exit(64);
 }
 if ((process.env.CUA_DRIVER_RS_ENABLE_WAYLAND === "1") !== wayland) process.exit(64);
@@ -189,7 +189,7 @@ const desktopEnv = {
   CUA_DRIVER_PATH: sentinel,
   OMB_COMPOSIO_BROKER_URL: `http://127.0.0.1:${brokerAddress.port}`,
   OMB_SMOKE_TEST: "1",
-  OMB_SMOKE_CUA: hardDeath || bundled || releaseBlocked ? "0" : "1",
+  OMB_SMOKE_CUA: hardDeath || bundled || sessionBlocked ? "0" : "1",
   OMB_SMOKE_BUNDLED_CUA: bundled ? "1" : "0",
   ...(hardDeath ? { OMB_SMOKE_KEEP_OPEN: "1" } : {}),
 };
@@ -289,11 +289,11 @@ try {
     throw new Error(`${wayland ? "Wayland" : "X11"} screen preview capability was not available`);
   }
   if (capabilities.dictation.available) throw new Error("dictation must be unavailable on Linux");
-  if (releaseBlocked) {
+  if (sessionBlocked) {
     if (
       initialCapabilities.localComputer.available ||
       initialCapabilities.localComputer.enabled ||
-      initialCapabilities.localComputer.reasonCode !== "linux-seat-safety-blocked"
+      initialCapabilities.localComputer.reasonCode !== "linux-wayland-seat-safety-blocked"
     ) {
       throw new Error(
         `Linux release did not fail closed: ${JSON.stringify(initialCapabilities.localComputer)}`,
@@ -317,9 +317,12 @@ try {
       }
     }
   }
+  if (result.hardwareAccelerationEnabled !== false) {
+    throw new Error("Linux package did not disable hardware acceleration before startup");
+  }
   if (displayMediaRequests !== 0) throw new Error("launch triggered display capture without user intent");
   await until(async () => brokerRequests > 0, "the optional slow-broker request");
-  if (releaseBlocked) {
+  if (sessionBlocked) {
     await waitForExit();
     if (existsSync(marker)) throw new Error("release safety block still invoked a CUA executable");
     const activeUserData = ["openmausbot", "OpenMausBot"]
@@ -333,7 +336,7 @@ try {
       throw new Error("release safety block did not clear the durable Linux opt-in");
     }
     console.log(
-      `[smoke-linux-package] OK (${wayland ? "GNOME/Wayland" : path.basename(executable)}): slow optional broker did not block first paint and Linux CUA failed closed`,
+      `[smoke-linux-package] OK (${wayland ? "GNOME/Wayland" : path.basename(executable)}): slow optional broker did not block first paint and Wayland CUA failed closed`,
     );
   } else if (bundled) {
     await waitForExit();

--- a/scripts/smoke-linux-package.mjs
+++ b/scripts/smoke-linux-package.mjs
@@ -47,7 +47,9 @@ for (const appName of ["openmausbot", "OpenMausBot"]) {
   chmodSync(userData, 0o700);
   writeFileSync(
     path.join(userData, "cua-local-control.json"),
-    JSON.stringify({ schemaVersion: 1, linuxLocalControlEnabled: true }),
+    // Keep this explicit: schema 2 prevents a safe build's opt-in from arming
+    // an older Linux package that started Cua without the seat-safety flags.
+    JSON.stringify({ schemaVersion: 2, linuxLocalControlEnabled: true }),
     { mode: 0o600 },
   );
 }

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { AppConfig } from "./config.ts";
 import {
+  applyManagedBrokerMessage,
   authorizeService,
   connectedServices,
   connectionMode,
@@ -143,6 +144,16 @@ describe.sequential("Composio Sessions", () => {
     ).toThrow(/HTTPS/);
     expect(() => setManagedBrokerAccess({ url: "https://broker.example", token: "short" })).toThrow();
     setManagedBrokerAccess(null);
+  });
+  it("ignores credential sync without access and clears only on explicit null", () => {
+    const messageType = "openmausbot:managed-composio";
+    setManagedBrokerAccess({ url: "http://127.0.0.1:3210/", token: "a".repeat(64) });
+
+    expect(applyManagedBrokerMessage({ type: messageType })).toBe(false);
+    expect(connectionMode({})).toBe("managed");
+
+    expect(applyManagedBrokerMessage({ type: messageType, access: null })).toBe(true);
+    expect(connectionMode({})).toBe("unavailable");
   });
   it("accepts only project API keys", async () => {
     await expect(prepareProjectSession("old_key")).rejects.toThrow(/start with ak_/i);

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -5,12 +5,14 @@ import type { AppConfig } from "./config.ts";
 import {
   authorizeService,
   connectedServices,
+  connectionMode,
   connectionStatus,
   mcpIntegration,
   normalizeAccountAlias,
   prepareProjectSession,
   removeAccount,
   removeService,
+  setManagedBrokerAccess,
 } from "./composio.ts";
 
 let api: Server;
@@ -125,11 +127,21 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  setManagedBrokerAccess(null);
   delete process.env.OMB_COMPOSIO_API;
   await new Promise<void>((resolve) => api.close(() => resolve()));
 });
 
 describe.sequential("Composio Sessions", () => {
+  it("accepts a private desktop credential update and rejects unsafe broker URLs", () => {
+    setManagedBrokerAccess({ url: "http://127.0.0.1:3210/", token: "a".repeat(64) });
+    expect(connectionMode({} as AppConfig)).toBe("managed");
+    expect(() =>
+      setManagedBrokerAccess({ url: "http://broker.example", token: "a".repeat(64) }),
+    ).toThrow(/HTTPS/);
+    expect(() => setManagedBrokerAccess({ url: "https://broker.example", token: "short" })).toThrow();
+    setManagedBrokerAccess(null);
+  });
   it("accepts only project API keys", async () => {
     await expect(prepareProjectSession("old_key")).rejects.toThrow(/start with ak_/i);
     await expect(prepareProjectSession("ak_wrong")).rejects.toThrow(/invalid project key/i);

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -135,7 +135,9 @@ afterAll(async () => {
 describe.sequential("Composio Sessions", () => {
   it("accepts a private desktop credential update and rejects unsafe broker URLs", () => {
     setManagedBrokerAccess({ url: "http://127.0.0.1:3210/", token: "a".repeat(64) });
-    expect(connectionMode({} as AppConfig)).toBe("managed");
+    expect(connectionMode({})).toBe("managed");
+    setManagedBrokerAccess({ url: "http://[::1]:3210/", token: "a".repeat(64) });
+    expect(connectionMode({})).toBe("managed");
     expect(() =>
       setManagedBrokerAccess({ url: "http://broker.example", token: "a".repeat(64) }),
     ).toThrow(/HTTPS/);

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -134,6 +134,26 @@ afterAll(async () => {
 });
 
 describe.sequential("Composio Sessions", () => {
+  it("rejects broker URL components and invalid tokens from the environment", () => {
+    process.env.OMB_COMPOSIO_BROKER_TOKEN = "a".repeat(64);
+    try {
+      for (const url of [
+        "https://user:secret@broker.example/root",
+        "https://broker.example/root?redirect=evil",
+        "https://broker.example/root#fragment",
+      ]) {
+        process.env.OMB_COMPOSIO_BROKER_URL = url;
+        expect(() => connectionMode({})).toThrow(/must not include/);
+      }
+      process.env.OMB_COMPOSIO_BROKER_URL = "http://[::1]:3210/root/";
+      expect(connectionMode({})).toBe("managed");
+      process.env.OMB_COMPOSIO_BROKER_TOKEN = "short";
+      expect(() => connectionMode({})).toThrow(/token is invalid/);
+    } finally {
+      delete process.env.OMB_COMPOSIO_BROKER_URL;
+      delete process.env.OMB_COMPOSIO_BROKER_TOKEN;
+    }
+  });
   it("accepts a private desktop credential update and rejects unsafe broker URLs", () => {
     setManagedBrokerAccess({ url: "http://127.0.0.1:3210/", token: "a".repeat(64) });
     expect(connectionMode({})).toBe("managed");
@@ -142,6 +162,13 @@ describe.sequential("Composio Sessions", () => {
     expect(() =>
       setManagedBrokerAccess({ url: "http://broker.example", token: "a".repeat(64) }),
     ).toThrow(/HTTPS/);
+    for (const url of [
+      "https://user:secret@broker.example/root",
+      "https://broker.example/root?redirect=evil",
+      "https://broker.example/root#fragment",
+    ]) {
+      expect(() => setManagedBrokerAccess({ url, token: "a".repeat(64) })).toThrow(/must not include/);
+    }
     expect(() => setManagedBrokerAccess({ url: "https://broker.example", token: "short" })).toThrow();
     setManagedBrokerAccess(null);
   });

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -113,7 +113,23 @@ interface IntegrationContext {
   threadId: string;
 }
 
+let managedBrokerAccess: { url: string; token: string } | null | undefined;
+
+export function setManagedBrokerAccess(access: unknown): void {
+  if (access === null) {
+    managedBrokerAccess = null;
+    return;
+  }
+  const parsed = z.object({ url: z.string().url(), token: z.string().regex(/^[0-9a-f]{64}$/) }).strict().parse(access);
+  const url = new URL(parsed.url);
+  if (url.protocol !== "https:" && url.hostname !== "127.0.0.1" && url.hostname !== "localhost") {
+    throw new Error("The connected-apps service must use HTTPS");
+  }
+  managedBrokerAccess = { url: url.toString().replace(/\/$/, ""), token: parsed.token };
+}
+
 function brokerAccess(): { url: string; token: string } | null {
+  if (managedBrokerAccess !== undefined) return managedBrokerAccess;
   const url = process.env.OMB_COMPOSIO_BROKER_URL?.trim().replace(/\/$/, "");
   const token = process.env.OMB_COMPOSIO_BROKER_TOKEN?.trim();
   if (!url || !token) return null;

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -116,6 +116,19 @@ interface IntegrationContext {
 let managedBrokerAccess: { url: string; token: string } | null | undefined;
 
 const managedBrokerMessageSchema = z.record(z.string(), z.unknown());
+const managedBrokerToken = /^[0-9a-f]{64}$/;
+
+function normalizeManagedBrokerUrl(value: string): string {
+  const url = new URL(value);
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("The connected-apps service URL must not include credentials, a query, or a fragment");
+  }
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("The connected-apps service must use HTTPS");
+  }
+  return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+}
 
 export function applyManagedBrokerMessage(message: unknown): boolean {
   const parsed = managedBrokerMessageSchema.safeParse(message);
@@ -135,34 +148,17 @@ export function setManagedBrokerAccess(access: unknown): void {
     managedBrokerAccess = null;
     return;
   }
-  const parsed = z.object({ url: z.string().url(), token: z.string().regex(/^[0-9a-f]{64}$/) }).strict().parse(access);
-  const url = new URL(parsed.url);
-  if (
-    url.protocol !== "https:" &&
-    url.hostname !== "127.0.0.1" &&
-    url.hostname !== "localhost" &&
-    url.hostname !== "[::1]"
-  ) {
-    throw new Error("The connected-apps service must use HTTPS");
-  }
-  managedBrokerAccess = { url: url.toString().replace(/\/$/, ""), token: parsed.token };
+  const parsed = z.object({ url: z.string().url(), token: z.string().regex(managedBrokerToken) }).strict().parse(access);
+  managedBrokerAccess = { url: normalizeManagedBrokerUrl(parsed.url), token: parsed.token };
 }
 
 function brokerAccess(): { url: string; token: string } | null {
   if (managedBrokerAccess !== undefined) return managedBrokerAccess;
-  const url = process.env.OMB_COMPOSIO_BROKER_URL?.trim().replace(/\/$/, "");
+  const url = process.env.OMB_COMPOSIO_BROKER_URL?.trim();
   const token = process.env.OMB_COMPOSIO_BROKER_TOKEN?.trim();
   if (!url || !token) return null;
-  const parsed = new URL(url);
-  if (
-    parsed.protocol !== "https:" &&
-    parsed.hostname !== "127.0.0.1" &&
-    parsed.hostname !== "localhost" &&
-    parsed.hostname !== "[::1]"
-  ) {
-    throw new Error("The connected-apps service must use HTTPS");
-  }
-  return { url, token };
+  if (!managedBrokerToken.test(token)) throw new Error("The connected-apps service token is invalid");
+  return { url: normalizeManagedBrokerUrl(url), token };
 }
 
 export function connectionMode(cfg: AppConfig): "managed" | "self-hosted" | "unavailable" {

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -115,6 +115,21 @@ interface IntegrationContext {
 
 let managedBrokerAccess: { url: string; token: string } | null | undefined;
 
+const managedBrokerMessageSchema = z.record(z.string(), z.unknown());
+
+export function applyManagedBrokerMessage(message: unknown): boolean {
+  const parsed = managedBrokerMessageSchema.safeParse(message);
+  if (
+    !parsed.success ||
+    parsed.data.type !== "openmausbot:managed-composio" ||
+    !Object.hasOwn(parsed.data, "access")
+  ) {
+    return false;
+  }
+  setManagedBrokerAccess(parsed.data.access);
+  return true;
+}
+
 export function setManagedBrokerAccess(access: unknown): void {
   if (access === null) {
     managedBrokerAccess = null;

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -122,7 +122,12 @@ export function setManagedBrokerAccess(access: unknown): void {
   }
   const parsed = z.object({ url: z.string().url(), token: z.string().regex(/^[0-9a-f]{64}$/) }).strict().parse(access);
   const url = new URL(parsed.url);
-  if (url.protocol !== "https:" && url.hostname !== "127.0.0.1" && url.hostname !== "localhost") {
+  if (
+    url.protocol !== "https:" &&
+    url.hostname !== "127.0.0.1" &&
+    url.hostname !== "localhost" &&
+    url.hostname !== "[::1]"
+  ) {
     throw new Error("The connected-apps service must use HTTPS");
   }
   managedBrokerAccess = { url: url.toString().replace(/\/$/, ""), token: parsed.token };
@@ -134,7 +139,12 @@ function brokerAccess(): { url: string; token: string } | null {
   const token = process.env.OMB_COMPOSIO_BROKER_TOKEN?.trim();
   if (!url || !token) return null;
   const parsed = new URL(url);
-  if (parsed.protocol !== "https:" && parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") {
+  if (
+    parsed.protocol !== "https:" &&
+    parsed.hostname !== "127.0.0.1" &&
+    parsed.hostname !== "localhost" &&
+    parsed.hostname !== "[::1]"
+  ) {
     throw new Error("The connected-apps service must use HTTPS");
   }
   return { url, token };

--- a/server/index.ts
+++ b/server/index.ts
@@ -176,10 +176,8 @@ type UtilityParentPort = {
 const utilityParentPort = (process as NodeJS.Process & { parentPort?: UtilityParentPort }).parentPort;
 utilityParentPort?.on("message", (event) => {
   const message = event?.data;
-  if (!message || typeof message !== "object" || Array.isArray(message)) return;
-  if ((message as { type?: unknown }).type !== "openmausbot:managed-composio") return;
   try {
-    composio.setManagedBrokerAccess((message as { access?: unknown }).access ?? null);
+    composio.applyManagedBrokerMessage(message);
   } catch (error) {
     console.error(`[connected-apps] rejected desktop credential sync: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -166,6 +166,25 @@ await registry.load(instanceConfigs(cfg));
 const bundledSkills = loadBundledSkills();
 const availableSkills = () => mergeSkills(bundledSkills, loadUserSkills(join(DATA_DIR, "skills")));
 
+// Electron's utility-process parent port is private to the desktop main
+// process. It lets a slow first-time managed Composio registration arrive
+// after first paint without putting the credential in the renderer or
+// restarting the embedded server. Plain Node/dev launches have no parentPort.
+type UtilityParentPort = {
+  on(event: "message", listener: (event: { data?: unknown }) => void): void;
+};
+const utilityParentPort = (process as NodeJS.Process & { parentPort?: UtilityParentPort }).parentPort;
+utilityParentPort?.on("message", (event) => {
+  const message = event?.data;
+  if (!message || typeof message !== "object" || Array.isArray(message)) return;
+  if ((message as { type?: unknown }).type !== "openmausbot:managed-composio") return;
+  try {
+    composio.setManagedBrokerAccess((message as { access?: unknown }).access ?? null);
+  } catch (error) {
+    console.error(`[connected-apps] rejected desktop credential sync: ${error instanceof Error ? error.message : String(error)}`);
+  }
+});
+
 const bus = new EventBus();
 bus.attach(registry.instances());
 

--- a/src/components/LinuxLocalControl.tsx
+++ b/src/components/LinuxLocalControl.tsx
@@ -24,6 +24,7 @@ export function LinuxLocalControl() {
   if (capabilities.host.platform !== "linux") return null;
   const busy = pending !== null || local.status === "checking" || local.status === "starting";
   const ready = local.available;
+  const safetyBlocked = local.reasonCode === "linux-seat-safety-blocked";
   const wayland = capabilities.host.session === "wayland";
   const bundledDriver = local.driverSource === "bundled";
 
@@ -59,14 +60,30 @@ export function LinuxLocalControl() {
         <span
           className={cn(
             "shrink-0 rounded-full px-2 py-1 text-[10px] font-medium",
-            ready ? "bg-success/10 text-success" : local.enabled ? "bg-warning/10 text-warning" : "bg-raised text-ink-secondary",
+            ready
+              ? "bg-success/10 text-success"
+              : safetyBlocked
+                ? "bg-danger/10 text-danger"
+                : local.enabled
+                  ? "bg-warning/10 text-warning"
+                  : "bg-raised text-ink-secondary",
           )}
         >
-          {ready ? "Ready" : local.enabled ? "Needs attention" : "Off"}
+          {ready ? "Ready" : safetyBlocked ? "Temporarily unavailable" : local.enabled ? "Needs attention" : "Off"}
         </span>
       </div>
 
-      {!local.enabled ? (
+      {safetyBlocked ? (
+        <div className="mt-3 rounded-lg border border-danger/20 bg-danger/5 p-3">
+          <div className="flex gap-2 text-[12px] leading-relaxed text-ink-secondary">
+            <AlertTriangle size={15} className="mt-0.5 shrink-0 text-danger" />
+            <span>
+              Local control is temporarily disabled on Linux while we fix an input-safety issue. Chat, Cloud, Local VM,
+              and screen preview remain available.
+            </span>
+          </div>
+        </div>
+      ) : !local.enabled ? (
         <div className="mt-3 rounded-lg border border-warning/20 bg-warning/5 p-3">
           <div className="flex gap-2 text-[12px] leading-relaxed text-ink-secondary">
             <AlertTriangle size={15} className="mt-0.5 shrink-0 text-warning" />
@@ -104,7 +121,7 @@ export function LinuxLocalControl() {
 
       {error && <div className="mt-2 text-[12px] text-danger">{error}</div>}
 
-      <div className="mt-3 flex gap-2">
+      {!safetyBlocked && <div className="mt-3 flex gap-2">
         {!local.enabled ? (
           <button
             type="button"
@@ -130,7 +147,7 @@ export function LinuxLocalControl() {
             )}
             <button
               type="button"
-              disabled={busy}
+              disabled={pending === "disable"}
               onClick={() => void run("disable")}
               className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
             >
@@ -139,7 +156,7 @@ export function LinuxLocalControl() {
             </button>
           </>
         )}
-      </div>
+      </div>}
 
       <button
         type="button"

--- a/src/components/LinuxLocalControl.tsx
+++ b/src/components/LinuxLocalControl.tsx
@@ -24,7 +24,7 @@ export function LinuxLocalControl() {
   if (capabilities.host.platform !== "linux") return null;
   const busy = pending !== null || local.status === "checking" || local.status === "starting";
   const ready = local.available;
-  const safetyBlocked = local.reasonCode === "linux-seat-safety-blocked";
+  const waylandSafetyBlocked = local.reasonCode === "linux-wayland-seat-safety-blocked";
   const wayland = capabilities.host.session === "wayland";
   const bundledDriver = local.driverSource === "bundled";
 
@@ -62,24 +62,25 @@ export function LinuxLocalControl() {
             "shrink-0 rounded-full px-2 py-1 text-[10px] font-medium",
             ready
               ? "bg-success/10 text-success"
-              : safetyBlocked
+              : waylandSafetyBlocked
                 ? "bg-danger/10 text-danger"
                 : local.enabled
                   ? "bg-warning/10 text-warning"
                   : "bg-raised text-ink-secondary",
           )}
         >
-          {ready ? "Ready" : safetyBlocked ? "Temporarily unavailable" : local.enabled ? "Needs attention" : "Off"}
+          {ready ? "Ready" : waylandSafetyBlocked ? "Unavailable on Wayland" : local.enabled ? "Needs attention" : "Off"}
         </span>
       </div>
 
-      {safetyBlocked ? (
+      {waylandSafetyBlocked ? (
         <div className="mt-3 rounded-lg border border-danger/20 bg-danger/5 p-3">
           <div className="flex gap-2 text-[12px] leading-relaxed text-ink-secondary">
             <AlertTriangle size={15} className="mt-0.5 shrink-0 text-danger" />
             <span>
-              Local control is temporarily disabled on Linux while we fix an input-safety issue. Chat, Cloud, Local VM,
-              and screen preview remain available.
+              Local control is available on Ubuntu Xorg. It remains disabled on Wayland until its input-safety
+              boundary is validated. Sign out and choose <strong className="font-medium text-ink">Ubuntu on Xorg</strong>
+              {" "}to use This computer; Chat, Cloud, Local VM, and screen preview still work here.
             </span>
           </div>
         </div>
@@ -121,7 +122,7 @@ export function LinuxLocalControl() {
 
       {error && <div className="mt-2 text-[12px] text-danger">{error}</div>}
 
-      {!safetyBlocked && <div className="mt-3 flex gap-2">
+      {!waylandSafetyBlocked && <div className="mt-3 flex gap-2">
         {!local.enabled ? (
           <button
             type="button"

--- a/src/components/LinuxLocalControl.tsx
+++ b/src/components/LinuxLocalControl.tsx
@@ -148,7 +148,7 @@ export function LinuxLocalControl() {
             )}
             <button
               type="button"
-              disabled={pending === "disable"}
+              disabled={pending !== null}
               onClick={() => void run("disable")}
               className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
             >

--- a/src/components/LinuxLocalControl.tsx
+++ b/src/components/LinuxLocalControl.tsx
@@ -107,7 +107,7 @@ export function LinuxLocalControl() {
             )}
             <span aria-live="polite">
               {ready
-                ? "Ready for bots explicitly assigned to this computer."
+                ? "Ready for bots explicitly assigned to this computer. Bot actions use a private cursor, so your pointer stays under your control."
                 : local.message ?? "Checking the driver and desktop session…"}
             </span>
           </div>

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -7,6 +7,7 @@ import {
   mergeCompleteConnectorStatus,
   mergeCurrentConnectorStatus,
   requiresAccountAlias,
+  onlyLatestConnectorResponses,
   type ConnectorStatus,
 } from "./PluginsPanel";
 
@@ -45,6 +46,21 @@ describe("connected-app status races", () => {
     );
 
     expect(merged.gmail).toEqual({ connected: true, pending: false, status: "ACTIVE" });
+  });
+
+  it("drops an older status response when a newer request for the same app has started", () => {
+    const latestRequests = new Map([["gmail", 2], ["slack", 1]]);
+    const requestIds = new Map([["gmail", 1], ["slack", 1]]);
+    expect(
+      onlyLatestConnectorResponses(
+        {
+          gmail: { connected: false, status: "not_connected" },
+          slack: { connected: true, status: "ACTIVE" },
+        },
+        latestRequests,
+        requestIds,
+      ),
+    ).toEqual({ slack: { connected: true, status: "ACTIVE" } });
   });
 
   it("keeps a connected account beyond the first 40 marketplace cards", () => {

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -128,6 +128,18 @@ export function mergeCompleteConnectorStatus(
   return mergeCurrentConnectorStatus(next, incoming, latestGenerations, requestGenerations);
 }
 
+export function onlyLatestConnectorResponses(
+  incoming: Record<string, ConnectorStatus>,
+  latestRequests: ReadonlyMap<string, number>,
+  requestIds: ReadonlyMap<string, number>,
+) {
+  return Object.fromEntries(
+    Object.entries(incoming).filter(
+      ([slug]) => (latestRequests.get(slug) ?? 0) === (requestIds.get(slug) ?? 0),
+    ),
+  );
+}
+
 function ServiceIcon({ card }: { card: ToolkitCard }) {
   // 0 = official logo, 1 = favicon by domain, 2 = monogram
   const [stage, setStage] = useState(card.logo ? 0 : card.domain ? 1 : 2);
@@ -175,14 +187,23 @@ export function PluginsPanel() {
 
   const pollTimers = useRef(new Map<string, ReturnType<typeof setInterval>>());
   const statusGenerations = useRef(new Map<string, number>());
+  const latestStatusRequests = useRef(new Map<string, number>());
 
   const refreshStatus = useCallback((slugs: string[]): Promise<Record<string, ConnectorStatus>> => {
     if (!slugs.length) return Promise.resolve({});
     const requestGenerations = new Map(slugs.map((slug) => [slug, statusGenerations.current.get(slug) ?? 0]));
-    setRefreshing(true);
+    const requestIds = new Map(slugs.map((slug) => {
+      const requestId = (latestStatusRequests.current.get(slug) ?? 0) + 1;
+      latestStatusRequests.current.set(slug, requestId);
+      return [slug, requestId];
+    }));
     return api(`/api/connectors?services=${slugs.join(",")}`)
       .then((r) => {
-        const services: Record<string, ConnectorStatus> = r.services ?? {};
+        const services = onlyLatestConnectorResponses(
+          r.services ?? {},
+          latestStatusRequests.current,
+          requestIds,
+        );
         // A one-service OAuth poll must not erase every other app's state.
         // A request that began before Connect must also not erase the newer
         // local INITIATED state when its stale not_connected result arrives.
@@ -203,8 +224,7 @@ export function PluginsPanel() {
         }
         return services;
       })
-      .catch(() => ({}))
-      .finally(() => setRefreshing(false));
+      .catch(() => ({}));
   }, []);
 
   const refreshConnectedStatus = useCallback((force = false): Promise<Record<string, ConnectorStatus>> => {
@@ -431,7 +451,8 @@ export function PluginsPanel() {
           <div className="flex items-center gap-1">
             <button
               onClick={() => void loadConnectionInventory(true)}
-              className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"
+              disabled={refreshing}
+              className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
               title="Refresh connection status"
             >
               <RefreshCw size={17} className={cn(refreshing && "animate-spin")} />
@@ -657,9 +678,11 @@ export function PluginsPanel() {
               {tab === "connected" && inventoryPhase === "error" && (
                 <button
                   type="button"
+                  disabled={refreshing}
                   onClick={() => void loadConnectionInventory(true)}
-                  className="mt-3 rounded-lg bg-raised px-3 py-2 text-[12px] text-ink hover:bg-raised-hover"
+                  className="mt-4 flex items-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[12.5px] text-ink transition-colors hover:bg-raised-hover disabled:opacity-50"
                 >
+                  <RefreshCw size={13} className={cn(refreshing && "animate-spin")} />
                   Retry
                 </button>
               )}

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -4,6 +4,7 @@ import {
   autoSelectsLocalComputer,
   instanceSupportsLocalComputer,
   linuxAutoDescription,
+  localComputerDisabledReason,
   localComputerSelectable,
 } from "./local-computer";
 
@@ -61,6 +62,23 @@ describe("local computer UI eligibility", () => {
         localSelectable: true,
       }),
     ).toBe(false);
+  });
+
+  it("explains the temporary Linux seat-safety block without suggesting setup", () => {
+    const capabilities = {
+      host: { platform: "linux" as const },
+      localComputer: {
+        available: false,
+        enabled: false,
+        reasonCode: "linux-seat-safety-blocked",
+      },
+    } as DesktopCapabilities;
+
+    expect(
+      localComputerDisabledReason({ capabilities, providerSupportsLocal: true }),
+    ).toBe(
+      "Local computer control is temporarily disabled on Linux while an input-safety issue is fixed.",
+    );
   });
 
   it("preserves the ready local fallback on supported non-Linux hosts", () => {

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -64,20 +64,20 @@ describe("local computer UI eligibility", () => {
     ).toBe(false);
   });
 
-  it("explains the temporary Linux seat-safety block without suggesting setup", () => {
+  it("explains the Wayland seat-safety block and names the supported session", () => {
     const capabilities = {
       host: { platform: "linux" as const },
       localComputer: {
         available: false,
         enabled: false,
-        reasonCode: "linux-seat-safety-blocked",
+        reasonCode: "linux-wayland-seat-safety-blocked",
       },
     } as DesktopCapabilities;
 
     expect(
       localComputerDisabledReason({ capabilities, providerSupportsLocal: true }),
     ).toBe(
-      "Local computer control is temporarily disabled on Linux while an input-safety issue is fixed.",
+      "Local computer control is not available on Wayland yet. Sign out and choose Ubuntu on Xorg to use This computer.",
     );
   });
 

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -38,8 +38,8 @@ export function localComputerDisabledReason({
   }
   if (capabilities.localComputer.available) return null;
   if (capabilities.host.platform === "linux") {
-    if (capabilities.localComputer.reasonCode === "linux-seat-safety-blocked") {
-      return "Local computer control is temporarily disabled on Linux while an input-safety issue is fixed.";
+    if (capabilities.localComputer.reasonCode === "linux-wayland-seat-safety-blocked") {
+      return "Local computer control is not available on Wayland yet. Sign out and choose Ubuntu on Xorg to use This computer.";
     }
     if (capabilities.localComputer.reasonCode === "wayland-compositor-unsupported") {
       return "Wayland local control is currently limited to GNOME. Xorg remains available on supported desktops.";

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -38,6 +38,9 @@ export function localComputerDisabledReason({
   }
   if (capabilities.localComputer.available) return null;
   if (capabilities.host.platform === "linux") {
+    if (capabilities.localComputer.reasonCode === "linux-seat-safety-blocked") {
+      return "Local computer control is temporarily disabled on Linux while an input-safety issue is fixed.";
+    }
     if (capabilities.localComputer.reasonCode === "wayland-compositor-unsupported") {
       return "Wayland local control is currently limited to GNOME. Xorg remains available on supported desktops.";
     }


### PR DESCRIPTION
## Summary

- repair legacy DEB ownership/modes, configure the Chromium SUID sandbox idempotently, and test a real 0.1.7-to-current package upgrade
- restore Ubuntu Xorg local computer control only after explicit opt-in, with the Cua overlay disabled so the user's physical pointer and keyboard remain available
- keep GNOME/Wayland local control fail-closed with a typed `linux-wayland-seat-safety-blocked` status
- invalidate legacy unsafe opt-ins with preference schema 2, route SIGINT/SIGTERM through normal cleanup, and reap only verified dead AppImage CUA stages
- move optional managed Connected Apps registration behind first paint, validate HTTPS/loopback broker URLs, reject redirects, strip unvalidated inherited broker variables, and synchronize credentials over the private Electron parent port
- prevent stale Connected Apps inventory requests from overwriting newer results and show retryable inventory errors
- update Ubuntu, contributor, and user documentation for the supported Xorg boundary and private logical cursor

## Safety boundary

This PR enables **Ubuntu 24.04 GNOME/Xorg** host control as a beta only after explicit user opt-in. The bundled Cua Driver starts with `--no-overlay`; bot actions use a private logical cursor and do not take over the user's physical pointer. Existing tool approvals and Auto-mode warnings remain in force.

GNOME/Wayland remains deliberately blocked and does not start Cua. Cloud and Local VM modes remain available on unsupported sessions. A schema-2 opt-in prevents preferences from older unsafe builds from silently re-enabling host control.

The hosted Connected Apps broker already contains the inventory route in this repository, but deployment of the current worker remains an external follow-up. The desktop reports that outage truthfully.

## Validation after rebase onto `ba3ad4b`

- `pnpm typecheck`
- `pnpm check:electron`: 46 Electron modules
- `pnpm test`: 178 files, 1,817 passed, 8 skipped; 1,825 total
- `pnpm check:contrast`: 21 pairs, no new failures
- `pnpm docs:build`: 111 static pages
- `pnpm package:linux:offline`
- `node scripts/verify-linux-package.mjs`
- `pnpm smoke:linux-package`: unpacked app, AppImage, AppImage SIGTERM cleanup, GNOME/X11 crash/retry, and fail-closed GNOME/Wayland
- `pnpm smoke:cua-x11-input`: no full-screen Cua overlay; an unrelated X11 window received click and keyboard input
- final local artifacts:
  - AppImage 0.1.33 SHA-256 `f72faed053b3da8c841413f6154b94aa2761cce88c2446b24b216ce88ec95b31`
  - DEB 0.1.33 SHA-256 `e77a2e2398f2b634d34c037845a5ea561e19f7dbcb2ba87798b5c345d983b536`

## Real Ubuntu acceptance evidence

On Ubuntu 24.04 GNOME/Xorg, local control enabled without capturing the user's physical mouse or keyboard. Computer-tool click and typing actions succeeded, screen preview started/stopped while the desktop remained usable, normal close and SIGTERM removed the owned daemon/socket/runtime, and stale AppImage stages were reaped safely.

A genuine Grok 4.6 turn was independently confirmed by the running process (`grok ... -m grok-4.6`) and OpenMausBot model selection. Through the local computer tools it typed and saved a valid LibreOffice Writer ODT whose exact content was:

> Verified by actual Grok 4.6 through OpenMausBot on Ubuntu.

The bot returned idle and Auto mode was disabled after the test.

Tracking issue: #345. Umbrella: #29.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed desktop broker credential registration and synchronization.
  * Added overlay-free Xorg input validation and safer Linux package installation and upgrades.

* **Bug Fixes**
  * Linux local control now fails closed on Wayland and unsupported environments.
  * Improved package permissions, shutdown cleanup, stale bundle cleanup, and plugin status refreshes.

* **Documentation**
  * Updated Linux guidance to explain control restrictions and Cloud or Local VM alternatives.

* **Tests**
  * Expanded coverage for input safety, packaging, upgrades, credentials, and installation verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->