### PR TITLE
Let Grok run a local model without a grok.com login

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -456,6 +456,27 @@ describe("ACP turns (fake CLI)", () => {
     expect(err.message).toMatch(/not signed in/);
   });
 
+  it("grok local inject does not require grok.com login", async () => {
+    process.env.FAKE_ACP_MODE = "no-auth";
+    mkdirSync(join(scratch, ".grok"), { recursive: true });
+    instance = await GrokAgentDriver.create({
+      instanceId: "acp-test",
+      displayName: "ACP Test",
+      environment: { HOME: scratch, GROK_HOME: join(scratch, ".grok") },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    recorder = recordEvents(instance.adapter);
+    await instance.adapter.sendTurn({
+      threadId: "t-local-auth",
+      text: "go",
+      model: "omlx::MiniMax-M3-4bit",
+    });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true });
+    expect(recorder.events.some((e) => e.type === "runtime.error")).toBe(false);
+  });
+
   it("gemini proceeds through a missing auth method (lenient login)", async () => {
     await create(GeminiAgentDriver, "no-auth");
     await instance.adapter.sendTurn({ threadId: "t-lenient", text: "go" });

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../../config.ts";
 import type { ProviderInstance } from "../../contracts.ts";
 import { recordEvents, type EventRecorder } from "../../testing/events.ts";
-import { createAcpDriver, type AcpSupport } from "./core.ts";
+import { createAcpDriver, skipSubscriptionAuthForLocalInject, type AcpSupport } from "./core.ts";
 import { GrokAgentDriver } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 import { KimiAgentDriver } from "./kimi.ts";
@@ -71,6 +71,15 @@ const ClassifiedErrorDriver = createAcpDriver({
     error && typeof error === "object" && (error as { code?: unknown }).code === -32000
       ? "invalid_credentials"
       : undefined,
+});
+
+describe("skipSubscriptionAuthForLocalInject", () => {
+  it("is true only for a host:: inject id", () => {
+    expect(skipSubscriptionAuthForLocalInject("omlx::MiniMax-M3-4bit")).toBe(true);
+    expect(skipSubscriptionAuthForLocalInject("unsloth::orcarouter/Qwen3.8-27B-Uncensored-GGUF")).toBe(true);
+    expect(skipSubscriptionAuthForLocalInject("grok-4.6")).toBe(false);
+    expect(skipSubscriptionAuthForLocalInject(undefined)).toBe(false);
+  });
 });
 
 describe("ACP decodeConfig", () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -16,6 +16,7 @@
 import { homedir } from "node:os";
 
 import { PROVIDER_CREDENTIAL_ENV, WORKSPACE_CREDENTIAL_ENV } from "../../config.ts";
+import { decodeInjectId } from "../local-inject.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../procs.ts";
 
 import type {
@@ -530,15 +531,21 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             );
             const methods: Array<{ id?: string }> = Array.isArray(init?.authMethods) ? init.authMethods : [];
             const methodId = support.pickAuthMethod(methods);
-            if (methodId) {
-              try {
-                await request("authenticate", { methodId }, INIT_TIMEOUT);
-              } catch {
-                if (support.authFailure === "fail") throw new Error(support.loginNote);
-                // else: proceed on an ambient login
+            // A host:: local pick talks to a loopback server with its own key.
+            // Subscription login (grok.com / cached_token) must not block it —
+            // the same hole Kimi/Droid already closed.
+            const localInject = Boolean(decodeInjectId(turn.model));
+            if (!localInject) {
+              if (methodId) {
+                try {
+                  await request("authenticate", { methodId }, INIT_TIMEOUT);
+                } catch {
+                  if (support.authFailure === "fail") throw new Error(support.loginNote);
+                  // else: proceed on an ambient login
+                }
+              } else if (support.authFailure === "fail") {
+                throw new Error(support.loginNote);
               }
-            } else if (support.authFailure === "fail") {
-              throw new Error(support.loginNote);
             }
 
             const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -19,6 +19,14 @@ import { PROVIDER_CREDENTIAL_ENV, WORKSPACE_CREDENTIAL_ENV } from "../../config.
 import { decodeInjectId } from "../local-inject.ts";
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../../procs.ts";
 
+/**
+ * A `host::model` pick talks to a loopback server with its own key.
+ * Subscription ACP login (grok.com cached_token) must not fail that turn.
+ */
+export function skipSubscriptionAuthForLocalInject(model: string | undefined): boolean {
+  return Boolean(decodeInjectId(model));
+}
+
 import type {
   DriverCreateInput,
   EffortLevel,
@@ -147,6 +155,10 @@ function decodeAcpConfig(defaultCli: string) {
   };
 }
 
+/**
+ * ACP JSON-RPC-over-stdio driver. Harness differences (argv, auth, catalog)
+ * live in `support`; this is the shared handshake and turn runtime.
+ */
 export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> {
   const DRIVER_KIND = support.driverKind;
   const SOURCE = support.nativeSource;
@@ -531,11 +543,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             );
             const methods: Array<{ id?: string }> = Array.isArray(init?.authMethods) ? init.authMethods : [];
             const methodId = support.pickAuthMethod(methods);
-            // A host:: local pick talks to a loopback server with its own key.
-            // Subscription login (grok.com / cached_token) must not block it —
-            // the same hole Kimi/Droid already closed.
-            const localInject = Boolean(decodeInjectId(turn.model));
-            if (!localInject) {
+            if (!skipSubscriptionAuthForLocalInject(turn.model)) {
               if (methodId) {
                 try {
                   await request("authenticate", { methodId }, INIT_TIMEOUT);


### PR DESCRIPTION
## What

Kimi and Droid already skip a cloud login for a `host::` local pick (#314). Grok ACP still required `cached_token` (grok.com) even when the picker was Unsloth/oMLX/LM Studio.

A loopback inject uses the host's own key. Subscription login must not fail the turn before that model is asked.

## How

In the shared ACP handshake, skip `authenticate` / fail-closed login when `turn.model` is a `host::` inject id. Cloud Grok picks still fail closed without `grok login`.

## Testing

- `vitest run server/drivers/acp/acp.test.ts server/drivers/claude.test.ts server/drivers/local-inject.test.ts` — 136 passed, 1 skipped
- New case: Grok `no-auth` + `omlx::MiniMax-M3-4bit` completes without `auth_required`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local model runs now proceed successfully without requiring ACP authentication.
  * Remote model authentication behavior remains unchanged.
  * Improved reliability for locally injected Grok models when no cached credentials are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->