### PR TITLE
fix(desktop): saved workspace keys were destroyed by the next launch

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -68,8 +68,15 @@ let secureCredentials = {};
 const CREDENTIALS_FILE = path.join(app.getPath("userData"), "credentials.bin");
 
 async function loadSecureCredentials() {
+  if (!fs.existsSync(CREDENTIALS_FILE)) return {};
+  if (!(await safeStorage.isAsyncEncryptionAvailable())) {
+    // Returning nothing here looks identical to "the user never saved keys".
+    // Say why, so an OS-store hiccup is diagnosable instead of reading as
+    // wiped credentials.
+    slog("OS credential store unavailable; saved credentials are not loaded this launch");
+    return {};
+  }
   try {
-    if (!fs.existsSync(CREDENTIALS_FILE) || !(await safeStorage.isAsyncEncryptionAvailable())) return {};
     const decrypted = await safeStorage.decryptStringAsync(fs.readFileSync(CREDENTIALS_FILE));
     return JSON.parse(decrypted.result);
   } catch (error) {

--- a/electron/workspace-credentials.mjs
+++ b/electron/workspace-credentials.mjs
@@ -18,12 +18,17 @@ export const WORKSPACE_CREDENTIALS = [
 /** One boot-time sweep of config.json: move every plaintext workspace secret
  * into the encrypted store and DELETE the plaintext field.
  *
- * Deleting (never blanking) keeps "" meaningful. The server persists a
- * credential save by writing the field — a mid-session save lands as the new
- * value, a mid-session clear lands as "". So on the next boot:
+ * Deleting (never blanking) keeps the meaning of what remains unambiguous:
  *   - non-empty value  → newest user intent: overwrite the stored secret
- *   - ""               → the user cleared it: drop the stored secret too
- *   - field absent     → already migrated: keep what the store holds
+ *   - "" or absent     → no plaintext information; the store stays authoritative
+ *
+ * "" must never drop a stored secret. The packaged app's external-secret
+ * save path writes an empty tombstone into config.json on EVERY credential
+ * commit (the real value goes to credentials.bin first), so reading "" as
+ * "the user cleared this" deleted freshly saved keys at the next boot.
+ * Clearing runs through the desktop shell's credential:set handler, which
+ * removes the entry from the store directly before persisting the same
+ * tombstone — so there is no "" case in which the store should lose data.
  * Running twice is a no-op, and nothing is lost if a boot dies between the
  * two writes — the caller persists credentials BEFORE rewriting config, so
  * the worst case re-runs the same overwrite.
@@ -43,13 +48,8 @@ export function migrateWorkspaceCredentials(config, credentials) {
     const value = home[field];
     if (typeof value !== "string") continue;
     const secret = value.trim();
-    if (secret) {
-      if (nextCredentials[name] !== secret) {
-        nextCredentials[name] = secret;
-        credentialsChanged = true;
-      }
-    } else if (Object.hasOwn(nextCredentials, name)) {
-      delete nextCredentials[name];
+    if (secret && nextCredentials[name] !== secret) {
+      nextCredentials[name] = secret;
       credentialsChanged = true;
     }
     delete home[field];

--- a/electron/workspace-credentials.test.mjs
+++ b/electron/workspace-credentials.test.mjs
@@ -63,15 +63,34 @@ describe("workspace credential migration", () => {
     expect(result.config.box).toEqual({});
   });
 
-  it("treats an empty saved value as a clear and drops the stored secret", () => {
+  it("treats an empty saved value as no information and keeps the stored secret", () => {
+    // The packaged app tombstones every external-mode save as "" in
+    // config.json while the real key goes to credentials.bin — a boot that
+    // read "" as "cleared" would delete freshly saved keys on every restart.
     const result = migrateWorkspaceCredentials(
       { xai: { key: "" }, tts: { key: "   " } },
       { xaiApiKey: "xai-OLD", ttsKey: "tts-OLD", boxToken: "box-keep" },
     );
-    expect(result.credentialsChanged).toBe(true);
-    expect(result.credentials).toEqual({ boxToken: "box-keep" });
-    // the tombstone field itself is swept away too
+    expect(result.credentialsChanged).toBe(false);
+    expect(result.credentials).toEqual({ xaiApiKey: "xai-OLD", ttsKey: "tts-OLD", boxToken: "box-keep" });
+    // the swept field itself is still removed from the file
     expect(result.config).toEqual({ xai: {}, tts: {} });
+    expect(result.configChanged).toBe(true);
+  });
+
+  it("keeps the packaged save → restart cycle lossless end to end", () => {
+    // first boot migrates the plaintext key in and sweeps the field
+    const boot = migrateWorkspaceCredentials({ opencodeGo: { apiKey: "ocg-secret" } }, {});
+    expect(boot.credentials).toEqual({ opencodeGoApiKey: "ocg-secret" });
+
+    // an external-mode save commits the key to the store and leaves a ""
+    // tombstone in config.json; the next boot must not read it as a clear
+    const afterTombstone = migrateWorkspaceCredentials(
+      { opencodeGo: { apiKey: "" }, profile: { name: "Ada" } },
+      { opencodeGoApiKey: "ocg-secret" },
+    );
+    expect(afterTombstone.credentials).toEqual({ opencodeGoApiKey: "ocg-secret" });
+    expect(afterTombstone.credentialsChanged).toBe(false);
   });
 
   it("keeps stored secrets when the field is absent (already migrated)", () => {


### PR DESCRIPTION
Saving an API key in the packaged app worked for the session and was then **gone after a restart** — the key had to be entered again every launch. Reproduced on 0.1.32/macOS; the on-disk fingerprint is a config.json whose credential sections end up as empty objects (e.g. `"opencodeGo": {}`).

## Root cause — two features reading the same field with opposite meanings

1. `credential:set` (electron/main.mjs) commits the real secret to the OS-encrypted store, then calls `PUT /api/config?secretStorage=external`. That route **tombstones every supplied credential as `""`** in config.json so no plaintext survives (server/index.ts, external-secret block).
2. The next boot, `migrateWorkspaceCredentials` (electron/workspace-credentials.mjs) swept plaintext into the store using semantics written for dev-mode files: non-empty = newest intent, **empty = "the user cleared this — drop the stored secret too"**, absent = keep.

So every packaged save left `apiKey: ""` behind, and the following launch obeyed it by deleting the just-saved key from credentials.bin. Composio's project key was spared only because its older sweep ignores empty fields; the five workspace credentials were not.

## Fix

The migration now treats an empty plaintext field as *no information*: the store stays authoritative, only a non-empty value overwrites it. This is lossless in every direction:

| disk field | store had | before | after |
|---|---|---|---|
| non-empty | old/newer | overwrite | overwrite (unchanged) |
| `""` tombstone after a packaged save | fresh key | **deleted (bug)** | kept |
| `""` after a UI clear | already removed | delete (no-op) | kept/no-op |
| absent | anything | keep | keep (unchanged) |

Clearing still works end-to-end because `credential:set("", …)` removes the store entry directly before the tombstone is persisted — there is no case where an empty field is the only evidence of a clear.

Also: `loadSecureCredentials()` returned `{}` silently when the OS store was unavailable at boot, which is indistinguishable from "never saved anything" — it now logs that specific condition.

## Tests

- Rewritten: empty-field migration keeps stored secrets and still sweeps the field.
- New: the full packaged cycle (plaintext migrate-in → external save leaves tombstone → next boot) asserts the key survives.
- Existing overwrite/idempotency/junk cases unchanged and passing.
- `pnpm test` green (162 files, 1,690 passed); `pnpm check:electron` clean (40 modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when secure credential storage is unavailable, preventing startup failures and allowing the app to continue without stored credentials.
  * Preserved saved credentials when configuration fields are empty or omitted.
  * Improved credential migration and removal behavior to prevent accidental loss of secrets.
  * Ensured credentials remain intact across application restarts after migration or configuration cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->