### PR TITLE
chore(release): bump version to 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop release version from `0.1.27` to `0.1.28`
- prepare the exact `main` commit for the cross-platform release workflow

## Validation

- package metadata resolves to `0.1.28`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->