### PR TITLE
Recorder: semantic element identity + file/clipboard context + safer typing

### DIFF
--- a/electron/resources/recorder-helper.swift
+++ b/electron/resources/recorder-helper.swift
@@ -128,11 +128,12 @@ final class Recorder {
         secureCachedMs = t
         var focused: CFTypeRef?
         let err = AXUIElementCopyAttributeValue(systemWide, "AXFocusedUIElement" as CFString, &focused)
-        // Deny-by-default: if focus can't be determined, treat as NOT secure.
+        // Deny by default: if focus cannot be determined, suppress content-
+        // adjacent events rather than risk treating a password field as safe.
         guard err == .success, let focusedRef = focused,
               CFGetTypeID(focusedRef) == AXUIElementGetTypeID() else {
-            secureCachedValue = false
-            return false
+            secureCachedValue = true
+            return true
         }
         let element = focusedRef as! AXUIElement
         secureCachedValue = (axString(element, "AXRole") == "AXSecureTextField")
@@ -186,7 +187,9 @@ final class Recorder {
         // secure field is focused OR the hit element is itself a secure field.
         let omitContent = secure || elementIsSecure
         if !omitContent {
-            if let name = axString(el, "AXTitle") ?? axString(el, "AXValue") ?? axString(el, "AXDescription") {
+            // AXValue is deliberately excluded: for text fields it is the
+            // user's entered text, which would reconstruct what they typed.
+            if let name = axString(el, "AXTitle") ?? axString(el, "AXDescription") {
                 values["name"] = String(name.prefix(120))
             }
             if let identifier = axString(el, "AXIdentifier") {
@@ -200,7 +203,7 @@ final class Recorder {
                       let pRef = parentRef, CFGetTypeID(pRef) == AXUIElementGetTypeID() else { break }
                 let parent = pRef as! AXUIElement
                 let role = axString(parent, "AXRole") ?? ""
-                let name = axString(parent, "AXTitle") ?? axString(parent, "AXValue") ?? axString(parent, "AXDescription") ?? ""
+                let name = axString(parent, "AXTitle") ?? axString(parent, "AXDescription") ?? ""
                 ancestry.append("\(role):\(String(name.prefix(120)))")
                 current = parent
             }
@@ -288,9 +291,29 @@ final class Recorder {
     private func readWhereFroms(_ path: String) -> [String] {
         guard let item = MDItemCreate(kCFAllocatorDefault, path as CFString),
               let value = MDItemCopyAttribute(item, kMDItemWhereFroms) else { return [] }
-        if let strings = value as? [String] { return strings }
-        if let anys = value as? [Any] { return anys.compactMap { $0 as? String } }
-        return []
+        let strings: [String]
+        if let values = value as? [String] {
+            strings = values
+        } else if let values = value as? [Any] {
+            strings = values.compactMap { $0 as? String }
+        } else {
+            return []
+        }
+        // Download metadata can contain signed query strings, credentials,
+        // fragments, or local file URLs. Only the web origin is useful to a
+        // reusable skill, so strip everything else before it leaves native.
+        return strings.compactMap { raw in
+            guard var components = URLComponents(string: raw),
+                  let scheme = components.scheme?.lowercased(),
+                  (scheme == "https" || scheme == "http"),
+                  components.host != nil else { return nil }
+            components.user = nil
+            components.password = nil
+            components.path = ""
+            components.query = nil
+            components.fragment = nil
+            return components.string
+        }
     }
 
     // MARK: - Event handling
@@ -372,7 +395,7 @@ final class Recorder {
         let callback: CGEventTapCallBack = { _, type, event, refcon in
             guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
             let recorder = Unmanaged<Recorder>.fromOpaque(refcon).takeUnretainedValue()
-            if type == .tapDisabledByTimeout {
+            if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
                 if let tap = recorder.tap {
                     CGEvent.tapEnable(tap: tap, enable: true)
                 }

--- a/electron/resources/recorder-helper.swift
+++ b/electron/resources/recorder-helper.swift
@@ -15,6 +15,27 @@ final class Recorder {
     private var lastContext = Context(app: "", windowTitle: "")
     private let startedAt = ProcessInfo.processInfo.systemUptime
 
+    // System-wide AX element used for click hit-tests and focus queries.
+    private let systemWide = AXUIElementCreateSystemWide()
+
+    // Typing aggregation state (privacy: plain keycodes never leave this process).
+    private var typingCount = 0
+    private var typingContext = Context(app: "", windowTitle: "")
+    private var typingStartMs = 0
+    private var lastTypingMs = 0
+
+    // Secure-field focus cache (~250ms).
+    private var secureCachedMs = -1_000_000
+    private var secureCachedValue = false
+
+    // Clipboard correlation state.
+    private var pendingClip: (op: String, baseline: Int, atMs: Int, ctx: Context)?
+
+    // Downloads polling state.
+    private let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+    private var knownDownloads: Set<String> = []
+    private let partialExtensions: Set<String> = ["crdownload", "download", "part", "tmp"]
+
     init(stopFile: String) {
         self.stopFile = stopFile
     }
@@ -55,44 +76,294 @@ final class Recorder {
     private func emitContextIfChanged(force: Bool = false) -> Context {
         let current = context()
         if force || current.app != lastContext.app || current.windowTitle != lastContext.windowTitle {
+            // Any in-flight typing burst belongs to the OLD context; flush it before
+            // announcing the new context so events stay in timeline order.
+            flushTyping()
             lastContext = current
             emit(["type": "app", "atMs": nowMs(), "app": current.app, "windowTitle": current.windowTitle])
         }
         return current
     }
 
-    func handle(type: CGEventType, event: CGEvent) {
+    // MARK: - Typing aggregation
+
+    private func flushTyping() {
+        guard typingCount > 0 else { return }
+        emit([
+            "type": "typing",
+            "atMs": typingStartMs,
+            "app": typingContext.app,
+            "windowTitle": typingContext.windowTitle,
+            "keyCount": typingCount,
+        ])
+        typingCount = 0
+    }
+
+    private func handlePlainKey() {
+        // Never count keystrokes while a secure text field is focused.
+        if isSecureFieldFocused() {
+            flushTyping()
+            return
+        }
+        // emitContextIfChanged flushes the old burst if the context changed.
         let current = emitContextIfChanged()
-        var values: [String: Any] = [
-            "atMs": nowMs(),
-            "app": current.app,
-            "windowTitle": current.windowTitle,
-        ]
+        if typingCount > 0 && (current.app != typingContext.app || current.windowTitle != typingContext.windowTitle) {
+            flushTyping()
+        }
+        if typingCount == 0 {
+            typingContext = current
+            typingStartMs = nowMs()
+        }
+        typingCount += 1
+        lastTypingMs = nowMs()
+    }
+
+    // MARK: - Secure field detection
+
+    private func isSecureFieldFocused() -> Bool {
+        let t = nowMs()
+        if t - secureCachedMs < 250 {
+            return secureCachedValue
+        }
+        secureCachedMs = t
+        var focused: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(systemWide, "AXFocusedUIElement" as CFString, &focused)
+        // Deny-by-default: if focus can't be determined, treat as NOT secure.
+        guard err == .success, let focusedRef = focused,
+              CFGetTypeID(focusedRef) == AXUIElementGetTypeID() else {
+            secureCachedValue = false
+            return false
+        }
+        let element = focusedRef as! AXUIElement
+        secureCachedValue = (axString(element, "AXRole") == "AXSecureTextField")
+        return secureCachedValue
+    }
+
+    // MARK: - AX helpers
+
+    private func axString(_ el: AXUIElement, _ attr: String) -> String? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr as CFString, &ref) == .success,
+              let value = ref, let string = value as? String, !string.isEmpty else { return nil }
+        return string
+    }
+
+    private func axPoint(_ el: AXUIElement, _ attr: String) -> CGPoint? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr as CFString, &ref) == .success,
+              let value = ref, CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+        let axValue = value as! AXValue
+        guard AXValueGetType(axValue) == .cgPoint else { return nil }
+        var point = CGPoint.zero
+        return AXValueGetValue(axValue, .cgPoint, &point) ? point : nil
+    }
+
+    private func axSize(_ el: AXUIElement, _ attr: String) -> CGSize? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr as CFString, &ref) == .success,
+              let value = ref, CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+        let axValue = value as! AXValue
+        guard AXValueGetType(axValue) == .cgSize else { return nil }
+        var size = CGSize.zero
+        return AXValueGetValue(axValue, .cgSize, &size) ? size : nil
+    }
+
+    /// Hit-test the click point and attach AX element identity. All fields are
+    /// optional: any failed/timed-out copy is simply omitted. Never blocks (the
+    /// 0.4s system-wide messaging timeout guards every call) and never crashes.
+    private func addElementIdentity(_ values: inout [String: Any], x: CGFloat, y: CGFloat, secure: Bool) {
+        var elRef: AXUIElement?
+        guard AXUIElementCopyElementAtPosition(systemWide, Float(x), Float(y), &elRef) == .success,
+              let el = elRef else { return }
+
+        var elementIsSecure = false
+        if let role = axString(el, "AXRole") {
+            values["role"] = role
+            if role == "AXSecureTextField" { elementIsSecure = true }
+        }
+
+        // Content-bearing fields (name/identifier/ancestry) are omitted whenever a
+        // secure field is focused OR the hit element is itself a secure field.
+        let omitContent = secure || elementIsSecure
+        if !omitContent {
+            if let name = axString(el, "AXTitle") ?? axString(el, "AXValue") ?? axString(el, "AXDescription") {
+                values["name"] = String(name.prefix(120))
+            }
+            if let identifier = axString(el, "AXIdentifier") {
+                values["identifier"] = identifier
+            }
+            var ancestry: [String] = []
+            var current: AXUIElement = el
+            for _ in 0..<4 {
+                var parentRef: CFTypeRef?
+                guard AXUIElementCopyAttributeValue(current, "AXParent" as CFString, &parentRef) == .success,
+                      let pRef = parentRef, CFGetTypeID(pRef) == AXUIElementGetTypeID() else { break }
+                let parent = pRef as! AXUIElement
+                let role = axString(parent, "AXRole") ?? ""
+                let name = axString(parent, "AXTitle") ?? axString(parent, "AXValue") ?? axString(parent, "AXDescription") ?? ""
+                ancestry.append("\(role):\(String(name.prefix(120)))")
+                current = parent
+            }
+            if !ancestry.isEmpty {
+                values["ancestry"] = ancestry
+            }
+        }
+
+        // Geometry is safe to record even for secure fields.
+        if let position = axPoint(el, "AXPosition"), let size = axSize(el, "AXSize") {
+            values["bbox"] = [
+                "x": Int(position.x),
+                "y": Int(position.y),
+                "w": Int(size.width),
+                "h": Int(size.height),
+            ]
+        }
+    }
+
+    // MARK: - Clipboard
+
+    private func trackClipboardChord(keycode: Int, meta: Bool, ctx: Context) {
+        guard meta else { return }
+        switch keycode {
+        case 8: // C
+            pendingClip = (op: "copy", baseline: NSPasteboard.general.changeCount, atMs: nowMs(), ctx: ctx)
+        case 7: // X
+            pendingClip = (op: "cut", baseline: NSPasteboard.general.changeCount, atMs: nowMs(), ctx: ctx)
+        case 9: // V — paste never changes the pasteboard, so emit immediately.
+            emit([
+                "type": "clipboard",
+                "atMs": nowMs(),
+                "app": ctx.app,
+                "windowTitle": ctx.windowTitle,
+                "op": "paste",
+            ])
+        default:
+            break
+        }
+    }
+
+    private func resolvePendingClipboard() {
+        guard let pending = pendingClip else { return }
+        // Only a changeCount bump confirms the copy/cut actually happened.
+        if NSPasteboard.general.changeCount != pending.baseline {
+            emit([
+                "type": "clipboard",
+                "atMs": pending.atMs,
+                "app": pending.ctx.app,
+                "windowTitle": pending.ctx.windowTitle,
+                "op": pending.op,
+            ])
+            pendingClip = nil
+        } else if nowMs() - pending.atMs > 1500 {
+            pendingClip = nil // no bump within the window; give up.
+        }
+    }
+
+    // MARK: - Downloads
+
+    private func baselineDownloads() {
+        guard let dir = downloadsURL,
+              let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return }
+        knownDownloads = Set(names)
+    }
+
+    private func checkDownloads() {
+        guard let dir = downloadsURL,
+              let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return }
+        for name in names where !knownDownloads.contains(name) {
+            knownDownloads.insert(name)
+            if name.hasPrefix(".") { continue }
+            let ext = (name as NSString).pathExtension.lowercased()
+            if partialExtensions.contains(ext) { continue } // still downloading
+            let path = dir.appendingPathComponent(name).path
+            emit([
+                "type": "download",
+                "atMs": nowMs(),
+                "filename": name,
+                "whereFroms": readWhereFroms(path),
+            ])
+        }
+    }
+
+    private func readWhereFroms(_ path: String) -> [String] {
+        guard let item = MDItemCreate(kCFAllocatorDefault, path as CFString),
+              let value = MDItemCopyAttribute(item, kMDItemWhereFroms) else { return [] }
+        if let strings = value as? [String] { return strings }
+        if let anys = value as? [Any] { return anys.compactMap { $0 as? String } }
+        return []
+    }
+
+    // MARK: - Event handling
+
+    func handle(type: CGEventType, event: CGEvent) {
+        // Plain typing keys are aggregated in-process and never emitted as keycodes.
+        if type == .keyDown {
+            let flags = event.flags
+            let isChord = flags.contains(.maskCommand) || flags.contains(.maskControl) || flags.contains(.maskAlternate)
+            if !isChord {
+                handlePlainKey()
+                return
+            }
+        }
+
+        // Any non-typing event ends the current typing burst.
+        flushTyping()
+        let current = emitContextIfChanged()
+        let secure = isSecureFieldFocused()
+
         switch type {
         case .leftMouseDown, .rightMouseDown, .otherMouseDown:
             let point = event.location
-            values["type"] = "click"
-            values["x"] = Int(point.x)
-            values["y"] = Int(point.y)
-            values["button"] = type == .leftMouseDown ? "left" : type == .rightMouseDown ? "right" : "other"
+            var values: [String: Any] = [
+                "type": "click",
+                "atMs": nowMs(),
+                "app": current.app,
+                "windowTitle": current.windowTitle,
+                "x": Int(point.x),
+                "y": Int(point.y),
+                "button": type == .leftMouseDown ? "left" : type == .rightMouseDown ? "right" : "other",
+            ]
+            addElementIdentity(&values, x: point.x, y: point.y, secure: secure)
+            emit(values)
         case .scrollWheel:
-            values["type"] = "scroll"
-            values["deltaY"] = event.getIntegerValueField(.scrollWheelEventDeltaAxis1)
+            emit([
+                "type": "scroll",
+                "atMs": nowMs(),
+                "app": current.app,
+                "windowTitle": current.windowTitle,
+                "deltaY": event.getIntegerValueField(.scrollWheelEventDeltaAxis1),
+            ])
         case .keyDown:
-            values["type"] = "key"
-            values["keycode"] = event.getIntegerValueField(.keyboardEventKeycode)
+            // Chord (has command/control/option). Keycodes here are shortcut names,
+            // not typed content, so they are safe to emit — unless a secure field is
+            // focused, in which case both the chord and any clipboard op are suppressed.
             let flags = event.flags
-            values["meta"] = flags.contains(.maskCommand)
-            values["control"] = flags.contains(.maskControl)
-            values["option"] = flags.contains(.maskAlternate)
-            values["shift"] = flags.contains(.maskShift)
+            let meta = flags.contains(.maskCommand)
+            let keycode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+            if secure { break }
+            trackClipboardChord(keycode: keycode, meta: meta, ctx: current)
+            emit([
+                "type": "key",
+                "atMs": nowMs(),
+                "app": current.app,
+                "windowTitle": current.windowTitle,
+                "keycode": keycode,
+                "meta": meta,
+                "control": flags.contains(.maskControl),
+                "option": flags.contains(.maskAlternate),
+                "shift": flags.contains(.maskShift),
+            ])
         default:
             return
         }
-        emit(values)
     }
 
     func start() -> Bool {
+        // One-time short messaging timeout so click hit-tests and focus queries can
+        // never hang the tap callback on a slow/unresponsive target app.
+        AXUIElementSetMessagingTimeout(systemWide, 0.4)
+        baselineDownloads()
+
         let mask = (1 << CGEventType.leftMouseDown.rawValue)
             | (1 << CGEventType.rightMouseDown.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
@@ -126,9 +397,16 @@ final class Recorder {
         timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
             guard let self = self else { return }
             if FileManager.default.fileExists(atPath: self.stopFile) {
+                self.flushTyping()
                 CFRunLoopStop(CFRunLoopGetMain())
                 return
             }
+            // End a typing burst that has gone idle.
+            if self.typingCount > 0 && self.nowMs() - self.lastTypingMs > 1200 {
+                self.flushTyping()
+            }
+            self.resolvePendingClipboard()
+            self.checkDownloads()
             _ = self.emitContextIfChanged()
         }
         return true

--- a/electron/skill-recorder.mjs
+++ b/electron/skill-recorder.mjs
@@ -204,6 +204,17 @@ function cleanText(value, max = 500) {
   return typeof value === "string" ? value.replace(/[\u0000-\u001f]+/g, " ").trim().slice(0, max) : "";
 }
 
+function safeWebOrigin(value) {
+  const cleaned = cleanText(value, 2_000);
+  if (!cleaned) return "";
+  try {
+    const url = new URL(cleaned);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.origin : "";
+  } catch {
+    return "";
+  }
+}
+
 export function skillSlug(value) {
   const slug = cleanText(value, 80)
     .toLowerCase()
@@ -347,7 +358,7 @@ export function saveSkillRecording(payload, options = {}) {
         ? raw.ancestry.map((entry) => cleanText(entry, 120)).filter(Boolean).slice(0, 6)
         : undefined;
       const whereFroms = Array.isArray(raw.whereFroms)
-        ? raw.whereFroms.map((entry) => cleanText(entry, 500)).filter(Boolean).slice(0, 5)
+        ? [...new Set(raw.whereFroms.map(safeWebOrigin).filter(Boolean))].slice(0, 5)
         : undefined;
       const event = {
         type,
@@ -399,7 +410,12 @@ export function saveSkillRecording(payload, options = {}) {
       events,
       truncated,
       omittedEvents,
-      privacy: { typedCharactersRetained: false, reviewedBeforeInstall: true },
+      privacy: {
+        rawKeystrokesRetained: false,
+        clipboardContentsRetained: false,
+        screenFramesMayContainVisibleText: true,
+        reviewedBeforeInstall: true,
+      },
     };
     writeFileSync(path.join(references, "recording.json"), `${JSON.stringify(recording, null, 2)}\n`, { mode: 0o600 });
     writeFileSync(

--- a/electron/skill-recorder.mjs
+++ b/electron/skill-recorder.mjs
@@ -37,7 +37,7 @@ const BUNDLE = app.isPackaged
 const BINARY = app.isPackaged
   ? path.join(BUNDLE, "Contents", "MacOS", "recorder-helper")
   : recorderHelperBinary;
-const MAX_EVENTS = 300;
+const MAX_EVENTS = 600;
 const MAX_IMAGE_BYTES = 2_000_000;
 const MAX_AUDIO_BYTES = 100_000_000;
 const SAFE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -233,19 +233,45 @@ function decodeDataUrl(dataUrl, maxBytes, allowed) {
   return { mime: match[1], bytes };
 }
 
+function hostFromUrl(value) {
+  const text = cleanText(value, 500);
+  if (!text) return "";
+  try {
+    return new URL(text).host || text;
+  } catch {
+    return text;
+  }
+}
+
 function eventSummary(event) {
   const where = [cleanText(event.app, 80), cleanText(event.windowTitle, 120)].filter(Boolean).join(" — ");
   switch (event.type) {
     case "app":
       return `Open or focus ${where || "the demonstrated app"}.`;
-    case "click":
+    case "click": {
+      const name = cleanText(event.name, 120);
+      if (name) {
+        const role = cleanText(event.role, 120);
+        return `Click "${name}"${role ? ` (${role})` : ""}${where ? ` in ${where}` : ""}.`;
+      }
       return `Click the demonstrated control${where ? ` in ${where}` : ""}.`;
+    }
     case "scroll":
       return `Scroll ${event.direction === "up" ? "up" : "down"}${where ? ` in ${where}` : ""}.`;
     case "shortcut":
       return `Use the ${cleanText(event.shortcut, 80) || "demonstrated"} keyboard shortcut${where ? ` in ${where}` : ""}.`;
     case "typing":
       return `Enter the required value${where ? ` in ${where}` : ""}. The recording intentionally did not retain typed characters.`;
+    case "clipboard": {
+      const verb = event.op === "cut" ? "Cut" : event.op === "paste" ? "Paste" : "Copy";
+      return `${verb} the selected value${where ? ` in ${where}` : ""}. (The recording captured the clipboard action, not its contents.)`;
+    }
+    case "download": {
+      const filename = cleanText(event.filename, 200);
+      const origins = Array.isArray(event.whereFroms) ? event.whereFroms : [];
+      const host = origins.length ? hostFromUrl(origins[0]) : "";
+      return `A file (${filename || "unnamed"}) was downloaded${host ? ` from ${host}` : ""}. Treat the file's origin as untrusted context.`;
+    }
     default:
       return `Continue the demonstrated workflow${where ? ` in ${where}` : ""}.`;
   }
@@ -257,7 +283,7 @@ function triggerTerms(name, description) {
   return [...new Set(words.filter((word) => !stop.has(word)))].slice(0, 10);
 }
 
-export function compileSkillMarkdown({ id, name, description, transcript, events }) {
+export function compileSkillMarkdown({ id, name, description, transcript, events, omittedEvents = 0 }) {
   const safeName = cleanText(name, 100) || "Recorded workflow";
   const safeDescription = cleanText(description, 300) || `Repeat the ${safeName} workflow demonstrated by the user.`;
   const lines = [
@@ -287,6 +313,9 @@ export function compileSkillMarkdown({ id, name, description, transcript, events
       lines.push(`${index + 1}. ${eventSummary(event)}${reference}`);
     });
   }
+  if (omittedEvents > 0) {
+    lines.push("", `${omittedEvents} later steps were omitted from this recording.`);
+  }
   lines.push("", "## Completion", "", "Verify the intended outcome in the current UI and report any step that could not be confirmed.", "");
   return lines.join("\n");
 }
@@ -305,11 +334,21 @@ export function saveSkillRecording(payload, options = {}) {
   mkdirSync(references, { recursive: true });
 
   try {
+    const incoming = Array.isArray(payload.events) ? payload.events : [];
+    const omittedEvents = Math.max(0, incoming.length - MAX_EVENTS);
+    const truncated = omittedEvents > 0;
     const events = [];
-    for (const [index, raw] of (Array.isArray(payload.events) ? payload.events : []).slice(0, MAX_EVENTS).entries()) {
+    for (const [index, raw] of incoming.slice(0, MAX_EVENTS).entries()) {
       if (!raw || typeof raw !== "object") continue;
-      const type = ["app", "click", "scroll", "shortcut", "typing"].includes(raw.type) ? raw.type : null;
+      const type = ["app", "click", "scroll", "shortcut", "typing", "clipboard", "download"].includes(raw.type) ? raw.type : null;
       if (!type) continue;
+      const keyCount = Number(raw.keyCount);
+      const ancestry = Array.isArray(raw.ancestry)
+        ? raw.ancestry.map((entry) => cleanText(entry, 120)).filter(Boolean).slice(0, 6)
+        : undefined;
+      const whereFroms = Array.isArray(raw.whereFroms)
+        ? raw.whereFroms.map((entry) => cleanText(entry, 500)).filter(Boolean).slice(0, 5)
+        : undefined;
       const event = {
         type,
         atMs: Math.max(0, Math.round(Number(raw.atMs) || 0)),
@@ -317,6 +356,14 @@ export function saveSkillRecording(payload, options = {}) {
         windowTitle: cleanText(raw.windowTitle, 120) || undefined,
         direction: raw.direction === "up" ? "up" : raw.direction === "down" ? "down" : undefined,
         shortcut: cleanText(raw.shortcut, 80) || undefined,
+        keyCount: Number.isFinite(keyCount) && keyCount > 0 ? Math.round(keyCount) : undefined,
+        role: cleanText(raw.role, 120) || undefined,
+        name: cleanText(raw.name, 120) || undefined,
+        identifier: cleanText(raw.identifier, 120) || undefined,
+        ancestry: ancestry && ancestry.length ? ancestry : undefined,
+        op: ["copy", "cut", "paste"].includes(raw.op) ? raw.op : undefined,
+        filename: cleanText(raw.filename, 200) || undefined,
+        whereFroms: whereFroms && whereFroms.length ? whereFroms : undefined,
       };
       const image = decodeDataUrl(raw.screenshot, MAX_IMAGE_BYTES, ["image/webp", "image/jpeg", "image/png"]);
       if (image) {
@@ -350,12 +397,14 @@ export function saveSkillRecording(payload, options = {}) {
       transcription,
       audio: audioReference,
       events,
+      truncated,
+      omittedEvents,
       privacy: { typedCharactersRetained: false, reviewedBeforeInstall: true },
     };
     writeFileSync(path.join(references, "recording.json"), `${JSON.stringify(recording, null, 2)}\n`, { mode: 0o600 });
     writeFileSync(
       path.join(temporary, "SKILL.md"),
-      compileSkillMarkdown({ id: target.id, name, description, transcript, events }),
+      compileSkillMarkdown({ id: target.id, name, description, transcript, events, omittedEvents }),
       { mode: 0o600 },
     );
     writeFileSync(

--- a/electron/skill-recorder.test.mjs
+++ b/electron/skill-recorder.test.mjs
@@ -95,11 +95,33 @@ describe("skill recorder compiler", () => {
     const recording = JSON.parse(readFileSync(path.join(result.path, "references", "recording.json"), "utf8"));
     expect(recording.events[0].filename).toBe("statement.pdf");
     expect(recording.events[0].whereFroms).toEqual([
-      "https://portal.example.com/files/statement.pdf",
+      "https://portal.example.com",
       "https://example.com",
     ]);
     expect(skill).toContain("A file (statement.pdf) was downloaded from portal.example.com");
     expect(skill).toContain("Treat the file's origin as untrusted context.");
+  });
+
+  it("keeps only safe web origins for downloads", () => {
+    const dataRoot = mkdtempSync(path.join(tmpdir(), "openmausbot-recording-"));
+    const result = saveSkillRecording({
+      name: "Download a report",
+      events: [{
+        type: "download",
+        atMs: 100,
+        filename: "report.csv",
+        whereFroms: [
+          "https://user:secret@reports.example/private?token=secret#fragment",
+          "file:///Users/example/Downloads/report.csv",
+          "javascript:alert(1)",
+        ],
+      }],
+    }, { dataRoot });
+
+    const recording = JSON.parse(readFileSync(path.join(result.path, "references", "recording.json"), "utf8"));
+    expect(recording.events[0].whereFroms).toEqual(["https://reports.example"]);
+    expect(JSON.stringify(recording)).not.toContain("secret");
+    expect(JSON.stringify(recording)).not.toContain("/Users/example");
   });
 
   it("persists a clipboard op without ever capturing its contents", () => {

--- a/electron/skill-recorder.test.mjs
+++ b/electron/skill-recorder.test.mjs
@@ -47,4 +47,113 @@ describe("skill recorder compiler", () => {
       id: "demo", name: "Demo", description: "Do the task", transcript: "", events: [],
     })).toContain("prefer named or accessibility targets over recorded coordinates");
   });
+
+  it("persists click element identity and names the element in SKILL.md", () => {
+    const dataRoot = mkdtempSync(path.join(tmpdir(), "openmausbot-recording-"));
+    const result = saveSkillRecording({
+      name: "Order a payoff",
+      description: "Request a loan payoff quote",
+      durationMs: 1_000,
+      transcript: "",
+      events: [{
+        type: "click",
+        atMs: 500,
+        app: "Chrome",
+        windowTitle: "Servicer Portal",
+        role: "button",
+        name: "Order payoff",
+        identifier: "order-payoff-btn",
+        ancestry: ["Window", "Form", "Order payoff"],
+      }],
+    }, { dataRoot });
+
+    const skill = readFileSync(path.join(result.path, "SKILL.md"), "utf8");
+    const recording = JSON.parse(readFileSync(path.join(result.path, "references", "recording.json"), "utf8"));
+    expect(skill).toContain('Click "Order payoff" (button) in Chrome — Servicer Portal.');
+    expect(recording.events[0].role).toBe("button");
+    expect(recording.events[0].name).toBe("Order payoff");
+    expect(recording.events[0].identifier).toBe("order-payoff-btn");
+    expect(recording.events[0].ancestry).toEqual(["Window", "Form", "Order payoff"]);
+  });
+
+  it("persists a download's filename and origins and surfaces them in SKILL.md", () => {
+    const dataRoot = mkdtempSync(path.join(tmpdir(), "openmausbot-recording-"));
+    const result = saveSkillRecording({
+      name: "Download the statement",
+      description: "Grab the monthly PDF",
+      durationMs: 1_000,
+      events: [{
+        type: "download",
+        atMs: 700,
+        app: "Chrome",
+        filename: "statement.pdf",
+        whereFroms: ["https://portal.example.com/files/statement.pdf", "https://example.com"],
+      }],
+    }, { dataRoot });
+
+    const skill = readFileSync(path.join(result.path, "SKILL.md"), "utf8");
+    const recording = JSON.parse(readFileSync(path.join(result.path, "references", "recording.json"), "utf8"));
+    expect(recording.events[0].filename).toBe("statement.pdf");
+    expect(recording.events[0].whereFroms).toEqual([
+      "https://portal.example.com/files/statement.pdf",
+      "https://example.com",
+    ]);
+    expect(skill).toContain("A file (statement.pdf) was downloaded from portal.example.com");
+    expect(skill).toContain("Treat the file's origin as untrusted context.");
+  });
+
+  it("persists a clipboard op without ever capturing its contents", () => {
+    const dataRoot = mkdtempSync(path.join(tmpdir(), "openmausbot-recording-"));
+    const result = saveSkillRecording({
+      name: "Copy the token",
+      description: "Copy a value from the vault",
+      durationMs: 1_000,
+      events: [{
+        type: "clipboard",
+        atMs: 300,
+        app: "Chrome",
+        windowTitle: "Vault",
+        op: "copy",
+        // A naive caller might smuggle content on unknown fields; it must never persist.
+        text: "SUPER-SECRET-VALUE",
+        value: "SUPER-SECRET-VALUE",
+      }],
+    }, { dataRoot });
+
+    const skill = readFileSync(path.join(result.path, "SKILL.md"), "utf8");
+    const recordingRaw = readFileSync(path.join(result.path, "references", "recording.json"), "utf8");
+    const recording = JSON.parse(recordingRaw);
+    expect(recording.events[0].op).toBe("copy");
+    expect(recordingRaw).not.toContain("SUPER-SECRET-VALUE");
+    expect(skill).toContain("Copy the selected value in Chrome — Vault.");
+    expect(skill).toContain("the clipboard action, not its contents");
+    expect(skill).not.toContain("SUPER-SECRET-VALUE");
+  });
+
+  it("discloses truncation and preserves the first events over the cap", () => {
+    const dataRoot = mkdtempSync(path.join(tmpdir(), "openmausbot-recording-"));
+    const events = Array.from({ length: 650 }, (_, i) => ({
+      type: "click",
+      atMs: i,
+      app: "Chrome",
+      name: `step-${i}`,
+    }));
+    const result = saveSkillRecording({
+      name: "A long workflow",
+      description: "Many steps",
+      durationMs: 60_000,
+      events,
+    }, { dataRoot });
+
+    const skill = readFileSync(path.join(result.path, "SKILL.md"), "utf8");
+    const recording = JSON.parse(readFileSync(path.join(result.path, "references", "recording.json"), "utf8"));
+    expect(result.events).toBe(600);
+    expect(recording.truncated).toBe(true);
+    expect(recording.omittedEvents).toBe(50);
+    expect(recording.events.length).toBe(600);
+    // Head-preserving: the first events survive, the tail is dropped.
+    expect(recording.events[0].name).toBe("step-0");
+    expect(recording.events[599].name).toBe("step-599");
+    expect(skill).toContain("50 later steps were omitted from this recording.");
+  });
 });

--- a/src/components/SkillRecorderPage.tsx
+++ b/src/components/SkillRecorderPage.tsx
@@ -391,7 +391,7 @@ export function SkillRecorderPage() {
                 <div className="mt-6 flex items-start gap-3 rounded-2xl bg-inset px-4 py-3">
                   <EyeOff size={17} className="mt-0.5 shrink-0 text-success" />
                   <p className="text-[12px] leading-5 text-ink-secondary">
-                    Typed characters are never stored. Clicks and screenshots stay on this computer; microphone audio is streamed to AssemblyAI for transcription. You review everything before creating the skill.
+                    Raw keystrokes and clipboard contents are never stored. Screen frames can contain visible text and stay on this computer; microphone audio is streamed to AssemblyAI for transcription. You review everything before creating the skill.
                   </p>
                 </div>
 

--- a/src/components/SkillRecorderPage.tsx
+++ b/src/components/SkillRecorderPage.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Check,
   Circle,
+  Clipboard,
   Cloud,
+  Download,
   EyeOff,
   FileText,
   Keyboard,
@@ -40,7 +42,18 @@ const iconFor = (type: RecordedSkillEvent["type"]) => {
   if (type === "click") return MousePointer2;
   if (type === "scroll") return ScrollText;
   if (type === "typing" || type === "shortcut") return Keyboard;
+  if (type === "clipboard") return Clipboard;
+  if (type === "download") return Download;
   return MonitorUp;
+};
+
+const originHost = (url?: string): string | undefined => {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
 };
 
 function blobDataUrl(blob: Blob): Promise<string> {
@@ -104,9 +117,13 @@ export function SkillRecorderPage() {
       if (phaseRef.current !== "recording") return;
       const result = appendNativeEvent(eventsRef.current, native);
       if (result.addedId) {
-        const screenshot = native.type === "key" && !(native.meta || native.control || native.option)
-          ? undefined
-          : takeScreenshot();
+        // A frame is worth keeping for visual/context-changing moments (clicks,
+        // app switches, scrolls, downloads) but not for typing bursts or
+        // clipboard ops — those add no visual evidence and a typing frame can
+        // catch field contents. Secure-field typing never reaches here (the
+        // native helper suppresses it), but skip typing frames regardless.
+        const noFrame = native.type === "typing" || native.type === "clipboard";
+        const screenshot = noFrame ? undefined : takeScreenshot();
         if (screenshot) {
           const index = result.events.findIndex((event) => event.id === result.addedId);
           if (index >= 0) result.events[index] = { ...result.events[index]!, screenshot };
@@ -441,6 +458,12 @@ export function SkillRecorderPage() {
                 <section className="min-w-0 space-y-3">
                   {events.map((event, index) => {
                     const Icon = iconFor(event.type);
+                    const context = [
+                      event.name,
+                      event.app,
+                      event.windowTitle,
+                      event.type === "download" ? originHost(event.whereFroms?.[0]) : undefined,
+                    ].filter(Boolean).join(" · ") || formatRecordingTime(event.atMs);
                     return (
                       <article key={event.id} className="group overflow-hidden rounded-2xl border border-hairline bg-panel">
                         {event.screenshot && <img src={event.screenshot} alt={`Recorded screen at step ${index + 1}`} className="aspect-[16/9] w-full bg-inset object-cover object-top" />}
@@ -448,7 +471,7 @@ export function SkillRecorderPage() {
                           <span className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-card text-ink-secondary"><Icon size={15} /></span>
                           <div className="min-w-0 flex-1">
                             <div className="text-[12px] font-medium">{index + 1}. {eventLabel(event)}</div>
-                            <div className="truncate text-[10.5px] text-ink-secondary">{[event.app, event.windowTitle].filter(Boolean).join(" · ") || formatRecordingTime(event.atMs)}</div>
+                            <div className="truncate text-[10.5px] text-ink-secondary">{context}</div>
                           </div>
                           <button type="button" aria-label={`Remove step ${index + 1}`} onClick={() => removeEvent(event.id)} className="rounded-lg p-2 text-ink-secondary opacity-60 hover:bg-raised hover:text-danger group-hover:opacity-100"><X size={14} /></button>
                         </div>

--- a/src/lib/skill-recorder.test.ts
+++ b/src/lib/skill-recorder.test.ts
@@ -1,22 +1,70 @@
 import { describe, expect, it } from "vitest";
-import { appendNativeEvent, shortcutLabel } from "./skill-recorder";
+import { appendNativeEvent, shortcutLabel, type RecordedSkillEvent } from "./skill-recorder";
 
 const event = (patch: Partial<NativeSkillRecordingEvent>): NativeSkillRecordingEvent => ({
   type: "key", atMs: 100, app: "Notes", windowTitle: "Ideas", ...patch,
 });
 
 describe("skill recording events", () => {
-  it("never retains ordinary typed characters and coalesces a typing burst", () => {
-    const first = appendNativeEvent([], event({ keycode: 0 }));
-    const second = appendNativeEvent(first.events, event({ atMs: 400, keycode: 11 }));
-    expect(second.events).toEqual([expect.objectContaining({ type: "typing", keyCount: 2 })]);
-    expect(JSON.stringify(second.events)).not.toContain("A");
+  it("collapses a ⌘C key chord into the clipboard event so one keystroke is one step", () => {
+    // The helper emits both a `key` chord and a `clipboard` event for ⌘C.
+    const afterChord = appendNativeEvent([], event({ keycode: 8, meta: true }));
+    expect(afterChord.events).toEqual([expect.objectContaining({ type: "shortcut", shortcut: "⌘C" })]);
+    const afterClip = appendNativeEvent(afterChord.events, event({ type: "clipboard", atMs: 220, op: "copy" }));
+    expect(afterClip.events).toEqual([expect.objectContaining({ type: "clipboard", op: "copy" })]);
+    expect(afterClip.events).toHaveLength(1);
+  });
+
+  it("keeps a non-clipboard chord (⌥⌘C) as its own shortcut step", () => {
+    const afterChord = appendNativeEvent([], event({ keycode: 8, meta: true, option: true }));
+    const afterClip = appendNativeEvent(afterChord.events, event({ type: "clipboard", atMs: 220, op: "copy" }));
+    expect(afterClip.events).toHaveLength(2);
+    expect(afterClip.events[0]).toMatchObject({ type: "shortcut" });
+    expect(afterClip.events[1]).toMatchObject({ type: "clipboard" });
+  });
+
+  it("stores a pre-aggregated typing burst as a keyCount, never characters", () => {
+    const result = appendNativeEvent([], event({ type: "typing", keyCount: 7 }));
+    expect(result.events).toEqual([expect.objectContaining({ type: "typing", keyCount: 7 })]);
+    const json = JSON.stringify(result.events);
+    expect(json).not.toContain("keycode");
+    expect(json).not.toContain("A");
+    expect(result.events[0]).not.toHaveProperty("shortcut");
+  });
+
+  it("folds consecutive typing bursts in the same context into one keyCount", () => {
+    const first = appendNativeEvent([], event({ type: "typing", keyCount: 3 }));
+    const second = appendNativeEvent(first.events, event({ type: "typing", atMs: 400, keyCount: 4 }));
+    expect(second.events).toEqual([expect.objectContaining({ type: "typing", keyCount: 7 })]);
+    expect(JSON.stringify(second.events)).not.toContain("keycode");
   });
 
   it("keeps modified keys as readable shortcuts", () => {
     const native = event({ keycode: 35, meta: true, shift: true });
     expect(shortcutLabel(native)).toBe("⇧⌘P");
     expect(appendNativeEvent([], native).events[0]).toMatchObject({ type: "shortcut", shortcut: "⇧⌘P" });
+  });
+
+  it("carries a click's element identity into the compiled event", () => {
+    const native = event({
+      type: "click", x: 10, y: 20, button: "left",
+      role: "AXButton", name: "Submit", identifier: "submit-btn", ancestry: ["Window", "Toolbar"],
+    });
+    expect(appendNativeEvent([], native).events[0]).toMatchObject({
+      type: "click", role: "AXButton", name: "Submit", identifier: "submit-btn", ancestry: ["Window", "Toolbar"],
+    });
+  });
+
+  it("records a clipboard action with its op", () => {
+    const result = appendNativeEvent([], event({ type: "clipboard", op: "copy" }));
+    expect(result.events[0]).toMatchObject({ type: "clipboard", op: "copy" });
+  });
+
+  it("records a download with its filename and origins", () => {
+    const native = event({ type: "download", filename: "invoice.pdf", whereFroms: ["https://acme.example/invoice.pdf"] });
+    expect(appendNativeEvent([], native).events[0]).toMatchObject({
+      type: "download", filename: "invoice.pdf", whereFroms: ["https://acme.example/invoice.pdf"],
+    });
   });
 
   it("coalesces repeated scrolling in the same window", () => {
@@ -29,5 +77,21 @@ describe("skill recording events", () => {
     const first = appendNativeEvent([], event({ type: "click", atMs: 100 }));
     const second = appendNativeEvent(first.events, event({ type: "click", atMs: 100 }));
     expect(second.events[0]?.id).not.toBe(second.events[1]?.id);
+  });
+
+  it("caps the timeline at 600 events and keeps the first ones", () => {
+    let events: RecordedSkillEvent[] = [];
+    for (let i = 0; i < 650; i += 1) {
+      events = appendNativeEvent(events, event({ type: "click", atMs: i })).events;
+    }
+    expect(events).toHaveLength(600);
+    expect(events[0]?.atMs).toBe(0);
+    expect(events.at(-1)?.atMs).toBe(599);
+
+    // Once at the cap, a new event is refused rather than dropping the head.
+    const atCap = appendNativeEvent(events, event({ type: "click", atMs: 999 }));
+    expect(atCap.addedId).toBeNull();
+    expect(atCap.events).toHaveLength(600);
+    expect(atCap.events[0]?.atMs).toBe(0);
   });
 });

--- a/src/lib/skill-recorder.ts
+++ b/src/lib/skill-recorder.ts
@@ -1,6 +1,6 @@
 export type RecordedSkillEvent = {
   id: string;
-  type: "app" | "click" | "scroll" | "shortcut" | "typing";
+  type: "app" | "click" | "scroll" | "shortcut" | "typing" | "clipboard" | "download";
   atMs: number;
   app?: string;
   windowTitle?: string;
@@ -8,12 +8,28 @@ export type RecordedSkillEvent = {
   shortcut?: string;
   screenshot?: string;
   keyCount?: number;
+  role?: string;
+  name?: string;
+  identifier?: string;
+  ancestry?: string[];
+  op?: "copy" | "cut" | "paste";
+  filename?: string;
+  whereFroms?: string[];
 };
 
 export type AppendNativeEventResult = {
   events: RecordedSkillEvent[];
   addedId: string | null;
 };
+
+// Cap the timeline but preserve the START of a long demo: once we hold this
+// many events we stop taking new ones rather than dropping the head.
+const MAX_EVENTS = 600;
+
+function commit(events: RecordedSkillEvent[], next: RecordedSkillEvent): AppendNativeEventResult {
+  if (events.length >= MAX_EVENTS) return { events, addedId: null };
+  return { events: [...events, next], addedId: next.id };
+}
 
 const MAC_KEYS = new Map<number, string>([
   [0, "A"], [1, "S"], [2, "D"], [3, "F"], [4, "H"], [5, "G"], [6, "Z"], [7, "X"], [8, "C"], [9, "V"],
@@ -56,53 +72,75 @@ export function appendNativeEvent(
   const last = events.at(-1);
   if (event.type === "app") {
     if (last?.type === "app" && contextMatches(last, event)) return { events, addedId: null };
-    const next: RecordedSkillEvent = {
+    return commit(events, {
       id: idFor(event), type: "app", atMs: event.atMs, app: event.app, windowTitle: event.windowTitle,
-    };
-    return { events: [...events, next].slice(-150), addedId: next.id };
+    });
   }
   if (event.type === "click") {
-    const next: RecordedSkillEvent = {
+    return commit(events, {
       id: idFor(event), type: "click", atMs: event.atMs, app: event.app, windowTitle: event.windowTitle,
-    };
-    return { events: [...events, next].slice(-150), addedId: next.id };
+      role: event.role, name: event.name, identifier: event.identifier, ancestry: event.ancestry,
+    });
   }
   if (event.type === "scroll") {
     const direction = (event.deltaY ?? 0) > 0 ? "up" : "down";
     if (last?.type === "scroll" && last.direction === direction && contextMatches(last, event) && event.atMs - last.atMs < 800) {
       return { events, addedId: null };
     }
-    const next: RecordedSkillEvent = {
+    return commit(events, {
       id: idFor(event), type: "scroll", direction, atMs: event.atMs, app: event.app, windowTitle: event.windowTitle,
-    };
-    return { events: [...events, next].slice(-150), addedId: next.id };
+    });
   }
-  const modified = Boolean(event.meta || event.control || event.option);
-  if (modified) {
-    const next: RecordedSkillEvent = {
-      id: idFor(event), type: "shortcut", shortcut: shortcutLabel(event), atMs: event.atMs,
-      app: event.app, windowTitle: event.windowTitle,
-    };
-    return { events: [...events, next].slice(-150), addedId: next.id };
+  if (event.type === "clipboard") {
+    // The helper emits the underlying ⌘C/⌘X/⌘V both as a `key` chord (already
+    // committed a beat earlier as a shortcut) and as this richer clipboard
+    // event. Collapse the duplicate so one keystroke is one step.
+    const prev = events.at(-1);
+    const collapsible =
+      prev?.type === "shortcut" &&
+      // Exactly ⌘C/⌘X/⌘V — not ⌥⌘C or other chords that merely end in the letter.
+      /^⌘[CXV]$/.test(prev.shortcut ?? "") &&
+      contextMatches(prev, event) &&
+      Math.abs(event.atMs - prev.atMs) < 1_500;
+    return commit(collapsible ? events.slice(0, -1) : events, {
+      id: idFor(event), type: "clipboard", atMs: event.atMs, app: event.app,
+      windowTitle: event.windowTitle, op: event.op,
+    });
   }
-  if (last?.type === "typing" && contextMatches(last, event) && event.atMs - last.atMs < 1_200) {
-    events[events.length - 1] = { ...last, atMs: event.atMs, keyCount: (last.keyCount ?? 1) + 1 };
-    return { events, addedId: null };
+  if (event.type === "download") {
+    return commit(events, {
+      id: idFor(event), type: "download", atMs: event.atMs,
+      filename: event.filename, whereFroms: event.whereFroms,
+    });
   }
-  const next: RecordedSkillEvent = {
-    id: idFor(event), type: "typing", atMs: event.atMs, app: event.app,
-    windowTitle: event.windowTitle, keyCount: 1,
-  };
-  return { events: [...events, next].slice(-150), addedId: next.id };
+  if (event.type === "typing") {
+    // The helper pre-aggregates plain typing into a keyCount; keep the timeline
+    // tidy by folding a follow-up burst in the same context into the last one.
+    if (last?.type === "typing" && contextMatches(last, event) && event.atMs - last.atMs < 1_200) {
+      events[events.length - 1] = { ...last, atMs: event.atMs, keyCount: (last.keyCount ?? 0) + (event.keyCount ?? 0) };
+      return { events, addedId: null };
+    }
+    return commit(events, {
+      id: idFor(event), type: "typing", atMs: event.atMs, app: event.app,
+      windowTitle: event.windowTitle, keyCount: event.keyCount ?? 0,
+    });
+  }
+  // A "key" event now always carries a modifier — map it to a readable shortcut.
+  return commit(events, {
+    id: idFor(event), type: "shortcut", shortcut: shortcutLabel(event), atMs: event.atMs,
+    app: event.app, windowTitle: event.windowTitle,
+  });
 }
 
 export function eventLabel(event: RecordedSkillEvent): string {
   switch (event.type) {
     case "app": return `Opened ${event.app || "an app"}`;
-    case "click": return "Clicked a control";
+    case "click": return event.name ? `Clicked "${event.name}"` : "Clicked a control";
     case "scroll": return `Scrolled ${event.direction ?? "the page"}`;
     case "shortcut": return `Pressed ${event.shortcut ?? "a shortcut"}`;
     case "typing": return `Typed ${event.keyCount ?? 1} character${event.keyCount === 1 ? "" : "s"}`;
+    case "clipboard": return event.op === "cut" ? "Cut" : event.op === "paste" ? "Pasted" : "Copied";
+    case "download": return `Downloaded ${event.filename ?? "a file"}`;
   }
 }
 

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -2,7 +2,7 @@
 
 declare global {
 type NativeSkillRecordingEvent = {
-  type: "app" | "click" | "scroll" | "key";
+  type: "app" | "click" | "scroll" | "key" | "typing" | "clipboard" | "download";
   atMs: number;
   app?: string;
   windowTitle?: string;
@@ -15,6 +15,18 @@ type NativeSkillRecordingEvent = {
   control?: boolean;
   option?: boolean;
   shift?: boolean;
+  /** Element identity for a click, from the accessibility tree. */
+  role?: string;
+  name?: string;
+  identifier?: string;
+  ancestry?: string[];
+  /** Typed keystroke count (never the characters themselves). */
+  keyCount?: number;
+  /** Clipboard action kind — never its contents. */
+  op?: "copy" | "cut" | "paste";
+  /** Downloaded file name and its origin URLs. */
+  filename?: string;
+  whereFroms?: string[];
 };
 
 type SkillRecordingPayload = {
@@ -25,13 +37,24 @@ type SkillRecordingPayload = {
   transcription?: { provider: "assemblyai"; model: string };
   audio?: string;
   events: Array<{
-    type: "app" | "click" | "scroll" | "shortcut" | "typing";
+    type: "app" | "click" | "scroll" | "shortcut" | "typing" | "clipboard" | "download";
     atMs: number;
     app?: string;
     windowTitle?: string;
     direction?: "up" | "down";
     shortcut?: string;
+    keyCount?: number;
     screenshot?: string;
+    /** Element identity for a click. */
+    role?: string;
+    name?: string;
+    identifier?: string;
+    ancestry?: string[];
+    /** Clipboard action kind — never its contents. */
+    op?: "copy" | "cut" | "paste";
+    /** Downloaded file name and its origin URLs. */
+    filename?: string;
+    whereFroms?: string[];
   }>;
 };
 


### PR DESCRIPTION
Stacks onto #383 (targets `codex/skill-recorder`, not `main`). Turns the recorder from coordinate+screenshot capture into semantic, context-aware capture — the P0/P1 items from the capture review.

## Why
The current recorder records *that* you clicked, in which app/window — but not *what* you clicked, and none of the surrounding context (files, clipboard). Replay grounding rested entirely on screenshots + narration. This adds the semantic evidence that makes a compiled skill diffable and durable.

## What changed
**Native helper**
- **AX element identity at click** — `AXUIElementCopyElementAtPosition` (0.4s messaging timeout, fully guarded) → role, accessible name, `AXIdentifier`, 4-level ancestry, bbox. Each field omitted on failure; never blocks the tap.
- **Typing aggregated in-helper** — plain keystrokes never leave the process as keycodes; only a per-burst count. Chords still emit as key events.
- **Secure-field suppression** — while an `AXSecureTextField` is focused, typing/chords/clipboard are suppressed and click name/identifier dropped (deny-by-default).
- **Clipboard events** — chord + `NSPasteboard.changeCount`, contents never read.
- **Downloads** — `~/Downloads` polling with `kMDItemWhereFroms` origin URLs.

**Schema + main** — persist the new identity/clipboard/download fields; SKILL.md now names elements (`Click "Order payoff" (button)`), summarizes file origin + clipboard ops; event cap raised to 600 and made **head-preserving with disclosure** (`truncated`/`omittedEvents`) instead of silently dropping the start of long demos.

**Renderer** — carry identity through; accept helper-aggregated typing; collapse the duplicate ⌘C/⌘X/⌘V chord into the clipboard event (but not ⌥⌘C); head-preserving 600 cap; skip screenshots for typing/clipboard; clipboard/download icons + origin host in the review list.

## Privacy properties (tested)
- No typed characters or keycodes ever reach disk (plain typing → count only).
- Clipboard contents never captured; secure-field input fully suppressed.
- Long recordings disclose truncation rather than silently losing the head.

## Verification
- `swiftc` clean (host + universal via `build:recorder`)
- `pnpm typecheck` · `pnpm build` · `pnpm check:electron` (38 modules)
- `pnpm test` — **1540 passed / 12 skipped**; +11 new recorder tests

## Notes / follow-ups (not in this PR)
- Windows Raw Input + UIA helper (same event contract) — deliberately deferred.
- Optional LLM "polish" compile pass (Claude with keyframes+narration → step prose/slots) on top of the deterministic compiler.
- Merges cleanly onto `codex/skill-recorder` @ bbffb46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added privacy-preserving typing activity tracking without storing raw keystrokes.
  - Added clipboard copy, cut, and paste events without capturing clipboard contents.
  - Added download events with sanitized source information.
  - Enhanced click details with accessible element names and context.
  - Updated recording reviews with event icons, application details, and download sources.

- **Privacy**
  - Sensitive fields now suppress typing and shortcut activity.
  - Screenshots are excluded for typing and clipboard events.
  - Recording metadata clearly indicates privacy protections.

- **Bug Fixes**
  - Improved event capture reliability after temporary input or accessibility interruptions.
  - Recordings now disclose when event limits cause omitted activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->