### PR TITLE
feat: section-scoped Chiefs and in-chat operator creation

### DIFF
--- a/server/chief-of-staff.test.ts
+++ b/server/chief-of-staff.test.ts
@@ -35,21 +35,24 @@ describe("chiefOfStaffSystemPrompt roster caps", () => {
 
 describe("chiefOfStaffSystemPrompt", () => {
   const bots = [
-    { id: "chief", name: "Atlas", title: "Operations" },
-    { id: "writer", name: "Quill", title: "Writer", description: "Drafts concise copy" },
-    { id: "coder", name: "Patch", title: "Engineer", busy: true },
-    { id: "hidden", name: "Secret", hidden: true },
+    { id: "chief", name: "Atlas", title: "Operations", section: "Work" },
+    { id: "writer", name: "Quill", title: "Writer", description: "Drafts concise copy", section: "Work" },
+    { id: "coder", name: "Patch", title: "Engineer", busy: true, section: "Work" },
+    { id: "hidden", name: "Secret", hidden: true, section: "Work" },
+    { id: "personal", name: "Scout", title: "Travel planner", section: "Personal" },
   ];
 
   it("describes visible teammates, roles, and availability", () => {
     const prompt = chiefOfStaffSystemPrompt("chief", bots, true);
 
-    expect(prompt).toContain("one Chief of Staff");
+    expect(prompt).toContain("Chief of Staff for the Work section");
     expect(prompt).toContain("Quill — Writer: Drafts concise copy (available)");
     expect(prompt).toContain("Patch — Engineer (working right now)");
     expect(prompt).not.toContain("Secret");
+    expect(prompt).not.toContain("Scout");
     expect(prompt).not.toContain("Atlas —");
     expect(prompt).toContain("Use ask_bot");
+    expect(prompt).toContain("use create_bot");
   });
 
   it("does not promise delegation when the engine cannot mount agent tools", () => {

--- a/server/chief-of-staff.ts
+++ b/server/chief-of-staff.ts
@@ -5,6 +5,7 @@ export interface ChiefTeamMember {
   description?: string;
   busy?: boolean;
   hidden?: boolean;
+  section?: string;
 }
 
 // The roster is interpolated into a TRUSTED bot's system prompt on every
@@ -20,7 +21,9 @@ const ROSTER_ABOUT_MAX = 200;
 
 const clip = (value: string, max: number) => (value.length > max ? `${value.slice(0, max - 1)}…` : value);
 
-/** Dynamic system context for the one workspace-wide Chief of Staff.
+const sectionKey = (section?: string): string => section?.trim() || "";
+
+/** Dynamic system context for a section's Chief of Staff.
  * It names the current team on every turn, while list_bots remains the
  * authoritative tool for IDs and live availability at delegation time. */
 export function chiefOfStaffSystemPrompt(
@@ -28,7 +31,12 @@ export function chiefOfStaffSystemPrompt(
   bots: ChiefTeamMember[],
   canDelegate: boolean,
 ): string {
-  const team = bots.filter((bot) => bot.id !== chiefId && !bot.hidden);
+  const chief = bots.find((bot) => bot.id === chiefId);
+  const chiefSection = sectionKey(chief?.section);
+  const sectionName = chiefSection || "General";
+  const team = bots.filter(
+    (bot) => bot.id !== chiefId && !bot.hidden && sectionKey(bot.section) === chiefSection,
+  );
   const listed = team.slice(0, ROSTER_MAX_BOTS);
   const overflow = team.length - listed.length;
   const roster = team.length
@@ -46,17 +54,18 @@ export function chiefOfStaffSystemPrompt(
   const delegation = canDelegate
     ? [
         "Use list_bots to confirm the live roster and IDs. Use ask_bot when a teammate is better suited to part of the request.",
+        "When the user asks you to assemble a team, use create_bot for each genuinely useful specialist. Give each one a clear role and instructions, then use delegate_bot to assign its work. Do not create duplicate or unnecessary bots.",
         "Delegate with a clear, self-contained brief and wait for the teammate's actual reply before claiming its work is complete.",
         "You may consult more than one teammate when the request genuinely benefits, then combine their results into one coherent answer.",
       ].join(" ")
     : "Your current engine cannot contact teammates. Be honest about that limitation and ask the user to choose a delegation-compatible engine before promising coordinated work.";
 
   return [
-    "You are the workspace's one Chief of Staff. You are the user's primary contact across their team of bots.",
+    `You are the Chief of Staff for the ${sectionName} section. You are the user's primary contact for this section's team of bots.`,
     "Own the outcome: understand the request, decide what to handle yourself, coordinate the right specialists when useful, and return one concise consolidated answer.",
     "Do not delegate trivial work merely to appear busy. Never invent a teammate's progress or result. Normal permission and approval rules still apply.",
     delegation,
-    "Current workspace team:",
+    `Current ${sectionName} section team:`,
     roster,
   ].join("\n");
 }

--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -2,7 +2,7 @@
 // per-thread chips. Extracted from /api/internal/ask-bot so delegations
 // (delegate_bot) and any future peer flow reuse the same UX without a copy.
 
-import type { BotRecord, GroupRecord, Message, Store } from "./store.ts";
+import { sectionKey, type BotRecord, type GroupRecord, type Message, type Store } from "./store.ts";
 
 /** What a peer-exchange helper needs from the outside world:
  * the store (for persisted messages + groups) and the SSE broadcasters
@@ -18,10 +18,14 @@ export interface CommsBus {
  * the pair's full exchange, lives in the sidebar like any room, and the
  * user can open it to chip in. */
 export function getOrCreateChannel(store: Store, from: BotRecord, target: BotRecord): GroupRecord {
-  return (
-    store.dmGroup(from.id, target.id) ??
-    store.createGroup(`${from.name} ⇄ ${target.name}`, [from.id, target.id], true)
-  );
+  const existing = store.dmGroup(from.id, target.id);
+  if (existing) {
+    if (sectionKey(existing.section) !== sectionKey(from.section)) {
+      return store.patchGroup(existing.id, { section: from.section }) ?? existing;
+    }
+    return existing;
+  }
+  return store.createGroup(`${from.name} ⇄ ${target.name}`, [from.id, target.id], true, from.section);
 }
 
 /** Mirror `from`'s outgoing message into the channel, drop chips into

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -118,6 +118,11 @@ describe("comms e2e (fake ACP fleet)", () => {
             environment: { FAKE_ACP_MODE: "delegate-peer" },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
+          chiefCreator: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "create-peer" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
           // a peer whose agent crashes at initialize — the delegated turn
           // ends with ok=false, so the channel must show a failed terminal
           // chip, not silence.
@@ -248,6 +253,52 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(helperBot.busy).toBeFalsy();
     },
     40_000,
+  );
+
+  it(
+    "lets a section Chief create a safe operator and delegate work to it",
+    async () => {
+      const chief = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${chief.id}`, {
+        name: "Atlas",
+        section: "Launch",
+        chiefOfStaff: true,
+        modelSelection: { instanceId: "chiefCreator", model: "fake-model" },
+      });
+
+      const send = await api("POST", `/api/bots/${chief.id}/messages`, {
+        text: "Create the specialist team and start the design review.",
+      });
+      expect(send.status).toBe(202);
+
+      const deadline = Date.now() + 30_000;
+      let operator: any;
+      for (;;) {
+        const state = (await api("GET", "/api/bots")).body;
+        operator = state.bots.find((bot: any) => bot.name === "Pixel" && bot.section === "Launch");
+        const replied = operator?.messages.some(
+          (message: any) => message.role === "bot" && message.text?.includes("hello from fake acp"),
+        );
+        if (operator && replied && !operator.busy) break;
+        if (Date.now() > deadline) {
+          throw new Error(`Chief never created and delegated to Pixel. stderr: ${stderr.slice(-2000)}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+
+      expect(operator).toMatchObject({
+        title: "Product designer",
+        description: "Design and review the user experience.",
+        section: "Launch",
+        composio: false,
+        autoApprove: false,
+        approvePeerComms: false,
+        modelSelection: { instanceId: "chiefCreator", model: "fake-model" },
+      });
+      expect(operator.chiefOfStaff).toBeFalsy();
+      expect(operator.messages.some((message: any) => message.text?.includes("Review the new onboarding flow."))).toBe(true);
+    },
+    45_000,
   );
 
   // ── async peer handoff (delegate_bot) ───────────────────────────────

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -20,6 +20,7 @@ let lastAskBody: any = null;
 let askResponse: unknown = { botName: "Helper", text: "hi from helper" };
 let lastDelegateBody: any = null;
 let delegateResponse: unknown = { queued: true, message: "Delegation queued." };
+let lastCreateBody: any = null;
 
 let child: ChildProcess;
 const pending = new Map<number, (msg: any) => void>();
@@ -72,6 +73,16 @@ beforeAll(async () => {
       });
       return;
     }
+    if (req.method === "POST" && req.url === "/api/internal/create-bot") {
+      let data = "";
+      req.on("data", (c) => (data += c));
+      req.on("end", () => {
+        lastCreateBody = JSON.parse(data);
+        res.writeHead(201, { "content-type": "application/json" });
+        res.end(JSON.stringify({ id: "bot-designer", name: "Pixel", section: "Work" }));
+      });
+      return;
+    }
     res.writeHead(404, { "content-type": "application/json" });
     res.end(JSON.stringify({ error: "unknown" }));
   });
@@ -110,11 +121,16 @@ afterAll(async () => {
 });
 
 describe("agents-proxy MCP surface", () => {
-  it("answers the MCP handshake and lists all three tools", async () => {
+  it("answers the MCP handshake and lists all four tools", async () => {
     const init = await rpc("initialize", { protocolVersion: "2024-11-05" });
     expect(init.result.serverInfo.name).toContain("agents");
     const list = await rpc("tools/list");
-    expect(list.result.tools.map((t: { name: string }) => t.name)).toEqual(["list_bots", "ask_bot", "delegate_bot"]);
+    expect(list.result.tools.map((t: { name: string }) => t.name)).toEqual([
+      "list_bots",
+      "ask_bot",
+      "delegate_bot",
+      "create_bot",
+    ]);
   });
 
   it("list_bots renders the roster and authenticates with the shared token", async () => {
@@ -176,6 +192,22 @@ describe("agents-proxy MCP surface", () => {
     const res = await callTool("delegate_bot", { bot_id: "bot-helper", message: "take this" });
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain("do this one yourself");
+  });
+
+  it("lets a Chief create a bounded specialist through the harness", async () => {
+    const res = await callTool("create_bot", {
+      name: "Pixel",
+      role: "Product designer",
+      instructions: "Design and review the user experience.",
+    });
+    expect(res.result.content[0].text).toContain("Created @Pixel in Work");
+    expect(lastCreateBody).toEqual({
+      fromBotId: "bot-asker",
+      fromThreadId: "thread-asker-routine",
+      name: "Pixel",
+      role: "Product designer",
+      instructions: "Design and review the user experience.",
+    });
   });
 
   it("rejects unknown tools with -32602", async () => {

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -1,15 +1,17 @@
 // Agent-to-agent comms MCP proxy — spawned as an MCP server inside a bot's
-// agent process (via the "agents" integration). Exposes three tools that
+// agent process (via the "agents" integration). Exposes four tools that
 // let one bot talk to another, routed back through the harness so the
 // harness stays the single owner of turns, permissions, and recursion
 // limits:
 //
-//   list_bots()                          → the other bots in this workspace + their status
+//   list_bots()                          → the other bots in this section + their status
 //   ask_bot(bot_id, msg)                 → send msg to that bot, wait, return its reply
 //   delegate_bot(bot_id, msg, reason?)   → hand the task to a peer ASYNC: returns
 //                                          immediately, the peer runs after your
 //                                          current turn finishes, the user sees
 //                                          the peer's reply as its own turn
+//   create_bot(name, role, instructions) → Chiefs can add a specialist to
+//                                          their own section
 //
 // Speaks raw JSON-RPC 2.0 over stdio (no MCP SDK — house style, matches
 // computer-proxy / permission-proxy). All state comes from env, injected by
@@ -25,18 +27,20 @@ const BOT_ID = process.env.OMB_BOT_ID ?? "";
 const THREAD_ID = process.env.OMB_THREAD_ID ?? "";
 const TOKEN = process.env.OMB_COMMS_TOKEN ?? "";
 const DEPTH = Number(process.env.OMB_TURN_DEPTH ?? "0") || 0;
+const MAX_CREATED_PER_TURN = 4;
+let createdThisTurn = 0;
 
 const TOOLS = [
   {
     name: "list_bots",
     description:
-      "List the other bots (agents) in this OpenMausBot workspace you can message, with their model and whether they're busy. Call this before ask_bot to discover who's available.",
+      "List the other bots (agents) in your OpenMausBot section you can message, with their model and whether they're busy. Call this before ask_bot to discover who's available.",
     inputSchema: { type: "object", properties: {} },
   },
   {
     name: "ask_bot",
     description:
-      "Send a message to another bot in this workspace and wait for its reply. Use it to delegate a subtask to a specialist bot or ask a peer a question. The other bot runs a full turn under its own model and permissions; the reply is returned to you as text. Returns promptly with a note if that bot is busy.",
+      "Send a message to another bot in your section and wait for its reply. Use it to delegate a subtask to a specialist bot or ask a peer a question. The other bot runs a full turn under its own model and permissions; the reply is returned to you as text. Returns promptly with a note if that bot is busy.",
     inputSchema: {
       type: "object",
       properties: {
@@ -58,6 +62,20 @@ const TOOLS = [
         reason: { type: "string", description: "Optional one-line reason for the delegation (shown to the user as a chip)." },
       },
       required: ["bot_id", "message"],
+    },
+  },
+  {
+    name: "create_bot",
+    description:
+      "Create a specialist bot in your section. Only a section's Chief of Staff may use this. The new bot inherits the Chief's engine, starts with connected apps and automatic approvals disabled, and can then receive work through delegate_bot. Create only the smallest useful team (maximum four per turn).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Short, unique display name for the specialist." },
+        role: { type: "string", description: "The specialist's job title or role." },
+        instructions: { type: "string", description: "What this specialist is responsible for and how it should work." },
+      },
+      required: ["name", "role", "instructions"],
     },
   },
 ];
@@ -83,7 +101,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
   if (name === "list_bots") {
     const r = await api(`/api/internal/agents?self=${encodeURIComponent(BOT_ID)}`);
     const bots = (r.bots as Array<Json>) ?? [];
-    if (!bots.length) return { text: "No other bots in this workspace yet." };
+    if (!bots.length) return { text: "No other bots in this section yet." };
     const lines = bots.map((b) => {
       const role = b.title ? ` — ${b.title}` : "";
       const about = b.description ? ` (${String(b.description).slice(0, 120)})` : "";
@@ -121,6 +139,31 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     // Fire-and-forget by contract: the harness returns immediately, the
     // peer turn runs after our current turn finishes.
     return { text: typeof r.message === "string" ? r.message : "Delegation queued." };
+  }
+  if (name === "create_bot") {
+    const botName = String(args.name ?? "").trim();
+    const role = String(args.role ?? "").trim();
+    const instructions = String(args.instructions ?? "").trim();
+    if (!botName || !role || !instructions) {
+      return { text: "create_bot needs name, role, and instructions.", isError: true };
+    }
+    if (createdThisTurn >= MAX_CREATED_PER_TURN) {
+      return { text: `You can create at most ${MAX_CREATED_PER_TURN} bots in one turn. Use the team you have before adding more.`, isError: true };
+    }
+    const r = await api(`/api/internal/create-bot`, {
+      method: "POST",
+      body: JSON.stringify({
+        fromBotId: BOT_ID,
+        fromThreadId: THREAD_ID,
+        name: botName,
+        role,
+        instructions,
+      }),
+    });
+    createdThisTurn += 1;
+    return {
+      text: `Created @${r.name ?? botName} in ${r.section ?? "General"} [id: ${r.id}]. Assign work with delegate_bot.`,
+    };
   }
   return { text: `Unknown tool: ${name}`, isError: true };
 }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -630,6 +630,35 @@ describe("harness HTTP API", () => {
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
   });
 
+  it("elects one Chief of Staff per section and preserves other section Chiefs", async () => {
+    const workA = (await api("POST", "/api/bots")).body.bot;
+    const workB = (await api("POST", "/api/bots")).body.bot;
+    const personal = (await api("POST", "/api/bots")).body.bot;
+    try {
+      await api("PATCH", `/api/bots/${workA.id}`, { section: "Work", chiefOfStaff: true });
+      await api("PATCH", `/api/bots/${workB.id}`, { section: "Work" });
+      await api("PATCH", `/api/bots/${personal.id}`, { section: "Personal", chiefOfStaff: true });
+
+      let bots = (await api("GET", "/api/bots")).body.bots;
+      expect(bots.find((bot: { id: string }) => bot.id === workA.id).chiefOfStaff).toBe(true);
+      expect(bots.find((bot: { id: string }) => bot.id === personal.id).chiefOfStaff).toBe(true);
+
+      await api("PATCH", `/api/bots/${workB.id}`, { chiefOfStaff: true });
+      bots = (await api("GET", "/api/bots")).body.bots;
+      expect(bots.find((bot: { id: string }) => bot.id === workA.id).chiefOfStaff).toBe(false);
+      expect(bots.find((bot: { id: string }) => bot.id === workB.id).chiefOfStaff).toBe(true);
+      expect(bots.find((bot: { id: string }) => bot.id === personal.id).chiefOfStaff).toBe(true);
+
+      // Moving a Chief keeps its role and hands off only in the destination.
+      await api("PATCH", `/api/bots/${workB.id}`, { section: "Personal" });
+      bots = (await api("GET", "/api/bots")).body.bots;
+      expect(bots.find((bot: { id: string }) => bot.id === workB.id).chiefOfStaff).toBe(true);
+      expect(bots.find((bot: { id: string }) => bot.id === personal.id).chiefOfStaff).toBe(false);
+    } finally {
+      for (const bot of [workA, workB, personal]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("explains when archived room members cannot respond", async () => {
     const archived = (await api("POST", "/api/bots")).body.bot;
     const active = (await api("POST", "/api/bots")).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -74,6 +74,7 @@ import { cancelPeerApprovalsFor, cancelPeerApprovalsForThread, dismissStalePeerC
 import {
   mentionedBots,
   roomResponders,
+  sectionKey,
   Store,
   type GroupDefaultResponder,
   type GroupRecord,
@@ -153,6 +154,7 @@ function authorizedComms(header: string | string[] | undefined): boolean {
 // a peer invoked via ask_bot runs at depth 1 and gets NO agents tool, so
 // A→B is allowed but B→C (and A→B→A loops) never start.
 const MAX_COMMS_DEPTH = 1;
+const MAX_WORKSPACE_BOTS = 100;
 // Resolved from the server root — see server/proxy-paths.ts. This descending
 // path happened to survive bundling, but it goes through the same anchor so
 // there is exactly one way proxies are located.
@@ -1609,10 +1611,16 @@ async function startTurn(
       // integrations.agents gate below, the prompt hint) — a bot on a driver
       // without it must not be told about tools it cannot call. Any bot can
       // still be the TARGET of ask_bot regardless of its driver.
+      const sectionPeers = store.bots.filter(
+        (candidate) =>
+          candidate.id !== bot.id &&
+          !candidate.hidden &&
+          sectionKey(candidate.section) === sectionKey(bot.section),
+      );
       if (
         commsDepth < MAX_COMMS_DEPTH &&
         instance.adapter.capabilities.agentsMcp === true &&
-        store.bots.filter((b) => b.id !== bot.id && !b.hidden).length > 0
+        (bot.chiefOfStaff || sectionPeers.length > 0)
       ) {
         integrations.agents = agentsIntegration(bot.id, threadId, commsDepth);
       }
@@ -1622,13 +1630,13 @@ async function startTurn(
       const tagged = integrations.agents
         ? mentionedBots(
             text,
-            store.bots.filter((b) => b.id !== bot.id),
+            sectionPeers,
           )
         : [];
       const coordinationPrompt = bot.chiefOfStaff
         ? chiefOfStaffSystemPrompt(bot.id, store.bots, Boolean(integrations.agents))
         : integrations.agents
-          ? "You can work with the user's other bots through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
+          ? "You can work with the other bots in your section through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
           : "";
 
       // (activeVpsThreads was already claimed above, before the provision or
@@ -2463,10 +2471,17 @@ const server = createServer(async (req, res) => {
       }
       if (method === "GET" && path === "/api/internal/agents") {
         const self = url.searchParams.get("self");
+        const sender = self ? store.bot(self) : null;
+        if (!sender) return json(res, 403, { error: "unknown sender" });
         // title/description included so a "chief of staff"-style bot can
         // judge the team (who does what, who has no job description yet)
         const bots = store.bots
-          .filter((b) => b.id !== self && !b.hidden)
+          .filter(
+            (b) =>
+              b.id !== self &&
+              !b.hidden &&
+              sectionKey(b.section) === sectionKey(sender.section),
+          )
           .map((b) => ({
             id: b.id,
             name: b.name,
@@ -2495,6 +2510,9 @@ const server = createServer(async (req, res) => {
         // hard refusal — every peer turn has an accountable sender.
         const from = store.bot(fromBotId);
         if (!from) return json(res, 403, { error: "unknown sender" });
+        if (sectionKey(from.section) !== sectionKey(target.section)) {
+          return json(res, 403, { error: "that bot belongs to a different section" });
+        }
         const fromThreadId = String(body.fromThreadId ?? from.threadId);
         if (!store.taskByThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
@@ -2528,6 +2546,9 @@ const server = createServer(async (req, res) => {
           const freshFrom = store.bot(fromBotId);
           const freshTarget = store.bot(toBotId);
           if (!freshFrom || !freshTarget) return json(res, 404, { error: "no such bot" });
+          if (sectionKey(freshFrom.section) !== sectionKey(freshTarget.section)) {
+            return json(res, 200, { error: "that bot moved to a different section" });
+          }
           if (!store.taskByThread(freshFrom.id, fromThreadId)) {
             return json(res, 404, { error: "source task no longer exists" });
           }
@@ -2555,6 +2576,11 @@ const server = createServer(async (req, res) => {
         if (!toBotId || !message) return json(res, 400, { error: "toBotId and message required" });
         const from = store.bot(fromBotId);
         if (!from) return json(res, 404, { error: "no such bot" });
+        const target = store.bot(toBotId);
+        if (!target) return json(res, 404, { error: "no such bot" });
+        if (sectionKey(from.section) !== sectionKey(target.section)) {
+          return json(res, 403, { error: "that bot belongs to a different section" });
+        }
         const fromThreadId = String(body.fromThreadId ?? from.threadId);
         if (!store.taskByThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
@@ -2583,6 +2609,64 @@ const server = createServer(async (req, res) => {
           message: from.approvePeerComms
             ? `Queued for review — @${targetName} will only pick it up if the user approves after your turn finishes.`
             : `Delegation queued — @${targetName} will pick it up after your current turn finishes.`,
+        });
+      }
+      if (method === "POST" && path === "/api/internal/create-bot") {
+        const body = await readBody(req);
+        const fromBotId = String(body.fromBotId ?? "");
+        const chief = store.bot(fromBotId);
+        if (!chief) return json(res, 403, { error: "unknown sender" });
+        const fromThreadId = String(body.fromThreadId ?? chief.threadId);
+        if (!store.taskByThread(chief.id, fromThreadId)) {
+          return json(res, 403, { error: "source thread does not belong to sender" });
+        }
+        if (!chief.chiefOfStaff) {
+          return json(res, 403, { error: "only a section's Chief of Staff can create operator bots" });
+        }
+        if (store.bots.length >= MAX_WORKSPACE_BOTS) {
+          return json(res, 409, { error: `this workspace is limited to ${MAX_WORKSPACE_BOTS} bots` });
+        }
+        const name = String(body.name ?? "").trim();
+        const role = String(body.role ?? "").trim();
+        const instructions = String(body.instructions ?? "").trim();
+        if (!name || !role || !instructions) {
+          return json(res, 400, { error: "name, role, and instructions are required" });
+        }
+        if (name.length > 80) return json(res, 400, { error: "name must be at most 80 characters" });
+        if (role.length > 120) return json(res, 400, { error: "role must be at most 120 characters" });
+        if (instructions.length > 1_000) {
+          return json(res, 400, { error: "instructions must be at most 1000 characters" });
+        }
+        const duplicate = store.bots.find(
+          (candidate) =>
+            !candidate.hidden &&
+            sectionKey(candidate.section) === sectionKey(chief.section) &&
+            candidate.name.trim().toLowerCase() === name.toLowerCase(),
+        );
+        if (duplicate) {
+          return json(res, 409, { error: `@${duplicate.name} already exists in this section; use list_bots` });
+        }
+        const created = store.createBot(
+          {
+            name,
+            title: role,
+            description: instructions,
+            modelSelection: { ...chief.modelSelection },
+            section: chief.section,
+          },
+          { seedMessages: false },
+        );
+        const safeBot = store.patchBot(created.id, {
+          composio: false,
+          autoApprove: false,
+          approvePeerComms: false,
+        })!;
+        return json(res, 201, {
+          id: safeBot.id,
+          name: safeBot.name,
+          title: safeBot.title,
+          section: safeBot.section || "General",
+          model: safeBot.modelSelection.model,
         });
       }
       if (method === "POST" && path === "/api/internal/connectors/mcp") {
@@ -3534,6 +3618,7 @@ const server = createServer(async (req, res) => {
         } else return json(res, 400, { error: "pinnedMessageId must be a message id" });
       }
       if (section !== undefined) patch.section = section ?? undefined;
+      if (body.chiefOfStaff === false) patch.chiefOfStaff = false;
       // per-bot gate on the workspace's connected apps (Composio)
       if (body.composio !== undefined) {
         if (typeof body.composio !== "boolean") return json(res, 400, { error: "composio must be true or false" });
@@ -3602,18 +3687,19 @@ const server = createServer(async (req, res) => {
           ?.adapter.interruptTurn(existingBot.threadId)
           .catch(() => {});
       }
+      const chiefMovedSections =
+        Boolean(existingBot?.chiefOfStaff) &&
+        body.chiefOfStaff !== false &&
+        section !== undefined &&
+        sectionKey(existingBot?.section) !== sectionKey(section);
       const bot = store.patchBot(m[1], patch);
       if (!bot) return json(res, 404, { error: "no such bot" });
       const chiefChanges =
-        body.chiefOfStaff === true
+        body.chiefOfStaff === true || chiefMovedSections
           ? store.setChiefOfStaff(bot.id)
-          : body.chiefOfStaff === false && bot.chiefOfStaff
-            ? store.setChiefOfStaff(null)
-            : [];
+          : [];
       if (chiefChanges === null) return json(res, 404, { error: "no such bot" });
-      const changed = new Map([[bot.id, store.bot(bot.id)!]]);
-      for (const changedBot of chiefChanges) changed.set(changedBot.id, changedBot);
-      return json(res, 200, { bot: wireBot(bot) });
+      return json(res, 200, { bot: wireBot(store.bot(bot.id)!) });
     }
 
     if (method === "POST" && path === "/api/local-computer/interrupt") {

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -179,23 +179,29 @@ describe("Store", () => {
     expect(reloaded.bot(bot.id)?.modelSelection.effort).toBe("high");
   });
 
-  it("keeps exactly one persisted Chief of Staff and supports handoff", () => {
+  it("keeps one persisted Chief of Staff per section and supports handoff", () => {
     const store = new Store(selection);
-    const first = store.createBot();
-    const second = store.createBot();
+    const first = store.createBot({ section: "Work" });
+    const second = store.createBot({ section: "Work" });
+    const personal = store.createBot({ section: "Personal" });
 
     expect(store.setChiefOfStaff(first.id)?.map((bot) => bot.id)).toEqual([first.id]);
     expect(store.bot(first.id)?.chiefOfStaff).toBe(true);
+    expect(store.setChiefOfStaff(personal.id)?.map((bot) => bot.id)).toEqual([personal.id]);
 
     const changed = store.setChiefOfStaff(second.id)!;
     expect(changed.map((bot) => bot.id).sort()).toEqual([first.id, second.id].sort());
     expect(store.bot(first.id)?.chiefOfStaff).toBe(false);
     expect(store.bot(second.id)?.chiefOfStaff).toBe(true);
+    expect(store.bot(personal.id)?.chiefOfStaff).toBe(true);
 
     const reloaded = new Store(selection);
-    expect(reloaded.bots.filter((bot) => bot.chiefOfStaff).map((bot) => bot.id)).toEqual([second.id]);
-    expect(reloaded.setChiefOfStaff(null)?.map((bot) => bot.id)).toEqual([second.id]);
-    expect(reloaded.bots.some((bot) => bot.chiefOfStaff)).toBe(false);
+    expect(reloaded.bots.filter((bot) => bot.chiefOfStaff).map((bot) => bot.id).sort()).toEqual(
+      [second.id, personal.id].sort(),
+    );
+    expect(reloaded.setChiefOfStaff(null, "Work")?.map((bot) => bot.id)).toEqual([second.id]);
+    expect(reloaded.bot(personal.id)?.chiefOfStaff).toBe(true);
+    expect(reloaded.bot(second.id)?.chiefOfStaff).toBe(false);
   });
 
   it("patchMessage merges card patches and returns null for unknown ids", () => {

--- a/server/store.ts
+++ b/server/store.ts
@@ -301,8 +301,8 @@ export interface BotRecord {
   /** the one message pinned to the top of this bot's active thread; a pin
    * that no longer resolves (branch switched away, deleted) renders nothing */
   pinnedMessageId?: string;
-  /** The single workspace-wide coordinator. The store enforces that at
-   * most one bot owns this role, even if an older/corrupt file says more. */
+  /** The coordinator for this bot's sidebar section. The store enforces
+   * at most one Chief per section (including the unsectioned area). */
   chiefOfStaff?: boolean;
   /** Pause for human approval before this bot talks to a peer (ask_bot,
    * delegate_bot). Off by default: a chief-of-staff-style bot is most
@@ -340,6 +340,10 @@ const COLORS: MausColor[] = [
   "teal",
   "coral",
 ];
+
+/** Sections are persisted as display labels, so exact trimmed labels are
+ * their identity. Missing/blank means the unsectioned (General) team. */
+export const sectionKey = (section?: string | null): string => section?.trim() || "";
 
 /** Resolve @mentions in a message against a bot roster: `@` must start a
  * word, the name must end on a word boundary (so "@New Bottle" never matches
@@ -447,7 +451,7 @@ export class Store {
     // busy never survives a restart — no turn does either. Rooms saved
     // before default responders existed adopt their first member as lead.
     let botsMigrated = false;
-    let chiefSeen = false;
+    const chiefSectionsSeen = new Set<string>();
     let groupsMigrated = false;
     for (const b of this.bots) {
       // transient state never survives a restart — and if a previous
@@ -472,8 +476,9 @@ export class Store {
     }
     for (const b of this.bots) {
       if (!b.chiefOfStaff) continue;
-      if (!chiefSeen) {
-        chiefSeen = true;
+      const key = sectionKey(b.section);
+      if (!chiefSectionsSeen.has(key)) {
+        chiefSectionsSeen.add(key);
         if (b.hidden) {
           b.hidden = false;
           botsMigrated = true;
@@ -778,7 +783,7 @@ export class Store {
 
   createBot(
     profile: Partial<
-      Pick<BotRecord, "name" | "title" | "description" | "color" | "mascotExpression" | "modelSelection">
+      Pick<BotRecord, "name" | "title" | "description" | "color" | "mascotExpression" | "modelSelection" | "section">
     > = {},
     opts: {
       /** false = no greeting/onboarding seed. Imported bots must not open
@@ -787,6 +792,7 @@ export class Store {
     } = {},
   ): BotRecord {
     const name = profile.name?.trim() || pickBotName(this.bots.map((b) => b.name));
+    const section = sectionKey(profile.section);
     const bot: BotRecord = {
       id: newId(),
       threadId: newId(),
@@ -801,6 +807,7 @@ export class Store {
       resumeCursors: {},
       createdAt: Date.now(),
     };
+    if (section) bot.section = section;
     bot.tasks = [{ threadId: bot.threadId, title: UNTITLED_TASK, createdAt: bot.createdAt, resumeCursors: {} }];
     this.bots.unshift(bot);
     this.saveBots();
@@ -859,18 +866,21 @@ export class Store {
     return bot;
   }
 
-  /** Elect one Chief of Staff (or clear the role) as one persisted change.
+  /** Elect one Chief of Staff in its section (or clear one section) as one persisted change.
    * The changed records are returned so the server can update every open
    * window, including the bot that just handed the role over. */
-  setChiefOfStaff(id: string | null): BotRecord[] | null {
-    if (id && !this.bot(id)) return null;
+  setChiefOfStaff(id: string | null, section?: string | null): BotRecord[] | null {
+    const selected = id ? this.bot(id) : null;
+    if (id && !selected) return null;
+    const targetSection = sectionKey(selected?.section ?? section);
     const changed: BotRecord[] = [];
     for (const bot of this.bots) {
+      if (sectionKey(bot.section) !== targetSection) continue;
       const next = bot.id === id;
       if (Boolean(bot.chiefOfStaff) === next && !(next && bot.hidden)) continue;
       if (next) {
         bot.chiefOfStaff = true;
-        // The workspace's main contact must stay reachable in the sidebar.
+        // A section's main contact must stay reachable in the sidebar.
         bot.hidden = false;
       } else {
         bot.chiefOfStaff = false;

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -14,6 +14,8 @@
 //                     peer, and reply with what the peer said — the comms e2e)
 //                   | delegate-peer (same as ask-peer but uses delegate_bot —
 //                     returns immediately, the peer runs after our turn)
+//                   | create-peer (a Chief creates a specialist, then delegates
+//                     work to it through the returned id)
 //                   | echo-gated (reply by echoing the full prompt, and when
 //                     FAKE_ACP_GATE_FILE is set hold the turn open until that
 //                     file exists — a deterministic busy window for the
@@ -380,6 +382,36 @@ function handle(msg: any) {
           })
           .catch((e) => {
             out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `peer error: ${(e as Error).message}` } } } });
+            complete();
+          });
+        return;
+      }
+      if (mode === "create-peer" && agentsMcp) {
+        void driveMcp(agentsMcp, [
+          {
+            name: "create_bot",
+            args: () => ({
+              name: "Pixel",
+              role: "Product designer",
+              instructions: "Design and review the user experience.",
+            }),
+          },
+          {
+            name: "delegate_bot",
+            args: (created) => ({
+              bot_id: /id: ([\w-]+)/.exec(created)?.[1] ?? "",
+              message: "Review the new onboarding flow.",
+              reason: "design review",
+            }),
+          },
+        ])
+          .then((reply) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `team created: ${reply}` } } } });
+            complete();
+          })
+          .catch((e) => {
+            const message = e instanceof Error ? e.message : String(e);
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `create error: ${message}` } } } });
             complete();
           });
         return;

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -353,7 +353,12 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
   const canUseVps = engine?.capabilities?.computerMcp === true && engine.driverKind !== "boxAgent";
   const connectedAppsConfigured = state.config?.composio?.configured === true;
   const connectedAppsEnabled = bot.composio !== false;
