### PR TITLE
feat(harness): redact secrets in tool results before storage

### DIFF
--- a/server/redact.test.ts
+++ b/server/redact.test.ts
@@ -165,4 +165,46 @@ describe("redactSecretsInText", () => {
     expect(out.command).toContain("«redacted");
     expect(out.note).toBe("fine");
   });
+
+  // Tool results are what actually leak: a `cat .env` or `printenv` dumps
+  // real credentials into the transcript as plain output. The same content
+  // rules apply — but a near-miss must survive, because debugging usefulness
+  // matters and a generic "long token" rule would rewrite real code.
+  describe("tool-output shapes (value-shape rules)", () => {
+    const alpha = "abcdefghijklmnopqrstuvwxyz0123456789";
+    it("masks every high-signal secret shape in raw tool output", () => {
+      const cases: Array<[string, RegExp]> = [
+        [`OPENAI_API_KEY=${"sk" + "-"}${alpha}`, /sk-[a-z]/],
+        [`aws ${"AKIA" + "ABCDEFGHIJKLMNOP"} example`, /AKIA[A-Z0-9]{16}/],
+        [`bare openai shape ${"sk" + "-"}${alpha.slice(0, 24)} trailing`, /sk-[a-z]/],
+        [`token: ${"gh" + "o_"}${alpha.slice(0, 36)}`, /gho_/],
+        [`fine-grained ${"github_" + "pat_"}11ABCDEFG0${alpha}`, /github_pat_/],
+        [`slack user token ${"xox" + "p-"}2400-${"1234567890123"}-${alpha.slice(0, 24)}`, /xoxp-/],
+      ];
+      for (const [input, leak] of cases) {
+        const out = redactSecretsInText(input);
+        expect(out, input).not.toMatch(leak);
+        expect(out).toMatch(/«redacted \d+ chars»/);
+      }
+      // PEM keeps its header/footer markers but loses the key body
+      const pemOut = redactSecretsInText(
+        `deploy key:\n-----BEGIN RSA PRIVATE KEY-----\n${"MIIEpAIBAAKCAQEA7abcd1234"}\n-----END RSA PRIVATE KEY-----`,
+      );
+      expect(pemOut).not.toContain("MIIEpAIBAAKCAQEA7abcd1234");
+      expect(pemOut).toMatch(/BEGIN RSA PRIVATE KEY[\s\S]*«redacted \d+ chars»[\s\S]*END RSA PRIVATE KEY/);
+    });
+
+    it("leaves near-misses alone so debugging stays useful", () => {
+      for (const s of [
+        `${"sk" + "-"}short12345`, // provider-less sk- but too short to be a key
+        "AKIAIOSFODNN7EXAMPL", // 19 chars — one short of the fixed 4+16 shape
+        `${"xox" + "b-"}short9chars`, // slack prefix, under the 20-char floor
+        `${"gh" + "p_"}short7`, // github prefix, too short to be real
+        "github_pat_tooshort", // fine-grained prefix, too short
+        "commit 3f2a9c1e7b4d5a6f8e9c0b1a2d3e4f5a6b7c8d9e is just a hash",
+      ]) {
+        expect(redactSecretsInText(s), s).toBe(s);
+      }
+    });
+  });
 });

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -521,6 +521,36 @@ describe("Store redacts bot-authored secrets on write", () => {
     const again = new Store(selection);
     expect(again.messagesFor(bot.threadId).find((m) => m.id === reply.id)?.text).not.toContain(key);
   });
