### PR TITLE
feat(voice): built-in Mac voices — calls with no ElevenLabs key

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -83,8 +83,10 @@ const appConfigSchema = z.object({
   vps: vpsConfigSchema.optional(),
   /** Optional OpenCode key; persisted write-only and passed only to its child. */
   opencodeGo: z.object({ apiKey: optionalText }).optional(),
-  /** Voice credentials and the selected voice id. */
-  tts: z.object({ key: optionalText, voice: optionalText }).optional(),
+  /** Voice credentials and the selected voice id. `provider` picks the
+   * engine: "elevenlabs" (default; needs a key) or "system" (the Mac's
+   * built-in voices, no key). */
+  tts: z.object({ key: optionalText, voice: optionalText, provider: z.enum(["elevenlabs", "system"]).optional() }).optional(),
   /** OpenAI key used only by the in-process avatar image generator. */
   imageGen: z.object({ key: optionalText }).optional(),
   /** Non-secret profile details shown in the sidebar. */
@@ -105,7 +107,7 @@ export interface AppConfig {
   /** A named host from the user's SSH config. Authentication stays with SSH. */
   vps?: { sshAlias?: string };
   opencodeGo?: { apiKey?: string };
-  tts?: { key?: string; voice?: string };
+  tts?: { key?: string; voice?: string; provider?: "elevenlabs" | "system" };
   imageGen?: { key?: string };
   profile?: { name?: string; email?: string };
   rooms?: { turnTimeoutMinutes: number };

--- a/server/tts/index.ts
+++ b/server/tts/index.ts
@@ -1,8 +1,13 @@
-// Voice, wired to config. The ElevenLabs API lives in elevenlabs.ts; this
-// file is only the part that reads ~/.openmausbot/config.json and decides
-// whether there is a voice at all.
+// Voice, wired to config. Two engines live behind this file: ElevenLabs
+// (elevenlabs.ts, needs a key) and the Mac's built-in voices
+// (system-voices.ts, no key). This file is only the part that reads
+// ~/.openmausbot/config.json, picks the engine, and decides whether there
+// is a voice at all.
 import type { AppConfig } from "../config.ts";
 import * as elevenlabs from "./elevenlabs.ts";
+import * as systemVoices from "./system-voices.ts";
+
+export type VoiceProvider = "elevenlabs" | "system";
 
 export class NoVoiceConfigured extends Error {
   // a plain field rather than a constructor parameter property: the harness
@@ -20,13 +25,30 @@ export class NoVoiceConfigured extends Error {
   }
 }
 
+export function voiceProvider(cfg: AppConfig): VoiceProvider {
+  return cfg.tts?.provider === "system" ? "system" : "elevenlabs";
+}
+
+/** The system provider needs no credential — it is only ever offered where
+ * the platform actually has it, so "configured" means "this engine can
+ * speak", not "a key is on file". */
+export function providerConfigured(cfg: AppConfig): boolean {
+  return voiceProvider(cfg) === "system" ? systemVoices.systemVoicesAvailable() : Boolean(cfg.tts?.key);
+}
+
 export function voiceConfigured(cfg: AppConfig): boolean {
+  if (voiceProvider(cfg) === "system") {
+    return systemVoices.systemVoicesAvailable() && Boolean(cfg.tts?.voice);
+  }
   return Boolean(cfg.tts?.key && cfg.tts?.voice);
 }
 
 /** A per-bot voice is a complete choice too; it should not be blocked just
  * because the app-wide fallback has not been selected yet. */
 export function voiceReady(cfg: AppConfig, voiceId?: string): boolean {
+  if (voiceProvider(cfg) === "system") {
+    return systemVoices.systemVoicesAvailable() && Boolean(voiceId || cfg.tts?.voice);
+  }
   return Boolean(cfg.tts?.key && (voiceId || cfg.tts?.voice));
 }
 
@@ -34,9 +56,10 @@ export function voiceReady(cfg: AppConfig, voiceId?: string): boolean {
  * rule as every other credential. */
 export function describeVoice(cfg: AppConfig) {
   return {
-    configured: Boolean(cfg.tts?.key),
+    configured: providerConfigured(cfg),
     ready: voiceConfigured(cfg),
     voice: cfg.tts?.voice ?? "",
+    provider: voiceProvider(cfg),
   };
 }
 
@@ -44,7 +67,8 @@ export function verifyKey(key: string) {
   return elevenlabs.verifyKey(key);
 }
 
-export async function listVoices(cfg: AppConfig): Promise<elevenlabs.Voice[]> {
+export async function listVoices(cfg: AppConfig, run?: systemVoices.Runner): Promise<elevenlabs.Voice[]> {
+  if (voiceProvider(cfg) === "system") return systemVoices.listSystemVoices(run);
   const key = cfg.tts?.key;
   if (!key) return [];
   return elevenlabs.listVoices(key);
@@ -52,7 +76,13 @@ export async function listVoices(cfg: AppConfig): Promise<elevenlabs.Voice[]> {
 
 /** Synthesize one utterance. Throws NoVoiceConfigured when there is nothing
  * to speak with, which the route turns into a 409 the client can explain. */
-export function speak(cfg: AppConfig, text: string, voiceId?: string) {
+export function speak(cfg: AppConfig, text: string, voiceId?: string, run?: systemVoices.Runner) {
+  if (voiceProvider(cfg) === "system") {
+    const voice = voiceId || cfg.tts?.voice;
+    if (!systemVoices.systemVoicesAvailable()) throw new NoVoiceConfigured("key");
+    if (!voice) throw new NoVoiceConfigured("voice");
+    return systemVoices.synthesizeSystem(text, voice, run);
+  }
   const key = cfg.tts?.key;
   if (!key) throw new NoVoiceConfigured("key");
   const voice = voiceId || cfg.tts?.voice;

--- a/server/tts/system-voices.ts
+++ b/server/tts/system-voices.ts
@@ -1,0 +1,78 @@
+// Built-in macOS speech synthesis — the zero-key voice provider.
+//
+// Calls and spoken replies work with no ElevenLabs account by using the
+// voices already installed on the Mac (`/usr/bin/say`, the same engine the
+// Spoken Content pane uses). Everything about driving `say` lives in this
+// file: listing voices, and turning one utterance into WAV bytes.
+//
+// It runs on the HARNESS for the same reason ElevenLabs does — one place to
+// spawn processes, one place that owns the utterance split — and the
+// renderer keeps playing opaque audio bytes, so it never learns or cares
+// which provider produced them.
+//
+// Platform-gated: `say` is a Darwin binary. Elsewhere the provider simply
+// never appears as an option, and the ElevenLabs path is unchanged.
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import type { Audio, Voice } from "./elevenlabs.ts";
+
+const SAY = "/usr/bin/say";
+const execFileAsync = promisify(execFile);
+
+export function systemVoicesAvailable(platform: string = process.platform): boolean {
+  return platform === "darwin";
+}
+
+export type Runner = (file: string, args: string[], timeout: number) => Promise<{ stdout: string }>;
+
+const defaultRun: Runner = (file, args, timeout) => execFileAsync(file, args, { timeout, maxBuffer: 4 * 1024 * 1024 });
+
+/** Parse `say -v ?` output. Lines look like:
+ * `Albert              en_US    # Hello! My name is Albert.`
+ * The header above the table is localized, so anything without the
+ * `name  lang  # sample` shape is ignored rather than parsed. */
+export function parseVoiceList(stdout: string): Voice[] {
+  const voices: Voice[] = [];
+  for (const line of stdout.split("\n")) {
+    const match = /^(.+?)\s{2,}(\S+)\s+#\s*(.+)$/.exec(line.trimEnd());
+    if (!match) continue;
+    const [, name, locale, sample] = match;
+    const id = name.trim();
+    if (!id) continue;
+    voices.push({ id, label: id, description: `${locale} — ${sample.trim()}` });
+  }
+  return voices;
+}
+
+export async function listSystemVoices(run: Runner = defaultRun): Promise<Voice[]> {
+  try {
+    const { stdout } = await run(SAY, ["-v", "?"], 5_000);
+    return parseVoiceList(stdout);
+  } catch {
+    return [];
+  }
+}
+
+/** Synthesize one utterance to 22 kHz mono WAV — small, and every browser
+ * plays it. `say` writes the container itself; no conversion step needed.
+ * The voice id is a system voice name; empty falls back to the system's
+ * own default, which is what a fresh Mac already sounds like. */
+export async function synthesizeSystem(text: string, voiceId: string | undefined, run: Runner = defaultRun): Promise<Audio> {
+  const trimmed = text.trim();
+  if (!trimmed) return { bytes: new Uint8Array(), mime: "audio/wav" };
+  const dir = await mkdtemp(join(tmpdir(), "openmausbot-say-"));
+  const out = join(dir, "utterance.wav");
+  try {
+    const args = ["-o", out, "--data-format=LEI16@22050"];
+    if (voiceId?.trim()) args.push("-v", voiceId.trim());
+    args.push(trimmed);
+    await run(SAY, args, 30_000);
+    return { bytes: new Uint8Array(await readFile(out)), mime: "audio/wav" };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/server/tts/tts.test.ts
+++ b/server/tts/tts.test.ts
@@ -74,7 +74,7 @@ describe("configuration", () => {
   it("never reports the key itself", async () => {
     const { describeVoice } = await voice();
     const described = describeVoice(cfg({ key: "sk-secret", voice: "v-1" }));
-    expect(described).toEqual({ configured: true, ready: true, voice: "v-1" });
+    expect(described).toEqual({ configured: true, ready: true, voice: "v-1", provider: "elevenlabs" });
     expect(JSON.stringify(described)).not.toContain("sk-secret");
   });
 
@@ -159,5 +159,84 @@ describe("ElevenLabs", () => {
     const message = await speak(cfg(ready), "hi").catch((e: Error) => e.message);
     refuse = null;
     expect(message).toContain("exceeded your quota");
+  });
+});
+
+describe("built-in macOS voices", () => {
+  // `say -v ?` output: name, locale, then a # sample sentence. The header
+  // above the table is localized, and some voice names contain spaces.
+  const LISTING = [
+    "Stimmen, die mit „say“ gesprochen werden können:", // localized header — must be ignored
+    "Albert              en_US    # Hello! My name is Albert.",
+    "Bad News            en_US    # The things I could tell you…",
+    "Amélie              fr_CA    # Bonjour! Je m’appelle Amélie.",
+    "", // trailing blank
+  ].join("\n");
+
+  /** A stand-in for `say`: records argv, writes a tiny WAV where -o points,
+   * and answers -v ? with the listing above. */
+  const fakeSay = (record: string[][]) => async (_file: string, args: string[]) => {
+    record.push(args);
+    if (args[0] === "-v" && args[1] === "?") return { stdout: LISTING };
+    const out = args[args.indexOf("-o") + 1];
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    const { dirname } = await import("node:path");
+    await mkdir(dirname(out), { recursive: true });
+    await writeFile(out, Buffer.from("RIFF....WAVEfmt "));
+    return { stdout: "" };
+  };
+
+  const system = { provider: "system" as const, voice: "Albert" };
+  const onMac = process.platform === "darwin";
+
+  it("needs no key — only a picked voice — once selected", async () => {
+    const { voiceConfigured, voiceReady, describeVoice } = await voice();
+    expect(voiceConfigured(cfg(system))).toBe(onMac);
+    expect(voiceReady(cfg({ provider: "system" }), "Albert")).toBe(onMac);
+    expect(voiceReady(cfg(system))).toBe(onMac);
+    const described = describeVoice(cfg(system));
+    expect(described).toEqual({
+      configured: onMac,
+      ready: onMac,
+      voice: "Albert",
+      provider: "system",
+    });
+  });
+
+  it("parses the say voice table, header junk and all", async () => {
+    const { listVoices } = await voice();
+    const record: string[][] = [];
+    expect(await listVoices(cfg({ provider: "system" }), fakeSay(record))).toEqual([
+      { id: "Albert", label: "Albert", description: "en_US — Hello! My name is Albert." },
+      { id: "Bad News", label: "Bad News", description: "en_US — The things I could tell you…" },
+      { id: "Amélie", label: "Amélie", description: "fr_CA — Bonjour! Je m’appelle Amélie." },
+    ]);
+    expect(record[0].slice(0, 2)).toEqual(["-v", "?"]);
+  });
+
+  it("synthesizes to a WAV without any key or network", async () => {
+    const { speak } = await voice();
+    const record: string[][] = [];
+    const audio = await speak(cfg({ provider: "system" }), "hello there", "Albert", fakeSay(record));
+    expect(audio.mime).toBe("audio/wav");
+    expect(Buffer.from(audio.bytes).toString()).toContain("WAVE");
+
+    const args = record.find((argv) => argv[0] === "-o")!;
+    expect(args).toContain("--data-format=LEI16@22050");
+    expect(args[args.indexOf("-v") + 1]).toBe("Albert");
+    expect(args.at(-1)).toBe("hello there");
+
+    // the utterance temp dir does not outlive the call
+    const { access } = await import("node:fs/promises");
+    const { dirname } = await import("node:path");
+    await expect(access(dirname(args[1]))).rejects.toThrow();
+  });
+
+  it("still demands a picked voice, and says so", async () => {
+    const { speak, NoVoiceConfigured } = await voice();
+    expect(() => speak(cfg({ provider: "system" }), "hi", undefined, fakeSay([]))).toThrow(NoVoiceConfigured);
+    expect(() => speak(cfg({ provider: "system" }), "hi", undefined, fakeSay([]))).toThrow(
+      "Pick a voice in the agent profile.",
+    );
   });
 });

--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -91,7 +91,7 @@ export function CallTargetButton({
       : !supported
         ? "Calls currently need the macOS desktop app"
         : !configured
-          ? "Add an ElevenLabs key in an agent profile to make calls"
+          ? "Set up a voice in an agent profile to make calls"
           : !voiceReady
             ? "Pick a voice in an agent profile to make calls"
             : `Call ${targetName}`;
@@ -103,11 +103,11 @@ export function CallTargetButton({
       : !window.ogb?.speechStart
         ? "The speech service is unavailable in this app build. Restart or update OpenMausBot."
         : !configured
-          ? "Add an ElevenLabs API key so the bot can speak during calls."
+          ? "Add an ElevenLabs API key — or switch to the built-in Mac voices — so the bot can speak during calls."
           : !voiceReady
             ? voices.length > 1
-              ? "Give every channel member an ElevenLabs voice before starting a channel call."
-              : "Choose an ElevenLabs voice before starting a call."
+              ? "Give every channel member a voice before starting a channel call."
+              : "Choose a voice before starting a call."
             : "";
 
   useEffect(() => {

--- a/src/components/VoiceSettings.tsx
+++ b/src/components/VoiceSettings.tsx
@@ -58,7 +58,7 @@ export function VoiceSettings({
   }, [configured, provider]);
 
   const setProvider = (next: "elevenlabs" | "system") => {
-    if (next === provider || switching) return;
+    if (next === provider || switching || (next === "system" && !systemVoicesAvailable)) return;
     setSwitching(true);
     setError(null);
     // the provider is a setting, not a secret — it rides the ordinary
@@ -96,23 +96,28 @@ export function VoiceSettings({
       <div className="text-[15px] font-medium text-ink">Voice</div>
       <div className="mt-0.5 text-[13px] text-ink-secondary">
         Give this agent a voice for calls and spoken replies. The voice choice belongs to this agent;
-        {provider === "system" ? " the voices are the ones already installed on this Mac." : " the ElevenLabs key is shared by the workspace."}
+        {provider === "system"
+          ? systemVoicesAvailable
+            ? " the voices are the ones already installed on this Mac."
+            : " built-in Mac voices are unavailable here. Switch to ElevenLabs to keep using voice."
+          : " the ElevenLabs key is shared by the workspace."}
       </div>
 
-      {systemVoicesAvailable && (
+      {(systemVoicesAvailable || provider === "system") && (
         <div className="mt-4">
           <div className="mb-2 text-[13px] text-ink-secondary">Voice engine</div>
           <div className="inline-flex rounded-xl bg-inset p-1" role="radiogroup" aria-label="Voice engine">
             {([
-              { value: "elevenlabs", label: "ElevenLabs" },
-              { value: "system", label: "Built-in Mac voices" },
+              { value: "elevenlabs", label: "ElevenLabs", available: true },
+              { value: "system", label: "Built-in Mac voices", available: systemVoicesAvailable },
             ] as const).map((option) => (
               <button
                 key={option.value}
                 type="button"
                 role="radio"
                 aria-checked={provider === option.value}
-                disabled={switching}
+                disabled={switching || !option.available}
+                title={!option.available ? "Built-in voices are available only on macOS" : undefined}
                 onClick={() => setProvider(option.value)}
                 className={cn(
                   "rounded-lg px-3.5 py-1.5 text-[12.5px] transition-colors disabled:opacity-50",

--- a/src/components/VoiceSettings.tsx
+++ b/src/components/VoiceSettings.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { Check, Loader2, Volume2 } from "lucide-react";
 
 import { api, useStore, type Bot, type ConfigStatus } from "@/state/store";
+import { useDesktopCapabilities } from "@/components/DesktopCapabilities";
 import { speaker } from "@/lib/tts";
 import { cn } from "@/lib/cn";
 
@@ -24,10 +25,16 @@ export function VoiceSettings({
 
   const [key, setKey] = useState("");
   const [saving, setSaving] = useState(false);
+  const [switching, setSwitching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [voices, setVoices] = useState<Array<{ id: string; label: string; description?: string }>>([]);
   const [loadingVoices, setLoadingVoices] = useState(false);
 
+  const { capabilities } = useDesktopCapabilities();
+  // Built-in voices are offered where the desktop contract says they exist —
+  // never inferred from a user agent.
+  const systemVoicesAvailable = capabilities.host.platform === "darwin";
+  const provider = tts?.provider ?? "elevenlabs";
   const configured = Boolean(tts?.configured);
 
   useEffect(() => {
@@ -48,7 +55,19 @@ export function VoiceSettings({
     return () => {
       alive = false;
     };
-  }, [configured]);
+  }, [configured, provider]);
+
+  const setProvider = (next: "elevenlabs" | "system") => {
+    if (next === provider || switching) return;
+    setSwitching(true);
+    setError(null);
+    // the provider is a setting, not a secret — it rides the ordinary
+    // config write, and the key row reappears or disappears with it
+    api("/api/config", { method: "PUT", body: JSON.stringify({ tts: { provider: next } }) })
+      .then((status: ConfigStatus) => dispatch({ type: "configStatus", config: status }))
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setSwitching(false));
+  };
 
   const saveKey = () => {
     const nextKey = key.trim();
@@ -76,11 +95,39 @@ export function VoiceSettings({
     <div className="rounded-xl bg-card p-4">
       <div className="text-[15px] font-medium text-ink">Voice</div>
       <div className="mt-0.5 text-[13px] text-ink-secondary">
-        Give this agent a voice for calls and spoken replies. The ElevenLabs key is shared by the workspace;
-        the voice choice belongs to this agent.
+        Give this agent a voice for calls and spoken replies. The voice choice belongs to this agent;
+        {provider === "system" ? " the voices are the ones already installed on this Mac." : " the ElevenLabs key is shared by the workspace."}
       </div>
 
-      <div className="mt-4">
+      {systemVoicesAvailable && (
+        <div className="mt-4">
+          <div className="mb-2 text-[13px] text-ink-secondary">Voice engine</div>
+          <div className="inline-flex rounded-xl bg-inset p-1" role="radiogroup" aria-label="Voice engine">
+            {([
+              { value: "elevenlabs", label: "ElevenLabs" },
+              { value: "system", label: "Built-in Mac voices" },
+            ] as const).map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={provider === option.value}
+                disabled={switching}
+                onClick={() => setProvider(option.value)}
+                className={cn(
+                  "rounded-lg px-3.5 py-1.5 text-[12.5px] transition-colors disabled:opacity-50",
+                  provider === option.value ? "bg-raised text-ink shadow" : "text-ink-secondary hover:text-ink",
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {provider === "elevenlabs" && (
+        <div className="mt-4">
         <div className="mb-1.5 flex items-center gap-2 text-[13px] text-ink-secondary">
           <span className={cn("size-1.5 rounded-full", configured ? "bg-success" : "bg-raised-hover")} />
           <span>ElevenLabs key</span>
@@ -115,7 +162,8 @@ export function VoiceSettings({
             Get a key from ElevenLabs
           </a>
         )}
-      </div>
+        </div>
+      )}
 
       {configured && (
         <div className="mt-4">

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -261,7 +261,7 @@ export interface ConfigStatus {
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND
    * a voice, which is what it takes to actually speak. The key itself is
    * never echoed back. */
-  tts?: { configured: boolean; ready: boolean; voice: string };
+  tts?: { configured: boolean; ready: boolean; voice: string; provider?: "elevenlabs" | "system" };
   /** Shared write-only credential for on-demand GPT Image avatars. */
   imageGen?: { configured: boolean };
   /** who's using the app — collected in onboarding, shown in the sidebar */


### PR DESCRIPTION
Today voice is all-or-nothing on an ElevenLabs key: calls show *"Add an ElevenLabs API key so the bot can speak during calls"* and there is no other engine. This adds a second one — the voices already installed on the Mac — so calls and spoken replies work with zero accounts, zero keys, and zero network.

## What it is

`tts.provider` picks the engine:

- **`elevenlabs`** (default) — exactly as before, byte-for-byte behavior when no provider is set.
- **`system`** — `/usr/bin/say`, the same engine the Spoken Content pane uses. One utterance per request to match the existing client pipeline, rendered to 22 kHz mono WAV (`--data-format=LEI16@22050`, no conversion step), temp dir cleaned up after every call. Voices are listed by parsing `say -v ?` with its localized header treated as junk; multi-word voice names ("Bad News") parse correctly.

The renderer keeps playing opaque audio bytes from `POST /api/tts/speak`, so nothing client-side changes shape or learns which engine answered. Utterance splitting, the 500-char ceiling, the speaker singleton, and interruption semantics are all untouched — only the bytes' origin changes.

## Wiring

- `describeVoice` reports `provider`, and `configured`/`ready` become provider-aware: the system engine needs a picked voice, not a key, so calls unblock the moment a voice is chosen.
- Voice settings gain an engine picker, offered only where the desktop capability contract reports Darwin (never inferred from a user agent). The ElevenLabs key row appears only in ElevenLabs mode; switching engines re-fetches the voice list, and per-bot voice choices persist across the switch.
- Call-gating copy no longer assumes ElevenLabs; the no-key hint now mentions the built-in voices as the alternative.
- Platform-gated like everything macOS: elsewhere the picker simply doesn't appear and ElevenLabs behaves exactly as today.

Deliberately out of scope: provider-native speech (using the selected chat model's own voice) — different plumbing per driver, worth its own discussion; this PR is the zero-key path that works on every Mac today.

## Tests

- New suite: voice-table parsing (localized header ignored, multi-word names), synthesis through a fake `say` runner asserting exact argv (`-o`, `--data-format`, `-v`, text) and temp-dir cleanup, no-key readiness, and the missing-voice error staying distinct.
- Existing ElevenLabs stub tests unchanged and passing; `describeVoice` assertion updated for the new `provider` field.
- `pnpm typecheck` clean; full `pnpm test` green (162 files, 1,693 passed); no new lint findings versus main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in Mac system voices alongside ElevenLabs.
  * Added a voice-engine selector with provider-specific guidance and automatic voice-list refresh.
  * Call setup now supports system voices and checks voices for all participants.
  * Added provider selection to text-to-speech configuration.
  * Added secret-request cards, message replies, team-map navigation, and VPS auto-start bot settings.

* **Bug Fixes**
  * Improved voice configuration checks and error messages.
  * Added cleanup and fallback handling during system voice generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->