### PR TITLE
feat: discover OpenCode providers and models

### DIFF
--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -6,6 +6,11 @@ icon: Clock
 
 The changelog tracks published desktop builds. Changes merged into `main` after a release are not listed as shipped until a new build is published.
 
+## Next release
+
+- Expanded the OpenCode engine from a Go-only catalog to the installed CLI's live Zen, Go, third-party, and local provider inventory.
+- Existing OpenCode logins and anonymous free models now work without duplicate setup in OpenMausBot.
+
 ## 0.1.29 — August 23, 2026
 
 - Fixed OpenCode Go's live cloud models appearing as local models and bypassing sign-in.

--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -6,10 +6,12 @@ icon: Clock
 
 The changelog tracks published desktop builds. Changes merged into `main` after a release are not listed as shipped until a new build is published.
 
-## Next release
+## 0.1.32 — August 23, 2026
 
 - Expanded the OpenCode engine from a Go-only catalog to the installed CLI's live Zen, Go, third-party, and local provider inventory.
 - Existing OpenCode logins and anonymous free models now work without duplicate setup in OpenMausBot.
+
+[Full 0.1.32 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.32)
 
 ## 0.1.29 — August 23, 2026
 

--- a/apps/docs/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/content/docs/getting-started/configuration.mdx
@@ -24,7 +24,7 @@ Explicit paths are useful when you:
 | Composio project key | Connected apps and OAuth sessions |
 | Box API key | Hosted Linux computers |
 | ElevenLabs API key | Spoken replies and voice mode |
-| OpenCode Go API key | OpenCode Go engine |
+| OpenCode API key | Optional alternative to an existing OpenCode provider login |
 
 Local agent chat works without these credentials.
 

--- a/apps/docs/content/docs/providers/index.mdx
+++ b/apps/docs/content/docs/providers/index.mdx
@@ -19,7 +19,7 @@ OpenMausBot does not proxy every message through its own model account. It start
 | Kimi | Kimi CLI login | ACP integration |
 | Droid | Factory Droid CLI login | ACP integration |
 | Antigravity | Google Antigravity CLI login | Default Google consumer engine |
-| OpenCode Go | OpenCode Go API key or provider login | ACP integration |
+| OpenCode | Existing OpenCode provider login or optional API key | Live Zen, Go, third-party, and local model discovery through ACP |
 | Qwen | Qwen CLI login | ACP integration |
 | Hermes | Hermes CLI login | ACP integration |
 | Pi | Pi CLI login | Native driver |

--- a/docs/opencode-go.md
+++ b/docs/opencode-go.md
@@ -1,6 +1,6 @@
-# OpenCode Go
+# OpenCode
 
-OpenCode Go is an optional OpenMausBot engine. OpenMausBot runs the maintained
+OpenCode is an optional OpenMausBot engine. OpenMausBot runs the maintained
 OpenCode CLI through its ACP stdio interface, so sessions, streaming, coding
 tools, permission requests, MCP integrations, resume, and cancellation use the
 same runtime as the other ACP engines.