-  const currentChief = state.bots.find((candidate) => candidate.chiefOfStaff);
+  const sectionName = bot.section?.trim() || "General";
+  const currentChief = state.bots.find(
+    (candidate) =>
+      candidate.chiefOfStaff &&
+      (candidate.section?.trim() || "") === (bot.section?.trim() || ""),
+  );
 
   return (
     <>
@@ -428,7 +433,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               </span>
               <div className="min-w-0 flex-1">
                 <div className="text-[15px] font-medium text-ink">Chief of Staff</div>
-                <div className="text-[11.5px] text-ink-secondary">One per workspace</div>
+                <div className="text-[11.5px] text-ink-secondary">One for {sectionName}</div>
               </div>
               <button
                 role="switch"
@@ -454,12 +459,12 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               {bot.chiefOfStaff && !canCoordinate
                 ? "This bot still holds the role, but its current engine cannot contact teammates. Choose a Claude or ACP engine to restore coordination."
                 : bot.chiefOfStaff
-                  ? "This is your primary contact. It can coordinate the other bots and combine their work into one answer."
+                  ? `This is the primary contact for ${sectionName}. It can create and coordinate specialists in this section, then combine their work into one answer.`
                 : !canCoordinate
                   ? "Choose a Claude or ACP engine to let this bot coordinate teammates."
                   : currentChief
-                    ? `Make this bot your primary contact and hand the role over from ${currentChief.name}.`
-                    : "Make this bot your primary contact for work that may involve several bots."}
+                    ? `Make this bot the ${sectionName} Chief and hand the role over from ${currentChief.name}.`
+                    : `Make this bot the primary contact for the ${sectionName} section.`}
             </div>
           </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1103,7 +1103,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       );
       for (const response of archiveNew) dispatch({ type: "botPatched", bot: response.bot });
 
