### PR TITLE
fix(drivers): flush assistant text before tool events

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -234,10 +234,10 @@ describe("ACP turns (fake CLI)", () => {
       "turn.started",
       "session.started",
       "content.delta",
+      "item.completed", // assistant_text before the tool, not summed on settle
       "item.started", // tool tc-1
       "item.completed", // tool tc-1 done
       "thread.token-usage.updated",
-      "item.completed", // assistant_text (summed) on settle
       "turn.completed",
     ]);
     expect(recorder.events.every((e) => e.turnId === turnId && e.provider === "grokAgent")).toBe(true);
@@ -248,6 +248,34 @@ describe("ACP turns (fake CLI)", () => {
     const done = recorder.events.at(-1)!;
     expect(done).toMatchObject({ type: "turn.completed", ok: true });
     expect(instance.adapter.hasSession("t-happy")).toBe(false);
+  });
+
+  it("emits each assistant text block before the tool that follows it", async () => {
+    await create(GrokAgentDriver, "interleave");
+    await instance.adapter.sendTurn({ threadId: "t-interleave", text: "go", model: "grok-4.5" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const types = recorder.events.map((e) => e.type);
+    expect(types).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "item.completed", // before one
+      "item.started", // tc-1
+      "item.completed", // tc-1
+      "content.delta",
+      "item.completed", // before two
+      "item.started", // tc-2
+      "item.completed", // tc-2
+      "content.delta",
+      "thread.token-usage.updated",
+      "item.completed", // after — no following tool, so settle flushes
+      "turn.completed",
+    ]);
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType?: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["before one", "before two", "after"]);
   });
 
   it("reads token usage from the root of the prompt result", async () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -336,6 +336,13 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
 
         const stop = () => killCliTree(child);
 
+        const flushAssistantText = () => {
+          const text = state.text;
+          if (!text.trim()) return;
+          state.text = "";
+          emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+        };
+
         const settle = (ok: boolean, stopReason: string | null) => {
           if (state.settled) return;
           state.settled = true;
@@ -347,9 +354,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           }
           rpcPending.clear();
           active.delete(threadId);
-          if (state.text.trim()) {
-            emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: state.text });
-          }
+          flushAssistantText();
           emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null });
           stop(); // the agent process does not exit on its own
         };
@@ -361,6 +366,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             return send({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "method not found" } });
           }
           const params = msg.params ?? {};
+          flushAssistantText();
           const options: Array<{ optionId?: string; kind?: string }> = Array.isArray(params.options) ? params.options : [];
           const optionFor = (want: "allow" | "reject") =>
             options.find((o) => String(o.kind ?? "").startsWith(want) && typeof o.optionId === "string")?.optionId ?? null;
@@ -447,6 +453,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
               break;
             }
             case "tool_call": {
+              flushAssistantText();
               emit({
                 ...base(threadId, turnId),
                 type: "item.started",

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -336,6 +336,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
 
         const stop = () => killCliTree(child);
 
+        /** Emit buffered assistant text as its own item, then clear it. */
         const flushAssistantText = () => {
           const text = state.text;
           if (!text.trim()) return;

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -339,8 +339,8 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         /** Emit buffered assistant text as its own item, then clear it. */
         const flushAssistantText = () => {
           const text = state.text;
-          if (!text.trim()) return;
           state.text = "";
+          if (!text.trim()) return;
           emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
         };
 

--- a/server/drivers/boxagent.test.ts
+++ b/server/drivers/boxagent.test.ts
@@ -11,12 +11,14 @@ import { BoxAgentDriver } from "./boxagent.ts";
 const BOX = "box-1";
 const PROMPT = "p1";
 
+/** JSON Response helper for the in-process Box HTTP fake. */
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
 type Poll = { events: unknown[]; status?: { promptRun: { status: string; result?: string } } };
 
+/** Stub fetch so each GET /events + /prompts pair advances one poll in `script`. */
 function installFakeBox(script: Poll[]) {
   let i = 0;
   const previous = globalThis.fetch;

--- a/server/drivers/boxagent.test.ts
+++ b/server/drivers/boxagent.test.ts
@@ -176,4 +176,23 @@ describe("BoxAgentDriver turns (fake API)", () => {
       .map((e) => (e as { text: string }).text);
     expect(texts).toEqual(["before", "done"]);
   });
+
+  it("flushes pending assistant text when the turn is interrupted", async () => {
+    restoreFetch = installFakeBox([
+      {
+        events: [{ id: "e1", type: "response", text: "half" }],
+        status: { promptRun: { status: "running" } },
+      },
+    ]);
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-cancel", text: "go", integrations: { computer } });
+    await recorder.until((e) => e.type === "content.delta");
+    await instance.adapter.interruptTurn("t-cancel");
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: false, stopReason: "interrupted" });
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["half"]);
+  });
 });

