### PR TITLE
fix(hermes): offer the model Hermes' own config names, not only local hosts

### DIFF
--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { removeTempDir } from "../../testing/cleanup.ts";
+import { HERMES_CONFIG_MODEL_ID, hermesAcpModelId, hermesConfiguredModel } from "./hermes.ts";
+
+describe("hermesConfiguredModel", () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    for (const d of dirs.splice(0)) await removeTempDir(d);
+  });
+
+  const home = (env: string, cfg?: string) => {
+    const root = mkdtempSync(join(tmpdir(), "omb-hermes-"));
+    dirs.push(root);
+    const h = join(root, ".hermes");
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, ".env"), env);
+    if (cfg !== undefined) writeFileSync(join(h, "config.yaml"), cfg);
+    return { HERMES_HOME: h };
+  };
+
+  it("offers the configured model when a hosted key is set", () => {
+    const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n", "model:\n  default: anthropic/claude-opus-4.6\n");
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "anthropic/claude-opus-4.6 (Hermes config)",
+    });
+  });
+
+  it("treats a commented-out key as not configured", () => {
+    // The shipped .env carries `# OPENROUTER_API_KEY=`; reading that as
+    // configured would offer a model that cannot authenticate.
+    const env = home("# OPENROUTER_API_KEY=\n", "model:\n  default: anthropic/claude-opus-4.6\n");
+    expect(hermesConfiguredModel(env)).toBeNull();
+  });
+
+  it("returns null when there is no .env at all, leaving local-only setups unchanged", () => {
+    const root = mkdtempSync(join(tmpdir(), "omb-hermes-bare-"));
+    dirs.push(root);
+    expect(hermesConfiguredModel({ HERMES_HOME: join(root, ".hermes") })).toBeNull();
+  });
+
+  it("still offers the model when config.yaml is unreadable, with a generic label", () => {
+    const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n");
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "Hermes default (config)",
+    });
+  });
+
+  it("does not map to an ACP model id, so no session/set_model is sent for it", () => {
+    // This is what makes Hermes fall through to its own configured provider.
+    expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+});

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -27,6 +27,8 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toEqual({
       id: HERMES_CONFIG_MODEL_ID,
       label: "anthropic/claude-opus-4.6 (Hermes config)",
+      // ModelPicker shows a custom-only agent ONLY its custom-flagged options.
+      custom: true,
     });
   });
 
@@ -48,11 +50,35 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toEqual({
       id: HERMES_CONFIG_MODEL_ID,
       label: "Hermes default (config)",
+      custom: true,
     });
   });
 
   it("does not map to an ACP model id, so no session/set_model is sent for it", () => {
     // This is what makes Hermes fall through to its own configured provider.
     expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+});
