### PR TITLE
feat(chat): fold a stretch of tool chips into one row

### DIFF
--- a/src/components/ActivityRun.tsx
+++ b/src/components/ActivityRun.tsx
@@ -1,0 +1,65 @@
+// A folded stretch of tool chips: one row saying what ran, click to open.
+//
+// Collapsed by default, with two exceptions the transcript would be worse
+// without: a run holding a failure opens itself (the failure is the reason
+// you would have opened it), and a run stays open once you have opened it.
+import { useEffect, useState } from "react";
+import { ChevronRight, Check, X } from "lucide-react";
+import type { Message } from "@/state/store";
+import { describeRun } from "@/lib/activity-runs";
+import { cn } from "@/lib/cn";
+
+export function ActivityRun({
+  messages,
+  forceOpen = false,
+  children,
+}: {
+  messages: Message[];
+  /** landing on a step inside this run — a search hit cannot scroll to a
+   * row that a fold has kept out of the DOM */
+  forceOpen?: boolean;
+  /** the individual chips, rendered by whichever transcript owns them */
+  children: React.ReactNode;
+}) {
+  const failed = messages.some((message) => message.tool?.ok === false);
+  const [open, setOpen] = useState(failed || forceOpen);
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
+  if (open) {
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-start">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-expanded
+            className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-control"
+          >
+            <ChevronRight size={13} className="rotate-90" />
+            <span>{describeRun(messages)}</span>
+          </button>
+        </div>
+        {children}
+      </div>
+    );
+  }
+  return (
+    <div className="flex justify-start">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-expanded={false}
+        title="Show every step"
+        className={cn(
+          "flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] hover:bg-control",
+          failed ? "text-danger" : "text-ink-secondary",
+        )}
+      >
+        {failed ? <X size={13} /> : <Check size={13} className="text-success" />}
+        <span className="max-w-[480px] truncate">{describeRun(messages)}</span>
+        <ChevronRight size={13} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ActivityRun.tsx
+++ b/src/components/ActivityRun.tsx
@@ -24,8 +24,8 @@ export function ActivityRun({
   const failed = messages.some((message) => message.tool?.ok === false);
   const [open, setOpen] = useState(failed || forceOpen);
   useEffect(() => {
-    if (forceOpen) setOpen(true);
-  }, [forceOpen]);
+    if (failed || forceOpen) setOpen(true);
+  }, [failed, forceOpen]);
   if (open) {
     return (
       <div className="flex flex-col gap-1">

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -58,6 +58,8 @@ import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
 import { COMPACT_BUBBLE, COMPACT_SQUARE } from "@/lib/compact-chip";
 import { useFocusMessage } from "@/lib/focus-message";
+import { groupActivityRuns } from "@/lib/activity-runs";
+import { ActivityRun } from "./ActivityRun";
 import { webhookMessageView } from "@/lib/webhook-message";
 import { splitAttachedImages } from "@/lib/composer-attachments";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
@@ -665,7 +667,14 @@ const MessagesList = memo(function MessagesList({
   onRegenerate: () => void;
   onReply: (message: Message) => void;
 }) {
-  const { dispatch } = useStore();
+  const { state, dispatch } = useStore();
+  // Fold finished tool chips into runs, so a stretch of them cannot bury
+  // what the bot actually said.
+  const items = useMemo(() => groupActivityRuns(messages), [messages]);
+  // A search hit inside a folded run has to open it: the fold keeps the
+  // row out of the DOM, and there is nothing for the scroll to land on.
+  const focus = state.focusMessage;
+  const focusedId = focus && !focus.consumed && focus.threadId === bot.threadId ? focus.messageId : null;
   return (
     <>
       {messages.length === 0 && !bot.busy && (
@@ -682,9 +691,26 @@ const MessagesList = memo(function MessagesList({
           </div>
         </div>
       )}
-      {messages.map((m, i) => {
-        const prev = messages[i - 1];
-        const newDay = !prev || new Date(prev.at).toDateString() !== new Date(m.at).toDateString();
+      {items.map((item, i) => {
+        const previous = items[i - 1];
+        const prev = previous && (previous.kind === "run" ? previous.messages.at(-1) : previous.message);
+        const first = item.kind === "run" ? item.messages[0] : item.message;
+        const newDay = !prev || new Date(prev.at).toDateString() !== new Date(first.at).toDateString();
+        if (item.kind === "run") {
+          return (
+            <div key={item.id} className="contents">
+              {newDay && <DaySeparator at={first.at} />}
+              <ActivityRun messages={item.messages} forceOpen={item.messages.some((step) => step.id === focusedId)}>
+                {item.messages.map((step) => (
+                  <div key={step.id} className="contents" data-mid={step.id}>
+                    <ActivityChip message={step} />
+                  </div>
+                ))}
+              </ActivityRun>
+            </div>
+          );
+        }
+        const m = item.message;
         const row = (() => {
           switch (m.kind) {
             case "secret":

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -28,6 +28,8 @@ import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 import { ReactionBar, ReactionChips } from "./Reactions";
 import { ApprovalCard } from "./ApprovalCard";
 import { ManageMembersPanel } from "./ManageMembersPanel";
+import { groupActivityRuns } from "@/lib/activity-runs";
+import { ActivityRun } from "./ActivityRun";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { cn } from "@/lib/cn";
 import { useFocusMessage } from "@/lib/focus-message";
@@ -51,6 +53,25 @@ function dayLabel(at: number): string {
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
   return d.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" });
+}
+
+/** One finished tool step in a room. Same pill the 1:1 chat uses, minus the
+ * status glyph — a room reads as a conversation, not a build log. */
+function RoomToolChip({ message }: { message: Message }) {
+  const tool = message.tool;
+  if (!tool) return null;
+  return (
+    <div className="flex justify-start">
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px]",
+          tool.ok === false ? "text-danger" : "text-ink-secondary",
+        )}
+      >
+        <span className="max-w-[480px] truncate font-mono">{tool.name}</span>
+      </div>
+    </div>
+  );
 }
 
 /** 16px maus + name, shown once per sender cluster. */
@@ -107,14 +128,43 @@ const Transcript = memo(function Transcript({
   transcript: Message[];
   onReply: (message: Message) => void;
 }) {
-  const { dispatch } = useStore();
+  const { state, dispatch } = useStore();
   const memberOf = (id?: string) => members.find((b) => b.id === id);
-  const textMessages = messages;
+  // Several bots working at once turn a room into a wall of chips; fold the
+  // finished ones the same way a 1:1 chat does.
+  const items = useMemo(() => groupActivityRuns(messages), [messages]);
+  const focus = state.focusMessage;
+  const focusedId = focus && !focus.consumed && focus.threadId === group.threadId ? focus.messageId : null;
   return (
     <>
-      {textMessages.map((m, i) => {
-        const prev = textMessages[i - 1];
-        const newDay = !prev || new Date(prev.at).toDateString() !== new Date(m.at).toDateString();
+      {items.map((item, i) => {
+        const previous = items[i - 1];
+        const prev = previous && (previous.kind === "run" ? previous.messages.at(-1) : previous.message);
+        const first = item.kind === "run" ? item.messages[0] : item.message;
+        const newDay = !prev || new Date(prev.at).toDateString() !== new Date(first.at).toDateString();
+        if (item.kind === "run") {
+          const cluster = !prev || prev.role !== first.role || prev.from?.botId !== first.from?.botId || newDay;
+          return (
+            <div key={item.id} className="contents">
+              {newDay && (
+                <div className="py-3 text-center text-[13px] text-ink-secondary">
+                  {dayLabel(first.at)} {formatTime(first.at)}
+                </div>
+              )}
+              {first.from && cluster && (
+                <ClusterLabel bot={memberOf(first.from.botId)} name={first.from.name} color={first.from.color} />
+              )}
+              <ActivityRun messages={item.messages} forceOpen={item.messages.some((step) => step.id === focusedId)}>
+                {item.messages.map((step) => (
+                  <div key={step.id} className="contents" data-mid={step.id}>
+                    <RoomToolChip message={step} />
+                  </div>
+                ))}
+              </ActivityRun>
+            </div>
+          );
+        }
+        const m = item.message;
         const user = m.role === "user";
         const attachedImages = user && m.text ? splitAttachedImages(m.text) : null;
         const newCluster = !prev || prev.role !== m.role || prev.from?.botId !== m.from?.botId || newDay;
@@ -133,16 +183,7 @@ const Transcript = memo(function Transcript({
               <ApprovalCard bot={memberOf(m.from?.botId)} message={m} />
             </div>
           ) : m.kind === "activity" && m.tool ? (
-            <div className="flex justify-start">
-              <div
-                className={cn(
-                  "flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px]",
-                  m.tool.ok === false ? "text-danger" : "text-ink-secondary",
-                )}
-              >
-                <span className="max-w-[480px] truncate font-mono">{m.tool.name}</span>
-              </div>
-            </div>
+            <RoomToolChip message={m} />
           ) : m.kind === "text" && m.text ? (
             <div className={cn("group flex w-full flex-col", user ? "items-end" : "items-start")}>
               <div className={cn("flex w-full items-end gap-1.5", user ? "justify-end" : "justify-start")}>

--- a/src/lib/activity-runs.test.ts
+++ b/src/lib/activity-runs.test.ts
@@ -5,12 +5,12 @@ import type { Message } from "@/state/store";
 
 let seq = 0;
 const tool = (name: string, ok = true): Message =>
-  ({ id: `t${++seq}`, at: seq, kind: "activity", tool: { name, ok } }) as Message;
+  ({ id: `t${++seq}`, at: seq, role: "bot", kind: "activity", tool: { name, ok } });
 /** a step with no verdict yet — `ok` absent, not `ok: undefined`, which a
  * default parameter would quietly turn back into a finished step */
 const running = (name: string): Message =>
-  ({ id: `t${++seq}`, at: seq, kind: "activity", tool: { name } }) as Message;
-const text = (body: string): Message => ({ id: `m${++seq}`, at: seq, kind: "text", text: body }) as Message;
+  ({ id: `t${++seq}`, at: seq, role: "bot", kind: "activity", tool: { name } });
+const text = (body: string): Message => ({ id: `m${++seq}`, at: seq, role: "bot", kind: "text", text: body });
 
 describe("groupActivityRuns", () => {
   it("folds consecutive tool steps into one run", () => {
@@ -45,6 +45,37 @@ describe("groupActivityRuns", () => {
     const steps = [tool("Edit"), tool("Edit")];
     const items = groupActivityRuns(steps);
     expect(items[0].kind === "run" && items[0].id).toBe(`run:${steps[0].id}`);
+  });
+
+  it("does not attribute consecutive room steps from different bots to one sender", () => {
+    const roomTool = (name: string, botId: string): Message => ({
+      ...tool(name),
+      from: { botId, name: botId, color: "blue" },
+    });
+
+    expect(
+      groupActivityRuns([
+        roomTool("Read", "alice"),
+        roomTool("Edit", "alice"),
+        roomTool("Write", "bob"),
+        roomTool("Bash", "bob"),
+      ]).map((item) => item.kind),
+    ).toEqual(["run", "run"]);
+  });
+
+  it("keeps local calendar-day boundaries between activity runs", () => {
+    const beforeMidnight = new Date(2026, 0, 1, 23, 59).getTime();
+    const afterMidnight = new Date(2026, 0, 2, 0, 1).getTime();
+    const stepAt = (name: string, at: number): Message => ({ ...tool(name), at });
+
+    expect(
+      groupActivityRuns([
+        stepAt("Read", beforeMidnight),
+        stepAt("Edit", beforeMidnight),
+        stepAt("Write", afterMidnight),
+        stepAt("Bash", afterMidnight),
+      ]).map((item) => item.kind),
+    ).toEqual(["run", "run"]);
   });
 });
 

--- a/src/lib/activity-runs.test.ts
+++ b/src/lib/activity-runs.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { describeRun, groupActivityRuns } from "./activity-runs";
+import type { Message } from "@/state/store";
+
+let seq = 0;
+const tool = (name: string, ok = true): Message =>
+  ({ id: `t${++seq}`, at: seq, kind: "activity", tool: { name, ok } }) as Message;
+/** a step with no verdict yet — `ok` absent, not `ok: undefined`, which a
+ * default parameter would quietly turn back into a finished step */
+const running = (name: string): Message =>
+  ({ id: `t${++seq}`, at: seq, kind: "activity", tool: { name } }) as Message;
+const text = (body: string): Message => ({ id: `m${++seq}`, at: seq, kind: "text", text: body }) as Message;
+
+describe("groupActivityRuns", () => {
+  it("folds consecutive tool steps into one run", () => {
+    const items = groupActivityRuns([tool("Edit"), tool("Bash"), tool("Edit")]);
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("run");
+    expect(items[0].kind === "run" && items[0].messages).toHaveLength(3);
+  });
+
+  it("keeps text between runs, so a run never swallows what the bot said", () => {
+    const items = groupActivityRuns([tool("Edit"), tool("Edit"), text("Now the sitemap:"), tool("Write"), tool("Write")]);
+    expect(items.map((i) => i.kind)).toEqual(["run", "message", "run"]);
+  });
+
+  it("leaves a lone tool step as an ordinary message", () => {
+    const items = groupActivityRuns([text("hi"), tool("Edit"), text("done")]);
+    expect(items.map((i) => i.kind)).toEqual(["message", "message", "message"]);
+  });
+
+  it("keeps a step that is still running out of the run, so live progress stays visible", () => {
+    const items = groupActivityRuns([tool("Edit"), tool("Edit"), running("Bash")]);
+    expect(items.map((i) => i.kind)).toEqual(["run", "message"]);
+    expect(items[1].kind === "message" && items[1].message.tool?.name).toBe("Bash");
+  });
+
+  it("never folds a failed turn, which renders as an error not a tool run", () => {
+    const items = groupActivityRuns([tool("Edit"), tool("error: the CLI exited")]);
+    expect(items.map((i) => i.kind)).toEqual(["message", "message"]);
+  });
+
+  it("gives a run a stable id taken from its first step", () => {
+    const steps = [tool("Edit"), tool("Edit")];
+    const items = groupActivityRuns(steps);
+    expect(items[0].kind === "run" && items[0].id).toBe(`run:${steps[0].id}`);
+  });
+});
+
+describe("describeRun", () => {
+  it("counts repeats and names the tools in order of first use", () => {
+    expect(describeRun([tool("Edit"), tool("Bash"), tool("Edit"), tool("Edit")])).toBe("4 steps · Edit ×3, Bash");
+  });
+
+  it("names a single repeat without a multiplier", () => {
+    expect(describeRun([tool("Edit"), tool("Bash")])).toBe("2 steps · Edit, Bash");
+  });
+
+  it("trims a long tail of tool names rather than running off the row", () => {
+    expect(describeRun([tool("Edit"), tool("Bash"), tool("Write"), tool("Grep"), tool("Read")])).toBe(
+      "5 steps · Edit, Bash, Write +2 more",
+    );
+  });
+
+  it("says how many steps failed, because that is the reason to open it", () => {
+    expect(describeRun([tool("Edit"), tool("Bash", false)])).toBe("2 steps · Edit, Bash · 1 failed");
+  });
+});

--- a/src/lib/activity-runs.ts
+++ b/src/lib/activity-runs.ts
@@ -1,0 +1,63 @@
+// Grouping a transcript's tool chips into runs.
+//
+// A bot working through a task emits one chip per tool call, and a long
+// stretch of them buries the thing you actually came to read: what the bot
+// SAID. Consecutive finished steps fold into a single row that names them;
+// text between two stretches breaks the run, so the bot's words always
+// separate one run from the next.
+import type { Message } from "@/state/store";
+
+export type TranscriptItem =
+  | { kind: "message"; message: Message }
+  | { kind: "run"; id: string; messages: Message[] };
+
+/** A step that may be folded away: finished, a real tool, and not a
+ * bot⇄bot chip (those are navigation, not work) or a failed turn (that
+ * renders as an error). A step still running stays out, so live progress
+ * is never hidden behind a fold. */
+function foldable(message: Message): boolean {
+  const tool = message.tool;
+  if (message.kind !== "activity" || !tool) return false;
+  if (message.comm) return false;
+  if (tool.ok === undefined) return false;
+  return !tool.name.startsWith("error:");
+}
+
+export function groupActivityRuns(messages: Message[]): TranscriptItem[] {
+  const items: TranscriptItem[] = [];
+  let run: Message[] = [];
+  const flush = () => {
+    // one step on its own is cheaper to read than a fold that hides it
+    if (run.length > 1) items.push({ kind: "run", id: `run:${run[0].id}`, messages: run });
+    else for (const message of run) items.push({ kind: "message", message });
+    run = [];
+  };
+  for (const message of messages) {
+    if (foldable(message)) {
+      run.push(message);
+      continue;
+    }
+    flush();
+    items.push({ kind: "message", message });
+  }
+  flush();
+  return items;
+}
+
+const MAX_NAMES = 3;
+
+/** The one line a folded run has to earn its place with: how much work it
+ * was, which tools did it, and whether anything failed — the last being the
+ * only reason you would open it. */
+export function describeRun(messages: Message[]): string {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    const name = message.tool?.name ?? "";
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  const names = [...counts].map(([name, count]) => (count > 1 ? `${name} ×${count}` : name));
+  const shown = names.slice(0, MAX_NAMES).join(", ");
+  const rest = names.length > MAX_NAMES ? ` +${names.length - MAX_NAMES} more` : "";
+  const failed = messages.filter((message) => message.tool?.ok === false).length;
+  return `${messages.length} steps · ${shown}${rest}${failed ? ` · ${failed} failed` : ""}`;
+}

--- a/src/lib/activity-runs.ts
+++ b/src/lib/activity-runs.ts
@@ -34,6 +34,15 @@ export function groupActivityRuns(messages: Message[]): TranscriptItem[] {
   };
   for (const message of messages) {
     if (foldable(message)) {
+      const first = run[0];
+      if (
+        first &&
+        (first.role !== message.role ||
+          first.from?.botId !== message.from?.botId ||
+          new Date(first.at).toDateString() !== new Date(message.at).toDateString())
+      ) {
+        flush();
+      }
       run.push(message);
       continue;
     }


### PR DESCRIPTION
## What changed

A bot working through a task emits one chip per tool call. Ten `Edit`s, a `Bash` and three `TaskUpdate`s fill a screen and a half between two sentences, and the thing you opened the chat to read — what the bot *said* — ends up buried.

Consecutive finished steps now fold into a single row naming what ran (`10 steps · Edit ×9, Bash`), which opens on click. Text breaks a run, so the bot's own words always separate one fold from the next — that is what makes the transcript readable again rather than merely shorter.

Three things deliberately stay out of a fold:

- **a step still running** — live progress is never hidden behind a fold
- **a failed turn** — that renders as an error, not a tool chip
- **a bot⇄bot chip** — navigation into another conversation, not work

A run holding a failure opens itself and says how many failed (`3 steps · Bash, Grep, Read · 1 failed`); that failure is the one reason you would have opened it. A run also opens when a search lands on a step inside it — a fold keeps the row out of the DOM, so there would otherwise be nothing for the scroll to find.

Rooms get the same treatment, where several bots working at once makes the wall of chips worst.

## Why

Reported from a real session: a stretch of ~14 chips between two sentences, with the request that they "merge into one thing".

## How it was verified

- 10 unit tests for the grouping and the summary line (`src/lib/activity-runs.test.ts`), written against a stubbed implementation and watched failing first. One of them failed for the *wrong* reason at first — the test helper's default parameter turned an explicit `undefined` back into a finished step, which is exactly the kind of thing a test-after would have hidden.
- `pnpm typecheck` clean; full suite 1696 tests pass
- `oxlint` — 4 errors in `GroupView.tsx`, all pre-existing on main (verified by stashing); no new ones
- Driven in a real browser against a seeded transcript matching the report: collapsed renders 3 fold rows with 5 chips visible (the failed run's, auto-opened); expanding gives all 15 chips back

## Screenshots (UI changes)

Before: ten `Edit` chips stacked between two sentences. After: `10 steps · Edit ×9, Bash ›`, `4 steps · Write, TaskUpdate ×3 ›`, and `3 steps · Bash, Grep, Read · 1 failed` already open. (Adding the images in a follow-up comment.)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — no server change; the grouping is pure and unit-tested
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity steps are grouped into collapsible runs with summaries of tools used, step counts, and failures.
  * Runs expand automatically for focused search results or errors.
  * Added conversation search, message quoting, reply navigation, and attached-image galleries in chat and room transcripts.
  * Added dedicated displays for secret requests and completed activities.
  * Shared activity displays are available across chat and room transcripts.
  * Running, failed, and standalone steps remain individually visible.

* **Bug Fixes**
  * Improved navigation to focused activity steps, including steps inside collapsed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->