### PR TITLE
feat(pi): give the pi engine hands — MCP integrations + permission cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ release
 cloudflare/composio-broker/worker-configuration.d.ts
 .claude/worktrees/
 .vercel/
+.pi/

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -18,6 +18,7 @@
 // drivers/ nested; import.meta.url still resolves to the same location, so
 // that lookup is unaffected.
 import { build } from "esbuild";
+import { copyFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -56,3 +57,13 @@ await build({
   allowOverwrite: true,
   logLevel: "info",
 });
+
+// pi-mcp-extension.ts is NOT an OpenMausBot entry point: it is loaded by the
+// external `pi` process (pi's own jiti), which resolves its
+// @earendil-works/pi-coding-agent and typebox imports from pi's install. Ship
+// it verbatim as .ts so the packaged app has it too — never bundle it, or
+// esbuild would inline pi's packages and the extension would stop loading.
+const piMcpExtSrc = join(server, "drivers", "pi-mcp-extension.ts");
+const piMcpExtDest = join(root, "dist-server", "drivers", "pi-mcp-extension.ts");
+mkdirSync(dirname(piMcpExtDest), { recursive: true });
+copyFileSync(piMcpExtSrc, piMcpExtDest);

--- a/server/drivers/pi-mcp-extension.ts
+++ b/server/drivers/pi-mcp-extension.ts
@@ -54,6 +54,14 @@ class StdioMcp {
     this.child.stdout.setEncoding("utf8");
     this.child.stdout.on("data", (chunk: string) => this.onData(chunk));
     this.child.on("error", (err) => this.failAll(err));
+    // A server that starts and then dies emits `exit`, never `error`; without
+    // settling on it, an in-flight init/listTools would hang the extension
+    // load for the whole turn.
+    this.child.on("exit", (code) => this.failAll(new Error(`MCP server exited (code ${code ?? "?"})`)));
+    // A write to a dead child errors asynchronously on the stream; an
+    // unhandled stream error would kill the pi process (the same hazard
+    // spawnCli documents for driver-spawned children in procs.ts).
+    this.child.stdin.on("error", () => this.failAll(new Error("MCP server stdin closed")));
   }
 
   private failAll(err: Error): void {
@@ -85,11 +93,25 @@ class StdioMcp {
     }
   }
 
-  private call(method: string, params?: unknown): Promise<unknown> {
+  private call(method: string, params?: unknown, timeoutMs = 30_000): Promise<unknown> {
     const id = this.nextId++;
     return new Promise<unknown>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`MCP ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, {
+        resolve: (v) => (clearTimeout(timer), resolve(v)),
+        reject: (e) => (clearTimeout(timer), reject(e)),
+      });
+      try {
+        this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   }
 

--- a/server/drivers/pi-mcp-extension.ts
+++ b/server/drivers/pi-mcp-extension.ts
@@ -20,6 +20,9 @@ interface McpServerDef {
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  /** "local-computer" marks the user's real host desktop: every tool on such
+   * a server is gated behind a permission card before it executes. */
+  scope?: string;
 }
 
 interface McpConfig {
@@ -194,6 +197,16 @@ function sanitizeToolName(server: string, tool: string): string {
   return raw.slice(0, 64) || `mcp_tool`;
 }
 
+/** A short human-readable line for the permission card's detail. */
+function summarizeParams(params: unknown): string {
+  try {
+    const s = JSON.stringify(params ?? {});
+    return s === "{}" ? "" : s.slice(0, 300);
+  } catch {
+    return "";
+  }
+}
+
 export default async function (pi: ExtensionAPI): Promise<void> {
   const configPath = process.env.OMB_MCP_CONFIG;
   if (!configPath) return;
@@ -210,6 +223,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   for (const [serverName, def] of Object.entries(config.mcpServers ?? {})) {
     if (!def || typeof def.command !== "string") continue;
+    const gated = def.scope === "local-computer";
     let client: StdioMcp | undefined;
     try {
       client = new StdioMcp(def);
@@ -224,7 +238,20 @@ export default async function (pi: ExtensionAPI): Promise<void> {
           label: `${serverName}:${tool.name}`,
           description: tool.description ?? `${tool.name} (MCP tool from ${serverName})`,
           parameters: toTypebox(tool.inputSchema),
-          async execute(_toolCallId, params) {
+          async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+            // Host tools ask first, using pi's native permission card
+            // (ctx.ui.confirm → extension_ui_request → Allow/Deny card). This
+            // mirrors ACP's session/request_permission and Codex's elicitation.
+            if (gated) {
+              const detail = summarizeParams(params);
+              const allowed = await ctx.ui.confirm(
+                `Allow ${tool.name} on your computer?`,
+                detail || `Run ${serverName}:${tool.name}`,
+              );
+              if (!allowed) {
+                return { content: [{ type: "text", text: "Blocked by the user." }], details: {} };
+              }
+            }
             const res = await client.callTool(tool.name, params);
             const text = res.isError ? `(tool returned an error)\n${res.text}` : res.text;
             return { content: [{ type: "text", text }], details: {} };

--- a/server/drivers/pi-mcp-extension.ts
+++ b/server/drivers/pi-mcp-extension.ts
@@ -1,0 +1,248 @@
+// pi-mcp-extension — the Pi-side half of "hands" for the pi engine.
+//
+// Pi core deliberately ships no MCP client (see pi's docs: "does not include
+// built-in MCP"). This extension is that client: loaded into the per-turn
+// `pi --mode rpc --no-session` process via `-e`, it reads a JSON file whose
+// path is handed in through OMB_MCP_CONFIG and mounts every server described
+// there as first-class pi tools (pi.registerTool). OpenMausBot ships this file
+// and the pi driver spawns it — the pi repo itself is never touched.
+//
+// Protocol: the OpenMausBot proxies speak raw JSON-RPC 2.0 over stdio, one
+// frame per line (no MCP SDK, no Content-Length framing) — see
+// server/mcp-bridge.ts and server/drivers/agents-proxy.ts. This client matches
+// that exactly.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+interface McpServerDef {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface McpConfig {
+  mcpServers?: Record<string, McpServerDef>;
+}
+
+interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+/** A minimal stdio JSON-RPC 2.0 MCP client, matched to OpenMausBot's
+ * newline-delimited house protocol. */
+class StdioMcp {
+  private child: ChildProcessWithoutNullStreams;
+  private buf = "";
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+  constructor(def: McpServerDef) {
+    this.child = spawn(def.command, def.args ?? [], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...(def.env ?? {}) },
+    });
+    this.child.stderr.on("data", () => {
+      /* best-effort drain so a chatty server never blocks */
+    });
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => this.onData(chunk));
+    this.child.on("error", (err) => this.failAll(err));
+  }
+
+  private failAll(err: Error): void {
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+  }
+
+  private onData(chunk: string): void {
+    this.buf += chunk;
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) !== -1) {
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      let msg: { id?: unknown; error?: { message?: string }; result?: unknown };
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id !== undefined && this.pending.has(msg.id as number)) {
+        const p = this.pending.get(msg.id as number)!;
+        this.pending.delete(msg.id as number);
+        if (msg.error) p.reject(new Error(msg.error.message ?? "MCP error"));
+        else p.resolve(msg.result);
+      }
+      // Server notifications/requests (e.g. notifications/tools/list_changed)
+      // carry no id and are intentionally ignored for this single-shot mount.
+    }
+  }
+
+  private call(method: string, params?: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  private notify(method: string, params?: unknown): void {
+    this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+
+  async init(): Promise<void> {
+    await this.call("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "openmausbot-pi", version: "1" },
+    });
+    this.notify("notifications/initialized");
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    const res = (await this.call("tools/list", {})) as { tools?: McpTool[] } | undefined;
+    return res?.tools ?? [];
+  }
+
+  /** tools/call → pi text result. Non-text content (screenshots, etc.) is
+   * folded into a marker so the agent still gets the structured state the
+   * proxies return alongside it. */
+  async callTool(name: string, args: unknown): Promise<{ text: string; isError: boolean }> {
+    const res = (await this.call("tools/call", { name, arguments: args ?? {} })) as
+      | { content?: unknown[]; isError?: boolean }
+      | undefined;
+    const content = Array.isArray(res?.content) ? res.content : [];
+    const text = content
+      .filter((c): c is { type: "text"; text: unknown } => (c as { type?: string })?.type === "text")
+      .map((c) => String(c.text ?? ""))
+      .join("\n");
+    const other = content.filter((c) => (c as { type?: string })?.type !== "text");
+    const note = other.length ? `\n[${other.length} non-text content item(s) omitted]` : "";
+    return {
+      text: (text || "(empty result)") + note,
+      isError: Boolean(res?.isError),
+    };
+  }
+
+  dispose(): void {
+    try {
+      this.child.kill();
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/** Best-effort JSON Schema → typebox for the common MCP tool shapes.
+ * Anything unrecognized degrades to a permissive record rather than failing
+ * the mount: a tool that works loosely beats one that never registers. */
+function toTypebox(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return Type.Record(Type.String(), Type.Any());
+  const s = schema as {
+    type?: string;
+    enum?: unknown[];
+    anyOf?: unknown;
+    oneOf?: unknown;
+    allOf?: unknown;
+    items?: unknown;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  if (Array.isArray(s.enum)) {
+    const lits = s.enum.filter((v) => ["string", "number", "boolean"].includes(typeof v));
+    if (lits.length === s.enum.length && lits.length > 0) {
+      return Type.Union(lits.map((v) => Type.Literal(v as string | number | boolean)));
+    }
+    return Type.Any();
+  }
+  if (s.anyOf || s.oneOf || s.allOf) return Type.Any();
+  switch (s.type) {
+    case "string":
+      return Type.String();
+    case "number":
+      return Type.Number();
+    case "integer":
+      return Type.Integer();
+    case "boolean":
+      return Type.Boolean();
+    case "null":
+      return Type.Null();
+    case "array":
+      return Type.Array(s.items ? toTypebox(s.items) : Type.Any());
+    case "object": {
+      const props: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(s.properties ?? {})) {
+        const required = Array.isArray(s.required) && s.required.includes(k);
+        props[k] = required ? toTypebox(v) : Type.Optional(toTypebox(v));
+      }
+      return Type.Object(props);
+    }
+    default:
+      return Type.Record(Type.String(), Type.Any());
+  }
+}
+
+/** pi tool names are lowercase snake identifiers; MCP tool names are not
+ * (COMPOSIO_SEARCH_TOOLS, browser_navigate, mcp__x…). Normalize and prefix
+ * with the server so two servers can never collide. */
+function sanitizeToolName(server: string, tool: string): string {
+  const raw = `${server}_${tool}`.toLowerCase().replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
+  return raw.slice(0, 64) || `mcp_tool`;
+}
+
+export default async function (pi: ExtensionAPI): Promise<void> {
+  const configPath = process.env.OMB_MCP_CONFIG;
+  if (!configPath) return;
+
+  let config: McpConfig;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf8")) as McpConfig;
+  } catch {
+    return;
+  }
+
+  const used = new Set<string>();
+  const clients: StdioMcp[] = [];
+
+  for (const [serverName, def] of Object.entries(config.mcpServers ?? {})) {
+    if (!def || typeof def.command !== "string") continue;
+    let client: StdioMcp | undefined;
+    try {
+      client = new StdioMcp(def);
+      await client.init();
+      const tools = await client.listTools();
+      for (const tool of tools) {
+        let name = sanitizeToolName(serverName, tool.name);
+        while (used.has(name)) name = `${name}_2`;
+        used.add(name);
+        pi.registerTool({
+          name,
+          label: `${serverName}:${tool.name}`,
+          description: tool.description ?? `${tool.name} (MCP tool from ${serverName})`,
+          parameters: toTypebox(tool.inputSchema),
+          async execute(_toolCallId, params) {
+            const res = await client.callTool(tool.name, params);
+            const text = res.isError ? `(tool returned an error)\n${res.text}` : res.text;
+            return { content: [{ type: "text", text }], details: {} };
+          },
+        });
+      }
+      clients.push(client);
+    } catch (err) {
+      // A server that fails to initialize must not take the whole turn down:
+      // skip its tools and let the agent work with whatever else mounted.
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[openmausbot-pi-mcp] ${serverName}: ${message}\n`);
+      client?.dispose();
+    }
+  }
+
+  pi.on("session_shutdown", () => {
+    for (const c of clients) c.dispose();
+    clients.length = 0;
+  });
+}

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { fetchPiModels, parsePiCatalog, PiDriver } from "./pi.ts";
+import { buildMcpServers, fetchPiModels, parsePiCatalog, PiDriver } from "./pi.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-pi-cli.ts");
 const MODELS_LINE =
