### PR TITLE
fix(rooms): explain when archived members cannot respond

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -597,6 +597,10 @@ describe("harness HTTP API", () => {
         chiefOfStaff: false,
       });
       expect(archivedBot.status).toBe(200);
+      await api("PATCH", `/api/bots/${active.id}`, {
+        name: "Atlas",
+        modelSelection: { instanceId: "ghost" },
+      });
       await api("PATCH", `/api/groups/${room.id}`, { defaultResponder: { kind: "mentions" } });
 
       expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "@Quill take this" })).status).toBe(202);
@@ -609,6 +613,34 @@ describe("harness HTTP API", () => {
           ok: false,
         },
       });
+
+      const archivedError = "Quill is archived and can't respond — restore it or mention an active room member.";
+      const beforeMixedMention = messages.filter((message: { tool?: { name?: string } }) =>
+        message.tool?.name === archivedError
+      ).length;
+      await api("POST", `/api/groups/${room.id}/messages`, { text: "@Quill and @Atlas take this" });
+      await expect.poll(async () => {
+        state = (await api("GET", "/api/bots?messages=20")).body;
+        messages = state.groups.find((group: { id: string }) => group.id === room.id).messages;
+        return {
+          archivedErrors: messages.filter((message: { tool?: { name?: string } }) =>
+            message.tool?.name === archivedError
+          ).length,
+          activeDispatched: messages.some((message: { tool?: { name?: string } }) =>
+            message.tool?.name === "error: Atlas's model is unavailable"
+          ),
+        };
+      }).toEqual({ archivedErrors: beforeMixedMention + 1, activeDispatched: true });
+
+      await api("PATCH", `/api/groups/${room.id}`, {
+        defaultResponder: { kind: "member", botId: archived.id },
+      });
+      await api("POST", `/api/groups/${room.id}/messages`, { text: "use the default responder" });
+      state = (await api("GET", "/api/bots?messages=20")).body;
+      messages = state.groups.find((group: { id: string }) => group.id === room.id).messages;
+      expect(messages.at(-1)?.tool).toEqual({ name: archivedError, ok: false });
+
+      await api("PATCH", `/api/groups/${room.id}`, { defaultResponder: { kind: "mentions" } });
 
       const beforeUnmentioned = messages.length;
       await api("POST", `/api/groups/${room.id}/messages`, { text: "no mention" });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -582,6 +582,59 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
