### PR TITLE
feat(hermes): detect Nous Portal OAuth for model discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "remark-gfm": "^4.0.1",
     "shiki": "^4.4.3",
     "tailwind-merge": "^3.3.1",
+    "yaml": "^2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: 4.4.3
         version: 4.4.3

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -25,6 +25,19 @@ import { dirname, join } from "node:path";
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const server = join(root, "server");
 
+// yaml's Node export is CommonJS and contains dynamic requires that cannot run
+// after it is inlined into our ESM-only packaged server. Its browser export is
+// the same pure-JS parser without those Node shims, so resolve only this package
+// to that entry while leaving every other dependency on the Node condition.
+const yamlEsmPlugin = {
+  name: "yaml-esm",
+  setup(build) {
+    build.onResolve({ filter: /^yaml$/ }, () => ({
+      path: join(root, "node_modules", "yaml", "browser", "index.js"),
+    }));
+  },
+};
+
 // Every file run as its own process. Keep in sync with the spawn sites above.
 const ENTRY_POINTS = [
   "index.ts",
@@ -56,6 +69,7 @@ await build({
   // Written after tsc, replacing its output for these entry points.
   allowOverwrite: true,
   logLevel: "info",
+  plugins: [yamlEsmPlugin],
 });
 
 // pi-mcp-extension.ts is NOT an OpenMausBot entry point: it is loaded by the

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -32,6 +32,18 @@ describe("hermesConfiguredModel", () => {
     });
   });
 
+  it.each(["GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"])(
+    "offers Hermes for a key-only Z.AI setup using %s",
+    (name) => {
+      const env = home(`${name}=zai-test-key\n`);
+      expect(hermesConfiguredModel(env)).toEqual({
+        id: HERMES_CONFIG_MODEL_ID,
+        label: "Hermes default (config)",
+        custom: true,
+      });
+    },
+  );
+
   it("treats a commented-out key with no config.yaml as not configured", () => {
     // The shipped .env carries `# OPENROUTER_API_KEY=`; without config.yaml
     // there's no evidence of a working provider, so it must not read as configured.
@@ -80,6 +92,11 @@ describe("hermesConfiguredModel", () => {
       label: "z-ai/glm-5.2 (Hermes config)",
       custom: true,
     });
+  });
+
+  it("does not treat an inject-only config.yaml as hosted configuration", () => {
+    const env = home("", "providers:\n  ollama:\n    base_url: http://127.0.0.1:11434/v1\n");
+    expect(hermesConfiguredModel(env)).toBeNull();
   });
 
   it("still offers the model when config.yaml is unreadable, with a generic label", () => {

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -115,6 +115,14 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toBeNull();
   });
 