@@ -51,6 +51,55 @@ describe("parsePiCatalog", () => {
       '{"type":"extension_ui_request","id":"x","method":"setStatus","statusKey":"loops"}\n' + MODELS_LINE + "\n";
     const catalog = parsePiCatalog(stdout);
     expect(catalog.options).toHaveLength(2);
+  });
+});
+
+describe("buildMcpServers", () => {
+  it("returns null when there are no integrations", () => {
+    expect(buildMcpServers({ threadId: "t", text: "hi" })).toBeNull();
+  });
+
+  it("passes composio/agents/phone through as stdio servers", () => {
+    const servers = buildMcpServers({
+      threadId: "t",
+      text: "hi",
+      integrations: {
+        composio: { command: "node", args: ["c"], env: { A: "1" } },
+        agents: { command: "node", args: ["a"], env: { B: "2" } },
+        phone: { command: "node", args: ["p"], env: {} },
+      },
+    });
+    expect(servers).toEqual({
+      composio: { command: "node", args: ["c"], env: { A: "1" } },
+      agents: { command: "node", args: ["a"], env: { B: "2" } },
+      phone: { command: "node", args: ["p"], env: {} },
+    });
+  });
+
+  it("wraps the cloud computer in the computer-proxy spawn contract", () => {
+    const servers = buildMcpServers({
+      threadId: "t",
+      text: "hi",
+      integrations: {
+        computer: { kind: "box", boxId: "b1", token: "tok", control: { url: "http://c", token: "ct" } },
+      },
+    });
+    expect(servers?.computer).toMatchObject({
+      command: process.execPath,
+      args: [expect.stringContaining("computer-proxy")],
+      env: expect.objectContaining({ OGB_BOX_ID: "b1", OGB_BOX_TOKEN: "tok" }),
+    });
+  });
+
+  it("passes a local computer (Cua/VPS) through as a direct stdio server", () => {
+    const servers = buildMcpServers({
+      threadId: "t",
+      text: "hi",
+      integrations: {
+        localComputer: { command: "node", args: ["mcp"], env: { X: "y" } },
+      },
+    });
+    expect(servers?.computer).toEqual({ command: "node", args: ["mcp"], env: { X: "y" } });
   });
 });
 

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -295,6 +295,42 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(JSON.stringify(rows)).not.toContain("openai-secret-value");
   });
 
