### PR TITLE
fix(connectors): keep connection state truthful and durable across launches

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -94,6 +94,16 @@ async function loadSecureCredentials() {
 }
 
 async function saveSecureCredentials(credentials) {
+  if (secureCredentialsUnreadable) {
+    // A store that exists but failed to read must never be replaced by a
+    // partial one: the file may hold recoverable credentials this launch
+    // cannot see. Every writer (boot migrations, credential:set) goes
+    // through here, so refusing covers them all; a launch that can read
+    // the store again is the recovery path.
+    throw new Error(
+      "The saved credential store could not be read this launch. Restart OpenMausBot before saving credentials so nothing is overwritten.",
+    );
+  }
   if (!(await safeStorage.isAsyncEncryptionAvailable())) {
     throw new Error("The operating-system credential store is unavailable");
   }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -64,16 +64,31 @@ app.on("second-instance", () => {
 let serverProc = null;
 let serverReady = true;
 let secureCredentials = {};
+// Set when credentials.bin exists but could not be read this launch (OS store
+// unavailable, decrypt/parse failure). Downstream boot steps check this
+// before replacing identity data: an unreadable store must not be treated as
+// "the user never connected anything".
+let secureCredentialsUnreadable = false;
 
 const CREDENTIALS_FILE = path.join(app.getPath("userData"), "credentials.bin");
 
 async function loadSecureCredentials() {
   try {
-    if (!fs.existsSync(CREDENTIALS_FILE) || !(await safeStorage.isAsyncEncryptionAvailable())) return {};
+    if (!fs.existsSync(CREDENTIALS_FILE)) {
+      secureCredentialsUnreadable = false;
+      return {};
+    }
+    if (!(await safeStorage.isAsyncEncryptionAvailable())) {
+      secureCredentialsUnreadable = true;
+      return {};
+    }
     const decrypted = await safeStorage.decryptStringAsync(fs.readFileSync(CREDENTIALS_FILE));
-    return JSON.parse(decrypted.result);
+    const parsed = JSON.parse(decrypted.result);
+    secureCredentialsUnreadable = false;
+    return parsed;
   } catch (error) {
     slog(`credential load failed: ${error?.message ?? error}`);
+    secureCredentialsUnreadable = true;
     return {};
   }
 }
@@ -159,6 +174,15 @@ function composioBrokerUrl() {
 async function ensureManagedComposioCredentials() {
   const brokerUrl = composioBrokerUrl();
   if (!brokerUrl) return;
+  if (secureCredentialsUnreadable) {
+    // The store holds this installation's broker identity, but it could not
+    // be read. Registering a fresh installation now would hand back empty
+    // connected-apps state for the user's existing authorizations, and
+    // persisting that new identity over the unreadable file could destroy
+    // recoverable data. Leave registration to a launch that can read it.
+    slog("skipping connected-apps registration: saved credentials could not be read this launch");
+    return;
+  }
   if (/^[0-9a-f]{64}$/.test(secureCredentials.composioBrokerToken ?? "")) {
     try {
       const check = await fetch(`${brokerUrl}/v1/me`, {

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   disconnectAccountConfirmation,
+  inventoryFailureMessage,
   mergeCompleteConnectorStatus,
   mergeCurrentConnectorStatus,
   type ConnectorStatus,
@@ -111,5 +112,16 @@ describe("connected-app status races", () => {
     expect(disconnectAccountConfirmation("GitHub", { id: "ca_personal" })).toContain(
       "Disconnect “ca_personal” from GitHub? Only this GitHub account will be revoked.",
     );
+  });
+});
+
+describe("connected-app inventory failures", () => {
+  it("reports a failed inventory fetch as retryable, not as disconnected", () => {
+    const message = inventoryFailureMessage("Connected apps: HTTP 404");
+    expect(message).toContain("Couldn't load your connected apps");
+    expect(message).toContain("HTTP 404");
+    // the point of the message: a service-side outage must not read like
+    // "your connections are gone"
+    expect(message).toContain("not lost");
   });
 });

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -571,7 +571,7 @@ export function PluginsPanel() {
               </div>
             </div>
           )}
-          {cards !== null && visible.length === 0 && !inventoryFailure && (
+          {cards !== null && visible.length === 0 && !(tab === "connected" && inventoryFailure) && (
             <div className="flex min-h-56 flex-col items-center justify-center text-center">
               <div className="text-[14px] font-medium text-ink">
                 {tab === "connected" ? "No connected apps yet" : "No apps found"}

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -3,7 +3,7 @@
 // Composio API key is configured, a curated set otherwise. Icons resolve
 // logo → favicon → monogram.
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, Loader2, RefreshCw, Search, X } from "lucide-react";
+import { Check, CircleAlert, Loader2, RefreshCw, Search, X } from "lucide-react";
 import { api, useStore } from "@/state/store";
 import { cn } from "@/lib/cn";
 
@@ -64,6 +64,13 @@ export function mergeCompleteConnectorStatus(
   return mergeCurrentConnectorStatus(next, incoming, latestGenerations, requestGenerations);
 }
 
+/** A failed inventory fetch must never read as "nothing is connected":
+ * connections live on the service's side, so a transient error says retry,
+ * it does not say disconnected. */
+export function inventoryFailureMessage(detail: string): string {
+  return `Couldn't load your connected apps (${detail}). Your connections are not lost — check your connection and try again.`;
+}
+
 function ServiceIcon({ card }: { card: ToolkitCard }) {
   // 0 = official logo, 1 = favicon by domain, 2 = monogram
   const [stage, setStage] = useState(card.logo ? 0 : card.domain ? 1 : 2);
@@ -101,6 +108,7 @@ export function PluginsPanel() {
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [inventoryFailure, setInventoryFailure] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [tab, setTab] = useState<"marketplace" | "connected">("marketplace");
 
@@ -143,6 +151,7 @@ export function PluginsPanel() {
     setRefreshing(true);
     return api("/api/connectors/connected")
       .then((r) => {
+        setInventoryFailure(null);
         const services: Record<string, ConnectorStatus> = r.services ?? {};
         setStatus((current) => mergeCompleteConnectorStatus(
           current,
@@ -161,7 +170,10 @@ export function PluginsPanel() {
         }
         return services;
       })
-      .catch(() => ({}))
+      .catch((e) => {
+        setInventoryFailure(inventoryFailureMessage(e instanceof Error ? e.message : String(e)));
+        return {};
+      })
       .finally(() => setRefreshing(false));
   }, []);
 
@@ -421,6 +433,21 @@ export function PluginsPanel() {
               <div className="mb-3 text-[12px] font-medium text-ink-secondary">
                 {tab === "connected" ? "Your connections" : search ? "Search results" : "Available apps"}
               </div>
+              {tab === "connected" && inventoryFailure && (
+                <div role="alert" className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-xl border border-warning/30 bg-warning/10 px-3.5 py-3 text-[12.5px] text-warning">
+                  <CircleAlert size={15} className="shrink-0" />
+                  <span className="min-w-0 flex-1">{inventoryFailure}</span>
+                  <button
+                    type="button"
+                    disabled={refreshing}
+                    onClick={() => void refreshConnectedStatus()}
+                    className="flex items-center gap-1.5 rounded-lg bg-warning/15 px-2.5 py-1.5 text-[11.5px] font-medium text-warning transition-colors hover:bg-warning/25 disabled:opacity-50"
+                  >
+                    {refreshing ? <Loader2 size={12} className="animate-spin" /> : null}
+                    Retry
+                  </button>
+                </div>
+              )}
               <div className="grid grid-cols-1 gap-x-10 md:grid-cols-2">
               {visible.map((card) => {
               const serviceStatus = status[card.slug];
@@ -544,7 +571,7 @@ export function PluginsPanel() {
               </div>
             </div>
           )}
-          {cards !== null && visible.length === 0 && (
+          {cards !== null && visible.length === 0 && !inventoryFailure && (
             <div className="flex min-h-56 flex-col items-center justify-center text-center">
               <div className="text-[14px] font-medium text-ink">
                 {tab === "connected" ? "No connected apps yet" : "No apps found"}


### PR DESCRIPTION
Follow-up to the restart-persistence family (#412): two gaps where managed Connected Apps could *look* or become disconnected without anything actually being wrong — or get truly orphaned by a bad launch.

## 1. A failed inventory fetch read as "nothing connected"

`refreshConnectedStatus` swallowed every `/api/connectors/connected` failure (`.catch(() => ({}))`). After a restart against a slow or erroring broker, the Connected tab rendered its "No connected apps yet" empty state even though all connections were intact server-side — bots kept using them, which made the UI look simply wrong.

Now a failed fetch keeps last-known state and renders a retryable alert:

> Couldn't load your connected apps (Connected apps: HTTP 502…). Your connections are not lost — check your connection and try again.

Success clears it; the misleading empty state is suppressed while the alert is up; Marketplace tab is unaffected. Per-slug background polls keep their silent catch on purpose.

## 2. A fresh broker installation could be registered over an unreadable credential store

`ensureManagedComposioCredentials` treats "empty in-memory credentials" as "nothing registered yet". But `loadSecureCredentials` also returns empty when credentials.bin **exists yet could not be read** this launch (OS store briefly unavailable, decrypt failure). Registration then minted a new installation identity and persisted it over the unreadable file — permanently orphaning every connection bound to the old installation.

The load now records *why* it came back empty, and registration is skipped for that launch with a log line explaining why Connected Apps state is deferred, instead of manufacturing a new identity.

## Tests

- New cases for `inventoryFailureMessage`: retryable phrasing, service detail preserved, no "disconnected" implication.
- Existing merge/generation race tests unchanged and passing.
- `pnpm typecheck`, full `pnpm test` (1,692 passed), `pnpm check:electron` green; no new lint findings versus main.

Note for reviewers: open PR #346 also touches inventory-request staleness as part of its much larger Ubuntu scope — happy to drop or rebase this slice if that one lands first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Connected-app inventory failures now display a clear, retryable warning with error details.
  - Existing connections remain visible when inventory loading fails, instead of appearing lost or empty.
  - Credential handling now distinguishes missing stores from unreadable encrypted stores to prevent unintended credential replacement.
  - Managed app registration waits until saved credentials can be read successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->