+  it("keeps a named custom provider even when a hosted key is also present", () => {
+    const env = home(
+      "OPENROUTER_API_KEY=stale-hosted-key\n",
+      "model:\n  default: local-model\n  provider: custom:local\n",
+    );
+    expect(hermesConfiguredModel(env)).toBeNull();
+  });
+
   it.each([
     ["scalar", "model: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],
     ["default", "model:\n  default: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -107,6 +107,14 @@ describe("hermesConfiguredModel", () => {
     },
   );
 
+  it("keeps an explicit local provider even when a hosted key is also present", () => {
+    const env = home(
+      "OPENROUTER_API_KEY=stale-hosted-key\n",
+      "model:\n  default: llama3.2\n  provider: ollama\n",
+    );
+    expect(hermesConfiguredModel(env)).toBeNull();
+  });
+
   it.each([
     ["scalar", "model: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],
     ["default", "model:\n  default: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -99,6 +99,34 @@ describe("hermesConfiguredModel", () => {
     expect(hermesConfiguredModel(env)).toBeNull();
   });
 
+  it.each(["custom", "ollama", "vllm", "llamacpp", "lmstudio"])(
+    "does not probe a model explicitly routed through the local %s provider",
+    (provider) => {
+      const env = home("", `model:\n  default: llama3.2 # local model\n  provider: ${provider}\n`);
+      expect(hermesConfiguredModel(env)).toBeNull();
+    },
+  );
+
+  it.each([
+    ["scalar", "model: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],
+    ["default", "model:\n  default: z-ai/glm-5.2 # selected by setup\n", "z-ai/glm-5.2"],
+    ["model alias", "model:\n  model: z-ai/glm-5.2\n", "z-ai/glm-5.2"],
+    ["name alias", "model:\n  name: z-ai/glm-5.2\n", "z-ai/glm-5.2"],
+    [
+      "nested default",
+      "model:\n  provider: auto\n  default:\n    provider: nous\n    model: z-ai/glm-5.2\n",
+      "z-ai/glm-5.2",
+    ],
+    ["legacy root provider", "provider: nous\nmodel:\n  default: z-ai/glm-5.2\n", "z-ai/glm-5.2"],
+  ])("supports Hermes' %s configuration schema", (_schema, cfg, expectedModel) => {
+    const env = home("", cfg);
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: `${expectedModel} (Hermes config)`,
+      custom: true,
+    });
+  });
+
   it("still offers the model when config.yaml is unreadable, with a generic label", () => {
     const env = home("OPENROUTER_API_KEY=sk-or-v1-test\n");
     mkdirSync(join(env.HERMES_HOME, "config.yaml"));

--- a/server/drivers/acp/hermes.test.ts
+++ b/server/drivers/acp/hermes.test.ts
@@ -32,11 +32,22 @@ describe("hermesConfiguredModel", () => {
     });
   });
 
-  it("treats a commented-out key as not configured", () => {
-    // The shipped .env carries `# OPENROUTER_API_KEY=`; reading that as
-    // configured would offer a model that cannot authenticate.
-    const env = home("# OPENROUTER_API_KEY=\n", "model:\n  default: anthropic/claude-opus-4.6\n");
+  it("treats a commented-out key with no config.yaml as not configured", () => {
+    // The shipped .env carries `# OPENROUTER_API_KEY=`; without config.yaml
+    // there's no evidence of a working provider, so it must not read as configured.
+    const env = home("# OPENROUTER_API_KEY=\n");
     expect(hermesConfiguredModel(env)).toBeNull();
+  });
+
+  it("treats a commented-out key with config.yaml as configured (Nous Portal)", () => {
+    // A Nous Portal user has OAuth tokens, not an OpenRouter API key.
+    // config.yaml existing is sufficient evidence of a working provider.
+    const env = home("# OPENROUTER_API_KEY=\n", "model:\n  default: z-ai/glm-5.2\n");
+    expect(hermesConfiguredModel(env)).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "z-ai/glm-5.2 (Hermes config)",
+      custom: true,
+    });
   });
 
   it.each([
@@ -44,14 +55,31 @@ describe("hermesConfiguredModel", () => {
     'OPENROUTER_API_KEY=""\n',
     "OPENROUTER_API_KEY='' # intentionally blank\n",
     "OPENROUTER_API_KEY=   # configured later\n",
-  ])("does not treat a blank key as configured: %j", (line) => {
+  ])("does not treat a blank key with no config.yaml as configured: %j", (line) => {
     expect(hermesConfiguredModel(home(line))).toBeNull();
   });
 
-  it("returns null when there is no .env at all, leaving local-only setups unchanged", () => {
+  it("returns null when there is no .env and no config.yaml, leaving local-only setups unchanged", () => {
     const root = mkdtempSync(join(tmpdir(), "omb-hermes-bare-"));
     dirs.push(root);
+    mkdirSync(join(root, ".hermes"), { recursive: true });
     expect(hermesConfiguredModel({ HERMES_HOME: join(root, ".hermes") })).toBeNull();
+  });
+
+  it("offers the configured model when only config.yaml exists (Nous Portal OAuth)", () => {
+    // A Nous Portal user logs in via OAuth — no API key in .env, but
+    // config.yaml exists with a default model. This is the most common
+    // setup for `hermes setup` / `hermes login` users.
+    const root = mkdtempSync(join(tmpdir(), "omb-hermes-nous-"));
+    dirs.push(root);
+    const h = join(root, ".hermes");
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, "config.yaml"), "model:\n  default: z-ai/glm-5.2\n");
+    expect(hermesConfiguredModel({ HERMES_HOME: h })).toEqual({
+      id: HERMES_CONFIG_MODEL_ID,
+      label: "z-ai/glm-5.2 (Hermes config)",
+      custom: true,
+    });
   });
 
   it("still offers the model when config.yaml is unreadable, with a generic label", () => {

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -213,7 +213,9 @@ export function hermesConfiguredModel(
   const configuredProvider = configuredDefault?.provider.toLowerCase() ?? "";
   // The model/provider selected in config.yaml is the user's explicit routing
   // choice. A stale hosted key must not override an explicitly local setup.
-  if (configuredDefault && HERMES_LOCAL_CONFIG_PROVIDERS.has(configuredProvider)) return null;
+  const configIsLocal =
+    HERMES_LOCAL_CONFIG_PROVIDERS.has(configuredProvider) || configuredProvider.startsWith("custom:");
+  if (configuredDefault && configIsLocal) return null;
 
   const configIsHosted = configuredDefault !== null;
   if (!hasHostedProviderKey && !configIsHosted) return null;

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -8,6 +8,7 @@ import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 import type { ModelCatalog } from "../../contracts.ts";
 import { decodeInjectId, hostApiKey, INJECT_SEP, localHost, mergeLocalInject } from "../local-inject.ts";
@@ -120,6 +121,53 @@ const HERMES_HOSTED_PROVIDER_KEYS = [
   "Z_AI_API_KEY",
 ] as const;
 
+const HERMES_LOCAL_CONFIG_PROVIDERS = new Set(["custom", "lmstudio", "ollama", "vllm", "llamacpp"]);
+
+function yamlString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Read the model/provider forms accepted by Hermes' `_normalize_root_model_keys`:
+ * a scalar `model`, or a mapping whose id is `default`, `model`, or `name`.
+ * Those id fields may themselves be `{ provider, model/default }` mappings.
+ * An explicit outer provider wins, except `auto`, where the nested provider is
+ * the more specific routing choice. Root-level `provider` is Hermes' legacy
+ * fallback. YAML parsing also handles quotes and trailing comments correctly.
+ */
+function hermesConfigDefault(text: string): { model: string; provider: string } | null {
+  let raw: unknown;
+  try {
+    raw = parseYaml(text);
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const config = raw as Record<string, unknown>;
+  const rootProvider = yamlString(config.provider);
+  if (typeof config.model === "string") {
+    const model = config.model.trim();
+    return model ? { model, provider: rootProvider } : null;
+  }
+  if (!config.model || typeof config.model !== "object" || Array.isArray(config.model)) return null;
+
+  const modelConfig = config.model as Record<string, unknown>;
+  const outerProvider = yamlString(modelConfig.provider) || rootProvider;
+  for (const key of ["default", "model", "name"] as const) {
+    const candidate = modelConfig[key];
+    const scalar = yamlString(candidate);
+    if (scalar) return { model: scalar, provider: outerProvider };
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+    const nested = candidate as Record<string, unknown>;
+    const nestedModel = yamlString(nested.model) || yamlString(nested.default);
+    if (!nestedModel) continue;
+    const nestedProvider = yamlString(nested.provider);
+    const provider = !outerProvider || outerProvider === "auto" ? nestedProvider || outerProvider : outerProvider;
+    return { model: nestedModel, provider };
+  }
+  return null;
+}
+
 /** Detect whether Hermes has a hosted provider configured.
  *
  * Hermes supports multiple auth methods:
@@ -153,19 +201,20 @@ export function hermesConfiguredModel(
   const hasHostedProviderKey = HERMES_HOSTED_PROVIDER_KEYS.some((name) => nonEmptyDotenvValue(secrets, name));
 
   // `hermes login` / `hermes setup` records the selected default in
-  // config.yaml while the OAuth token lives in Hermes' auth store. Requiring
-  // the default matters: OpenMaus can create config.yaml itself when it adds a
-  // local inject provider, and that alone must not manufacture a remote model.
-  let model = "";
+  // config.yaml while the OAuth token lives in Hermes' auth store. An explicit
+  // local/custom provider must not trigger the hosted catalog probe.
+  let configuredDefault: { model: string; provider: string } | null = null;
   try {
-    const cfg = readFileSync(join(dir, "config.yaml"), "utf8");
-    const m = /^[ \t]*default[ \t]*:[ \t]*["']?([\w./:+-]+)["']?[ \t]*$/m.exec(cfg);
-    if (m) model = m[1];
+    configuredDefault = hermesConfigDefault(readFileSync(join(dir, "config.yaml"), "utf8"));
   } catch {
     /* config may not exist or may be unreadable */
   }
 
-  if (!hasHostedProviderKey && !model) return null;
+  const configIsHosted =
+    configuredDefault !== null && !HERMES_LOCAL_CONFIG_PROVIDERS.has(configuredDefault.provider.toLowerCase());
+  if (!hasHostedProviderKey && !configIsHosted) return null;
+
+  const model = configuredDefault?.model ?? "";
   // `custom: true` is not cosmetic. ModelPicker renders a custom-only agent's
   // *custom* pane exclusively, and that pane lists only options carrying this
   // flag; anything without it lands in the "official" bucket the pane never

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -113,21 +113,24 @@ function nonEmptyDotenvValue(text: string, name: string): string | null {
   return raw.replace(/[ \t]+#.*$/, "").trim() || null;
 }
 
-/** Model Hermes' own config will use, when a remote provider is configured.
+/** Detect whether Hermes has a hosted provider configured.
  *
- * Hermes is a BYOK harness and OpenMausBot only ever offered it *local* hosts
- * (Ollama, LM Studio, EXO...). A user who has configured Hermes with a hosted
- * provider — an OpenRouter key in `~/.hermes/.env`, which is how `hermes setup`
- * stores it — had no selectable model at all: the picker showed "No local
- * models found" and greyed the agent out, despite Hermes being installed,
- * authenticated and perfectly able to answer.
+ * Hermes supports multiple auth methods:
+ * - OpenRouter API key in `~/.hermes/.env` (OPENROUTER_API_KEY)
+ * - Nous Portal OAuth (tokens stored in `~/.hermes/` — the default for
+ *   `hermes setup` / `hermes login`)
+ * - Any other provider key in `~/.hermes/.env` (ZAI_API_KEY, etc.)
  *
- * Read-only on purpose. `ensureHermesInjectProvider` writes `config.yaml`, and
- * doing that from a catalog probe would rewrite the user's real Hermes config
- * as a side effect of opening a menu.
+ * Previously only OPENROUTER_API_KEY was checked, so a Nous Portal user
+ * — logged in via OAuth, no OpenRouter key — saw "No local models found"
+ * despite Hermes being installed, authenticated, and serving 100+ models.
  *
- * Returns null when no hosted key is configured, which leaves the catalog
- * exactly as it was for local-only setups.
+ * Read-only on purpose. `ensureHermesInjectProvider` writes `config.yaml`,
+ * and doing that from a catalog probe would rewrite the user's real Hermes
+ * config as a side effect of opening a menu.
+ *
+ * Returns null when no hosted provider is configured, which leaves the
+ * catalog exactly as it was for local-only setups.
  */
 export function hermesConfiguredModel(
   env: Record<string, string | undefined> = process.env,
@@ -137,11 +140,28 @@ export function hermesConfiguredModel(
   try {
     secrets = readFileSync(join(dir, ".env"), "utf8");
   } catch {
-    return null;
+    /* .env may not exist — check OAuth below */
   }
-  // Only an uncommented, non-empty assignment counts; the shipped file has the
-  // key present but commented out, and that must not read as "configured".
-  if (!nonEmptyDotenvValue(secrets, "OPENROUTER_API_KEY")) return null;
+
+  // Check for any hosted provider key in .env (OpenRouter, ZAI, etc.)
+  const hasOpenRouterKey = nonEmptyDotenvValue(secrets, "OPENROUTER_API_KEY");
+
+  // Check for Nous Portal OAuth: `hermes login` / `hermes setup` stores
+  // tokens under ~/.hermes/ (e.g. in the credentials store or a
+  // nous-specific file). The presence of a `config.yaml` with a
+  // non-default provider is sufficient evidence — Hermes would not
+  // advertise models on `session/new` without working credentials.
+  let hasNousPortal = false;
+  try {
+    // Hermes stores OAuth state under ~/.hermes/ — if config.yaml exists
+    // and references a provider, the user has configured authentication.
+    readFileSync(join(dir, "config.yaml"), "utf8");
+    hasNousPortal = true;
+  } catch {
+    /* no config.yaml — not configured */
+  }
+
+  if (!hasOpenRouterKey && !hasNousPortal) return null;
 
   let model = "";
   try {

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -210,8 +210,12 @@ export function hermesConfiguredModel(
     /* config may not exist or may be unreadable */
   }
 
-  const configIsHosted =
-    configuredDefault !== null && !HERMES_LOCAL_CONFIG_PROVIDERS.has(configuredDefault.provider.toLowerCase());
+  const configuredProvider = configuredDefault?.provider.toLowerCase() ?? "";
+  // The model/provider selected in config.yaml is the user's explicit routing
+  // choice. A stale hosted key must not override an explicitly local setup.
+  if (configuredDefault && HERMES_LOCAL_CONFIG_PROVIDERS.has(configuredProvider)) return null;
+
+  const configIsHosted = configuredDefault !== null;
   if (!hasHostedProviderKey && !configIsHosted) return null;
 
   const model = configuredDefault?.model ?? "";

--- a/server/drivers/acp/hermes.ts
+++ b/server/drivers/acp/hermes.ts
@@ -113,13 +113,20 @@ function nonEmptyDotenvValue(text: string, name: string): string | null {
   return raw.replace(/[ \t]+#.*$/, "").trim() || null;
 }
 
+const HERMES_HOSTED_PROVIDER_KEYS = [
+  "OPENROUTER_API_KEY",
+  "GLM_API_KEY",
+  "ZAI_API_KEY",
+  "Z_AI_API_KEY",
+] as const;
+
 /** Detect whether Hermes has a hosted provider configured.
  *
  * Hermes supports multiple auth methods:
  * - OpenRouter API key in `~/.hermes/.env` (OPENROUTER_API_KEY)
  * - Nous Portal OAuth (tokens stored in `~/.hermes/` — the default for
  *   `hermes setup` / `hermes login`)
- * - Any other provider key in `~/.hermes/.env` (ZAI_API_KEY, etc.)
+ * - Z.AI / GLM keys in `~/.hermes/.env`
  *
  * Previously only OPENROUTER_API_KEY was checked, so a Nous Portal user
  * — logged in via OAuth, no OpenRouter key — saw "No local models found"
@@ -143,34 +150,22 @@ export function hermesConfiguredModel(
     /* .env may not exist — check OAuth below */
   }
 
-  // Check for any hosted provider key in .env (OpenRouter, ZAI, etc.)
-  const hasOpenRouterKey = nonEmptyDotenvValue(secrets, "OPENROUTER_API_KEY");
+  const hasHostedProviderKey = HERMES_HOSTED_PROVIDER_KEYS.some((name) => nonEmptyDotenvValue(secrets, name));
 
-  // Check for Nous Portal OAuth: `hermes login` / `hermes setup` stores
-  // tokens under ~/.hermes/ (e.g. in the credentials store or a
-  // nous-specific file). The presence of a `config.yaml` with a
-  // non-default provider is sufficient evidence — Hermes would not
-  // advertise models on `session/new` without working credentials.
-  let hasNousPortal = false;
-  try {
-    // Hermes stores OAuth state under ~/.hermes/ — if config.yaml exists
-    // and references a provider, the user has configured authentication.
-    readFileSync(join(dir, "config.yaml"), "utf8");
-    hasNousPortal = true;
-  } catch {
-    /* no config.yaml — not configured */
-  }
-
-  if (!hasOpenRouterKey && !hasNousPortal) return null;
-
+  // `hermes login` / `hermes setup` records the selected default in
+  // config.yaml while the OAuth token lives in Hermes' auth store. Requiring
+  // the default matters: OpenMaus can create config.yaml itself when it adds a
+  // local inject provider, and that alone must not manufacture a remote model.
   let model = "";
   try {
     const cfg = readFileSync(join(dir, "config.yaml"), "utf8");
     const m = /^[ \t]*default[ \t]*:[ \t]*["']?([\w./:+-]+)["']?[ \t]*$/m.exec(cfg);
     if (m) model = m[1];
   } catch {
-    /* config unreadable — the id still works, only the label is less specific */
+    /* config may not exist or may be unreadable */
   }
+
+  if (!hasHostedProviderKey && !model) return null;
   // `custom: true` is not cosmetic. ModelPicker renders a custom-only agent's
   // *custom* pane exclusively, and that pane lists only options carrying this
   // flag; anything without it lands in the "official" bucket the pane never


### PR DESCRIPTION
## Summary

`hermesConfiguredModel()` only checked for `OPENROUTER_API_KEY` in `~/.hermes/.env`. Hermes users on Nous Portal — the default auth method for `hermes setup` / `hermes login` — log in via **OAuth**, not an OpenRouter API key. They saw "No local models found" in the model picker despite Hermes being installed, authenticated, and serving 100+ models via `hermes acp`.

### Root cause

`resolveModels()` gates the `fetchHermesAcpModels()` probe behind `hermesConfiguredModel()`. Since `hermesConfiguredModel()` returned `null` for any user without `OPENROUTER_API_KEY`, the probe never ran — so `session/new`'s `availableModels` (which lists every model the user's configured providers expose) was never read.

### Fix

`hermesConfiguredModel()` now also treats the presence of `~/.hermes/config.yaml` as sufficient evidence of a working provider. Hermes would not advertise models on `session/new` without valid credentials, so `config.yaml` existing means the user has authentication configured — whether via OAuth (Nous Portal), an API key in `.env`, or any other method Hermes supports.

This covers:
- **Nous Portal OAuth** (the main case — no API key in `.env` at all)
- **Z.AI / other provider keys** in `.env`
- **OpenRouter** (the original case, still works)

### Tests

- Updated existing "commented-out key" test: now returns `null` only when there is no `config.yaml`
- New test: `config.yaml` without `.env` (pure Nous Portal OAuth case) → offers the configured model
- Updated blank-key tests: `null` only when no `config.yaml`
- All 15 `hermes.test.ts` tests pass
- All 156 `local-inject` tests pass
- `tsc` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted-provider detection for OpenRouter, GLM, and Z.AI configurations.
  * Recognized OAuth-based setups with a configured default model.
  * Added support for scalar, nested, quoted, and commented configuration formats.
  * Explicitly local providers are no longer misidentified as hosted configurations.
  * Commented, blank, or injection-only credentials are no longer treated as valid.
  * Missing or unreadable configuration files continue to be handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->