### PR TITLE
fix: recover VPS computers after image upgrades

### DIFF
--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -37,6 +37,7 @@ import {
   localComputerDisabledReason,
   localComputerSelectable,
 } from "@/lib/local-computer";
+import { vpsComputerNeedsReplacement, type VpsComputerStatus } from "@/lib/vps-computer";
 
 async function api(path: string, init?: RequestInit): Promise<any> {
   const res = await fetch(path, { headers: { "content-type": "application/json" }, ...init });
@@ -53,6 +54,7 @@ type Phase =
   | "vm"
   | "vm-unavailable"
   | "vps-unconfigured"
+  | "vps-incompatible"
   | "vps-stopped"
   | "local"
   | "local-unavailable"
@@ -122,9 +124,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   // the only way a person can actually drive the VM.
   const [vmViewerUrl, setVmViewerUrl] = useState<string | null>(null);
   const [vmStatus, setVmStatus] = useState<LocalVmStatus | null>(null);
+  const [vpsStatus, setVpsStatus] = useState<VpsComputerStatus | null>(null);
   const [localFrame, setLocalFrame] = useState<string | null>(null);
   const [pending, setPending] = useState<
-    "join" | "sleep" | "provision" | "vm-create" | "vm-recreate" | "vm-delete" | null
+    "join" | "sleep" | "provision" | "vps-replace" | "vm-create" | "vm-recreate" | "vm-delete" | null
   >(null);
   const [controlPending, setControlPending] = useState(false);
   const [viewerOpen, setViewerOpen] = useState(false);
@@ -195,6 +198,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     setVmFrame(null);
     setVmViewerUrl(null);
     setVmStatus(null);
+    setVpsStatus(null);
     setLocalFrame(null);
     setError(null);
     if (bot.computer === "off") {
@@ -279,8 +283,10 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         return;
       }
       api(`/api/bots/${bot.id}/computer`)
-        .then((status) => {
+        .then((rawStatus) => {
           if (!alive) return;
+          const status: VpsComputerStatus = rawStatus;
+          setVpsStatus(status);
           if (!status.configured) {
             if (autoLocal) setPhase("local");
             else {
@@ -292,6 +298,15 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
           if (status.ready) {
             setBoxState(status.container ?? null);
             setPhase("ready");
+            return;
+          }
+          // App updates can bump IMAGE_LAYER_VERSION while this bot still has
+          // a managed container from the previous release. Provision refuses
+          // to overwrite it by design, so surface the explicit replacement
+          // path instead of automatically issuing a request that can only 409.
+          if (vpsComputerNeedsReplacement(status)) {
+            setError(status.problem);
+            setPhase("vps-incompatible");
             return;
           }
           if (bot.computer === "cloud") {
@@ -617,6 +632,29 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     }
   };
 
+  const replaceVpsComputer = async () => {
+    if (!window.confirm(`Replace ${bot.name}'s VPS computer with the version required by this OpenMausBot update? Files stored only inside the disposable container will be deleted.`)) return;
+    setPending("vps-replace");
+    setError(null);
+    try {
+      await api(`/api/bots/${bot.id}/computer/remove`, { method: "POST", body: "{}" });
+      const result: VpsComputerStatus = await api(`/api/bots/${bot.id}/computer/provision`, {
+        method: "POST",
+        body: "{}",
+      });
+      setVpsStatus(result);
+      setBoxState(result.container ?? null);
+      setPhase(result.ready ? "ready" : "error");
+      if (!result.ready) setError(result.problem ?? "The replacement VPS Cua desktop is not ready yet");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setPhase("error");
+    } finally {
+      setPending(null);
+      setRetry((n) => n + 1);
+    }
+  };
+
   const openVmSettings = () => {
     window.sessionStorage.setItem("openmausbot.settings.section", "computer");
     dispatch({ type: "toggleAppSettings", open: true });
@@ -631,6 +669,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     starting: "Starting your bot's computer…",
     unconfigured: "No cloud computer configured",
     "vps-unconfigured": "No managed VPS computer is configured for this bot",
+    "vps-incompatible": "This VPS computer belongs to an earlier OpenMausBot version",
     "vps-stopped": "The managed VPS computer is stopped",
     "local-unavailable": localDisabledReason ?? "Local computer control isn't ready.",
     "vm-unavailable": "The Local VM isn't available for this bot",
@@ -772,6 +811,16 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 >
                   {pending === "provision" && <Loader2 size={13} className="mr-1.5 inline animate-spin" />}
                   Start VPS computer
+                </button>
+              )}
+              {phase === "vps-incompatible" && vpsStatus?.managed && (
+                <button
+                  onClick={() => void replaceVpsComputer()}
+                  disabled={pending === "vps-replace"}
+                  className="mt-1 rounded-lg bg-accent px-3 py-1.5 text-[12px] font-medium text-white hover:brightness-110 disabled:opacity-50"
+                >
+                  {pending === "vps-replace" && <Loader2 size={13} className="mr-1.5 inline animate-spin" />}
+                  Replace VPS computer
                 </button>
               )}
             </div>

--- a/src/lib/vps-computer.test.ts
+++ b/src/lib/vps-computer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { vpsComputerNeedsReplacement, type VpsComputerStatus } from "./vps-computer";
+
+const current: VpsComputerStatus = {
+  configured: true,
+  imageMatches: true,
+  managed: true,
+  container: "running",
+  ready: true,
+  problem: null,
+};
+
+describe("VPS computer upgrade recovery", () => {
+  it("offers replacement only for an existing managed container with an incompatible image", () => {
+    expect(vpsComputerNeedsReplacement({ ...current, imageMatches: false, ready: false })).toBe(true);
+    expect(vpsComputerNeedsReplacement({ ...current, container: "stopped", imageMatches: false, ready: false })).toBe(true);
+    expect(vpsComputerNeedsReplacement({ ...current, container: "missing", imageMatches: false, ready: false })).toBe(false);
+    expect(vpsComputerNeedsReplacement({ ...current, managed: false, imageMatches: false, ready: false })).toBe(false);
+    expect(vpsComputerNeedsReplacement(current)).toBe(false);
+  });
+});

--- a/src/lib/vps-computer.ts
+++ b/src/lib/vps-computer.ts
@@ -1,0 +1,14 @@
+export interface VpsComputerStatus {
+  configured: boolean;
+  imageMatches: boolean;
+  managed: boolean;
+  container: "running" | "stopped" | "missing";
+  ready: boolean;
+  problem: string | null;
+}
+
+/** A managed container from an older release must be explicitly replaced.
+ * Provision deliberately refuses to overwrite it. */
+export function vpsComputerNeedsReplacement(status: VpsComputerStatus): boolean {
+  return status.managed && status.container !== "missing" && !status.imageMatches;
+}


### PR DESCRIPTION
## Summary

- detect a managed VPS container whose image no longer matches the current image layer before auto-provisioning
- show an explicit **Replace VPS computer** recovery action instead of issuing a Provision request that is guaranteed to return 409
- require confirmation before removing the disposable container, then remove and reprovision it through the existing guarded endpoints
- add a regression test for the stale-managed-container decision

## Reproduction

After updating OpenMausBot 0.1.27 → 0.1.32, an existing BYO-VPS bot still had `driver-0.20.0-v3`, while the app required `driver-0.20.0-v4`.

The Computer panel automatically called Provision. The server correctly refused to overwrite the existing incompatible container, but the panel exposed no Remove/replace action. The user was left at:

```text
Prepare the pinned OpenMausBot Cua image on the VPS (Driver 0.20.0)
```

The only recovery was an out-of-band API sequence:

```text
POST /computer/remove → POST /computer/provision
```

This PR makes that already-supported recovery discoverable and confirmed in the Computer panel.

## Safety

- replacement is offered only when the container is app-managed, present, and image-incompatible
- no automatic deletion: the user must click Replace and confirm the disposable-container warning
- unowned containers remain protected by the existing server-side ownership gate

## Verification

- `pnpm typecheck`
- `vitest run src/lib/vps-computer.test.ts server/vps-computer.test.ts` — 19/19 passed
- full `pnpm test` — 1,699 passed, 12 skipped (1,711 total)
- live recovery on a BYO-VPS installation: v4 image labels matched, container healthy/hardened/private, `desktopReady: true`, and a 1280×900 Cua screenshot succeeded

## Lint note

`pnpm lint` currently reports existing repository-wide anti-slop findings in untouched files; TypeScript and all test suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VPS compatibility checks for managed computers.
  * Displays a clear warning when a computer requires replacement.
  * Added a confirmation flow to replace and reprovision incompatible computers.
  * The desktop viewer now closes automatically when control is handed back.

* **Bug Fixes**
  * Prevents incompatible container images from continuing to be used.

* **Tests**
  * Added coverage for compatible, incompatible, missing, managed, and unmanaged computers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->