### PR TITLE
fix(opencode): distinguish Go from Zen auth

### DIFF
--- a/apps/docs/content/docs/providers/index.mdx
+++ b/apps/docs/content/docs/providers/index.mdx
@@ -19,7 +19,7 @@ OpenMausBot does not proxy every message through its own model account. It start
 | Kimi | Kimi CLI login | ACP integration |
 | Droid | Factory Droid CLI login | ACP integration |
 | Antigravity | Google Antigravity CLI login | Default Google consumer engine |
-| OpenCode Go | OpenCode login | ACP integration |
+| OpenCode Go | OpenCode Go API key or provider login | ACP integration |
 | Qwen | Qwen CLI login | ACP integration |
 | Hermes | Hermes CLI login | ACP integration |
 | Pi | Pi CLI login | Native driver |

--- a/docs/opencode-go.md
+++ b/docs/opencode-go.md
@@ -23,7 +23,9 @@ arguments.
 OpenCode Go remains unavailable until both the `opencode` executable and the
 credential are present. It is never selected as a runnable default while either
 requirement is missing. Users may instead manage OpenCode's own login flow with
-`opencode auth login`; OpenMausBot does not edit OpenCode auth/config files.
+`opencode auth login --provider opencode-go`; OpenMausBot does not edit
+OpenCode auth/config files. A normal OpenCode Zen login is a different
+provider and does not authenticate OpenCode Go.
 
 ## Models
 

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -116,6 +116,9 @@ export interface AcpSupport {
   /** snapshot(): can this harness actually run a turn? (env already carries the
    *  merged config). May be async for harnesses that have to ask the CLI. */
   isAuthenticated(env: Record<string, string | undefined>, config: AcpConfig): boolean | Promise<boolean>;
+  /** Refuse a first-party cloud turn before spawning when snapshot auth is
+   * false. Local injected models deliberately bypass this subscription gate. */
+  requireAuthenticationBeforeSpawn?: boolean;
   /** Classify provider-native failures without coupling the core to messages. */
   classifyError?(error: unknown): ProviderErrorCode | undefined;
   /** Compose the session/prompt text. Default prepends the persona. */
@@ -289,6 +292,16 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         const turnId = newId();
         const cwd = turn.cwd ?? config.workspace ?? homedir();
         const env = childEnv();
+        if (
+          support.requireAuthenticationBeforeSpawn
+          && !skipSubscriptionAuthForLocalInject(turn.model)
+          && !(await support.isAuthenticated(env, config))
+        ) {
+          emit({ ...base(threadId, turnId), type: "turn.started" });
+          emit({ ...base(threadId, turnId), type: "runtime.error", message: support.loginNote, setup: true });
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "auth_required", cost: null });
+          return { turnId };
+        }
         const resolvedModel = support.resolveTurnModel?.(turn.model, env);
         support.applyTurnEnv?.(env, { model: resolvedModel, requestedModel: turn.model });
         const cliTurn =

