### PR TITLE
feat(composer): attach a file, and switch auto mode where you type

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -167,16 +167,20 @@ export function Composer({
   // a chip on its own is a message: the send control has to appear for it
   const fileInput = useRef<HTMLInputElement>(null);
   const [autoWarn, setAutoWarn] = useState(false);
+  const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   // Auto mode belongs to one bot; a room has several, each with its own.
   const autoBot = group ? undefined : bot;
   const pickFiles = async (picked: FileList | null) => {
     if (!picked?.length) return;
-    const { attachments: added } = await intakeFiles(Array.from(picked), {
+    const { attachments: added, notice } = await intakeFiles(Array.from(picked), {
       allowImages: engineSupportsImages,
       getPath: pathForFile,
       uploadImage: imageAttachmentFromFile,
     });
     if (added.length) addAttachments(added);
+    // Keep file-specific failures beside the attachments. A successful
+    // overlapping intake must not erase an earlier failure before it is read.
+    if (notice) setAttachmentNotice(notice);
   };
   const toggleAuto = () => {
     if (!autoBot) return;
@@ -354,6 +358,8 @@ export function Composer({
           onAdd={addAttachments}
           onRemove={removeAttachment}
           allowImages={engineSupportsImages}
+          notice={attachmentNotice}
+          onNotice={setAttachmentNotice}
         />
         <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-2 pr-2">
         <input

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,14 +1,16 @@
 import { track } from "@/lib/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowUp, Clock, Mic, Square, Users, X } from "lucide-react";
+import { ArrowUp, Clock, Mic, Plus, Square, Users, X, Zap } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { useComposerDraft } from "@/lib/drafts";
 import { MausAvatar } from "./Avatar";
-import { ComposerAttachments } from "./ComposerAttachments";
+import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
+import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import {
   composeMessage,
   imageAttachmentFromFile,
+  intakeFiles,
   isImageFile,
   isLongPaste,
   pasteAttachment,
@@ -163,6 +165,32 @@ export function Composer({
       ? state.pendingQueued?.[bot.threadId]?.map((entry) => entry.text).join("\n")
       : undefined;
   // a chip on its own is a message: the send control has to appear for it
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [autoWarn, setAutoWarn] = useState(false);
+  // Auto mode belongs to one bot; a room has several, each with its own.
+  const autoBot = group ? undefined : bot;
+  const pickFiles = async (picked: FileList | null) => {
+    if (!picked?.length) return;
+    const { attachments: added } = await intakeFiles(Array.from(picked), {
+      allowImages: engineSupportsImages,
+      getPath: pathForFile,
+      uploadImage: imageAttachmentFromFile,
+    });
+    if (added.length) addAttachments(added);
+  };
+  const toggleAuto = () => {
+    if (!autoBot) return;
+    // Turning it on for a bot that drives THIS computer is the one case that
+    // has to be acknowledged first. The flag the dialog sends is stripped by
+    // the reducer rather than stored, so — exactly like the settings panel —
+    // the warning is shown on every switch-on, not just the first.
+    if (!autoBot.autoApprove && autoBot.computer === "local") {
+      setAutoWarn(true);
+      return;
+    }
+    dispatch({ type: "updateBot", botId: autoBot.id, patch: { autoApprove: !autoBot.autoApprove } });
+  };
+
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const send = () => {
     if (locked) return;
@@ -327,7 +355,28 @@ export function Composer({
           onRemove={removeAttachment}
           allowImages={engineSupportsImages}
         />
-        <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-3 pr-2">
+        <div className="flex items-end gap-2 rounded-3xl border border-hairline/40 bg-raised/60 py-2 pl-2 pr-2">
+        <input
+          ref={fileInput}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            void pickFiles(e.target.files);
+            // same file twice in a row still fires onChange
+            e.target.value = "";
+          }}
+        />
+        {!locked && (
+          <button
+            onClick={() => fileInput.current?.click()}
+            aria-label="Attach a file"
+            title="Attach a file"
+            className="flex size-8 shrink-0 items-center justify-center self-end rounded-full text-ink-secondary hover:bg-control hover:text-ink"
+          >
+            <Plus size={18} />
+          </button>
+        )}
         <textarea
           ref={inputRef}
           rows={1}
@@ -428,6 +477,28 @@ export function Composer({
           aria-label={`Message ${group ? group.name : (bot?.name ?? "")}`}
           className="max-h-40 w-full resize-none self-center bg-transparent py-1 text-[15px] leading-6 text-ink placeholder:text-ink-secondary focus:outline-none"
         />
+        {autoBot && !locked && (
+          <button
+            onClick={toggleAuto}
+            role="switch"
+            aria-checked={Boolean(autoBot.autoApprove)}
+            aria-label="Auto mode"
+            title={
+              autoBot.autoApprove
+                ? "Auto mode is on — this bot keeps going without asking. Anything destructive still stops for you."
+                : "Auto mode is off — you approve each action"
+            }
+            className={cn(
+              "flex shrink-0 items-center gap-1 self-end rounded-full px-2 py-1.5 text-[12.5px] font-medium",
+              autoBot.autoApprove
+                ? "bg-accent/15 text-accent-text"
+                : "text-ink-secondary hover:bg-control hover:text-ink",
+            )}
+          >
+            <Zap size={13} className={autoBot.autoApprove ? "fill-current" : undefined} />
+            Auto
+          </button>
+        )}
         {busy && !locked && (
           <button
             onClick={() => {
@@ -471,6 +542,20 @@ export function Composer({
         )}
         </div>
       </div>
+      <LocalComputerAutoWarning
+        open={autoWarn}
+        onCancel={() => setAutoWarn(false)}
+        onConfirm={() => {
+          if (autoBot) {
+            dispatch({
+              type: "updateBot",
+              botId: autoBot.id,
+              patch: { autoApprove: true, acknowledgeLocalAuto: true },
+            });
+          }
+          setAutoWarn(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -24,14 +24,17 @@ export function ComposerAttachments({
   onAdd,
   onRemove,
   allowImages = true,
+  notice,
+  onNotice,
 }: {
   items: Attachment[];
   onAdd: (attachments: Attachment[]) => void;
   onRemove: (id: string) => void;
   allowImages?: boolean;
+  notice: string | null;
+  onNotice: (notice: string | null) => void;
 }) {
   const [dragging, setDragging] = useState(false);
-  const [notice, setNotice] = useState<string | null>(null);
   // dragenter/dragleave fire once per element crossed, so the overlay
   // tracks depth rather than the last event it happened to see
   const depth = useRef(0);
@@ -62,7 +65,7 @@ export function ComposerAttachments({
       setDragging(false);
       const files = Array.from(e.dataTransfer?.files ?? []);
       // Same intake the attach button uses: a dropped file and a picked one
-      // must not sort differently.
+      // must not appear in a different order.
       const { attachments, notice: message } = await intakeFiles(files, {
         allowImages,
         getPath: pathForFile,
@@ -70,7 +73,9 @@ export function ComposerAttachments({
       });
       if (!active) return;
       if (attachments.length) onAdd(attachments);
-      setNotice(message);
+      // Only a failure changes the notice. This keeps a concurrent successful
+      // intake from clearing an error before the user can read it.
+      if (message) onNotice(message);
     };
 
     window.addEventListener("dragenter", onEnter);
@@ -84,7 +89,7 @@ export function ComposerAttachments({
       window.removeEventListener("dragover", onOver);
       window.removeEventListener("drop", onDrop);
     };
-  }, [onAdd, allowImages]);
+  }, [onAdd, allowImages, onNotice]);
 
   return (
     <>
@@ -100,7 +105,7 @@ export function ComposerAttachments({
         <div className="mb-2 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
           <span className="min-w-0 flex-1">{notice}</span>
           <button
-            onClick={() => setNotice(null)}
+            onClick={() => onNotice(null)}
             aria-label="Dismiss"
             className="shrink-0 rounded p-0.5"
           >

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -7,16 +7,15 @@ import { ClipboardPaste, File as FileIcon, Image as ImageIcon, X } from "lucide-
 import { cn } from "@/lib/cn";
 import {
   attachmentBasename,
-  attachmentsFromDroppedFiles,
+  intakeFiles,
   formatSize,
   imageAttachmentFromFile,
-  isImageFile,
   pasteSummary,
   type Attachment,
 } from "@/lib/composer-attachments";
 
 /** Electron 32 removed File.path — only the preload can name a file. */
-function pathForFile(file: File): string {
+export function pathForFile(file: File): string {
   return window.ogb?.getPathForFile?.(file) ?? "";
 }
 
@@ -62,30 +61,16 @@ export function ComposerAttachments({
       depth.current = 0;
       setDragging(false);
       const files = Array.from(e.dataTransfer?.files ?? []);
-      const images = allowImages ? files.filter(isImageFile) : [];
-      const rest = files.filter((f) => !isImageFile(f));
-      const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(rest, pathForFile);
-      const uploaded: Attachment[] = [];
-      const imageErrors: string[] = [];
-      for (const file of images) {
-        try {
-          const attachment = await imageAttachmentFromFile(file);
-          if (attachment) uploaded.push(attachment);
-        } catch (err) {
-          imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
-        }
-      }
+      // Same intake the attach button uses: a dropped file and a picked one
+      // must not sort differently.
+      const { attachments, notice: message } = await intakeFiles(files, {
+        allowImages,
+        getPath: pathForFile,
+        uploadImage: imageAttachmentFromFile,
+      });
       if (!active) return;
-      if (attachments.length || uploaded.length) onAdd([...attachments, ...uploaded]);
-      setNotice(
-        rejectedNames.length && imageErrors.length
-          ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder. (${imageErrors.join("; ")})`
-          : rejectedNames.length
-            ? `${rejectedNames.join(", ")} — that drag carried no file on disk. Save it first, then drop it from Finder.`
-            : imageErrors.length
-              ? imageErrors.join("; ")
-              : null,
-      );
+      if (attachments.length) onAdd(attachments);
+      setNotice(message);
     };
 
     window.addEventListener("dragenter", onEnter);

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -242,7 +242,7 @@ export function attachmentBasename(path: string): string {
 /** One intake path for files arriving by drop OR by the composer's attach
  * button, so a picked file and a dropped one can never behave differently.
  * The image uploader is injected: the caller owns the network, this owns
- * the sorting and the sentence the user reads when something is refused. */
+ * the ordering and the sentence the user reads when something is refused. */
 export async function intakeFiles<T extends DroppedFile & { type: string }>(
   _files: readonly T[],
   _opts: {
@@ -253,25 +253,31 @@ export async function intakeFiles<T extends DroppedFile & { type: string }>(
 ): Promise<{ attachments: Attachment[]; notice: string | null }> {
   const files = [..._files];
   const { allowImages, getPath, uploadImage } = _opts;
-  const images = allowImages ? files.filter((file) => isImageFile(file)) : [];
-  const rest = files.filter((file) => !images.includes(file));
-  const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(rest, getPath);
-  const uploaded: Attachment[] = [];
+  const attachments: Attachment[] = [];
+  const rejectedNames: string[] = [];
   const imageErrors: string[] = [];
-  for (const file of images) {
-    try {
-      const attachment = await uploadImage(file);
-      if (attachment) uploaded.push(attachment);
-    } catch (err) {
-      imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
+  // Finish each selected file in sequence so the chips retain the order in
+  // which the user chose or dropped them.
+  for (const file of files) {
+    if (allowImages && isImageFile(file)) {
+      try {
+        const attachment = await uploadImage(file);
+        if (attachment) attachments.push(attachment);
+      } catch (err) {
+        imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
+      }
+      continue;
     }
+    const result = await attachmentsFromDroppedFiles([file], getPath);
+    attachments.push(...result.attachments);
+    rejectedNames.push(...result.rejectedNames);
   }
   const pathless = rejectedNames.length
     ? `${rejectedNames.join(", ")} — that file has no path on disk. Save it first, then attach it from Finder.`
     : null;
   const failed = imageErrors.length ? imageErrors.join("; ") : null;
   return {
-    attachments: [...attachments, ...uploaded],
+    attachments,
     notice: pathless && failed ? `${pathless} (${failed})` : (pathless ?? failed),
   };
 }

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -238,3 +238,40 @@ export function attachmentBasename(path: string): string {
   const parts = path.split(/[\\/]/);
   return parts[parts.length - 1] ?? "";
 }
+
+/** One intake path for files arriving by drop OR by the composer's attach
+ * button, so a picked file and a dropped one can never behave differently.
+ * The image uploader is injected: the caller owns the network, this owns
+ * the sorting and the sentence the user reads when something is refused. */
+export async function intakeFiles<T extends DroppedFile & { type: string }>(
+  _files: readonly T[],
+  _opts: {
+    allowImages: boolean;
+    getPath: (file: T) => string;
+    uploadImage: (file: T) => Promise<Attachment | null>;
+  },
+): Promise<{ attachments: Attachment[]; notice: string | null }> {
+  const files = [..._files];
+  const { allowImages, getPath, uploadImage } = _opts;
+  const images = allowImages ? files.filter((file) => isImageFile(file)) : [];
+  const rest = files.filter((file) => !images.includes(file));
+  const { attachments, rejectedNames } = await attachmentsFromDroppedFiles(rest, getPath);
+  const uploaded: Attachment[] = [];
+  const imageErrors: string[] = [];
+  for (const file of images) {
+    try {
+      const attachment = await uploadImage(file);
+      if (attachment) uploaded.push(attachment);
+    } catch (err) {
+      imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
+    }
+  }
+  const pathless = rejectedNames.length
+    ? `${rejectedNames.join(", ")} — that file has no path on disk. Save it first, then attach it from Finder.`
+    : null;
+  const failed = imageErrors.length ? imageErrors.join("; ") : null;
+  return {
+    attachments: [...attachments, ...uploaded],
+    notice: pathless && failed ? `${pathless} (${failed})` : (pathless ?? failed),
+  };
+}

--- a/src/lib/intake-files.test.ts
+++ b/src/lib/intake-files.test.ts
@@ -26,7 +26,10 @@ describe("intakeFiles", () => {
       getPath: onDisk,
       uploadImage: upload,
     });
-    expect(out.attachments.map((a) => a.kind).sort()).toEqual(["file", "image"]);
+    expect(out.attachments.map((a) => [a.kind, "name" in a ? a.name : ""])).toEqual([
+      ["image", "shot.png"],
+      ["file", "notes.txt"],
+    ]);
     expect(out.notice).toBeNull();
   });
 

--- a/src/lib/intake-files.test.ts
+++ b/src/lib/intake-files.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { intakeFiles, type Attachment } from "./composer-attachments";
+
+type Fake = { name: string; size: number; type: string; text: () => Promise<string> };
+const file = (name: string, type: string, size = 10): Fake => ({
+  name,
+  size,
+  type,
+  text: async () => "contents",
+});
+const upload = async (f: Fake): Promise<Attachment> => ({
+  kind: "image",
+  id: `id-${f.name}`,
+  name: f.name,
+  path: `/api/attachments/${f.name}`,
+  size: f.size,
+  mime: f.type,
+});
+const onDisk = (f: Fake) => `/Users/me/${f.name}`;
+
+describe("intakeFiles", () => {
+  it("uploads images and keeps ordinary files as paths", async () => {
+    const out = await intakeFiles([file("shot.png", "image/png"), file("notes.txt", "text/plain")], {
+      allowImages: true,
+      getPath: onDisk,
+      uploadImage: upload,
+    });
+    expect(out.attachments.map((a) => a.kind).sort()).toEqual(["file", "image"]);
+    expect(out.notice).toBeNull();
+  });
+
+  it("treats an image as an ordinary file when the engine cannot read one", async () => {
+    const out = await intakeFiles([file("shot.png", "image/png")], {
+      allowImages: false,
+      getPath: onDisk,
+      uploadImage: async () => {
+        throw new Error("must not upload");
+      },
+    });
+    expect(out.attachments).toHaveLength(1);
+    expect(out.attachments[0].kind).toBe("file");
+  });
+
+  it("names the files it could not take, rather than dropping them in silence", async () => {
+    const out = await intakeFiles([{ ...file("ghost.bin", "application/octet-stream", 999_999_999) }], {
+      allowImages: true,
+      getPath: () => "",
+      uploadImage: upload,
+    });
+    expect(out.attachments).toHaveLength(0);
+    expect(out.notice).toMatch(/ghost\.bin/);
+  });
+
+  it("reports an upload that failed without losing the files that worked", async () => {
+    const out = await intakeFiles([file("ok.png", "image/png"), file("bad.png", "image/png")], {
+      allowImages: true,
+      getPath: onDisk,
+      uploadImage: async (f) => {
+        if (f.name === "bad.png") throw new Error("too large");
+        return upload(f);
+      },
+    });
+    expect(out.attachments).toHaveLength(1);
+    expect(out.notice).toMatch(/bad\.png: too large/);
+  });
+});


### PR DESCRIPTION
## What changed

**Auto mode moves to the composer.** It already existed — a toggle most of the way down a bot's settings panel — and it was reported as missing, which is the same thing from the user's side. The moment you want auto mode is the moment a bot stops to ask, and that moment is spent looking at the composer, not at settings. There is now an `⚡ Auto` pill in the composer that switches the same `bot.autoApprove`, behind the same acknowledgement dialog that a bot driving *this* computer has always required. Rooms get no pill: auto mode belongs to one bot, and a room has several.

**It does not widen the grant.** Anything matching a destructive pattern (`rm -rf`, `git push --force`, `DROP TABLE`) or reaching for a secret (`.env`, `.ssh`, credentials) still cards exactly as before — see `server/auto-approve.ts`. The pill is a shorter route to the existing switch, not a new one.

**Attaching a file gets a button.** It was drop-or-paste only, which is invisible until someone tells you it exists. The new `+` opens a picker and hands the files to the same intake the drop path uses.

That intake used to live inline inside the drop effect. It is now `intakeFiles` — one tested function both paths call, so a picked file and a dropped one cannot sort differently: an image uploads, a file on disk becomes a path, and anything with neither gets named in the notice rather than dropped in silence.

## Why

Both came from a real session: a bot stopped for approval on every command with no visible way to say "keep going", and the composer offered no way to attach anything.

## How it was verified

- 4 unit tests for `intakeFiles` (`src/lib/intake-files.test.ts`), written against a stub and watched failing first. The image uploader is injected rather than mocked, so the tests exercise the real sorting and the real notice text.
- `pnpm typecheck` clean; full suite 1690 tests pass
- `oxlint` — 20 errors across the touched files, identical to main (verified by stashing); none new
- Driven in a real browser: the composer exposes `Attach a file` and `Auto mode`; toggling the pill flips `aria-checked` false → true and the change lands on the server (`autoApprove = True` over the API)

## Screenshots (UI changes)

Composer with the pill off, and on (accent fill). (Adding the images in a follow-up comment.)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — no server change; the approval rules are untouched
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file attachment support through file selection and drag-and-drop.
  * Added image attachment handling when supported, with notices for unsupported or failed uploads.
  * Added per-bot Auto mode for eligible composers, including a confirmation warning before enabling local computer access.
  * Preserved successful attachments and maintained attachment order during intake.
  * Added the ability to dismiss file-intake notices.

* **Bug Fixes**
  * Improved handling and reporting of files that cannot be processed.
  * Preserved successful attachments when individual uploads fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->