+  it("mounts integrations as stdio MCP servers and loads the pi-mcp-extension", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-pi-mcp-dump-"));
+    const dump = join(dir, "dump.jsonl");
+    await create(undefined, { FAKE_PI_DUMP: dump });
+    const { turnId } = await instance.adapter.sendTurn({
+      threadId: "t-mcp",
+      text: "hi",
+      integrations: {
+        composio: { command: "node", args: ["connector-proxy.js"], env: { COMPOSIO_KEY: "ck" } },
+        computer: { kind: "box", boxId: "b1", token: "bt", control: { url: "http://c", token: "ct" } },
+      },
+    });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+
+    const rows = readFileSync(dump, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { argv: string[]; mcpConfig?: { mcpServers?: Record<string, any> } | null });
+    const mcpRow = rows.find((r) => r.mcpConfig != null);
+    expect(mcpRow).toBeTruthy();
+
+    // the extension rides `-e` so the external pi process mounts the servers
+    const extIndex = mcpRow!.argv.indexOf("-e");
+    expect(extIndex).toBeGreaterThanOrEqual(0);
+    expect(mcpRow!.argv[extIndex + 1]).toContain("pi-mcp-extension");
+
+    const servers = mcpRow!.mcpConfig!.mcpServers!;
+    // composio passes through verbatim as a stdio server
+    expect(servers.composio).toMatchObject({ command: "node", args: ["connector-proxy.js"], env: { COMPOSIO_KEY: "ck" } });
+    // the cloud computer wraps in the computer-proxy spawn contract
+    expect(servers.computer.args[0]).toContain("computer-proxy");
+    expect(servers.computer.env).toMatchObject({ OGB_BOX_ID: "b1", OGB_BOX_TOKEN: "bt" });
+    // the box token lives in the 0600 config file, never in argv
+    expect(JSON.stringify(mcpRow!.argv)).not.toContain("bt");
+  });
+
   it("rides the toolUse auto-continue and only settles on the final end_turn", async () => {
     await create("tooluse");
     await instance.adapter.sendTurn({ threadId: "t-tool", text: "run it" });

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -101,19 +101,31 @@ describe("buildMcpServers", () => {
     });
     expect(servers?.computer).toEqual({ command: "node", args: ["mcp"], env: { X: "y" } });
   });