@@ -9,38 +9,35 @@ same runtime as the other ACP engines.
 
 1. Install the official CLI using the
    [OpenCode installation guide](https://opencode.ai/docs/).
-2. Create or obtain an OpenCode Go API key according to the live
-   [OpenCode Go documentation](https://opencode.ai/docs/go/).
-3. Open OpenMausBot Settings → Connections and save the key under **OpenCode
-   Go API key**.
+2. Connect the providers you want in the OpenCode app, or run
+   `opencode auth login`.
+3. Restart OpenMausBot. It reuses OpenCode's existing connections and model
+   configuration automatically.
 
-The key is stored locally as write-only configuration. OpenMausBot reports only
-whether it is configured, never the value. A key saved in OpenMausBot is
-injected as `OPENCODE_API_KEY` only into the OpenCode child process; it is not
-sent to the renderer, logs, analytics, snapshots, error messages, or command
-arguments.
+OpenCode includes anonymous free models. A Zen, Go, OpenRouter, or other
+provider connection expands the catalog according to the installed CLI. An
+OpenCode API key can optionally be stored under Settings → Connections. It is
+write-only and injected as `OPENCODE_API_KEY` only into the OpenCode child
+process; it is not sent to the renderer, logs, analytics, snapshots, error
+messages, or command arguments.
 
-OpenCode Go remains unavailable until both the `opencode` executable and the
-credential are present. It is never selected as a runnable default while either
-requirement is missing. Users may instead manage OpenCode's own login flow with
-`opencode auth login --provider opencode-go`; OpenMausBot does not edit
-OpenCode auth/config files. A normal OpenCode Zen login is a different
-provider and does not authenticate OpenCode Go.
+OpenMausBot does not copy or rewrite `auth.json`. The OpenCode CLI remains the
+owner of provider authentication, and the same Zen or Go connection used by
+the OpenCode desktop/TUI is used by OpenMausBot.
 
 ## Models
 
-The model picker refreshes the public catalog from
-`https://opencode.ai/zen/go/v1/models`. IDs are normalized to the full
-`opencode-go/<model-id>` form required by ACP. If the catalog is unavailable,
-the last successful catalog is used, followed by a small static fallback. The
-catalog is mutable; current names, pricing, limits, and retention terms remain
-defined by the live OpenCode documentation.
+The model picker runs `opencode models --verbose` against the configured binary
+and preserves every exact `provider/model` ID returned by the CLI. This can
+include Zen (`opencode/*`), Go (`opencode-go/*`), third-party providers, custom
+configuration, and local endpoints. If discovery temporarily fails, the last
+successful catalog is used, followed by a small anonymous-model fallback.
 
 Before every prompt, ACP receives `session/set_config_option` with
 `configId: "model"` and the exact selected provider-qualified model ID.
 
 ## Testing
 
-Normal unit and ACP protocol tests do not require a subscription. Live tests,
-if added, must be explicitly enabled and must never print credentials or upload
-native protocol logs from a credentialed run.
+Normal unit and ACP protocol tests do not require a subscription. Live tests
+must be explicitly enabled and must never print credentials or upload native
+protocol logs from a credentialed run.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -126,7 +126,7 @@ async function secureComposioConfig() {
   }
 }
 
-// The remaining workspace credentials (xai/box/voice/OpenCode Go keys) get
+// The remaining workspace credentials (xai/box/voice/OpenCode keys) get
 // the same at-rest treatment as the Composio key above. New packaged-app
 // saves go straight through credential:set below; this boot-time sweep also
 // migrates plaintext left by older versions or direct development clients.
@@ -290,7 +290,7 @@ async function startServerOn(port) {
       ...(secureCredentials.composioApiKey
         ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
         : {}),
-      // one env var per stored workspace secret (xai/box/voice/OpenCode Go);
+      // one env var per stored workspace secret (xai/box/voice/OpenCode);
       // the server prefers these over config.json, whose plaintext fields
       // the boot migration has deleted
       ...workspaceCredentialEnv(secureCredentials),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/config.ts
+++ b/server/config.ts
@@ -81,7 +81,7 @@ const appConfigSchema = z.object({
   composio: z.object({ apiKey: optionalText, userId: optionalText, sessionId: optionalText }).optional(),
   box: z.object({ token: optionalText }).optional(),
   vps: vpsConfigSchema.optional(),
-  /** OpenCode Go key; persisted write-only and passed only to its child. */
+  /** Optional OpenCode key; persisted write-only and passed only to its child. */
   opencodeGo: z.object({ apiKey: optionalText }).optional(),
   /** Voice credentials and the selected voice id. */
   tts: z.object({ key: optionalText, voice: optionalText }).optional(),
@@ -352,7 +352,7 @@ interface InstanceCliUpdate {
  * withInstanceCli() so the inject rule and the strip rule cannot drift apart.
  * Each secret goes only to the driver that actually reads it: the API-key
  * Grok driver reads XAI_API_KEY, the Computer driver reads BOX_TOKEN, and
- * OpenCode Go reads OPENCODE_API_KEY. Every other engine brings its own
+ * OpenCode reads OPENCODE_API_KEY. Every other engine brings its own
  * login, so handing it a key it never uses would only put that key in the
  * environment of an unrelated child process. */
 function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string> {

--- a/server/drivers/acp/opencode-go.test.ts
+++ b/server/drivers/acp/opencode-go.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -7,82 +7,107 @@ import { fileURLToPath } from "node:url";
 import { removeTempDir } from "../../testing/cleanup.ts";
 import { recordEvents } from "../../testing/events.ts";
 import {
-  classifyOpenCodeGoError,
-  createOpenCodeGoDriver,
-  fetchOpenCodeGoModels,
-  resetOpenCodeGoModelCache,
+  classifyOpenCodeError,
+  createOpenCodeDriver,
+  normalizeLegacyOpenCodeModel,
+  parseOpenCodeModelsOutput,
 } from "./opencode-go.ts";
+import type { ModelCatalog } from "../../contracts.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
 
-describe("OpenCode Go catalog", () => {
-  beforeEach(() => resetOpenCodeGoModelCache());
+const catalog = (...ids: string[]): ModelCatalog => ({
+  default: ids[0]!,
+  options: ids.map((id) => ({ id, label: id })),
+});
 
-  it("normalizes valid catalog records to provider-qualified model ids", async () => {
-    const models = await fetchOpenCodeGoModels(async () =>
-      new Response(JSON.stringify({
-        data: [
-          { id: "minimax-m3", object: "model" },
-          { id: "ox-alpha-free", object: "model" },
-          { id: "bad id", object: "model" },
-          { object: "model" },
-        ],
-      }), { status: 200 }),
-    );
-
-    expect(models.default).toBe("opencode-go/minimax-m3");
-    expect(models.options.map((option) => option.id)).toEqual([
+describe("OpenCode catalog", () => {
+  it("parses Zen, Go, third-party, and local models using exact CLI slugs", () => {
+    const models = parseOpenCodeModelsOutput([
+      "opencode/x-preview-f-free",
+      JSON.stringify({ name: "Ox Alpha Free", status: "active", limit: { context: 1_000_000 } }, null, 2),
       "opencode-go/minimax-m3",
-      "opencode-go/kimi-k3",
-      "opencode-go/glm-5.2",
-      "opencode-go/ox-alpha-free",
+      JSON.stringify({ name: "MiniMax M3", status: "active" }, null, 2),
+      "openrouter/vendor/model-v2",
+      JSON.stringify({ name: "Vendor Model", status: "active" }, null, 2),
+      "ollama/qwen3",
+      JSON.stringify({ name: "Qwen 3", api: { url: "http://127.0.0.1:11434/v1" } }, null, 2),
+      "opencode/retired",
+      JSON.stringify({ name: "Retired", status: "deprecated" }, null, 2),
+    ].join("\n"));
+
+    expect(models?.default).toBe("opencode/x-preview-f-free");
+    expect(models?.options).toEqual([
+      expect.objectContaining({
+        id: "opencode/x-preview-f-free",
+        label: "Zen · Ox Alpha Free",
+        contextWindow: 1_000_000,
+      }),
+      expect.objectContaining({ id: "opencode-go/minimax-m3", label: "Go · MiniMax M3" }),
+      expect.objectContaining({ id: "openrouter/vendor/model-v2", label: "OpenRouter · Vendor Model" }),
+      expect.objectContaining({ id: "ollama/qwen3", custom: true, loaded: true }),
     ]);
-    expect(models.options.some((option) => option.custom)).toBe(false);
   });
 
-  it("uses the last successful catalog when the endpoint fails", async () => {
-    const fetcher = async () =>
-      new Response(JSON.stringify([{ id: "kimi-k3" }, { id: "extra-live" }]), { status: 200 });
-    await fetchOpenCodeGoModels(fetcher);
+  it("accepts header-only output from older CLIs and rejects malformed lines", () => {
+    const models = parseOpenCodeModelsOutput([
+      "Available models",
+      "opencode/x-preview-f-free",
+      "bad model/with space",
+      "openrouter/anthropic/claude-sonnet-5",
+    ].join("\n"));
 
-    const fallback = await fetchOpenCodeGoModels(async () => {
-      throw new Error("network down");
-    });
-
-    expect(fallback.default).toBe("opencode-go/minimax-m3");
-    expect(fallback.options.some((option) => option.id === "opencode-go/extra-live" && !option.custom)).toBe(true);
+    expect(models?.options.map((option) => option.id)).toEqual([
+      "opencode/x-preview-f-free",
+      "openrouter/anthropic/claude-sonnet-5",
+    ]);
   });
 
   it("refreshes the same instance catalog on each explicit refresh", async () => {
     let calls = 0;
-    const driver = createOpenCodeGoDriver(async () => {
+    const driver = createOpenCodeDriver(async () => {
       calls += 1;
-      const id = calls === 1 ? "minimax-m3" : calls === 2 ? "extra-two" : "extra-three";
-      return new Response(JSON.stringify([{ id }]), { status: 200 });
+      const id = calls === 1
+        ? "opencode/x-preview-f-free"
+        : calls === 2
+          ? "opencode-go/extra-two"
+          : "openrouter/vendor/extra-three";
+      return catalog(id);
     });
     const instance = await driver.create({
       instanceId: "opencode-refresh",
-      displayName: "OpenCode Go",
+      displayName: "OpenCode",
       environment: {},
       enabled: true,
       config: driver.defaultConfig(),
     });
 
-    expect(instance.models.default).toBe("opencode-go/minimax-m3");
+    expect(instance.models.default).toBe("opencode/x-preview-f-free");
     expect(instance.models.options.some((option) => option.custom)).toBe(false);
     await instance.refreshModels?.();
     expect(instance.models.options.some((option) => option.id === "opencode-go/extra-two" && !option.custom)).toBe(true);
     await instance.refreshModels?.();
-    expect(instance.models.options.some((option) => option.id === "opencode-go/extra-three" && !option.custom)).toBe(true);
+    expect(instance.models.options.some((option) => option.id === "openrouter/vendor/extra-three" && !option.custom)).toBe(true);
     await instance.dispose();
   });
 
   it("keeps the driver optional and declares the OpenCode CLI setup", () => {
-    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const driver = createOpenCodeDriver(async () => catalog("opencode/x-preview-f-free"));
     expect(driver.driverKind).toBe("opencodeGo");
+    expect(driver.metadata.displayName).toBe("OpenCode");
     expect(driver.decodeConfig(undefined)).toEqual({ cli: "opencode", fullAuto: false, workspace: undefined });
     expect(driver.install?.docsUrl).toContain("opencode.ai");
-    expect(driver.install?.signInCommand).toBe("opencode auth login --provider opencode-go");
+    expect(driver.install?.signInCommand).toBe("opencode auth login");
+  });
+
+  it("migrates the retired Ox preview id without changing current ids", () => {
+    expect(normalizeLegacyOpenCodeModel("opencode-go/ox-alpha-free", {})).toBe(
+      "opencode/x-preview-f-free",
+    );
+    expect(normalizeLegacyOpenCodeModel("opencode-go/ox-alpha-free", { OPENCODE_API_KEY: "configured" })).toBe(
+      "opencode-go/x-preview-f-free",
+    );
+    expect(normalizeLegacyOpenCodeModel("opencode/gpt-5.6-sol", {})).toBe("opencode/gpt-5.6-sol");
   });
 
   it("recognizes an OpenCode Go login stored by the CLI", async () => {
@@ -92,10 +117,10 @@ describe("OpenCode Go catalog", () => {
     writeFileSync(join(authDir, "auth.json"), JSON.stringify({
       "opencode-go": { type: "api", key: "stored-secret" },
     }));
-    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const driver = createOpenCodeDriver(async () => catalog("opencode-go/minimax-m3"));
     const instance = await driver.create({
       instanceId: "opencode-auth",
-      displayName: "OpenCode Go",
+      displayName: "OpenCode",
       environment: { XDG_DATA_HOME: scratch, OPENCODE_API_KEY: "" },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
@@ -119,10 +144,10 @@ describe("OpenCode Go catalog", () => {
     writeFileSync(join(authDir, "auth.json"), JSON.stringify({
       "opencode-go": { type: "api", key: "stored-secret" },
     }));
-    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const driver = createOpenCodeDriver(async () => catalog("opencode-go/minimax-m3"));
     const instance = await driver.create({
       instanceId: "opencode-home-auth",
-      displayName: "OpenCode Go",
+      displayName: "OpenCode",
       environment: { HOME: scratch, USERPROFILE: scratch, XDG_DATA_HOME: "", OPENCODE_API_KEY: "" },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
@@ -135,41 +160,68 @@ describe("OpenCode Go catalog", () => {
     }
   });
 
-  it("does not mistake an OpenCode Zen login for OpenCode Go", async () => {
+  it("recognizes an existing OpenCode Zen login", async () => {
     const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-oauth-"));
     const authDir = join(scratch, "opencode");
     mkdirSync(authDir, { recursive: true });
     writeFileSync(join(authDir, "auth.json"), JSON.stringify({
       opencode: { type: "oauth", access: "acc-token", refresh: "ref-token" },
     }));
-    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const driver = createOpenCodeDriver(async () => catalog("opencode/x-preview-f-free"));
     const instance = await driver.create({
       instanceId: "opencode-oauth-auth",
-      displayName: "OpenCode Go",
+      displayName: "OpenCode",
       environment: { XDG_DATA_HOME: scratch, OPENCODE_API_KEY: "" },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
     });
     try {
-      expect((await instance.snapshot()).authenticated).toBe(false);
+      expect((await instance.snapshot()).authenticated).toBe(true);
     } finally {
       await instance.dispose();
       await removeTempDir(scratch);
     }
   });
 
-  it("shows setup before spawning a Go turn when only Zen is connected", async () => {
+  it("treats OpenCode's anonymous free catalog as runnable without a saved key", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-free-"));
+    const driver = createOpenCodeDriver(async () => catalog("opencode/x-preview-f-free"));
+    const instance = await driver.create({
+      instanceId: "opencode-free",
+      displayName: "OpenCode",
+      environment: {
+        HOME: scratch,
+        USERPROFILE: scratch,
+        XDG_DATA_HOME: join(scratch, "data"),
+        FAKE_ACP_MODELS: "opencode/x-preview-f-free",
+      },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect((await instance.snapshot()).authenticated).toBe(true);
+    } finally {
+      await instance.dispose();
+      await removeTempDir(scratch);
+    }
+  });
+
+  it("runs a Zen model through ACP using the exact discovered id", async () => {
     const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-zen-only-"));
     const authDir = join(scratch, "opencode");
     mkdirSync(authDir, { recursive: true });
     writeFileSync(join(authDir, "auth.json"), JSON.stringify({
       opencode: { type: "api", key: "zen-only-secret" },
     }));
-    const driver = createOpenCodeGoDriver(async () => new Response("[]", { status: 200 }));
+    const driver = createOpenCodeDriver(async () => catalog("opencode/x-preview-f-free"));
     const instance = await driver.create({
       instanceId: "opencode-zen-only",
-      displayName: "OpenCode Go",
-      environment: { XDG_DATA_HOME: scratch, OPENCODE_API_KEY: "" },
+      displayName: "OpenCode",
+      environment: {
+        XDG_DATA_HOME: scratch,
+        OPENCODE_API_KEY: "",
+        FAKE_ACP_MODELS: "opencode/x-preview-f-free",
+      },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: false },
     });
@@ -178,15 +230,13 @@ describe("OpenCode Go catalog", () => {
       await instance.adapter.sendTurn({
         threadId: "t-opencode-zen-only",
         text: "hello",
-        model: "opencode-go/ox-alpha-free",
+        model: "opencode/x-preview-f-free",
       });
       const done = await recorder.until((event) => event.type === "turn.completed");
-      expect(done).toMatchObject({ ok: false, stopReason: "auth_required" });
-      expect(recorder.events.find((event) => event.type === "runtime.error")).toMatchObject({
-        setup: true,
-        message: expect.stringContaining("--provider opencode-go"),
-      });
-      expect(recorder.events.some((event) => event.type === "session.started")).toBe(false);
+      expect(done).toMatchObject({ ok: true });
+      expect(recorder.events).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: "session.started", model: "opencode/x-preview-f-free" }),
+      ]));
     } finally {
       recorder.stop();
       await instance.dispose();
@@ -195,17 +245,17 @@ describe("OpenCode Go catalog", () => {
   });
 
   it("classifies ACP's standard authentication error", () => {
-    expect(classifyOpenCodeGoError({ code: -32000 })).toBe("invalid_credentials");
+    expect(classifyOpenCodeError({ code: -32000 })).toBe("invalid_credentials");
   });
 
   it("keeps the OpenCode key in the child environment only", async () => {
     const scratch = mkdtempSync(join(tmpdir(), "omb-opencode-go-"));
     try {
       const dump = join(scratch, "env.json");
-      const driver = createOpenCodeGoDriver(async () => new Response(JSON.stringify([{ id: "minimax-m3" }]), { status: 200 }));
+      const driver = createOpenCodeDriver(async () => catalog("opencode-go/minimax-m3"));
       const instance = await driver.create({
         instanceId: "opencode-go",
-        displayName: "OpenCode Go",
+        displayName: "OpenCode",
         environment: {
           OPENCODE_API_KEY: "secret-value",
           OPENAI_API_KEY: "wrong-provider-secret",

--- a/server/drivers/acp/opencode-go.test.ts
+++ b/server/drivers/acp/opencode-go.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -8,6 +8,7 @@ import { removeTempDir } from "../../testing/cleanup.ts";
 import { recordEvents } from "../../testing/events.ts";
 import {
   classifyOpenCodeError,
+  canListOpenCodeModels,
   createOpenCodeDriver,
   normalizeLegacyOpenCodeModel,
   parseOpenCodeModelsOutput,
@@ -24,29 +25,41 @@ const catalog = (...ids: string[]): ModelCatalog => ({
 describe("OpenCode catalog", () => {
   it("parses Zen, Go, third-party, and local models using exact CLI slugs", () => {
     const models = parseOpenCodeModelsOutput([
+      "openrouter/vendor/model-v2",
+      JSON.stringify({ name: "Vendor Model", status: "active" }, null, 2),
       "opencode/x-preview-f-free",
       JSON.stringify({ name: "Ox Alpha Free", status: "active", limit: { context: 1_000_000 } }, null, 2),
       "opencode-go/minimax-m3",
       JSON.stringify({ name: "MiniMax M3", status: "active" }, null, 2),
-      "openrouter/vendor/model-v2",
-      JSON.stringify({ name: "Vendor Model", status: "active" }, null, 2),
       "ollama/qwen3",
       JSON.stringify({ name: "Qwen 3", api: { url: "http://127.0.0.1:11434/v1" } }, null, 2),
+      "lmstudio/qwen3-ipv6",
+      JSON.stringify({ name: "Qwen 3 IPv6", api: { url: "http://[::1]:1234/v1" } }, null, 2),
       "opencode/retired",
       JSON.stringify({ name: "Retired", status: "deprecated" }, null, 2),
     ].join("\n"));
 
     expect(models?.default).toBe("opencode/x-preview-f-free");
     expect(models?.options).toEqual([
+      expect.objectContaining({ id: "openrouter/vendor/model-v2", label: "OpenRouter · Vendor Model" }),
       expect.objectContaining({
         id: "opencode/x-preview-f-free",
         label: "Zen · Ox Alpha Free",
         contextWindow: 1_000_000,
       }),
       expect.objectContaining({ id: "opencode-go/minimax-m3", label: "Go · MiniMax M3" }),
-      expect.objectContaining({ id: "openrouter/vendor/model-v2", label: "OpenRouter · Vendor Model" }),
       expect.objectContaining({ id: "ollama/qwen3", custom: true, loaded: true }),
+      expect.objectContaining({ id: "lmstudio/qwen3-ipv6", custom: true, loaded: true }),
     ]);
+  });
+
+  it("caches the anonymous model probe across authentication checks", async () => {
+    const runModels = vi.fn(async () => "opencode/x-preview-f-free\n");
+
+    await expect(canListOpenCodeModels({}, "counting-opencode", runModels)).resolves.toBe(true);
+    await expect(canListOpenCodeModels({}, "counting-opencode", runModels)).resolves.toBe(true);
+
+    expect(runModels).toHaveBeenCalledOnce();
   });
 
   it("accepts header-only output from older CLIs and rejects malformed lines", () => {

--- a/server/drivers/acp/opencode-go.ts
+++ b/server/drivers/acp/opencode-go.ts
@@ -1,5 +1,6 @@
-// OpenCode Go subscription/API product through the maintained OpenCode CLI's
-// ACP stdio interface. The generic protocol runtime lives in core.ts.
+// The maintained OpenCode CLI through its ACP stdio interface. OpenCode is
+// the harness; Zen, Go, OpenRouter, and user-configured/local providers are
+// models discovered from that harness rather than separate OpenMaus drivers.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -7,18 +8,25 @@ import { join } from "node:path";
 import { decodeInjectId, hostApiKey, localHost, mergeLocalInject } from "../local-inject.ts";
 import { createAcpDriver, type AcpSupport } from "./core.ts";
 import type { ModelCatalog, ProviderErrorCode } from "../../contracts.ts";
+import { execCli } from "../../procs.ts";
 
-const CATALOG_URL = "https://opencode.ai/zen/go/v1/models";
 const STATIC_MODELS: ModelCatalog = {
-  default: "opencode-go/minimax-m3",
+  default: "opencode/x-preview-f-free",
   options: [
-    { id: "opencode-go/minimax-m3", label: "Minimax M3" },
-    { id: "opencode-go/kimi-k3", label: "Kimi K3" },
-    { id: "opencode-go/glm-5.2", label: "GLM 5.2" },
+    {
+      id: "opencode/x-preview-f-free",
+      label: "Zen · Ox Alpha Free",
+      contextWindow: 1_000_000,
+    },
   ],
 };
 
 let lastSuccessfulCatalog: ModelCatalog | null = null;
+
+export type OpenCodeCatalogLoader = (
+  environment: Record<string, string | undefined>,
+  cli: string,
+) => Promise<ModelCatalog>;
 
 function labelForModel(id: string): string {
   return id
@@ -28,50 +36,141 @@ function labelForModel(id: string): string {
     .join(" ");
 }
 
-export function resetOpenCodeGoModelCache() {
-  lastSuccessfulCatalog = null;
+function providerLabel(id: string): string {
+  if (id === "opencode") return "Zen";
+  if (id === "opencode-go") return "Go";
+  if (id === "openrouter") return "OpenRouter";
+  return labelForModel(id);
 }
 
-export async function fetchOpenCodeGoModels(fetcher: typeof fetch = fetch): Promise<ModelCatalog> {
+function validModelSlug(value: string): boolean {
+  const separator = value.indexOf("/");
+  if (separator <= 0 || separator >= value.length - 1 || /\s/u.test(value)) return false;
+  return [...value].every((character) => (character.codePointAt(0) ?? 0) > 0x1f);
+}
+
+function localModelRecord(record: Record<string, unknown>): boolean {
+  const api = record.api && typeof record.api === "object" && !Array.isArray(record.api)
+    ? record.api as Record<string, unknown>
+    : {};
+  if (typeof api.url !== "string") return false;
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8_000);
-    timeout.unref?.();
-    try {
-      const response = await fetcher(CATALOG_URL, { signal: controller.signal });
-      if (!response.ok) throw new Error(`catalog HTTP ${response.status}`);
-      const payload = await response.json() as unknown;
-      const records = Array.isArray(payload)
-        ? payload
-        : payload && typeof payload === "object" && Array.isArray((payload as { data?: unknown }).data)
-          ? (payload as { data: unknown[] }).data
-          : [];
-      const ids = records
-        .map((record) => record && typeof record === "object" ? (record as { id?: unknown }).id : undefined)
-        .filter((id): id is string => typeof id === "string" && /^[a-z0-9][a-z0-9._-]*$/i.test(id));
-      if (!ids.length) throw new Error("catalog contained no valid models");
-      const options = STATIC_MODELS.options.map((option) => ({ ...option }));
-      const seen = new Set(options.map((option) => option.id));
-      for (const id of ids) {
-        const full = `opencode-go/${id}`;
-        if (seen.has(full)) continue;
-        seen.add(full);
-        // These are live OpenCode Go cloud models. `custom` is reserved for
-        // models discovered on a user's own Ollama/oMLX/LM Studio-style host;
-        // marking catalog additions custom moves them into the Local pane and
-        // incorrectly bypasses the OpenCode Go sign-in gate.
-        options.push({ id: full, label: labelForModel(id) });
+    const host = new URL(api.url).hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+/** Parse the authoritative inventory printed by the installed OpenCode CLI.
+ *
+ * `models --verbose` is a sequence of `provider/model` header lines followed
+ * by one JSON object. Model IDs can themselves contain `/` (OpenRouter), so
+ * only the first separator identifies the provider. Older CLIs may print just
+ * the headers; those still produce a usable catalog without metadata. */
+export function parseOpenCodeModelsOutput(stdout: string): ModelCatalog | null {
+  const options: ModelCatalog["options"] = [];
+  const seen = new Set<string>();
+  let slug: string | null = null;
+  let jsonLines: string[] = [];
+
+  const flush = () => {
+    if (!slug || seen.has(slug)) return;
+    const separator = slug.indexOf("/");
+    const provider = slug.slice(0, separator);
+    const model = slug.slice(separator + 1);
+    let record: Record<string, unknown> = {};
+    const raw = jsonLines.join("\n").trim();
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          record = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // A header-only/older CLI remains useful; fall back to the model id.
       }
-      const catalog = { default: STATIC_MODELS.default, options } satisfies ModelCatalog;
-      lastSuccessfulCatalog = catalog;
-      return catalog;
-    } finally {
-      clearTimeout(timeout);
     }
+    if (record.status === "deprecated") return;
+    const name = typeof record.name === "string" && record.name.trim()
+      ? record.name.trim()
+      : labelForModel(model);
+    const limit = record.limit && typeof record.limit === "object" && !Array.isArray(record.limit)
+      ? record.limit as Record<string, unknown>
+      : {};
+    const contextWindow = typeof limit.context === "number" && Number.isFinite(limit.context) && limit.context > 0
+      ? Math.floor(limit.context)
+      : undefined;
+    seen.add(slug);
+    options.push({
+      id: slug,
+      label: `${providerLabel(provider)} · ${name}`,
+      ...(localModelRecord(record) ? { custom: true, loaded: true } : {}),
+      ...(contextWindow ? { contextWindow } : {}),
+    });
+  };
+
+  for (const line of stdout.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (line === trimmed && validModelSlug(trimmed)) {
+      flush();
+      slug = trimmed;
+      jsonLines = [];
+      continue;
+    }
+    if (slug) jsonLines.push(line);
+  }
+  flush();
+
+  if (!options.length) return null;
+  return { default: options[0]!.id, options };
+}
+
+function runOpenCodeModels(
+  cli: string,
+  environment: Record<string, string | undefined>,
+  verbose: boolean,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execCli(
+      cli,
+      ["models", ...(verbose ? ["--verbose"] : [])],
+      { timeout: 20_000, maxBuffer: 8 * 1024 * 1024, env: environment },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr?.trim() || error.message, { cause: error }));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+/** Ask the same OpenCode binary that will run ACP for its effective catalog.
+ * This automatically includes Zen, Go, other connected providers, custom
+ * config, and anonymous free models with the exact IDs the session accepts. */
+export async function discoverOpenCodeModels(
+  environment: Record<string, string | undefined>,
+  cli = "opencode",
+): Promise<ModelCatalog> {
+  try {
+    const catalog = parseOpenCodeModelsOutput(await runOpenCodeModels(cli, environment, true));
+    if (!catalog) throw new Error("OpenCode returned no usable models");
+    lastSuccessfulCatalog = catalog;
+    return catalog;
   } catch {
     return lastSuccessfulCatalog ?? STATIC_MODELS;
   }
 }
+
+export function resetOpenCodeModelCache() {
+  lastSuccessfulCatalog = null;
+}
+
+/** Compatibility export for older tests/imports while the product migrates
+ * from the Go-only name. */
+export const resetOpenCodeGoModelCache = resetOpenCodeModelCache;
 
 const stripForeignProviderKeys = (env: Record<string, string | undefined>) => {
   for (const key of [
@@ -172,20 +271,18 @@ function storedAuthPaths(env: Record<string, string | undefined>): string[] {
   return [...new Set(roots)].map((root) => join(root, "opencode", "auth.json"));
 }
 
-/** True when auth.json contains a usable OpenCode Go login.
- *
- * The CLI writes `{type:"api", key}` for pasted keys and
- * `{type:"oauth", access, refresh}` for browser sign-ins. OpenCode Zen uses
- * the separate `"opencode"` id and does not load the `opencode-go` provider,
- * so accepting it here produces a misleading "model not found" at runtime. */
+/** True when auth.json contains any usable provider login managed by
+ * OpenCode. The generic harness can run all of them, including `opencode`
+ * (Zen), `opencode-go`, and third-party providers such as OpenRouter. */
 function usableAuthEntry(parsed: Record<string, unknown>): boolean {
-  const auth = parsed["opencode-go"];
-  if (!auth || typeof auth !== "object") return false;
-  const entry = auth as { key?: unknown; access?: unknown; refresh?: unknown };
-  return Boolean(entry.key || entry.access || entry.refresh);
+  return Object.values(parsed).some((auth) => {
+    if (!auth || typeof auth !== "object" || Array.isArray(auth)) return false;
+    const entry = auth as { key?: unknown; access?: unknown; refresh?: unknown };
+    return Boolean(entry.key || entry.access || entry.refresh);
+  });
 }
 
-function hasStoredOpenCodeGoAuth(env: Record<string, string | undefined>) {
+function hasStoredOpenCodeAuth(env: Record<string, string | undefined>) {
   const candidates: string[] = [];
   if (env.OPENCODE_AUTH_CONTENT) candidates.push(env.OPENCODE_AUTH_CONTENT);
   for (const path of storedAuthPaths(env)) {
@@ -204,14 +301,42 @@ function hasStoredOpenCodeGoAuth(env: Record<string, string | undefined>) {
   });
 }
 
-const support = (fetcher: typeof fetch): AcpSupport => ({
+async function canListOpenCodeModels(
+  env: Record<string, string | undefined>,
+  cli: string,
+): Promise<boolean> {
+  try {
+    return (await runOpenCodeModels(cli, env, false))
+      .split(/\r?\n/u)
+      .some((line) => validModelSlug(line.trim()));
+  } catch {
+    return false;
+  }
+}
+
+/** Migrate the model name published during Ox Alpha's first preview. The
+ * current CLI calls the same model `x-preview-f-free`; prefer Go for an old
+ * Go bot with an explicit key, otherwise use Zen's anonymous/free route. */
+export function normalizeLegacyOpenCodeModel(
+  model: string,
+  env: Record<string, string | undefined>,
+): string {
+  if (model !== "opencode-go/ox-alpha-free") return model;
+  return env.OPENCODE_API_KEY
+    ? "opencode-go/x-preview-f-free"
+    : "opencode/x-preview-f-free";
+}
+
+const support = (loadCatalog: OpenCodeCatalogLoader): AcpSupport => ({
   driverKind: "opencodeGo",
-  displayName: "OpenCode Go",
+  // Keep the historical driver kind so existing bots and instance config do
+  // not break; only the product name/catalog expand from Go to OpenCode.
+  displayName: "OpenCode",
   models: STATIC_MODELS,
   defaultCli: "opencode",
-  nativeSource: "opencode-go.acp",
+  nativeSource: "opencode.acp",
   loginNote:
-    "OpenCode Go is not connected — run `opencode auth login --provider opencode-go`, or add your OpenCode Go API key in Settings → Connections",
+    "OpenCode has no usable models — run `opencode auth login` or connect a provider in the OpenCode app",
   install: {
     command: {
       darwin: "npm install -g opencode-ai",
@@ -219,24 +344,33 @@ const support = (fetcher: typeof fetch): AcpSupport => ({
       win32: "npm install -g opencode-ai",
     },
     docsUrl: "https://opencode.ai/docs/",
-    signInCommand: "opencode auth login --provider opencode-go",
+    signInCommand: "opencode auth login",
     needsNode: true,
   },
   spawnArgs: () => ["acp"],
   credentialEnv: ["OPENCODE_API_KEY"],
   selectModel: { configId: "model" },
-  resolveTurnModel: (model, env) => (model ? ensureOpenCodeInjectModel(model, env) : model),
+  resolveTurnModel: (model, env) => model
+    ? ensureOpenCodeInjectModel(normalizeLegacyOpenCodeModel(model, env), env)
+    : model,
   transformEnv: stripForeignProviderKeys,
   pickAuthMethod: () => null,
   authFailure: "continue",
-  isAuthenticated: (env) => Boolean(env.OPENCODE_API_KEY) || hasStoredOpenCodeGoAuth(env),
+  isAuthenticated: async (env, config) => (
+    Boolean(env.OPENCODE_API_KEY)
+    || hasStoredOpenCodeAuth(env)
+    || await canListOpenCodeModels(env, config.cli)
+  ),
   requireAuthenticationBeforeSpawn: true,
-  classifyError: classifyOpenCodeGoError,
-  resolveModels: async (environment) => mergeLocalInject(await fetchOpenCodeGoModels(fetcher), environment),
+  classifyError: classifyOpenCodeError,
+  resolveModels: async (environment, config) => mergeLocalInject(
+    await loadCatalog(environment, config.cli),
+    environment,
+  ),
   buildPromptText: (turn) => turn.system ? `${turn.system}\n\n${turn.text}` : turn.text,
 });
 
-export function classifyOpenCodeGoError(error: unknown): ProviderErrorCode | undefined {
+export function classifyOpenCodeError(error: unknown): ProviderErrorCode | undefined {
   const value = error && typeof error === "object" ? error as Record<string, unknown> : {};
   const code = value.code;
   if (code === -32000) return "invalid_credentials";
@@ -248,8 +382,12 @@ export function classifyOpenCodeGoError(error: unknown): ProviderErrorCode | und
   return undefined;
 }
 
-export function createOpenCodeGoDriver(fetcher: typeof fetch = fetch) {
-  return createAcpDriver(support(fetcher));
+export const classifyOpenCodeGoError = classifyOpenCodeError;
+
+export function createOpenCodeDriver(loadCatalog: OpenCodeCatalogLoader = discoverOpenCodeModels) {
+  return createAcpDriver(support(loadCatalog));
 }
 
-export const OpenCodeGoDriver = createOpenCodeGoDriver();
+export const createOpenCodeGoDriver = createOpenCodeDriver;
+export const OpenCodeDriver = createOpenCodeDriver();
+export const OpenCodeGoDriver = OpenCodeDriver;

--- a/server/drivers/acp/opencode-go.ts
+++ b/server/drivers/acp/opencode-go.ts
@@ -22,6 +22,8 @@ const STATIC_MODELS: ModelCatalog = {
 };
 
 let lastSuccessfulCatalog: ModelCatalog | null = null;
+const MODEL_PROBE_TTL_MS = 30_000;
+const modelProbeCache = new Map<string, { expiresAt: number; result: Promise<boolean> }>();
 
 export type OpenCodeCatalogLoader = (
   environment: Record<string, string | undefined>,
@@ -55,7 +57,7 @@ function localModelRecord(record: Record<string, unknown>): boolean {
     : {};
   if (typeof api.url !== "string") return false;
   try {
-    const host = new URL(api.url).hostname;
+    const host = new URL(api.url).hostname.replace(/^\[|\]$/gu, "");
     return host === "localhost" || host === "127.0.0.1" || host === "::1";
   } catch {
     return false;
@@ -123,7 +125,8 @@ export function parseOpenCodeModelsOutput(stdout: string): ModelCatalog | null {
   flush();
 
   if (!options.length) return null;
-  return { default: options[0]!.id, options };
+  const preferred = options.find((option) => option.id === STATIC_MODELS.default);
+  return { default: (preferred ?? options[0]!).id, options };
 }
 
 function runOpenCodeModels(
@@ -166,6 +169,7 @@ export async function discoverOpenCodeModels(
 
 export function resetOpenCodeModelCache() {
   lastSuccessfulCatalog = null;
+  modelProbeCache.clear();
 }
 
 /** Compatibility export for older tests/imports while the product migrates
@@ -301,17 +305,28 @@ function hasStoredOpenCodeAuth(env: Record<string, string | undefined>) {
   });
 }
 
-async function canListOpenCodeModels(
+export async function canListOpenCodeModels(
   env: Record<string, string | undefined>,
   cli: string,
+  runModels: typeof runOpenCodeModels = runOpenCodeModels,
 ): Promise<boolean> {
-  try {
-    return (await runOpenCodeModels(cli, env, false))
+  const cached = modelProbeCache.get(cli);
+  if (cached && cached.expiresAt > Date.now()) return cached.result;
+
+  const entry = {
+    expiresAt: Number.POSITIVE_INFINITY,
+    result: Promise.resolve(false),
+  };
+  entry.result = runModels(cli, env, false)
+    .then((stdout) => stdout
       .split(/\r?\n/u)
-      .some((line) => validModelSlug(line.trim()));
-  } catch {
-    return false;
-  }
+      .some((line) => validModelSlug(line.trim())))
+    .catch(() => false)
+    .finally(() => {
+      entry.expiresAt = Date.now() + MODEL_PROBE_TTL_MS;
+    });
+  modelProbeCache.set(cli, entry);
+  return entry.result;
 }
 
 /** Migrate the model name published during Ox Alpha's first preview. The

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -11,7 +11,7 @@ import { GeminiAgentDriver } from "./acp/gemini.ts";
 import { KimiAgentDriver } from "./acp/kimi.ts";
 import { DroidAgentDriver } from "./acp/droid.ts";
 import { CursorAgentDriver } from "./acp/cursor.ts";
-import { OpenCodeGoDriver } from "./acp/opencode-go.ts";
+import { OpenCodeDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
@@ -25,7 +25,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   KimiAgentDriver,
   DroidAgentDriver,
   CursorAgentDriver,
-  OpenCodeGoDriver,
+  OpenCodeDriver,
   QwenAgentDriver,
   HermesAgentDriver,
   PiDriver,

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -117,6 +117,24 @@ if (argv[0] === "status" || argv[0] === "whoami") {
   process.exit(0);
 }
 if (argv[0] === "models" || argv.includes("--list-models")) {
+  if (models.length) {
+    const verbose = argv.includes("--verbose");
+    console.log(
+      models.flatMap((slug) => verbose
+        ? [
+            slug,
+            JSON.stringify({
+              id: slug.slice(slug.indexOf("/") + 1),
+              providerID: slug.slice(0, slug.indexOf("/")),
+              name: slug,
+              status: "active",
+              limit: { context: 200_000 },
+            }, null, 2),
+          ]
+        : [slug]).join("\n"),
+    );
+    process.exit(0);
+  }
   console.log(
     [
       "Available models",

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -56,11 +56,11 @@ const CREDENTIALS: Record<
     warning: "Box is a paid service after its trial. Usage may incur charges.",
   },
   opencodeGo: {
-    label: "OpenCode Go API key",
-    placeholder: "Paste your OpenCode Go API key",
-    description: "Run OpenCode Go models through the maintained OpenCode CLI and ACP.",
-    href: "https://opencode.ai/docs/go/",
-    linkLabel: "Open OpenCode Go setup guide",
+    label: "OpenCode API key",
+    placeholder: "Paste an OpenCode API key",
+    description: "Optional. Existing OpenCode Zen, Go, and other provider connections are detected automatically.",
+    href: "https://opencode.ai/docs/providers/",
+    linkLabel: "Open the OpenCode provider guide",
     optional: true,
   },
 };


### PR DESCRIPTION
## Summary

- treat OpenCode as one agent harness instead of a separate Go-only engine
- discover the installed CLI model inventory with exact Zen, Go, OpenRouter, custom, and local provider IDs
- reuse existing OpenCode logins and anonymous free models while preserving old bots and stored configuration
- migrate the retired `opencode-go/ox-alpha-free` selection to the current Ox preview ID
- cache anonymous model probes and correctly identify IPv6-local providers
- prefer the free Ox model regardless of upstream catalog ordering
- update Settings and provider documentation for the generic integration
- bump the desktop release candidate to 0.1.32

## Verification

- `pnpm test` — 1,689 tests passed across 162 files; broker, updater, desktop-viewer, and packaged-server checks passed
- `pnpm typecheck`
- `pnpm --dir apps/docs build` — 111 static pages generated
- live OpenCode inventory — 422 models discovered; `opencode/x-preview-f-free` present
- focused OpenCode tests — 13 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to OpenCode through existing provider logins or an optional API key.
  - Added live OpenCode model discovery, including local, third-party, free, and legacy models.
  - Reused existing OpenCode CLI authentication and supported anonymous free-model access.
  - Improved model discovery reliability with refreshed results and support for local IPv6 connections.

- **Documentation**
  - Updated setup, provider, credential, and release documentation to describe the unified OpenCode experience.
  - Clarified model discovery, authentication options, and compatibility with existing OpenCode connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->