+  it("explains when archived room members cannot respond", async () => {
+    const archived = (await api("POST", "/api/bots")).body.bot;
+    const active = (await api("POST", "/api/bots")).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Archived member feedback",
+      memberIds: [archived.id, active.id],
+    })).body.group;
+
+    try {
+      const archivedBot = await api("PATCH", `/api/bots/${archived.id}`, {
+        name: "Quill",
+        hidden: true,
+        chiefOfStaff: false,
+      });
+      expect(archivedBot.status).toBe(200);
+      await api("PATCH", `/api/groups/${room.id}`, { defaultResponder: { kind: "mentions" } });
+
+      expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "@Quill take this" })).status).toBe(202);
+      let state = (await api("GET", "/api/bots?messages=20")).body;
+      let messages = state.groups.find((group: { id: string }) => group.id === room.id).messages;
+      expect(messages.at(-1)).toMatchObject({
+        kind: "activity",
+        tool: {
+          name: "Quill is archived and can't respond — restore it or mention an active room member.",
+          ok: false,
+        },
+      });
+
+      const beforeUnmentioned = messages.length;
+      await api("POST", `/api/groups/${room.id}/messages`, { text: "no mention" });
+      state = (await api("GET", "/api/bots?messages=20")).body;
+      messages = state.groups.find((group: { id: string }) => group.id === room.id).messages;
+      expect(messages).toHaveLength(beforeUnmentioned + 1);
+      expect(messages.at(-1)).toMatchObject({ kind: "text", role: "user", text: "no mention" });
+
+      await api("PATCH", `/api/bots/${active.id}`, { hidden: true });
+      await api("POST", `/api/groups/${room.id}/messages`, { text: "hello everyone" });
+      state = (await api("GET", "/api/bots?messages=20")).body;
+      messages = state.groups.find((group: { id: string }) => group.id === room.id).messages;
+      expect(messages.at(-1)).toMatchObject({
+        kind: "activity",
+        tool: {
+          name: "No active room members can respond — restore an archived bot or add an active member.",
+          ok: false,
+        },
+      });
+    } finally {
+      await api("DELETE", `/api/groups/${room.id}`);
+      await api("DELETE", `/api/bots/${archived.id}`);
+      await api("DELETE", `/api/bots/${active.id}`);
+    }
+  });
+
   it("saves, serves, and guards image attachments", async () => {
     // a real 1x1 PNG so the bytes round-trip intact
     const png = Buffer.from(

--- a/server/index.ts
+++ b/server/index.ts
@@ -2002,7 +2002,28 @@ function startGroupTurn(groupId: string, text: string) {
     const last = members.find((b) => b.id === lastSpeakerId) ?? members[0];
     responders = last ? [last] : [];
   }
-  if (!responders.length) return;
+  if (!responders.length) {
+    const archived = members.filter((member) => member.hidden);
+    const mentionedArchived = mentionedBots(text, archived.map(({ name }) => ({ name })))[0];
+    const defaultArchivedId = group.defaultResponder.kind === "member" ? group.defaultResponder.botId : undefined;
+    const defaultArchived = archived.find((member) => member.id === defaultArchivedId);
+    let unavailableMessage: string | undefined;
+    if (mentionedArchived) {
+      unavailableMessage = `${mentionedArchived.name} is archived and can't respond — restore it or mention an active room member.`;
+    } else if (!members.some((member) => !member.hidden)) {
+      unavailableMessage = "No active room members can respond — restore an archived bot or add an active member.";
+    } else if (defaultArchived) {
+      unavailableMessage = `${defaultArchived.name} is archived and can't respond — restore it or mention an active room member.`;
+    }
+    if (unavailableMessage) {
+      store.appendMessage(group.threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name: unavailableMessage, ok: false },
+      });
+    }
+    return;
+  }
 
   const prev = groupQueues.get(groupId) ?? Promise.resolve();
   const next = prev.then(async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1993,26 +1993,35 @@ function startGroupTurn(groupId: string, text: string) {
   const members = group.memberIds
     .map((id) => store.bot(id))
     .filter((b): b is NonNullable<typeof b> => Boolean(b));
+  const availableMembers = members.filter((member) => !member.hidden);
+  const archived = members.filter((member) => member.hidden);
+  const mentionedArchived = mentionedBots(text, archived.map(({ name }) => ({ name })))[0];
+  if (mentionedArchived) {
+    store.appendMessage(group.threadId, {
+      role: "bot",
+      kind: "activity",
+      tool: {
+        name: `${mentionedArchived.name} is archived and can't respond — restore it or mention an active room member.`,
+        ok: false,
+      },
+    });
+  }
   let responders = roomResponders(text, members, group.defaultResponder);
   // bot⇄bot channels: chipping in without a tag addresses the last speaker
   if (!responders.length && group.dm) {
     const lastSpeakerId = [...store.messagesFor(group.threadId)]
       .reverse()
       .find((msg) => msg.kind === "text" && msg.from)?.from?.botId;
-    const last = members.find((b) => b.id === lastSpeakerId) ?? members[0];
+    const last = availableMembers.find((b) => b.id === lastSpeakerId) ?? availableMembers[0];
     responders = last ? [last] : [];
   }
   if (!responders.length) {
-    const archived = members.filter((member) => member.hidden);
-    const mentionedArchived = mentionedBots(text, archived.map(({ name }) => ({ name })))[0];
     const defaultArchivedId = group.defaultResponder.kind === "member" ? group.defaultResponder.botId : undefined;
     const defaultArchived = archived.find((member) => member.id === defaultArchivedId);
     let unavailableMessage: string | undefined;
-    if (mentionedArchived) {
-      unavailableMessage = `${mentionedArchived.name} is archived and can't respond — restore it or mention an active room member.`;
-    } else if (!members.some((member) => !member.hidden)) {
+    if (!mentionedArchived && !availableMembers.length) {
       unavailableMessage = "No active room members can respond — restore an archived bot or add an active member.";
-    } else if (defaultArchived) {
+    } else if (!mentionedArchived && defaultArchived) {
       unavailableMessage = `${defaultArchived.name} is archived and can't respond — restore it or mention an active room member.`;
     }
     if (unavailableMessage) {


### PR DESCRIPTION
Replaces #341 on current `main` and preserves the contributor’s implementation while resolving conflicts with the new room-member management API.

It now:
- reports archived mentions even when active members also respond
- explains archived default responders and rooms with no active members
- prevents DM fallback from selecting archived members
- includes the missing archived-default and mixed-mention coverage

Verified with `pnpm exec vitest run server/index.test.ts` (79 tests) and `pnpm typecheck`.

Authored from the original work by @xuyi-lab.