### PR TITLE
fix: keep OpenCode Go models in cloud picker

### DIFF
--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -6,6 +6,13 @@ icon: Clock
 
 The changelog tracks published desktop builds. Changes merged into `main` after a release are not listed as shipped until a new build is published.
 
+## 0.1.29 — August 23, 2026
+
+- Fixed OpenCode Go's live cloud models appearing as local models and bypassing sign-in.
+- Added direct latest-build downloads for Apple silicon, Intel Mac, Windows, and Ubuntu.
+
+[Full 0.1.29 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.29)
+
 ## 0.1.27 — August 20, 2026
 
 - Added the Cursor Agent CLI engine with ACP model discovery.

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -6,14 +6,14 @@ icon: Download
 
 ## Download a released build
 
-Choose the package for your computer from the [latest release](https://github.com/milind-soni/openmausbot-releases/releases/latest).
+Choose your computer below. Each link always downloads the latest published build.
 
 | Platform | Recommended package | Notes |
 |---|---|---|
-| macOS Apple silicon | `OpenMausBot.dmg` | Signed and notarized. Drag to Applications. |
-| macOS Intel | `OpenMausBot-intel.dmg` | Signed and notarized. |
-| Windows x64 | `OpenMausBot-setup.exe` | Per-user installer; Windows signing is not yet available. |
-| Ubuntu 24.04 x64 | `OpenMausBot-amd64.deb` | Recommended Ubuntu package; the AppImage is portable. |
+| macOS Apple silicon | [Download `.dmg`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Signed and notarized. Drag to Applications. |
+| macOS Intel | [Download `.dmg`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg) | Signed and notarized. |
+| Windows x64 | [Download installer](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Per-user installer; Windows signing is not yet available. |
+| Ubuntu 24.04 x64 | [Download `.deb`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) · [AppImage](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) | The `.deb` is recommended; the AppImage is portable. |
 
 <Callout type="warn" title="Windows SmartScreen">
   The Windows installer is not code-signed yet. Windows may show “Unknown publisher.” Verify that you downloaded it from the official OpenMausBot releases repository before choosing **More info → Run anyway**.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/drivers/acp/opencode-go.test.ts
+++ b/server/drivers/acp/opencode-go.test.ts
@@ -22,6 +22,7 @@ describe("OpenCode Go catalog", () => {
       new Response(JSON.stringify({
         data: [
           { id: "minimax-m3", object: "model" },
+          { id: "ox-alpha-free", object: "model" },
           { id: "bad id", object: "model" },
           { object: "model" },
         ],
@@ -29,10 +30,11 @@ describe("OpenCode Go catalog", () => {
     );
 
     expect(models.default).toBe("opencode-go/minimax-m3");
-    expect(models.options.filter((option) => !option.custom).map((option) => option.id)).toEqual([
+    expect(models.options.map((option) => option.id)).toEqual([
       "opencode-go/minimax-m3",
       "opencode-go/kimi-k3",
       "opencode-go/glm-5.2",
+      "opencode-go/ox-alpha-free",
     ]);
     expect(models.options.some((option) => option.custom)).toBe(false);
   });
@@ -47,7 +49,7 @@ describe("OpenCode Go catalog", () => {
     });
 
     expect(fallback.default).toBe("opencode-go/minimax-m3");
-    expect(fallback.options.some((option) => option.id === "opencode-go/extra-live" && option.custom)).toBe(true);
+    expect(fallback.options.some((option) => option.id === "opencode-go/extra-live" && !option.custom)).toBe(true);
   });
 
   it("refreshes the same instance catalog on each explicit refresh", async () => {
@@ -68,9 +70,9 @@ describe("OpenCode Go catalog", () => {
     expect(instance.models.default).toBe("opencode-go/minimax-m3");
     expect(instance.models.options.some((option) => option.custom)).toBe(false);
     await instance.refreshModels?.();
-    expect(instance.models.options.some((option) => option.id === "opencode-go/extra-two" && option.custom)).toBe(true);
+    expect(instance.models.options.some((option) => option.id === "opencode-go/extra-two" && !option.custom)).toBe(true);
     await instance.refreshModels?.();
-    expect(instance.models.options.some((option) => option.id === "opencode-go/extra-three" && option.custom)).toBe(true);
+    expect(instance.models.options.some((option) => option.id === "opencode-go/extra-three" && !option.custom)).toBe(true);
     await instance.dispose();
   });
 

--- a/server/drivers/acp/opencode-go.ts
+++ b/server/drivers/acp/opencode-go.ts
@@ -56,7 +56,11 @@ export async function fetchOpenCodeGoModels(fetcher: typeof fetch = fetch): Prom
         const full = `opencode-go/${id}`;
         if (seen.has(full)) continue;
         seen.add(full);
-        options.push({ id: full, label: labelForModel(id), custom: true });
+        // These are live OpenCode Go cloud models. `custom` is reserved for
+        // models discovered on a user's own Ollama/oMLX/LM Studio-style host;
+        // marking catalog additions custom moves them into the Local pane and
+        // incorrectly bypasses the OpenCode Go sign-in gate.
+        options.push({ id: full, label: labelForModel(id) });
       }
       const catalog = { default: STATIC_MODELS.default, options } satisfies ModelCatalog;
       lastSuccessfulCatalog = catalog;


### PR DESCRIPTION
## Summary

- keep live OpenCode Go catalogue entries in the Cloud pane
- prevent cloud models such as Ox Alpha from bypassing the OpenCode sign-in gate
- publish direct latest-download links in the documentation for every desktop platform
- prepare desktop release 0.1.29

## Validation

- OpenCode Go regression: 9 tests passed
- full suite: 1,690 tests passed (12 skipped)
- typecheck passed
- packaged server smoke passed
- docs production build passed
- README stable download buttons verified against release asset names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct downloads for the latest release on supported platforms.
  * Ubuntu installation now offers both `.deb` and AppImage packages, with `.deb` recommended.

* **Bug Fixes**
  * Improved OpenCode Go model classification and sign-in behavior.
  * Updated model discovery handling so fetched models use the standard authentication flow.

* **Documentation**
  * Added the version 0.1.29 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->