+
+describe("hermesAcpModelId", () => {
+  it("forwards Hermes' own provider-scoped ids untouched", () => {
+    // These are what `session/new` advertises. Returning null for them is what
+    // confined the picker to locally injected hosts.
+    expect(hermesAcpModelId("openrouter:qwen/qwen3.8-max")).toBe("openrouter:qwen/qwen3.8-max");
+    expect(hermesAcpModelId("openrouter:deepseek/deepseek-v4-flash")).toBe(
+      "openrouter:deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("still maps local inject ids to Hermes' custom:<host>:<model> form", () => {
+    expect(hermesAcpModelId("ollama::llama3")).toBe("custom:ollama:llama3");
+  });
+
+  it("returns null for the config sentinel, so Hermes keeps its own default", () => {
+    expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+
+  it("returns null for a bare word that names no provider", () => {
+    expect(hermesAcpModelId("gpt-5")).toBeNull();
   });
 });

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -4,12 +4,13 @@
 // without an OpenRouter key — that is the "HTTP 401: Missing Authentication
 // header" failure. Inject writes providers.<host> and session/set_model
 // `custom:<host>:<model>` instead.
+import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { ModelCatalog } from "../../contracts.ts";
-import { decodeInjectId, hostApiKey, localHost, mergeLocalInject } from "../local-inject.ts";
+import { decodeInjectId, hostApiKey, INJECT_SEP, localHost, mergeLocalInject } from "../local-inject.ts";
 import { createAcpDriver, type AcpSupport } from "./core.ts";
 
 const EMPTY: ModelCatalog = { default: "", options: [] };
@@ -78,8 +79,13 @@ export function ensureHermesInjectProvider(
 /** ACP session/set_model id. Hermes parse_model_input treats `custom:name:model`. */
 export function hermesAcpModelId(modelId: string | null | undefined): string | null {
   const inject = decodeInjectId(modelId);
-  if (!inject) return null;
-  return `custom:${inject.host}:${inject.model}`;
+  if (inject) return `custom:${inject.host}:${inject.model}`;
+  // Hermes' own ACP ids are `<provider>:<model>` (`openrouter:qwen/qwen3.8-max`).
+  // They are not inject ids and must be forwarded untouched; returning null here
+  // is what limited the picker to locally injected hosts.
+  const native = typeof modelId === "string" ? modelId.trim() : "";
+  if (native && !native.includes(INJECT_SEP) && /^[a-z0-9_-]+:[\w./:-]+$/i.test(native)) return native;
+  return null;
 }
 
 /** The id used when Hermes should run on the provider its own config names.
@@ -109,7 +115,7 @@ export const HERMES_CONFIG_MODEL_ID = "hermes-default";
  */
 export function hermesConfiguredModel(
   env: Record<string, string | undefined> = process.env,
-): { id: string; label: string } | null {
+): { id: string; label: string; custom: true } | null {
   const dir = hermesHome(env);
   let secrets = "";
   try {
@@ -130,18 +136,113 @@ export function hermesConfiguredModel(
   } catch {
     /* config unreadable — the id still works, only the label is less specific */
   }
+  // `custom: true` is not cosmetic. ModelPicker renders a custom-only agent's
+  // *custom* pane exclusively, and that pane lists only options carrying this
+  // flag; anything without it lands in the "official" bucket the pane never
+  // shows. Omitting it puts the option in the API response while leaving the
+  // picker saying "No local models found" — present, but unselectable.
   return {
     id: HERMES_CONFIG_MODEL_ID,
     label: model ? `${model} (Hermes config)` : "Hermes default (config)",
+    custom: true as const,
   };
 }
 
-async function resolveModels(env: Record<string, string | undefined>): Promise<ModelCatalog> {
+/** Ask a short-lived `hermes acp` session what models it can actually run.
+ *
+ * Hermes advertises its full catalog on `session/new` — every model its
+ * configured providers expose, ids shaped `openrouter:qwen/qwen3.8-max`. There
+ * is no `hermes models` subcommand, so a throwaway session is the only way to
+ * read it, and it is worth the spawn: without it the picker can only offer
+ * locally injected hosts, which is a fraction of what the user is paying for.
+ *
+ * Failure is non-fatal and returns [] — a catalog probe must never be the
+ * reason an agent becomes unselectable.
+ */
+async function fetchHermesAcpModels(
+  cli: string,
+  env: Record<string, string | undefined>,
+): Promise<{ id: string; label: string; custom: true }[]> {
+  return await new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cli, ["acp"], { stdio: ["pipe", "pipe", "ignore"], env: env as NodeJS.ProcessEnv });
+    } catch {
+      return resolve([]);
+    }
+    const done = (out: { id: string; label: string; custom: true }[]) => {
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      resolve(out);
+    };
+    const timer = setTimeout(() => done([]), 25_000);
+    child.on("error", () => done([]));
+
+    let buf = "";
+    let id = 0;
+    const send = (method: string, params: unknown) => {
+      id += 1;
+      child.stdin?.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+      return id;
+    };
+    const initId = send("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
+    });
+    let sessionId = 0;
+    child.stdout?.on("data", (chunk) => {
+      buf += String(chunk);
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        let msg: any;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg?.id === initId && msg.result) {
+          sessionId = send("session/new", { cwd: env.HOME || "/tmp", mcpServers: [] });
+        } else if (sessionId && msg?.id === sessionId) {
+          const list = Array.isArray(msg.result?.models?.availableModels)
+            ? msg.result.models.availableModels
+            : [];
+          done(
+            list
+              .filter((m: any) => typeof m?.modelId === "string" && m.modelId)
+              .map((m: any) => ({
+                id: m.modelId as string,
+                // Hermes labels these "OpenRouter · <model>"; keep its wording.
+                label: (typeof m.name === "string" && m.name.trim()) || (m.modelId as string),
+                custom: true as const,
+              })),
+          );
+        }
+      }
+    });
+  });
+}
+
+async function resolveModels(
+  env: Record<string, string | undefined>,
+  config?: { cli?: string },
+): Promise<ModelCatalog> {
   const catalog = await mergeLocalInject(EMPTY, env);
   const configured = hermesConfiguredModel(env);
-  // Listed first so it is the default: someone who configured a hosted provider
-  // meant to use it, and a local host may not even be running.
-  const options = configured ? [configured, ...catalog.options] : catalog.options;
+  // Only probe when a hosted provider is configured; a local-only install has
+  // nothing to gain from the spawn.
+  const remote = configured ? await fetchHermesAcpModels(config?.cli || "hermes", env) : [];
+  const seen = new Set<string>();
+  const options = [...(configured ? [configured] : []), ...remote, ...catalog.options].filter((o) => {
+    if (seen.has(o.id)) return false;
+    seen.add(o.id);
+    return true;
+  });
   return { default: options[0]?.id ?? "", options };
 }
 
