### PR TITLE
fix(hermes): expose configured and advertised models

### DIFF
--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { removeTempDir } from "../../testing/cleanup.ts";
+import { HERMES_CONFIG_MODEL_ID, hermesAcpModelId, hermesConfiguredModel } from "./hermes.ts";
+
+describe("hermesConfiguredModel", () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    for (const d of dirs.splice(0)) await removeTempDir(d);
+  });
+
+  const home = (env: string, cfg?: string) => {
+    const root = mkdtempSync(join(tmpdir(), "omb-hermes-"));
+    dirs.push(root);
+    const h = join(root, ".hermes");
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, ".env"), env);
+    if (cfg !== undefined) writeFileSync(join(h, "config.yaml"), cfg);
+    return { HERMES_HOME: h };
+  };
+
+  it("offers the configured model when a hosted key is set", () => {
+    const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n", "model:\n  default: anthropic/claude-opus-4.6\n");
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "anthropic/claude-opus-4.6 (Hermes config)",
+    });
+  });
+
+  it("treats a commented-out key as not configured", () => {
+    // The shipped .env carries `# OPENROUTER_API_KEY=`; reading that as
+    // configured would offer a model that cannot authenticate.
+    const env = home("# OPENROUTER_API_KEY=\n", "model:\n  default: anthropic/claude-opus-4.6\n");
+    expect(hermesConfiguredModel(env)).toBeNull();
+  });
+
+  it("returns null when there is no .env at all, leaving local-only setups unchanged", () => {
+    const root = mkdtempSync(join(tmpdir(), "omb-hermes-bare-"));
+    dirs.push(root);
+    expect(hermesConfiguredModel({ HERMES_HOME: join(root, ".hermes") })).toBeNull();
+  });
+
+  it("still offers the model when config.yaml is unreadable, with a generic label", () => {
+    const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n");
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "Hermes default (config)",
+    });
+  });
+
+  it("does not map to an ACP model id, so no session/set_model is sent for it", () => {
+    // This is what makes Hermes fall through to its own configured provider.
+    expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+});

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -27,6 +27,8 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toEqual({
       id: HERMES_CONFIG_MODEL_ID,
       label: "anthropic/claude-opus-4.6 (Hermes config)",
+      // ModelPicker shows a custom-only agent ONLY its custom-flagged options.
+      custom: true,
     });
   });
 
@@ -48,11 +50,35 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toEqual({
       id: HERMES_CONFIG_MODEL_ID,
       label: "Hermes default (config)",
+      custom: true,
     });
   });
 
   it("does not map to an ACP model id, so no session/set_model is sent for it", () => {
     // This is what makes Hermes fall through to its own configured provider.
     expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+});
+
+describe("hermesAcpModelId", () => {
+  it("forwards Hermes' own provider-scoped ids untouched", () => {
+    // These are what `session/new` advertises. Returning null for them is what
+    // confined the picker to locally injected hosts.
+    expect(hermesAcpModelId("openrouter:qwen/qwen3.8-max")).toBe("openrouter:qwen/qwen3.8-max");
+    expect(hermesAcpModelId("openrouter:deepseek/deepseek-v4-flash")).toBe(
+      "openrouter:deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("still maps local inject ids to Hermes' custom:<host>:<model> form", () => {
+    expect(hermesAcpModelId("ollama::llama3")).toBe("custom:ollama:llama3");
+  });
+
+  it("returns null for the config sentinel, so Hermes keeps its own default", () => {
+    expect(hermesAcpModelId(HERMES_CONFIG_MODEL_ID)).toBeNull();
+  });
+
+  it("returns null for a bare word that names no provider", () => {
+    expect(hermesAcpModelId("gpt-5")).toBeNull();
   });
 });

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -39,6 +39,15 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toBeNull();
   });
 
