### PR TITLE
feat(desktop): enforce single-instance lock

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -9,6 +9,7 @@ import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
+import { activateExistingWindow } from "./single-instance.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
@@ -34,6 +35,17 @@ let desktopViewerContextId = null;
 // GNOME groups the window with its installed desktop entry only when both
 // identities match. This must run before Electron becomes ready.
 if (process.platform === "linux") app.setDesktopName("com.openmausbot.app.desktop");
+
+// One instance per user: without this lock a second launch forks a second
+// harness server on a fallback port and splits data dirs in two. The loser
+// exits before any child or window exists; the winner surfaces itself.
+if (!app.requestSingleInstanceLock()) {
+  console.log("[desktop] OpenMausBot is already running — focusing that window");
+  process.exit(0);
+}
+app.on("second-instance", () => {
+  activateExistingWindow(BrowserWindow.getAllWindows());
+});
 
 // Packaged: the harness server ships in Resources (compiled JS, zero deps)
 // and runs on Electron's own Node via utilityProcess. It serves the built

--- a/electron/single-instance.mjs
+++ b/electron/single-instance.mjs
@@ -1,0 +1,16 @@
+// Single-instance policy for the desktop shell, kept Electron-free so the
+// activation rules stay unit-testable with plain object fakes.
+
+// Surface the existing app when a second launch gets absorbed: restore a
+// minimized window, then show and focus. Prefer whatever window currently
+// holds focus so a future multi-window layout lands predictably; otherwise
+// the first living window wins.
+export function activateExistingWindow(windows) {
+  const alive = windows.filter((win) => win && !win.isDestroyed());
+  if (alive.length === 0) return false;
+  const target = alive.findLast((win) => win.isFocused()) ?? alive[0];
+  if (target.isMinimized()) target.restore();
+  target.show();
+  target.focus();
+  return true;
+}

--- a/electron/single-instance.node-test.mjs
+++ b/electron/single-instance.node-test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { activateExistingWindow } from "./single-instance.mjs";
+
+function fakeWindow({ destroyed = false, minimized = false, focused = false } = {}) {
+  const calls = [];
+  return {
+    calls,
+    isDestroyed: () => destroyed,
+    isMinimized: () => minimized,
+    isFocused: () => focused,
+    restore: () => calls.push("restore"),
+    show: () => calls.push("show"),
+    focus: () => calls.push("focus"),
+  };
+}
+
+test("shows and focuses the only living window", () => {
+  const win = fakeWindow();
+  assert.equal(activateExistingWindow([win]), true);
+  assert.deepEqual(win.calls, ["show", "focus"]);
+});
+
+test("restores a minimized window before showing it", () => {
+  const win = fakeWindow({ minimized: true });
+  assert.equal(activateExistingWindow([win]), true);
+  assert.deepEqual(win.calls, ["restore", "show", "focus"]);
+});
+
+test("skips destroyed windows without touching them", () => {
+  const dead = fakeWindow({ destroyed: true });
+  const alive = fakeWindow();
+  assert.equal(activateExistingWindow([dead, alive]), true);
+  assert.deepEqual(dead.calls, []);
+  assert.deepEqual(alive.calls, ["show", "focus"]);
+});
+
+test("prefers the focused window among several", () => {
+  const first = fakeWindow();
+  const second = fakeWindow({ focused: true });
+  assert.equal(activateExistingWindow([first, second]), true);
+  assert.deepEqual(first.calls, []);
+  assert.deepEqual(second.calls, ["show", "focus"]);
+});
+
+test("reports failure when no window can be activated", () => {
+  const dead = fakeWindow({ destroyed: true });
+  assert.equal(activateExistingWindow([]), false);
+  assert.equal(activateExistingWindow([dead]), false);
+  assert.deepEqual(dead.calls, []);
+});


### PR DESCRIPTION
## Summary

- A second launch of OpenMausBot used to fork a **second harness server** on a fallback port (8799 → 18799 → 28799), leaving two windows over two data dirs of truth and confusing duplicate bots. There was no guard anywhere in `electron/main.mjs`.
- This PR acquires Electron's `requestSingleInstanceLock()` at the very top of startup — before any server child spawn, CUA daemon start, or window creation — so a duplicate launch exits immediately with a short log line.
- The surviving instance handles `second-instance` by restoring/showing/focusing its window (preferring whichever window currently holds focus), using only cross-platform `BrowserWindow` APIs — identical behavior on macOS, Windows, and Linux.

## Changes

- `electron/main.mjs` (+12): early lock acquisition + `second-instance` handler placed right after the Linux desktop-name setup and well ahead of `app.whenReady()`.
- `electron/single-instance.mjs` (+16, new): pure helper `activateExistingWindow(windows)` — Electron-free logic (destroyed-filter, minimized→restore→show→focus) kept unit-testable with plain object fakes.
- `electron/single-instance.node-test.mjs` (+52, new): `node --test` coverage following the repo's `*.node-test.mjs` pattern — 5 tests covering plain show/focus, restore-before-show ordering, skipping destroyed windows, preferring the focused window, and the no-living-window case.

Note on argv forwarding: the app registers **no** `open-file` / `open-url` / deep-link handling today (verified across `electron/` and `src/`), so there is no existing path to forward second-launch arguments through; none was invented.

## Test Plan

Automated (run locally):

- [x] `node --test electron/single-instance.node-test.mjs` — 5/5 pass
- [x] `pnpm typecheck` (`tsc -b && tsc -p tsconfig.server.json`) — clean
- [x] `npx oxlint electron src` — 209 findings on this branch vs 209 on pristine `origin/main` (zero new findings introduced)

Manual — macOS:

1. Launch the app (packaged build, or `pnpm dev:desktop`).
2. Launch it a **second** time from Finder/Dock/terminal.
3. Expected: the second process exits almost immediately (console shows `[desktop] OpenMausBot is already running — focusing that window`); no second window appears and `~/Library/Logs/OpenMausBot/server.log` shows no new server fork.
4. Minimize the main window, then launch again → expected: the existing window un-minimizes, raises to front, and gains focus.

Manual — Windows:

1. Launch the packaged app.
2. Double-click the exe again in Explorer (or relaunch from Start).
3. Expected: the second process exits silently with no visible flash; still exactly one window and one active server port in `%APPDATA%\OpenMausBot\logs\server.log`.
4. Minimize the main window, then launch again → expected: the taskbar window restores to the foreground and is focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevented multiple application instances from running simultaneously.
  * Launching the app again now activates the existing window.
  * Minimized windows are restored and focused when reactivated.

* **Bug Fixes**
  * Improved handling of unavailable or closed windows during app activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->