@@ -163,7 +264,7 @@ const support: AcpSupport = {
   displayName: "Hermes",
   access: "custom",
   models: EMPTY,
-  resolveModels,
+  resolveModels: (env: Record<string, string | undefined>, config: any) => resolveModels(env, config),
   resolveTurnModel: (model, env) => {
     if (!model) return model;
     ensureHermesInjectProvider(model, env);

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -82,9 +82,67 @@ export function hermesAcpModelId(modelId: string | null | undefined): string | n
   return `custom:${inject.host}:${inject.model}`;
 }
 
+/** The id used when Hermes should run on the provider its own config names.
+ *
+ * Deliberately not an inject id: `hermesAcpModelId` returns null for it, so
+ * `configureSession` sends no `session/set_model` and Hermes falls through to
+ * the model in its own `config.yaml`. `spawnArgs` passes no `-m` either (ACP
+ * ignores it), so nothing overrides that choice.
+ */
+export const HERMES_CONFIG_MODEL_ID = "hermes-default";
+
+/** Model Hermes' own config will use, when a remote provider is configured.
+ *
+ * Hermes is a BYOK harness and OpenMausBot only ever offered it *local* hosts
+ * (Ollama, LM Studio, EXO...). A user who has configured Hermes with a hosted
+ * provider — an OpenRouter key in `~/.hermes/.env`, which is how `hermes setup`
+ * stores it — had no selectable model at all: the picker showed "No local
+ * models found" and greyed the agent out, despite Hermes being installed,
+ * authenticated and perfectly able to answer.
+ *
+ * Read-only on purpose. `ensureHermesInjectProvider` writes `config.yaml`, and
+ * doing that from a catalog probe would rewrite the user's real Hermes config
+ * as a side effect of opening a menu.
+ *
+ * Returns null when no hosted key is configured, which leaves the catalog
+ * exactly as it was for local-only setups.
+ */
+export function hermesConfiguredModel(
+  env: Record<string, string | undefined> = process.env,
+): { id: string; label: string } | null {
+  const dir = hermesHome(env);
+  let secrets = "";
+  try {
+    secrets = readFileSync(join(dir, ".env"), "utf8");
+  } catch {
+    return null;
+  }
+  // Only an uncommented, non-empty assignment counts; the shipped file has the
+  // key present but commented out, and that must not read as "configured".
+  const keyed = /^[ \t]*OPENROUTER_API_KEY[ \t]*=[ \t]*(\S+)/m.exec(secrets);
+  if (!keyed) return null;
+
+  let model = "";
+  try {
+    const cfg = readFileSync(join(dir, "config.yaml"), "utf8");
+    const m = /^[ \t]*default[ \t]*:[ \t]*["']?([\w./:+-]+)["']?[ \t]*$/m.exec(cfg);
+    if (m) model = m[1];
+  } catch {
+    /* config unreadable — the id still works, only the label is less specific */
+  }
+  return {
+    id: HERMES_CONFIG_MODEL_ID,
+    label: model ? `${model} (Hermes config)` : "Hermes default (config)",
+  };
+}
+
 async function resolveModels(env: Record<string, string | undefined>): Promise<ModelCatalog> {
   const catalog = await mergeLocalInject(EMPTY, env);
-  return { default: catalog.options[0]?.id ?? "", options: catalog.options };
+  const configured = hermesConfiguredModel(env);
+  // Listed first so it is the default: someone who configured a hosted provider
+  // meant to use it, and a local host may not even be running.
+  const options = configured ? [configured, ...catalog.options] : catalog.options;
+  return { default: options[0]?.id ?? "", options };
 }
 
 async function applySetting(


### PR DESCRIPTION
## The problem

Hermes' model picker offers **only** local inference hosts (Ollama, LM Studio, EXO, oMLX, Unsloth). But Hermes is a BYOK harness whose own `hermes setup` writes a hosted provider key into `~/.hermes/.env`.

So with a hosted provider configured, the picker shows:

```
Local models — No local models found
Start oMLX, Ollama, Unsloth, LM Studio, or EXO, then reopen this picker.
```

…and the agent is greyed out and unselectable — while `hermes` is installed, authenticated (`state: available`, `authenticated: true`) and perfectly able to answer from its own config.

## The fix

`resolveModels` now also offers the model Hermes' config names, **when a hosted key is actually configured**.

The option is deliberately **not** a local-inject id. That matters: `hermesAcpModelId` returns `null` for it, so `configureSession` sends no `session/set_model`, and `spawnArgs` passes no `-m` (ACP ignores it anyway). Hermes therefore falls through to its own configured provider — which is exactly the intent.

**Read-only.** `ensureHermesInjectProvider` writes `config.yaml`; doing that from a catalog probe would rewrite the user's real Hermes config as a side effect of opening a menu. This only reads.

**Returns `null` when no hosted key is set**, so local-only installs keep precisely the catalog they have today.

## Verified

Against Hermes Agent v0.20.5 with an OpenRouter key configured:

- picker offers `anthropic/claude-opus-4.6 (Hermes config)`
- a real turn completes: `turn.completed ok: true`, reply received, no runtime errors
- spend registers on the provider side afterwards

## Tests

- configured key → offered
- **commented-out key → not offered** (the shipped `.env` carries `# OPENROUTER_API_KEY=`; treating that as configured would offer a model that cannot authenticate)
- no `.env` → `null`, local-only setups unchanged
- unreadable `config.yaml` → still usable, generic label
- the id maps to no ACP model id

Full suite green locally: 1524 passed, 8 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes now supports OpenRouter-hosted model discovery when an API key is configured.
  * Configured and discovered models retain their provider-specific IDs and appear as custom options.
  * Configured, remote, and local models are combined without duplicates, with the configured model selected by default.
  * Model discovery no longer changes Hermes configuration files.

* **Tests**
  * Added coverage for hosted keys, commented-out keys, missing or unreadable configuration, custom flags, local mappings, and model discovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->