--- a/server/drivers/boxagent.test.ts
+++ b/server/drivers/boxagent.test.ts
@@ -192,6 +192,10 @@ describe("BoxAgentDriver turns (fake API)", () => {
     await instance.adapter.interruptTurn("t-cancel");
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: false, stopReason: "interrupted" });
+    const assistantIndex = recorder.events.findIndex(
+      (event) => event.type === "item.completed" && (event as { itemType: string }).itemType === "assistant_text",
+    );
+    expect(assistantIndex).toBeLessThan(recorder.events.indexOf(done));
     const texts = recorder.events
       .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
       .map((e) => (e as { text: string }).text);

--- a/server/drivers/boxagent.test.ts
+++ b/server/drivers/boxagent.test.ts
@@ -1,0 +1,179 @@
+// Box agent contract tests against a scripted fake of ascii.dev's box HTTP
+// API. The driver polls events + prompt status; the fake advances one poll
+// per GET so we can assert message → tool → message order without sleeping.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ensureDirs } from "../config.ts";
+import type { ProviderInstance } from "../contracts.ts";
+import { recordEvents, type EventRecorder } from "../testing/events.ts";
+import { BoxAgentDriver } from "./boxagent.ts";
+
+const BOX = "box-1";
+const PROMPT = "p1";
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+type Poll = { events: unknown[]; status?: { promptRun: { status: string; result?: string } } };
+
+function installFakeBox(script: Poll[]) {
+  let i = 0;
+  const previous = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = String(init?.method ?? "GET").toUpperCase();
+    if (url.endsWith("/me")) return json({ ok: true });
+    if (method === "POST" && /\/boxes\/[^/]+\/prompt$/.test(url)) return json({ promptRun: { id: PROMPT } });
+    if (method === "POST" && url.includes("/interrupt")) return json({ ok: true });
+    if (url.includes("/events")) {
+      const step = script[Math.min(i, script.length - 1)]!;
+      i += 1;
+      return json({ events: step.events });
+    }
+    if (url.includes(`/prompts/${PROMPT}`)) {
+      const step = script[Math.min(Math.max(i - 1, 0), script.length - 1)]!;
+      return json(step.status ?? { promptRun: { status: "running" } });
+    }
+    return json({ error: `unexpected ${method} ${url}` }, 404);
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = previous;
+  };
+}
+
+const computer = { boxId: BOX, token: "box-test-token" };
+
+describe("BoxAgentDriver turns (fake API)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+  let restoreFetch: (() => void) | undefined;
+
+  const create = async () => {
+    instance = await BoxAgentDriver.create({
+      instanceId: "box-test",
+      displayName: "Box Test",
+      environment: { BOX_TOKEN: "box-test-token" },
+      enabled: true,
+      config: { pollMs: 0 },
+    });
+    recorder = recordEvents(instance.adapter);
+  };
+
+  beforeEach(() => {
+    ensureDirs();
+  });
+
+  afterEach(async () => {
+    recorder?.stop();
+    await instance?.dispose();
+    restoreFetch?.();
+    restoreFetch = undefined;
+  });
+
+  it("flushes prefix-grown text before a tool, then the tail at settle", async () => {
+    restoreFetch = installFakeBox([
+      {
+        events: [{ id: "e1", type: "response", text: "hel" }],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "hel" },
+          { id: "e2", type: "tool", title: "run" },
+        ],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "hel" },
+          { id: "e2", type: "tool", title: "run" },
+          { id: "e3", type: "response", text: "hello there" },
+        ],
+        status: { promptRun: { status: "finished", result: "hello there" } },
+      },
+    ]);
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-prefix", text: "go", integrations: { computer } });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["hel", "lo there"]);
+  });
+
+  it("keeps a non-prefix response after a flush instead of slicing it away", async () => {
+    restoreFetch = installFakeBox([
+      {
+        events: [{ id: "e1", type: "response", text: "before" }],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "before" },
+          { id: "e2", type: "tool", title: "run" },
+        ],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "before" },
+          { id: "e2", type: "tool", title: "run" },
+          { id: "e3", type: "response", text: "after" },
+        ],
+        status: { promptRun: { status: "finished", result: "after" } },
+      },
+    ]);
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-nonprefix", text: "go", integrations: { computer } });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const types = recorder.events.map((e) => e.type);
+    expect(types).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "item.completed", // before
+      "item.started",
+      "content.delta",
+      "item.completed", // after — must not be sliced to ""
+      "turn.completed",
+    ]);
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["before", "after"]);
+  });
+
+  it("ingests a non-prefix prompt result when events already set lastText", async () => {
+    restoreFetch = installFakeBox([
+      {
+        events: [{ id: "e1", type: "response", text: "before" }],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "before" },
+          { id: "e2", type: "tool", title: "run" },
+        ],
+        status: { promptRun: { status: "running" } },
+      },
+      {
+        events: [
+          { id: "e1", type: "response", text: "before" },
+          { id: "e2", type: "tool", title: "run" },
+        ],
+        status: { promptRun: { status: "finished", result: "done" } },
+      },
+    ]);
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-status", text: "go", integrations: { computer } });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["before", "done"]);
+  });
+});