+
+  it("marks a host computer with scope so the extension gates its tools", () => {
+    const servers = buildMcpServers({
+      threadId: "t",
+      text: "hi",
+      integrations: {
+        localComputer: { command: "node", args: ["mcp"], env: {}, scope: "local-computer" },
+      },
+    });
+    expect(servers?.computer).toMatchObject({ scope: "local-computer" });
+  });
 });
 
 describe("PiDriver config + install", () => {
   it("defaults to the `pi` binary", () => {
-    expect(PiDriver.decodeConfig({})).toEqual({ cli: "pi" });
-    expect(PiDriver.decodeConfig(undefined)).toEqual({ cli: "pi" });
-    expect(PiDriver.decodeConfig(null)).toEqual({ cli: "pi" });
-    expect(PiDriver.decodeConfig({ cli: "  " })).toEqual({ cli: "pi" });
+    expect(PiDriver.decodeConfig({})).toEqual({ cli: "pi", fullAuto: false });
+    expect(PiDriver.decodeConfig(undefined)).toEqual({ cli: "pi", fullAuto: false });
+    expect(PiDriver.decodeConfig(null)).toEqual({ cli: "pi", fullAuto: false });
+    expect(PiDriver.decodeConfig({ cli: "  " })).toEqual({ cli: "pi", fullAuto: false });
   });
 
   it("rejects invalid config (throws → shadow snapshot)", () => {
     expect(() => PiDriver.decodeConfig(5)).toThrow(/object/);
     expect(() => PiDriver.decodeConfig({ cli: 5 })).toThrow(/string/);
+    expect(() => PiDriver.decodeConfig({ fullAuto: "yes" })).toThrow(/boolean/);
   });
 
   it("publishes the npm installer on every platform and points docs at pi.dev", () => {
@@ -166,7 +178,7 @@ describe("PiDriver turns (fake CLI)", () => {
       displayName: "pi Test",
       environment: { ...environment, ...(mode ? { FAKE_PI_MODE: mode } : {}) },
       enabled: true,
-      config: { cli: FAKE_CLI },
+      config: { cli: FAKE_CLI, fullAuto: false },
     });
     recorder = recordEvents(instance.adapter);
   };
@@ -365,7 +377,7 @@ describe("PiDriver snapshot", () => {
       displayName: undefined,
       environment: {},
       enabled: true,
-      config: { cli: FAKE_CLI },
+      config: { cli: FAKE_CLI, fullAuto: false },
     });
     const snap = await instance.snapshot();
     expect(snap.state).toBe("available");
@@ -380,7 +392,7 @@ describe("PiDriver snapshot", () => {
       displayName: undefined,
       environment: {},
       enabled: true,
-      config: { cli: "pi-definitely-not-on-path-xyz" },
+      config: { cli: "pi-definitely-not-on-path-xyz", fullAuto: false },
     });
     const snap = await instance.snapshot();
     expect(snap.state).toBe("unavailable");

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -319,15 +319,31 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       }
       const childArgs = mcpServers ? [...PI_ARGS, "-e", SPAWNED_PROXIES.piMcpExtension] : PI_ARGS;
 
-      const child = spawnCli(config.cli, childArgs, {
-        stdio: ["pipe", "pipe", "pipe"],
-        cwd: turn.cwd,
-        env: piEnvironment({
-          ...process.env,
-          ...input.environment,
-          ...(mcpServers && mcpTempDir ? { OMB_MCP_CONFIG: join(mcpTempDir, "mcp.json") } : {}),
-        }),
-      });
+      // spawnCli can throw synchronously (unresolvable CLI); if it does, the
+      // 0600 temp file with the box token / composio key / comms token must
+      // not be left on disk — settle() never runs because no child existed.
+      const child = (() => {
+        try {
+          return spawnCli(config.cli, childArgs, {
+            stdio: ["pipe", "pipe", "pipe"],
+            cwd: turn.cwd,
+            env: piEnvironment({
+              ...process.env,
+              ...input.environment,
+              ...(mcpServers && mcpTempDir ? { OMB_MCP_CONFIG: join(mcpTempDir, "mcp.json") } : {}),
+            }),
+          });
+        } catch (err) {
+          if (mcpTempDir) {
+            try {
+              rmSync(mcpTempDir, { recursive: true, force: true });
+            } catch {
+              /* best effort */
+            }
+          }
+          throw err;
+        }
+      })();
       let buf = "";
       let assistantText = "";
       // resolve one-shot RPC responses (new_session / switch_session / set_model)

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -17,12 +17,15 @@
 // `get_available_models` and every entry is flagged `custom` because pi is a
 // custom-only (BYOK) engine — the model picker's Local pane only lists
 // `custom` options for custom-only engines.
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { PROVIDER_CREDENTIAL_ENV, stripWorkspaceCredentialEnv } from "../config.ts";
+import { computerProxyEnv } from "../container-computer.ts";
 import { augmentedPath } from "../env-path.ts";
 import { describeSpawnFailure, killCliTree, spawnCli } from "../procs.ts";
+import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 
 import type {
   DriverCreateInput,
@@ -39,6 +42,35 @@ import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "piAgent";
 const PI_ARGS = ["--mode", "rpc", "--no-session"];
+const NODE_ENV_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
+
+/** Mirror of the Claude driver's integration → stdio MCP mount: every entry is
+ * a JSON-RPC 2.0 stdio server the pi-mcp-extension consumes. Returns null when
+ * there is nothing to mount (the common case). */
+export function buildMcpServers(turn: SendTurnInput): Record<string, unknown> | null {
+  const servers: Record<string, unknown> = {};
+  if (turn.integrations?.composio) servers.composio = { ...turn.integrations.composio };
+  if (turn.integrations?.computer) {
+    servers.computer = {
+      command: process.execPath,
+      args: [SPAWNED_PROXIES.computer],
+      env: { ...NODE_ENV_FLAG, ...computerProxyEnv(turn.integrations.computer) },
+    };
+  } else if (turn.integrations?.localComputer) {
+    const local = turn.integrations.localComputer;
+    servers.computer = { command: local.command, args: local.args, env: local.env };
+  }
+  if (turn.integrations?.agents) servers.agents = { ...turn.integrations.agents };
+  if (turn.integrations?.phone) servers.phone = { ...turn.integrations.phone };
+  if (turn.integrations?.dweb) {
+    servers.dweb = {
+      command: process.execPath,
+      args: [SPAWNED_PROXIES.dweb],
+      env: { ...NODE_ENV_FLAG, DWEB_URL: turn.integrations.dweb.url },
+    };
+  }
+  return Object.keys(servers).length ? servers : null;
+}
 
 /** A pi `get_available_models` response payload, parsed at its I/O boundary. */
 interface PiModelEntry {
@@ -253,10 +285,26 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       const pending = new Map<string, (decision: { behavior: "allow" | "deny" | "answer"; message?: string }) => void>();
       let settled = false;
 
-      const child = spawnCli(config.cli, PI_ARGS, {
+      // integrations → stdio MCP servers for the pi-mcp-extension. The config
+      // carries credentials (box token, composio key, comms token), so it goes
+      // into a 0600 temp file removed when the turn settles — never on argv.
+      const mcpServers = buildMcpServers(turn);
+      let mcpTempDir: string | null = null;
+      if (mcpServers) {
+        mcpTempDir = mkdtempSync(join(tmpdir(), "omb-pi-mcp-"));
+        const mcpConfigPath = join(mcpTempDir, "mcp.json");
+        writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
+      }
+      const childArgs = mcpServers ? [...PI_ARGS, "-e", SPAWNED_PROXIES.piMcpExtension] : PI_ARGS;
+
+      const child = spawnCli(config.cli, childArgs, {
         stdio: ["pipe", "pipe", "pipe"],
         cwd: turn.cwd,
-        env: piEnvironment({ ...process.env, ...input.environment }),
+        env: piEnvironment({
+          ...process.env,
+          ...input.environment,
+          ...(mcpServers && mcpTempDir ? { OMB_MCP_CONFIG: join(mcpTempDir, "mcp.json") } : {}),
+        }),
       });
       let buf = "";
       let assistantText = "";
@@ -312,6 +360,13 @@ export const PiDriver: ProviderDriver<PiConfig> = {
           killCliTree(child);
         } catch {
           /* already gone */
+        }
+        if (mcpTempDir) {
+          try {
+            rmSync(mcpTempDir, { recursive: true, force: true });
+          } catch {
+            /* best effort */
+          }
         }
         active.delete(threadId);
       };
@@ -536,11 +591,17 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         capabilities: {
           // model is set per turn via set_model before prompt
           sessionModelSwitch: "in-session",
-          // pi's own tools are first-party; the harness MCP integrations are
-          // not mounted in this driver yet.
-          agentsMcp: false,
-          computerMcp: false,
-          composioMcp: false,
+          // Integrations arrive as stdio MCP servers mounted by the
+          // pi-mcp-extension (pi core has no MCP client of its own).
+          agentsMcp: true,
+          computerMcp: true,
+          composioMcp: true,
+          phoneMcp: true,
+          // Host control (the user's real Mac) is deliberately OFF: the
+          // harness routes those actions through its permission broker, which
+          // the pi RPC bridge does not wire up yet. Cloud box / Local VM / VPS
+          // ride `computerMcp` and are isolated, so they are safe to mount.
+          localComputerMcp: false,
           images: false,
         },
         sendTurn,

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -314,8 +314,18 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       let mcpTempDir: string | null = null;
       if (mcpServers) {
         mcpTempDir = mkdtempSync(join(tmpdir(), "omb-pi-mcp-"));
-        const mcpConfigPath = join(mcpTempDir, "mcp.json");
-        writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
+        try {
+          writeFileSync(join(mcpTempDir, "mcp.json"), JSON.stringify({ mcpServers }), { mode: 0o600 });
+        } catch (err) {
+          // A failed write must not leave the temp dir behind — a partial file
+          // could still hold the box token / composio key / comms token.
+          try {
+            rmSync(mcpTempDir, { recursive: true, force: true });
+          } catch {
+            /* best effort */
+          }
+          throw err;
+        }
       }
       const childArgs = mcpServers ? [...PI_ARGS, "-e", SPAWNED_PROXIES.piMcpExtension] : PI_ARGS;
 

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -58,7 +58,14 @@ export function buildMcpServers(turn: SendTurnInput): Record<string, unknown> | 
     };
   } else if (turn.integrations?.localComputer) {
     const local = turn.integrations.localComputer;
-    servers.computer = { command: local.command, args: local.args, env: local.env };
+    servers.computer = {
+      command: local.command,
+      args: local.args,
+      env: local.env,
+      // Host control carries scope so the extension gates every call behind
+      // a permission card; isolated computers deliberately omit it.
+      ...(local.scope ? { scope: local.scope } : {}),
+    };
   }
   if (turn.integrations?.agents) servers.agents = { ...turn.integrations.agents };
   if (turn.integrations?.phone) servers.phone = { ...turn.integrations.phone };
@@ -180,14 +187,22 @@ export async function fetchPiModels(
 
 export interface PiConfig {
   cli: string;
+  /** Full-auto: never ask before an action. Host control is unavailable in
+   * this mode — the same knob as Claude's `bypassPermissions` and the ACP
+   * engines' `fullAuto`. */
+  fullAuto: boolean;
 }
 
 function decodeConfig(raw: unknown): PiConfig {
-  if (raw === null || raw === undefined) return { cli: "pi" };
+  if (raw === null || raw === undefined) return { cli: "pi", fullAuto: false };
   if (typeof raw !== "object") throw new Error("pi config must be an object");
-  const obj = raw as { cli?: unknown };
+  const obj = raw as { cli?: unknown; fullAuto?: unknown };
   if (obj.cli !== undefined && typeof obj.cli !== "string") throw new Error("pi config `cli` must be a string");
-  return { cli: obj.cli && obj.cli.trim() ? obj.cli.trim() : "pi" };
+  if (obj.fullAuto !== undefined && typeof obj.fullAuto !== "boolean") throw new Error("pi config `fullAuto` must be a boolean");
+  return {
+    cli: obj.cli && obj.cli.trim() ? obj.cli.trim() : "pi",
+    fullAuto: obj.fullAuto === true,
+  };
 }
 
 const EMPTY: ModelCatalog = { default: "", options: [] };
@@ -281,6 +296,13 @@ export const PiDriver: ProviderDriver<PiConfig> = {
     const sendTurn = async (turn: SendTurnInput) => {
       const { threadId } = turn;
       if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      // Host control always routes through the permission card; full-auto must
+      // never get unapproved hands on the user's machine (same guard as the
+      // Claude and ACP drivers).
+      const controlsHost = turn.integrations?.localComputer?.scope === "local-computer";
+      if (controlsHost && config.fullAuto) {
+        throw new Error("local computer control requires the interactive approval broker");
+      }
       const turnId = newId();
       const pending = new Map<string, (decision: { behavior: "allow" | "deny" | "answer"; message?: string }) => void>();
       let settled = false;
@@ -597,11 +619,11 @@ export const PiDriver: ProviderDriver<PiConfig> = {
           computerMcp: true,
           composioMcp: true,
           phoneMcp: true,
-          // Host control (the user's real Mac) is deliberately OFF: the
-          // harness routes those actions through its permission broker, which
-          // the pi RPC bridge does not wire up yet. Cloud box / Local VM / VPS
-          // ride `computerMcp` and are isolated, so they are safe to mount.
-          localComputerMcp: false,
+          // Host control (the user's real Mac) rides the pi-native permission
+          // card (`ctx.ui.confirm` → extension_ui_request) gated in the
+          // extension, so it is offered exactly when the other engines offer
+          // it: enabled unless the bot is in full-auto.
+          localComputerMcp: !config.fullAuto,
           images: false,
         },
         sendTurn,

--- a/server/proxy-paths.ts
+++ b/server/proxy-paths.ts
@@ -42,4 +42,8 @@ export const SPAWNED_PROXIES = {
   dweb: resolveProxy("drivers/dweb-proxy"),
   connectors: resolveProxy("connector-proxy"),
   phone: resolveProxy("drivers/phone-proxy"),
+  // Loaded by the external `pi` process via `-e`, not by this server — but
+  // resolved through the same single source of truth so the packaged layout
+  // check can assert it ships.
+  piMcpExtension: resolveProxy("drivers/pi-mcp-extension"),
 } as const;

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -10,7 +10,7 @@
 //   FAKE_PI_DUMP   path to append {argv, env} JSON, so a test can assert argv shape
 //                  and env hygiene (no leaked secrets into the pi child).
 
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 
 const mode = process.env.FAKE_PI_MODE ?? "happy";
 const modelPairs = (process.env.FAKE_PI_MODELS ?? "ollama-cloud/glm-5.2,openai/gpt-4o")
@@ -31,6 +31,18 @@ if (argv.includes("--version") || argv.includes("-v")) {
 
 if (process.env.FAKE_PI_DUMP) {
   try {
+    // When the driver mounts integrations it hands the MCP config through
+    // OMB_MCP_CONFIG; read it here so a test can assert the mount contract
+    // (servers, proxy wrap, credential hygiene) without racing the temp file
+    // cleanup the driver runs at turn settle.
+    let mcpConfig: unknown = null;
+    if (process.env.OMB_MCP_CONFIG) {
+      try {
+        mcpConfig = JSON.parse(readFileSync(process.env.OMB_MCP_CONFIG, "utf8"));
+      } catch {
+        /* unreadable config dumps as null */
+      }
+    }
     appendFileSync(
       process.env.FAKE_PI_DUMP,
       JSON.stringify({
@@ -38,6 +50,7 @@ if (process.env.FAKE_PI_DUMP) {
         envConfigured: ["PATH", "HOME", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "BOX_TOKEN"].filter(
           (k) => process.env[k] !== undefined,
         ),
+        mcpConfig,
       }) + "\n",
     );
   } catch {

--- a/tsconfig.server.build.json
+++ b/tsconfig.server.build.json
@@ -9,7 +9,8 @@
   },
   "exclude": [
     "server/**/*.test.ts",
-    "server/testing"
+    "server/testing",
+    "server/drivers/pi-mcp-extension.ts"
   ],
   "include": [
     "server"

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -21,5 +21,8 @@
   "include": [
     "server",
     "companion"
+  ],
+  "exclude": [
+    "server/drivers/pi-mcp-extension.ts"
   ]
 }


### PR DESCRIPTION
## What

The `pi` engine (the pi coding agent, BYOK) now gets the same "hands" every other CLI engine has: the harness's managed integrations mount as first-class pi tools.

- **MCP integrations**: `computerMcp` (cloud Box / Local VM / VPS), `composioMcp` (500+ connected apps), `agentsMcp` (bot↔bot comms), and `phoneMcp` are now enabled and delivered to pi as stdio JSON-RPC 2.0 servers.
- **A pi extension, shipped by OpenMausBot** (`server/drivers/pi-mcp-extension.ts`): pi core ships no MCP client, so this extension — loaded via `pi -e` — spawns each stdio server, performs the initialize/tools-list handshake, converts JSON Schema to typebox, and registers every tool with `pi.registerTool`. **The pi repo itself is never touched** (public `registerTool` extension API only).
- **Permission cards, standard parity**: host control (the user's real Mac) is gated behind pi's native `ctx.ui.confirm` → `extension_ui_request` → the same Allow/Deny card the Claude/ACP/Codex drivers produce. A new `fullAuto` config (== Claude `bypassPermissions` == ACP `fullAuto`) disables host control in full-auto mode and throws if a host-control turn is requested.

## Why

`pi` was previously a "brain-only" engine: it reasoned and used pi's own local tools, but couldn't reach the harness's computer/apps/bots — the whole point of the OpenMausBot surface.

## How (details)

- `server/drivers/pi.ts`: `buildMcpServers()` mirrors the Claude driver's mount; the MCP config rides a 0600 temp file (credentials never on argv), removed at turn settle; capabilities flip `computerMcp/composioMcp/agentsMcp/phoneMcp` on and expose `localComputerMcp: !fullAuto`.
- `server/drivers/pi-mcp-extension.ts`: a pi extension (loaded `-e`) that reads `OMB_MCP_CONFIG`, mounts each stdio MCP server, and gates `scope=local-computer` tools behind a permission card.
- `server/proxy-paths.ts` + `scripts/bundle-server.mjs`: resolve + ship the extension verbatim as `.ts` (never bundled — pi resolves its own `@earendil-works/*` and `typebox`).
- `tsconfig.*`: exclude the extension from OpenMausBot typecheck (it imports pi's packages).

## Memory note

Not part of this PR: per-bot durable memory already exists (`server/workspace.ts`, `MEMORY.md` + `memory/<topic>.md`, injected into the system prompt), and it already works for pi — no change needed.

## Testing

- `pnpm typecheck` ✅
- `vitest run` — 163 files / 1705 tests passing ✅
- New `pi.test.ts` cases cover the integration → stdio MCP mount contract (composio passthrough, computer-proxy wrap, credentials out of argv).
- Smoke-tested the extension against the real `pi` binary + a fake MCP server: `initialize → notifications/initialized → tools/list` handshake completes with no errors.

## Not in scope (follow-ups)

- Image passthrough (`images: true`) and non-text MCP content (screenshots).
- Automatic memory synthesis from transcripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for connecting configured MCP integrations to Pi.
  - Discovered MCP tools are now available within Pi sessions.
  - Added optional full-auto mode, restricting host computer control for safety.
  - Added confirmation requirements for local computer actions.

- **Bug Fixes**
  - Improved handling of invalid configurations, startup failures, disconnected servers, timeouts, and MCP errors.
  - Securely manages temporary integration configuration and removes it after use.

- **Tests**
  - Expanded coverage for integration setup, permissions, configuration validation, error handling, and credential protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->