--- a/server/drivers/acp/opencode-go.test.ts
+++ b/server/drivers/acp/opencode-go.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { removeTempDir } from "../../testing/cleanup.ts";
+import { recordEvents } from "../../testing/events.ts";
 import {
   classifyOpenCodeGoError,
   createOpenCodeGoDriver,
@@ -81,6 +82,7 @@ describe("OpenCode Go catalog", () => {
     expect(driver.driverKind).toBe("opencodeGo");
     expect(driver.decodeConfig(undefined)).toEqual({ cli: "opencode", fullAuto: false, workspace: undefined });
     expect(driver.install?.docsUrl).toContain("opencode.ai");
+    expect(driver.install?.signInCommand).toBe("opencode auth login --provider opencode-go");
   });
 
   it("recognizes an OpenCode Go login stored by the CLI", async () => {
@@ -133,11 +135,7 @@ describe("OpenCode Go catalog", () => {
     }
   });
 
-  it("accepts a browser (oauth) sign-in stored under the plain 'opencode' id", async () => {
-    // `opencode auth login` -> OpenCode writes {type:"oauth", access, refresh}
-    // under "opencode", not an api `key` under "opencode-go". Both unlock the
-    // Go models; demanding `key` under "opencode-go" rejected every real
-    // browser login.
+  it("does not mistake an OpenCode Zen login for OpenCode Go", async () => {
     const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-oauth-"));
     const authDir = join(scratch, "opencode");
     mkdirSync(authDir, { recursive: true });
@@ -153,8 +151,44 @@ describe("OpenCode Go catalog", () => {
       config: { cli: FAKE_CLI, fullAuto: false },
     });
     try {
-      expect((await instance.snapshot()).authenticated).toBe(true);
+      expect((await instance.snapshot()).authenticated).toBe(false);
     } finally {
+      await instance.dispose();
+      await removeTempDir(scratch);
+    }
+  });
+
+  it("shows setup before spawning a Go turn when only Zen is connected", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-zen-only-"));
+    const authDir = join(scratch, "opencode");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), JSON.stringify({
+      opencode: { type: "api", key: "zen-only-secret" },
+    }));
+    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const instance = await driver.create({
+      instanceId: "opencode-zen-only",
+      displayName: "OpenCode Go",
+      environment: { XDG_DATA_HOME: scratch, OPENCODE_API_KEY: "" },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    const recorder = recordEvents(instance.adapter);
+    try {
+      await instance.adapter.sendTurn({
+        threadId: "t-opencode-zen-only",
+        text: "hello",
+        model: "opencode-go/ox-alpha-free",
+      });
+      const done = await recorder.until((event) => event.type === "turn.completed");
+      expect(done).toMatchObject({ ok: false, stopReason: "auth_required" });
+      expect(recorder.events.find((event) => event.type === "runtime.error")).toMatchObject({
+        setup: true,
+        message: expect.stringContaining("--provider opencode-go"),
+      });
+      expect(recorder.events.some((event) => event.type === "session.started")).toBe(false);
+    } finally {
+      recorder.stop();
       await instance.dispose();
       await removeTempDir(scratch);
     }

--- a/server/drivers/acp/opencode-go.ts
+++ b/server/drivers/acp/opencode-go.ts
@@ -172,20 +172,17 @@ function storedAuthPaths(env: Record<string, string | undefined>): string[] {
   return [...new Set(roots)].map((root) => join(root, "opencode", "auth.json"));
 }
 
-/** True when an auth.json entry looks like a usable OpenCode login.
+/** True when auth.json contains a usable OpenCode Go login.
  *
  * The CLI writes `{type:"api", key}` for pasted keys and
- * `{type:"oauth", access, refresh}` for browser sign-ins — demanding `key`
- * alone rejects every OAuth login. The entry id is `"opencode"` for the
- * standard Zen sign-in and `"opencode-go"` for the Go product; both unlock
- * the Go models, so both count. */
+ * `{type:"oauth", access, refresh}` for browser sign-ins. OpenCode Zen uses
+ * the separate `"opencode"` id and does not load the `opencode-go` provider,
+ * so accepting it here produces a misleading "model not found" at runtime. */
 function usableAuthEntry(parsed: Record<string, unknown>): boolean {
-  return ["opencode-go", "opencode"].some((id) => {
-    const auth = parsed[id];
-    if (!auth || typeof auth !== "object") return false;
-    const entry = auth as { key?: unknown; access?: unknown; refresh?: unknown };
-    return Boolean(entry.key || entry.access || entry.refresh);
-  });
+  const auth = parsed["opencode-go"];
+  if (!auth || typeof auth !== "object") return false;
+  const entry = auth as { key?: unknown; access?: unknown; refresh?: unknown };
+  return Boolean(entry.key || entry.access || entry.refresh);
 }
 
 function hasStoredOpenCodeGoAuth(env: Record<string, string | undefined>) {
@@ -214,7 +211,7 @@ const support = (fetcher: typeof fetch): AcpSupport => ({
   defaultCli: "opencode",
   nativeSource: "opencode-go.acp",
   loginNote:
-    "OpenCode is not signed in — run `opencode auth login` and pick OpenCode, or add an OPENCODE_API_KEY in OpenMausBot settings",
+    "OpenCode Go is not connected — run `opencode auth login --provider opencode-go`, or add your OpenCode Go API key in Settings → Connections",
   install: {
     command: {
       darwin: "npm install -g opencode-ai",
@@ -222,7 +219,7 @@ const support = (fetcher: typeof fetch): AcpSupport => ({
       win32: "npm install -g opencode-ai",
     },
     docsUrl: "https://opencode.ai/docs/",
-    signInCommand: "opencode auth login",
+    signInCommand: "opencode auth login --provider opencode-go",
     needsNode: true,
   },
   spawnArgs: () => ["acp"],
@@ -233,6 +230,7 @@ const support = (fetcher: typeof fetch): AcpSupport => ({
   pickAuthMethod: () => null,
   authFailure: "continue",
   isAuthenticated: (env) => Boolean(env.OPENCODE_API_KEY) || hasStoredOpenCodeGoAuth(env),
+  requireAuthenticationBeforeSpawn: true,
   classifyError: classifyOpenCodeGoError,
   resolveModels: async (environment) => mergeLocalInject(await fetchOpenCodeGoModels(fetcher), environment),
   buildPromptText: (turn) => turn.system ? `${turn.system}\n\n${turn.text}` : turn.text,


### PR DESCRIPTION
## What changed
- stop treating a normal OpenCode Zen login as OpenCode Go authentication
- preflight cloud ACP turns and show a setup card before spawning when credentials are missing
- point setup directly at `opencode auth login --provider opencode-go`
- clarify the provider boundary in both documentation surfaces

## Root cause
OpenCode stores Zen under `opencode` and Go under `opencode-go`. OpenMausBot accepted either entry, but the CLI does not load the Go provider from a Zen-only login, which made valid models such as `opencode-go/ox-alpha-free` fail as “model not found.”

The live Go catalog and official documentation confirm `opencode-go/ox-alpha-free`; a Zen-only key was also verified to be rejected by the Go endpoint, so silently reusing it is not safe.

## Validation
- `pnpm exec vitest run server/drivers/acp/opencode-go.test.ts server/drivers/acp/acp.test.ts`
- `pnpm typecheck`
- `pnpm test` (1,686 passed, 12 skipped)

Repository lint still reports the existing anti-slop baseline in these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode Go now requires valid OpenCode Go credentials before starting a cloud session.
  * Locally configured models continue to work without this authentication step.
  * Authentication failures now provide a setup-related message before a session begins.

* **Bug Fixes**
  * OpenCode Zen credentials are no longer incorrectly treated as OpenCode Go credentials.

* **Documentation**
  * Updated login instructions to use the provider-specific OpenCode Go sign-in command.
  * Clarified that OpenCode Zen authentication does not sign in to OpenCode Go.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->