### PR TITLE
fix(drivers): auto-retry transient failures in claude/codex/grok

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -87,6 +87,14 @@ export type RuntimeEvent = RuntimeEventBase &
     | { type: "session.exited"; reason?: string }
     | { type: "turn.started" }
     | {
+        type: "turn.retrying";
+        /** 1-based: the retry about to be launched (1 = first relaunch). */
+        attempt: number;
+        delayMs: number;
+        /** Why this failure was judged retry-worthy (classifyError's reason). */
+        reason: string;
+      }
+    | {
         type: "turn.completed";
         ok: boolean;
         stopReason?: string | null;

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -157,6 +157,10 @@ describe("ClaudeDriver turns (fake CLI)", () => {
   afterEach(async () => {
     delete process.env.FAKE_CLAUDE_MODE;
     delete process.env.FAKE_CLAUDE_DUMP;
+    delete process.env.FAKE_CLAUDE_TRANSIENTS;
+    delete process.env.FAKE_CLAUDE_PARTIAL_FAILS;
+    delete process.env.FAKE_CLAUDE_STATE;
+    delete process.env.FAKE_CLAUDE_RETRY_SCALE;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.XAI_API_KEY;
     delete process.env.COMPOSIO_API_KEY;
@@ -566,6 +570,72 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const error = recorder.events.find((e) => e.type === "runtime.error")!;
     expect(error.message).toContain("simulated crash");
   });
+
+  it("auto-retries transient exits, then completes with exactly one final message", async () => {
+    process.env.FAKE_CLAUDE_TRANSIENTS = "2";
+    process.env.FAKE_CLAUDE_STATE = join(scratch, "launches");
+    process.env.FAKE_CLAUDE_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-retry", text: "go" });
+
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === true);
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+    expect(retries.every((e) => e.delayMs > 0 && typeof e.reason === "string")).toBe(true);
+    // exactly one settled reply across all three launches
+    const replies = recorder.events.filter((e) => e.type === "item.completed" && e.itemType === "assistant_text");
+    expect(replies).toHaveLength(1);
+  }, 20_000);
+
+  it("stops retrying at the attempt cap and settles the turn as failed", async () => {
+    process.env.FAKE_CLAUDE_TRANSIENTS = "9";
+    process.env.FAKE_CLAUDE_STATE = join(scratch, "launches-cap");
+    process.env.FAKE_CLAUDE_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-cap", text: "go" });
+
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === false);
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+    expect(recorder.events.some((e) => e.type === "runtime.error")).toBe(true);
+  }, 20_000);
+
+  it("never retries a terminal (auth-shaped) exit", async () => {
+    await create("exit-early"); // exit 3 with no transient vocabulary — terminal
+    await instance.adapter.sendTurn({ threadId: "t-terminal", text: "go" });
+
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === false);
+    expect(recorder.events.some((e) => e.type === "turn.retrying")).toBe(false);
+  }, 20_000);
+
+  it("never retries after assistant text already streamed (duplicate-text hazard)", async () => {
+    process.env.FAKE_CLAUDE_TRANSIENTS = "9";
+    process.env.FAKE_CLAUDE_PARTIAL_FAILS = "1";
+    process.env.FAKE_CLAUDE_STATE = join(scratch, "launches-partial");
+    process.env.FAKE_CLAUDE_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-partial", text: "go" });
+
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === false);
+    expect(recorder.events.some((e) => e.type === "content.delta" && e.streamKind === "assistant_text")).toBe(true);
+    expect(recorder.events.some((e) => e.type === "turn.retrying")).toBe(false);
+  }, 20_000);
+
+  it("an interrupt during the retry backoff cancels cleanly without a zombie relaunch", async () => {
+    process.env.FAKE_CLAUDE_TRANSIENTS = "9";
+    process.env.FAKE_CLAUDE_STATE = join(scratch, "launches-cancel");
+    process.env.FAKE_CLAUDE_RETRY_SCALE = "60"; // long backoff — we cancel inside it
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-cancel-backoff", text: "go" });
+
+    await recorder.until((e) => e.type === "turn.retrying");
+    await instance.adapter.interruptTurn("t-cancel-backoff");
+    await recorder.until((e) => e.type === "turn.completed");
+    // no second launch ever happened: no further retries, no extra replies
+    expect(recorder.events.filter((e) => e.type === "turn.retrying")).toHaveLength(1);
+    expect(recorder.events.filter((e) => e.type === "item.completed" && e.itemType === "assistant_text")).toHaveLength(0);
+  }, 30_000);
+
 
   it("skips malformed protocol lines without losing the turn", async () => {
     await create("malformed");

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -600,6 +600,20 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.some((e) => e.type === "runtime.error")).toBe(true);
   }, 20_000);
 
+  it("gives a later turn on the same thread a fresh retry budget", async () => {
+    process.env.FAKE_CLAUDE_TRANSIENTS = "9";
+    process.env.FAKE_CLAUDE_STATE = join(scratch, "launches-fresh-budget");
+    process.env.FAKE_CLAUDE_RETRY_SCALE = "0.001";
+    await create();
+
+    await instance.adapter.sendTurn({ threadId: "t-fresh-budget", text: "one" });
+    const firstDone = await recorder.until((e) => e.type === "turn.completed");
+    await instance.adapter.sendTurn({ threadId: "t-fresh-budget", text: "two" });
+    await recorder.until((e) => e.type === "turn.completed" && e.eventId !== firstDone.eventId);
+
+    expect(recorder.events.filter((e) => e.type === "turn.retrying").map((e) => e.attempt)).toEqual([1, 2, 1, 2]);
+  }, 20_000);
+
   it("never retries a terminal (auth-shaped) exit", async () => {
     await create("exit-early"); // exit 3 with no transient vocabulary — terminal
     await instance.adapter.sendTurn({ threadId: "t-terminal", text: "go" });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -30,6 +30,7 @@ import type {
 } from "../contracts.ts";
 import { computerProxyEnv } from "../container-computer.ts";
 import { newEventId, newId } from "../contracts.ts";
+import { classifyError, computeBackoff, interruptibleDelay, RETRY_MAX_ATTEMPTS } from "./retry.ts";
 import {
   applyClaudeInject,
   decodeInjectId,
@@ -517,6 +518,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       turnId,
       createdAt: new Date().toISOString(),
     });
+    // retry bookkeeping lives PER THREAD, not per sendTurn call: a relaunch
+    // is a fresh sendTurn, and the attempt cap must survive across launches
+    const retryState = new Map<string, { attempt: number; cancelled: boolean }>();
 
     const sendTurn = async (turn: SendTurnInput) => {
       const { threadId } = turn;
@@ -526,6 +530,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         throw new Error("local computer control requires the interactive approval broker");
       }
       const turnId = newId();
+      const retryAbort = new AbortController();
+      const retry = retryState.get(threadId) ?? { attempt: 0, cancelled: false };
+      retry.cancelled = false;
+      retryState.set(threadId, retry);
+      // a retry relaunches the whole CLI; the backoff is scaled down in tests
+      // so a fake's transient failures don't stall real seconds
+      const retryScale = Number(process.env.FAKE_CLAUDE_RETRY_SCALE ?? "1");
       const sessionId = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
       const newSessionId = sessionId ? null : newId();
 
@@ -852,10 +863,82 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         // process that exited between turns (idle close, contract change)
         // is just a session ending
         if (session.turn && !session.turn.settled) {
+          const message = `claude exited ${code} before result${session.stderr ? `: ${session.stderr.trim().slice(-300)}` : ""}`;
+          const verdict = classifyError({ exitCode: code, stderr: message });
+          if (
+            !retry.cancelled &&
+            code !== 0 &&
+            verdict.transient &&
+            !session.turn.sawStreamDelta &&
+            retry.attempt < RETRY_MAX_ATTEMPTS - 1
+          ) {
+            // the CLI is gone but the TURN continues: keep the thread busy,
+            // emit no terminal event, and relaunch after the backoff. The
+            // `active` entry STAYS — it is what makes an interrupt during
+            // the backoff reach this turn's stop() and cancel the retry.
+            session.broker?.pause();
+            if (session.mcpConfigPath) {
+              try {
+                rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+              } catch {}
+              session.mcpConfigPath = null;
+            }
+            sessions.delete(threadId);
+            session.turn = null;
+            retry.attempt++;
+            const delayMs = computeBackoff(retry.attempt - 1);
+            emit({
+              ...base(threadId, turnId),
+              type: "turn.retrying",
+              attempt: retry.attempt,
+              delayMs,
+              reason: verdict.reason,
+            });
+            void (async () => {
+              const wait = interruptibleDelay(delayMs * retryScale, retryAbort.signal);
+              await wait.promise;
+              // an interrupt during the backoff landed here via stop(); the
+              // turn settles as interrupted and no zombie relaunch happens
+              if (retry.cancelled) {
+                active.delete(threadId);
+                retryState.delete(threadId);
+                emit({
+                  ...base(threadId, turnId),
+                  type: "turn.completed",
+                  ok: false,
+                  stopReason: "interrupted",
+                  cost: null,
+                });
+                return;
+              }
+              // hand the thread back before recursing — the relaunch's own
+              // guard would otherwise reject it as "already running"
+              active.delete(threadId);              try {
+                const cursor = session.sessionId ?? sessionId ?? undefined;
+                await sendTurn({ ...turn, resumeCursor: cursor });
+              } catch (e) {
+                retryState.delete(threadId);
+                emit({
+                  ...base(threadId, turnId),
+                  type: "runtime.error",
+                  message: e instanceof Error ? e.message : String(e),
+                });
+                emit({
+                  ...base(threadId, turnId),
+                  type: "turn.completed",
+                  ok: false,
+                  stopReason: "exit_before_result",
+                  cost: null,
+                });
+              }
+            })();
+            return;
+          }
+          retryState.delete(threadId);
           emit({
             ...base(threadId, currentTurnId()),
             type: "runtime.error",
-            message: `claude exited ${code} before result${session.stderr ? `: ${session.stderr.trim().slice(-300)}` : ""}`,
+            message,
           });
           settle(false, "exit_before_result");
         }
@@ -869,7 +952,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         if (sessions.get(threadId) === session) sessions.delete(threadId);
       });
 