+  it.each([
+    "OPENROUTER_API_KEY=\n",
+    'OPENROUTER_API_KEY=""\n',
+    "OPENROUTER_API_KEY='' # intentionally blank\n",
+    "OPENROUTER_API_KEY=   # configured later\n",
+  ])("does not treat a blank key as configured: %j", (line) => {
+    expect(hermesConfiguredModel(home(line))).toBeNull();
+  });
+
   it("returns null when there is no .env at all, leaving local-only setups unchanged", () => {
     const root = mkdtempSync(join(tmpdir(), "omb-hermes-bare-"));
     dirs.push(root);
@@ -47,6 +56,7 @@ describe("hermesConfiguredModel", () => {
 
   it("still offers the model when config.yaml is unreadable, with a generic label", () => {
     const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n");
+    mkdirSync(join(env.HERMES_HOME, "config.yaml"));
     expect(hermesConfiguredModel(env)).toEqual({
       id: HERMES_CONFIG_MODEL_ID,
       label: "Hermes default (config)",

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -4,12 +4,13 @@
 // without an OpenRouter key — that is the "HTTP 401: Missing Authentication
 // header" failure. Inject writes providers.<host> and session/set_model
 // `custom:<host>:<model>` instead.
+import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { ModelCatalog } from "../../contracts.ts";
-import { decodeInjectId, hostApiKey, localHost, mergeLocalInject } from "../local-inject.ts";
+import { decodeInjectId, hostApiKey, INJECT_SEP, localHost, mergeLocalInject } from "../local-inject.ts";
 import { createAcpDriver, type AcpSupport } from "./core.ts";
 
 const EMPTY: ModelCatalog = { default: "", options: [] };
@@ -78,8 +79,13 @@ export function ensureHermesInjectProvider(
 /** ACP session/set_model id. Hermes parse_model_input treats `custom:name:model`. */
 export function hermesAcpModelId(modelId: string | null | undefined): string | null {
   const inject = decodeInjectId(modelId);
-  if (!inject) return null;
-  return `custom:${inject.host}:${inject.model}`;
+  if (inject) return `custom:${inject.host}:${inject.model}`;
+  // Hermes' own ACP ids are `<provider>:<model>` (`openrouter:qwen/qwen3.8-max`).
+  // They are not inject ids and must be forwarded untouched; returning null here
+  // is what limited the picker to locally injected hosts.
+  const native = typeof modelId === "string" ? modelId.trim() : "";
+  if (native && !native.includes(INJECT_SEP) && /^[a-z0-9_-]+:[\w./:-]+$/i.test(native)) return native;
+  return null;
 }
 
 /** The id used when Hermes should run on the provider its own config names.
@@ -109,7 +115,7 @@ export const HERMES_CONFIG_MODEL_ID = "hermes-default";
  */
 export function hermesConfiguredModel(
   env: Record<string, string | undefined> = process.env,
-): { id: string; label: string } | null {
+): { id: string; label: string; custom: true } | null {
   const dir = hermesHome(env);
   let secrets = "";
   try {
@@ -130,18 +136,113 @@ export function hermesConfiguredModel(
   } catch {
     /* config unreadable — the id still works, only the label is less specific */
   }
+  // `custom: true` is not cosmetic. ModelPicker renders a custom-only agent's
+  // *custom* pane exclusively, and that pane lists only options carrying this
+  // flag; anything without it lands in the "official" bucket the pane never
+  // shows. Omitting it puts the option in the API response while leaving the
+  // picker saying "No local models found" — present, but unselectable.
   return {
     id: HERMES_CONFIG_MODEL_ID,
     label: model ? `${model} (Hermes config)` : "Hermes default (config)",
+    custom: true as const,
   };
 }
 
-async function resolveModels(env: Record<string, string | undefined>): Promise<ModelCatalog> {
+/** Ask a short-lived `hermes acp` session what models it can actually run.
+ *
+ * Hermes advertises its full catalog on `session/new` — every model its
+ * configured providers expose, ids shaped `openrouter:qwen/qwen3.8-max`. There
+ * is no `hermes models` subcommand, so a throwaway session is the only way to
+ * read it, and it is worth the spawn: without it the picker can only offer
+ * locally injected hosts, which is a fraction of what the user is paying for.
+ *
+ * Failure is non-fatal and returns [] — a catalog probe must never be the
+ * reason an agent becomes unselectable.
+ */
+async function fetchHermesAcpModels(
+  cli: string,
+  env: Record<string, string | undefined>,
+): Promise<{ id: string; label: string; custom: true }[]> {
+  return await new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cli, ["acp"], { stdio: ["pipe", "pipe", "ignore"], env: env as NodeJS.ProcessEnv });
+    } catch {
+      return resolve([]);
+    }
+    const done = (out: { id: string; label: string; custom: true }[]) => {
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      resolve(out);
+    };
+    const timer = setTimeout(() => done([]), 25_000);
+    child.on("error", () => done([]));
+
+    let buf = "";
+    let id = 0;
+    const send = (method: string, params: unknown) => {
+      id += 1;
+      child.stdin?.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+      return id;
+    };
+    const initId = send("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
+    });
+    let sessionId = 0;
+    child.stdout?.on("data", (chunk) => {
+      buf += String(chunk);
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        let msg: any;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg?.id === initId && msg.result) {
+          sessionId = send("session/new", { cwd: env.HOME || "/tmp", mcpServers: [] });
+        } else if (sessionId && msg?.id === sessionId) {
+          const list = Array.isArray(msg.result?.models?.availableModels)
+            ? msg.result.models.availableModels
+            : [];
+          done(
+            list
+              .filter((m: any) => typeof m?.modelId === "string" && m.modelId)
+              .map((m: any) => ({
+                id: m.modelId as string,
+                // Hermes labels these "OpenRouter · <model>"; keep its wording.
+                label: (typeof m.name === "string" && m.name.trim()) || (m.modelId as string),
+                custom: true as const,
+              })),
+          );
+        }
+      }
+    });
+  });
+}
+
+async function resolveModels(
+  env: Record<string, string | undefined>,
+  config?: { cli?: string },
+): Promise<ModelCatalog> {
   const catalog = await mergeLocalInject(EMPTY, env);
   const configured = hermesConfiguredModel(env);
-  // Listed first so it is the default: someone who configured a hosted provider
-  // meant to use it, and a local host may not even be running.
-  const options = configured ? [configured, ...catalog.options] : catalog.options;
+  // Only probe when a hosted provider is configured; a local-only install has
+  // nothing to gain from the spawn.
+  const remote = configured ? await fetchHermesAcpModels(config?.cli || "hermes", env) : [];
+  const seen = new Set<string>();
+  const options = [...(configured ? [configured] : []), ...remote, ...catalog.options].filter((o) => {
+    if (seen.has(o.id)) return false;
+    seen.add(o.id);
+    return true;
+  });
   return { default: options[0]?.id ?? "", options };
 }
 
@@ -163,7 +264,7 @@ const support: AcpSupport = {
   displayName: "Hermes",
   access: "custom",
   models: EMPTY,
-  resolveModels,
+  resolveModels: (env: Record<string, string | undefined>, config: any) => resolveModels(env, config),
   resolveTurnModel: (model, env) => {
     if (!model) return model;
     ensureHermesInjectProvider(model, env);

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -97,6 +97,22 @@ export function hermesAcpModelId(modelId: string | null | undefined): string | n
  */
 export const HERMES_CONFIG_MODEL_ID = "hermes-default";
 
+function nonEmptyDotenvValue(text: string, name: string): string | null {
+  const match = new RegExp(`^[ \\t]*(?:export[ \\t]+)?${name}[ \\t]*=[ \\t]*([^\\r\\n]*)$`, "m").exec(text);
+  if (!match) return null;
+  const raw = match[1].trim();
+  if (!raw || raw.startsWith("#")) return null;
+  const quote = raw[0];
+  if (quote === '"' || quote === "'") {
+    const closing = raw.indexOf(quote, 1);
+    if (closing < 0) return null;
+    const trailing = raw.slice(closing + 1).trim();
+    if (trailing && !trailing.startsWith("#")) return null;
+    return raw.slice(1, closing).trim() || null;
+  }
+  return raw.replace(/[ \\t]+#.*$/, "").trim() || null;
+}
+
 /** Model Hermes' own config will use, when a remote provider is configured.
  *
  * Hermes is a BYOK harness and OpenMausBot only ever offered it *local* hosts
@@ -125,8 +141,7 @@ export function hermesConfiguredModel(
   }
   // Only an uncommented, non-empty assignment counts; the shipped file has the
   // key present but commented out, and that must not read as "configured".
-  const keyed = /^[ \t]*OPENROUTER_API_KEY[ \t]*=[ \t]*(\S+)/m.exec(secrets);
-  if (!keyed) return null;
+  if (!nonEmptyDotenvValue(secrets, "OPENROUTER_API_KEY")) return null;
 
   let model = "";
   try {
@@ -170,8 +185,12 @@ async function fetchHermesAcpModels(
     } catch {
       return resolve([]);
     }
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const done = (out: { id: string; label: string; custom: true }[]) => {
-      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
       try {
         child.kill();
       } catch {
@@ -179,20 +198,29 @@ async function fetchHermesAcpModels(
       }
       resolve(out);
     };
-    const timer = setTimeout(() => done([]), 25_000);
-    child.on("error", () => done([]));
+    timer = setTimeout(() => done([]), 25_000);
+    child.once("error", () => done([]));
+    child.once("close", () => done([]));
 
     let buf = "";
     let id = 0;
     const send = (method: string, params: unknown) => {
       id += 1;
-      child.stdin?.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+      try {
+        if (!child.stdin?.writable) {
+          done([]);
+          return 0;
+        }
+        child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`, (error) => {
+          if (error) done([]);
+        });
+      } catch {
+        done([]);
+        return 0;
+      }
       return id;
     };
-    const initId = send("initialize", {
-      protocolVersion: 1,
-      clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
-    });
+    let initId = 0;
     let sessionId = 0;
     child.stdout?.on("data", (chunk) => {
       buf += String(chunk);
@@ -206,8 +234,9 @@ async function fetchHermesAcpModels(
         } catch {
           continue;
         }
-        if (msg?.id === initId && msg.result) {
-          sessionId = send("session/new", { cwd: env.HOME || "/tmp", mcpServers: [] });
+        if (msg?.id === initId) {
+          if (!msg.result) return done([]);
+          sessionId = send("session/new", { cwd: env.HOME || env.USERPROFILE || homedir(), mcpServers: [] });
         } else if (sessionId && msg?.id === sessionId) {
           const list = Array.isArray(msg.result?.models?.availableModels)
             ? msg.result.models.availableModels
@@ -224,6 +253,10 @@ async function fetchHermesAcpModels(
           );
         }
       }
+    });
+    initId = send("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
     });
   });
 }

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -110,7 +110,7 @@ function nonEmptyDotenvValue(text: string, name: string): string | null {
     if (trailing && !trailing.startsWith("#")) return null;
     return raw.slice(1, closing).trim() || null;
   }
-  return raw.replace(/[ \\t]+#.*$/, "").trim() || null;
+  return raw.replace(/[ \t]+#.*$/, "").trim() || null;
 }
 
 /** Model Hermes' own config will use, when a remote provider is configured.
@@ -187,20 +187,33 @@ async function fetchHermesAcpModels(
     }
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let hardKillTimer: ReturnType<typeof setTimeout> | undefined;
     const done = (out: { id: string; label: string; custom: true }[]) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
       try {
-        child.kill();
+        if (child.kill()) {
+          hardKillTimer = setTimeout(() => {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              /* already gone */
+            }
+          }, 1_000);
+          hardKillTimer.unref?.();
+        }
       } catch {
         /* already gone */
       }
       resolve(out);
     };
-    timer = setTimeout(() => done([]), 25_000);
+    timer = setTimeout(() => done([]), 5_000);
     child.once("error", () => done([]));
-    child.once("close", () => done([]));
+    child.once("close", () => {
+      if (hardKillTimer) clearTimeout(hardKillTimer);
+      done([]);
+    });
 
     let buf = "";
     let id = 0;

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -82,9 +82,67 @@ export function hermesAcpModelId(modelId: string | null | undefined): string | n
   return `custom:${inject.host}:${inject.model}`;
 }
 
