### PR TITLE
fix(composio): preserve multi-account inventory

### DIFF
--- a/cloudflare/composio-broker/src/index.test.ts
+++ b/cloudflare/composio-broker/src/index.test.ts
@@ -136,7 +136,10 @@ describe("connected-apps broker boundaries", () => {
           });
         }
         const body = {
-          items: [{ slug: "gmail", connected_account: { id: "ca_work", status: "ACTIVE" } }],
+          items: [
+            { slug: "gmail", connected_account: { id: "ca_work", status: "ACTIVE" } },
+            { slug: "unconnected", connected_account: null },
+          ],
           next_cursor: query.has("toolkits") ? undefined : "toolkits-page-2",
         };
         return Response.json(body);

--- a/cloudflare/composio-broker/src/index.ts
+++ b/cloudflare/composio-broker/src/index.ts
@@ -66,7 +66,7 @@ const connectedAccountsPageSchema = z.object({
 const toolkitItemSchema = z.object({
   slug: z.string().optional(),
   is_no_auth: z.boolean().optional(),
-  connected_account: z.object({ id: z.string().optional(), status: z.string().optional() }).optional(),
+  connected_account: z.object({ id: z.string().optional(), status: z.string().optional() }).nullable().optional(),
 });
 type ToolkitItem = z.infer<typeof toolkitItemSchema>;
 const toolkitPageSchema = z.object({

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -78,6 +78,7 @@ beforeAll(async () => {
           { slug: "github", connected_account: { id: "ca_github", status: "ACTIVE" } },
           { slug: "gmail", is_no_auth: true },
           { slug: "slack" },
+          { slug: "unconnected", connected_account: null },
         ],
         next_cursor: url.searchParams.has("toolkits") ? undefined : "toolkits-page-2",
       };

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -64,7 +64,7 @@ const connectedAccountsPageSchema = z.object({
 const toolkitItemSchema = z.object({
   slug: z.string().optional(),
   is_no_auth: z.boolean().optional(),
-  connected_account: z.object({ id: z.string().optional(), status: z.string().optional() }).optional(),
+  connected_account: z.object({ id: z.string().optional(), status: z.string().optional() }).nullable().optional(),
 });
 type ToolkitItem = z.infer<typeof toolkitItemSchema>;
 const toolkitPageSchema = z.object({


### PR DESCRIPTION
## What changed
- accept Composio toolkit entries whose `connected_account` is `null`
- apply the fix to both self-hosted and managed broker paths
- cover the upstream response shape in both test suites

## Why
Composio includes unconnected toolkits with `connected_account: null`. Rejecting that shape made the whole connection inventory fail, so the UI could not detect an existing account and show the alias-first **Add account** flow.

## Validation
- `pnpm exec vitest run server/composio.test.ts`
- `pnpm broker:test`
- `pnpm typecheck`
- `pnpm test` (1,685 passed, 12 skipped)

Repository-wide `pnpm lint` remains blocked by existing anti-slop findings in unrelated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of toolkit entries without a connected account.
  * Unconnected toolkits are now represented correctly when no account is linked.
  * Updated validation to accept explicitly empty connection values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->