### PR TITLE
feat(drivers): add a safe OpenAI-compatible provider

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -106,6 +106,7 @@ describe("default fleet", () => {
     expect(map.qwen?.driver).toBe("qwenAgent");
     expect(map.hermes?.driver).toBe("hermesAgent");
     expect(map.cursor?.driver).toBe("cursorAgent");
+    expect(map.openaiCompat?.driver).toBe("openai-compat");
   });
 
   it("does not expand a one-off shadow fleet", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -399,6 +399,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   // is not expanded, matching the claude/grok/codex product-fleet probe.
   const PRODUCT_FLEET_ADDITIONS = {
     cursor: { driver: "cursorAgent" },
+    openaiCompat: { driver: "openai-compat" },
     ...CUSTOM_ONLY,
   } as const;
   const configured = cfg.instances && Object.keys(cfg.instances).length ? cfg.instances : null;

--- a/server/config.ts
+++ b/server/config.ts
@@ -71,6 +71,7 @@ const instanceConfigSchema = z.object({
 const instanceConfigMapSchema = z.record(z.string(), instanceConfigSchema);
 const appConfigSchema = z.object({
   xai: z.object({ key: optionalText, url: optionalText }).optional(),
+  openaiCompat: z.object({ key: optionalText, url: optionalText }).optional(),
   /** Project key used for Sessions, catalog and agent tools. userId/sessionId
    * are non-secret local identifiers used to reuse one Composio Session. */
   composio: z.object({ apiKey: optionalText, userId: optionalText, sessionId: optionalText }).optional(),
@@ -93,6 +94,7 @@ const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
+  openaiCompat?: { key?: string; url?: string };
   composio?: { apiKey?: string; userId?: string; sessionId?: string };
   box?: { token?: string };
   /** A named host from the user's SSH config. Authentication stays with SSH. */
@@ -344,6 +346,10 @@ interface InstanceCliUpdate {
 function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string> {
   const environment = new Map<string, string>();
   if (driver === "grok" && cfg.xai?.key) environment.set("XAI_API_KEY", cfg.xai.key);
+  if (driver === "openai-compat" && cfg.openaiCompat?.key)
+    environment.set("OPENAI_COMPAT_API_KEY", cfg.openaiCompat.key);
+  if (driver === "openai-compat" && cfg.openaiCompat?.url)
+    environment.set("OPENAI_COMPAT_URL", cfg.openaiCompat.url);
   if (driver === "boxAgent" && cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
   if (driver === "opencodeGo" && cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
   return environment;
@@ -378,6 +384,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     antigravity: { driver: "antigravityAgent" },
     opencodeGo: { driver: "opencodeGo" },
     computer: { driver: "boxAgent" },
+    openaiCompat: { driver: "openai-compat" },
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
     pi: { driver: "piAgent" },

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -14,6 +14,7 @@ import { CursorAgentDriver } from "./acp/cursor.ts";
 import { OpenCodeGoDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
+import { OpenAICompatDriver } from "./openai-compat.ts";
 import { PiDriver } from "./pi.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
@@ -27,6 +28,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   QwenAgentDriver,
   HermesAgentDriver,
   PiDriver,
+  OpenAICompatDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { OpenAICompatDriver } from "./openai-compat.ts";
+
+describe("OpenAICompatDriver", () => {
+  it("registers with the openai-compat kind and a display name", () => {
+    expect(OpenAICompatDriver.driverKind).toBe("openai-compat");
+    expect(OpenAICompatDriver.metadata.displayName).toMatch(/OpenRouter|Groq/);
+  });
+
+  it("falls back to the OpenRouter endpoint by default", () => {
+    const cfg = OpenAICompatDriver.defaultConfig();
+    expect(cfg.url).toBe("https://openrouter.ai/api/v1");
+    expect(cfg.apiKeyEnv).toBe("OPENAI_COMPAT_API_KEY");
+  });
+
+  it("honours an explicit url and apiKeyEnv override", () => {
+    const cfg = OpenAICompatDriver.decodeConfig({
+      url: "https://api.groq.com/openai/v1/",
+      apiKeyEnv: "GROQ_KEY",
+    });
+    expect(cfg.url).toBe("https://api.groq.com/openai/v1");
+    expect(cfg.apiKeyEnv).toBe("GROQ_KEY");
+  });
+
+  it("reports unavailable without an API key", async () => {
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-1",
+      displayName: "Free",
+      enabled: true,
+      config: { url: "https://openrouter.ai/api/v1", apiKeyEnv: "OPENAI_COMPAT_API_KEY" },
+      environment: {},
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("unavailable");
+  });
+});

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -1,7 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { recordEvents } from "../testing/events.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
 
 describe("OpenAICompatDriver", () => {
+  const savedUrl = process.env.OPENAI_COMPAT_URL;
+  const savedKey = process.env.OPENAI_COMPAT_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_COMPAT_URL;
+    delete process.env.OPENAI_COMPAT_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedUrl === undefined) delete process.env.OPENAI_COMPAT_URL;
+    else process.env.OPENAI_COMPAT_URL = savedUrl;
+    if (savedKey === undefined) delete process.env.OPENAI_COMPAT_API_KEY;
+    else process.env.OPENAI_COMPAT_API_KEY = savedKey;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it("registers with the openai-compat kind and a display name", () => {
     expect(OpenAICompatDriver.driverKind).toBe("openai-compat");
     expect(OpenAICompatDriver.metadata.displayName).toMatch(/OpenRouter|Groq/);
@@ -32,5 +50,72 @@ describe("OpenAICompatDriver", () => {
     });
     const snap = await inst.snapshot();
     expect(snap.state).toBe("unavailable");
+    await inst.dispose();
+  });
+
+  it("exposes a refreshed model catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              { id: "vendor/model-a", name: "Model A" },
+              { id: "vendor/model-b" },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-models",
+      displayName: "Models",
+      enabled: true,
+      config: { url: "https://example.test/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+
+    await inst.refreshModels?.();
+
+    expect(inst.models).toEqual({
+      default: "vendor/model-a",
+      options: [
+        { id: "vendor/model-a", label: "Model A" },
+        { id: "vendor/model-b", label: "vendor/model-b" },
+      ],
+    });
+    await inst.dispose();
+  });
+
+  it("includes streamed token totals in turn.completed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hello"}}]}\n' +
+            'data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":3}}\n' +
+            "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-turn",
+      displayName: "Turn",
+      enabled: true,
+      config: { url: "https://example.test/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread", text: "private prompt", model: "vendor/model" });
+    const completed = await recorder.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: true, usage: { input: 12, output: 3 } });
+    recorder.stop();
+    await inst.dispose();
   });
 });

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -42,7 +42,6 @@ export interface OpenAICompatConfig {
 function decodeConfig(raw: unknown): OpenAICompatConfig {
   const o = (raw ?? {}) as Record<string, unknown>;
   const envUrl = process.env.OPENAI_COMPAT_URL;
-  const envKey = process.env.OPENAI_COMPAT_API_KEY;
   return {
     url:
       typeof o.url === "string" && o.url
@@ -50,12 +49,7 @@ function decodeConfig(raw: unknown): OpenAICompatConfig {
         : envUrl
           ? envUrl.replace(/\/+$/, "")
           : "https://openrouter.ai/api/v1",
-    apiKeyEnv:
-      typeof o.apiKeyEnv === "string" && o.apiKeyEnv
-        ? o.apiKeyEnv
-        : envKey
-          ? "OPENAI_COMPAT_API_KEY"
-          : "OPENAI_COMPAT_API_KEY",
+    apiKeyEnv: typeof o.apiKeyEnv === "string" && o.apiKeyEnv ? o.apiKeyEnv : "OPENAI_COMPAT_API_KEY",
   };
 }
 
@@ -233,7 +227,9 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
       appendNative(threadId, {
         dir: "out",
         source: "openai-compat.chat.completions",
-        msg: { model: turn.model, messages },
+        // Native logs are diagnostic artifacts users commonly attach to
+        // issues. Keep routing metadata, not prompts or transcript content.
+        msg: { model: turn.model ?? catalog.default, messageCount: messages.length },
       });
 
       emit({ ...base(threadId, turnId), type: "turn.started" });
@@ -264,7 +260,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           appendNative(threadId, {
             dir: "in",
             source: "openai-compat.chat.completions",
-            msg: { text, usage },
+            msg: { textLength: text.length, usage },
           });
           if (text.trim()) {
             emit({
@@ -288,6 +284,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
             ok: true,
             stopReason: null,
             cost: null,
+            ...(usage ? { usage } : {}),
           });
         } catch (e) {
           active.delete(threadId);
@@ -327,7 +324,9 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
       driverKind: DRIVER_KIND,
       displayName: input.displayName,
       enabled: input.enabled,
-      models: catalog,
+      get models() {
+        return catalog;
+      },
       refreshModels: fetchModels,
       snapshot,
       adapter: {

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -1,0 +1,362 @@
+// OpenAI-compatible driver — any endpoint that speaks the OpenAI
+// chat-completions shape (OpenRouter, Groq, Together, a local llama.cpp,
+// …). This is the "free models" entry point: point it at OpenRouter's
+// free tier or Groq's open-model endpoints and a bot runs without a
+// paid Claude/Codex/Grok subscription.
+//
+// Transcript-replay like grok.ts: the harness folds thread history and
+// hands it back each turn (SendTurnInput.transcript); we emit true
+// token-level content.delta events and supply generateText.
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "openai-compat";
+
+// Default catalog — overwritten by /models when the endpoint answers.
+// Free-tier-friendly defaults so the picker is never empty.
+const DEFAULT_MODELS: ModelCatalog = {
+  default: "meta-llama/llama-3.3-70b-instruct",
+  options: [
+    { id: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B (OpenRouter)" },
+    { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B (Groq)" },
+  ],
+};
+
+export interface OpenAICompatConfig {
+  /** Base URL, no trailing /v1 assumed — we append /chat/completions. */
+  url: string;
+  /** Env var (instance environment or process.env) carrying the API key. */
+  apiKeyEnv: string;
+}
+
+function decodeConfig(raw: unknown): OpenAICompatConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const envUrl = process.env.OPENAI_COMPAT_URL;
+  const envKey = process.env.OPENAI_COMPAT_API_KEY;
+  return {
+    url:
+      typeof o.url === "string" && o.url
+        ? o.url.replace(/\/+$/, "")
+        : envUrl
+          ? envUrl.replace(/\/+$/, "")
+          : "https://openrouter.ai/api/v1",
+    apiKeyEnv:
+      typeof o.apiKeyEnv === "string" && o.apiKeyEnv
+        ? o.apiKeyEnv
+        : envKey
+          ? "OPENAI_COMPAT_API_KEY"
+          : "OPENAI_COMPAT_API_KEY",
+  };
+}
+
+export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "OpenAI-compatible (OpenRouter / Groq)",
+    supportsMultipleInstances: true,
+    access: "custom",
+  },
+  models: DEFAULT_MODELS,
+  // No CLI to install — the "install" is getting a free API key.
+  install: {
+    docsUrl: "https://openrouter.ai/keys",
+    signInCommand:
+      "add {\"openaiCompat\":{\"key\":\"sk-or-v1-…\"}} to ~/.openmausbot/config.json (or set OPENAI_COMPAT_API_KEY)",
+    command: {
+      darwin:
+        "Get a free key at https://openrouter.ai/keys (or https://console.groq.com) then add it to ~/.openmausbot/config.json under openaiCompat.key",
+      linux:
+        "Get a free key at https://openrouter.ai/keys (or https://console.groq.com) then add it to ~/.openmausbot/config.json under openaiCompat.key",
+      win32:
+        "Get a free key at https://openrouter.ai/keys (or https://console.groq.com) then add it to %USERPROFILE%\\.openmausbot\\config.json under openaiCompat.key",
+    },
+  },
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+
+  async create(input: DriverCreateInput<OpenAICompatConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const apiKey =
+      input.environment[config.apiKeyEnv] ?? process.env[config.apiKeyEnv] ?? "";
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string }>();
+    let catalog = DEFAULT_MODELS;
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const complete = async (
+      messages: Array<{ role: string; content: string }>,
+      model: string,
+      opts: { stream: boolean; signal?: AbortSignal; onDelta?: (d: string) => void },
+    ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+      const res = await fetch(`${config.url}/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model, messages, stream: opts.stream }),
+        signal: opts.signal ?? AbortSignal.timeout(120_000),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(
+          `upstream HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`,
+        );
+      }
+      if (!opts.stream) {
+        const json: any = await res.json();
+        return {
+          text: json.choices?.[0]?.message?.content ?? "",
+          usage: json.usage
+            ? {
+                input: json.usage.prompt_tokens ?? 0,
+                output: json.usage.completion_tokens ?? 0,
+              }
+            : null,
+        };
+      }
+      let text = "";
+      let usage: { input: number; output: number } | null = null;
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line.startsWith("data:")) continue;
+          const data = line.slice(5).trim();
+          if (data === "[DONE]") continue;
+          let chunk: any;
+          try {
+            chunk = JSON.parse(data);
+          } catch {
+            continue;
+          }
+          const delta = chunk.choices?.[0]?.delta?.content;
+          if (delta) {
+            text += delta;
+            opts.onDelta?.(delta);
+          }
+          if (chunk.usage) {
+            usage = {
+              input: chunk.usage.prompt_tokens ?? 0,
+              output: chunk.usage.completion_tokens ?? 0,
+            };
+          }
+        }
+      }
+      return { text, usage };
+    };
+
+    const fetchModels = async (): Promise<void> => {
+      if (!apiKey) return;
+      try {
+        const res = await fetch(`${config.url}/models`, {
+          headers: { authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(8_000),
+        });
+        if (!res.ok) return;
+        const json: any = await res.json();
+        const rows: Array<{ id?: unknown; name?: unknown }> = Array.isArray(json)
+          ? json
+          : Array.isArray(json?.data)
+            ? json.data
+            : [];
+        const seen = new Set<string>();
+        const options: ModelCatalog["options"] = [];
+        for (const row of rows) {
+          const id = typeof row.id === "string" ? row.id : "";
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+          const label =
+            typeof row.name === "string" && row.name.trim()
+              ? row.name
+              : id;
+          options.push({ id, label });
+        }
+        if (options.length) {
+          catalog = { default: options[0].id, options };
+        }
+      } catch {
+        // keep DEFAULT_MODELS — never fail the instance on a catalog miss
+      }
+    };
+    if (apiKey) void fetchModels();
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (!apiKey) {
+        throw new Error(
+          `no API key — set ${config.apiKeyEnv} or add it to the instance config`,
+        );
+      }
+      if (active.has(threadId)) {
+        throw new Error("a turn is already running on this thread");
+      }
+      const turnId = newId();
+      const abort = new AbortController();
+      active.set(threadId, { abort, turnId });
+
+      const messages = [
+        ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+        ...(turn.transcript ?? []).map((m) => ({
+          role: m.role === "assistant" ? "assistant" : "user",
+          content: m.text,
+        })),
+        { role: "user", content: turn.text },
+      ];
+      appendNative(threadId, {
+        dir: "out",
+        source: "openai-compat.chat.completions",
+        msg: { model: turn.model, messages },
+      });
+
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({
+        ...base(threadId, turnId),
+        type: "session.started",
+        sessionId: null,
+        model: turn.model ?? catalog.default,
+      });
+
+      (async () => {
+        try {
+          const { text, usage } = await complete(
+            messages,
+            turn.model || catalog.default,
+            {
+              stream: true,
+              signal: abort.signal,
+              onDelta: (delta) =>
+                emit({
+                  ...base(threadId, turnId),
+                  type: "content.delta",
+                  streamKind: "assistant_text",
+                  delta,
+                }),
+            },
+          );
+          appendNative(threadId, {
+            dir: "in",
+            source: "openai-compat.chat.completions",
+            msg: { text, usage },
+          });
+          if (text.trim()) {
+            emit({
+              ...base(threadId, turnId),
+              type: "item.completed",
+              itemType: "assistant_text",
+              text,
+            });
+          }
+          if (usage) {
+            emit({
+              ...base(threadId, turnId),
+              type: "thread.token-usage.updated",
+              ...usage,
+            });
+          }
+          active.delete(threadId);
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: true,
+            stopReason: null,
+            cost: null,
+          });
+        } catch (e) {
+          active.delete(threadId);
+          const aborted = (e as Error).name === "AbortError";
+          if (!aborted) {
+            emit({
+              ...base(threadId, turnId),
+              type: "runtime.error",
+              message: (e as Error).message,
+            });
+          }
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: false,
+            stopReason: aborted ? "interrupted" : "error",
+            cost: null,
+          });
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      if (!apiKey) {
+        return {
+          state: "unavailable",
+          reason: `no API key — set ${config.apiKeyEnv} or add it to the instance config`,
+        };
+      }
+      return { state: "available", authenticated: true, version: null, billing: "metered" };
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      models: catalog,
+      refreshModels: fetchModels,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "in-session" },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+        respondToRequest: async () => "unavailable" as const,
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { abort } of active.values()) abort.abort();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      generateText: async (prompt: string) => {
+        const { text } = await complete(
+          [{ role: "user", content: prompt }],
+          catalog.default,
+          { stream: false },
+        );
+        return text;
+      },
+      dispose: async () => {
+        for (const { abort } of active.values()) abort.abort();
+        listeners.clear();
+      },
+    };
+  },
+};


### PR DESCRIPTION
Replaces #348 on current `main`, preserving @Ansygroup’s provider work and addressing the outstanding review findings.

This adds an OpenAI-compatible driver for OpenRouter, Groq, Together, and similar `/v1` endpoints, including dynamic model discovery and streamed responses. The replacement also:
- adds the provider to existing product fleets
- keeps full prompts and responses out of native diagnostic logs
- exposes refreshed model catalogs
- reports streamed token usage on turn completion
- isolates environment-dependent tests

Verified with 43 focused tests and `pnpm typecheck`.

Authored from the original work by @Ansygroup.