-      const previousChief = result.archived.find((bot) => bot.chiefOfStaff);
+      const previousChiefs = result.archived.filter((bot) => bot.chiefOfStaff);
       const restoreOthers = await Promise.all(
         result.archived
           .filter((bot) => !bot.chiefOfStaff)
@@ -1115,13 +1115,15 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           ),
       );
       for (const response of restoreOthers) dispatch({ type: "botPatched", bot: response.bot });
-      if (previousChief) {
-        const response = await api(`/api/bots/${previousChief.id}`, {
-          method: "PATCH",
-          body: JSON.stringify({ hidden: false, chiefOfStaff: true }),
-        });
-        dispatch({ type: "botPatched", bot: response.bot });
-      }
+      const restoredChiefs = await Promise.all(
+        previousChiefs.map((previousChief) =>
+          api(`/api/bots/${previousChief.id}`, {
+            method: "PATCH",
+            body: JSON.stringify({ hidden: false, chiefOfStaff: true }),
+          }),
+        ),
+      );
+      for (const response of restoredChiefs) dispatch({ type: "botPatched", bot: response.bot });
       const first = result.archived[0];
       if (first) dispatch({ type: "select", id: first.id });
       setTeamFeedback({ error: false, text: "Previous team restored" });
@@ -1197,7 +1199,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         (b.title ?? "").toLowerCase().includes(q) ||
         preview(b).toLowerCase().includes(q),
     );
