### PR TITLE
feat: organize conversations into channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Secrets are write-only: the UI only ever sees "configured" flags.
 </tr>
 </table>
 
+### #️⃣ Channels for every context
+
+Keep Work, Personal, and each project in separate channels without cloning your bots. Every channel has
+its own transcript, shared instructions, working folder, responder rules, and editable bot roster. File a
+channel and its bots under a named context, then rename it or change its members whenever the team changes.
+
 ### 🎧 Bots that talk back
 
 Press the speaker on any reply, or switch a bot to read its answers out as they land — so you can listen
@@ -140,7 +146,7 @@ to what ran overnight while you make breakfast. Hit **call** and it's a conversa
 you what it's doing while it works, and asks for approvals out loud.
 
 Bring your own ElevenLabs key — paste it once in App Settings, pick a voice, and every bot can talk.
-Give a bot its own voice and a room stops sounding like one person.
+Give a bot its own voice and a channel stops sounding like one person.
 
 **Also in the box:** streaming replies with tool-run activity chips · native macOS dictation from the
 composer mic (on-device Apple speech recognition — desktop app) · SupaMaus cursor mascots with role-aware

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -559,8 +559,20 @@ describe("harness HTTP API", () => {
     expect(clearedEmpty.status).toBe(200);
     expect(clearedEmpty.body.bot).not.toHaveProperty("section");
 
-    // rooms file under the same sidebar sections, with the same contract
-    const sectionRoom = (await api("POST", "/api/groups", { name: "Filed", memberIds: [bot.id] })).body.group;
+    // Channels can be born inside a Work/Personal/project context, and can
+    // later move through the same context contract as bots.
+    const createdInContext = await api("POST", "/api/groups", {
+      name: "Filed",
+      memberIds: [bot.id, bot.id],
+      section: "  Work  ",
+    });
+    expect(createdInContext.status).toBe(201);
+    expect(createdInContext.body.group).toMatchObject({ section: "Work", memberIds: [bot.id] });
+    expect((await api("POST", "/api/groups", { name: 7, memberIds: [bot.id] })).status).toBe(400);
+    expect((await api("POST", "/api/groups", { name: "N".repeat(101), memberIds: [bot.id] })).status).toBe(400);
+    expect((await api("POST", "/api/groups", { name: "Bad context", memberIds: [bot.id], section: 7 })).status).toBe(400);
+    expect((await api("POST", "/api/groups", { name: "Long context", memberIds: [bot.id], section: "S".repeat(61) })).status).toBe(400);
+    const sectionRoom = createdInContext.body.group;
     const roomSectioned = await api("PATCH", `/api/groups/${sectionRoom.id}`, { section: "  Clients  " });
     expect(roomSectioned.status).toBe(200);
     expect(roomSectioned.body.group).toMatchObject({ section: "Clients" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -2968,18 +2968,32 @@ const server = createServer(async (req, res) => {
       return res.end(lines.join("\n"));
     }
 
-    // ── rooms (group chats) ─────────────────────────────────────────────
+    // ── channels (persisted internally as groups) ───────────────────────
     if (method === "POST" && path === "/api/groups") {
       const body = await readBody(req);
-      const memberIds = (Array.isArray(body.memberIds) ? body.memberIds : []).filter(
-        (id: unknown): id is string => typeof id === "string" && Boolean(store.bot(id)),
-      );
-      if (memberIds.length === 0) return json(res, 400, { error: "a room needs at least one bot" });
-      const name =
-        typeof body.name === "string" && body.name.trim()
-          ? body.name.trim()
-          : `${store.bot(memberIds[0])!.name} & co.`;
-      const group = store.createGroup(name, memberIds);
+      const requestedMemberIds: unknown[] = Array.isArray(body.memberIds) ? body.memberIds : [];
+      const memberIds = [
+        ...new Set(
+          requestedMemberIds.filter(
+            (id): id is string => typeof id === "string" && Boolean(store.bot(id)),
+          ),
+        ),
+      ];
+      if (memberIds.length === 0) return json(res, 400, { error: "a channel needs at least one bot" });
+      if (body.name !== undefined && typeof body.name !== "string") {
+        return json(res, 400, { error: "channel name must be a string" });
+      }
+      const name = body.name?.trim() || `${store.bot(memberIds[0])!.name} & co.`;
+      if (name.length > 100) return json(res, 400, { error: "channel name must be at most 100 characters" });
+      let section: string | undefined;
+      if (body.section !== undefined && body.section !== null) {
+        if (typeof body.section !== "string") return json(res, 400, { error: "context must be a string" });
+        section = body.section.trim() || undefined;
+        if (section && section.length > 60) {
+          return json(res, 400, { error: "context must be at most 60 characters" });
+        }
+      }
+      const group = store.createGroup(name, memberIds, false, section);
       return json(res, 201, { group: { ...group, messages: [] } });
     }
     if (method === "POST" && path === "/api/teams/export") {

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -82,6 +82,15 @@ describe("Store", () => {
     expect(reloaded.group(group.id)?.defaultResponder).toEqual({ kind: "member", botId: second.id });
   });
 
+  it("persists a channel's context when it is created", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const channel = store.createGroup("Website launch", [bot.id], false, "Work");
+
+    expect(channel.section).toBe("Work");
+    expect(new Store(selection).group(channel.id)?.section).toBe("Work");
+  });
+
   it("migrates old rooms without routing to their first member", () => {
     const store = new Store(selection);
     const first = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -565,7 +565,7 @@ export class Store {
     return this.groups.find((g) => g.threadId === threadId);
   }
 
-  createGroup(name: string, memberIds: string[], dm = false): GroupRecord {
+  createGroup(name: string, memberIds: string[], dm = false, section?: string): GroupRecord {
     const group: GroupRecord = {
       id: newId(),
       threadId: newId(),
@@ -577,6 +577,7 @@ export class Store {
       createdAt: Date.now(),
       dm: dm || undefined,
       busyBotId: null,
+      section,
     };
     this.groups.unshift(group);
     this.saveGroups();

--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -106,7 +106,7 @@ export function CallTargetButton({
           ? "Add an ElevenLabs API key so the bot can speak during calls."
           : !voiceReady
             ? voices.length > 1
-              ? "Give every room member an ElevenLabs voice before starting a room call."
+              ? "Give every channel member an ElevenLabs voice before starting a channel call."
               : "Choose an ElevenLabs voice before starting a call."
             : "";
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -161,7 +161,7 @@ export function CommandPalette() {
             autoFocus
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search bots, rooms, messages…"
+            placeholder="Search bots, channels, messages…"
             className="w-full bg-transparent text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
           />
           <kbd className="shrink-0 rounded-md border border-hairline/40 px-1.5 py-0.5 text-[11px] text-ink-secondary">
@@ -195,7 +195,7 @@ export function CommandPalette() {
           )}
           {rooms.length > 0 && (
             <div className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-              Rooms
+              Channels
             </div>
           )}
           {rooms.map((group, i) =>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -296,7 +296,7 @@ export function Composer({
                   </span>
                 )}
                 <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-ink">{peer.name}</span>
-                <span className="shrink-0 text-xs text-ink-secondary">{peer.bot ? "Agent" : "Room"}</span>
+                <span className="shrink-0 text-xs text-ink-secondary">{peer.bot ? "Agent" : "Channel"}</span>
               </button>
             ))}
           </div>

--- a/src/components/GroupCallView.tsx
+++ b/src/components/GroupCallView.tsx
@@ -297,7 +297,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
       const member = members.find((candidate) => candidate.id === approval.message.from?.botId);
       askedApproval.current = { requestId: approval.requestId, member };
       spokenIds.current.add(approval.message.id);
-      const name = member?.name ?? approval.message.from?.name ?? "A room member";
+      const name = member?.name ?? approval.message.from?.name ?? "A channel member";
       enqueueSpeech(
         name + " wants to " + approval.tool + ". " + approval.detail + ". Should I allow it?",
         member,
@@ -309,7 +309,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
       const member = members.find((candidate) => candidate.id === question.from?.botId);
       askedQuestion.current = { requestId: question.card.requestId, member };
       spokenIds.current.add(question.id);
-      const name = member?.name ?? question.from?.name ?? "A room member";
+      const name = member?.name ?? question.from?.name ?? "A channel member";
       const detail = question.card.subtitle.trim();
       const choices = question.card.options.length
         ? " The options are " + question.card.options.join(", ") + "."
@@ -389,9 +389,9 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
         ? "Push to talk"
         : "Listening"
       : phase === "sending"
-        ? "Bringing the room in"
+        ? "Bringing the channel in"
         : phase === "speaking"
-          ? (speakingMember?.name ?? "Room member") + " is speaking"
+          ? (speakingMember?.name ?? "Channel member") + " is speaking"
           : workingMember
             ? workingMember.name + " is working"
             : "Working";
@@ -457,7 +457,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
             <span className="text-ink-secondary">
               {pushToTalk
                 ? "Release Control + Option to send…"
-                : "Say a name, say “everyone,” or just talk to the room…"}
+                : "Say a name, say “everyone,” or just talk to the channel…"}
             </span>
           )
         ) : phase === "speaking" ? (

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -80,7 +80,7 @@ function PinToggle({ group, message }: { group: Group; message: Message }) {
       }
       aria-label={pinned ? "Unpin message" : "Pin message"}
       className="rounded-md p-1.5 text-ink-secondary opacity-0 transition-opacity hover:bg-raised hover:text-ink focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
-      title={pinned ? "Unpin this message" : "Pin this message to the top of the room"}
+      title={pinned ? "Unpin this message" : "Pin this message to the top of the channel"}
     >
       {pinned ? <PinOff size={14} /> : <Pin size={14} />}
     </button>
@@ -189,7 +189,7 @@ function DefaultResponderSelect({ group, members }: { group: Group; members: Bot
   const lead = responder.kind === "member" ? members.find((member) => member.id === responder.botId) : undefined;
   const title =
     responder.kind === "everyone"
-      ? "Plain messages go to every room member; @mentions override this"
+      ? "Plain messages go to every channel member; @mentions override this"
       : responder.kind === "mentions"
         ? "Only explicitly @mentioned bots respond"
         : `Plain messages go to ${lead?.name ?? "the lead bot"}; @mentions override this`;
@@ -210,14 +210,14 @@ function DefaultResponderSelect({ group, members }: { group: Group; members: Bot
         onChange={(event) => change(event.target.value)}
         className="h-8 max-w-[190px] appearance-none truncate rounded-full border border-hairline/40 bg-raised/60 py-1 pl-3 pr-7 text-[12.5px] font-medium text-ink outline-none hover:bg-raised focus:border-accent"
       >
-        <optgroup label="Room lead">
+        <optgroup label="Channel lead">
           {members.map((member) => (
             <option key={member.id} value={`member:${member.id}`}>
               Lead: {member.name}
             </option>
           ))}
         </optgroup>
-        <optgroup label="Room behavior">
+        <optgroup label="Channel behavior">
           <option value="everyone">Everyone responds</option>
           <option value="mentions">Mentions only</option>
         </optgroup>
@@ -269,14 +269,14 @@ function RoomWorkingFolder({ group }: { group: Group }) {
   return (
     <div className="rounded-xl bg-card p-4">
       <div className="text-[15px] font-medium text-ink">Working folder</div>
-      <div className="mt-0.5 text-[13px] text-ink-secondary">Where every bot in this room runs its shell and file tools.</div>
+      <div className="mt-0.5 text-[13px] text-ink-secondary">Where every bot in this channel runs its shell and file tools.</div>
       {locked ? (
         <div className="mt-3">
           <div className="truncate rounded-lg border border-hairline/40 bg-inset px-3 py-2 font-mono text-[12.5px] text-ink" title={shownCwd}>
             {shownCwd ? shortPath(shownCwd, home) : <span className="text-ink-secondary">Each bot's own folder</span>}
           </div>
           <div className="mt-2 text-[12px] text-ink-secondary">
-            Fixed after this room's first turn. Create a new room and choose its folder before sending the first message to work somewhere else.
+            Fixed after this channel's first turn. Create a new channel and choose its folder before sending the first message to work somewhere else.
           </div>
         </div>
       ) : canPick ? (
@@ -328,7 +328,7 @@ function RoomWorkingFolderChip({ group, onToggle }: { group: Group; onToggle: ()
       <button
         onClick={onToggle}
         className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
-        title="Room working folder"
+        title="Channel working folder"
       >
         <Folder size={14} />
       </button>
@@ -521,7 +521,7 @@ export function GroupView({ group }: { group: Group }) {
               type="button"
               onClick={() => setMembersOpen(true)}
               title="Manage members"
-              aria-label={`Manage members — ${members.length} ${members.length === 1 ? "bot" : "bots"} in this room`}
+              aria-label={`Manage members — ${members.length} ${members.length === 1 ? "bot" : "bots"} in this channel`}
               className="flex items-center gap-1.5 rounded-full py-0.5 pl-1 pr-1.5 hover:bg-raised/60"
             >
               {memberMauses}
@@ -549,7 +549,7 @@ export function GroupView({ group }: { group: Group }) {
                   setBulletinOpen(false);
                 }
               }}
-              placeholder="Room instructions — every bot in this room follows them (who does what, tone, goals, a task checklist…)"
+              placeholder="Channel instructions — every bot in this channel follows them (who does what, tone, goals, a task checklist…)"
               rows={4}
               className="w-full resize-none bg-transparent text-[13px] leading-relaxed text-ink placeholder:text-ink-secondary focus:outline-none"
             />
@@ -558,11 +558,11 @@ export function GroupView({ group }: { group: Group }) {
           <button
             onClick={() => setBulletinOpen(true)}
             className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-raised/40"
-            title="Room bulletin — shared instructions for every bot here"
+            title="Channel bulletin — shared instructions for every bot here"
           >
             <Pin size={12} className="shrink-0 text-ink-secondary" />
             <span className={cn("truncate text-[12.5px]", group.bulletin ? "text-ink-secondary" : "text-ink-secondary/60")}>
-              {group.bulletin.split("\n")[0] || "Add room instructions…"}
+              {group.bulletin.split("\n")[0] || "Add channel instructions…"}
             </span>
           </button>
         )}

--- a/src/components/ManageMembersPanel.tsx
+++ b/src/components/ManageMembersPanel.tsx
@@ -85,7 +85,7 @@ export function ManageMembersPanel({
     const rosterChanged =
       opened.length !== group.memberIds.length || opened.some((id, index) => id !== group.memberIds[index]);
     if (rosterChanged) {
-      setSaveError("This room's members changed while the panel was open. Close it and try again.");
+      setSaveError("This channel's members changed while the panel was open. Close it and try again.");
       return;
     }
     if (changed) {
@@ -113,8 +113,8 @@ export function ManageMembersPanel({
       >
         <div className="mb-1 text-[15px] font-semibold text-ink">Manage Members</div>
         <div className="mb-3 truncate text-[13px] text-ink-secondary">{group.name}</div>
-        <BotPickerList bots={bots} picked={picked} onToggle={toggle} emptyHint="Create a bot first — rooms are made of bots." />
-        {!memberIds.length && <div className="mt-2 text-[12px] text-ink-secondary">A room needs at least one bot.</div>}
+        <BotPickerList bots={bots} picked={picked} onToggle={toggle} emptyHint="Create a bot first — channels are made of bots." />
+        {!memberIds.length && <div className="mt-2 text-[12px] text-ink-secondary">A channel needs at least one bot.</div>}
         {saveError && (
           <div role="alert" className="mt-2 text-[12px] text-danger">
             {saveError}

--- a/src/components/RoomTurnTimeoutSettings.tsx
+++ b/src/components/RoomTurnTimeoutSettings.tsx
@@ -85,7 +85,7 @@ export function RoomTurnTimeoutSettings() {
         <span className="pr-3 text-[13px] text-ink-secondary">minutes</span>
       </div>
       <p id="room-turn-timeout-help" className="text-[12px] leading-relaxed text-ink-secondary">
-        Applies to every bot turn in rooms. Direct chats use the inactivity watchdog instead.
+        Applies to every bot turn in channels. Direct chats use the inactivity watchdog instead.
       </p>
       {error ? (
         <p id="room-turn-timeout-error" role="alert" className="text-[12px] text-danger">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -287,7 +287,7 @@ export function SettingsModal() {
                 <Card title="Skin" subtitle="Applies instantly and is remembered on this machine.">
                   <SkinPicker />
                 </Card>
-                <Card title="Room turns" subtitle="Set one maximum duration for every bot turn in a room.">
+                <Card title="Channel turns" subtitle="Set one maximum duration for every bot turn in a channel.">
                   <RoomTurnTimeoutSettings />
                 </Card>
                 <UpdatesRow />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -323,7 +323,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={saveRename}
-            aria-label="Save room name"
+            aria-label="Save channel name"
             title="Save"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -332,7 +332,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Cancel room rename"
+            aria-label="Cancel channel rename"
             title="Cancel"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -348,7 +348,7 @@ function RoomContextMenu({
           className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
         >
           <Pencil size={16} className="text-ink-secondary" />
-          Rename Room
+          Rename Channel
         </button>
       )}
       <button
@@ -359,7 +359,7 @@ function RoomContextMenu({
         className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
       >
         <FolderPlus size={16} className="text-ink-secondary" />
-        Move to section
+        Move to context
       </button>
       <button
         onClick={() => {
@@ -379,17 +379,18 @@ function RoomContextMenu({
         className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-danger hover:bg-raised/70"
       >
         <Trash2 size={16} />
-        Delete Room
+        Delete Channel
       </button>
     </div>,
     document.body,
   );
 }
 
-/** Pick members → Create. The room name is optional; the server defaults it. */
+/** Pick members and an optional Work/Personal/project context, then create. */
 function NewRoomPanel({ onClose }: { onClose: () => void }) {
   const { state, dispatch } = useStore();
   const [name, setName] = useState("");
+  const [section, setSection] = useState("");
   const [picked, setPicked] = useState<Set<string>>(new Set());
   const bots = state.bots.filter((b) => !b.hidden);
   const toggle = (id: string) =>
@@ -401,8 +402,13 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
     });
   const create = () => {
     if (!picked.size) return;
-    dispatch({ type: "createGroup", memberIds: [...picked], name: name.trim() || undefined });
-    track("room_created", { members: picked.size });
+    dispatch({
+      type: "createGroup",
+      memberIds: [...picked],
+      name: name.trim() || undefined,
+      section: section.trim() || undefined,
+    });
+    track("room_created", { members: picked.size, context: Boolean(section.trim()) });
     onClose();
   };
   return (
@@ -411,7 +417,7 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
       onMouseDown={(e) => e.target === e.currentTarget && onClose()}
     >
       <div className="w-[340px] rounded-2xl border border-hairline/50 bg-card p-4 shadow-2xl">
-        <div className="mb-3 text-[15px] font-semibold text-ink">New Room</div>
+        <div className="mb-3 text-[15px] font-semibold text-ink">New Channel</div>
         <input
           autoFocus
           value={name}
@@ -420,21 +426,33 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
             if (e.key === "Enter") create();
             if (e.key === "Escape") onClose();
           }}
-          placeholder="Room name (optional)"
+          placeholder="Channel name (for example, Website launch)"
+          className="mb-3 w-full rounded-lg bg-raised/70 px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
+        />
+        <input
+          value={section}
+          maxLength={60}
+          onChange={(e) => setSection(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") create();
+            if (e.key === "Escape") onClose();
+          }}
+          placeholder="Context (optional): Work, Personal, Client…"
+          aria-label="Channel context"
           className="mb-3 w-full rounded-lg bg-raised/70 px-3 py-2 text-[14px] text-ink placeholder:text-ink-secondary focus:outline-none"
         />
         <BotPickerList
           bots={bots}
           picked={picked}
           onToggle={toggle}
-          emptyHint="Create a bot first — rooms are made of bots."
+          emptyHint="Create a bot first — channels are made of bots."
         />
         <button
           onClick={create}
           disabled={!picked.size}
           className="mt-3 w-full rounded-lg bg-accent py-2 text-[14px] font-medium text-white hover:brightness-110 disabled:opacity-40"
         >
-          Create Room{picked.size ? ` · ${picked.size} ${picked.size === 1 ? "bot" : "bots"}` : ""}
+          Create Channel{picked.size ? ` · ${picked.size} ${picked.size === 1 ? "bot" : "bots"}` : ""}
         </button>
       </div>
     </div>
@@ -456,7 +474,7 @@ function SectionDivider({ name }: { name: string }) {
 
 /** Move-to-section popover: existing sections as chips (checkmark on the
  * target's current one), a create field, and a remove action. Serves bots
- * and rooms alike — the caller supplies the assignment. Mirrors the
+ * and channels alike — the caller supplies the assignment. Mirrors the
  * context menu's fixed positioning + dismiss-on-outside-click contract. */
 function SectionPicker({
   current,
@@ -490,8 +508,8 @@ function SectionPicker({
     };
   }, [onClose]);
 
-  // hidden bots can carry a stale assignment; don't offer it as a section.
-  // Rooms and bots share one namespace, so a heading can hold both.
+  // Hidden bots can carry a stale assignment; don't offer it as a context.
+  // Channels and bots share one namespace, so Work or Personal can hold both.
   const sections = [
     ...new Set([
       ...state.bots.filter((b) => !b.hidden && b.section).map((b) => b.section!),
@@ -514,7 +532,7 @@ function SectionPicker({
       className="fixed z-40 w-[236px] overflow-hidden rounded-xl border border-hairline/50 bg-card py-2 shadow-2xl shadow-black/60"
     >
       <div className="px-3.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-        Move to section
+        Move to context
       </div>
       {sections.length > 0 && (
         <div className="flex flex-col gap-0.5 px-1.5 py-1">
@@ -546,8 +564,8 @@ function SectionPicker({
           maxLength={60}
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="New section…"
-          aria-label="New section name"
+          placeholder="New context…"
+          aria-label="New context name"
           className="w-full rounded-lg bg-raised/70 px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
         />
         <button
@@ -569,7 +587,7 @@ function SectionPicker({
             className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[13px] text-danger hover:bg-raised/70"
           >
             <FolderMinus size={15} />
-            Remove from section
+            Remove from context
           </button>
         </>
       )}
@@ -1321,7 +1339,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                   className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
                 >
                   <Users size={16} className="text-ink-secondary" />
-                  New Room
+                  New Channel
                 </button>
                 <button
                   onClick={() => {
@@ -1395,9 +1413,11 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
               />
             </div>
           )}
+          {unsectionedGroups.length > 0 && density !== "icons" && <SectionDivider name="Channels" />}
           {unsectionedGroups.map((g) => (
             <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
           ))}
+          {visibleBots.length > 0 && density !== "icons" && <SectionDivider name="Bots" />}
           {visibleBots.map((b) => (
             <BotListItem
               key={b.id}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -420,6 +420,7 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
         <div className="mb-3 text-[15px] font-semibold text-ink">New Channel</div>
         <input
           autoFocus
+          maxLength={100}
           value={name}
           onChange={(e) => setName(e.target.value)}
           onKeyDown={(e) => {

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -482,7 +482,7 @@ export function TeamLibraryPanel({
                     </>
                   )
                 ) : (
-                  "No room is created—you can make one later if you want."
+                  "No channel is created—you can make one later if you want."
                 )}
               </div>
               <button
@@ -799,7 +799,7 @@ export function TeamLibraryPanel({
                         <input
                           value={roomName}
                           onChange={(event) => setRoomName(event.target.value)}
-                          aria-label="Project room name"
+                          aria-label="Project channel name"
                           className="min-w-0 flex-1 rounded-xl bg-raised/80 px-3 py-2.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
                         />
                         <button
@@ -808,11 +808,11 @@ export function TeamLibraryPanel({
                           className="flex shrink-0 items-center justify-center gap-2 rounded-full bg-accent px-5 py-2.5 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-60"
                         >
                           {creating && <Loader2 size={15} className="animate-spin" />}
-                          {creating ? "Creating…" : "Create project room"}
+                          {creating ? "Creating…" : "Create project channel"}
                         </button>
                       </div>
                       <p className="mt-2 text-[12px] text-ink-secondary">
-                        Creates the team as new bots, opens a room for them, and points the room at this folder.
+                        Creates the team as new bots, opens a channel for them, and points the channel at this folder.
                       </p>
                     </div>
                   )}

--- a/src/lib/room-turn-timeout.test.ts
+++ b/src/lib/room-turn-timeout.test.ts
@@ -61,7 +61,7 @@ describe("room turn timeout input", () => {
       throw "unavailable";
     });
 
-    expect(result).toEqual({ ok: false, error: "Could not save the room turn limit." });
+    expect(result).toEqual({ ok: false, error: "Could not save the channel turn limit." });
   });
 
   it("blocks a second save while the first is pending and allows a later save", async () => {

--- a/src/lib/room-turn-timeout.ts
+++ b/src/lib/room-turn-timeout.ts
@@ -48,6 +48,6 @@ export async function saveRoomTurnTimeoutMinutes(
   try {
     return { ok: true, minutes: await persist(parsed.minutes) };
   } catch (cause) {
-    return { ok: false, error: cause instanceof Error ? cause.message : "Could not save the room turn limit." };
+    return { ok: false, error: cause instanceof Error ? cause.message : "Could not save the channel turn limit." };
   }
 }

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -403,7 +403,7 @@ export type Action =
   | { type: "markRoutineRunSeen"; runId: string }
   | { type: "groupPatched"; group: Partial<Group> & { id: string } }
   | { type: "groupDeleted"; groupId: string }
-  | { type: "createGroup"; memberIds: string[]; name?: string }
+  | { type: "createGroup"; memberIds: string[]; name?: string; section?: string }
   | { type: "sendGroup"; groupId: string; text: string }
   | {
       type: "patchGroup";
@@ -1317,7 +1317,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         case "createGroup":
           api(`/api/groups`, {
             method: "POST",
-            body: JSON.stringify({ memberIds: action.memberIds, name: action.name }),
+            body: JSON.stringify({ memberIds: action.memberIds, name: action.name, section: action.section }),
           })
             .then(({ group }) => {
               rawDispatch({ type: "groupPatched", group });


### PR DESCRIPTION
## Summary
- productize the existing isolated room runtime as Channels without migrating or duplicating conversation data
- let a channel start in a named context such as Work, Personal, or a project, and move between contexts later
- separate Channels and Bots visually in the sidebar and use Channel language consistently across chat, calls, search, settings, and Team Library
- retain the room editor shipped in #381, so channels can be renamed and bots can be added or removed after creation
- validate and bound channel names and contexts at the API boundary, and deduplicate member IDs

## Why this shape
The existing group model already gives every conversation a separate transcript, provider thread, shared instructions, working folder, responder policy, and roster. Building Channels on it makes existing rooms become channels automatically and avoids a second runtime with different behavior.

This is the first usable delivery from the broader plan in #370. It intentionally does not promise concurrent turns by the same bot across multiple channels; the existing busy guard remains the safety boundary.

## Validation
- `pnpm exec vitest run server/store.test.ts server/index.test.ts src/lib/room-turn-timeout.test.ts` — 142 passed
- `pnpm build`
- `git diff --check`

Repository-wide `pnpm lint` still reports the existing anti-slop backlog in unrelated drivers and tests; this PR does not add a separate lint baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create channels with optional contexts for better organization.
  * Channels retain their context after being saved and reloaded.
  * Unsectioned channels appear under a dedicated “Channels” heading.
  * Channel creation validates names, contexts, member IDs, and duplicate members.

* **Bug Fixes**
  * Improved error messages for invalid channel details and turn-limit save failures.

* **Style**
  * Updated interface terminology from “rooms” and “sections” to “channels” and “contexts” throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->