### PR TITLE
fix(steer): queue busy 1:1 sends without corrupting the transcript

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1156,12 +1156,13 @@ bus.subscribe((event: RuntimeEvent) => {
 });
 
 function drainQueuedSends() {
-  drainSteeredMessages(store, (botId, threadId, prompt, userMessage) =>
+  drainSteeredMessages(store, (botId, threadId, prompt, userMessage, excludeIds) =>
     // A plain attended turn — no automationSource, no unattended, no comms
     // depth: exactly what typing the same words into an idle bot would run.
     // Drain just appended the held lines; userMessage keeps startTurn
-    // from duplicating the last one.
-    startTurn(botId, prompt, { threadId, userMessage }).catch((err) => {
+    // from duplicating the last one, and excludeIds drops every drained
+    // line from the transcript-replay so they are not also in `prompt`.
+    startTurn(botId, prompt, { threadId, userMessage, excludeMessageIds: excludeIds }).catch((err) => {
       store.appendMessage(threadId, {
         role: "bot",
         kind: "activity",
@@ -1286,6 +1287,8 @@ async function startTurn(
   opts?: {
     commsDepth?: number;
     userMessage?: Message;
+    /** Extra transcript ids to omit (every drained queued line, not just the last). */
+    excludeMessageIds?: string[];
     /** Routines run in detached tasks; pin the destination for the whole turn. */
     threadId?: string;
     /** Cloud routines run the whole agent inside the bot's Box VM instead
@@ -1354,9 +1357,10 @@ async function startTurn(
 
   // transcript for API-backed drivers: settled text turns on the ACTIVE
   // branch only — abandoned forks never reach the model
+  const skipTranscript = new Set<string>([userMessage.id, ...(opts?.excludeMessageIds ?? [])]);
   const transcript = store
     .activePath(threadId)
-    .filter((m) => m.kind === "text" && m.text && m.id !== userMessage.id)
+    .filter((m) => m.kind === "text" && m.text && !skipTranscript.has(m.id))
     .slice(-40)
     .map((m) => ({ role: m.role === "user" ? ("user" as const) : ("assistant" as const), text: m.text! }));
 
@@ -3665,7 +3669,7 @@ const server = createServer(async (req, res) => {
           }
         }
         const queued = queueSteeredMessage(bot, text);
-        return json(res, 202, { ok: true, queued: true, messageId: queued.id });
+        return json(res, 202, { ok: true, queued: true, queueId: queued.id });
       }
       await startTurn(bot.id, text);
       return json(res, 202, { ok: true });

--- a/server/index.ts
+++ b/server/index.ts
@@ -3669,7 +3669,7 @@ const server = createServer(async (req, res) => {
           }
         }
         const queued = queueSteeredMessage(bot, text);
-        return json(res, 202, { ok: true, queued: true, queueId: queued.id });
+        return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId: bot.threadId });
       }
       await startTurn(bot.id, text);
       return json(res, 202, { ok: true });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1159,8 +1159,8 @@ function drainQueuedSends() {
   drainSteeredMessages(store, (botId, threadId, prompt, userMessage) =>
     // A plain attended turn — no automationSource, no unattended, no comms
     // depth: exactly what typing the same words into an idle bot would run.
-    // The messages are already in the transcript; userMessage keeps
-    // startTurn from appending the joined prompt as a duplicate.
+    // Drain just appended the held lines; userMessage keeps startTurn
+    // from duplicating the last one.
     startTurn(botId, prompt, { threadId, userMessage }).catch((err) => {
       store.appendMessage(threadId, {
         role: "bot",
@@ -3664,8 +3664,8 @@ const server = createServer(async (req, res) => {
             return json(res, 202, { ok: true, steered: true });
           }
         }
-        const message = queueSteeredMessage(store, bot, text);
-        return json(res, 202, { ok: true, queued: true, messageId: message.id });
+        const queued = queueSteeredMessage(bot, text);
+        return json(res, 202, { ok: true, queued: true, messageId: queued.id });
       }
       await startTurn(bot.id, text);
       return json(res, 202, { ok: true });

--- a/server/steer-e2e.test.ts
+++ b/server/steer-e2e.test.ts
@@ -129,13 +129,10 @@ posixOnly("mid-turn steering e2e", () => {
     const queued = await api("POST", `/api/bots/${created.id}/messages`, { text: "second" });
     expect(queued.status).toBe(202);
     expect(queued.body.queued).toBe(true);
-    await waitFor(
-      async () => (await getBot(created.id)).messages.some((m: any) => m.text === "second" && m.queued === true),
-      "the queued message to appear",
-    );
+    expect((await getBot(created.id)).messages.some((m: any) => m.text === "second")).toBe(false);
     await api("POST", `/api/bots/${created.id}/interrupt`);
     await waitFor(
-      async () => (await getBot(created.id)).messages.some((m: any) => m.text === "second" && m.queued !== true),
+      async () => (await getBot(created.id)).messages.some((m: any) => m.text === "second"),
       "the queued message to begin its turn",
     );
     await api("POST", `/api/bots/${created.id}/interrupt`);

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -75,7 +75,12 @@ describe("steer-queue module", () => {
     const run = vi.fn();
     drainSteeredMessages(store, run);
     expect(store.messages).toHaveLength(1);
-    expect(store.messages[0]).toMatchObject({ role: "user", kind: "text", text: "hold that thought" });
+    expect(store.messages[0]).toMatchObject({
+      role: "user",
+      kind: "text",
+      text: "hold that thought",
+      queueId: queued.id,
+    });
     expect(store.messages[0]!.queued).toBeUndefined();
     expect(run).toHaveBeenCalledTimes(1);
     expect(_queuedCount("thread-a")).toBe(0);
@@ -84,8 +89,8 @@ describe("steer-queue module", () => {
   it("holds the queue while the bot is busy and drains it once when idle", () => {
     const bot = fakeBot("bot-b", "thread-b", true);
     const store = fakeStore([bot]);
-    queueSteeredMessage(bot, "first note");
-    queueSteeredMessage(bot, "second note");
+    const first = queueSteeredMessage(bot, "first note");
+    const second = queueSteeredMessage(bot, "second note");
     const run = vi.fn();
 
     drainSteeredMessages(store, run);
@@ -103,6 +108,7 @@ describe("steer-queue module", () => {
     expect(prompt).toBe("first note\nsecond note");
     // appended at drain, last message so startTurn adds nothing new
     expect(store.messages.map((m) => m.text)).toEqual(["first note", "second note"]);
+    expect(store.messages.map((m) => m.queueId)).toEqual([first.id, second.id]);
     expect(userMessage.text).toBe("second note");
     expect(run.mock.calls[0][4]).toEqual(store.messages.map((m) => m.id));
     expect(store.messages.every((m) => !m.queued)).toBe(true);

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -63,26 +63,34 @@ function fakeStore(bots: BotRecord[]): SteerStore & { messages: Message[] } {
 }
 
 describe("steer-queue module", () => {
-  it("appends a queued user message to the thread immediately", () => {
+  it("does not append a queued user message until drain", () => {
     const bot = fakeBot("bot-a", "thread-a", true);
     const store = fakeStore([bot]);
-    const message = queueSteeredMessage(store, bot, "hold that thought");
-    expect(message).toMatchObject({ role: "user", kind: "text", text: "hold that thought", queued: true });
-    expect(store.messages).toHaveLength(1);
+    const queued = queueSteeredMessage(bot, "hold that thought");
+    expect(queued).toMatchObject({ id: expect.any(String) });
+    expect(store.messages).toHaveLength(0);
     expect(_queuedCount("thread-a")).toBe(1);
-    // consume it so module state never leaks into another test
-    drainSteeredMessages(fakeStore([fakeBot("bot-a", "thread-a", false)]), () => {});
+
+    bot.busy = false;
+    const run = vi.fn();
+    drainSteeredMessages(store, run);
+    expect(store.messages).toHaveLength(1);
+    expect(store.messages[0]).toMatchObject({ role: "user", kind: "text", text: "hold that thought" });
+    expect(store.messages[0]!.queued).toBeUndefined();
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(_queuedCount("thread-a")).toBe(0);
   });
 
   it("holds the queue while the bot is busy and drains it once when idle", () => {
     const bot = fakeBot("bot-b", "thread-b", true);
     const store = fakeStore([bot]);
-    queueSteeredMessage(store, bot, "first note");
-    queueSteeredMessage(store, bot, "second note");
+    queueSteeredMessage(bot, "first note");
+    queueSteeredMessage(bot, "second note");
     const run = vi.fn();
 
     drainSteeredMessages(store, run);
     expect(run).not.toHaveBeenCalled();
+    expect(store.messages).toHaveLength(0);
     expect(_queuedCount("thread-b")).toBe(2);
 
     bot.busy = false;
@@ -93,9 +101,9 @@ describe("steer-queue module", () => {
     expect(threadId).toBe("thread-b");
     // ONE turn for the whole burst: the texts joined with newlines
     expect(prompt).toBe("first note\nsecond note");
-    // the last queued message, so the caller appends nothing new
+    // appended at drain, last message so startTurn adds nothing new
+    expect(store.messages.map((m) => m.text)).toEqual(["first note", "second note"]);
     expect(userMessage.text).toBe("second note");
-    // the affordance is cleared the moment the queue is consumed
     expect(store.messages.every((m) => !m.queued)).toBe(true);
     expect(_queuedCount("thread-b")).toBe(0);
 
@@ -112,25 +120,13 @@ describe("steer-queue module", () => {
 
   it("drops the queue of a deleted bot without running it", () => {
     const bot = fakeBot("bot-d", "thread-d", true);
-    const store = fakeStore([bot]);
-    queueSteeredMessage(store, bot, "orphaned");
+    queueSteeredMessage(bot, "orphaned");
     const run = vi.fn();
     drainSteeredMessages(fakeStore([]), run);
     expect(run).not.toHaveBeenCalled();
     expect(_queuedCount("thread-d")).toBe(0);
   });
 
-  it("skips the run when the queued messages vanished from the store", () => {
-    const bot = fakeBot("bot-e", "thread-e", true);
-    const store = fakeStore([bot]);
-    queueSteeredMessage(store, bot, "gone soon");
-    store.messages.length = 0; // the thread was deleted under the queue
-    bot.busy = false;
-    const run = vi.fn();
-    drainSteeredMessages(store, run);
-    expect(run).not.toHaveBeenCalled();
-    expect(_queuedCount("thread-e")).toBe(0);
-  });
 });
 
 // ── e2e: the real server on the gated fake ACP fleet ───────────────────
@@ -258,7 +254,7 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
       expect(first.body.queued).toBeUndefined();
       expect((await botById(bot.id)).busy).toBe(true);
 
-      // sends while busy land in the transcript at once, marked queued
+      // sends while busy stay off the transcript so they cannot become the leaf
       const second = await api("POST", `/api/bots/${bot.id}/messages`, { text: "steer two" });
       expect(second.status).toBe(202);
       expect(second.body).toMatchObject({ ok: true, queued: true });
@@ -267,10 +263,9 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
 
       let snapshot = await botById(bot.id);
       expect(snapshot.busy).toBe(true);
-      const queuedTexts = snapshot.messages
-        .filter((m: any) => m.role === "user" && m.queued)
-        .map((m: any) => m.text);
-      expect(queuedTexts).toEqual(["steer two", "steer three"]);
+      expect(snapshot.messages.filter((m: any) => m.role === "user").map((m: any) => m.text)).toEqual([
+        "first task please",
+      ]);
       expect(echoes(snapshot)).toHaveLength(0); // nothing has answered yet
 
       // open the gate: turn 1 settles, and the queue drains into ONE turn
@@ -290,7 +285,9 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
       // framing, no rewind replay wrapper
       expect(replies[1].text).not.toContain("authenticated external webhook");
       expect(replies[1].text).not.toContain("[The user rewound");
-      // consumed: the queued affordance is gone from both messages
+      // drain appends the queued lines after the first turn's reply
+      const userTexts = snapshot.messages.filter((m: any) => m.role === "user").map((m: any) => m.text);
+      expect(userTexts).toEqual(["first task please", "steer two", "steer three"]);
       expect(snapshot.messages.some((m: any) => m.queued)).toBe(false);
 
       // an idle send with an empty queue runs one normal turn — the drain

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -104,6 +104,7 @@ describe("steer-queue module", () => {
     // appended at drain, last message so startTurn adds nothing new
     expect(store.messages.map((m) => m.text)).toEqual(["first note", "second note"]);
     expect(userMessage.text).toBe("second note");
+    expect(run.mock.calls[0][4]).toEqual(store.messages.map((m) => m.id));
     expect(store.messages.every((m) => !m.queued)).toBe(true);
     expect(_queuedCount("thread-b")).toBe(0);
 

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -1,17 +1,15 @@
 // Queue-and-steer for busy 1:1 bots.
 //
-// A message sent to a bot mid-turn used to bounce with a 409. Now it lands
-// in the thread immediately — visible, persisted, marked `queued` — and
-// waits here until the bot settles. On settle, every queued message for
-// the thread drains into ONE follow-up turn whose prompt is the queued
-// texts joined with newlines, so a burst of steering notes costs one turn.
+// A message sent to a bot mid-turn used to bounce with a 409. Now it waits
+// here until the bot settles, then lands in the thread and runs as ONE
+// follow-up turn whose prompt is the queued texts joined with newlines.
 //
-// The queue itself is memory-only on purpose: each queued message is
-// already an ordinary persisted thread message, so a restart loses only
-// the "auto-run on settle" intent, never the words — the same honesty as
-// delegations and provider approvals, which also die with the process.
-// (The client renders the queued affordance only while the bot is busy, so
-// a flag stranded by a restart is invisible rather than a false promise.)
+// The queue is memory-only and is NOT in `messages[]` while the current
+// turn is running: appending immediately would make the queued line the
+// active leaf, so remaining tool/assistant events of *this* turn would
+// hang off a user line the model has not seen. Restart loses the queue
+// (same as delegations / approvals). The composer shows a pending chip
+// until drain appends the words.
 //
 // Unlike the delegation drain, an interrupted or failed turn does NOT
 // discard this queue: delegations are a bot's fan-out (dropping them on
@@ -19,6 +17,7 @@
 // stop-then-steer (queue a correction, hit Stop, the correction runs) is
 // the feature.
 
+import { newId } from "./contracts.ts";
 import type { BotRecord, Message } from "./store.ts";
 
 /** The slice of Store this module needs — narrow so tests can fake it. */
@@ -38,23 +37,21 @@ interface QueueEntry {
 
 const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
 
-/** Land a message in the busy bot's active thread now; it auto-sends when
- * the turn settles. The `queued` flag is the transcript's "will send when
- * this turn finishes" affordance — drain clears it when consumed. */
-export function queueSteeredMessage(store: SteerStore, bot: BotRecord, text: string): Message {
+/** Hold a mid-turn send off the transcript until drain. */
+export function queueSteeredMessage(bot: BotRecord, text: string): { id: string } {
   const threadId = bot.threadId;
-  const message = store.appendMessage(threadId, { role: "user", kind: "text", text, queued: true });
+  const id = newId();
   const entry = queues.get(threadId) ?? { botId: bot.id, items: [] };
-  entry.items.push({ messageId: message.id, text });
+  entry.items.push({ messageId: id, text });
   queues.set(threadId, entry);
-  return message;
+  return { id };
 }
 
-/** Drain every queue whose bot is idle: one run per thread, prompt = the
- * queued texts joined with newlines. `userMessage` is the last queued
- * message so the caller's startTurn appends nothing new — the messages are
- * already in the transcript. Entries are removed BEFORE running so a
- * settle racing another settle can never fire the same queue twice. */
+/** Drain every queue whose bot is idle: append the held lines (leaf is now
+ * the finished turn's last item), then one run per thread whose prompt is
+ * the texts joined with newlines. `userMessage` is the last appended line
+ * so startTurn does not duplicate it. Entries leave the map BEFORE running
+ * so a settle racing another settle can never fire the same queue twice. */
 export function drainSteeredMessages(
   store: SteerStore,
   run: (botId: string, threadId: string, prompt: string, userMessage: Message) => void | Promise<void>,
@@ -71,14 +68,10 @@ export function drainSteeredMessages(
     // committed to draining: the entry leaves the map before anything runs,
     // so a settle racing another settle can never fire the same queue twice
     queues.delete(threadId);
-    // clear the affordance before dispatch, so the user never sees
-    // "queued" on a message the bot is already answering
     let last: Message | null = null;
     for (const item of entry.items) {
-      last = store.patchMessage(threadId, item.messageId, { queued: undefined }) ?? last;
+      last = store.appendMessage(threadId, { role: "user", kind: "text", text: item.text });
     }
-    // every queued message gone from the store = the thread itself was
-    // deleted out from under the queue; there is nothing to run against
     if (!last) continue;
     const prompt = entry.items.map((item) => item.text).join("\n");
     void run(entry.botId, threadId, prompt, last);

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -50,11 +50,19 @@ export function queueSteeredMessage(bot: BotRecord, text: string): { id: string 
 /** Drain every queue whose bot is idle: append the held lines (leaf is now
  * the finished turn's last item), then one run per thread whose prompt is
  * the texts joined with newlines. `userMessage` is the last appended line
- * so startTurn does not duplicate it. Entries leave the map BEFORE running
- * so a settle racing another settle can never fire the same queue twice. */
+ * so startTurn does not duplicate it; `excludeIds` is every drained line
+ * so transcript-replay adapters do not also see earlier queued texts.
+ * Entries leave the map BEFORE running so a settle racing another settle
+ * can never fire the same queue twice. */
 export function drainSteeredMessages(
   store: SteerStore,
-  run: (botId: string, threadId: string, prompt: string, userMessage: Message) => void | Promise<void>,
+  run: (
+    botId: string,
+    threadId: string,
+    prompt: string,
+    userMessage: Message,
+    excludeIds: string[],
+  ) => void | Promise<void>,
 ): void {
   // deleting only the entry being visited is safe under Map iteration
   for (const [threadId, entry] of queues) {
@@ -68,13 +76,20 @@ export function drainSteeredMessages(
     // committed to draining: the entry leaves the map before anything runs,
     // so a settle racing another settle can never fire the same queue twice
     queues.delete(threadId);
-    let last: Message | null = null;
+    const appended: Message[] = [];
     for (const item of entry.items) {
-      last = store.appendMessage(threadId, { role: "user", kind: "text", text: item.text });
+      appended.push(store.appendMessage(threadId, { role: "user", kind: "text", text: item.text }));
     }
+    const last = appended.at(-1);
     if (!last) continue;
     const prompt = entry.items.map((item) => item.text).join("\n");
-    void run(entry.botId, threadId, prompt, last);
+    void run(
+      entry.botId,
+      threadId,
+      prompt,
+      last,
+      appended.map((message) => message.id),
+    );
   }
 }
 

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -78,7 +78,16 @@ export function drainSteeredMessages(
     queues.delete(threadId);
     const appended: Message[] = [];
     for (const item of entry.items) {
-      appended.push(store.appendMessage(threadId, { role: "user", kind: "text", text: item.text }));
+      // queueId is the pending-chip identity from the 202; append still
+      // assigns a fresh transcript id so replay/exclude keep using message.id.
+      appended.push(
+        store.appendMessage(threadId, {
+          role: "user",
+          kind: "text",
+          text: item.text,
+          queueId: item.messageId,
+        }),
+      );
     }
     const last = appended.at(-1);
     if (!last) continue;

--- a/server/store.ts
+++ b/server/store.ts
@@ -103,6 +103,9 @@ export interface Message {
    * them; a true stranded by a restart is inert because the client only
    * shows the affordance while the bot is busy. */
   queued?: boolean;
+  /** steer-queue entry this drained user line came from. The client pending
+   * chip matches on this id, not on equal text. Absent on ordinary sends. */
+  queueId?: string;
 }
 
 export type GroupDefaultResponder =

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -154,7 +154,11 @@ export function Composer({
   // queue), but stay off the transcript until drain — the chip here is the
   // pending row so they cannot become the active leaf mid-turn.
   const [queued, setQueued] = useState<string | null>(null);
-  const pendingChip = group ? queued : bot ? state.pendingQueued?.[bot.id] : undefined;
+  const pendingChip = group
+    ? queued
+    : bot
+      ? state.pendingQueued?.[bot.threadId]?.join("\n")
+      : undefined;
   // a chip on its own is a message: the send control has to appear for it
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -150,9 +150,9 @@ export function Composer({
   };
 
   // Rooms hold one message client-side while a member speaks; it auto-sends
-  // the moment the room settles. 1:1 sends go straight to the server even
-  // mid-turn — the harness queues them (steer-queue), so the message shows
-  // in the transcript immediately with a queued affordance.
+  // the moment the room settles. 1:1 mid-turn sends still POST (the harness
+  // queue), but stay off the transcript until drain — the chip here is the
+  // pending row so they cannot become the active leaf mid-turn.
   const [queued, setQueued] = useState<string | null>(null);
   // a chip on its own is a message: the send control has to appear for it
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
@@ -175,12 +175,14 @@ export function Composer({
     } else if (bot) {
       dispatch({ type: "send", botId: bot.id, text: t });
       track("message_sent", { driver: bot.modelSelection?.instanceId, queued: busy });
+      if (busy) setQueued((prev) => (prev ? `${prev}\n${t}` : t));
     }
     setText("");
     setAttachments([]);
   };
   useEffect(() => {
-    if (!busy && queued && group) {
+    if (busy || !queued) return;
+    if (group) {
       if (queued.includes("<attached-image ") && !imageTargetsSupport(queued)) {
         dispatch({ type: "error", message: "The selected responder does not support image attachments." });
         setQueued(null);
@@ -188,8 +190,8 @@ export function Composer({
       }
       dispatch({ type: "sendGroup", groupId: group.id, text: queued });
       track("message_sent", { room: true, queued: true });
-      setQueued(null);
     }
+    setQueued(null);
   }, [busy, queued, group, members, state.instances, dispatch]);
 
   // native dictation: partials stream into the input while the Swift
@@ -249,13 +251,15 @@ export function Composer({
             <span className="min-w-0 flex-1 truncate">
               Queued — sends when {busyName} finishes: “{queued}”
             </span>
-            <button
-              onClick={() => setQueued(null)}
-              aria-label="Discard queued message"
-              className="rounded p-0.5 hover:bg-raised hover:text-ink"
-            >
-              <X size={13} />
-            </button>
+            {group && (
+              <button
+                onClick={() => setQueued(null)}
+                aria-label="Discard queued message"
+                className="rounded p-0.5 hover:bg-raised hover:text-ink"
+              >
+                <X size={13} />
+              </button>
+            )}
           </div>
         )}
         {pickerOpen && (

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -157,7 +157,7 @@ export function Composer({
   const pendingChip = group
     ? queued
     : bot
-      ? state.pendingQueued?.[bot.threadId]?.join("\n")
+      ? state.pendingQueued?.[bot.threadId]?.map((entry) => entry.text).join("\n")
       : undefined;
   // a chip on its own is a message: the send control has to appear for it
   const hasContent = Boolean(text.trim()) || attachments.length > 0;

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -154,6 +154,7 @@ export function Composer({
   // queue), but stay off the transcript until drain — the chip here is the
   // pending row so they cannot become the active leaf mid-turn.
   const [queued, setQueued] = useState<string | null>(null);
+  const pendingChip = group ? queued : bot ? state.pendingQueued?.[bot.id] : undefined;
   // a chip on its own is a message: the send control has to appear for it
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
@@ -174,8 +175,7 @@ export function Composer({
       track("message_sent", { room: true });
     } else if (bot) {
       dispatch({ type: "send", botId: bot.id, text: t });
-      track("message_sent", { driver: bot.modelSelection?.instanceId, queued: busy });
-      if (busy) setQueued((prev) => (prev ? `${prev}\n${t}` : t));
+      track("message_sent", { driver: bot.modelSelection?.instanceId, queued: busy && !canSteer });
     }
     setText("");
     setAttachments([]);
@@ -245,11 +245,11 @@ export function Composer({
         </div>
       )}
       <div className="relative mx-auto max-w-[900px]">
-        {queued && (
+        {pendingChip && (
           <div className="mb-2 flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel px-3 py-2 text-[12.5px] text-ink-secondary">
             <Clock size={13} className="shrink-0" />
             <span className="min-w-0 flex-1 truncate">
-              Queued — sends when {busyName} finishes: “{queued}”
+              Queued — sends when {busyName} finishes: “{pendingChip}”
             </span>
             {group && (
               <button

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -121,12 +121,17 @@ describe("pending queued chip", () => {
 
   it("records queue-fallback text and drops it when that user line lands", () => {
     const withBot = reducer(initialState, { type: "botPatched", bot });
-    const queued = reducer(withBot, { type: "pendingQueued", threadId: "t1", text: "later" });
-    expect(queued.pendingQueued).toEqual({ t1: ["later"] });
+    const queued = reducer(withBot, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "q1",
+      text: "later",
+    });
+    expect(queued.pendingQueued).toEqual({ t1: [{ queueId: "q1", text: "later" }] });
     const landed = reducer(queued, {
       type: "consumePendingQueued",
       threadId: "t1",
-      text: "later",
+      queueId: "q1",
     });
     expect(landed.pendingQueued).toEqual({});
   });
@@ -136,31 +141,83 @@ describe("pending queued chip", () => {
     const queued = reducer(withBot, {
       type: "pendingQueued",
       threadId: "t1",
+      queueId: "q-ml",
       text: "line one\nline two",
     });
-    expect(queued.pendingQueued).toEqual({ t1: ["line one\nline two"] });
+    expect(queued.pendingQueued).toEqual({ t1: [{ queueId: "q-ml", text: "line one\nline two" }] });
     const landed = reducer(queued, {
       type: "consumePendingQueued",
       threadId: "t1",
-      text: "line one\nline two",
+      queueId: "q-ml",
     });
     expect(landed.pendingQueued).toEqual({});
   });
 
   it("leaves the chip on the old thread after a task switch", () => {
     const withBot = reducer(initialState, { type: "botPatched", bot });
-    const queued = reducer(withBot, { type: "pendingQueued", threadId: "t1", text: "stay here" });
+    const queued = reducer(withBot, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "q-stay",
+      text: "stay here",
+    });
     const switched = reducer(queued, {
       type: "botPatched",
       bot: { ...bot, threadId: "t2", messages: [] },
     });
-    expect(switched.pendingQueued).toEqual({ t1: ["stay here"] });
+    expect(switched.pendingQueued).toEqual({ t1: [{ queueId: "q-stay", text: "stay here" }] });
     expect(switched.pendingQueued[switched.bots[0]!.threadId]).toBeUndefined();
     const drained = reducer(switched, {
       type: "consumePendingQueued",
       threadId: "t1",
-      text: "stay here",
+      queueId: "q-stay",
     });
     expect(drained.pendingQueued).toEqual({});
+  });
+
+  it("consumes only the matching queue id when two pending lines share text", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const first = reducer(withBot, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "qa",
+      text: "same",
+    });
+    const both = reducer(first, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "qb",
+      text: "same",
+    });
+    expect(both.pendingQueued).toEqual({
+      t1: [
+        { queueId: "qa", text: "same" },
+        { queueId: "qb", text: "same" },
+      ],
+    });
+    const afterOther = reducer(both, {
+      type: "consumePendingQueued",
+      threadId: "t1",
+      queueId: "qa",
+    });
+    expect(afterOther.pendingQueued).toEqual({ t1: [{ queueId: "qb", text: "same" }] });
+  });
+
+  it("does not add a chip when the drain frame arrives before the POST continuation", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const drained = reducer(withBot, {
+      type: "consumePendingQueued",
+      threadId: "t1",
+      queueId: "q1",
+    });
+    expect(drained.pendingQueued).toEqual({});
+    const late = reducer(drained, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "q1",
+      text: "later",
+    });
+    expect(late.pendingQueued).toEqual({});
+    expect(late.consumedQueueIds).toEqual({});
   });
 });

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -107,26 +107,60 @@ describe("cross-client bot creation", () => {
 });
 
 describe("pending queued chip", () => {
+  const bot = {
+    id: "b1",
+    threadId: "t1",
+    name: "Ada",
+    title: "",
+    description: "",
+    notifications: false,
+    color: "green",
+    unread: false,
+    modelSelection: { instanceId: "acp", model: "fake" },
+  } satisfies Omit<Bot, "messages">;
+
   it("records queue-fallback text and drops it when that user line lands", () => {
-    const bot = {
-      id: "b1",
-      threadId: "t1",
-      name: "Ada",
-      title: "",
-      description: "",
-      notifications: false,
-      color: "green",
-      unread: false,
-      modelSelection: { instanceId: "acp", model: "fake" },
-    } satisfies Omit<Bot, "messages">;
     const withBot = reducer(initialState, { type: "botPatched", bot });
-    const queued = reducer(withBot, { type: "pendingQueued", botId: "b1", text: "later" });
-    expect(queued.pendingQueued).toEqual({ b1: "later" });
+    const queued = reducer(withBot, { type: "pendingQueued", threadId: "t1", text: "later" });
+    expect(queued.pendingQueued).toEqual({ t1: ["later"] });
     const landed = reducer(queued, {
       type: "consumePendingQueued",
       threadId: "t1",
       text: "later",
     });
     expect(landed.pendingQueued).toEqual({});
+  });
+
+  it("keeps a Shift+Enter multiline message as one entry", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const queued = reducer(withBot, {
+      type: "pendingQueued",
+      threadId: "t1",
+      text: "line one\nline two",
+    });
+    expect(queued.pendingQueued).toEqual({ t1: ["line one\nline two"] });
+    const landed = reducer(queued, {
+      type: "consumePendingQueued",
+      threadId: "t1",
+      text: "line one\nline two",
+    });
+    expect(landed.pendingQueued).toEqual({});
+  });
+
+  it("leaves the chip on the old thread after a task switch", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const queued = reducer(withBot, { type: "pendingQueued", threadId: "t1", text: "stay here" });
+    const switched = reducer(queued, {
+      type: "botPatched",
+      bot: { ...bot, threadId: "t2", messages: [] },
+    });
+    expect(switched.pendingQueued).toEqual({ t1: ["stay here"] });
+    expect(switched.pendingQueued[switched.bots[0]!.threadId]).toBeUndefined();
+    const drained = reducer(switched, {
+      type: "consumePendingQueued",
+      threadId: "t1",
+      text: "stay here",
+    });
+    expect(drained.pendingQueued).toEqual({});
   });
 });

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -220,4 +220,29 @@ describe("pending queued chip", () => {
     expect(late.pendingQueued).toEqual({});
     expect(late.consumedQueueIds).toEqual({});
   });
+
+  it("bounds unmatched queue tombstones from other clients", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    let state = withBot;
+    for (let index = 0; index < 100; index += 1) {
+      state = reducer(state, {
+        type: "consumePendingQueued",
+        threadId: "t1",
+        queueId: `foreign-${index}`,
+      });
+    }
+
+    expect(Object.keys(state.consumedQueueIds)).toHaveLength(64);
+    expect(state.consumedQueueIds["foreign-0"]).toBeUndefined();
+    expect(state.consumedQueueIds["foreign-99"]).toBe(true);
+
+    const late = reducer(state, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "foreign-99",
+      text: "already drained",
+    });
+    expect(late.pendingQueued).toEqual({});
+    expect(late.consumedQueueIds["foreign-99"]).toBeUndefined();
+  });
 });

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -105,3 +105,28 @@ describe("cross-client bot creation", () => {
     expect(greeted.bots[0]?.messages).toEqual([greeting]);
   });
 });
+
+describe("pending queued chip", () => {
+  it("records queue-fallback text and drops it when that user line lands", () => {
+    const bot = {
+      id: "b1",
+      threadId: "t1",
+      name: "Ada",
+      title: "",
+      description: "",
+      notifications: false,
+      color: "green",
+      unread: false,
+      modelSelection: { instanceId: "acp", model: "fake" },
+    } satisfies Omit<Bot, "messages">;
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const queued = reducer(withBot, { type: "pendingQueued", botId: "b1", text: "later" });
+    expect(queued.pendingQueued).toEqual({ b1: "later" });
+    const landed = reducer(queued, {
+      type: "consumePendingQueued",
+      threadId: "t1",
+      text: "later",
+    });
+    expect(landed.pendingQueued).toEqual({});
+  });
+});

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -83,6 +83,9 @@ export interface Message {
    * Rendered only while the bot is busy, so a flag stranded by a server
    * restart never shows a promise nothing will keep. */
   queued?: boolean;
+  /** steer-queue entry this drained user line came from. Pending chips
+   * match on this id, not on equal text. Absent on ordinary sends. */
+  queueId?: string;
 }
 
 export type GroupDefaultResponder =
@@ -355,8 +358,12 @@ export interface AppState {
     nonce: number;
     kind: Exclude<MausMotion, "none">;
   } | null;
-  /** 1:1 queue-fallback lines waiting for drain; keyed by threadId. */
-  pendingQueued: Record<string, string[]>;
+  /** 1:1 queue-fallback lines waiting for drain; keyed by threadId.
+   * Each entry is identified by the server queueId, not by text. */
+  pendingQueued: Record<string, Array<{ queueId: string; text: string }>>;
+  /** queueIds whose drain frame beat the POST continuation. One-shot:
+   * a late pendingQueued for the same id must not resurrect the chip. */
+  consumedQueueIds: Record<string, true>;
 }
 
 export type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
@@ -399,8 +406,8 @@ export type Action =
   | { type: "configStatus"; config: ConfigStatus }
   | { type: "select"; id: string }
   | { type: "send"; botId: string; text: string }
-  | { type: "pendingQueued"; threadId: string; text: string }
-  | { type: "consumePendingQueued"; threadId: string; text: string }
+  | { type: "pendingQueued"; threadId: string; queueId: string; text: string }
+  | { type: "consumePendingQueued"; threadId: string; queueId: string }
   | { type: "editMessage"; botId: string; messageId: string; text: string }
   | { type: "switchBranch"; botId: string; messageId: string }
   | { type: "threadActive"; threadId: string; activeLeafId: string }
@@ -899,17 +906,30 @@ export function reducer(state: AppState, action: Action): AppState {
     }
     // handled entirely by the async wrapper
     case "pendingQueued": {
+      if (state.consumedQueueIds[action.queueId]) {
+        const consumedQueueIds = { ...state.consumedQueueIds };
+        delete consumedQueueIds[action.queueId];
+        return { ...state, consumedQueueIds };
+      }
       const prev = state.pendingQueued[action.threadId] ?? [];
+      if (prev.some((entry) => entry.queueId === action.queueId)) return state;
       return {
         ...state,
-        pendingQueued: { ...state.pendingQueued, [action.threadId]: [...prev, action.text] },
+        pendingQueued: {
+          ...state.pendingQueued,
+          [action.threadId]: [...prev, { queueId: action.queueId, text: action.text }],
+        },
       };
     }
     case "consumePendingQueued": {
-      const prev = state.pendingQueued[action.threadId];
-      if (!prev?.length) return state;
-      const at = prev.indexOf(action.text);
-      if (at < 0) return state;
+      const prev = state.pendingQueued[action.threadId] ?? [];
+      const at = prev.findIndex((entry) => entry.queueId === action.queueId);
+      if (at < 0) {
+        return {
+          ...state,
+          consumedQueueIds: { ...state.consumedQueueIds, [action.queueId]: true },
+        };
+      }
       const rest = prev.filter((_, i) => i !== at);
       const pendingQueued = { ...state.pendingQueued };
       if (rest.length) pendingQueued[action.threadId] = rest;
@@ -972,6 +992,7 @@ export const initialState: AppState = {
   error: null,
   mascotMotion: null,
   pendingQueued: {},
+  consumedQueueIds: {},
 };
 
 // ── API client ─────────────────────────────────────────────────────────
@@ -1139,8 +1160,17 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             body: JSON.stringify({ text: action.text }),
           })
             .then((body) => {
-              if (body?.queued && typeof body.threadId === "string") {
-                rawDispatch({ type: "pendingQueued", threadId: body.threadId, text: action.text });
+              if (
+                body?.queued &&
+                typeof body.threadId === "string" &&
+                typeof body.queueId === "string"
+              ) {
+                rawDispatch({
+                  type: "pendingQueued",
+                  threadId: body.threadId,
+                  queueId: body.queueId,
+                  text: action.text,
+                });
               }
             })
             .catch(showError);
@@ -1427,8 +1457,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       switch (frame.kind) {
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
-          if (frame.message?.role === "user" && frame.message.text) {
-            rawDispatch({ type: "consumePendingQueued", threadId: frame.threadId, text: frame.message.text });
+          if (frame.message?.role === "user" && typeof frame.message.queueId === "string") {
+            rawDispatch({
+              type: "consumePendingQueued",
+              threadId: frame.threadId,
+              queueId: frame.message.queueId,
+            });
           }
           // a settled assistant bubble replaces the in-flight stream
           if (frame.message?.role === "bot" && frame.message?.kind === "text") {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -361,9 +361,20 @@ export interface AppState {
   /** 1:1 queue-fallback lines waiting for drain; keyed by threadId.
    * Each entry is identified by the server queueId, not by text. */
   pendingQueued: Record<string, Array<{ queueId: string; text: string }>>;
-  /** queueIds whose drain frame beat the POST continuation. One-shot:
-   * a late pendingQueued for the same id must not resurrect the chip. */
+  /** queueIds whose drain frame beat the POST continuation. One-shot and
+   * bounded to a short event window so other clients cannot grow it forever. */
   consumedQueueIds: Record<string, true>;
+}
+
+const MAX_CONSUMED_QUEUE_IDS = 64;
+
+function rememberConsumedQueueId(consumed: Record<string, true>, queueId: string): Record<string, true> {
+  const next = { ...consumed, [queueId]: true as const };
+  const overflow = Object.keys(next).length - MAX_CONSUMED_QUEUE_IDS;
+  if (overflow > 0) {
+    for (const id of Object.keys(next).slice(0, overflow)) delete next[id];
+  }
+  return next;
 }
 
 export type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
@@ -927,7 +938,7 @@ export function reducer(state: AppState, action: Action): AppState {
       if (at < 0) {
         return {
           ...state,
-          consumedQueueIds: { ...state.consumedQueueIds, [action.queueId]: true },
+          consumedQueueIds: rememberConsumedQueueId(state.consumedQueueIds, action.queueId),
         };
       }
       const rest = prev.filter((_, i) => i !== at);

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -355,6 +355,8 @@ export interface AppState {
     nonce: number;
     kind: Exclude<MausMotion, "none">;
   } | null;
+  /** 1:1 queue-fallback lines waiting for drain; keyed by botId. */
+  pendingQueued: Record<string, string>;
 }
 
 export type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
@@ -397,6 +399,8 @@ export type Action =
   | { type: "configStatus"; config: ConfigStatus }
   | { type: "select"; id: string }
   | { type: "send"; botId: string; text: string }
+  | { type: "pendingQueued"; botId: string; text: string }
+  | { type: "consumePendingQueued"; threadId: string; text: string }
   | { type: "editMessage"; botId: string; messageId: string; text: string }
   | { type: "switchBranch"; botId: string; messageId: string }
   | { type: "threadActive"; threadId: string; activeLeafId: string }
@@ -894,6 +898,30 @@ export function reducer(state: AppState, action: Action): AppState {
       };
     }
     // handled entirely by the async wrapper
+    case "pendingQueued": {
+      const prev = state.pendingQueued[action.botId];
+      return {
+        ...state,
+        pendingQueued: {
+          ...state.pendingQueued,
+          [action.botId]: prev ? `${prev}\n${action.text}` : action.text,
+        },
+      };
+    }
+    case "consumePendingQueued": {
+      const owner = state.bots.find((b) => b.threadId === action.threadId);
+      if (!owner) return state;
+      const prev = state.pendingQueued[owner.id];
+      if (!prev) return state;
+      const lines = prev.split("\n");
+      const at = lines.indexOf(action.text);
+      if (at < 0) return state;
+      const rest = lines.filter((_, i) => i !== at);
+      const pendingQueued = { ...state.pendingQueued };
+      if (rest.length) pendingQueued[owner.id] = rest.join("\n");
+      else delete pendingQueued[owner.id];
+      return { ...state, pendingQueued };
+    }
     case "send":
     case "editMessage":
       return withMascotMotion(state, action.botId, "working");
@@ -949,6 +977,7 @@ export const initialState: AppState = {
   connected: false,
   error: null,
   mascotMotion: null,
+  pendingQueued: {},
 };
 
 // ── API client ─────────────────────────────────────────────────────────
@@ -1111,10 +1140,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           api(`/api/routine-runs/${action.runId}/seen`, { method: "POST" }).catch(showError);
           break;
         case "send":
-          api(`/api/bots/${action.botId}/messages`, {
+          void api(`/api/bots/${action.botId}/messages`, {
             method: "POST",
             body: JSON.stringify({ text: action.text }),
-          }).catch(showError);
+          })
+            .then((body) => {
+              if (body?.queued) {
+                rawDispatch({ type: "pendingQueued", botId: action.botId, text: action.text });
+              }
+            })
+            .catch(showError);
           break;
         case "editMessage":
           api(`/api/bots/${action.botId}/messages/${action.messageId}/edit`, {
@@ -1398,6 +1433,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       switch (frame.kind) {
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
+          if (frame.message?.role === "user" && frame.message.text) {
+            rawDispatch({ type: "consumePendingQueued", threadId: frame.threadId, text: frame.message.text });
+          }
           // a settled assistant bubble replaces the in-flight stream
           if (frame.message?.role === "bot" && frame.message?.kind === "text") {
             clearStream(frame.threadId);

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -355,8 +355,8 @@ export interface AppState {
     nonce: number;
     kind: Exclude<MausMotion, "none">;
   } | null;
-  /** 1:1 queue-fallback lines waiting for drain; keyed by botId. */
-  pendingQueued: Record<string, string>;
+  /** 1:1 queue-fallback lines waiting for drain; keyed by threadId. */
+  pendingQueued: Record<string, string[]>;
 }
 
 export type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
@@ -399,7 +399,7 @@ export type Action =
   | { type: "configStatus"; config: ConfigStatus }
   | { type: "select"; id: string }
   | { type: "send"; botId: string; text: string }
-  | { type: "pendingQueued"; botId: string; text: string }
+  | { type: "pendingQueued"; threadId: string; text: string }
   | { type: "consumePendingQueued"; threadId: string; text: string }
   | { type: "editMessage"; botId: string; messageId: string; text: string }
   | { type: "switchBranch"; botId: string; messageId: string }
@@ -899,27 +899,21 @@ export function reducer(state: AppState, action: Action): AppState {
     }
     // handled entirely by the async wrapper
     case "pendingQueued": {
-      const prev = state.pendingQueued[action.botId];
+      const prev = state.pendingQueued[action.threadId] ?? [];
       return {
         ...state,
-        pendingQueued: {
-          ...state.pendingQueued,
-          [action.botId]: prev ? `${prev}\n${action.text}` : action.text,
-        },
+        pendingQueued: { ...state.pendingQueued, [action.threadId]: [...prev, action.text] },
       };
     }
     case "consumePendingQueued": {
-      const owner = state.bots.find((b) => b.threadId === action.threadId);
-      if (!owner) return state;
-      const prev = state.pendingQueued[owner.id];
-      if (!prev) return state;
-      const lines = prev.split("\n");
-      const at = lines.indexOf(action.text);
+      const prev = state.pendingQueued[action.threadId];
+      if (!prev?.length) return state;
+      const at = prev.indexOf(action.text);
       if (at < 0) return state;
-      const rest = lines.filter((_, i) => i !== at);
+      const rest = prev.filter((_, i) => i !== at);
       const pendingQueued = { ...state.pendingQueued };
-      if (rest.length) pendingQueued[owner.id] = rest.join("\n");
-      else delete pendingQueued[owner.id];
+      if (rest.length) pendingQueued[action.threadId] = rest;
+      else delete pendingQueued[action.threadId];
       return { ...state, pendingQueued };
     }
     case "send":
@@ -1145,8 +1139,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             body: JSON.stringify({ text: action.text }),
           })
             .then((body) => {
-              if (body?.queued) {
-                rawDispatch({ type: "pendingQueued", botId: action.botId, text: action.text });
+              if (body?.queued && typeof body.threadId === "string") {
+                rawDispatch({ type: "pendingQueued", threadId: body.threadId, text: action.text });
               }
             })
             .catch(showError);


### PR DESCRIPTION
Replaces #356 on current `main` and preserves @donggyun112’s implementation while resolving the remaining review blocker.

Queued sends now stay off the active transcript branch until the running turn finishes, remain visible as pending chips, preserve multiline message boundaries, and match drain events by queue identity. The replacement also bounds unmatched cross-client queue tombstones so another client cannot grow browser state indefinitely.

Verified with 19 focused queue, end-to-end, and reducer tests plus `pnpm typecheck`.

Authored from the original work by @donggyun112.