-      const stop = () => killCliTree(child);
+      const stop = () => {
+        retry.cancelled = true;
+        retryAbort.abort();
+        killCliTree(child);
+      };
       active.set(threadId, { stop, turnId, broker });
       emit({ ...base(threadId, turnId), type: "turn.started" });
 

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -745,6 +745,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         }
         active.delete(threadId);
         session.turn = null;
+        // A settled turn owns no retry budget. Retained CLI sessions may run
+        // many later turns on this thread, and each must start fresh.
+        retryState.delete(threadId);
         emit({ ...base(threadId, t.turnId), type: "turn.completed", ok, stopReason, cost, ...(usage ? { usage } : {}) });
         if (session.child.exitCode === null && !session.closing) armIdle(threadId);
       };
@@ -876,7 +879,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             // emit no terminal event, and relaunch after the backoff. The
             // `active` entry STAYS — it is what makes an interrupt during
             // the backoff reach this turn's stop() and cancel the retry.
-            session.broker?.pause();
+            const failedBroker = session.broker;
+            session.broker = undefined;
+            failedBroker?.pause();
+            failedBroker?.close();
             if (session.mcpConfigPath) {
               try {
                 rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
@@ -913,7 +919,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               }
               // hand the thread back before recursing — the relaunch's own
               // guard would otherwise reject it as "already running"
-              active.delete(threadId);              try {
+              active.delete(threadId);
+              try {
                 const cursor = session.sessionId ?? sessionId ?? undefined;
                 await sendTurn({ ...turn, resumeCursor: cursor });
               } catch (e) {

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -486,6 +486,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     const retries = recorder.events.filter((e) => e.type === "turn.retrying");
     expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
     expect(retries.every((e) => e.delayMs > 0 && typeof e.reason === "string")).toBe(true);
+    expect(recorder.events.filter((e) => e.type === "turn.started")).toHaveLength(1);
     // exactly one settled reply across all three app-server launches
     const replies = recorder.events.filter((e) => e.type === "item.completed" && e.itemType === "assistant_text");
     expect(replies).toHaveLength(1);

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -55,6 +55,10 @@ describe("CodexDriver turns (fake app-server)", () => {
   afterEach(async () => {
     delete process.env.FAKE_CODEX_MODE;
     delete process.env.FAKE_CODEX_DUMP;
+    delete process.env.FAKE_CODEX_TRANSIENTS;
+    delete process.env.FAKE_CODEX_PARTIAL_FAILS;
+    delete process.env.FAKE_CODEX_STATE;
+    delete process.env.FAKE_CODEX_RETRY_SCALE;
     delete process.env.OPENAI_API_KEY;
     delete process.env.BOX_TOKEN;
     delete process.env.OMB_TTS_KEY;
@@ -470,6 +474,48 @@ describe("CodexDriver turns (fake app-server)", () => {
       stopReason: "auth_required",
     });
   });
+
+  it("auto-retries a transient turn/start failure, then completes with one final message", async () => {
+    process.env.FAKE_CODEX_TRANSIENTS = "2";
+    process.env.FAKE_CODEX_STATE = join(scratch, "codex-launches");
+    process.env.FAKE_CODEX_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-codex-retry", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === true);
+
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+    expect(retries.every((e) => e.delayMs > 0 && typeof e.reason === "string")).toBe(true);
+    // exactly one settled reply across all three app-server launches
+    const replies = recorder.events.filter((e) => e.type === "item.completed" && e.itemType === "assistant_text");
+    expect(replies).toHaveLength(1);
+  }, 20_000);
+
+  it("stops retrying at the attempt cap and settles as failed", async () => {
+    process.env.FAKE_CODEX_TRANSIENTS = "9";
+    process.env.FAKE_CODEX_STATE = join(scratch, "codex-launches-cap");
+    process.env.FAKE_CODEX_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-codex-cap", text: "hi" });
+
+    await expect(recorder.until((e) => e.type === "turn.completed" && e.ok === false)).resolves.toBeTruthy();
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+  }, 20_000);
+
+  it("never retries after agent text already streamed (duplicate-text hazard)", async () => {
+    process.env.FAKE_CODEX_TRANSIENTS = "1";
+    process.env.FAKE_CODEX_PARTIAL_FAILS = "1";
+    process.env.FAKE_CODEX_STATE = join(scratch, "codex-launches-partial");
+    process.env.FAKE_CODEX_RETRY_SCALE = "0.001";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-codex-partial", text: "hi" });
+
+    await expect(recorder.until((e) => e.type === "turn.completed" && e.ok === false)).resolves.toBeTruthy();
+    expect(recorder.events.some((e) => e.type === "content.delta" && e.streamKind === "assistant_text")).toBe(true);
+    expect(recorder.events.some((e) => e.type === "turn.retrying")).toBe(false);
+  }, 20_000);
+
 
   it("uses the explicit login command from the official Codex flow", () => {
     expect(CodexDriver.install?.signInCommand).toBe("codex login");

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -503,6 +503,23 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
   }, 20_000);
 
+  it("interrupting one thread does not cancel another thread's retry", async () => {
+    process.env.FAKE_CODEX_TRANSIENTS = "2";
+    process.env.FAKE_CODEX_STATE = join(scratch, "codex-launches-concurrent");
+    await create();
+
+    const first = instance.adapter.sendTurn({ threadId: "t-codex-stop", text: "stop me" });
+    const second = instance.adapter.sendTurn({ threadId: "t-codex-continue", text: "keep going" });
+    await recorder.until((e) => e.type === "turn.retrying" && e.threadId === "t-codex-stop");
+    await recorder.until((e) => e.type === "turn.retrying" && e.threadId === "t-codex-continue");
+    await instance.adapter.interruptTurn("t-codex-stop");
+
+    await expect(
+      recorder.until((e) => e.type === "turn.completed" && e.threadId === "t-codex-continue"),
+    ).resolves.toMatchObject({ ok: true });
+    await Promise.allSettled([first, second]);
+  }, 20_000);
+
   it("never retries after agent text already streamed (duplicate-text hazard)", async () => {
     process.env.FAKE_CODEX_TRANSIENTS = "1";
     process.env.FAKE_CODEX_PARTIAL_FAILS = "1";

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -137,9 +137,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       createdAt: new Date().toISOString(),
     });
 
-    let stopRequested = false;
     const sendTurn = async (turn: SendTurnInput) => {
-      stopRequested = false;
+      // One driver instance serves many threads. Interrupt state belongs to
+      // this turn so activity elsewhere cannot cancel or revive its retry.
+      let stopRequested = false;
       const { threadId } = turn;
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
       const turnId = newId();
@@ -194,6 +195,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           stdio: ["pipe", "pipe", "pipe"],
         });
 
+      let abandoned = false;
       const state = {
         settled: false,
         lastText: "",
@@ -467,10 +469,12 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         if (stderr.length > 8192) stderr = stderr.slice(-8192);
       });
       child.on("error", (e) => {
+        if (abandoned) return;
         emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
         settle(false, "spawn_error");
       });
       child.on("close", (code) => {
+        if (abandoned) return;
         if (!state.settled) {
           emit({
             ...base(threadId, turnId),
@@ -544,13 +548,17 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             delayMs,
             reason: verdict.reason,
           });
+          // This app-server never exits by itself. Retire the failed attempt
+          // and silence its late handlers before the replacement launches.
+          abandoned = true;
+          killCliTree(child);
           await new Promise<void>((resolve) => {
             const timer = setTimeout(resolve, Math.max(1, Math.round(delayMs * retryScale)));
             timer.unref?.();
           });
-          if (!state.settled && !stopRequested) {
+          if (!stopRequested) {
             void launchAttempt(attempt).catch(() => {});
-          } else if (!state.settled) {
+          } else {
             settle(false, "interrupted");
           }
           return;

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -29,6 +29,7 @@ import { newEventId, newId } from "../contracts.ts";
 import { decodeCodexSelection, readCodexModelCatalog, STATIC_CODEX_MODELS } from "./codex-catalog.ts";
 import { codexLocalProviderArgs } from "./local-inject.ts";
 import { augmentedPath } from "../env-path.ts";
+import { classifyError, computeBackoff, RETRY_MAX_ATTEMPTS } from "./retry.ts";
 import { appendNative } from "./native.ts";
 
 export { decodeCodexSelection, readCodexModelCatalog, STATIC_CODEX_MODELS } from "./codex-catalog.ts";
@@ -136,56 +137,62 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       createdAt: new Date().toISOString(),
     });
 
+    let stopRequested = false;
     const sendTurn = async (turn: SendTurnInput) => {
+      stopRequested = false;
       const { threadId } = turn;
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
       const turnId = newId();
+      // a retry relaunches the whole app-server; the backoff is scaled down in
+      // tests so a fake's transient failures don't stall real seconds
+      const retryScale = Number(process.env.FAKE_CODEX_RETRY_SCALE ?? "1");
 
-      const env = childEnv();
-      const appServerArgs = ["app-server", ...codexLocalProviderArgs(env, turn.model)];
-      if (turn.integrations?.composio) {
-        mountMcpServer(appServerArgs, env, "openmausbot_connectors", turn.integrations.composio);
-      }
-      if (turn.integrations?.agents) {
-        mountMcpServer(appServerArgs, env, "agents", turn.integrations.agents);
-      }
-      if (turn.integrations?.computer) {
-        const proxyEnv = computerProxyEnv(turn.integrations.computer);
-        mountMcpServer(appServerArgs, env, "computer", {
-          command: process.execPath,
-          args: [SPAWNED_PROXIES.computer],
-          env: {
-            ELECTRON_RUN_AS_NODE: "1",
-            OGB_BOX_ID: proxyEnv.OGB_BOX_ID ?? "",
-            OGB_BOX_TOKEN: proxyEnv.OGB_BOX_TOKEN ?? "",
-            // who-is-driving endpoint, so a person taking the wheel in the
-            // panel pauses this bot's hands mid-turn
-            OMB_CONTROL_URL: proxyEnv.OMB_CONTROL_URL ?? "",
-            OMB_CONTROL_TOKEN: proxyEnv.OMB_CONTROL_TOKEN ?? "",
-          },
+      const launchAttempt = async (attempt: number): Promise<void> => {
+        const env = childEnv();
+        const appServerArgs = ["app-server", ...codexLocalProviderArgs(env, turn.model)];
+        if (turn.integrations?.composio) {
+          mountMcpServer(appServerArgs, env, "openmausbot_connectors", turn.integrations.composio);
+        }
+        if (turn.integrations?.agents) {
+          mountMcpServer(appServerArgs, env, "agents", turn.integrations.agents);
+        }
+        if (turn.integrations?.computer) {
+          const proxyEnv = computerProxyEnv(turn.integrations.computer);
+          mountMcpServer(appServerArgs, env, "computer", {
+            command: process.execPath,
+            args: [SPAWNED_PROXIES.computer],
+            env: {
+              ELECTRON_RUN_AS_NODE: "1",
+              OGB_BOX_ID: proxyEnv.OGB_BOX_ID ?? "",
+              OGB_BOX_TOKEN: proxyEnv.OGB_BOX_TOKEN ?? "",
+              // who-is-driving endpoint, so a person taking the wheel in the
+              // panel pauses this bot's hands mid-turn
+              OMB_CONTROL_URL: proxyEnv.OMB_CONTROL_URL ?? "",
+              OMB_CONTROL_TOKEN: proxyEnv.OMB_CONTROL_TOKEN ?? "",
+            },
+          });
+        } else if (turn.integrations?.localComputer) {
+          // The host daemon and isolated Local VM both arrive as a direct Cua
+          // Driver stdio MCP server. Codex sees the same computer tool surface.
+          mountMcpServer(appServerArgs, env, "computer", turn.integrations.localComputer);
+        }
+        if (turn.integrations?.phone) {
+          const bridge = turn.integrations.phone;
+          Object.assign(env, bridge.env);
+          const prefix = "mcp_servers.openmausbot_phone";
+          appServerArgs.push(
+            "-c", `${prefix}.command=${JSON.stringify(bridge.command)}`,
+            "-c", `${prefix}.args=${JSON.stringify(bridge.args)}`,
+            "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(bridge.env))}`,
+            "-c", `${prefix}.default_tools_approval_mode="auto"`,
+          );
+        }
+
+        const child = spawnCli(config.cli, appServerArgs, {
+          cwd: turn.cwd ?? homedir(),
+          env,
+          stdio: ["pipe", "pipe", "pipe"],
         });
-      } else if (turn.integrations?.localComputer) {
-        // The host daemon and isolated Local VM both arrive as a direct Cua
-        // Driver stdio MCP server. Codex sees the same computer tool surface.
-        mountMcpServer(appServerArgs, env, "computer", turn.integrations.localComputer);
-      }
-      if (turn.integrations?.phone) {
-        const bridge = turn.integrations.phone;
-        Object.assign(env, bridge.env);
-        const prefix = "mcp_servers.openmausbot_phone";
-        appServerArgs.push(
-          "-c", `${prefix}.command=${JSON.stringify(bridge.command)}`,
-          "-c", `${prefix}.args=${JSON.stringify(bridge.args)}`,
-          "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(bridge.env))}`,
-          "-c", `${prefix}.default_tools_approval_mode="auto"`,
-        );
-      }
-
-      const child = spawnCli(config.cli, appServerArgs, {
-        cwd: turn.cwd ?? homedir(),
-        env,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
 
       const state = {
         settled: false,
@@ -195,6 +202,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         // wants this turn's figure, so the last report is banked on settle
         usage: undefined as { input: number; output: number } | undefined,
       };
+
       const asks = new Map<string, (behavior: "allow" | "deny" | "answer", message?: string, source?: "user" | "timeout" | "system") => void>();
       let nextId = 1;
       const rpcPending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
@@ -227,7 +235,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           send({ jsonrpc: "2.0", id, method, params });
         });
 
-      const stop = () => killCliTree(child);
+      const stop = () => {
+        stopRequested = true;
+        killCliTree(child);
+      };
 
       const settle = (ok: boolean, stopReason: string | null) => {
         if (state.settled) return;
@@ -473,129 +484,154 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       active.set(threadId, { stop, turnId, asks });
       emit({ ...base(threadId, turnId), type: "turn.started" });
 
-      // handshake + kickoff; any refusal surfaces as failure, not a hang
-      (async () => {
-        try {
-          await request("initialize", { clientInfo: { name: "openmausbot", version: "1" } });
-          send({ jsonrpc: "2.0", method: "initialized", params: {} });
-          const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
-          let codexThreadId: string | null = null;
-          let startedModel: string | null = null;
-          if (cursor) {
-            try {
-              const resumed = await request("thread/resume", { threadId: cursor });
-              codexThreadId = resumed?.thread?.id ?? cursor;
-            } catch {
-              /* resume unsupported or thread gone — start fresh below */
-            }
-          }
-          if (!codexThreadId) {
-            const selection = decodeCodexSelection(turn.model);
-            const started = await request("thread/start", {
-              cwd: turn.cwd ?? homedir(),
-              model: selection.model,
-              ...(selection.modelProvider ? { modelProvider: selection.modelProvider } : {}),
-              sandbox: config.fullAuto ? "danger-full-access" : "workspace-write",
-              approvalPolicy: config.fullAuto ? "never" : "on-request",
-              ephemeral: false,
-            });
-            codexThreadId = started?.thread?.id ?? null;
-            startedModel = started?.model ?? null;
-          }
-          emit({ ...base(threadId, turnId), type: "session.started", sessionId: codexThreadId, model: startedModel ?? turn.model ?? null });
-          await request("turn/start", {
-            threadId: codexThreadId,
-            input: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
-            // Spread, not `effort: turn.effort ?? null`. Probed against
-            // codex-cli 0.146.0: null is indistinguishable from an absent key
-            // — both leave the thread's current effort alone, emitting no
-            // thread/settings/updated, and thread/resume reads the old value
-            // back. The app-server offers no way to clear a level either:
-            // "" is rejected outright and thread/start takes no effort at
-            // all. So a thread keeps the last level it was sent until it is
-            // sent another, and choosing Default lands on the bot's next new
-            // thread rather than the current one.
-            ...(turn.effort ? { effort: turn.effort } : {}),
-          });
-        } catch (e) {
-          if (!state.settled) {
-            const message = e instanceof Error ? e.message : String(e);
-            const needsAuth = /(?:\b401\b|unauthorized|missing bearer|authentication required)/i.test(message);
-            emit({
-              ...base(threadId, turnId),
-              type: "runtime.error",
-              message,
-              ...(needsAuth ? { setup: true } : {}),
-            });
-            settle(false, needsAuth ? "auth_required" : "rpc_error");
+      // handshake + kickoff; a transient failure (5xx/overloaded/reset) gets
+      // one relaunch of the whole app-server after backoff — but only when
+      // nothing streamed yet, and never for auth/shape errors or interrupts
+      try {
+        await request("initialize", { clientInfo: { name: "openmausbot", version: "1" } });
+        send({ jsonrpc: "2.0", method: "initialized", params: {} });
+        const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
+        let codexThreadId: string | null = null;
+        let startedModel: string | null = null;
+        if (cursor) {
+          try {
+            const resumed = await request("thread/resume", { threadId: cursor });
+            codexThreadId = resumed?.thread?.id ?? cursor;
+          } catch {
+            /* resume unsupported or thread gone — start fresh below */
           }
         }
-      })();
-
-      return { turnId };
+        if (!codexThreadId) {
+          const selection = decodeCodexSelection(turn.model);
+          const started = await request("thread/start", {
+            cwd: turn.cwd ?? homedir(),
+            model: selection.model,
+            ...(selection.modelProvider ? { modelProvider: selection.modelProvider } : {}),
+            sandbox: config.fullAuto ? "danger-full-access" : "workspace-write",
+            approvalPolicy: config.fullAuto ? "never" : "on-request",
+            ephemeral: false,
+          });
+          codexThreadId = started?.thread?.id ?? null;
+          startedModel = started?.model ?? null;
+        }
+        emit({ ...base(threadId, turnId), type: "session.started", sessionId: codexThreadId, model: startedModel ?? turn.model ?? null });
+        await request("turn/start", {
+          threadId: codexThreadId,
+          input: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
+          // Spread, not `effort: turn.effort ?? null`. Probed against
+          // codex-cli 0.146.0: null is indistinguishable from an absent key
+          // — both leave the thread's current effort alone, emitting no
+          // thread/settings/updated, and thread/resume reads the old value
+          // back. The app-server offers no way to clear a level either:
+          // "" is rejected outright and thread/start takes no effort at
+          // all. So a thread keeps the last level it was sent until it is
+          // sent another, and choosing Default lands on the bot's next new
+          // thread rather than the current one.
+          ...(turn.effort ? { effort: turn.effort } : {}),
+        });
+      } catch (e) {
+        const failure = e instanceof Error ? e : { text: String(e) };
+        const message = e instanceof Error ? e.message : String(e);
+        const needsAuth = /(?:\b401\b|unauthorized|missing bearer|authentication required)/i.test(message);
+        const verdict = classifyError(failure);
+        if (!state.settled && !needsAuth && verdict.transient && attempt < RETRY_MAX_ATTEMPTS - 1 && state.sawStreamDelta === false) {
+          const delayMs = computeBackoff(attempt);
+          attempt++;
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.retrying",
+            attempt,
+            delayMs,
+            reason: verdict.reason,
+          });
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, Math.max(1, Math.round(delayMs * retryScale)));
+            timer.unref?.();
+          });
+          if (!state.settled && !stopRequested) {
+            void launchAttempt(attempt).catch(() => {});
+          } else if (!state.settled) {
+            settle(false, "interrupted");
+          }
+          return;
+        }
+        if (!state.settled) {
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message,
+            ...(needsAuth ? { setup: true } : {}),
+          });
+          settle(false, needsAuth ? "auth_required" : "rpc_error");
+        }
+      }
     };
 
-    const snapshot = async (): Promise<ProviderSnapshot> => {
-      const env = childEnv();
-      const version = await new Promise<string | null>((resolve) => {
-        execCli(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
-          resolve(err ? null : stdout.trim()),
-        );
-      });
-      if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
-      const authenticated = await new Promise<boolean>((resolve) => {
-        execCli(config.cli, ["login", "status"], { timeout: 8000, env }, (err, stdout, stderr) =>
-          resolve(!err && /^logged in\b/im.test(`${stdout}\n${stderr ?? ""}`)),
-        );
-      });
-      // childEnv drops OPENAI_API_KEY on purpose — turns run on the ChatGPT login
-      return { state: "available", version, authenticated, billing: "subscription" };
-    };
+    void launchAttempt(0).catch(() => {});
+    return { turnId };
+  };
 
-    return {
-      instanceId,
-      driverKind: DRIVER_KIND,
-      displayName: input.displayName,
-      enabled: input.enabled,
-      get models() {
-        return models;
+  const snapshot = async (): Promise<ProviderSnapshot> => {
+    const env = childEnv();
+    const version = await new Promise<string | null>((resolve) => {
+      execCli(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
+        resolve(err ? null : stdout.trim()),
+      );
+    });
+    if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+    const authenticated = await new Promise<boolean>((resolve) => {
+      execCli(config.cli, ["login", "status"], { timeout: 8000, env }, (err, stdout, stderr) =>
+        resolve(!err && /^logged in\b/im.test(`${stdout}\n${stderr ?? ""}`)),
+      );
+    });
+    // childEnv drops OPENAI_API_KEY on purpose — turns run on the ChatGPT login
+    return { state: "available", version, authenticated, billing: "subscription" };
+  };
+
+  return {
+    instanceId,
+    driverKind: DRIVER_KIND,
+    displayName: input.displayName,
+    enabled: input.enabled,
+    get models() {
+      return models;
+    },
+    refreshModels,
+    snapshot,
+    adapter: {
+      provider: DRIVER_KIND,
+      capabilities: {
+        sessionModelSwitch: "unsupported",
+        computerMcp: true,
+        localComputerMcp: true,
+        composioMcp: true,
+        agentsMcp: true,
+        phoneMcp: true,
+        images: true,
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
-      refreshModels,
-      snapshot,
-      adapter: {
-        provider: DRIVER_KIND,
-        capabilities: {
-          sessionModelSwitch: "unsupported",
-          computerMcp: true,
-          localComputerMcp: true,
-          composioMcp: true,
-          agentsMcp: true,
-          phoneMcp: true,
-          images: true,
-          effortLevels: ["low", "medium", "high", "xhigh", "max"],
-        },
-        sendTurn,
-        interruptTurn: async (threadId) => active.get(threadId)?.stop(),
-        respondToRequest: async (threadId, requestId, decision) => {
-          const turn = active.get(threadId);
-          const finish = turn?.asks.get(requestId);
-          if (!finish) return "unavailable"; // settled, timed out, or turn gone
-          finish(decision.behavior, decision.message, "user");
-          return decision.behavior === "allow" ? "allowed-once" : decision.behavior === "answer" ? "answered" : "rejected";
-        },
-        hasSession: (threadId) => active.has(threadId),
-        stopAll: async () => {
-          for (const { stop } of active.values()) stop();
-        },
-        onEvent: (listener) => {
-          listeners.add(listener);
-          return () => listeners.delete(listener);
-        },
+      sendTurn,
+      interruptTurn: async (threadId) => active.get(threadId)?.stop(),
+      respondToRequest: async (threadId, requestId, decision) => {
+        const turn = active.get(threadId);
+        const finish = turn?.asks.get(requestId);
+        if (!finish) return "unavailable"; // settled, timed out, or turn gone
+        finish(decision.behavior, decision.message, "user");
+        return decision.behavior === "allow" ? "allowed-once" : decision.behavior === "answer" ? "answered" : "rejected";
       },
-      dispose: async () => {
+      hasSession: (threadId) => active.has(threadId),
+      stopAll: async () => {
         for (const { stop } of active.values()) stop();
-        listeners.clear();
       },
-    };
-  },
+      onEvent: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+    dispose: async () => {
+      for (const { stop } of active.values()) stop();
+      listeners.clear();
+    },
+  };
+},
 };

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -486,7 +486,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       });
 
       active.set(threadId, { stop, turnId, asks });
-      emit({ ...base(threadId, turnId), type: "turn.started" });
+      // Relaunching the app-server is still the same logical turn. Keep the
+      // active process current on every attempt, but announce the turn once.
+      if (attempt === 0) emit({ ...base(threadId, turnId), type: "turn.started" });
 
       // handshake + kickoff; a transient failure (5xx/overloaded/reset) gets
       // one relaunch of the whole app-server after backoff — but only when

--- a/server/drivers/grok.test.ts
+++ b/server/drivers/grok.test.ts
@@ -1,0 +1,172 @@
+// Grok driver contract tests — the API-backed driver rides fetch, so the
+// fake is a stubbed globalThis.fetch that scripts HTTP failures and SSE
+// bodies. Covers the auto-retry policy: transient (429/5xx) retried with
+// backoff, terminal (401/400) never, partial streamed output never.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ProviderInstance } from "../contracts.ts";
+import { recordEvents, type EventRecorder } from "../testing/events.ts";
+import { GrokDriver } from "./grok.ts";
+
+const SSE_BODY = (text: string) =>
+  [
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}`,
+    "data: [DONE]",
+    "",
+  ].join("\n");
+
+const sseResponse = (body: string) =>
+  new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+
+describe("GrokDriver turns (fake fetch)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+  let previousFetch: typeof globalThis.fetch;
+  /** Script of responses/errors consumed in order; empty = succeed with text. */
+  let script: Array<{ status?: number; sse?: string }> = [];
+  let calls = 0;
+
+  const create = async () => {
+    instance = await GrokDriver.create({
+      instanceId: "grok-test",
+      displayName: "Grok Test",
+      environment: { XAI_API_KEY: "xai-fake" },
+      enabled: true,
+      config: { url: "https://fake.xai.invalid/v1", apiKeyEnv: "XAI_API_KEY" },
+    });
+    recorder = recordEvents(instance.adapter);
+  };
+
+  beforeEach(() => {
+    process.env.FAKE_GROK_RETRY_SCALE = "0.001";
+    previousFetch = globalThis.fetch;
+    calls = 0;
+    // SAFETY: the stub only returns real Response objects, the sole member
+    // of fetch's return type this driver consumes.
+    globalThis.fetch = (async () => {
+      const step = script.shift();
+      calls++;
+      if (!step || step.sse !== undefined) return sseResponse(step?.sse ?? SSE_BODY("done from fake grok"));
+      return new Response(`HTTP ${step.status} body`, { status: step.status });
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = previousFetch;
+    delete process.env.FAKE_GROK_RETRY_SCALE;
+    recorder?.stop();
+    await instance?.dispose();
+  });
+
+  it("normalizes a full turn into the canonical event sequence", async () => {
+    script = [];
+    await create();
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-happy", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(recorder.events.map((e) => e.type)).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "item.completed", // assistant_text
+      "turn.completed",
+    ]);
+    expect(recorder.events.every((e) => e.turnId === turnId && e.provider === "grok")).toBe(true);
+    expect(recorder.events.find((e) => e.type === "item.completed")).toMatchObject({
+      itemType: "assistant_text",
+      text: "done from fake grok",
+    });
+  });
+
+  it("auto-retries transient 429/5xx responses, then completes once", async () => {
+    script = [{ status: 429 }, { status: 503 }];
+    await create();
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-retry", text: "go" });
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === true);
+
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+    expect(retries.every((e) => e.delayMs > 0)).toBe(true);
+    expect(retries.map((e) => e.reason)).toEqual(["rate_limited", "server_error"]);
+    // exactly one settled reply across all three attempts
+    expect(recorder.events.filter((e) => e.type === "item.completed" && e.itemType === "assistant_text")).toHaveLength(1);
+    expect(calls).toBe(3);
+    expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true, turnId });
+  }, 20_000);
+
+  it("stops at the attempt cap and settles as failed", async () => {
+    script = [{ status: 500 }, { status: 500 }, { status: 500 }];
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-cap", text: "go" });
+    await recorder.until((e) => e.type === "turn.completed" && e.ok === false);
+
+    const retries = recorder.events.filter((e) => e.type === "turn.retrying");
+    expect(retries.map((e) => e.attempt)).toEqual([1, 2]);
+    // original + two retries; the third failure is past the cap and fails
+    expect(calls).toBe(3);
+    expect(recorder.events.some((e) => e.type === "runtime.error")).toBe(true);
+  }, 20_000);
+
+  it("never retries a terminal auth or invalid-request failure", async () => {
+    script = [{ status: 401 }];
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-auth", text: "go" });
+    await recorder.until((e) => e.threadId === "t-auth" && e.type === "turn.completed" && e.ok === false);
+
+    expect(recorder.events.filter((e) => e.threadId === "t-auth" && e.type === "turn.retrying")).toHaveLength(0);
+    expect(calls).toBe(1);
+
+    script = [{ status: 400 }];
+    await instance.adapter.sendTurn({ threadId: "t-badreq", text: "go" });
+    await recorder.until((e) => e.threadId === "t-badreq" && e.type === "turn.completed" && e.ok === false);
+    expect(recorder.events.filter((e) => e.type === "turn.retrying" && e.threadId === "t-badreq")).toHaveLength(0);
+  }, 20_000);
+
+  it("never retries after assistant text already streamed (duplicate-text hazard)", async () => {
+    // an SSE body whose stream ERRORS after delivering a delta — the
+    // partial-output guard must forbid the retry that would duplicate it
+    const failingStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "half an answer" } }] })}\n\n`));
+        setTimeout(() => controller.error(new Error("connection reset by peer")), 10);
+      },
+    });
+    previousFetch = globalThis.fetch;
+    // SAFETY: a real Response built from a live stream, same as above.
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(failingStream, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-partial", text: "go" });
+    await recorder.until((e) => e.threadId === "t-partial" && e.type === "turn.completed" && e.ok === false);
+
+    expect(recorder.events.some((e) => e.type === "content.delta" && e.streamKind === "assistant_text")).toBe(true);
+    expect(recorder.events.filter((e) => e.threadId === "t-partial" && e.type === "turn.retrying")).toHaveLength(0);
+    expect(calls).toBe(1);
+  }, 20_000);
+
+  it("an interrupt during the retry backoff cancels cleanly without another attempt", async () => {
+    script = [{ status: 503 }];
+    process.env.FAKE_GROK_RETRY_SCALE = "60"; // long backoff — we cancel inside it
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-cancel-backoff", text: "go" });
+    await recorder.until((e) => e.type === "turn.retrying");
+
+    await instance.adapter.interruptTurn("t-cancel-backoff");
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(recorder.events.filter((e) => e.type === "turn.retrying")).toHaveLength(1);
+    expect(calls).toBe(1);
+    expect(recorder.events.at(-1)).toMatchObject({
+      type: "turn.completed",
+      ok: false,
+      stopReason: "interrupted",
+    });
+  }, 20_000);
+
+  it("declares no interactive channels this engine cannot honor", async () => {
+    script = [];
+    await create();
+    await expect(instance.adapter.respondToRequest("t-x", "r", { behavior: "allow" })).resolves.toBe("unavailable");
+  });
+});