--- a/server/drivers/boxagent.ts
+++ b/server/drivers/boxagent.ts
@@ -130,12 +130,14 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
         const startedAt = Date.now();
         let lastText = "";
         let pendingText = "";
+        /** Emit unflushed deltas as assistant_text and reset pendingText. */
         const flushAssistantText = () => {
           const text = pendingText;
           pendingText = "";
           if (!text.trim()) return;
           emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
         };
+        /** Stream a full-text snapshot as a delta and accumulate it for flush. */
         const ingest = (text: string) => {
           const delta = text.startsWith(lastText) ? text.slice(lastText.length) : text;
           lastText = text;

--- a/server/drivers/boxagent.ts
+++ b/server/drivers/boxagent.ts
@@ -214,9 +214,11 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
             }
           }
           // cancelled
+          flushAssistantText();
           active.delete(threadId);
           emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "interrupted", cost: null });
         } catch (e) {
+          flushAssistantText();
           active.delete(threadId);
           emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
           emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "error", cost: null });

--- a/server/drivers/boxagent.ts
+++ b/server/drivers/boxagent.ts
@@ -129,6 +129,20 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
         const seen = new Set<string>();
         const startedAt = Date.now();
         let lastText = "";
+        let pendingText = "";
+        const flushAssistantText = () => {
+          const text = pendingText;
+          pendingText = "";
+          if (!text.trim()) return;
+          emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+        };
+        const ingest = (text: string) => {
+          const delta = text.startsWith(lastText) ? text.slice(lastText.length) : text;
+          lastText = text;
+          if (!delta) return;
+          pendingText += delta;
+          emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
+        };
         try {
           for (;;) {
             if (cancelled) break;
@@ -148,12 +162,9 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
               // stream anyway.
               const text = ev.text ?? ev.message ?? ev.data?.text ?? ev.data?.content ?? null;
               if (/assistant|message|output|response/i.test(kind) && typeof text === "string" && text.trim()) {
-                const delta = text.startsWith(lastText) ? text.slice(lastText.length) : text;
-                lastText = text;
-                if (delta) {
-                  emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
-                }
+                ingest(text);
               } else if (/tool|command|exec|browse/i.test(kind)) {
+                flushAssistantText();
                 emit({
                   ...base(threadId, turnId),
                   type: "item.started",
@@ -167,9 +178,7 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
               // events themselves instead of hanging to the 30-min ceiling
               if (!promptId && /complete|finish|done|success|fail|error/i.test(kind)) {
                 active.delete(threadId);
-                if (lastText) {
-                  emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: lastText });
-                }
+                flushAssistantText();
                 const failed = /fail|error/i.test(kind);
                 emit({ ...base(threadId, turnId), type: "turn.completed", ok: !failed, stopReason: failed ? kind : null, cost: null });
                 return;
@@ -184,30 +193,17 @@ export const BoxAgentDriver: ProviderDriver<BoxAgentConfig> = {
               const state = String(run?.status ?? "");
               if (/completed|succeeded|done|finished/i.test(state)) {
                 const result = run?.result ?? run?.output ?? lastText;
-                // stream only the growth past what events already sent —
-                // the settled message below carries the full text regardless
-                if (typeof result === "string" && result.trim() && result !== lastText && result.startsWith(lastText)) {
-                  emit({
-                    ...base(threadId, turnId),
-                    type: "content.delta",
-                    streamKind: "assistant_text",
-                    delta: result.slice(lastText.length),
-                  });
+                if (typeof result === "string" && result.trim() && result !== lastText) {
+                  ingest(result);
                 }
-                emit({
-                  ...base(threadId, turnId),
-                  type: "item.completed",
-                  itemType: "assistant_text",
-                  text: typeof result === "string" && result.trim() ? result : lastText || "(finished)",
-                });
+                if (!pendingText.trim() && !lastText.trim()) pendingText = "(finished)";
+                flushAssistantText();
                 active.delete(threadId);
                 emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
                 return;
               }
               if (/failed|error|cancelled|interrupted/i.test(state)) {
-                if (lastText) {
-                  emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: lastText });
-                }
+                flushAssistantText();
                 active.delete(threadId);
                 emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: state, cost: null });
                 return;

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -251,6 +251,33 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-tool")).toBe(false);
   });
 
+  it("emits each assistant text block before the tool that follows it", async () => {
+    await create("interleave");
+    await instance.adapter.sendTurn({ threadId: "t-interleave", text: "go", model: "ollama-cloud/glm-5.2" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const types = recorder.events.map((e) => e.type);
+    expect(types).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "item.completed", // before one
+      "item.started",
+      "item.completed", // tool
+      "content.delta",
+      "item.completed", // before two
+      "item.started",
+      "item.completed", // tool
+      "content.delta",
+      "item.completed", // after
+      "turn.completed",
+    ]);
+    const texts = recorder.events
+      .filter((e) => e.type === "item.completed" && (e as { itemType: string }).itemType === "assistant_text")
+      .map((e) => (e as { text: string }).text);
+    expect(texts).toEqual(["before one", "before two", "after"]);
+  });
+
   it("brokers a permission ask through request.opened → respondToRequest", async () => {
     await create("permission");
     await instance.adapter.sendTurn({ threadId: "t-perm", text: "go" });

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -286,9 +286,9 @@ export const PiDriver: ProviderDriver<PiConfig> = {
 
       /** Emit buffered assistant text as its own item, then clear it. */
       const flushAssistantText = () => {
-        if (!assistantText.trim()) return;
         const text = assistantText;
         assistantText = "";
+        if (!text.trim()) return;
         emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
       };
 

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -284,6 +284,7 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         child.stdin.write(JSON.stringify(obj) + "\n");
       };
 
+      /** Emit buffered assistant text as its own item, then clear it. */
       const flushAssistantText = () => {
         if (!assistantText.trim()) return;
         const text = assistantText;

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -284,12 +284,17 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         child.stdin.write(JSON.stringify(obj) + "\n");
       };
 
+      const flushAssistantText = () => {
+        if (!assistantText.trim()) return;
+        const text = assistantText;
+        assistantText = "";
+        emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+      };
+
       const settle = (ok: boolean, stopReason?: string | null, usage?: { input?: number; output?: number }) => {
         if (settled) return;
         settled = true;
-        if (assistantText.trim()) {
-          emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: assistantText });
-        }
+        flushAssistantText();
         emit({
           ...base(threadId, turnId),
           type: "turn.completed",
@@ -350,6 +355,7 @@ export const PiDriver: ProviderDriver<PiConfig> = {
             return;
           }
           case "tool_execution_start": {
+            flushAssistantText();
             emit({
               ...base(threadId, turnId),
               type: "item.started",
@@ -373,6 +379,7 @@ export const PiDriver: ProviderDriver<PiConfig> = {
             // pi floods setWidget/setStatus for TUI bookkeeping; only
             // select/confirm/input are questions that wait for an answer.
             if (evt.method === "select" || evt.method === "confirm" || evt.method === "input") {
+              flushAssistantText();
               const reqId = evt.id ?? newId();
               const isQuestion = evt.method === "input";
               emit({

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -203,6 +203,7 @@ function playTurn() {
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "completed" } } });
 }
 
+/** Scripted text → tool → text → tool → text turn for order-contract tests. */
 function playInterleaveTurn() {
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "before one" } } } });
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: "run" } } });

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -6,6 +6,7 @@
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
 //   FAKE_ACP_MODE   happy (default) | empty-reply | exit-early | fail-after-text | hang | no-auth | auth-required | permission
