### PR TITLE
feat(desktop): export privacy-safe diagnostics

### DIFF
--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -32,8 +32,6 @@ const CREDENTIAL_TOKEN_FORMATS = [
   /\bAIza[0-9A-Za-z_-]{30,}/g,
   /\bnpm_[A-Za-z0-9]{20,}/g,
 ];
-const SECRET_NAME =
-  /(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)/i;
 const KEY_VALUE_PAIR =
   /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
 const BEARER = /(\bbearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi;
@@ -68,26 +66,15 @@ export function redactSecretsInLine(line) {
 const APP_INFO_KEYS = ["version", "platform", "arch", "electron", "node", "packaged", "uptimeSeconds"];
 
 // A config summary entry is publishable only when it carries no credential:
-// booleans and finite numbers always pass; strings must be short, not
-// secret-named, and free of token formats. Everything else (objects beyond
-// flattening, arrays, nulls) never reaches the file.
+// Only booleans and finite numbers pass. Strings can contain names, paths,
+// account identifiers, or other personal data even when the field name is
+// not credential-shaped, so they never reach the file. Everything else
+// (objects beyond flattening, arrays, nulls) is dropped too.
 const isFiniteNumber = (value) => Number.isFinite(value) && Object.prototype.toString.call(value) === "[object Number]";
 
-function summaryAllows(key, value) {
+function summaryAllows(value) {
   if (Object.prototype.toString.call(value) === "[object Boolean]") return true;
-  if (isFiniteNumber(value)) return true;
-  if (Object.prototype.toString.call(value) !== "[object String]") return false;
-  const leaf = key.slice(key.lastIndexOf(".") + 1);
-  // `key`/`keys` alone are too common as prose to regex on values, but as a
-  // *field name* they mean credential here (xai.key, tts.key) — drop them.
-  if (/^(?:.*[_.-])?keys?$/i.test(leaf)) return false;
-  if (SECRET_NAME.test(leaf)) return false;
-  if (CREDENTIAL_ENV_NAMES.some((name) => key.toUpperCase().includes(name))) return false;
-  if (value.length > 64) return false;
-  return CREDENTIAL_TOKEN_FORMATS.every((format) => {
-    format.lastIndex = 0;
-    return !format.test(value);
-  });
+  return isFiniteNumber(value);
 }
 
 function flattenSummary(input, prefix = "", depth = 0, out = {}) {
@@ -106,7 +93,6 @@ export function buildDiagnosticsReport({
   appInfo = {},
   configSummary = {},
   logTail,
-  logPath = "",
   now = new Date().toISOString(),
 } = {}) {
   const lines = [];
@@ -124,17 +110,13 @@ export function buildDiagnosticsReport({
   const summary = flattenSummary(configSummary);
   let shown = 0;
   for (const key of Object.keys(summary).sort()) {
-    if (!summaryAllows(key, summary[key])) continue;
+    if (!summaryAllows(summary[key])) continue;
     lines.push(`${key}=${summary[key]}`);
     shown += 1;
   }
   if (!shown) lines.push("(no configuration summary available)");
   lines.push("");
-  lines.push(
-    logTail && logTail.trim()
-      ? `## Server log tail${logPath ? ` (${logPath})` : ""} — secrets auto-masked`
-      : "## Server log tail",
-  );
+  lines.push(logTail && logTail.trim() ? "## Server log tail — known credential patterns auto-masked" : "## Server log tail");
   if (logTail && logTail.trim()) {
     for (const line of logTail.split(/\r?\n/)) lines.push(redactSecretsInLine(line));
   } else {

--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -1,0 +1,153 @@
+// One-click bug-report bundle: app facts, a safe config summary and the
+// server.log tail, formatted for pasting into a public issue. Pure string
+// work lives here so redaction stays unit-testable without Electron; main.mjs
+// owns the fs and dialog plumbing. Safety is layered: the collector never
+// reads secret fields at all (only the server's booleans-only config status),
+// and everything that does get in is scrubbed again here before it lands on
+// disk — so a future collector mistake still cannot leak a credential.
+//
+// CREDENTIAL_ENV_NAMES mirrors WORKSPACE_CREDENTIAL_ENV (server/config.ts).
+// Duplicated because the desktop shell cannot import TypeScript; a test
+// asserts the two lists never drift apart.
+export const CREDENTIAL_ENV_NAMES = [
+  "XAI_API_KEY",
+  "BOX_TOKEN",
+  "OPENCODE_API_KEY",
+  "OMB_TTS_KEY",
+  "OMB_OPENAI_IMAGE_KEY",
+  "COMPOSIO_API_KEY",
+  "OMB_COMPOSIO_BROKER_TOKEN",
+];
+
+// Credential-shaped tokens (server/redact.ts parity): unmistakable formats
+// are masked wherever they appear, keyed or not.
+const CREDENTIAL_TOKEN_FORMATS = [
+  /\bsk-[A-Za-z0-9_-]{16,}/g,
+  /\bxai-[A-Za-z0-9]{16,}/g,
+  /\bak_[A-Za-z0-9_-]{16,}/g,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  /\bxox[abposr]-[A-Za-z0-9-]{20,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{30,}/g,
+  /\bnpm_[A-Za-z0-9]{20,}/g,
+];
+const SECRET_NAME =
+  /(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)/i;
+const KEY_VALUE_PAIR =
+  /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
+const BEARER = /(\bbearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi;
+const PEM_BLOCK =
+  /(-----BEGIN [A-Z ]*PRIVATE KEY-----)[\s\S]*?(-----END [A-Z ]*PRIVATE KEY-----)/g;
+
+const mask = (value) => `«redacted ${value.length} chars»`;
+const unquote = (value) => value.replace(/^["']|["']$/g, "");
+
+// Shared value grammar; String.raw keeps \s and \] intact when the pattern
+// is embedded into the dynamically built env-name regexes below.
+const VALUE_PART = String.raw`("[^"]*"|'[^']*'|[^\s"',;)\]}]+)`;
+
+export function redactSecretsInLine(line) {
+  let out = String(line ?? "");
+  const alreadyMasked = (value) => String(value).includes("«redacted");
+  for (const name of CREDENTIAL_ENV_NAMES) {
+    out = out.replace(
+      new RegExp(`\\b(${name})\\s*[:=]\\s*${VALUE_PART}`, "gi"),
+      (_match, key, value) => `${key}=${mask(unquote(value))}`,
+    );
+  }
+  out = out.replace(BEARER, (_match, lead, token) => `${lead}${mask(token)}`);
+  out = out.replace(PEM_BLOCK, (_match, open, close) => `${open}«redacted private key»${close}`);
+  out = out.replace(KEY_VALUE_PAIR, (_match, key, value) =>
+    alreadyMasked(value) ? _match : `${key}=${mask(unquote(value))}`,
+  );
+  for (const format of CREDENTIAL_TOKEN_FORMATS) out = out.replace(format, (found) => mask(found));
+  return out;
+}
+
+const APP_INFO_KEYS = ["version", "platform", "arch", "electron", "node", "packaged", "uptimeSeconds"];
+
+// A config summary entry is publishable only when it carries no credential:
+// booleans and finite numbers always pass; strings must be short, not
+// secret-named, and free of token formats. Everything else (objects beyond
+// flattening, arrays, nulls) never reaches the file.
+const isFiniteNumber = (value) => Number.isFinite(value) && Object.prototype.toString.call(value) === "[object Number]";
+
+function summaryAllows(key, value) {
+  if (Object.prototype.toString.call(value) === "[object Boolean]") return true;
+  if (isFiniteNumber(value)) return true;
+  if (Object.prototype.toString.call(value) !== "[object String]") return false;
+  const leaf = key.slice(key.lastIndexOf(".") + 1);
+  // `key`/`keys` alone are too common as prose to regex on values, but as a
+  // *field name* they mean credential here (xai.key, tts.key) — drop them.
+  if (/^(?:.*[_.-])?keys?$/i.test(leaf)) return false;
+  if (SECRET_NAME.test(leaf)) return false;
+  if (CREDENTIAL_ENV_NAMES.some((name) => key.toUpperCase().includes(name))) return false;
+  if (value.length > 64) return false;
+  return CREDENTIAL_TOKEN_FORMATS.every((format) => {
+    format.lastIndex = 0;
+    return !format.test(value);
+  });
+}
+
+function flattenSummary(input, prefix = "", depth = 0, out = {}) {
+  if (!input || Object.prototype.toString.call(input) !== "[object Object]") return out;
+  for (const [key, value] of Object.entries(input)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (Array.isArray(value)) continue;
+    if (value && Object.prototype.toString.call(value) === "[object Object]" && depth < 3)
+      flattenSummary(value, path, depth + 1, out);
+    else out[path] = value;
+  }
+  return out;
+}
+
+export function buildDiagnosticsReport({
+  appInfo = {},
+  configSummary = {},
+  logTail,
+  logPath = "",
+  now = new Date().toISOString(),
+} = {}) {
+  const lines = [];
+  lines.push("OpenMausBot diagnostics");
+  lines.push(`Generated: ${now}`);
+  lines.push("");
+  lines.push("## App");
+  for (const key of APP_INFO_KEYS) {
+    if (appInfo[key] === undefined || appInfo[key] === null) continue;
+    lines.push(`${key}=${String(appInfo[key])}`);
+  }
+  lines.push("");
+  lines.push("## Configuration");
+  lines.push("# presence/count/mode only — credentials stay OS-encrypted and are never read");
+  const summary = flattenSummary(configSummary);
+  let shown = 0;
+  for (const key of Object.keys(summary).sort()) {
+    if (!summaryAllows(key, summary[key])) continue;
+    lines.push(`${key}=${summary[key]}`);
+    shown += 1;
+  }
+  if (!shown) lines.push("(no configuration summary available)");
+  lines.push("");
+  lines.push(
+    logTail && logTail.trim()
+      ? `## Server log tail${logPath ? ` (${logPath})` : ""} — secrets auto-masked`
+      : "## Server log tail",
+  );
+  if (logTail && logTail.trim()) {
+    for (const line of logTail.split(/\r?\n/)) lines.push(redactSecretsInLine(line));
+  } else {
+    lines.push("(server log unavailable)");
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function diagnosticsFileName(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return (
+    `openmausbot-diagnostics-${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}.txt`
+  );
+}

--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -34,6 +34,8 @@ const CREDENTIAL_TOKEN_FORMATS = [
 ];
 const KEY_VALUE_PAIR =
   /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
+const AUTHORIZATION =
+  /\b(authorization)\s*[:=]\s*(?:"|')?([A-Za-z][A-Za-z0-9_-]*\s+[A-Za-z0-9._~+/=-]+)(?:"|')?/gi;
 const BEARER = /(\bbearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi;
 const PEM_BLOCK =
   /(-----BEGIN [A-Z ]*PRIVATE KEY-----)[\s\S]*?(-----END [A-Z ]*PRIVATE KEY-----)/g;
@@ -54,6 +56,7 @@ export function redactSecretsInLine(line) {
       (_match, key, value) => `${key}=${mask(unquote(value))}`,
     );
   }
+  out = out.replace(AUTHORIZATION, (_match, key, value) => `${key}=${mask(value)}`);
   out = out.replace(BEARER, (_match, lead, token) => `${lead}${mask(token)}`);
   out = out.replace(PEM_BLOCK, (_match, open, close) => `${open}«redacted private key»${close}`);
   out = out.replace(KEY_VALUE_PAIR, (_match, key, value) =>
@@ -61,6 +64,18 @@ export function redactSecretsInLine(line) {
   );
   for (const format of CREDENTIAL_TOKEN_FORMATS) out = out.replace(format, (found) => mask(found));
   return out;
+}
+
+/** Decode a bounded log buffer without exporting the partial first line that
+ * may begin before the read boundary. */
+export function decodeLogTail(buffer, truncated = false) {
+  if (!Buffer.isBuffer(buffer)) return { tail: "", bytes: 0 };
+  let complete = buffer;
+  if (truncated) {
+    const newline = buffer.indexOf(0x0a);
+    complete = newline < 0 ? buffer.subarray(0, 0) : buffer.subarray(newline + 1);
+  }
+  return { tail: complete.toString("utf8"), bytes: complete.length };
 }
 
 const APP_INFO_KEYS = ["version", "platform", "arch", "electron", "node", "packaged", "uptimeSeconds"];
@@ -118,7 +133,7 @@ export function buildDiagnosticsReport({
   lines.push("");
   lines.push(logTail && logTail.trim() ? "## Server log tail — known credential patterns auto-masked" : "## Server log tail");
   if (logTail && logTail.trim()) {
-    for (const line of logTail.split(/\r?\n/)) lines.push(redactSecretsInLine(line));
+    for (const line of redactSecretsInLine(logTail).split(/\r?\n/)) lines.push(line);
   } else {
     lines.push("(server log unavailable)");
   }

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+
+const require = createRequire(import.meta.url);
+const { buildDiagnosticsReport, diagnosticsFileName, redactSecretsInLine, CREDENTIAL_ENV_NAMES } =
+  require("./diagnostics.mjs");
+
+// The desktop shell cannot import TypeScript, so its credential list is a
+// hand copy of server/config.ts WORKSPACE_CREDENTIAL_ENV. This test is the
+// drift alarm: a name added server-side without updating the copy here would
+// otherwise ship an unredacted export path.
+describe("credential env parity with server/config.ts", () => {
+  it("matches WORKSPACE_CREDENTIAL_ENV exactly", () => {
+    const config = readFileSync(new URL("../server/config.ts", import.meta.url), "utf8");
+    const match = config.match(/WORKSPACE_CREDENTIAL_ENV = \[([\s\S]*?)\] as const/);
+    expect(match).not.toBeNull();
+    const names = [...match[1].matchAll(/"([A-Z0-9_]+)"/g)].map((m) => m[1]);
+    expect(CREDENTIAL_ENV_NAMES).toEqual(names);
+  });
+});
+
+describe("buildDiagnosticsReport", () => {
+  const appInfo = {
+    version: "0.1.27",
+    platform: "darwin",
+    arch: "arm64",
+    electron: "43.4.0",
+    node: "24.0.0",
+    packaged: true,
+    uptimeSeconds: 42,
+  };
+
+  it("renders app facts and a sorted config summary", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {
+        xai: { configured: true },
+        box: { configured: false },
+        rooms: { turnTimeoutMinutes: 5 },
+      },
+      logTail: "",
+    });
+    expect(report).toContain("version=0.1.27");
+    expect(report).toContain("platform=darwin");
+    expect(report).toContain("arch=arm64");
+    expect(report).toContain("xai.configured=true");
+    expect(report).toContain("box.configured=false");
+    expect(report).toContain("rooms.turnTimeoutMinutes=5");
+    expect(report).toContain("(server log unavailable)");
+  });
+
+  it("drops non-scalar, secret-named and credential-shaped summary values", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {
+        xai: { key: "xai-real-secret" },
+        composio: { apiKey: "ak_live_abcdef123456789" },
+        vps: { sshAlias: "" },
+        profile: { name: "Ada" },
+        instances: [{ driver: "claudeAgent", environment: { TOKEN: "hunter2" } }],
+        note: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+      },
+      logTail: "",
+    });
+    expect(report).not.toContain("xai-real-secret");
+    expect(report).not.toContain("ak_live_abcdef123456789");
+    expect(report).not.toContain("hunter2");
+    expect(report).not.toContain("driver");
+    expect(report).not.toContain("environment");
+    expect(report).toContain("profile.name=Ada");
+    expect(report).not.toContain("note=");
+  });
+
+  it.each(CREDENTIAL_ENV_NAMES)("masks any value riding on %s in the log tail", (name) => {
+    const value = "s3cr3t-value-123456";
+    const line = `spawn env ${name}=${value} ready`;
+    const report = buildDiagnosticsReport({ appInfo, configSummary: {}, logTail: line });
+    expect(report).not.toContain(value);
+    expect(redactSecretsInLine(line)).toBe(`spawn env ${name}=«redacted ${value.length} chars» ready`);
+  });
+
+  it("masks generic key=value secrets and content-shaped tokens in the log tail", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      logTail: [
+        'config {"apiKey":"sk-proj-abcdefghijklmnop"}',
+        "Authorization: Bearer abcdefghijklmnop",
+        "password=hunter2000",
+      ].join("\n"),
+    });
+    expect(report).not.toContain("sk-proj-abcdefghijklmnop");
+    expect(report).not.toContain("abcdefghijklmnop");
+    expect(report).not.toContain("hunter2000");
+    expect(report).toContain("«redacted");
+  });
+
+  it("leaves ordinary log lines untouched", () => {
+    const line = "[2026-08-22T20:00:00.000Z] [out] fork server/index.js port=8799 spawned pid=4242";
+    expect(redactSecretsInLine(line)).toBe(line);
+  });
+
+  it("handles an empty or missing log gracefully", () => {
+    for (const logTail of ["", null, undefined]) {
+      const report = buildDiagnosticsReport({ appInfo, configSummary: {}, logTail });
+      expect(report).toContain("(server log unavailable)");
+      expect(report.endsWith("\n")).toBe(true);
+    }
+  });
+
+  it("keeps long prose lines that merely mention a key by name", () => {
+    const line = "user asked whether the XAI_API_KEY variable needs to be set manually";
+    expect(redactSecretsInLine(line)).toBe(line);
+  });
+});
+
+describe("diagnosticsFileName", () => {
+  it("uses openmausbot-diagnostics-YYYYMMDD-HHmmss.txt", () => {
+    expect(diagnosticsFileName(new Date(2026, 7, 22, 16, 5, 9))).toBe(
+      "openmausbot-diagnostics-20260822-160509.txt",
+    );
+  });
+});

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -3,8 +3,13 @@ import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 
 const require = createRequire(import.meta.url);
-const { buildDiagnosticsReport, diagnosticsFileName, redactSecretsInLine, CREDENTIAL_ENV_NAMES } =
-  require("./diagnostics.mjs");
+const {
+  buildDiagnosticsReport,
+  decodeLogTail,
+  diagnosticsFileName,
+  redactSecretsInLine,
+  CREDENTIAL_ENV_NAMES,
+} = require("./diagnostics.mjs");
 
 // The desktop shell cannot import TypeScript, so its credential list is a
 // hand copy of server/config.ts WORKSPACE_CREDENTIAL_ENV. This test is the
@@ -108,6 +113,38 @@ describe("buildDiagnosticsReport", () => {
     expect(report).toContain("«redacted");
   });
 
+  it.each(["Bearer abcdefghijklmnop", "Basic dXNlcjpwYXNzd29yZA=="])(
+    "masks the full Authorization credential for %s",
+    (authorization) => {
+      const report = buildDiagnosticsReport({
+        appInfo,
+        configSummary: {},
+        logTail: `request Authorization: ${authorization}`,
+      });
+      expect(report).not.toContain(authorization);
+      expect(report).not.toContain(authorization.split(" ")[1]);
+      expect(report).toContain("Authorization=«redacted");
+    },
+  );
+
+  it("masks a multiline PEM private key as one value", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      logTail: [
+        "loading credential",
+        "-----BEGIN PRIVATE KEY-----",
+        "super-secret-line-one",
+        "super-secret-line-two",
+        "-----END PRIVATE KEY-----",
+        "ready",
+      ].join("\n"),
+    });
+    expect(report).not.toContain("super-secret-line-one");
+    expect(report).not.toContain("super-secret-line-two");
+    expect(report).toContain("«redacted private key»");
+  });
+
   it("leaves ordinary log lines untouched", () => {
     const line = "[2026-08-22T20:00:00.000Z] [out] fork server/index.js port=8799 spawned pid=4242";
     expect(redactSecretsInLine(line)).toBe(line);
@@ -124,6 +161,22 @@ describe("buildDiagnosticsReport", () => {
   it("keeps long prose lines that merely mention a key by name", () => {
     const line = "user asked whether the XAI_API_KEY variable needs to be set manually";
     expect(redactSecretsInLine(line)).toBe(line);
+  });
+});
+
+describe("decodeLogTail", () => {
+  it("preserves the full buffer when the read starts at the beginning", () => {
+    expect(decodeLogTail(Buffer.from("first\nsecond"), false)).toEqual({ tail: "first\nsecond", bytes: 12 });
+  });
+
+  it("drops a credential assignment split by a bounded tail read", () => {
+    const decoded = decodeLogTail(Buffer.from("RET=split-secret\nserver ready\n"), true);
+    expect(decoded).toEqual({ tail: "server ready\n", bytes: 13 });
+    expect(decoded.tail).not.toContain("split-secret");
+  });
+
+  it("returns an empty tail when a truncated buffer has no complete line", () => {
+    expect(decodeLogTail(Buffer.from("partial-secret"), true)).toEqual({ tail: "", bytes: 0 });
   });
 });
 

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -50,7 +50,7 @@ describe("buildDiagnosticsReport", () => {
     expect(report).toContain("(server log unavailable)");
   });
 
-  it("drops non-scalar, secret-named and credential-shaped summary values", () => {
+  it("drops strings, non-scalars and credential-shaped summary values", () => {
     const report = buildDiagnosticsReport({
       appInfo,
       configSummary: {
@@ -68,8 +68,20 @@ describe("buildDiagnosticsReport", () => {
     expect(report).not.toContain("hunter2");
     expect(report).not.toContain("driver");
     expect(report).not.toContain("environment");
-    expect(report).toContain("profile.name=Ada");
+    expect(report).not.toContain("profile.name=");
+    expect(report).not.toContain("Ada");
     expect(report).not.toContain("note=");
+  });
+
+  it("never includes an absolute log path in the report heading", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      logTail: "server ready",
+      logPath: "/Users/ada/Library/Logs/OpenMausBot/server.log",
+    });
+    expect(report).toContain("## Server log tail");
+    expect(report).not.toContain("/Users/ada");
   });
 
   it.each(CREDENTIAL_ENV_NAMES)("masks any value riding on %s in the log tail", (name) => {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -247,7 +247,9 @@ function readLogTail(logPath) {
 // file is safe to paste into a public issue even if a future log line ever
 // carried a secret.
 async function gatherDiagnostics() {
-  const serverStatus = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config`)
+  const serverStatus = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config`, {
+    signal: AbortSignal.timeout(3_000),
+  })
     .then((res) => (res.ok ? res.json() : null))
     .catch(() => null);
   const logPath = path.join(LOG_DIR, "server.log");
@@ -264,7 +266,6 @@ async function gatherDiagnostics() {
     },
     configSummary: serverStatus ?? {},
     logTail: log?.tail ?? "",
-    logPath: log ? logPath : "",
   });
 }
 
@@ -693,7 +694,11 @@ ipcMain.handle("desktop:export-diagnostics", async (event) => {
     filters: [{ name: "Text", extensions: ["txt"] }],
   });
   if (result.canceled || !result.filePath) return null;
+  // `mode` only applies when a file is first created. Secure an existing
+  // destination before overwriting it, then verify the final mode as well.
+  if (process.platform !== "win32" && fs.existsSync(result.filePath)) fs.chmodSync(result.filePath, 0o600);
   fs.writeFileSync(result.filePath, report, { mode: 0o600 });
+  if (process.platform !== "win32") fs.chmodSync(result.filePath, 0o600);
   return result.filePath;
 });
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,6 +8,7 @@ import { createAndroidDeviceController } from "./android-device.mjs";
 import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
+import { buildDiagnosticsReport, diagnosticsFileName } from "./diagnostics.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow } from "./single-instance.mjs";
 import capabilitiesModule from "./capabilities.cjs";
@@ -219,6 +220,52 @@ function slog(line) {
   } catch {
     /* logging must never break startup */
   }
+}
+
+const LOG_TAIL_BYTES = 256 * 1024;
+
+function readLogTail(logPath) {
+  try {
+    const size = fs.statSync(logPath).size;
+    const start = Math.max(0, size - LOG_TAIL_BYTES);
+    const handle = fs.openSync(logPath, "r");
+    try {
+      const buffer = Buffer.alloc(size - start);
+      fs.readSync(handle, buffer, 0, buffer.length, start);
+      return { tail: buffer.toString("utf8"), bytes: buffer.length };
+    } finally {
+      fs.closeSync(handle);
+    }
+  } catch {
+    return null;
+  }
+}
+
+// Everything the bug-report bundle needs. The config summary comes from the
+// server's own booleans-only /api/config status (credentials are never
+// echoed), and the log goes through the redactor in diagnostics.mjs — so the
+// file is safe to paste into a public issue even if a future log line ever
+// carried a secret.
+async function gatherDiagnostics() {
+  const serverStatus = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/config`)
+    .then((res) => (res.ok ? res.json() : null))
+    .catch(() => null);
+  const logPath = path.join(LOG_DIR, "server.log");
+  const log = readLogTail(logPath);
+  return buildDiagnosticsReport({
+    appInfo: {
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      electron: process.versions.electron,
+      node: process.versions.node,
+      packaged: app.isPackaged,
+      uptimeSeconds: Math.round(process.uptime()),
+    },
+    configSummary: serverStatus ?? {},
+    logTail: log?.tail ?? "",
+    logPath: log ? logPath : "",
+  });
 }
 
 async function startServerOn(port) {
@@ -632,6 +679,22 @@ ipcMain.handle("desktop:pick-folder", async (event, current) => {
     ...(typeof current === "string" && current ? { defaultPath: current } : {}),
   });
   return result.canceled ? null : (result.filePaths[0] ?? null);
+});
+
+// One-click bug-report bundle. Secrets are never read; the report is
+// redacted again on the way out (diagnostics.mjs). null means the user
+// cancelled the save dialog.
+ipcMain.handle("desktop:export-diagnostics", async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender) ?? undefined;
+  const report = await gatherDiagnostics();
+  const result = await dialog.showSaveDialog(owner, {
+    title: "Export diagnostics",
+    defaultPath: diagnosticsFileName(),
+    filters: [{ name: "Text", extensions: ["txt"] }],
+  });
+  if (result.canceled || !result.filePath) return null;
+  fs.writeFileSync(result.filePath, report, { mode: 0o600 });
+  return result.filePath;
 });
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,7 +8,7 @@ import { createAndroidDeviceController } from "./android-device.mjs";
 import { finishSpeech, startSpeech, stopSpeech } from "./speech.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
-import { buildDiagnosticsReport, diagnosticsFileName } from "./diagnostics.mjs";
+import { buildDiagnosticsReport, decodeLogTail, diagnosticsFileName } from "./diagnostics.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow } from "./single-instance.mjs";
 import capabilitiesModule from "./capabilities.cjs";
@@ -232,7 +232,7 @@ function readLogTail(logPath) {
     try {
       const buffer = Buffer.alloc(size - start);
       fs.readSync(handle, buffer, 0, buffer.length, start);
-      return { tail: buffer.toString("utf8"), bytes: buffer.length };
+      return decodeLogTail(buffer, start > 0);
     } finally {
       fs.closeSync(handle);
     }
@@ -694,11 +694,18 @@ ipcMain.handle("desktop:export-diagnostics", async (event) => {
     filters: [{ name: "Text", extensions: ["txt"] }],
   });
   if (result.canceled || !result.filePath) return null;
-  // `mode` only applies when a file is first created. Secure an existing
-  // destination before overwriting it, then verify the final mode as well.
-  if (process.platform !== "win32" && fs.existsSync(result.filePath)) fs.chmodSync(result.filePath, 0o600);
-  fs.writeFileSync(result.filePath, report, { mode: 0o600 });
-  if (process.platform !== "win32") fs.chmodSync(result.filePath, 0o600);
+  if (process.platform === "win32") {
+    fs.writeFileSync(result.filePath, report, { mode: 0o600 });
+  } else {
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW;
+    const handle = fs.openSync(result.filePath, flags, 0o600);
+    try {
+      fs.fchmodSync(handle, 0o600);
+      fs.writeFileSync(handle, report, "utf8");
+    } finally {
+      fs.closeSync(handle);
+    }
+  }
   return result.filePath;
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -88,6 +88,9 @@ contextBridge.exposeInMainWorld("ogb", {
   },
   /** Native folder picker for a bot's working folder; null when cancelled. */
   pickFolder: (current) => ipcRenderer.invoke("desktop:pick-folder", current),
+  /** Writes the redacted diagnostics report to a user-chosen file; resolves
+   * the path, or null when the save dialog was cancelled. */
+  exportDiagnostics: () => ipcRenderer.invoke("desktop:export-diagnostics"),
   /** Store a provider credential with OS-backed encryption. */
   setCredential: (name, value) => ipcRenderer.invoke("credential:set", name, value),
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -134,22 +134,22 @@ const cnSwitch = (on: boolean) =>
 const cnKnob = (on: boolean) =>
   `absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white transition-all ${on ? "left-[21px]" : "left-[3px]"}`;
 
-/** Writes a redacted, paste-anywhere diagnostics file the user picks. The
+/** Writes a redacted diagnostics file to a location the user picks. The
  * report holds versions, configured-or-not booleans and the server.log tail —
  * never credential values (the desktop shell does not read secret fields). */
 function DiagnosticsRow() {
-  const { dispatch } = useStore();
   const [exporting, setExporting] = useState(false);
+  const [result, setResult] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
   const exportDiagnostics = async () => {
     if (!window.ogb?.exportDiagnostics || exporting) return;
     setExporting(true);
+    setResult(null);
     try {
       const path = await window.ogb.exportDiagnostics();
-      if (path) dispatch({ type: "error", message: `Diagnostics saved to ${path}` });
+      if (path) setResult({ kind: "success", message: `Saved to ${path}` });
     } catch (e) {
-      dispatch({ type: "error", message: e instanceof Error ? e.message : String(e) });
-      setTimeout(() => dispatch({ type: "error", message: null }), 6000);
+      setResult({ kind: "error", message: e instanceof Error ? e.message : String(e) });
     } finally {
       setExporting(false);
     }
@@ -158,16 +158,26 @@ function DiagnosticsRow() {
   return (
     <Card
       title="Diagnostics"
-      subtitle="Versions, configuration on/off state and the server log tail — secrets are never included. Safe to attach to a bug report."
+      subtitle="Versions, configuration on/off state and a redacted server log tail. Review the file before sharing it."
     >
-      <button
-        onClick={() => void exportDiagnostics()}
-        disabled={exporting}
-        aria-label="Export diagnostics to a text file"
-        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
-      >
-        Export Diagnostics…
-      </button>
+      <div className="flex min-w-0 flex-col items-end gap-2">
+        <button
+          onClick={() => void exportDiagnostics()}
+          disabled={exporting}
+          aria-label="Export diagnostics to a text file"
+          className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
+        >
+          {exporting ? "Exporting…" : "Export Diagnostics…"}
+        </button>
+        {result ? (
+          <span
+            role={result.kind === "error" ? "alert" : "status"}
+            className={`max-w-64 break-all text-right text-[12px] ${result.kind === "error" ? "text-danger" : "text-success"}`}
+          >
+            {result.message}
+          </span>
+        ) : null}
+      </div>
     </Card>
   );
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -134,6 +134,44 @@ const cnSwitch = (on: boolean) =>
 const cnKnob = (on: boolean) =>
   `absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white transition-all ${on ? "left-[21px]" : "left-[3px]"}`;
 
+/** Writes a redacted, paste-anywhere diagnostics file the user picks. The
+ * report holds versions, configured-or-not booleans and the server.log tail —
+ * never credential values (the desktop shell does not read secret fields). */
+function DiagnosticsRow() {
+  const { dispatch } = useStore();
+  const [exporting, setExporting] = useState(false);
+
+  const exportDiagnostics = async () => {
+    if (!window.ogb?.exportDiagnostics || exporting) return;
+    setExporting(true);
+    try {
+      const path = await window.ogb.exportDiagnostics();
+      if (path) dispatch({ type: "error", message: `Diagnostics saved to ${path}` });
+    } catch (e) {
+      dispatch({ type: "error", message: e instanceof Error ? e.message : String(e) });
+      setTimeout(() => dispatch({ type: "error", message: null }), 6000);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Diagnostics"
+      subtitle="Versions, configuration on/off state and the server log tail — secrets are never included. Safe to attach to a bug report."
+    >
+      <button
+        onClick={() => void exportDiagnostics()}
+        disabled={exporting}
+        aria-label="Export diagnostics to a text file"
+        className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
+      >
+        Export Diagnostics…
+      </button>
+    </Card>
+  );
+}
+
 export function SettingsModal() {
   const { state, dispatch } = useStore();
   const section = state.appSettingsSection;
@@ -243,6 +281,7 @@ export function SettingsModal() {
                   <RoomTurnTimeoutSettings />
                 </Card>
                 <UpdatesRow />
+                <DiagnosticsRow />
                 <AnalyticsRow />
               </>
             )}

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -90,6 +90,9 @@ declare global {
       };
       /** Native folder picker; resolves null when the user cancels. */
       pickFolder?(current?: string): Promise<string | null>;
+      /** Writes the redacted diagnostics report to a user-chosen file;
+       * resolves the path, or null when cancelled. */
+      exportDiagnostics?(): Promise<string | null>;
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(
         name: "composioApiKey" | "xaiApiKey" | "boxToken" | "opencodeGoApiKey" | "ttsKey" | "openaiImageApiKey",


### PR DESCRIPTION
Carries forward #374 by @willsigmon and addresses every review finding before merge.\n\n- limits configuration output to booleans and numbers\n- removes the absolute log path and softens the public-sharing claim\n- bounds the local config request with a timeout\n- enforces owner-only permissions when overwriting an existing file on POSIX\n- shows success and failure inside Settings instead of the hidden global error banner\n\nValidated with 16 diagnostics tests and the full TypeScript check. Replaces #374.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics export option in General settings.
  * Generates a report with app details, configuration status, and recent server logs.
  * Shows export progress and confirms the saved file location.
  * Supports cancelling the save dialog without creating a file.

* **Security**
  * Automatically redacts credentials, tokens, private keys, authorization headers, and other sensitive values from exported reports.

* **Bug Fixes**
  * Handles missing, empty, or truncated configuration and log data with clear fallback information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->