### PR TITLE
feat: gate Teach a skill behind an experimental setting

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -13,6 +13,7 @@ import {
   parseConfigPatch,
   parseStoredConfig,
   roomTurnTimeoutMinutes,
+  skillRecorderEnabled,
   stripWorkspaceCredentialEnv,
   syncCredentialEnv,
   vpsSshAlias,
@@ -77,6 +78,17 @@ describe("configuration boundaries", () => {
     });
     expect(localVmMode({ localVm: { mode: "per-bot" } })).toBe("per-bot");
     expect(localVmMaxInstances({ localVm: { maxInstances: 3 } })).toBe(3);
+  });
+
+  it("keeps experimental features off by default and accepts an explicit opt-in", () => {
+    expect(skillRecorderEnabled({})).toBe(false);
+    expect(parseConfigPatch({ features: { skillRecorder: true } })).toEqual({
+      features: { skillRecorder: true },
+    });
+    expect(skillRecorderEnabled({ features: { skillRecorder: true } })).toBe(true);
+    expect(() => parseConfigPatch({ features: { skillRecorder: "yes" } })).toThrow(
+      "features.skillRecorder",
+    );
   });
 
   it.each([0, 1.5, 5, "2", null])("rejects an invalid per-bot VM limit: %j", (maxInstances) => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -60,6 +60,10 @@ const localVmConfigSchema = z.object({
     .max(MAX_LOCAL_VM_MAX_INSTANCES)
     .optional(),
 });
+const featureConfigSchema = z.object({
+  /** Experimental desktop workflow recorder. Hidden unless explicitly enabled. */
+  skillRecorder: z.boolean().optional(),
+});
 const instanceConfigSchema = z.object({
   driver: z.string().min(1),
   displayName: optionalText,
@@ -87,6 +91,7 @@ const appConfigSchema = z.object({
   profile: z.object({ name: optionalText, email: optionalText }).optional(),
   rooms: roomConfigSchema.optional(),
   localVm: localVmConfigSchema.optional(),
+  features: featureConfigSchema.optional(),
   instances: instanceConfigMapSchema.optional(),
 });
 const appConfigPatchSchema = appConfigSchema.omit({ instances: true });
@@ -107,6 +112,8 @@ export interface AppConfig {
   /** Shared preserves the historical singleton. Per-bot gives every bot a
    * separate container, durable workspace, viewer and lease. */
   localVm?: { mode?: "shared" | "per-bot"; maxInstances?: number };
+  /** Opt-in product experiments. Every flag defaults to disabled. */
+  features?: { skillRecorder?: boolean };
   instances?: InstanceConfigMap;
 }
 export type ConfigPatch = z.output<typeof appConfigPatchSchema>;
@@ -139,6 +146,10 @@ export function localVmMode(cfg: AppConfig): "shared" | "per-bot" {
 
 export function localVmMaxInstances(cfg: AppConfig): number {
   return cfg.localVm?.maxInstances ?? DEFAULT_LOCAL_VM_MAX_INSTANCES;
+}
+
+export function skillRecorderEnabled(cfg: AppConfig): boolean {
+  return cfg.features?.skillRecorder === true;
 }
 
 // OMB_DATA_DIR isolates test/soak rigs from the user's real fleet.
@@ -263,7 +274,7 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     /* first write */
   }
   const checkedPatch = appConfigSchema.partial().parse(patch);
-  for (const key of ["xai", "composio", "box", "opencodeGo", "tts", "imageGen", "profile", "rooms", "localVm"] as const) {
+  for (const key of ["xai", "composio", "box", "opencodeGo", "tts", "imageGen", "profile", "rooms", "localVm", "features"] as const) {
     const section = checkedPatch[key];
     if (!section) continue;
     const current = jsonObjectSchema.safeParse(disk[key]);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1508,6 +1508,23 @@ describe("harness HTTP API", () => {
     await api("PUT", "/api/config", { rooms: { turnTimeoutMinutes: 5 } });
   });
 
+  it("keeps Teach a skill off by default and persists an explicit opt-in", async () => {
+    const before = await api("GET", "/api/config");
+    expect(before.status).toBe(200);
+    expect(before.body.features).toEqual({ skillRecorder: false });
+
+    const saved = await api("PATCH", "/api/config", {
+      features: { skillRecorder: true },
+    });
+    expect(saved.status).toBe(200);
+    expect(saved.body.features).toEqual({ skillRecorder: true });
+
+    const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
+    expect(disk.features).toEqual({ skillRecorder: true });
+
+    await api("PATCH", "/api/config", { features: { skillRecorder: false } });
+  });
+
   it("keeps shared Local VM mode by default and resolves isolated targets per bot when enabled", async () => {
     const first = (await api("POST", "/api/bots")).body.bot;
     const second = (await api("POST", "/api/bots")).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -49,6 +49,7 @@ import {
   parseConfigPatch,
   roomTurnTimeoutMinutes,
   saveConfig,
+  skillRecorderEnabled,
   syncCredentialEnv,
   withInstanceCli,
   vpsSshAlias,
@@ -2322,6 +2323,7 @@ function configStatus() {
       mode: localVmMode(cfg),
       maxInstances: localVmMaxInstances(cfg),
     },
+    features: { skillRecorder: skillRecorderEnabled(cfg) },
   };
 }
 
@@ -4349,7 +4351,8 @@ const server = createServer(async (req, res) => {
           key !== "imageGen" &&
           key !== "vps" &&
           key !== "rooms" &&
-          key !== "localVm",
+          key !== "localVm" &&
+          key !== "features",
       );
       if (reloadKeys.length > 0) await reloadProviders();
       const status = configStatus();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,8 +4,9 @@
 // machine your bots can borrow.
 import { useEffect, useRef, useState } from "react";
 import { Coins, KeyRound, Monitor, Smartphone, Terminal, User, X } from "lucide-react";
-import { useStore, type AppSettingsSection } from "@/state/store";
+import { api, useStore, type AppSettingsSection, type ConfigStatus } from "@/state/store";
 import { analyticsEnabled, setAnalyticsEnabled } from "@/lib/analytics";
+import { skillRecorderEnabled } from "@/lib/feature-flags";
 import { ApiKeyRow, VpsConnection } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
 import { EnginesSettings } from "./EnginesSettings";
@@ -126,6 +127,57 @@ function AnalyticsRow() {
       >
         <span className={cnKnob(on)} />
       </button>
+    </Card>
+  );
+}
+
+function ExperimentalFeaturesRow() {
+  const { state, dispatch } = useStore();
+  const enabled = skillRecorderEnabled(state.config);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const toggle = async () => {
+    if (saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      const config: ConfigStatus = await api("/api/config", {
+        method: "PATCH",
+        body: JSON.stringify({ features: { skillRecorder: !enabled } }),
+      });
+      dispatch({ type: "configStatus", config });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save the experimental feature setting.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Experimental features"
+      subtitle="Early features may change while we test them. They stay off unless you enable them."
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-[14px] font-medium text-ink">Teach a skill</div>
+          <div className="mt-0.5 text-[12px] leading-relaxed text-ink-secondary">
+            Show the workflow recorder in the sidebar.
+          </div>
+        </div>
+        <button
+          role="switch"
+          aria-checked={enabled}
+          aria-label="Show Teach a skill"
+          disabled={saving}
+          onClick={() => void toggle()}
+          className={`${cnSwitch(enabled)} disabled:cursor-wait disabled:opacity-50`}
+        >
+          <span className={cnKnob(enabled)} />
+        </button>
+      </div>
+      {error ? <p role="alert" className="mt-2 text-[12px] text-danger">{error}</p> : null}
     </Card>
   );
 }
@@ -291,6 +343,7 @@ export function SettingsModal() {
                 <Card title="Channel turns" subtitle="Set one maximum duration for every bot turn in a channel.">
                   <RoomTurnTimeoutSettings />
                 </Card>
+                <ExperimentalFeaturesRow />
                 <UpdatesRow />
                 <DiagnosticsRow />
                 <AnalyticsRow />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -36,6 +36,7 @@ import { BotAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
+import { skillRecorderEnabled } from "@/lib/feature-flags";
 import { nextRename } from "@/lib/rename";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
@@ -1476,19 +1477,21 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
 
       {/* Footer */}
       <div className={cn("pb-3 pt-2", density === "icons" ? "px-2" : "px-3")}>
-        <button
-          onClick={() => dispatch({ type: "showSkillRecorder" })}
-          aria-label={density === "icons" ? "Teach a skill" : undefined}
-          title={density === "icons" ? "Teach a skill" : undefined}
-          className={cn(
-            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-            state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-          )}
-        >
-          <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
-        </button>
+        {skillRecorderEnabled(state.config) && (
+          <button
+            onClick={() => dispatch({ type: "showSkillRecorder" })}
+            aria-label={density === "icons" ? "Teach a skill" : undefined}
+            title={density === "icons" ? "Teach a skill" : undefined}
+            className={cn(
+              "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+              density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+              state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+            )}
+          >
+            <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
+            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
+          </button>
+        )}
         <button
           onClick={() => dispatch({ type: "showRoutines" })}
           aria-label={density === "icons" ? "Tasks and routines" : undefined}

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { skillRecorderEnabled } from "./feature-flags";
+
+describe("experimental feature flags", () => {
+  it("keeps Teach a skill hidden by default", () => {
+    expect(skillRecorderEnabled(null)).toBe(false);
+    expect(skillRecorderEnabled({})).toBe(false);
+    expect(skillRecorderEnabled({ features: { skillRecorder: false } })).toBe(false);
+  });
+
+  it("shows Teach a skill only after explicit opt-in", () => {
+    expect(skillRecorderEnabled({ features: { skillRecorder: true } })).toBe(true);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,8 @@
+export interface FeatureFlagConfig {
+  features?: { skillRecorder?: boolean };
+}
+
+/** Experimental features are available only after an explicit opt-in. */
+export function skillRecorderEnabled(config: FeatureFlagConfig | null | undefined): boolean {
+  return config?.features?.skillRecorder === true;
+}

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -56,6 +56,7 @@ describe("config status frames", () => {
         opencodeGo: { configured: true },
         tts: { configured: true, ready: true, voice: "Ada" },
         profile: { name: "Ian", email: "ian@example.test" },
+        features: { skillRecorder: true },
       }),
     ).toEqual({
       xai: { configured: true },
@@ -67,7 +68,34 @@ describe("config status frames", () => {
       opencodeGo: { configured: true },
       tts: { configured: true, ready: true, voice: "Ada" },
       profile: { name: "Ian", email: "ian@example.test" },
+      features: { skillRecorder: true },
     });
+  });
+});
+
+describe("Teach a skill feature flag", () => {
+  const config = configStatusFromFrame({
+    composio: { configured: false },
+    box: { configured: false },
+    vps: { configured: false, sshAlias: "" },
+    rooms: { turnTimeoutMinutes: 5 },
+    localVm: { mode: "shared", maxInstances: 2 },
+    features: { skillRecorder: true },
+  });
+
+  it("does not open the recorder while the experiment is disabled", () => {
+    expect(reducer(initialState, { type: "showSkillRecorder" }).activeView).toBe("chat");
+  });
+
+  it("opens after opt-in and returns to chat when disabled", () => {
+    const enabled = reducer({ ...initialState, config }, { type: "showSkillRecorder" });
+    expect(enabled.activeView).toBe("skill-recorder");
+
+    const disabled = reducer(enabled, {
+      type: "configStatus",
+      config: { ...config, features: { skillRecorder: false } },
+    });
+    expect(disabled.activeView).toBe("chat");
   });
 });
 

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -22,6 +22,7 @@ import { currentCall } from "@/lib/call";
 import { showNotification, type NotificationTarget } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
+import { skillRecorderEnabled } from "@/lib/feature-flags";
 
 export type { MausColor } from "@/lib/mascot";
 
@@ -247,11 +248,13 @@ export interface ConfigStatus {
   imageGen?: { configured: boolean };
   /** who's using the app — collected in onboarding, shown in the sidebar */
   profile?: { name: string; email: string };
+  /** Experimental features are opt-in and default off when absent. */
+  features?: { skillRecorder: boolean };
 }
 
 export type ConfigStatusFrame = Pick<
   ConfigStatus,
-  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile"
+  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "features"
 >;
 
 export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
@@ -266,6 +269,7 @@ export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
     tts: frame.tts,
     imageGen: frame.imageGen,
     profile: frame.profile,
+    features: frame.features,
   };
 }
 
@@ -548,6 +552,7 @@ export function reducer(state: AppState, action: Action): AppState {
         pluginsOpen: false,
       };
     case "showSkillRecorder":
+      if (!skillRecorderEnabled(state.config)) return state;
       return {
         ...state,
         activeView: "skill-recorder",
@@ -615,7 +620,14 @@ export function reducer(state: AppState, action: Action): AppState {
     case "instances":
       return { ...state, instances: action.instances };
     case "configStatus":
-      return { ...state, config: action.config };
+      return {
+        ...state,
+        config: action.config,
+        activeView:
+          state.activeView === "skill-recorder" && !skillRecorderEnabled(action.config)
+            ? "chat"
+            : state.activeView,
+      };
     case "select": {
       if (state.groups.some((g) => g.id === action.id)) {
         return {


### PR DESCRIPTION
## What changed
- hide **Teach a skill** from the sidebar by default
- add **Settings → General → Experimental features → Teach a skill**
- persist the opt-in in app configuration and sync it across clients
- return to chat if the feature is disabled while its page is open
- avoid provider restarts when this display-only setting changes

## Verification
- `pnpm test` — 1,684 passed, 12 skipped
- `pnpm typecheck`
- `pnpm build`
- packaged-server smoke test passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Skill Recorder setting that can be enabled or disabled from General settings.
  * Added persistent configuration support for the Skill Recorder feature.
  * The “Teach a skill” option now appears only when Skill Recorder is enabled.

* **Bug Fixes**
  * Automatically returns to Chat if Skill Recorder is disabled while open.
  * Added validation and error handling for invalid feature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->