### PR TITLE
chore(release): bump version to 0.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Release
Bumps OpenMausBot from `0.1.29` to `0.1.30` so the merged section-Chief fix and experimental Teach a skill flag can be packaged without overwriting the published `v0.1.29`.

## Verification
- package version resolves to `0.1.30`
- `v0.1.30` is available in the release repository
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.1.29 to 0.1.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->