### PR TITLE
fix(computer): make live desktop non-modal so control can be handed back

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -410,12 +410,25 @@ function openDesktopViewer(owner, rawUrl, rawTitle, contextId) {
   const titleCandidate = Object.prototype.toString.call(rawTitle) === "[object String]" ? rawTitle.trim() : "";
   const title = titleCandidate ? titleCandidate.slice(0, 80) : "Live desktop";
 
+  const nextContextId =
+    Object.prototype.toString.call(contextId) === "[object String]" ? contextId.slice(0, 120) : null;
+
   // Desktop URLs contain rotating access tokens. A newly minted URL replaces
   // the old viewer instead of being retained anywhere after its window closes.
-  if (desktopViewerWindow && !desktopViewerWindow.isDestroyed()) desktopViewerWindow.close();
+  // Clear the ref first so the stale window's close handler no-ops; on a bot
+  // change, tell the previous bot to release (same-bot reopen stays quiet).
+  if (desktopViewerWindow && !desktopViewerWindow.isDestroyed()) {
+    const previous = desktopViewerWindow;
+    const previousOwner = desktopViewerOwner;
+    const previousContextId = desktopViewerContextId;
+    desktopViewerWindow = null;
+    previous.close();
+    if (previousContextId !== nextContextId && previousOwner && !previousOwner.isDestroyed()) {
+      previousOwner.send("desktop-viewer:state", { open: false, contextId: previousContextId });
+    }
+  }
   desktopViewerOwner = owner.webContents;
-  desktopViewerContextId =
-    Object.prototype.toString.call(contextId) === "[object String]" ? contextId.slice(0, 120) : null;
+  desktopViewerContextId = nextContextId;
 
   const viewer = new BrowserWindow({
     width: 1220,
@@ -423,7 +436,9 @@ function openDesktopViewer(owner, rawUrl, rawTitle, contextId) {
     minWidth: 760,
     minHeight: 520,
     parent: owner,
-    modal: true,
+    // Not modal: the person still needs the app's "Hand control back" button
+    // while the desktop is open. `parent` keeps it floating above the app.
+    modal: false,
     show: false,
     title,
     icon: APP_ICON,
@@ -451,6 +466,7 @@ function openDesktopViewer(owner, rawUrl, rawTitle, contextId) {
   viewer.on("closed", () => {
     if (desktopViewerWindow !== viewer) return;
     desktopViewerWindow = null;
+    // The panel drops its "viewer open" state and releases control on this.
     notifyDesktopViewer(false);
     desktopViewerOwner = null;
     desktopViewerContextId = null;
@@ -738,6 +754,21 @@ ipcMain.handle("desktop-viewer:open", (event, rawUrl, title, contextId) => {
   const owner = BrowserWindow.fromWebContents(event.sender);
   return openDesktopViewer(owner, rawUrl, title, contextId);
 });
+
+// Close only when the caller owns the current viewer — otherwise one bot's
+// "Hand control back" would close (and release) another bot's viewer.
+ipcMain.handle("desktop-viewer:close", (_event, contextId) => {
+  const scoped = Object.prototype.toString.call(contextId) === "[object String]" ? contextId : null;
+  if (scoped !== desktopViewerContextId) return false;
+  if (desktopViewerWindow && !desktopViewerWindow.isDestroyed()) desktopViewerWindow.close();
+  return true;
+});
+
+// Lets a (re)mounted panel seed viewer-open state instead of defaulting to false.
+ipcMain.handle("desktop-viewer:state-now", () => ({
+  open: Boolean(desktopViewerWindow && !desktopViewerWindow.isDestroyed()),
+  contextId: desktopViewerContextId,
+}));
 
 ipcMain.handle("perm:status", () => ({
   mic:

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -100,9 +100,11 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Open a web link in the default browser. Unlike renderer window.open,
    * this remains reliable after an asynchronous API request. */
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
-  /** Live VNC/noVNC in a sandboxed modal owned by the app window. */
+  /** Live VNC/noVNC in a sandboxed window owned by the app window. */
   desktopViewer: {
     open: (url, title, contextId) => ipcRenderer.invoke("desktop-viewer:open", url, title, contextId),
+    close: (contextId) => ipcRenderer.invoke("desktop-viewer:close", contextId),
+    currentState: () => ipcRenderer.invoke("desktop-viewer:state-now"),
     onState: (cb) => {
       const handler = (_event, state) => cb(state);
       ipcRenderer.on("desktop-viewer:state", handler);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,25 @@ function Shell() {
     setDrawerOpen(false);
   }, [state.selectedId, state.activeView, state.pluginsOpen, state.settingsOpen]);
 
+  // The viewer outlives ComputerPanel and can target any bot, so release control
+  // here (always mounted) when a bot's viewer closes. release() is idempotent.
+  useEffect(() => {
+    return window.ogb?.desktopViewer?.onState((viewer) => {
+      if (viewer.open || !viewer.contextId) return;
+      const botId = viewer.contextId;
+      void fetch(`/api/bots/${botId}/computer/control`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "release" }),
+      })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((snap) => {
+          if (snap) dispatch({ type: "computerControl", botId, held: snap.held === true, helpReason: snap.helpReason ?? null });
+        })
+        .catch(() => {});
+    });
+  }, [dispatch]);
+
   return (
     <div className="flex h-full flex-col">
       {/* fixed-position popup, bottom-left — outside the layout flow */}

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -140,10 +140,26 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     (instance) => instance.instanceId === bot.modelSelection.instanceId,
   );
 
+  // Pause the screenshot poll while this bot's viewer is open; seed from the
+  // live viewer so a remount/switch mid-session doesn't wrongly resume it.
   useEffect(() => {
-    return window.ogb?.desktopViewer?.onState((viewer) => {
+    let alive = true;
+    const dv = window.ogb?.desktopViewer;
+    if (dv?.currentState) {
+      void dv
+        .currentState()
+        .then((s) => {
+          if (alive) setViewerOpen(s.open && s.contextId === bot.id);
+        })
+        .catch(() => {});
+    }
+    const off = dv?.onState((viewer) => {
       if (viewer.contextId === bot.id) setViewerOpen(viewer.open);
     });
+    return () => {
+      alive = false;
+      off?.();
+    };
   }, [bot.id]);
 
   useEffect(() => {
@@ -843,7 +859,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
               {phase === "vm" && " Use Open desktop to drive — the preview here is watch-only."}
             </div>
             <button
-              onClick={() => controlAction("release")}
+              onClick={() => {
+                controlAction("release");
+                void window.ogb?.desktopViewer?.close(bot.id);
+              }}
               disabled={controlPending}
               className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-accent py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-50"
             >

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -152,9 +152,13 @@ type SkillRecordingPayload = {
       openInstallTerminal?(command: string): Promise<boolean>;
       /** Opens an http(s) link in the user's default browser. */
       openExternal?(url: string): Promise<boolean>;
-      /** Opens a live desktop as a sandboxed modal owned by OpenMausBot. */
+      /** Opens a live desktop as a sandboxed window owned by OpenMausBot. */
       desktopViewer?: {
         open(url: string, title: string, contextId: string): Promise<boolean>;
+        /** Closes the live-desktop window, but only when it belongs to this bot. */
+        close(contextId: string): Promise<boolean>;
+        /** The current viewer state, for a panel to initialize from on mount. */
+        currentState(): Promise<{ open: boolean; contextId: string | null }>;
         onState(cb: (state: { open: boolean; contextId: string | null }) => void): () => void;
       };
       /** Native folder picker; resolves null when the user cancels. */


### PR DESCRIPTION
## Problem

Taking control of a bot's computer — **Take control** on a Cloud/Box or Local VM computer — opens the live desktop as a **modal** window (`openDesktopViewer`, `modal: true` in `electron/main.mjs`). A modal window disables the main app window while it's open, but the only **Hand control back** button lives in the Computer panel *in that main window* (`src/components/ComputerPanel.tsx`). So once the live desktop is open:

- you can't reach **Hand control back** — the app is blocked by the modal, and
- closing the viewer window doesn't release control either — the `closed` handler only clears the "viewer open" UI flag, it never releases the hold, so the bot's hands stay paused.

Net effect: after taking control you can get stuck — unable to hand control back or to cleanly close the live desktop.

## Fix

- **Non-modal viewer** — the live desktop keeps `parent` (so it still floats above the app) but is no longer `modal`, so the app stays usable and **Hand control back** is reachable while you watch/drive.
- **Closing the viewer hands control back** — the window's `closed` broadcast now releases control. `release()` is idempotent, so this is safe.
- **`desktopViewer.close()` bridge** — the panel's **Hand control back** button now also closes the viewer window, keeping the button and the window in sync.

Because the viewer is a separate window that outlives the panel, the close→release is reconciled at a scope that's always mounted rather than in the panel itself:

- **App-wide reconciliation** — the close→release listener lives in `Shell` (always mounted), so control is handed back even if the Computer panel was closed, or switched to another bot, while the viewer stayed open.
- **Context-changing replacement** — when one bot's viewer is replaced by another bot's, an explicit close is emitted for the previous bot so its control is released too. A same-bot reopen stays suppressed to avoid a spurious release.
- **Remount/switch initialization** — a (re)mounted panel initializes its viewer-open state from the live viewer, so switching to or reopening a panel while the viewer is open keeps the screenshot poll paused instead of resuming it.
- **Scoped close** — the **Hand control back** close request is scoped to the requesting bot, so a bot that holds control without a viewer of its own (e.g. a self-hosted VPS) can't close — and thereby release — another bot's open viewer.

## Testing

- `pnpm typecheck` passes
- `pnpm test:desktop-viewer`, `pnpm test:updater`, and the `computer-control` suite pass
- Traced OS-chrome close, panel-button close, panel-closed-while-viewer-open, cross-bot replacement, same-bot reopen, VPS (no viewer), and plain-web (no bridge) paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls to close the desktop viewer and check its current status.
  - The viewer now reflects the active bot context and updates control state when closed.
  - Desktop viewing is non-modal, allowing continued interaction with the app.
  - Returning control to the bot now closes its desktop viewer.

- **Bug Fixes**
  - Improved handling when switching between bot contexts.
  - Prevented stale viewer references and preserved screenshot polling behavior across remounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->