--- a/server/drivers/grok.test.ts
+++ b/server/drivers/grok.test.ts
@@ -131,7 +131,6 @@ describe("GrokDriver turns (fake fetch)", () => {
         setTimeout(() => controller.error(new Error("connection reset by peer")), 10);
       },
     });
-    previousFetch = globalThis.fetch;
     // SAFETY: a real Response built from a live stream, same as above.
     globalThis.fetch = (async () => {
       calls++;

--- a/server/drivers/grok.ts
+++ b/server/drivers/grok.ts
@@ -13,6 +13,7 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { newEventId, newId } from "../contracts.ts";
+import { classifyError, computeBackoff, interruptibleDelay, RETRY_MAX_ATTEMPTS } from "./retry.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "grok";
@@ -131,6 +132,10 @@ export const GrokDriver: ProviderDriver<GrokConfig> = {
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
       const turnId = newId();
       const abort = new AbortController();
+      let streamedText = false;
+      // the backoff is scaled down in tests so a fake's transient failures
+      // don't stall real seconds
+      const retryScale = Number(process.env.FAKE_GROK_RETRY_SCALE ?? "1");
       active.set(threadId, { abort, turnId });
 
       const messages = [
@@ -147,35 +152,69 @@ export const GrokDriver: ProviderDriver<GrokConfig> = {
       emit({ ...base(threadId, turnId), type: "session.started", sessionId: null, model: turn.model ?? MODELS.default });
 
       (async () => {
-        try {
-          const { text, usage } = await complete(messages, turn.model || MODELS.default, {
-            stream: true,
-            signal: abort.signal,
-            onDelta: (delta) =>
-              emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta }),
-          });
-          appendNative(threadId, { dir: "in", source: "xai.chat.completions", msg: { text, usage } });
-          if (text.trim()) {
-            emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+        let attempt = 0;
+        for (;;) {
+          try {
+            const { text, usage } = await complete(messages, turn.model || MODELS.default, {
+              stream: true,
+              signal: abort.signal,
+              onDelta: (delta) => {
+                streamedText = true;
+                emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
+              },
+            });
+            appendNative(threadId, { dir: "in", source: "xai.chat.completions", msg: { text, usage } });
+            if (text.trim()) {
+              emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text });
+            }
+            if (usage) {
+              emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+            }
+            active.delete(threadId);
+            emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
+            return;
+          } catch (e) {
+            const aborted = (e as Error).name === "AbortError";
+            const failure = e instanceof Error ? e : { text: String(e) };
+            const verdict = classifyError(failure);
+            if (!aborted && !streamedText && verdict.transient && attempt < RETRY_MAX_ATTEMPTS - 1) {
+              const delayMs = computeBackoff(attempt);
+              attempt++;
+              emit({
+                ...base(threadId, turnId),
+                type: "turn.retrying",
+                attempt,
+                delayMs,
+                reason: verdict.reason,
+              });
+              const wait = interruptibleDelay(delayMs * retryScale, abort.signal);
+              const outcome = await wait.promise;
+              if (outcome === "cancelled" || abort.signal.aborted) {
+                active.delete(threadId);
+                emit({
+                  ...base(threadId, turnId),
+                  type: "turn.completed",
+                  ok: false,
+                  stopReason: "interrupted",
+                  cost: null,
+                });
+                return;
+              }
+              continue;
+            }
+            active.delete(threadId);
+            if (!aborted) {
+              emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
+            }
+            emit({
+              ...base(threadId, turnId),
+              type: "turn.completed",
+              ok: false,
+              stopReason: aborted ? "interrupted" : "error",
+              cost: null,
+            });
+            return;
           }
-          if (usage) {
-            emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
-          }
-          active.delete(threadId);
-          emit({ ...base(threadId, turnId), type: "turn.completed", ok: true, stopReason: null, cost: null });
-        } catch (e) {
-          active.delete(threadId);
-          const aborted = (e as Error).name === "AbortError";
-          if (!aborted) {
-            emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
-          }
-          emit({
-            ...base(threadId, turnId),
-            type: "turn.completed",
-            ok: false,
-            stopReason: aborted ? "interrupted" : "error",
-            cost: null,
-          });
         }
       })();
 

--- a/server/drivers/retry.test.ts
+++ b/server/drivers/retry.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { BACKOFF_BASE_MS, RETRY_MAX_ATTEMPTS, classifyError, computeBackoff } from "./retry.ts";
+
+describe("classifyError", () => {
+  it("calls provider rate limits transient", () => {
+    expect(classifyError(new Error("xAI HTTP 429: Too Many Requests"))).toEqual({
+      transient: true,
+      reason: "rate_limited",
+    });
+    expect(classifyError({ text: "rate limit exceeded, slow down" })).toEqual({
+      transient: true,
+      reason: "rate_limited",
+    });
+  });
+
+  it("calls 5xx and overloaded transient", () => {
+    expect(classifyError(new Error("xAI HTTP 503: Service Unavailable"))).toEqual({
+      transient: true,
+      reason: "server_error",
+    });
+    expect(classifyError(new Error("Internal Server Error"))).toEqual({ transient: true, reason: "server_error" });
+    expect(classifyError(new Error("The API is temporarily overloaded"))).toEqual({
+      transient: true,
+      reason: "overloaded",
+    });
+    expect(classifyError(new Error("upstream error (529 overloaded)"))).toEqual({
+      transient: true,
+      reason: "overloaded",
+    });
+  });
+
+  it("calls connection failures and timeouts transient", () => {
+    expect(classifyError(new Error("fetch failed"))).toMatchObject({ transient: true });
+    expect(classifyError(new Error("read ECONNRESET"))).toMatchObject({ transient: true, reason: "connection_reset" });
+    expect(classifyError(new Error("request timed out after 120000ms"))).toMatchObject({
+      transient: true,
+      reason: "timeout",
+    });
+  });
+
+  it("never retries auth, quota, unknown model, or invalid request", () => {
+    expect(classifyError(new Error("unexpected status 401 Unauthorized: Missing bearer"))).toEqual({
+      transient: false,
+      reason: "auth",
+    });
+    expect(classifyError(new Error("invalid api key"))).toEqual({ transient: false, reason: "auth" });
+    expect(classifyError(new Error("quota exceeded for this plan"))).toEqual({ transient: false, reason: "quota" });
+    expect(classifyError(new Error("model not found: grok-99"))).toEqual({
+      transient: false,
+      reason: "unknown_model",
+    });
+    expect(classifyError(new Error("400 invalid request body"))).toEqual({
+      transient: false,
+      reason: "invalid_request",
+    });
+  });
+
+  it("treats a bare nonzero CLI exit as terminal", () => {
+    expect(classifyError({ exitCode: 3 })).toEqual({ transient: false, reason: "terminal_exit" });
+  });
+
+  it("never retries a signal kill or interrupt", () => {
+    expect(classifyError({ exitCode: -1 })).toEqual({ transient: false, reason: "interrupted" });
+    expect(classifyError(new Error("interrupted"))).toEqual({ transient: false, reason: "interrupted" });
+    expect(classifyError(new Error("turn cancelled by user"))).toEqual({ transient: false, reason: "interrupted" });
+  });
+
+  it("prefers the transient reading when stderr carries both shapes", () => {
+    // a crash whose stderr mentions throttling is worth one more try
+    expect(classifyError({ exitCode: 1, stderr: "error: 429 too many requests" })).toEqual({
+      transient: true,
+      reason: "rate_limited",
+    });
+  });
+
+  it("classifies unrecognizable input as terminal", () => {
+    expect(classifyError(null)).toEqual({ transient: false, reason: "unknown" });
+    expect(classifyError(new Error(""))).toEqual({ transient: false, reason: "unknown" });
+  });
+});
+
+describe("computeBackoff", () => {
+  it("follows the capped exponential schedule", () => {
+    expect(BACKOFF_BASE_MS).toHaveLength(RETRY_MAX_ATTEMPTS);
+    for (const [attempt, base] of BACKOFF_BASE_MS.entries()) {
+      const mid = computeBackoff(attempt, () => 0.5);
+      expect(mid).toBe(base);
+    }
+  });
+
+  it("jitter stays within ±25% of the schedule", () => {
+    for (const attempt of [0, 1, 2, 5]) {
+      const low = computeBackoff(attempt, () => 0);
+      const high = computeBackoff(attempt, () => 1);
+      const base = BACKOFF_BASE_MS[Math.min(attempt, BACKOFF_BASE_MS.length - 1)];
+      expect(low).toBeGreaterThanOrEqual(base * 0.75);
+      expect(high).toBeLessThanOrEqual(base * 1.25 + 1);
+    }
+  });
+});

--- a/server/drivers/retry.ts
+++ b/server/drivers/retry.ts
@@ -1,0 +1,149 @@
+// Transient-failure classification + capped backoff for turn drivers
+// (plan v2 §3.4). Pure functions — no timers, no events — so the drivers
+// keep owning process lifetime while sharing one policy: a provider hiccup
+// (429/5xx/overloaded/reset) gets up to MAX_ATTEMPTS tries, an auth or
+// request-shape problem never does.
+import type { ProviderErrorCode } from "../contracts.ts";
+
+export const RETRY_MAX_ATTEMPTS = 3;
+
+/** Backoff schedule before attempt N (N is 1-based over retries): 1s / 3s / 8s. */
+export const BACKOFF_BASE_MS = [1_000, 3_000, 8_000] as const;
+
+export type TransientReason =
+  | "rate_limited"
+  | "overloaded"
+  | "server_error"
+  | "connection_reset"
+  | "timeout";
+
+export type TerminalReason =
+  | "auth"
+  | "quota"
+  | "unknown_model"
+  | "invalid_request"
+  | "not_found"
+  | ProviderErrorCode
+  | "terminal_exit"
+  | "interrupted"
+  | "unknown";
+
+export interface ErrorClassification {
+  transient: boolean;
+  reason: string;
+}
+
+const TRANSIENT_PATTERNS: Array<{ pattern: RegExp; reason: TransientReason }> = [
+  { pattern: /\b(?:429|rate.?limit|too many requests)\b/i, reason: "rate_limited" },
+  { pattern: /\boverloaded\b|\bcapacity\b/i, reason: "overloaded" },
+  { pattern: /\b5\d{2}\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b/i, reason: "server_error" },
+  {
+    pattern:
+      /\b(?:econnreset|econnrefused|epipe|etimedout|eai_again|connection reset|connection refused|socket hang up|network error|fetch failed)\b/i,
+    reason: "connection_reset",
+  },
+  { pattern: /\btimeout(ed)?\b|\btimed? out\b/i, reason: "timeout" },
+];
+
+const TERMINAL_PATTERNS: Array<{ pattern: RegExp; reason: TerminalReason }> = [
+  {
+    pattern: /\b(?:40[13]|unauthorized|forbidden|invalid api key|missing bearer|authentication required|not logged in|logged out)\b/i,
+    reason: "auth",
+  },
+  { pattern: /\b402\b|\bquota\b|\bbilling\b|\bsubscription\b/i, reason: "quota" },
+  { pattern: /\bmodel not found\b|\bunknown model\b|\bdoes not exist for model\b|\bunsupported model\b/i, reason: "unknown_model" },
+  { pattern: /\b400\b|\b422\b|\binvalid request\b|\bmalformed\b|\bunexpected status\b/i, reason: "invalid_request" },
+  { pattern: /\b404\b|\bno such thread\b|\bthread gone\b/i, reason: "not_found" },
+  // interrupt/cancel vocabulary from the drivers' own stop paths — a turn the
+  // user stopped must never come back as an auto-retry
+  { pattern: /\b(?:interrupted|cancelled by user)\b/i, reason: "interrupted" },
+];
+
+/** A CLI exit report, as drivers assemble it from a child process's close
+ * event: the numeric exit code plus whatever stderr survived. */
+interface CliExit {
+  exitCode: number | null;
+  stderr?: string;
+}
+
+/** A bare failure message, wrapped so the classifier's inputs stay named
+ * domain values rather than unparsed primitives. */
+interface FailureText {
+  text: string;
+}
+
+/** The failure shapes drivers actually hand the classifier. */
+type FailureInput = Error | CliExit | FailureText | null;
+
+const messageOf = (err: FailureInput): string => {
+  if (!err) return "";
+  if (err instanceof Error) return `${err.message}${err.cause ? ` ${String(err.cause)}` : ""}`;
+  if ("text" in err) return err.text;
+  return [err.stderr ?? "", ""].join(" ").trim();
+};
+
+/** Classify a thrown error or a CLI exit into retry-worthy vs terminal.
+ *
+ * Exit-report shape: a nonzero exit with no error text is treated as
+ * terminal (`terminal_exit`) — drivers only reach it after the CLI already
+ * reported its own protocol-level failure. A signal kill (negative code) is
+ * never retried either.
+ */
+export function classifyError(err: FailureInput): ErrorClassification {
+  const text = messageOf(err);
+  if (err && "exitCode" in err) {
+    const { exitCode: code } = err;
+    if (code !== null && code < 0) return { transient: false, reason: "interrupted" };
+    for (const { pattern, reason } of TRANSIENT_PATTERNS) {
+      if (pattern.test(text)) return { transient: true, reason };
+    }
+    for (const { pattern, reason } of TERMINAL_PATTERNS) {
+      if (pattern.test(text)) return { transient: false, reason };
+    }
+    return { transient: false, reason: "terminal_exit" };
+  }
+  for (const { pattern, reason } of TERMINAL_PATTERNS) {
+    if (pattern.test(text)) return { transient: false, reason };
+  }
+  for (const { pattern, reason } of TRANSIENT_PATTERNS) {
+    if (pattern.test(text)) return { transient: true, reason };
+  }
+  return { transient: false, reason: "unknown" };
+}
+
+/** Capped exponential delay with jitter, in milliseconds. Attempt 0 (the
+ * first retry) waits ~1s, then ~3s, then ~8s; beyond that the cap holds.
+ * Jitter stays within ±25% so tests can bound it and a thundering herd of
+ * bots doesn't re-sync on the same tick. */
+export function computeBackoff(attempt: number, random: () => number = Math.random): number {
+  const base = BACKOFF_BASE_MS[Math.min(Math.max(attempt, 0), BACKOFF_BASE_MS.length - 1)];
+  const jitter = base * 0.25;
+  return Math.round(base - jitter + random() * jitter * 2);
+}
+
+/** A cancellable backoff sleep. An interrupt during the wait resolves at
+ * once with "cancelled" — the caller settles the turn as interrupted
+ * instead of relaunching, so no zombie process outlives the user's stop. */
+export interface BackoffWait {
+  promise: Promise<"elapsed" | "cancelled">;
+  cancel: () => void;
+}
+
+export function interruptibleDelay(ms: number, signal?: AbortSignal): BackoffWait {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let onCancel: (() => void) | null = null;
+  const promise = new Promise<"elapsed" | "cancelled">((resolve) => {
+    timer = setTimeout(() => resolve("elapsed"), Math.max(1, ms));
+    timer.unref?.();
+    if (signal?.aborted) return resolve("cancelled");
+    onCancel = () => {
+      clearTimeout(timer!);
+      resolve("cancelled");
+    };
+    signal?.addEventListener("abort", onCancel, { once: true });
+  });
+  return {
+    promise,
+    cancel: () => onCancel?.(),
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -61,6 +61,7 @@ import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts"
 import { describeSpawnFailure, execCli } from "./procs.ts";
 import { buildNotification, type Notification } from "./notify.ts";
 import { isEffortLevel, type RequestOutcome, type RuntimeEvent } from "./contracts.ts";
+import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
@@ -941,6 +942,15 @@ bus.subscribe((event: RuntimeEvent) => {
       }
       break;
     }
+    case "turn.retrying":
+      // the driver is about to relaunch the turn after a transient failure;
+      // the activity chip keeps the bot visibly busy through the backoff
+      pushMessage({
+        role: "bot",
+        kind: "activity",
+        tool: { name: `retry ${event.attempt}/${RETRY_MAX_ATTEMPTS} in ${Math.round(event.delayMs / 1000)}s — ${event.reason}`, ok: true },
+      });
+      break;
     case "runtime.error":
       pushMessage({
         role: "bot",

--- a/server/index.ts
+++ b/server/index.ts
@@ -948,7 +948,7 @@ bus.subscribe((event: RuntimeEvent) => {
       pushMessage({
         role: "bot",
         kind: "activity",
-        tool: { name: `retry ${event.attempt}/${RETRY_MAX_ATTEMPTS} in ${Math.round(event.delayMs / 1000)}s — ${event.reason}`, ok: true },
+        tool: { name: `retrying — attempt ${event.attempt + 1}/${RETRY_MAX_ATTEMPTS} in ${Math.round(event.delayMs / 1000)}s — ${event.reason}`, ok: true },
       });
       break;
     case "runtime.error":

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -498,6 +498,10 @@ export class RoutineManager {
       run.output = event.text.trim().slice(0, 2_000);
     } else if (event.type === "runtime.error") {
       run.error = event.message.slice(0, 500);
+    } else if (event.type === "turn.retrying") {
+      // the driver will relaunch this same run; a transient blip is not a
+      // receipt-worthy failure, so keep the run running and stay quiet
+      return null;
     } else if (event.type === "turn.completed") {
       run.cost = event.cost;
       run.denials = event.denials;

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -109,6 +109,29 @@ const playTurn = (prompt: JsonValue) => {
     process.stderr.write("fake-claude: simulated crash before result\n");
     process.exit(3);
   }
+  // transient-failure script for retry tests. FAKE_CLAUDE_TRANSIENTS is how
+  // many launches fail transiently (503-shaped stderr, exit 5); the count of
+  // launches so far lives in a state FILE because child processes cannot
+  // mutate the parent's environment. When the quota is exhausted (or
+  // FAKE_CLAUDE_STATE is unset) the turn completes normally.
+  // FAKE_CLAUDE_PARTIAL_FAILS makes the FIRST launch emit a text delta
+  // before failing — the partial-output guard must forbid retrying it.
+  if (process.env.FAKE_CLAUDE_TRANSIENTS && process.env.FAKE_CLAUDE_STATE) {
+    let launched = 0;
+    try {
+      launched = Number(readFileSync(process.env.FAKE_CLAUDE_STATE, "utf8")) || 0;
+    } catch {}
+    const quota = Number(process.env.FAKE_CLAUDE_TRANSIENTS) || 0;
+    writeFileSync(process.env.FAKE_CLAUDE_STATE, String(launched + 1));
+    out({ type: "system", subtype: "init", session_id: sessionId, model });
+    if (launched < quota) {
+      if (process.env.FAKE_CLAUDE_PARTIAL_FAILS) {
+        out({ type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "half an answer" } } });
+      }
+      process.stderr.write("claude: API error (503): service temporarily unavailable\n");
+      process.exit(5);
+    }
+  }
 
   // the real CLI re-announces init on every turn of a live process
   out({ type: "system", subtype: "init", session_id: sessionId, model });

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -9,7 +9,7 @@
 //   FAKE_CODEX_DUMP   path to write {argv, env, calls, decision} as JSON
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CODEX_MODE ?? "happy";
 
@@ -132,6 +132,33 @@ process.stdin.on("data", (chunk) => {
             },
           });
           break;
+        }
+        // transient-failure script for retry tests. FAKE_CODEX_TRANSIENTS is
+        // how many launches fail transiently; the launch count lives in a
+        // state FILE because child processes cannot mutate the parent's env.
+        // FAKE_CODEX_PARTIAL_FAILS makes the FIRST failing turn stream a text
+        // delta first, so the partial-output guard has something to see.
+        if (process.env.FAKE_CODEX_TRANSIENTS && process.env.FAKE_CODEX_STATE) {
+          let launched = 0;
+          try {
+            launched = Number(readFileSync(process.env.FAKE_CODEX_STATE, "utf8")) || 0;
+          } catch {}
+          const quota = Number(process.env.FAKE_CODEX_TRANSIENTS) || 0;
+          writeFileSync(process.env.FAKE_CODEX_STATE, String(launched + 1));
+          if (launched < quota) {
+            if (process.env.FAKE_CODEX_PARTIAL_FAILS) {
+              out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+              notify("item/agentMessage/delta", { itemId: "m1", delta: "half an answer" });
+              notify("turn/completed", { turn: { status: "failed", error: { message: "provider overloaded, try again" } } });
+              break;
+            }
+            out({
+              jsonrpc: "2.0",
+              id: msg.id,
+              error: { code: -32603, message: "provider returned 503: upstream capacity exceeded" },
+            });
+            break;
+          }
         }
         out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
         const command = mode === "windows-command"

--- a/server/thread-events.test.ts
+++ b/server/thread-events.test.ts
@@ -99,6 +99,25 @@ describe("readThreadEvents", () => {
     expect(page.total).toEqual({ runtime: 3, native: 2 });
   });
 
+  it("rejects malformed retry telemetry while retaining a valid retry event", () => {
+    const eventsDir = tmp();
+    const nativeDir = tmp();
+    const retry = (eventId: string, attempt: unknown, delayMs: unknown, reason: unknown) =>
+      runtime({ eventId, createdAt: eventId, type: "turn.retrying", attempt, delayMs, reason });
+    writeFileSync(
+      join(eventsDir, "t1.ndjson"),
+      line(retry("fractional", 1.5, 1_000, "overloaded")) +
+        line(retry("negative-attempt", -1, 1_000, "overloaded")) +
+        line(retry("negative-delay", 1, -1, "overloaded")) +
+        line(retry("infinite-delay", 1, Number.POSITIVE_INFINITY, "overloaded")) +
+        line(retry("missing-reason", 1, 1_000, undefined)) +
+        line(retry("valid-retry", 1, 1_000, "overloaded")),
+    );
+
+    const page = readThreadEvents({ eventsDir, nativeDir, threadId: "t1" });
+    expect(page.entries.map((entry) => (entry.data as { eventId: string }).eventId)).toEqual(["valid-retry"]);
+  });
+
   it("keeps walking backward when a corrupt tail record would otherwise consume the limit", () => {
     const eventsDir = tmp();
     const nativeDir = tmp();

--- a/server/thread-events.ts
+++ b/server/thread-events.ts
@@ -158,6 +158,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 const stringOrMissing = (value: unknown) => value === undefined || typeof value === "string";
 const stringOrNullOrMissing = (value: unknown) => value === undefined || value === null || typeof value === "string";
 const numberOrNullOrMissing = (value: unknown) => value === undefined || value === null || typeof value === "number";
+const numberIs = (value: unknown) => typeof value === "number";
 const stringsOrMissing = (value: unknown) => value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"));
 
 function isRuntimeEvent(value: unknown): value is RuntimeEvent {
@@ -180,6 +181,12 @@ function isRuntimeEvent(value: unknown): value is RuntimeEvent {
       return stringOrMissing(value.reason);
     case "turn.started":
       return true;
+    case "turn.retrying":
+      return (
+        numberIs(value.attempt) &&
+        numberIs(value.delayMs) &&
+        stringOrMissing(value.reason)
+      );
     case "turn.completed":
       return (
         typeof value.ok === "boolean" &&

--- a/server/thread-events.ts
+++ b/server/thread-events.ts
@@ -158,7 +158,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 const stringOrMissing = (value: unknown) => value === undefined || typeof value === "string";
 const stringOrNullOrMissing = (value: unknown) => value === undefined || value === null || typeof value === "string";
 const numberOrNullOrMissing = (value: unknown) => value === undefined || value === null || typeof value === "number";
-const numberIs = (value: unknown) => typeof value === "number";
 const stringsOrMissing = (value: unknown) => value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"));
 
 function isRuntimeEvent(value: unknown): value is RuntimeEvent {
@@ -183,9 +182,13 @@ function isRuntimeEvent(value: unknown): value is RuntimeEvent {
       return true;
     case "turn.retrying":
       return (
-        numberIs(value.attempt) &&
-        numberIs(value.delayMs) &&
-        stringOrMissing(value.reason)
+        typeof value.attempt === "number" &&
+        Number.isInteger(value.attempt) &&
+        value.attempt >= 1 &&
+        typeof value.delayMs === "number" &&
+        Number.isFinite(value.delayMs) &&
+        value.delayMs >= 0 &&
+        typeof value.reason === "string"
       );
     case "turn.completed":
       return (

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -69,6 +69,8 @@ export function summarizeRuntime(e: RuntimeEvent): { summary: string; tone: Insp
       return { summary: `session exited${e.reason ? ` · ${e.reason}` : ""}`, tone: "plain" };
     case "turn.started":
       return { summary: `turn started${e.turnId ? ` · ${e.turnId.slice(0, 8)}` : ""}`, tone: "boundary" };
+    case "turn.retrying":
+      return { summary: `retrying (${e.reason}) · attempt ${e.attempt} · ${Math.round(e.delayMs / 1000)}s`, tone: "plain" };
     case "turn.completed": {
       const parts = [e.ok ? "turn ok" : "turn failed"];
       if (e.stopReason) parts.push(e.stopReason);


### PR DESCRIPTION
## Summary
A provider hiccup (429 / overloaded / 5xx / connection reset) killed a turn outright in the three main CLI drivers even though box/webhook drivers already rode out transients. This adds one shared retry policy and wires it into claude, codex, and grok.

## Changes
- **`server/drivers/retry.ts`** (new): `classifyError` sorts failures into transient (`rate_limited`, `overloaded`, `server_error`, `connection_reset`, `timeout`) vs terminal (`auth`, `quota`, `unknown_model`, `invalid_request`, `not_found`, user-interrupted); `computeBackoff` is capped 1s/3s/8s with ±25% jitter; `interruptibleDelay` makes the wait cancellable so an interrupt during backoff settles the turn instead of relaunching (no zombie processes).
- **Runtime events**: new `turn.retrying` event in `contracts.ts` carrying `{ attempt, delayMs, reason }`; handled exhaustively across transcript/thread-event/inspector switches so each retry is visible.
- **Drivers**: claude/codex/grok relaunch up to `RETRY_MAX_ATTEMPTS = 3` on transient-only failures. Terminal errors never retry. A turn that already streamed assistant text **never** auto-retries — the duplicate-text hazard outweighs the recovery. Test-scale env knobs (`FAKE_*_RETRY_SCALE`) keep tests instant.
- **Tests**: new `retry.test.ts` (10 cases: classification positives/negatives, backoff bounds + jitter determinism, cancellation) plus per-driver retry suites via the existing fake-CLI/app-server infrastructure: transient-twice-then-success produces exactly two `turn.retrying` events and one final message; terminal errors and partial-output turns produce zero retries.

## Verification
- `pnpm typecheck` — clean
- `npx vitest run server/drivers/retry.test.ts` — 10 passed
- `npx vitest run server/drivers/grok.test.ts` — 7 passed
- `npx vitest run server/drivers/claude.test.ts` — 48 passed, 1 skipped (pre-existing skip)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for temporary provider and service failures before response streaming begins.
  * Retry attempts use increasing delays and stop after a defined limit.
  * Retry progress now displays the attempt, delay, and failure reason.
  * Added support for handling interactive tool requests during Codex sessions.
* **Bug Fixes**
  * Stopping a turn now cancels pending retries promptly.
  * Retries no longer occur after assistant content has started streaming or for permanent failures.
  * Failed retries provide clearer final error and interruption handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->