### PR TITLE
feat(rooms): manage members after creation

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -317,6 +317,72 @@ describe("harness HTTP API", () => {
     expect(body.bots[0].messages.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("adds and removes room members through PATCH", async () => {
+    const [first, second, third] = await Promise.all([
+      api("POST", "/api/bots"),
+      api("POST", "/api/bots"),
+      api("POST", "/api/bots"),
+    ]).then((created) => created.map((response) => response.body.bot));
+    const room = (await api("POST", "/api/groups", { name: "Roster", memberIds: [first.id, second.id] })).body.group;
+    try {
+      const added = await api("PATCH", `/api/groups/${room.id}`, { memberIds: [first.id, second.id, third.id] });
+      expect(added.status).toBe(200);
+      expect(added.body.group.memberIds).toEqual([first.id, second.id, third.id]);
+
+      const removed = await api("PATCH", `/api/groups/${room.id}`, { memberIds: [third.id] });
+      expect(removed.status).toBe(200);
+      expect(removed.body.group.memberIds).toEqual([third.id]);
+
+      const state = (await api("GET", "/api/bots")).body;
+      expect(state.groups.find((group: { id: string }) => group.id === room.id).memberIds).toEqual([third.id]);
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      for (const bot of [first, second, third]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("refuses to empty a room's roster", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const room = (await api("POST", "/api/groups", { name: "Never empty", memberIds: [bot.id] })).body.group;
+    try {
+      for (const memberIds of [[], ["no-such-bot"]]) {
+        const attempted = await api("PATCH", `/api/groups/${room.id}`, { memberIds });
+        expect(attempted.status).toBe(400);
+        expect(attempted.body.error).toMatch(/at least one bot/i);
+      }
+      const state = (await api("GET", "/api/bots")).body;
+      expect(state.groups.find((group: { id: string }) => group.id === room.id).memberIds).toEqual([bot.id]);
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("keeps direct-message channels a fixed pair at the API boundary", async () => {
+    const attempted = await api("PATCH", "/api/groups/test-dm", { memberIds: ["test-bot-a"] });
+    expect(attempted.status).toBe(400);
+    expect(attempted.body.error).toMatch(/direct-message.*members/i);
+    const state = await api("GET", "/api/bots");
+    const dm = state.body.groups.find((group: { id: string }) => group.id === "test-dm");
+    expect(dm.memberIds).toEqual(["test-bot-a", "test-bot-b"]);
+  });
+
+  it("hands the lead to a remaining member when the lead leaves the room", async () => {
+    const [lead, other] = await Promise.all([api("POST", "/api/bots"), api("POST", "/api/bots")]).then((created) =>
+      created.map((response) => response.body.bot),
+    );
+    const room = (await api("POST", "/api/groups", { name: "Handover", memberIds: [lead.id, other.id] })).body.group;
+    try {
+      expect(room.defaultResponder).toEqual({ kind: "member", botId: lead.id });
+      const patched = await api("PATCH", `/api/groups/${room.id}`, { memberIds: [other.id] });
+      expect(patched.status).toBe(200);
+      expect(patched.body.group.defaultResponder).toEqual({ kind: "member", botId: other.id });
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      for (const bot of [lead, other]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("keeps direct-message channels folderless at the API boundary", async () => {
     const attempted = await api("PATCH", "/api/groups/test-dm", { cwd: home });
     expect(attempted.status).toBe(400);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -358,6 +358,23 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("deduplicates repeated room members while preserving their first-seen order", async () => {
+    const [first, second] = await Promise.all([api("POST", "/api/bots"), api("POST", "/api/bots")]).then(
+      (created) => created.map((response) => response.body.bot),
+    );
+    const room = (await api("POST", "/api/groups", { name: "Unique roster", memberIds: [first.id] })).body.group;
+    try {
+      const patched = await api("PATCH", `/api/groups/${room.id}`, {
+        memberIds: [second.id, first.id, second.id, first.id],
+      });
+      expect(patched.status).toBe(200);
+      expect(patched.body.group.memberIds).toEqual([second.id, first.id]);
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      for (const bot of [first, second]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("keeps direct-message channels a fixed pair at the API boundary", async () => {
     const attempted = await api("PATCH", "/api/groups/test-dm", { memberIds: ["test-bot-a"] });
     expect(attempted.status).toBe(400);

--- a/server/index.ts
+++ b/server/index.ts
@@ -3123,7 +3123,11 @@ const server = createServer(async (req, res) => {
       if (Array.isArray(body.memberIds)) {
         // A DM is the pair it was opened for; only real rooms have a roster.
         if (existing.dm) return json(res, 400, { error: "direct-message channels cannot change members" });
-        const ids = body.memberIds.filter((id: unknown): id is string => typeof id === "string" && Boolean(store.bot(id)));
+        const ids = [
+          ...new Set(
+            body.memberIds.filter((id: unknown): id is string => typeof id === "string" && Boolean(store.bot(id))),
+          ),
+        ];
         if (!ids.length) return json(res, 400, { error: "a room needs at least one bot" });
         patch.memberIds = ids;
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -3121,8 +3121,11 @@ const server = createServer(async (req, res) => {
         if (body[key] !== undefined) patch[key] = body[key];
       }
       if (Array.isArray(body.memberIds)) {
+        // A DM is the pair it was opened for; only real rooms have a roster.
+        if (existing.dm) return json(res, 400, { error: "direct-message channels cannot change members" });
         const ids = body.memberIds.filter((id: unknown): id is string => typeof id === "string" && Boolean(store.bot(id)));
-        if (ids.length) patch.memberIds = ids;
+        if (!ids.length) return json(res, 400, { error: "a room needs at least one bot" });
+        patch.memberIds = ids;
       }
       if (body.defaultResponder !== undefined) {
         const value = body.defaultResponder as { kind?: unknown; botId?: unknown } | null;

--- a/src/components/BotPickerList.tsx
+++ b/src/components/BotPickerList.tsx
@@ -1,0 +1,46 @@
+// The checkbox roster shared by "New Room" and "Manage Members": one row per
+// bot, a tick on the ones picked. Both callers own their own selection state —
+// this only draws it, so the two lists can never drift apart visually.
+import { Check } from "lucide-react";
+import type { Bot } from "@/state/store";
+import { BotAvatar } from "./Avatar";
+import { cn } from "@/lib/cn";
+
+export function BotPickerList({
+  bots,
+  picked,
+  onToggle,
+  emptyHint,
+}: {
+  bots: Bot[];
+  picked: Set<string>;
+  onToggle: (id: string) => void;
+  /** shown in place of the list when there is nothing to pick from */
+  emptyHint: string;
+}) {
+  return (
+    <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">
+      {bots.length === 0 && <div className="px-2 py-4 text-center text-[13px] text-ink-secondary">{emptyHint}</div>}
+      {bots.map((b) => (
+        <button
+          key={b.id}
+          onClick={() => onToggle(b.id)}
+          role="checkbox"
+          aria-checked={picked.has(b.id)}
+          className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left hover:bg-raised/50"
+        >
+          <BotAvatar bot={b} state="happy" size={28} />
+          <span className="min-w-0 flex-1 truncate text-[14px] text-ink">{b.name}</span>
+          <span
+            className={cn(
+              "flex size-[18px] shrink-0 items-center justify-center rounded-full border",
+              picked.has(b.id) ? "border-accent bg-accent text-white" : "border-hairline/60",
+            )}
+          >
+            {picked.has(b.id) && <Check size={12} />}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ChevronDown, Folder, FolderOpen, Pin, PinOff, X } from "lucide-react";
+import { ArrowDown, ChevronDown, Folder, FolderOpen, Pin, PinOff, Plus, X } from "lucide-react";
 import {
   api,
   useStore,
@@ -23,6 +23,7 @@ import { ConnectorCard } from "./ConnectorCard";
 import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
+import { ManageMembersPanel } from "./ManageMembersPanel";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { cn } from "@/lib/cn";
 import { useFocusMessage } from "@/lib/focus-message";
@@ -358,6 +359,7 @@ export function GroupView({ group }: { group: Group }) {
   const [bulletinOpen, setBulletinOpen] = useState(false);
   const [bulletinDraft, setBulletinDraft] = useState(group.bulletin);
   const [folderOpen, setFolderOpen] = useState(false);
+  const [membersOpen, setMembersOpen] = useState(false);
 
   const members = useMemo(
     () => group.memberIds.map((id) => state.bots.find((b) => b.id === id)).filter((b): b is Bot => Boolean(b)),
@@ -415,6 +417,7 @@ export function GroupView({ group }: { group: Group }) {
   useEffect(() => setBulletinDraft(group.bulletin), [group.id, group.bulletin]);
   // an open folder editor belongs to the room it was opened in
   useEffect(() => setFolderOpen(false), [group.id]);
+  useEffect(() => setMembersOpen(false), [group.id]);
   // deps track the FULL messages.length, so expanding the window (which only
   // changes windowedMessages) can never re-trigger this bottom scrollTo
   useEffect(() => {
@@ -464,6 +467,23 @@ export function GroupView({ group }: { group: Group }) {
     }
   };
 
+  // Static mauses: one per member, a ring + dot on whoever is working.
+  const memberMauses = members.map((b) => (
+    <span
+      key={b.id}
+      title={`${b.name}${group.busyBotId === b.id ? " — working…" : ""}`}
+      className={cn(
+        "relative inline-flex rounded-full",
+        group.busyBotId === b.id && "ring-2 ring-accent/50 ring-offset-1 ring-offset-app",
+      )}
+    >
+      <MausAvatar color={b.color} state={normalizeState(b.mascotExpression) ?? "happy"} size={24} animated={false} />
+      {group.busyBotId === b.id && (
+        <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full border border-app bg-accent" />
+      )}
+    </span>
+  ));
+
   const isWin = window.ogb?.platform === "win32";
   const drag = isWin ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
   const noDrag = isWin ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
@@ -471,6 +491,7 @@ export function GroupView({ group }: { group: Group }) {
   return (
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
       <GroupCallOverlay group={group} members={members} />
+      {membersOpen && !group.dm && <ManageMembersPanel group={group} onClose={() => setMembersOpen(false)} />}
       {/* Header: static member mauses; a ring + dot marks the working bot. */}
       <div
         className={cn(
@@ -486,26 +507,24 @@ export function GroupView({ group }: { group: Group }) {
           <GroupCallButton group={group} members={members} />
           {!group.dm && <RoomWorkingFolderChip group={group} onToggle={() => setFolderOpen((open) => !open)} />}
           {!group.dm && <DefaultResponderSelect group={group} members={members} />}
-          {members.map((b) => (
-            <span
-              key={b.id}
-              title={`${b.name}${group.busyBotId === b.id ? " — working…" : ""}`}
-              className={cn(
-                "relative inline-flex rounded-full",
-                group.busyBotId === b.id && "ring-2 ring-accent/50 ring-offset-1 ring-offset-app",
-              )}
+          {group.dm ? (
+            memberMauses
+          ) : (
+            // The roster lives where you already look to see who is in the
+            // room; a dashed + says the row is editable without shouting.
+            <button
+              type="button"
+              onClick={() => setMembersOpen(true)}
+              title="Manage members"
+              aria-label={`Manage members — ${members.length} ${members.length === 1 ? "bot" : "bots"} in this room`}
+              className="flex items-center gap-1.5 rounded-full py-0.5 pl-1 pr-1.5 hover:bg-raised/60"
             >
-              <MausAvatar
-                color={b.color}
-                state={normalizeState(b.mascotExpression) ?? "happy"}
-                size={24}
-                animated={false}
-              />
-              {group.busyBotId === b.id && (
-                <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full border border-app bg-accent" />
-              )}
-            </span>
-          ))}
+              {memberMauses}
+              <span className="flex size-[18px] items-center justify-center rounded-full border border-dashed border-hairline/70 text-ink-secondary">
+                <Plus size={11} />
+              </span>
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -360,6 +360,8 @@ export function GroupView({ group }: { group: Group }) {
   const [bulletinDraft, setBulletinDraft] = useState(group.bulletin);
   const [folderOpen, setFolderOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
+  const membersTriggerRef = useRef<HTMLButtonElement>(null);
+  const closeMembers = useCallback(() => setMembersOpen(false), []);
 
   const members = useMemo(
     () => group.memberIds.map((id) => state.bots.find((b) => b.id === id)).filter((b): b is Bot => Boolean(b)),
@@ -491,7 +493,9 @@ export function GroupView({ group }: { group: Group }) {
   return (
     <main className="relative flex h-full min-w-0 flex-1 flex-col bg-app">
       <GroupCallOverlay group={group} members={members} />
-      {membersOpen && !group.dm && <ManageMembersPanel group={group} onClose={() => setMembersOpen(false)} />}
+      {membersOpen && !group.dm && (
+        <ManageMembersPanel group={group} onClose={closeMembers} triggerRef={membersTriggerRef} />
+      )}
       {/* Header: static member mauses; a ring + dot marks the working bot. */}
       <div
         className={cn(
@@ -513,6 +517,7 @@ export function GroupView({ group }: { group: Group }) {
             // The roster lives where you already look to see who is in the
             // room; a dashed + says the row is editable without shouting.
             <button
+              ref={membersTriggerRef}
               type="button"
               onClick={() => setMembersOpen(true)}
               title="Manage members"

--- a/src/components/ManageMembersPanel.tsx
+++ b/src/components/ManageMembersPanel.tsx
@@ -2,15 +2,24 @@
 // from the member mauses in the room header and pre-ticked with who is
 // already in. Membership is the only thing this touches — the transcript
 // keeps every message a departing bot already sent.
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { track } from "@/lib/analytics";
 import { useStore, type Group } from "@/state/store";
 import { BotPickerList } from "./BotPickerList";
 import { nextMemberIds } from "@/lib/room-members";
 
-export function ManageMembersPanel({ group, onClose }: { group: Group; onClose: () => void }) {
+export function ManageMembersPanel({
+  group,
+  onClose,
+  triggerRef,
+}: {
+  group: Group;
+  onClose: () => void;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) {
   const { state, dispatch } = useStore();
   const [picked, setPicked] = useState<Set<string>>(() => new Set(group.memberIds));
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Archived bots stay listed while they are still members — otherwise a
   // room could keep a member you have no way to remove.
@@ -20,10 +29,38 @@ export function ManageMembersPanel({ group, onClose }: { group: Group; onClose: 
   );
 
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = () =>
+      [...dialog.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])')].filter(
+        (element) => !element.hasAttribute("hidden"),
+      );
+    focusable()[0]?.focus();
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const controls = focusable();
+      if (!controls.length) return event.preventDefault();
+      const first = controls[0];
+      const last = controls[controls.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener("keydown", onKey);
+    return () => {
+      dialog.removeEventListener("keydown", onKey);
+      triggerRef.current?.focus();
+    };
+  }, [onClose, triggerRef]);
 
   const toggle = (id: string) =>
     setPicked((prev) => {
@@ -59,6 +96,7 @@ export function ManageMembersPanel({ group, onClose }: { group: Group; onClose: 
       onMouseDown={(e) => e.target === e.currentTarget && onClose()}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label={`Manage members of ${group.name}`}

--- a/src/components/ManageMembersPanel.tsx
+++ b/src/components/ManageMembersPanel.tsx
@@ -19,6 +19,8 @@ export function ManageMembersPanel({
 }) {
   const { state, dispatch } = useStore();
   const [picked, setPicked] = useState<Set<string>>(() => new Set(group.memberIds));
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const openedMemberIds = useRef([...group.memberIds]);
   const dialogRef = useRef<HTMLDivElement>(null);
 
   // Archived bots stay listed while they are still members — otherwise a
@@ -79,6 +81,13 @@ export function ManageMembersPanel({
 
   const save = () => {
     if (!memberIds.length) return;
+    const opened = openedMemberIds.current;
+    const rosterChanged =
+      opened.length !== group.memberIds.length || opened.some((id, index) => id !== group.memberIds[index]);
+    if (rosterChanged) {
+      setSaveError("This room's members changed while the panel was open. Close it and try again.");
+      return;
+    }
     if (changed) {
       dispatch({ type: "patchGroup", groupId: group.id, patch: { memberIds } });
       track("room_members_changed", {
@@ -106,6 +115,11 @@ export function ManageMembersPanel({
         <div className="mb-3 truncate text-[13px] text-ink-secondary">{group.name}</div>
         <BotPickerList bots={bots} picked={picked} onToggle={toggle} emptyHint="Create a bot first — rooms are made of bots." />
         {!memberIds.length && <div className="mt-2 text-[12px] text-ink-secondary">A room needs at least one bot.</div>}
+        {saveError && (
+          <div role="alert" className="mt-2 text-[12px] text-danger">
+            {saveError}
+          </div>
+        )}
         <div className="mt-3 flex gap-2">
           <button
             onClick={onClose}

--- a/src/components/ManageMembersPanel.tsx
+++ b/src/components/ManageMembersPanel.tsx
@@ -1,0 +1,89 @@
+// Edit an existing room's roster: the same picker "New Room" uses, opened
+// from the member mauses in the room header and pre-ticked with who is
+// already in. Membership is the only thing this touches — the transcript
+// keeps every message a departing bot already sent.
+import { useEffect, useMemo, useState } from "react";
+import { track } from "@/lib/analytics";
+import { useStore, type Group } from "@/state/store";
+import { BotPickerList } from "./BotPickerList";
+import { nextMemberIds } from "@/lib/room-members";
+
+export function ManageMembersPanel({ group, onClose }: { group: Group; onClose: () => void }) {
+  const { state, dispatch } = useStore();
+  const [picked, setPicked] = useState<Set<string>>(() => new Set(group.memberIds));
+
+  // Archived bots stay listed while they are still members — otherwise a
+  // room could keep a member you have no way to remove.
+  const bots = useMemo(
+    () => state.bots.filter((b) => !b.hidden || group.memberIds.includes(b.id)),
+    [state.bots, group.memberIds],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const toggle = (id: string) =>
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const memberIds = nextMemberIds(
+    group.memberIds,
+    picked,
+    bots.map((b) => b.id),
+  );
+  const changed = memberIds.length !== group.memberIds.length || memberIds.some((id, i) => id !== group.memberIds[i]);
+
+  const save = () => {
+    if (!memberIds.length) return;
+    if (changed) {
+      dispatch({ type: "patchGroup", groupId: group.id, patch: { memberIds } });
+      track("room_members_changed", {
+        members: memberIds.length,
+        added: memberIds.filter((id) => !group.memberIds.includes(id)).length,
+        removed: group.memberIds.filter((id) => !memberIds.includes(id)).length,
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Manage members of ${group.name}`}
+        className="w-[340px] rounded-2xl border border-hairline/50 bg-card p-4 shadow-2xl"
+      >
+        <div className="mb-1 text-[15px] font-semibold text-ink">Manage Members</div>
+        <div className="mb-3 truncate text-[13px] text-ink-secondary">{group.name}</div>
+        <BotPickerList bots={bots} picked={picked} onToggle={toggle} emptyHint="Create a bot first — rooms are made of bots." />
+        {!memberIds.length && <div className="mt-2 text-[12px] text-ink-secondary">A room needs at least one bot.</div>}
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 rounded-lg bg-raised py-2 text-[14px] font-medium text-ink hover:brightness-110"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={save}
+            disabled={!memberIds.length}
+            className="flex-1 rounded-lg bg-accent py-2 text-[14px] font-medium text-white hover:brightness-110 disabled:opacity-40"
+          >
+            Save{memberIds.length ? ` · ${memberIds.length} ${memberIds.length === 1 ? "bot" : "bots"}` : ""}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,6 +41,7 @@ import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { MIN_QUERY, SearchResults } from "./SearchResults";
 import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
+import { BotPickerList } from "./BotPickerList";
 import {
   loadSidebarDensity,
   saveSidebarDensity,
@@ -401,29 +402,12 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
           placeholder="Room name (optional)"
           className="mb-3 w-full rounded-lg bg-raised/70 px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
         />
-        <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">
-          {bots.length === 0 && (
-            <div className="px-2 py-4 text-center text-[13px] text-ink-secondary">Create a bot first — rooms are made of bots.</div>
-          )}
-          {bots.map((b) => (
-            <button
-              key={b.id}
-              onClick={() => toggle(b.id)}
-              className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left hover:bg-raised/50"
-            >
-              <BotAvatar bot={b} state="happy" size={28} />
-              <span className="min-w-0 flex-1 truncate text-[14px] text-ink">{b.name}</span>
-              <span
-                className={cn(
-                  "flex size-[18px] shrink-0 items-center justify-center rounded-full border",
-                  picked.has(b.id) ? "border-accent bg-accent text-white" : "border-hairline/60",
-                )}
-              >
-                {picked.has(b.id) && <Check size={12} />}
-              </span>
-            </button>
-          ))}
-        </div>
+        <BotPickerList
+          bots={bots}
+          picked={picked}
+          onToggle={toggle}
+          emptyHint="Create a bot first — rooms are made of bots."
+        />
         <button
           onClick={create}
           disabled={!picked.size}

--- a/src/lib/room-members.test.ts
+++ b/src/lib/room-members.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { nextMemberIds } from "./room-members";
+
+const pick = (...ids: string[]) => new Set(ids);
+
+describe("nextMemberIds", () => {
+  it("keeps the existing roster in place so the room's lead does not move", () => {
+    expect(nextMemberIds(["lead", "second"], pick("lead", "second"), ["second", "lead"])).toEqual(["lead", "second"]);
+  });
+
+  it("appends newly ticked bots after the members already in the room", () => {
+    expect(nextMemberIds(["lead"], pick("lead", "scout", "archivist"), ["archivist", "lead", "scout"])).toEqual([
+      "lead",
+      "archivist",
+      "scout",
+    ]);
+  });
+
+  it("drops members that were unticked", () => {
+    expect(nextMemberIds(["lead", "second"], pick("second"), ["lead", "second"])).toEqual(["second"]);
+  });
+
+  it("ignores ticked ids that are not offered in the list", () => {
+    expect(nextMemberIds(["lead"], pick("lead", "ghost"), ["lead"])).toEqual(["lead"]);
+  });
+
+  it("returns nothing when every member is unticked", () => {
+    expect(nextMemberIds(["lead"], pick(), ["lead"])).toEqual([]);
+  });
+});

--- a/src/lib/room-members.ts
+++ b/src/lib/room-members.ts
@@ -1,0 +1,6 @@
+// Turning a set of ticked bots back into a room's ordered roster. Existing
+// members keep their order, so the room's lead does not move when someone new
+// joins; additions land at the end, in the order the picker listed them.
+export function nextMemberIds(current: string[], picked: Set<string>, order: string[]): string[] {
+  return [...current.filter((id) => picked.has(id)), ...order.filter((id) => picked.has(id) && !current.includes(id))];
+}


### PR DESCRIPTION
Carries forward #362 by @aivsomkar on current main and addresses both review findings. Existing rooms gain a reusable member picker without losing their transcript; the API rejects empty/DM edits and now deduplicates repeated IDs.\n\nThe replacement also moves focus into the modal, traps keyboard navigation, restores focus to the roster trigger, and adds duplicate-roster coverage. Validated locally: 83 room/server tests pass and the full TypeScript check is clean. Replaces #362.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added member management for group rooms, including selecting, adding, and removing bots.
  * Added a reusable bot picker with avatars, selection states, and empty-list messaging.
  * Preserved member ordering and displayed indicators for active bots.
  * Added accessible modal behavior, including keyboard dismissal and focus management.

* **Bug Fixes**
  * Prevented empty room rosters and duplicate members.
  * Protected direct-message membership from changes.
  * Ensured the default responder transfers when the lead leaves.

* **Tests**
  * Added coverage for room membership updates and roster selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->