### PR TITLE
feat(desktop): one-click diagnostics export

### DIFF
--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -1,0 +1,153 @@
+// One-click bug-report bundle: app facts, a safe config summary and the
+// server.log tail, formatted for pasting into a public issue. Pure string
+// work lives here so redaction stays unit-testable without Electron; main.mjs
+// owns the fs and dialog plumbing. Safety is layered: the collector never
+// reads secret fields at all (only the server's booleans-only config status),
+// and everything that does get in is scrubbed again here before it lands on
+// disk — so a future collector mistake still cannot leak a credential.
+//
+// CREDENTIAL_ENV_NAMES mirrors WORKSPACE_CREDENTIAL_ENV (server/config.ts).
+// Duplicated because the desktop shell cannot import TypeScript; a test
+// asserts the two lists never drift apart.
+export const CREDENTIAL_ENV_NAMES = [
+  "XAI_API_KEY",
+  "BOX_TOKEN",
+  "OPENCODE_API_KEY",
+  "OMB_TTS_KEY",
+  "OMB_OPENAI_IMAGE_KEY",
+  "COMPOSIO_API_KEY",
+  "OMB_COMPOSIO_BROKER_TOKEN",
+];
+
+// Credential-shaped tokens (server/redact.ts parity): unmistakable formats
+// are masked wherever they appear, keyed or not.
+const CREDENTIAL_TOKEN_FORMATS = [
+  /\bsk-[A-Za-z0-9_-]{16,}/g,
+  /\bxai-[A-Za-z0-9]{16,}/g,
+  /\bak_[A-Za-z0-9_-]{16,}/g,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  /\bxox[abposr]-[A-Za-z0-9-]{20,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{30,}/g,
+  /\bnpm_[A-Za-z0-9]{20,}/g,
+];
+const SECRET_NAME =
+  /(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)/i;
+const KEY_VALUE_PAIR =
+  /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
+const BEARER = /(\bbearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi;
+const PEM_BLOCK =
+  /(-----BEGIN [A-Z ]*PRIVATE KEY-----)[\s\S]*?(-----END [A-Z ]*PRIVATE KEY-----)/g;
+
+const mask = (value) => `«redacted ${value.length} chars»`;
+const unquote = (value) => value.replace(/^["']|["']$/g, "");
+
+// Shared value grammar; String.raw keeps \s and \] intact when the pattern
+// is embedded into the dynamically built env-name regexes below.
+const VALUE_PART = String.raw`("[^"]*"|'[^']*'|[^\s"',;)\]}]+)`;
+
+export function redactSecretsInLine(line) {
+  let out = String(line ?? "");
+  const alreadyMasked = (value) => String(value).includes("«redacted");
+  for (const name of CREDENTIAL_ENV_NAMES) {
+    out = out.replace(
+      new RegExp(`\\b(${name})\\s*[:=]\\s*${VALUE_PART}`, "gi"),
+      (_match, key, value) => `${key}=${mask(unquote(value))}`,
+    );
+  }
+  out = out.replace(BEARER, (_match, lead, token) => `${lead}${mask(token)}`);
+  out = out.replace(PEM_BLOCK, (_match, open, close) => `${open}«redacted private key»${close}`);
+  out = out.replace(KEY_VALUE_PAIR, (_match, key, value) =>
+    alreadyMasked(value) ? _match : `${key}=${mask(unquote(value))}`,
+  );
+  for (const format of CREDENTIAL_TOKEN_FORMATS) out = out.replace(format, (found) => mask(found));
+  return out;
+}
+
+const APP_INFO_KEYS = ["version", "platform", "arch", "electron", "node", "packaged", "uptimeSeconds"];
+
+// A config summary entry is publishable only when it carries no credential:
+// booleans and finite numbers always pass; strings must be short, not
+// secret-named, and free of token formats. Everything else (objects beyond
+// flattening, arrays, nulls) never reaches the file.
+const isFiniteNumber = (value) => Number.isFinite(value) && Object.prototype.toString.call(value) === "[object Number]";
+
+function summaryAllows(key, value) {
+  if (Object.prototype.toString.call(value) === "[object Boolean]") return true;
+  if (isFiniteNumber(value)) return true;
+  if (Object.prototype.toString.call(value) !== "[object String]") return false;
+  const leaf = key.slice(key.lastIndexOf(".") + 1);
+  // `key`/`keys` alone are too common as prose to regex on values, but as a
+  // *field name* they mean credential here (xai.key, tts.key) — drop them.
+  if (/^(?:.*[_.-])?keys?$/i.test(leaf)) return false;
+  if (SECRET_NAME.test(leaf)) return false;
+  if (CREDENTIAL_ENV_NAMES.some((name) => key.toUpperCase().includes(name))) return false;
+  if (value.length > 64) return false;
+  return CREDENTIAL_TOKEN_FORMATS.every((format) => {
+    format.lastIndex = 0;
+    return !format.test(value);
+  });
+}
+
+function flattenSummary(input, prefix = "", depth = 0, out = {}) {
+  if (!input || Object.prototype.toString.call(input) !== "[object Object]") return out;
+  for (const [key, value] of Object.entries(input)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (Array.isArray(value)) continue;
+    if (value && Object.prototype.toString.call(value) === "[object Object]" && depth < 3)
+      flattenSummary(value, path, depth + 1, out);
+    else out[path] = value;
+  }
+  return out;
+}
+
+export function buildDiagnosticsReport({
+  appInfo = {},
+  configSummary = {},
+  logTail,
+  logPath = "",
+  now = new Date().toISOString(),
+} = {}) {
+  const lines = [];
+  lines.push("OpenMausBot diagnostics");
+  lines.push(`Generated: ${now}`);
+  lines.push("");
+  lines.push("## App");
+  for (const key of APP_INFO_KEYS) {
+    if (appInfo[key] === undefined || appInfo[key] === null) continue;
+    lines.push(`${key}=${String(appInfo[key])}`);
+  }
+  lines.push("");
+  lines.push("## Configuration");
+  lines.push("# presence/count/mode only — credentials stay OS-encrypted and are never read");
+  const summary = flattenSummary(configSummary);
+  let shown = 0;
+  for (const key of Object.keys(summary).sort()) {
+    if (!summaryAllows(key, summary[key])) continue;
+    lines.push(`${key}=${summary[key]}`);
+    shown += 1;
+  }
+  if (!shown) lines.push("(no configuration summary available)");
+  lines.push("");
+  lines.push(
+    logTail && logTail.trim()
+      ? `## Server log tail${logPath ? ` (${logPath})` : ""} — secrets auto-masked`
+      : "## Server log tail",
+  );
+  if (logTail && logTail.trim()) {
+    for (const line of logTail.split(/\r?\n/)) lines.push(redactSecretsInLine(line));
+  } else {
+    lines.push("(server log unavailable)");
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function diagnosticsFileName(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return (
+    `openmausbot-diagnostics-${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}.txt`
+  );
+}

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+
+const require = createRequire(import.meta.url);
+const { buildDiagnosticsReport, diagnosticsFileName, redactSecretsInLine, CREDENTIAL_ENV_NAMES } =
+  require("./diagnostics.mjs");
+
+// The desktop shell cannot import TypeScript, so its credential list is a
+// hand copy of server/config.ts WORKSPACE_CREDENTIAL_ENV. This test is the
+// drift alarm: a name added server-side without updating the copy here would
+// otherwise ship an unredacted export path.
+describe("credential env parity with server/config.ts", () => {
+  it("matches WORKSPACE_CREDENTIAL_ENV exactly", () => {
+    const config = readFileSync(new URL("../server/config.ts", import.meta.url), "utf8");
+    const match = config.match(/WORKSPACE_CREDENTIAL_ENV = \[([\s\S]*?)\] as const/);
+    expect(match).not.toBeNull();
+    const names = [...match[1].matchAll(/"([A-Z0-9_]+)"/g)].map((m) => m[1]);
+    expect(CREDENTIAL_ENV_NAMES).toEqual(names);
+  });
+});
+
+describe("buildDiagnosticsReport", () => {
+  const appInfo = {
+    version: "0.1.27",
+    platform: "darwin",
+    arch: "arm64",
+    electron: "43.4.0",
+    node: "24.0.0",
+    packaged: true,
+    uptimeSeconds: 42,
+  };
+
+  it("renders app facts and a sorted config summary", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {
+        xai: { configured: true },
+        box: { configured: false },
+        rooms: { turnTimeoutMinutes: 5 },
+      },
+      logTail: "",
+    });
+    expect(report).toContain("version=0.1.27");
+    expect(report).toContain("platform=darwin");
+    expect(report).toContain("arch=arm64");
+    expect(report).toContain("xai.configured=true");
+    expect(report).toContain("box.configured=false");
+    expect(report).toContain("rooms.turnTimeoutMinutes=5");
+    expect(report).toContain("(server log unavailable)");
+  });
+
+  it("drops non-scalar, secret-named and credential-shaped summary values", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {
+        xai: { key: "xai-real-secret" },
+        composio: { apiKey: "ak_live_abcdef123456789" },
+        vps: { sshAlias: "" },
+        profile: { name: "Ada" },
+        instances: [{ driver: "claudeAgent", environment: { TOKEN: "hunter2" } }],
+        note: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+      },
+      logTail: "",
+    });
+    expect(report).not.toContain("xai-real-secret");
+    expect(report).not.toContain("ak_live_abcdef123456789");
+    expect(report).not.toContain("hunter2");
+    expect(report).not.toContain("driver");
+    expect(report).not.toContain("environment");
+    expect(report).toContain("profile.name=Ada");
+    expect(report).not.toContain("note=");
+  });
+
+  it.each(CREDENTIAL_ENV_NAMES)("masks any value riding on %s in the log tail", (name) => {
+    const value = "s3cr3t-value-123456";
+    const line = `spawn env ${name}=${value} ready`;
+    const report = buildDiagnosticsReport({ appInfo, configSummary: {}, logTail: line });
+    expect(report).not.toContain(value);
+    expect(redactSecretsInLine(line)).toBe(`spawn env ${name}=«redacted ${value.length} chars» ready`);
+  });
+
+  it("masks generic key=value secrets and content-shaped tokens in the log tail", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      logTail: [
+        'config {"apiKey":"sk-proj-abcdefghijklmnop"}',
+        "Authorization: Bearer abcdefghijklmnop",
+        "password=hunter2000",
+      ].join("\n"),
+    });
+    expect(report).not.toContain("sk-proj-abcdefghijklmnop");
+    expect(report).not.toContain("abcdefghijklmnop");
+    expect(report).not.toContain("hunter2000");
+    expect(report).toContain("«redacted");
+  });
+
+  it("leaves ordinary log lines untouched", () => {
+    const line = "[2026-08-22T20:00:00.000Z] [out] fork server/index.js port=8799 spawned pid=4242";
+    expect(redactSecretsInLine(line)).toBe(line);
+  });
+
+  it("handles an empty or missing log gracefully", () => {
+    for (const logTail of ["", null, undefined]) {
+      const report = buildDiagnosticsReport({ appInfo, configSummary: {}, logTail });
+      expect(report).toContain("(server log unavailable)");
+      expect(report.endsWith("\n")).toBe(true);
+    }
+  });
+
+  it("keeps long prose lines that merely mention a key by name", () => {
+    const line = "user asked whether the XAI_API_KEY variable needs to be set manually";
+    expect(redactSecretsInLine(line)).toBe(line);
+  });
+});
+
+describe("diagnosticsFileName", () => {
+  it("uses openmausbot-diagnostics-YYYYMMDD-HHmmss.txt", () => {
+    expect(diagnosticsFileName(new Date(2026, 7, 22, 16, 5, 9))).toBe(
+      "openmausbot-diagnostics-20260822-160509.txt",
+    );
+  });
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,6 +8,7 @@ import { createAndroidDeviceController } from "./android-device.mjs";
 import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
+import { buildDiagnosticsReport, diagnosticsFileName } from "./diagnostics.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 
@@ -207,6 +208,52 @@ function slog(line) {
   } catch {
     /* logging must never break startup */
   }
+}
+
+const LOG_TAIL_BYTES = 256 * 1024;
+
+function readLogTail(logPath) {
+  try {
+    const size = fs.statSync(logPath).size;
+    const start = Math.max(0, size - LOG_TAIL_BYTES);
+    const handle = fs.openSync(logPath, "r");
+    try {
+      const buffer = Buffer.alloc(size - start);
+      fs.readSync(handle, buffer, 0, buffer.length, start);
+      return { tail: buffer.toString("utf8"), bytes: buffer.length };
+    } finally {
+      fs.closeSync(handle);
+    }
+  } catch {
+    return null;
+  }
+}
+
+// Everything the bug-report bundle needs. The config summary comes from the
+// server's own booleans-only /api/config status (credentials are never
+// echoed), and the log goes through the redactor in diagnostics.mjs — so the
+// file is safe to paste into a public issue even if a future log line ever
+// carried a secret.
+async function gatherDiagnostics() {
+  const serverStatus = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config`)
+    .then((res) => (res.ok ? res.json() : null))
+    .catch(() => null);
+  const logPath = path.join(LOG_DIR, "server.log");
+  const log = readLogTail(logPath);
+  return buildDiagnosticsReport({
+    appInfo: {
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      electron: process.versions.electron,
+      node: process.versions.node,
+      packaged: app.isPackaged,
+      uptimeSeconds: Math.round(process.uptime()),
+    },
+    configSummary: serverStatus ?? {},
+    logTail: log?.tail ?? "",
+    logPath: log ? logPath : "",
+  });
 }
 
 async function startServerOn(port) {
@@ -620,6 +667,22 @@ ipcMain.handle("desktop:pick-folder", async (event, current) => {
     ...(typeof current === "string" && current ? { defaultPath: current } : {}),
   });
   return result.canceled ? null : (result.filePaths[0] ?? null);
+});
+
+// One-click bug-report bundle. Secrets are never read; the report is
+// redacted again on the way out (diagnostics.mjs). null means the user
+// cancelled the save dialog.
+ipcMain.handle("desktop:export-diagnostics", async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender) ?? undefined;
+  const report = await gatherDiagnostics();
+  const result = await dialog.showSaveDialog(owner, {
+    title: "Export diagnostics",
+    defaultPath: diagnosticsFileName(),
+    filters: [{ name: "Text", extensions: ["txt"] }],
+  });
+  if (result.canceled || !result.filePath) return null;
+  fs.writeFileSync(result.filePath, report, { mode: 0o600 });
+  return result.filePath;
 });
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -88,6 +88,9 @@ contextBridge.exposeInMainWorld("ogb", {
   },
   /** Native folder picker for a bot's working folder; null when cancelled. */
   pickFolder: (current) => ipcRenderer.invoke("desktop:pick-folder", current),
+  /** Writes the redacted diagnostics report to a user-chosen file; resolves
+   * the path, or null when the save dialog was cancelled. */
+  exportDiagnostics: () => ipcRenderer.invoke("desktop:export-diagnostics"),
   /** Store a provider credential with OS-backed encryption. */
   setCredential: (name, value) => ipcRenderer.invoke("credential:set", name, value),
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -134,6 +134,44 @@ const cnSwitch = (on: boolean) =>
 const cnKnob = (on: boolean) =>
   `absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white transition-all ${on ? "left-[21px]" : "left-[3px]"}`;
 
+/** Writes a redacted, paste-anywhere diagnostics file the user picks. The
+ * report holds versions, configured-or-not booleans and the server.log tail —
+ * never credential values (the desktop shell does not read secret fields). */
+function DiagnosticsRow() {
+  const { dispatch } = useStore();
+  const [exporting, setExporting] = useState(false);
+
+  const exportDiagnostics = async () => {
+    if (!window.ogb?.exportDiagnostics || exporting) return;
+    setExporting(true);
+    try {
+      const path = await window.ogb.exportDiagnostics();
+      if (path) dispatch({ type: "error", message: `Diagnostics saved to ${path}` });
+    } catch (e) {
+      dispatch({ type: "error", message: e instanceof Error ? e.message : String(e) });
+      setTimeout(() => dispatch({ type: "error", message: null }), 6000);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Diagnostics"
+      subtitle="Versions, configuration on/off state and the server log tail — secrets are never included. Safe to attach to a bug report."
+    >
+      <button
+        onClick={() => void exportDiagnostics()}
+        disabled={exporting}
+        aria-label="Export diagnostics to a text file"
+        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
+      >
+        Export Diagnostics…
+      </button>
+    </Card>
+  );
+}
+
 export function SettingsModal() {
   const { state, dispatch } = useStore();
   const section = state.appSettingsSection;
@@ -243,6 +281,7 @@ export function SettingsModal() {
                   <RoomTurnTimeoutSettings />
                 </Card>
                 <UpdatesRow />
+                <DiagnosticsRow />
                 <AnalyticsRow />
               </>
             )}

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -90,6 +90,9 @@ declare global {
       };
       /** Native folder picker; resolves null when the user cancels. */
       pickFolder?(current?: string): Promise<string | null>;
+      /** Writes the redacted diagnostics report to a user-chosen file;
+       * resolves the path, or null when cancelled. */
+      exportDiagnostics?(): Promise<string | null>;
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(
         name: "composioApiKey" | "xaiApiKey" | "boxToken" | "opencodeGoApiKey" | "ttsKey" | "openaiImageApiKey",


### PR DESCRIPTION
## Summary

Adds a one-click diagnostics export for bug reports. Settings → General now has an "Export Diagnostics…" button that writes `openmausbot-diagnostics-YYYYMMDD-HHmmss.txt` (user-chosen via the native save dialog) containing app facts, a safe configuration summary, and the last ~256KB of `server.log` — safe to paste into a public issue.

**Redaction strategy (the point of this PR):**
1. **Secrets are never read.** The config summary comes from the server's own booleans-only `/api/config` status (`configStatus()` in `server/index.ts`) — configured-or-not flags and non-secret settings only. The desktop shell never touches secret fields, credential values, or `credentials.bin`.
2. **Defense-in-depth scrubber.** Everything that reaches the file passes through a redactor in the pure builder (`electron/diagnostics.mjs`) anyway: every env var name from `WORKSPACE_CREDENTIAL_ENV` (`server/config.ts`) is masked when it appears as `NAME=value`, generic key/value pairs with secret-shaped names (`apiKey`, `token`, `password`, …), `Bearer` tokens, PEM private-key blocks, and content-shaped credentials (`sk-…`, `xai-…`, `ak_…`, GitHub/Slack/AWS/Google/npm tokens) are masked wherever they appear — even unkeyed.
3. **Summary allow-list.** Config summary entries are flattened to dotted paths and only published if they are booleans, finite numbers, or short (<64 char) strings whose field name is not secret-like; anything else is dropped.
4. **Drift alarm.** The desktop shell can't import TypeScript, so it keeps its own copy of the credential-env list. A unit test parses `WORKSPACE_CREDENTIAL_ENV` out of `server/config.ts` and fails if the two lists ever diverge.

## Changes

- `electron/diagnostics.mjs` (new): pure, unit-testable builder `buildDiagnosticsReport({ appInfo, configSummary, logTail, logPath })`, line-level `redactSecretsInLine`, and `diagnosticsFileName()`. No Electron imports.
- `electron/main.mjs`: `gatherDiagnostics()` collects versions/platform/arch/electron/node/packaged/uptime, fetches the server's booleans-only config status (tolerates the server being down), reads the last 256KB of `server.log` (tolerates a missing file); new `desktop:export-diagnostics` IPC handler shows the save dialog and writes the report with mode 0600.
- `electron/preload.cjs`: `exportDiagnostics()` on the existing `window.ogb` bridge.
- `src/types/ogb.d.ts`: optional bridge typing.
- `src/components/SettingsModal.tsx`: Diagnostics card next to Updates/Analytics in General, labeled "Export Diagnostics…" with an aria-label; success ("saved to <path>") and failure messages use the app's existing error-banner surface (`dispatch({type:"error"})`, 6s auto-clear).
- `electron/diagnostics.test.mjs` (new): 15 tests — parity with `WORKSPACE_CREDENTIAL_ENV`, per-name masking across all seven credential env vars, generic KV/Bearer/token-format masking, allow-list behavior (drops `xai.key`, arrays, oversized values; keeps `profile.name`, booleans), graceful empty/missing log, filename format.

Desktop-only; zero new dependencies.

## Test Plan

- [x] `npx vitest run electron/diagnostics.test.mjs` → 15 passed
- [x] `pnpm typecheck` → clean (exit 0)
- [x] `npx oxlint electron src` → 206 pre-existing errors, 0 in touched files (baseline before this PR: 219)
- [ ] Manual: Settings → General → Export Diagnostics… → save → open file, confirm sections and no secrets
- [ ] Manual: cancel save dialog → no error banner shown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option in General settings to export a diagnostics report.
  * Reports include app and system details, safe configuration summaries, and a redacted server-log excerpt.
  * Users can choose where to save the report or cancel the export.
  * Added success and error notifications for export results.

* **Security**
  * Sensitive credentials, tokens, and unsupported values are excluded or redacted from exported reports.

* **Tests**
  * Added coverage for report generation, filtering, redaction, missing logs, and filename formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->