-  const chiefBot = matchingBots.find((bot) => bot.chiefOfStaff);
+  const unsectionedChief = matchingBots.find((bot) => bot.chiefOfStaff && !bot.section);
+  const sectionChiefs = matchingBots.filter((bot) => bot.chiefOfStaff && bot.section);
   const sectionedBots = matchingBots
     .filter((bot) => !bot.chiefOfStaff && bot.section)
     .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
@@ -1211,6 +1214,9 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   // whose members all moved away (or fell out of the filter) simply vanishes
   const sectionNames: string[] = [];
   for (const bot of sectionedBots) {
+    if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
+  }
+  for (const bot of sectionChiefs) {
     if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
   }
   for (const group of sectionedGroups) {
@@ -1401,13 +1407,13 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       {/* Bot list */}
       <div className="flex-1 overflow-y-auto px-2">
         <div className="flex flex-col gap-0.5">
-          {!chiefBot && visibleBots.length === 0 && sectionedBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
+          {!unsectionedChief && sectionChiefs.length === 0 && visibleBots.length === 0 && sectionedBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
           )}
-          {chiefBot && (
+          {unsectionedChief && (
             <div className="mb-1.5">
               <BotListItem
-                bot={chiefBot}
+                bot={unsectionedChief}
                 density={density}
                 onMenu={setMenu}
                 onArchive={(bot) => void archiveBot(bot)}
@@ -1433,6 +1439,18 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           {sectionNames.map((name) => (
             <Fragment key={name}>
               {density !== "icons" && <SectionDivider name={name} />}
+              {sectionChiefs
+                .filter((bot) => bot.section === name)
+                .map((bot) => (
+                  <BotListItem
+                    key={bot.id}
+                    bot={bot}
+                    density={density}
+                    onMenu={setMenu}
+                    onArchive={(candidate) => void archiveBot(candidate)}
+                    archiveDisabled
+                  />
+                ))}
               {sectionedGroups
                 .filter((g) => g.section === name)
                 .map((g) => (

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -106,6 +106,41 @@ describe("cross-client bot creation", () => {
   });
 });
 
+describe("section Chiefs", () => {
+  const bot = (id: string, section: string, chiefOfStaff = false) => ({
+    id,
+    threadId: `thread-${id}`,
+    name: id,
+    title: "",
+    description: "",
+    notifications: true,
+    color: "green" as const,
+    unread: false,
+    modelSelection: { instanceId: "codex", model: "default" },
+    section,
+    chiefOfStaff,
+  });
+
+  it("hands off only within the patched bot's section", () => {
+    const workChief = bot("work-a", "Work", true);
+    const workCandidate = bot("work-b", "Work");
+    const personalChief = bot("personal", "Personal", true);
+    const state = {
+      ...initialState,
+      bots: [workChief, workCandidate, personalChief].map((candidate) => ({ ...candidate, messages: [] })),
+    };
+
+    const next = reducer(state, {
+      type: "botPatched",
+      bot: { ...workCandidate, chiefOfStaff: true },
+    });
+
+    expect(next.bots.find((candidate) => candidate.id === workChief.id)?.chiefOfStaff).toBe(false);
+    expect(next.bots.find((candidate) => candidate.id === workCandidate.id)?.chiefOfStaff).toBe(true);
+    expect(next.bots.find((candidate) => candidate.id === personalChief.id)?.chiefOfStaff).toBe(true);
+  });
+});
+
 describe("pending queued chip", () => {
   const bot = {
     id: "b1",

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -190,7 +190,7 @@ export interface Bot {
   section?: string;
   /** the one message pinned to the top of this bot's active thread */
   pinnedMessageId?: string;
-  /** The workspace's one primary coordinator. */
+  /** This sidebar section's primary coordinator. */
   chiefOfStaff?: boolean;
   /** When this bot wants to talk to another bot (ask_bot/delegate_bot),
    * pause and ask the user first. Off by default. */
@@ -684,7 +684,9 @@ export function reducer(state: AppState, action: Action): AppState {
         ? {
             ...animated,
             bots: animated.bots.map((b) =>
-              b.id === action.bot.id ? b : { ...b, chiefOfStaff: false },
+              b.id === action.bot.id || (b.section?.trim() || "") !== (action.bot.section?.trim() || "")
+                ? b
+                : { ...b, chiefOfStaff: false },
             ),
           }
         : animated;


### PR DESCRIPTION
## What this does

- allows one Chief of Staff per sidebar section, including General
- renders each Chief inside its own section and makes Chief handoff section-aware
- scopes bot discovery, mentions, synchronous asks, async delegation, and bot-to-bot channels to the sender’s section
- gives Chiefs a `create_bot` tool so they can assemble specialists directly from chat and delegate work immediately
- lets a Chief mount agent tools even when its section starts with no other bots

## Safety boundaries

- only a persisted Chief can create operators
- operators always stay in the Chief’s section and inherit its engine/model
- connected apps, auto-approval, and peer-contact approval are disabled on newly created operators
- duplicate names are rejected within a section
- creation is capped at four operators per turn and 100 bots per workspace
- one-hop delegation and existing per-turn delegation caps remain intact

## Migration and UX

- existing workspaces keep their current Chief in General
- persisted duplicate Chiefs are repaired per section at startup
- moving a Chief to another section keeps the role and hands off only in the destination
- team-import undo restores every previous section Chief

## Validation

- `pnpm typecheck`
- `pnpm test` — 1,678 passed, 12 skipped
- packaged server smoke passed with all spawned proxy paths resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams can now have a separate Chief of Staff for each sidebar section.
  * Chiefs of Staff can create specialist bots and delegate work to them.
  * Bot coordination, discovery, and messaging are limited to the current section.
* **Improvements**
  * Chief of Staff handoffs and assignments now clearly identify the relevant section.
  * Sidebar organization and team undo better support section-specific Chiefs of Staff.
  * Bot-to-bot communication channels automatically remain aligned with their section.
* **Bug Fixes**
  * Moving or replacing a Chief of Staff no longer affects Chiefs in other sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->