+/** The id used when Hermes should run on the provider its own config names.
+ *
+ * Deliberately not an inject id: `hermesAcpModelId` returns null for it, so
+ * `configureSession` sends no `session/set_model` and Hermes falls through to
+ * the model in its own `config.yaml`. `spawnArgs` passes no `-m` either (ACP
+ * ignores it), so nothing overrides that choice.
+ */
+export const HERMES_CONFIG_MODEL_ID = "hermes-default";
+
+/** Model Hermes' own config will use, when a remote provider is configured.
+ *
+ * Hermes is a BYOK harness and OpenMausBot only ever offered it *local* hosts
+ * (Ollama, LM Studio, EXO...). A user who has configured Hermes with a hosted
+ * provider — an OpenRouter key in `~/.hermes/.env`, which is how `hermes setup`
+ * stores it — had no selectable model at all: the picker showed "No local
+ * models found" and greyed the agent out, despite Hermes being installed,
+ * authenticated and perfectly able to answer.
+ *
+ * Read-only on purpose. `ensureHermesInjectProvider` writes `config.yaml`, and
+ * doing that from a catalog probe would rewrite the user's real Hermes config
+ * as a side effect of opening a menu.
+ *
+ * Returns null when no hosted key is configured, which leaves the catalog
+ * exactly as it was for local-only setups.
+ */
+export function hermesConfiguredModel(
+  env: Record<string, string | undefined> = process.env,
+): { id: string; label: string } | null {
+  const dir = hermesHome(env);
+  let secrets = "";
+  try {
+    secrets = readFileSync(join(dir, ".env"), "utf8");
+  } catch {
+    return null;
+  }
+  // Only an uncommented, non-empty assignment counts; the shipped file has the
+  // key present but commented out, and that must not read as "configured".
+  const keyed = /^[ \t]*OPENROUTER_API_KEY[ \t]*=[ \t]*(\S+)/m.exec(secrets);
+  if (!keyed) return null;
+
+  let model = "";
+  try {
+    const cfg = readFileSync(join(dir, "config.yaml"), "utf8");
+    const m = /^[ \t]*default[ \t]*:[ \t]*["']?([\w./:+-]+)["']?[ \t]*$/m.exec(cfg);
+    if (m) model = m[1];
+  } catch {
+    /* config unreadable — the id still works, only the label is less specific */
+  }
+  return {
+    id: HERMES_CONFIG_MODEL_ID,
+    label: model ? `${model} (Hermes config)` : "Hermes default (config)",
+  };
+}
+
 async function resolveModels(env: Record<string, string | undefined>): Promise<ModelCatalog> {
   const catalog = await mergeLocalInject(EMPTY, env);
-  return { default: catalog.options[0]?.id ?? "", options: catalog.options };
+  const configured = hermesConfiguredModel(env);
+  // Listed first so it is the default: someone who configured a hosted provider
+  // meant to use it, and a local host may not even be running.
+  const options = configured ? [configured, ...catalog.options] : catalog.options;
+  return { default: options[0]?.id ?? "", options };
 }
 
 async function applySetting(


### PR DESCRIPTION
Carries forward #363 by @gmuniz21 on current main and resolves all outstanding review findings. Hermes users with an OpenRouter setup can select the model from their config plus the provider catalog advertised by Hermes ACP, while local-injected models continue to work.\n\nThe follow-up hardens blank-key parsing, early ACP exits, malformed initialization, duplicate completion, and the unreadable-config test. Validated locally: 54 Hermes/ACP tests pass and the full TypeScript check is clean. Replaces #363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering available remote Hermes models when hosted credentials are configured.
  * Added a selectable configured OpenRouter model for Hermes.
  * Preserved native Hermes model options and added support for locally injected models.
  * Improved model selection across configured, remote, and local options.

* **Bug Fixes**
  * Improved handling of unsupported model names.
  * Hermes now continues safely when model discovery or startup checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->