### PR TITLE
fix(skins): make controls visible on cards in the light skins

### DIFF
--- a/scripts/check-skin-contrast.mjs
+++ b/scripts/check-skin-contrast.mjs
@@ -110,6 +110,25 @@ const PAIRS = [
   ["--color-focus", "--color-app", 3],
   ["--color-focus", "--color-panel", 3],
   ["--color-focus", "--color-card", 3],
+  // Surface against surface. Text contrast alone will not catch a skin that
+  // gives two surfaces the same value: Atelier and Lagoon both defined
+  // `raised` as the pure white they use for a card, so every chip, hover fill
+  // and answered row painted in `raised` on a card was invisible while this
+  // file stayed green. A surface is not text — it only has to be seen at all —
+  // so the bar is a just-perceptible step rather than a WCAG ratio.
+  //
+  // `control` is measured against every surface it can land on, which is the
+  // whole list: a tone chosen to clear the card and the panel drifted into
+  // `inset` instead, and the badges inside an inset row went invisible again.
+  ["--color-control", "--color-card", 1.06],
+  ["--color-control", "--color-panel", 1.06],
+  ["--color-control", "--color-app", 1.04],
+  ["--color-control", "--color-inset", 1.04],
+  ["--color-control", "--color-raised-hover", 1.04],
+  ["--color-raised-hover", "--color-card", 1.04],
+  ["--color-inset", "--color-card", 1.04],
+  ["--color-card", "--color-app", 1.04],
+  ["--color-panel", "--color-app", 1.03],
 ];
 
 const skins = parseSkins(css);

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -101,7 +101,7 @@ function CredentialHelp({ section }: { section: ConfigSection }) {
         aria-expanded={open}
         aria-controls={popoverId}
         onClick={() => setOpen((current) => !current)}
-        className="flex size-6 items-center justify-center rounded-md text-ink-secondary outline-none transition-colors hover:bg-raised hover:text-ink focus-visible:ring-2 focus-visible:ring-accent/70"
+        className="flex size-6 items-center justify-center rounded-md text-ink-secondary outline-none transition-colors hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent/70"
       >
         <CircleHelp size={14} aria-hidden="true" />
       </button>
@@ -178,7 +178,7 @@ export function ApiKeyRow({
         <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
         <span>{credential.label}</span>
         {credential.optional && (
-          <span className="rounded bg-raised px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-secondary">
+          <span className="rounded bg-control px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-secondary">
             Optional
           </span>
         )}
@@ -202,8 +202,8 @@ export function ApiKeyRow({
           className={cn(
             "flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg py-2 text-[13px]",
             clearing
-              ? "bg-raised text-danger hover:bg-raised-hover"
-              : "bg-raised text-ink hover:bg-raised-hover",
+              ? "bg-control text-danger hover:bg-raised-hover"
+              : "bg-control text-ink hover:bg-raised-hover",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
           title={clearing ? "Remove the saved key" : "Save"}
@@ -249,7 +249,7 @@ export function VpsConnection() {
       <div className="mb-1.5 flex items-center gap-2 text-[13px] text-ink-secondary">
         <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
         <span>Self-hosted VPS</span>
-        <span className="rounded bg-raised px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-secondary">
+        <span className="rounded bg-control px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-secondary">
           Optional
         </span>
         {configured && <span className="text-[11px] text-success">Connected</span>}
@@ -283,7 +283,7 @@ export function VpsConnection() {
           disabled={saving || (!alias.trim() && !configured)}
           className={cn(
             "flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg py-2 text-[13px]",
-            !alias.trim() && configured ? "bg-raised text-danger hover:bg-raised-hover" : "bg-raised text-ink hover:bg-raised-hover",
+            !alias.trim() && configured ? "bg-control text-danger hover:bg-raised-hover" : "bg-control text-ink hover:bg-raised-hover",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
           title={!alias.trim() && configured ? "Remove the saved alias" : "Save"}

--- a/src/components/BotProfileAvatarCard.tsx
+++ b/src/components/BotProfileAvatarCard.tsx
@@ -129,10 +129,10 @@ export function BotProfileAvatarCard({
   return (
     <div className="overflow-hidden rounded-xl border border-hairline/40 bg-card">
       <div className="flex items-center justify-between border-b border-hairline/40 px-3 py-2.5">
-        <span className="rounded-lg bg-raised px-3 py-1.5 text-[14px] font-medium text-ink">Avatar</span>
+        <span className="rounded-lg bg-control px-3 py-1.5 text-[14px] font-medium text-ink">Avatar</span>
         <button
           onClick={() => onPatch({ avatarCrop: "mascot", color: "green", mascotExpression: null })}
-          className="rounded-md px-2 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
+          className="rounded-md px-2 py-1.5 text-[13px] text-ink-secondary hover:bg-control hover:text-ink"
         >
           Reset mascot
         </button>
@@ -161,7 +161,7 @@ export function BotProfileAvatarCard({
             type="button"
             onClick={() => fileRef.current?.click()}
             disabled={uploading || generating}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
           >
             {uploading ? <Loader2 size={14} className="animate-spin" /> : <ImagePlus size={14} />}
             Upload image
@@ -173,7 +173,7 @@ export function BotProfileAvatarCard({
               disabled={uploading || generating}
               aria-label="Remove custom avatar image"
               title="Remove custom image"
-              className="flex size-10 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-danger disabled:opacity-50"
+              className="flex size-10 items-center justify-center rounded-lg text-ink-secondary hover:bg-control hover:text-danger disabled:opacity-50"
             >
               <Trash2 size={14} />
             </button>
@@ -194,7 +194,7 @@ export function BotProfileAvatarCard({
               className={cn(
                 "py-1.5 text-[12.5px]",
                 index > 0 && "border-l border-hairline/40",
-                crop === candidate ? "bg-raised text-ink" : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
+                crop === candidate ? "bg-control text-ink" : "text-ink-secondary hover:bg-control/60 hover:text-ink",
               )}
             >
               {CROP_LABEL[candidate]}
@@ -215,7 +215,7 @@ export function BotProfileAvatarCard({
                   aria-pressed={activeState === expression}
                   onClick={() => onPatch({ mascotExpression: expression })}
                   className={cn(
-                    "flex h-[58px] items-center justify-center rounded-xl bg-inset transition-colors hover:bg-raised",
+                    "flex h-[58px] items-center justify-center rounded-xl bg-inset transition-colors hover:bg-control",
                     activeState === expression && "ring-2 ring-accent-border",
                   )}
                   title={expression}
@@ -274,7 +274,7 @@ export function BotProfileAvatarCard({
                   type="button"
                   onClick={() => void saveImageKey()}
                   disabled={savingKey || !imageKey.trim()}
-                  className="flex w-[72px] items-center justify-center gap-1.5 rounded-lg bg-raised text-[12.5px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                  className="flex w-[72px] items-center justify-center gap-1.5 rounded-lg bg-control text-[12.5px] text-ink hover:bg-raised-hover disabled:opacity-50"
                 >
                   {savingKey ? <Loader2 size={13} className="animate-spin" /> : <><Check size={13} /> Save</>}
                 </button>
@@ -320,7 +320,7 @@ export function BotProfileAvatarCard({
                     type="button"
                     onClick={() => void saveImageKey()}
                     disabled={savingKey || !imageKey.trim()}
-                    className="flex w-[72px] items-center justify-center gap-1.5 rounded-lg bg-raised text-[12px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                    className="flex w-[72px] items-center justify-center gap-1.5 rounded-lg bg-control text-[12px] text-ink hover:bg-raised-hover disabled:opacity-50"
                   >
                     {savingKey ? <Loader2 size={13} className="animate-spin" /> : <><Check size={13} /> Save</>}
                   </button>

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -273,7 +273,7 @@ export function CompanionSection() {
               <button
                 disabled={busy}
                 onClick={() => void act((c) => c.pairing(false))}
-                className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised disabled:opacity-40"
+                className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
               >
                 Cancel
               </button>
@@ -324,7 +324,7 @@ export function CompanionSection() {
                   disabled={busy}
                   onClick={() => void act((c) => c.revoke(device.id))}
                   aria-label={`Remove ${device.name}`}
-                  className="shrink-0 rounded p-1 text-ink-secondary hover:bg-raised hover:text-danger disabled:opacity-40"
+                  className="shrink-0 rounded p-1 text-ink-secondary hover:bg-control hover:text-danger disabled:opacity-40"
                 >
                   <Trash2 size={14} />
                 </button>
@@ -338,6 +338,6 @@ export function CompanionSection() {
 }
 
 const cnSwitch = (on: boolean) =>
-  `relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-40 ${on ? "bg-accent" : "bg-raised"}`;
+  `relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-40 ${on ? "bg-accent" : "bg-control"}`;
 const cnKnob = (on: boolean) =>
   `absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white transition-all ${on ? "left-[21px]" : "left-[3px]"}`;

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -645,7 +645,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       <div className="flex items-center justify-between px-4 py-3">
         <button
           onClick={() => dispatch({ type: "toggleSettings", open: true })}
-          className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+          className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
           title="Bot settings"
         >
           <Settings size={18} />
@@ -657,7 +657,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               aria-pressed={panelView === "computer"}
               className={cn(
                 "flex items-center gap-1.5 px-2.5 py-1 text-[12.5px]",
-                panelView === "computer" ? "bg-raised text-ink" : "text-ink-secondary hover:text-ink",
+                panelView === "computer" ? "bg-control text-ink" : "text-ink-secondary hover:text-ink",
               )}
             >
               <Monitor size={13} /> Computer
@@ -667,7 +667,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               aria-pressed={panelView === "android"}
               className={cn(
                 "flex items-center gap-1.5 border-l border-hairline/40 px-2.5 py-1 text-[12.5px]",
-                panelView === "android" ? "bg-raised text-ink" : "text-ink-secondary hover:text-ink",
+                panelView === "android" ? "bg-control text-ink" : "text-ink-secondary hover:text-ink",
               )}
             >
               <Smartphone size={13} /> Android
@@ -678,7 +678,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         )}
         <button
           onClick={() => dispatch({ type: "toggleComputer", open: false })}
-          className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+          className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
         >
           <X size={18} />
         </button>
@@ -730,7 +730,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               {phase === "local" && !isLinux && localMisses >= 3 && (
                 <button
                   onClick={() => window.ogb?.permOpenSettings?.("screen")}
-                  className="mt-1 rounded-lg bg-raised px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
+                  className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                 >
                   Open Settings
                 </button>
@@ -750,7 +750,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 ) : (
                   <button
                     onClick={openVmSettings}
-                    className="mt-1 rounded-lg bg-raised px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
+                    className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                   >
                     Open Local VM setup
                   </button>
@@ -759,7 +759,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               {(phase === "vps-unconfigured" || phase === "vps-stopped") && (
                 <button
                   onClick={openConnectionSettings}
-                  className="mt-1 rounded-lg bg-raised px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
+                  className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                 >
                   Open VPS settings
                 </button>
@@ -768,7 +768,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 <button
                   onClick={() => run("provision")}
                   disabled={pending === "provision"}
-                  className="mt-1 rounded-lg bg-raised px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                  className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover disabled:opacity-50"
                 >
                   {pending === "provision" && <Loader2 size={13} className="mr-1.5 inline animate-spin" />}
                   Start VPS computer
@@ -801,7 +801,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             </div>
             <button
               onClick={openConnectionSettings}
-              className="rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
+              className="rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
             >
               Open VPS settings
             </button>
@@ -828,7 +828,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               <button
                 onClick={() => controlAction("dismiss-help")}
                 disabled={controlPending}
-                className="rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                className="rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
               >
                 Dismiss
               </button>
@@ -856,7 +856,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
           <button
             onClick={() => void openDesktop()}
             disabled={pending === "join"}
-            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
             title="Open the Local VM's live desktop inside OpenMausBot"
           >
             {pending === "join" ? <Loader2 size={14} className="animate-spin" /> : <Monitor size={14} />}
@@ -867,7 +867,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
           <button
             onClick={() => void openDesktop()}
             disabled={controlPending || pending === "join" || !vmViewerUrl}
-            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
             title="Pause the bot's hands and open the Local VM's live desktop"
           >
             {pending === "join" ? <Loader2 size={14} className="animate-spin" /> : <Hand size={14} />}
@@ -894,7 +894,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                   cloudBackend === "box" ? void openDesktop() : controlAction("take")
                 }
                 disabled={controlPending || pending === "join"}
-                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
                 title="Pause the bot's hands and drive this computer yourself"
               >
                 {pending === "join" ? <Loader2 size={14} className="animate-spin" /> : <Hand size={14} />}
@@ -905,7 +905,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               <button
                 onClick={() => void openDesktop()}
                 disabled={pending === "join"}
-                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
               >
                 {pending === "join" ? <Loader2 size={14} className="animate-spin" /> : <Monitor size={14} />}
                 Open live desktop
@@ -915,7 +915,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               <button
                 onClick={() => run("sleep")}
                 disabled={pending === "sleep"}
-                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
                 title="Put the computer to sleep"
               >
                 {pending === "sleep" ? <Loader2 size={14} className="animate-spin" /> : <Moon size={14} />}
@@ -982,8 +982,8 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                   i > 0 && "border-l border-hairline/40",
                   disabled && "cursor-not-allowed opacity-40",
                   bot.computer === mode
-                    ? "bg-raised text-ink"
-                    : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
+                    ? "bg-control text-ink"
+                    : "text-ink-secondary hover:bg-control/60 hover:text-ink",
                 )}
               >
                 {label}
@@ -1009,7 +1009,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               Scheduled tasks
             </div>
             {botRoutines.length > 0 && (
-              <span className="rounded-full bg-raised px-2 py-0.5 text-[10px] font-medium text-ink-secondary">
+              <span className="rounded-full bg-control px-2 py-0.5 text-[10px] font-medium text-ink-secondary">
                 {botRoutines.length}
               </span>
             )}
@@ -1040,7 +1040,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 <button
                   key={routine.id}
                   onClick={() => dispatch({ type: "showRoutines" })}
-                  className="flex w-full items-center gap-2 rounded-lg bg-inset px-3 py-2 text-left hover:bg-raised/60"
+                  className="flex w-full items-center gap-2 rounded-lg bg-inset px-3 py-2 text-left hover:bg-control/60"
                 >
                   <span className={cn("size-1.5 shrink-0 rounded-full", routine.enabled ? "bg-success" : "bg-ink-secondary/40")} />
                   <span className="min-w-0 flex-1">
@@ -1064,7 +1064,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             </button>
             <button
               onClick={() => dispatch({ type: "showRoutines" })}
-              className="flex items-center justify-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
+              className="flex items-center justify-center gap-1.5 rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
               title="Open schedules"
             >
               <CalendarDays size={14} />

--- a/src/components/ConnectorCard.tsx
+++ b/src/components/ConnectorCard.tsx
@@ -93,7 +93,7 @@ export function ConnectorCard({ botId, threadId, message }: { botId: string; thr
     <div className="flex w-full justify-start">
       <div className="w-full max-w-[520px] overflow-hidden rounded-2xl border border-hairline/50 bg-card shadow-sm">
         <div className="flex items-start gap-3 p-4">
-          <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-raised text-[16px] font-semibold text-ink">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-control text-[16px] font-semibold text-ink">
             {connector.label.slice(0, 1).toUpperCase() || <PlugZap size={19} />}
           </div>
           <div className="min-w-0 flex-1">
@@ -120,7 +120,7 @@ export function ConnectorCard({ botId, threadId, message }: { botId: string; thr
             {error && <p className="mt-2 text-[12px] text-danger">{error}</p>}
           </div>
           {!connected && (
-            <button onClick={dismiss} aria-label="Not now" title="Not now" className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink">
+            <button onClick={dismiss} aria-label="Not now" title="Not now" className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink">
               <X size={15} />
             </button>
           )}

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -69,7 +69,7 @@ function CommandRow({ command, actionLabel }: { command: string; actionLabel: st
             onClick={() => void copy()}
             aria-label="Copy command"
             title="Copy command"
-            className="flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[11.5px] font-medium text-ink-secondary hover:bg-raised hover:text-ink"
+            className="flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[11.5px] font-medium text-ink-secondary hover:bg-control hover:text-ink"
           >
             {status === "copied" ? <Check size={12} className="text-success" /> : <Copy size={12} />}
             {status === "copied" ? "Copied" : "Copy"}
@@ -95,7 +95,7 @@ function CommandRow({ command, actionLabel }: { command: string; actionLabel: st
         <button
           type="button"
           onClick={() => void copy()}
-          className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-raised px-3 py-2 text-[12.5px] font-semibold text-ink hover:bg-raised-hover"
+          className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-control px-3 py-2 text-[12.5px] font-semibold text-ink hover:bg-raised-hover"
         >
           {status === "copied" ? <Check size={14} className="text-success" /> : <Copy size={14} />}
           {status === "copied" ? "Command copied" : "Copy command"}
@@ -131,7 +131,7 @@ export function EngineSetup({
   // token) and intentionally have no install descriptor.
   if (!install) {
     return (
-      <div className={cn("rounded-xl border border-hairline/40 bg-raised/30 p-3", className)}>
+      <div className={cn("rounded-xl border border-hairline/40 bg-control/30 p-3", className)}>
         <div className="text-[13px] font-semibold text-ink">{instance.displayName} isn’t ready</div>
         <p className="mt-1 text-[12px] leading-relaxed text-ink-secondary">
           {instance.snapshot.reason ?? "This engine is not available on this machine."}
@@ -141,7 +141,7 @@ export function EngineSetup({
   }
 
   return (
-    <div className={cn("rounded-xl border border-hairline/40 bg-raised/30 p-3", className)}>
+    <div className={cn("rounded-xl border border-hairline/40 bg-control/30 p-3", className)}>
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-inset text-ink-secondary">
           {signInOnly ? <LogIn size={14} /> : <Download size={14} />}

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -233,7 +233,7 @@ export function LocalComputerSection() {
           <span
             className={cn(
               "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12.5px]",
-              headerReady ? "bg-success/15 text-success" : "bg-raised text-ink-secondary",
+              headerReady ? "bg-success/15 text-success" : "bg-control text-ink-secondary",
             )}
           >
             {loading ? <Loader2 size={12} className="animate-spin" /> : headerReady ? <Check size={12} /> : <Circle size={9} />}
@@ -255,7 +255,7 @@ export function LocalComputerSection() {
               setRefreshKey((key) => key + 1);
             }}
             disabled={loading || pending !== null}
-            className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-40"
           >
             <RefreshCw size={12} /> Re-check
           </button>
@@ -264,7 +264,7 @@ export function LocalComputerSection() {
               href={status?.viewer_url ?? c?.view}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink hover:bg-raised"
+              className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink hover:bg-control"
             >
               <ExternalLink size={12} /> Watch screen
             </a>
@@ -287,7 +287,7 @@ export function LocalComputerSection() {
               className={cn(
                 "flex-1 px-3 py-2 text-[13px] disabled:opacity-50",
                 index > 0 && "border-l border-hairline/40",
-                status?.mode === mode ? "bg-raised text-ink" : "text-ink-secondary hover:text-ink",
+                status?.mode === mode ? "bg-control text-ink" : "text-ink-secondary hover:text-ink",
               )}
             >
               {mode === "shared" ? "Shared" : "Per bot"}
@@ -304,7 +304,7 @@ export function LocalComputerSection() {
             value={status?.max_instances ?? 2}
             disabled={!status || policyPending}
             onChange={(event) => void savePolicy(status?.mode ?? "shared", Number(event.target.value))}
-            className="rounded-lg border border-hairline/40 bg-raised px-2.5 py-1.5 text-[13px] text-ink disabled:opacity-50"
+            className="rounded-lg border border-hairline/40 bg-control px-2.5 py-1.5 text-[13px] text-ink disabled:opacity-50"
           >
             {[1, 2, 3, 4].map((value) => <option key={value} value={value}>{value}</option>)}
           </select>

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -41,8 +41,8 @@ function ModelRow({
       type="button"
       onClick={onPick}
       className={cn(
-        "flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] text-ink hover:bg-raised/60",
-        current && "bg-raised",
+        "flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] text-ink hover:bg-control/60",
+        current && "bg-control",
       )}
     >
       <span className="flex min-w-0 items-center gap-2">
@@ -208,7 +208,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
         aria-expanded={open}
         aria-haspopup="dialog"
         className={cn(
-          "flex items-center gap-1.5 rounded-full border border-hairline/40 bg-raised/60 py-1 pl-2 pr-2.5 text-[13px] text-ink hover:bg-raised",
+          "flex items-center gap-1.5 rounded-full border border-hairline/40 bg-control/60 py-1 pl-2 pr-2.5 text-[13px] text-ink hover:bg-raised-hover",
           // in a narrow chat header fold to a rounded square with just the
           // provider mark; the model name rides the tooltip (a bot with no
           // resolved engine keeps its label — the mark is what would hide it)
@@ -249,7 +249,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                     title={`${instance.displayName} · ${engineStatus(instance)}`}
                     className={cn(
                       "relative flex size-9 items-center justify-center rounded-lg",
-                      selected ? "bg-raised ring-1 ring-hairline/50" : "hover:bg-raised/60",
+                      selected ? "bg-control ring-1 ring-hairline/50" : "hover:bg-control/60",
                     )}
                   >
                     <ProviderMark driverKind={instance.driverKind} size={18} />
@@ -303,7 +303,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                       setPane("main");
                       resetList();
                     }}
-                    className="mx-2 mb-1 flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1.5 text-left text-[12px] text-ink-secondary hover:bg-raised/60"
+                    className="mx-2 mb-1 flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1.5 text-left text-[12px] text-ink-secondary hover:bg-control/60"
                   >
                     <ChevronLeft size={13} /> Back to {railInstance.displayName} models
                   </button>
@@ -352,7 +352,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                             <button
                               type="button"
                               onClick={() => setShowAll(true)}
-                              className="mt-1 flex w-full items-center justify-between rounded-lg border-t border-hairline/40 px-2.5 py-2 text-[12.5px] font-medium text-ink-secondary hover:bg-raised/60 hover:text-ink"
+                              className="mt-1 flex w-full items-center justify-between rounded-lg border-t border-hairline/40 px-2.5 py-2 text-[12.5px] font-medium text-ink-secondary hover:bg-control/60 hover:text-ink"
                             >
                               Show all {official.length} models <ChevronDown size={13} />
                             </button>
@@ -361,7 +361,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                             <button
                               type="button"
                               onClick={() => setShowAll(false)}
-                              className="mt-1 w-full rounded-lg px-2.5 py-2 text-[12px] text-ink-secondary hover:bg-raised/60 hover:text-ink"
+                              className="mt-1 w-full rounded-lg px-2.5 py-2 text-[12px] text-ink-secondary hover:bg-control/60 hover:text-ink"
                             >
                               Show suggested only
                             </button>
@@ -407,7 +407,7 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                       setPane("custom");
                       resetList();
                     }}
-                    className="flex w-full shrink-0 items-center justify-between gap-2 border-t border-hairline/40 px-4 py-3 text-left text-[12.5px] font-medium text-ink hover:bg-raised/60 disabled:cursor-not-allowed disabled:text-ink-secondary/40 disabled:hover:bg-transparent"
+                    className="flex w-full shrink-0 items-center justify-between gap-2 border-t border-hairline/40 px-4 py-3 text-left text-[12.5px] font-medium text-ink hover:bg-control/60 disabled:cursor-not-allowed disabled:text-ink-secondary/40 disabled:hover:bg-transparent"
                   >
                     <span>Use a local model</span>
                     <span className="flex items-center gap-2">

--- a/src/components/OptionCard.tsx
+++ b/src/components/OptionCard.tsx
@@ -50,12 +50,18 @@ export function OptionCard({
             className={cn(
               "flex w-full items-center gap-3 px-3 py-3 text-left text-[15px] text-ink",
               i > 0 && "border-t border-hairline/40",
+              // `raised` is the wrong fill here: the light skins define it as
+              // pure white, the same value as the card underneath, so a
+              // hovered or answered row used to be invisible. `raised-hover`
+              // is the one tone every skin guarantees stands off a surface.
               card.answered === opt
-                ? "bg-raised"
-                : "hover:bg-raised/60 disabled:hover:bg-transparent",
+                ? "bg-raised-hover"
+                : "hover:bg-raised-hover/60 disabled:hover:bg-transparent",
             )}
           >
-            <span className="flex size-6 items-center justify-center rounded-md bg-raised text-[12px] font-medium text-ink-secondary">
+            {/* the hairline keeps the letter a chip even when the row it sits
+                on is filled */}
+            <span className="flex size-6 items-center justify-center rounded-md border border-hairline/50 bg-inset text-[12px] font-medium text-ink-secondary">
               {LETTERS[i]}
             </span>
             {opt}

--- a/src/components/OptionCard.tsx
+++ b/src/components/OptionCard.tsx
@@ -35,7 +35,7 @@ export function OptionCard({
           onClick={() =>
             dispatch({ type: "dismissCard", botId, messageId: message.id })
           }
-          className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+          className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
         >
           <X size={16} />
         </button>
@@ -59,9 +59,9 @@ export function OptionCard({
                 : "hover:bg-raised-hover/60 disabled:hover:bg-transparent",
             )}
           >
-            {/* the hairline keeps the letter a chip even when the row it sits
-                on is filled */}
-            <span className="flex size-6 items-center justify-center rounded-md border border-hairline/50 bg-inset text-[12px] font-medium text-ink-secondary">
+            {/* `control` is the chip tone every skin guarantees on a card; the
+                hairline keeps it a chip even on a row that is itself filled */}
+            <span className="flex size-6 items-center justify-center rounded-md border border-hairline/50 bg-control text-[12px] font-medium text-ink-secondary">
               {LETTERS[i]}
             </span>
             {opt}

--- a/src/components/PendingApproval.tsx
+++ b/src/components/PendingApproval.tsx
@@ -61,11 +61,11 @@ export const PendingApprovalPanel = memo(function PendingApprovalPanel({
   index: number;
 }) {
   return (
-    <div className="rounded-t-2xl border-b border-hairline/50 bg-raised/40 px-4 py-3">
+    <div className="rounded-t-2xl border-b border-hairline/50 bg-control/40 px-4 py-3">
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-[11px] uppercase tracking-[0.18em] text-ink-secondary">Pending approval</span>
         {count > 1 && (
-          <span className="rounded-full bg-raised px-1.5 py-0.5 text-[11px] tabular-nums text-ink-secondary">
+          <span className="rounded-full bg-control px-1.5 py-0.5 text-[11px] tabular-nums text-ink-secondary">
             {index + 1} of {count}
           </span>
         )}
@@ -107,7 +107,7 @@ export function PendingApprovalActions({
   const base = "rounded-full px-3.5 py-1.5 text-[13.5px] transition-colors";
   return (
     <div className="flex flex-wrap items-center justify-end gap-2 px-2 py-2">
-      <button onClick={onCancelTurn} className={cn(base, "text-ink-secondary hover:bg-raised hover:text-ink")}>
+      <button onClick={onCancelTurn} className={cn(base, "text-ink-secondary hover:bg-control hover:text-ink")}>
         Cancel turn
       </button>
       <button
@@ -120,7 +120,7 @@ export function PendingApprovalActions({
         <button
           onClick={() => decide("allow", true)}
           title={`Stop asking ${bot.name} about ${pending.allowKey}`}
-          className={cn(base, "border border-hairline/50 text-ink hover:bg-raised")}
+          className={cn(base, "border border-hairline/50 text-ink hover:bg-control")}
         >
           Always allow
         </button>

--- a/src/components/Reactions.tsx
+++ b/src/components/Reactions.tsx
@@ -55,7 +55,7 @@ export function ReactionBar({ threadId, message }: { threadId: string; message: 
             key={emoji}
             onClick={() => dispatch({ type: "toggleReaction", threadId, messageId: message.id, emoji })}
             aria-label={`React ${emoji}`}
-            className="rounded-full px-1 py-0.5 text-[13px] leading-none hover:bg-raised"
+            className="rounded-full px-1 py-0.5 text-[13px] leading-none hover:bg-control"
           >
             {emoji}
           </button>
@@ -65,7 +65,7 @@ export function ReactionBar({ threadId, message }: { threadId: string; message: 
           aria-label="More reactions"
           aria-expanded={pickerOpen}
           title="More reactions"
-          className="flex size-[22px] items-center justify-center rounded-full text-ink-secondary hover:bg-raised hover:text-ink"
+          className="flex size-[22px] items-center justify-center rounded-full text-ink-secondary hover:bg-control hover:text-ink"
         >
           {pickerOpen ? <X size={12} /> : <Plus size={12} />}
         </button>
@@ -85,7 +85,7 @@ export function ReactionBar({ threadId, message }: { threadId: string; message: 
                   setPickerOpen(false);
                 }}
                 aria-label={`React ${emoji}`}
-                className="rounded-lg px-1 py-1 text-[15px] leading-none hover:bg-raised"
+                className="rounded-lg px-1 py-1 text-[15px] leading-none hover:bg-control"
               >
                 {emoji}
               </button>
@@ -127,7 +127,7 @@ export function ReactionChips({
             "flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[12px] leading-none",
             bys.includes("user")
               ? "border-accent/50 bg-accent/15"
-              : "border-hairline/40 bg-panel hover:bg-raised",
+              : "border-hairline/40 bg-panel hover:bg-control",
           )}
         >
           <span>{emoji}</span>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -89,7 +89,7 @@ function UpdatesRow() {
           void updater.check();
         }}
         disabled={s?.status === "checking" || s?.status === "downloading"}
-        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-raised disabled:opacity-40"
+        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
       >
         {s?.status === "available"
           ? "Download"
@@ -130,7 +130,7 @@ function AnalyticsRow() {
 }
 
 const cnSwitch = (on: boolean) =>
-  `relative h-6 w-11 shrink-0 rounded-full transition-colors ${on ? "bg-accent" : "bg-raised"}`;
+  `relative h-6 w-11 shrink-0 rounded-full transition-colors ${on ? "bg-accent" : "bg-control"}`;
 const cnKnob = (on: boolean) =>
   `absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white transition-all ${on ? "left-[21px]" : "left-[3px]"}`;
 
@@ -207,7 +207,7 @@ export function SettingsModal() {
               aria-current={section === id ? "page" : undefined}
               className={cn(
                 "flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[14px]",
-                section === id ? "bg-raised text-ink" : "text-ink-secondary hover:bg-raised/50 hover:text-ink",
+                section === id ? "bg-control text-ink" : "text-ink-secondary hover:bg-control/50 hover:text-ink",
               )}
             >
               <Icon size={15} />
@@ -224,7 +224,7 @@ export function SettingsModal() {
             <button
               onClick={() => dispatch({ type: "toggleAppSettings", open: false })}
               aria-label="Close settings"
-              className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+              className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
             >
               <X size={18} />
             </button>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -116,7 +116,7 @@ function WorkingFolder({ bot }: { bot: Bot }) {
           <div className="min-w-0 flex-1 truncate rounded-lg border border-hairline/40 bg-inset px-3 py-2 font-mono text-[12.5px] text-ink" title={bot.cwd}>
             {bot.cwd ? shortPath(bot.cwd, home) : <span className="text-ink-secondary">Private bot workspace</span>}
           </div>
-          <button onClick={() => void pick()} disabled={saving} className="flex shrink-0 items-center gap-1.5 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50">
+          <button onClick={() => void pick()} disabled={saving} className="flex shrink-0 items-center gap-1.5 rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50">
             <FolderOpen size={14} /> Choose…
           </button>
           {bot.cwd && (
@@ -140,7 +140,7 @@ function WorkingFolder({ bot }: { bot: Bot }) {
             value={draft ?? bot.cwd ?? ""}
             onChange={(e) => setDraft(e.target.value)}
           />
-          <button type="submit" disabled={saving || draft === null} className="shrink-0 rounded-lg bg-raised px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50">
+          <button type="submit" disabled={saving || draft === null} className="shrink-0 rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50">
             Save
           </button>
         </form>
@@ -250,7 +250,7 @@ function MemoryCard({ bot }: { bot: Bot }) {
             <span className="truncate font-mono text-[12.5px] text-ink">memory/{topic.name}</span>
             <button
               onClick={() => setTopic(null)}
-              className="shrink-0 rounded-md px-2 py-1 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
+              className="shrink-0 rounded-md px-2 py-1 text-[13px] text-ink-secondary hover:bg-control hover:text-ink"
             >
               Back
             </button>
@@ -277,7 +277,7 @@ function MemoryCard({ bot }: { bot: Bot }) {
             <button
               onClick={() => void save()}
               disabled={saving || !dirty}
-              className="rounded-lg bg-raised px-3 py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
+              className="rounded-lg bg-control px-3 py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
             >
               {saving ? "Saving…" : "Save"}
             </button>
@@ -297,7 +297,7 @@ function MemoryCard({ bot }: { bot: Bot }) {
                   <button
                     key={entry.name}
                     onClick={() => void openTopic(entry.name)}
-                    className="flex w-full items-center justify-between gap-2 border-b border-hairline/40 px-3 py-2 text-left last:border-b-0 hover:bg-raised/60"
+                    className="flex w-full items-center justify-between gap-2 border-b border-hairline/40 px-3 py-2 text-left last:border-b-0 hover:bg-control/60"
                   >
                     <span className="truncate font-mono text-[12.5px] text-ink">{entry.name}</span>
                     <span className="shrink-0 text-[11.5px] text-ink-secondary">{formatBytes(entry.bytes)}</span>
@@ -364,7 +364,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
           onClick={() => dispatch({ type: "toggleSettings", open: false })}
           aria-label="Collapse agent profile"
           title="Collapse agent profile"
-          className="flex size-10 items-center justify-center rounded-md text-ink-secondary hover:bg-raised hover:text-ink"
+          className="flex size-10 items-center justify-center rounded-md text-ink-secondary hover:bg-control hover:text-ink"
         >
           <ChevronLeft size={18} />
         </button>
@@ -373,7 +373,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
           onClick={() => dispatch({ type: "toggleSettings", open: false })}
           aria-label="Close agent profile"
           title="Close agent profile"
-          className="flex size-10 items-center justify-center rounded-md text-ink-secondary hover:bg-raised hover:text-ink"
+          className="flex size-10 items-center justify-center rounded-md text-ink-secondary hover:bg-control hover:text-ink"
         >
           <X size={18} />
         </button>
@@ -422,7 +422,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             <div className="flex items-center gap-3">
               <span className={cn(
                 "flex size-8 shrink-0 items-center justify-center rounded-lg",
-                bot.chiefOfStaff ? "bg-accent text-white" : "bg-raised text-ink-secondary",
+                bot.chiefOfStaff ? "bg-accent text-white" : "bg-control text-ink-secondary",
               )}>
                 <Crown size={17} />
               </span>
@@ -439,7 +439,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                 title={!bot.chiefOfStaff && !canCoordinate ? "This engine cannot contact other bots" : undefined}
                 className={cn(
                   "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40",
-                  bot.chiefOfStaff ? "bg-accent" : "bg-raised",
+                  bot.chiefOfStaff ? "bg-accent" : "bg-control",
                 )}
               >
                 <span
@@ -483,7 +483,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               title={!bot.approvePeerComms && !canCoordinate ? "This engine cannot contact other bots" : undefined}
               className={cn(
                 "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40",
-                bot.approvePeerComms ? "bg-accent" : "bg-raised",
+                bot.approvePeerComms ? "bg-accent" : "bg-control",
               )}
             >
               <span
@@ -525,7 +525,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               }
               className={cn(
                 "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40",
-                connectedAppsEnabled ? "bg-accent" : "bg-raised",
+                connectedAppsEnabled ? "bg-accent" : "bg-control",
               )}
             >
               <span
@@ -568,8 +568,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                       "flex-1 py-1.5 text-[13px] capitalize",
                       i > 0 && "border-l border-hairline/40",
                       bot.modelSelection.effort === level
-                        ? "bg-raised text-ink"
-                        : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
+                        ? "bg-control text-ink"
+                        : "text-ink-secondary hover:bg-control/60 hover:text-ink",
                     )}
                   >
                     {/* the others capitalize cleanly; "xhigh" would read "Xhigh" */}
@@ -606,8 +606,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                     i > 0 && "border-l border-hairline/40",
                     mode === "local" && !localSelectable && "cursor-not-allowed opacity-40",
                     bot.computer === mode
-                      ? "bg-raised text-ink"
-                      : "text-ink-secondary hover:bg-raised/60 hover:text-ink",
+                      ? "bg-control text-ink"
+                      : "text-ink-secondary hover:bg-control/60 hover:text-ink",
                   )}
                 >
                   {label}
@@ -652,7 +652,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               }}
               className={cn(
                 "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors",
-                bot.autoApprove ? "bg-accent" : "bg-raised",
+                bot.autoApprove ? "bg-accent" : "bg-control",
               )}
             >
               <span
@@ -686,7 +686,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               }}
               className={cn(
                 "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors",
-                bot.notifications ? "bg-accent" : "bg-raised",
+                bot.notifications ? "bg-accent" : "bg-control",
               )}
             >
               <span

--- a/src/components/SkinPicker.tsx
+++ b/src/components/SkinPicker.tsx
@@ -20,7 +20,7 @@ function Miniature({ skin }: { skin: SkinId }) {
     <div
       data-skin={skin}
       aria-hidden="true"
-      className="flex h-[78px] w-full overflow-hidden rounded-lg bg-app"
+      className="flex h-[78px] w-full overflow-hidden rounded-lg bg-app ring-1 ring-hairline/60"
     >
       {/* rail */}
       <div className="flex w-[11px] shrink-0 flex-col items-center gap-[3px] bg-panel pt-[5px]">
@@ -91,8 +91,8 @@ export function SkinPicker() {
             className={cn(
               "flex flex-col gap-2 rounded-xl border p-2 text-left transition-colors",
               selected
-                ? "border-accent-border bg-raised"
-                : "border-hairline/60 hover:border-hairline hover:bg-raised/50",
+                ? "border-accent-border bg-control"
+                : "border-hairline/60 hover:border-hairline hover:bg-control/50",
             )}
           >
             <Miniature skin={skin.id} />

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/cn";
 // flat raised grey — the "I heard you" the click needs while the main process
 // gets going.
 const primaryAction =
-  "flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-1.5 text-[13px] font-medium text-white transition-colors disabled:cursor-default disabled:bg-raised disabled:text-ink-secondary";
+  "flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent py-1.5 text-[13px] font-medium text-white transition-colors disabled:cursor-default disabled:bg-control disabled:text-ink-secondary";
 
 // electron-updater surfaces failures as a whole HTTP dump — status line,
 // every response header, stack trace. That is unreadable in a 300px popup,
@@ -86,7 +86,7 @@ export function UpdateBanner() {
         {!busy && (
           <button
             onClick={() => setDismissed(key)}
-            className="shrink-0 rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink"
+            className="shrink-0 rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
             title="Dismiss"
           >
             <X size={14} />
@@ -95,7 +95,7 @@ export function UpdateBanner() {
       </div>
 
       {s.status === "downloading" && (
-        <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-raised">
+        <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-control">
           <div
             className={cn(
               "h-full rounded-full bg-accent transition-[width]",
@@ -112,7 +112,7 @@ export function UpdateBanner() {
         <div className="mt-2.5 flex gap-2">
           <button
             disabled
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-raised py-1.5 text-[13px] font-medium text-ink-secondary"
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-control py-1.5 text-[13px] font-medium text-ink-secondary"
           >
             <Loader2 size={13} className="animate-spin" /> Restarting…
           </button>
@@ -168,7 +168,7 @@ export function UpdateBanner() {
                 void updater.check();
               }}
               disabled={pending !== null}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-raised py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:text-ink-secondary disabled:hover:bg-raised"
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-control py-1.5 text-[13px] text-ink hover:bg-raised-hover disabled:text-ink-secondary disabled:hover:bg-control"
             >
               {pending === "check" ? (
                 <>
@@ -182,7 +182,7 @@ export function UpdateBanner() {
           <button
             onClick={() => setDismissed(key)}
             disabled={pending !== null}
-            className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50 disabled:hover:bg-transparent"
+            className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-50 disabled:hover:bg-transparent"
           >
             Later
           </button>

--- a/src/components/VoiceSettings.tsx
+++ b/src/components/VoiceSettings.tsx
@@ -100,7 +100,7 @@ export function VoiceSettings({
           <button
             onClick={() => void saveKey()}
             disabled={saving || !key.trim()}
-            className="flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? <Loader2 size={13} className="animate-spin" /> : <><Check size={13} />Save</>}
           </button>
@@ -149,7 +149,7 @@ export function VoiceSettings({
               disabled={!ready}
               title={ready ? "Hear this voice" : "Pick a voice first"}
               aria-label="Hear this voice"
-              className="flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-raised py-2 text-[13px] text-ink hover:bg-raised-hover disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex w-[72px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Volume2 size={14} /> Try
             </button>
@@ -171,7 +171,7 @@ export function VoiceSettings({
           onClick={() => onPatch({ speakReplies: !bot.speakReplies })}
           className={cn(
             "relative h-[26px] w-[44px] shrink-0 rounded-full transition-colors",
-            bot.speakReplies ? "bg-accent" : "bg-raised",
+            bot.speakReplies ? "bg-accent" : "bg-control",
           )}
         >
           <span

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,6 +35,10 @@
   --color-raised-hover: #3d3d3d;
   --color-card: #262626;
   --color-inset: #191919;
+  /* a control ON a card. The dark skins take their `raised` value, so this
+     is a no-op for them; the light skins need a tone of their own, because
+     there `raised` is pure white and a card is too. */
+  --color-control: #2f2f2f;
   --color-hairline: #333333;
   --color-ink: #fcfcfc;
   --color-ink-secondary: #fcfcfc99;
@@ -82,6 +86,7 @@
   --color-raised-hover: #3d3d3d;
   --color-card: #262626;
   --color-inset: #191919;
+  --color-control: #2f2f2f;       /* = raised: Midnight is unchanged */
   --color-hairline: #333333;
   --color-ink: #fcfcfc;
   --color-ink-secondary: #fcfcfc99;
@@ -119,6 +124,9 @@
   --color-raised-hover: #f2e9dc;  /* warm beige doubles as the hover fill */
   --color-card: #ffffff;
   --color-inset: #f5f1eb;         /* inset surfaces pick the rail tone back up */
+  --color-control: #ece4d6;       /* raised is white here and so is a card, so
+                                     a control needs its own tone: 1.26:1 on a
+                                     card, and raised-hover still lifts off it */
   --color-hairline: #c8bda8;      /* #ece7dd was 1.11:1 on the rail → 1.65:1 */
 
   --color-ink: #1a1a18;           /* 17.4:1 on white */
@@ -170,6 +178,7 @@
   --color-raised-hover: #322b21;
   --color-card: #1e1a14;
   --color-inset: #0b0a08;         /* inset sinks below the ground */
+  --color-control: #262019;       /* = raised: Foundry is unchanged */
   --color-hairline: #3d3529;      /* visible on purpose — this UI has edges */
 
   --color-ink: #f4efe4;           /* warm off-white, never pure #fff */
@@ -222,6 +231,12 @@
   --color-raised-hover: #cfe4e1;
   --color-card: #ffffff;
   --color-inset: #d5e8e5;
+  --color-control: #c3dcd9;       /* Lagoon's surfaces climb white → panel →
+                                     app → inset → hover in small steps, so a
+                                     control has to sit below the lot to clear
+                                     every one it can land on: 1.44:1 on a
+                                     card, 1.29:1 on the panel, 1.13:1 on an
+                                     inset row, 1.09:1 under the hover tone. */
   --color-hairline: #aebfbd;      /* 1.60:1 — level with the other three */
 
   --color-ink: #14201f;           /* dark petrol; a neutral black would read


### PR DESCRIPTION
## What changed

Reported as "the A/B/C/D options are hard to see" in Lagoon. It turned out to be one instance of a pattern, so this PR is the specific fix plus the sweep behind it.

**The bug.** Atelier and Lagoon both define `--color-raised` as the pure white they also use for `--color-card`. Anything painted in `raised` on a card was therefore invisible in both light skins — letter chips, hover fills, answered rows, segmented controls, toggle tracks, badges, dismiss buttons. Midnight and Foundry were fine, because there `raised` (#2f2f2f) genuinely does sit above `card` (#262626).

**The fix.** A new `--color-control` token for what those call sites actually mean: a control sitting *on* a card. The dark skins define it as their existing `raised` value, so they render identically; only the light skins gain a tone. 105 usages across 16 components moved from `bg-raised` to `bg-control`.

Retinting `raised` in the light skins would have fixed all of it in one line, and it is the wrong fix: both skins build their layering on `raised` being the white anchor, and moving it inverts panel against raised.

**Supporting changes.** The skin picker's miniature gets a hairline ring — the selected tile became a control tone, which in Lagoon lands within 1.02:1 of the miniature's own ground. The model chip hovers to `raised-hover` rather than to a fill one step from where it started.

**The guard.** `scripts/check-skin-contrast.mjs` now measures surface against surface, not only text against surface. It was green through this entire bug: a skin that gives two surfaces the same value is precisely what it could not see.

## Why

A room-sized version of the same question: the skins were verified for text contrast, and never for whether one surface can be seen against another. That gap is invisible to a reader of the hex values and obvious the moment you measure the rendered result.

## How it was verified

Written as a DOM audit rather than a code review, because the question — "does this element's fill differ from what is actually behind it?" — cannot be answered from the source. It walks the rendered app in all four skins across 21 screens (chat, rooms, model picker, agent profile, bot computer, reactions, every settings tab), resolves each Tailwind `bg-*` utility to the colour it paints, composites alpha, and compares against the nearest painted ancestor. Hover fills are resolved through a probe element so a hover that would paint its own resting colour is caught without hovering. Elements whose shape is drawn by a border or ring are exempt.

- before: **21 sites**, all in Atelier and Lagoon, none in the dark skins
- after: **0 sites in all four skins**, every screen reached

Two of the light values were wrong on the first and second try, and measurement caught both: Lagoon's first tone cleared cards but landed 1.05:1 on the sidebar panel; the second cleared the panel but drifted into `inset`, putting the badges in an inset row back where they started. Lagoon stacks white → panel → app → inset → hover in steps of 1.04–1.14, so a control has to sit below the whole ladder. **Its buttons and chips now read as a noticeably deeper teal — that is the cost of clearing all five surfaces, and it is the one judgement call in here worth a second opinion.**

- `pnpm typecheck` — clean
- `pnpm test` — 1521 tests pass
- `node scripts/check-skin-contrast.mjs` — all four skins pass, 36 pairs each
- `oxlint` — repo error count unchanged (1305, all pre-existing anti-slop debt)
- Clicked through on macOS in the dev app, and screenshotted in every skin

## Screenshots (UI changes)

Question card in Lagoon — before: bare grey letters, no chip, and hovering a row did nothing visible. After: chips with a hairline, and a hovered row that fills. Midnight and Foundry are unchanged to the eye. (Adding the images in a follow-up comment.)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests) — no server change here; the guard is `check-skin-contrast.mjs`
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined backgrounds, hover states, selected states, and disabled controls across settings, setup, connection, model, profile, and update interfaces.
  * Added consistent control-surface styling across all available visual themes.
  * Improved skin picker previews with subtle borders and clearer selection treatment.

* **Accessibility**
  * Expanded contrast checks for common surface combinations to improve readability and control visibility across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->