+
+  it("masks a key in a TOOL RESULT at store time while normal prose survives untouched", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const skKey = `sk-proj-abcdefghijklmnopqrstuvwxyz0123456789`;
+    const envDump = `Bash: cat .env\nDATABASE_URL=postgres://localhost/app\nOPENAI_API_KEY=${skKey}\nPORT=3000`;
+    const chip = store.appendMessage(bot.threadId, {
+      role: "bot",
+      kind: "activity",
+      tool: { name: envDump, ok: true },
+    });
+    expect(chip.tool?.name).not.toContain(skKey);
+    expect(chip.tool?.name).toContain("«redacted");
+    // prose and non-secret lines in the same output stay readable
+    expect(chip.tool?.name).toContain("cat .env");
+    expect(chip.tool?.name).toContain("DATABASE_URL=postgres://localhost/app");
+    expect(chip.tool?.name).toContain("PORT=3000");
+    // the persisted copy is redacted too, not just what append returned
+    const again = new Store(selection);
+    const stored = again.messagesFor(bot.threadId).find((m) => m.id === chip.id)?.tool?.name ?? "";
+    expect(stored).not.toContain(skKey);
+  });
+
+  it("tool-result redaction never touches user messages", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const key = `sk-ant-api03-${"abcdefghijklmnopqrstuvwxyz0123456789"}`;
+    const mine = store.appendMessage(bot.threadId, { role: "user", kind: "activity", tool: { name: `paste ${key}` } });
+    expect(mine.tool?.name).toBe(`paste ${key}`);
+  });
 });
 
 describe("Store task usage", () => {

--- a/server/store.ts
+++ b/server/store.ts
@@ -184,7 +184,13 @@ export interface TaskUsage {
  * the whole command line), a permission card's summary. What the user typed
  * is theirs and stays as typed. Stored, not just displayed: the transcript
  * is replayed into every rebuild, and a leaked key would otherwise be
- * permanent. */
+ * permanent.
+ *
+ * Tool RESULTS take the same pass, and for the same reason — `cat .env`
+ * output lands in the transcript as an activity chip's title and would be
+ * replayed verbatim forever — but they are not "bot-authored", so this is
+ * deliberately separate from redactBotAuthored: user text must stay as
+ * typed even when it happens to carry a key. */
 function redactBotAuthored<T extends Omit<Message, "id" | "at"> & { at?: number }>(message: T): T {
   if (message.role !== "bot") return message;
   const out = { ...message };
@@ -206,6 +212,11 @@ function redactBotAuthored<T extends Omit<Message, "id" | "at"> & { at?: number 
     };
   }
   return out;
+}
+
+function redactToolResult<T extends Omit<Message, "id" | "at"> & { at?: number }>(message: T): T {
+  if (!message.tool?.name || message.role === "user") return message;
+  return { ...message, tool: { ...message.tool, name: redactSecretsInText(message.tool.name) } };
 }
 
 /** What changed, emitted by the store itself right after each write. The
@@ -672,7 +683,7 @@ export class Store {
 
   appendMessage(threadId: string, message: Omit<Message, "id" | "at"> & { at?: number }): Message {
     const t = this.thread(threadId);
-    const full: Message = { id: newId(), at: Date.now(), parentId: t.activeLeafId, ...redactBotAuthored(message) };
+    const full: Message = { id: newId(), at: Date.now(), parentId: t.activeLeafId, ...redactBotAuthored(redactToolResult(message)) };
     t.messages.push(full);
     t.activeLeafId = full.id;
     mdb.appendMessage(threadId, full);


### PR DESCRIPTION
## Summary

Tool **results** were the one transcript input that bypassed redaction. `Store.appendMessage` scrubbed everything the *bot authored* (reply text, tool titles, card copy) via `redactBotAuthored`, but a `cat .env`-style tool output lands in the persisted thread as an activity chip's tool name — and since rebuilds replay activity into every handed-over context, a secret printed by a command was stored (and re-fed to models) in plaintext, permanently.

This PR closes that gap at the single store choke point rather than at each driver/append call site:

- `server/store.ts`: new `redactToolResult` pass runs inside `appendMessage`, applying the existing `redactSecretsInText` to `tool.name` on activity messages regardless of role — except user-authored ones, which stay exactly as typed (same rule as user text today).
- Value-shape rules for high-signal credential formats already exist in `server/redact.ts` (`AKIA…` AWS key ids, `sk-`/`sk-proj-` API keys, `ghp_`/`gho_`/… and `github_pat_` GitHub tokens, `xox[bposar]-` Slack tokens, PEM `PRIVATE KEY` blocks) — this PR puts those rules to work on tool results too, with tests proving each shape is masked in raw command output.
- Over-redaction guard: no generic long-token/hex rule is added; near-miss fixtures (short prefixes, one-char-short AKIA, plain commit hashes, prose) assert ordinary text survives so debugging usefulness is preserved.
- Marker style is unchanged: the same `«redacted N chars»` convention as every existing call site.

Note: the audit evidence this task was scoped from claimed these shape rules were missing from `redact.ts`; they were in fact already present on origin/main with passing tests. The genuine gap was the missing result-side hook, which is what this PR implements.

## Changes

- `server/store.ts`: add `redactToolResult`; fold it into `appendMessage`; document why it sits beside (not inside) `redactBotAuthored`.
- `server/redact.test.ts`: new "tool-output shapes" suite — positive masks for sk-, AKIA, gho_, github_pat_, xoxp- and PEM bodies in raw tool output; near-miss negatives proving short/partial shapes are left untouched.
- `server/store.test.ts`: end-to-end store-time test (`cat .env` dump containing an sk-proj key gets masked in both the returned message and the persisted record while surrounding prose survives), plus a guard test that user messages with `tool.name` are never rewritten.

## Test Plan

- [x] `export VITEST_CACHE_DIR=$PWD/.vitest && pnpm typecheck` — passes
- [x] `npx vitest run server/redact.test.ts server/store.test.ts` — 61/61 passed (all 59 pre-existing redaction/store tests unmodified)
- [x] `npx oxlint server` — no findings on any added line (repo has a large pre-existing anti-slop baseline on untouched files)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection for secrets appearing in bot-generated tool results.
  - Redacts recognized OpenAI, AWS, GitHub, Slack, and PEM private-key patterns in stored tool-result titles and content.
  - Preserves ordinary hashes, near-miss values, and user-authored tool messages without unintended changes.
  - Ensures redaction remains applied to persisted messages. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->