+//                   | interleave (message → tool → message → tool → message)
 //                   | no-session-config (reject session/set_mode + set_model
 //                     with -32601, i.e. an agent predating those methods)
 //                   | ask-peer (spawn the injected "agents" MCP server from
@@ -200,6 +201,16 @@ function playTurn() {
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "hello from fake acp" } } } });
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: "run" } } });
   out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "completed" } } });
+}
+
+function playInterleaveTurn() {
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "before one" } } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: "run" } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "completed" } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "before two" } } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call", toolCallId: "tc-2", title: "run" } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call_update", toolCallId: "tc-2", status: "completed" } } });
+  out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "after" } } } });
 }
 
 let buf = "";
@@ -419,7 +430,8 @@ function handle(msg: any) {
           });
         return;
       }
-      if (mode !== "empty-reply") playTurn();
+      if (mode === "interleave") playInterleaveTurn();
+      else if (mode !== "empty-reply") playTurn();
       if (mode === "permission") {
         // ask the client to approve a tool, then complete once answered
         pendingPermissionId = 9001;

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -91,7 +91,7 @@ const streamPermissionTurn = () => {
   // wait for the answer before finishing
 };
 
-// message → tool → message → tool → message — the order the driver must keep
+/** Scripted text → tool → text → tool → text turn for order-contract tests. */
 const streamInterleaveTurn = () => {
   send({ type: "agent_start" });
   send({ type: "turn_start" });

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -5,7 +5,7 @@
 // / set_model, and streams a scripted turn in response to `prompt`. Failure
 // modes mirror how the real CLI misbehaves:
 //
-//   FAKE_PI_MODE   happy (default) | tooluse | permission | no-models | exit-early
+//   FAKE_PI_MODE   happy (default) | tooluse | permission | interleave | no-models | exit-early
 //   FAKE_PI_MODELS comma-separated provider/model pairs (default "ollama-cloud/glm-5.2,openai/gpt-4o")
 //   FAKE_PI_DUMP   path to append {argv, env} JSON, so a test can assert argv shape
 //                  and env hygiene (no leaked secrets into the pi child).
@@ -91,6 +91,21 @@ const streamPermissionTurn = () => {
   // wait for the answer before finishing
 };
 
+// message → tool → message → tool → message — the order the driver must keep
+const streamInterleaveTurn = () => {
+  send({ type: "agent_start" });
+  send({ type: "turn_start" });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "before one" } });
+  send({ type: "tool_execution_start", toolCallId: "call_1", toolName: "bash", args: { command: "echo one" } });
+  send({ type: "tool_execution_end", toolCallId: "call_1", toolName: "bash", isError: false });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "before two" } });
+  send({ type: "tool_execution_start", toolCallId: "call_2", toolName: "bash", args: { command: "echo two" } });
+  send({ type: "tool_execution_end", toolCallId: "call_2", toolName: "bash", isError: false });
+  send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "after" } });
+  send({ type: "turn_end", message: { stopReason: "end_turn", usage: { input: 12, output: 3 } }, usage: { input: 12, output: 3 } });
+  send({ type: "agent_end" });
+};
+
 const finishPermissionTurn = () => {
   send({ type: "tool_execution_start", toolCallId: "call_1", toolName: "bash", args: { command: "echo hi" } });
   send({ type: "tool_execution_end", toolCallId: "call_1", toolName: "bash", isError: false });
@@ -147,6 +162,7 @@ function handle(cmd: any) {
       send({ type: "response", command: "prompt", success: true });
       if (mode === "tooluse") streamToolTurn();
       else if (mode === "permission") streamPermissionTurn();
+      else if (mode === "interleave") streamInterleaveTurn();
       else streamTurn();
       return;
     case "extension_ui_response":


### PR DESCRIPTION
Carries forward #354 by @donggyun112 on current main and adds the requested terminal-order assertion. ACP, Pi, and BoxAgent now close each accumulated assistant-text segment before emitting a tool, approval, question, interruption, failure, or final turn event, preserving transcript order.\n\nValidated locally: 66 focused driver tests pass and the full TypeScript check is clean. Replaces #354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved assistant text in the correct order when interleaved with tool activity.
  * Ensured pending assistant responses are completed before tool calls, permission requests, interruptions, cancellations, errors, and turn completion.
  * Improved handling of final prompt results and completed runs when no assistant text is received.

* **Tests**
  * Added coverage for interleaved assistant messages, tool events, polling, interruptions, and event ordering across supported agent integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->