### PR TITLE
fix: preserve Chiefs across sidebar sections

### DIFF
--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -139,6 +139,26 @@ describe("section Chiefs", () => {
     expect(next.bots.find((candidate) => candidate.id === workCandidate.id)?.chiefOfStaff).toBe(true);
     expect(next.bots.find((candidate) => candidate.id === personalChief.id)?.chiefOfStaff).toBe(true);
   });
+
+  it("keeps other section Chiefs during an optimistic settings update", () => {
+    const workChief = bot("work-a", "Work", true);
+    const workCandidate = bot("work-b", "Work");
+    const personalChief = bot("personal", "Personal", true);
+    const state = {
+      ...initialState,
+      bots: [workChief, workCandidate, personalChief].map((candidate) => ({ ...candidate, messages: [] })),
+    };
+
+    const next = reducer(state, {
+      type: "updateBot",
+      botId: workCandidate.id,
+      patch: { chiefOfStaff: true },
+    });
+
+    expect(next.bots.find((candidate) => candidate.id === workChief.id)?.chiefOfStaff).toBe(false);
+    expect(next.bots.find((candidate) => candidate.id === workCandidate.id)?.chiefOfStaff).toBe(true);
+    expect(next.bots.find((candidate) => candidate.id === personalChief.id)?.chiefOfStaff).toBe(true);
+  });
 });
 
 describe("pending queued chip", () => {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -876,11 +876,15 @@ export function reducer(state: AppState, action: Action): AppState {
       const animated = mascotChanged
         ? withMascotMotion(state, action.botId, "customize")
         : state;
+      const target = animated.bots.find((bot) => bot.id === action.botId);
+      const chiefSection = (action.patch.section ?? target?.section)?.trim() || "";
       const next = action.patch.chiefOfStaff
         ? {
             ...animated,
             bots: animated.bots.map((b) =>
-              b.id === action.botId ? b : { ...b, chiefOfStaff: false },
+              b.id === action.botId || (b.section?.trim() || "") !== chiefSection
+                ? b
+                : { ...b, chiefOfStaff: false },
             ),
           }
         : animated;


### PR DESCRIPTION
## What changed
- scope the optimistic Chief handoff to the selected bot's section
- preserve Chiefs assigned to every other section
- add a regression test for the settings toggle path

## Why
The server already supports one Chief per section, but the desktop reducer still cleared the Chief flag from every other bot while saving. Because unchanged Chiefs were not sent back by the server, the UI incorrectly showed only one workspace-wide Chief.

## Verification
- `pnpm exec vitest run src/state/store.test.ts` (13 passed)
- `pnpm typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chief-of-staff assignments so updating a bot only clears the previous assignment within the same sidebar section.
  * Preserved chief-of-staff assignments in other sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->