### PR TITLE
chore(release): bump version to 0.1.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop release version from `0.1.30` to `0.1.31`.

This release includes the OpenCode Go authentication fix merged in #405.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->