### PR TITLE
Stop burning CPU on decoration: idle mascots, hidden polls, lazy sidecar

### DIFF
--- a/companion/src/advertise-watch.ts
+++ b/companion/src/advertise-watch.ts
@@ -39,8 +39,10 @@ export interface AddressWatcher {
 }
 
 /** How often the interface table is consulted. Reading it is a syscall, not
- * a packet — nothing goes on the wire unless something changed. */
-const DEFAULT_INTERVAL_MS = 5000;
+ * a packet — nothing goes on the wire unless something changed. Networks
+ * change on the minutes scale (sleep/wake, wifi hop); this is the sidecar's
+ * only recurring wakeup, so it earns a lazy cadence. */
+const DEFAULT_INTERVAL_MS = 30_000;
 
 export function createAddressWatcher(options: AddressWatchOptions): AddressWatcher {
   // The set last *acted on*, as a canonical key. `null` means "never", which

--- a/ios/App/AgentProfileView.swift
+++ b/ios/App/AgentProfileView.swift
@@ -50,7 +50,7 @@ struct AgentProfileView: View {
                 Section {
                     HStack {
                         Spacer()
-                        BotAvatarView(bot: current, size: 112, state: .happy)
+                        BotAvatarView(bot: current, size: 112, state: .happy, animated: true)
                         Spacer()
                     }
                     .listRowBackground(Color.clear)

--- a/ios/App/BotAvatarView.swift
+++ b/ios/App/BotAvatarView.swift
@@ -9,7 +9,8 @@ struct BotAvatarView: View {
     let bot: Bot
     let size: CGFloat
     var state: MausState = .idle
-    var animated = true
+    /// Opt-in, mirroring MausAvatar: an animated face is a 30fps canvas.
+    var animated = false
     var comets = false
 
     @EnvironmentObject private var session: Session
@@ -62,7 +63,8 @@ struct ChatAvatarView: View {
     let chat: Chat
     let size: CGFloat
     var state: MausState = .idle
-    var animated = true
+    /// Opt-in, mirroring MausAvatar: an animated face is a 30fps canvas.
+    var animated = false
     var comets = false
 
     var body: some View {

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -412,7 +412,7 @@ struct ChatRow: View {
             .frame(maxHeight: .infinity)
 
             HStack(alignment: .top, spacing: 14) {
-                ChatAvatarView(chat: chat, size: 52, state: state)
+                ChatAvatarView(chat: chat, size: 52, state: state, animated: state.showsActivity)
                     .padding(.top, 12)
 
                 VStack(alignment: .leading, spacing: 4) {

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -180,7 +180,7 @@ struct ChatView: View {
                                 Color.clear
                             }
                         }
-                        ChatAvatarView(chat: current, size: faceSize, state: MausState.forChat(current, in: session.state), comets: islandExpanded)
+                        ChatAvatarView(chat: current, size: faceSize, state: MausState.forChat(current, in: session.state), animated: MausState.forChat(current, in: session.state).showsActivity || islandExpanded, comets: islandExpanded)
                             .offset(y: faceCentre - faceSize / 2)
                             .allowsHitTesting(false)
                     }

--- a/ios/App/Island.swift
+++ b/ios/App/Island.swift
@@ -73,6 +73,10 @@ struct NeedsYouIsland: View {
     @State private var shown: ChatUpdate?
     @State private var dismissedCardIds = Set<String>()
     @State private var answering = false
+    // The comet face is the costliest draw in the app. It earns a beat of
+    // motion when the island appears; an approval left unattended overnight
+    // must not keep a 30fps orbit running until morning.
+    @State private var attentionLive = true
 
     private var expanded: Bool { shown != nil }
 
@@ -90,9 +94,14 @@ struct NeedsYouIsland: View {
                         // The hardware island covers the first 37pt of the
                         // square; the face sits clear of it, centred.
                         Button { open(shown.chat) } label: {
-                            ChatAvatarView(chat: shown.chat, size: 120, state: MausState.forChat(shown.chat, in: session.state), comets: true)
+                            ChatAvatarView(chat: shown.chat, size: 120, state: MausState.forChat(shown.chat, in: session.state), animated: attentionLive, comets: attentionLive)
                         }
                         .buttonStyle(.plain)
+                        .task(id: shown.chat.id) {
+                            attentionLive = true
+                            try? await Task.sleep(for: .seconds(30))
+                            attentionLive = false
+                        }
                         .padding(.top, IslandGeometry.size.height + 14)
 
                         VStack(spacing: 4) {

--- a/ios/App/MausAvatar.swift
+++ b/ios/App/MausAvatar.swift
@@ -208,16 +208,22 @@ struct MausAvatar: View {
     let color: String
     var size: CGFloat = 52
     var state: MausState = .idle
-    /// Off draws the state's resting face, still. For lists of many.
-    var animated: Bool = true
+    /// Animation is OPT-IN: a mounted face costs a 30fps Canvas redraw, and a
+    /// roster of them once pegged the app (and SimRenderServer) all night.
+    /// Pass true only where motion carries meaning — a busy bot, an open
+    /// profile, the needs-you island's opening beat.
+    var animated: Bool = false
     /// Comets orbiting the body — the island's "something is happening".
     var comets: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @State private var engine = MausFaceEngine()
 
     var body: some View {
-        let live = animated && !reduceMotion
+        // Even an opted-in face stops when the app is not active: nothing is
+        // watching, and in the background the redraws only cost battery.
+        let live = animated && !reduceMotion && scenePhase == .active
         TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: !live)) { timeline in
             Canvas { context, canvasSize in
                 engine.setState(state, now: timeline.date)

--- a/ios/App/MausFaceData.swift
+++ b/ios/App/MausFaceData.swift
@@ -5,6 +5,15 @@
 import CoreGraphics
 
 enum MausState: String, CaseIterable {
+    /// States whose motion carries information — a turn in progress. Faces in
+    /// lists animate only for these; a resting bot earns a resting face.
+    var showsActivity: Bool {
+        switch self {
+        case .listening, .thinking, .searching, .working: return true
+        default: return false
+        }
+    }
+
     case sleeping = "sleeping"
     case waking = "waking"
     case idle = "idle"

--- a/src/components/AndroidDevicePanel.tsx
+++ b/src/components/AndroidDevicePanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, Circle, Loader2, RotateCcw, ShieldCheck, Smartphone, Usb } from "lucide-react";
+import { usePageVisible } from "@/lib/page-visible";
 import type { AndroidDeviceInput, AndroidDeviceStatus, AndroidUsbDevice } from "@/types/ogb";
 
 type UnitPoint = { x: number; y: number };
@@ -9,9 +10,11 @@ const EMPTY_STATUS: AndroidDeviceStatus = { available: false, devices: [] };
 export function useAndroidUsbDevices() {
   const bridge = window.ogb?.androidDevice;
   const [status, setStatus] = useState<AndroidDeviceStatus>(EMPTY_STATUS);
+  const pageVisible = usePageVisible();
 
   useEffect(() => {
-    if (!bridge) return;
+    // every tick is an adb subprocess — nothing to learn while hidden
+    if (!bridge || !pageVisible) return;
     let alive = true;
     const refresh = async () => {
       try {
@@ -34,7 +37,7 @@ export function useAndroidUsbDevices() {
       alive = false;
       window.clearInterval(timer);
     };
-  }, [bridge]);
+  }, [bridge, pageVisible]);
 
   return status;
 }
@@ -45,6 +48,7 @@ function deviceLabel(device: AndroidUsbDevice) {
 
 export function AndroidDevicePanel({ status }: { status: AndroidDeviceStatus }) {
   const bridge = window.ogb?.androidDevice;
+  const pageVisible = usePageVisible();
   const authorized = status.devices.filter((device) => device.state === "device");
   const [serial, setSerial] = useState(authorized[0]?.serial ?? status.devices[0]?.serial ?? "");
   const [frame, setFrame] = useState<string | null>(null);
@@ -69,7 +73,9 @@ export function AndroidDevicePanel({ status }: { status: AndroidDeviceStatus }) 
   }, [selected, status.devices]);
 
   useEffect(() => {
-    if (!bridge || !selectedSerial || selectedState !== "device") {
+    // an adb screencap subprocess per tick — pause the mirror while hidden
+    if (!bridge || !selectedSerial || selectedState !== "device" || !pageVisible) {
+      if (!pageVisible) return;
       setFrame(null);
       return;
     }
@@ -93,7 +99,7 @@ export function AndroidDevicePanel({ status }: { status: AndroidDeviceStatus }) 
       alive = false;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [bridge, selectedSerial, selectedState]);
+  }, [bridge, selectedSerial, selectedState, pageVisible]);
 
   useEffect(
     () => () => {

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -22,6 +22,7 @@ import { useStore, type Bot } from "@/state/store";
 import type { Routine } from "@/lib/routines";
 import { ApiKeyRow } from "./ApiKeys";
 import { cn } from "@/lib/cn";
+import { usePageVisible } from "@/lib/page-visible";
 import { CloudBackendPicker } from "./CloudBackendPicker";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { RoutineEditor } from "./RoutinesPage";
@@ -402,12 +403,15 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
     state.config?.vps?.sshAlias,
   ]);
 
-  // cloud preview: SSE frames win while the bot works; otherwise poll
+  // cloud preview: SSE frames win while the bot works; otherwise poll.
+  // Every preview poll below gates on visibility and slows way down for an
+  // idle bot — a drawer left open overnight must not keep shooting.
+  const pageVisible = usePageVisible();
   const live = state.screens[bot.id];
   const sseFlowing = Boolean(bot.busy && live);
   const inFlight = useRef(false);
   useEffect(() => {
-    if (phase !== "ready" || sseFlowing || viewerOpen) return;
+    if (phase !== "ready" || sseFlowing || viewerOpen || !pageVisible) return;
     let alive = true;
     const shoot = async () => {
       if (inFlight.current) return;
@@ -422,18 +426,18 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       }
     };
     void shoot();
-    const timer = setInterval(shoot, 4000);
+    const timer = setInterval(shoot, bot.busy ? 4000 : 30_000);
     return () => {
       alive = false;
       clearInterval(timer);
     };
-  }, [phase, sseFlowing, bot.id, viewerOpen]);
+  }, [phase, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
 
   // Local VM preview comes directly from Cua Driver through the harness. It
   // does not use the password-protected noVNC viewer or cloud endpoints.
   const vmInFlight = useRef(false);
   useEffect(() => {
-    if (phase !== "vm" || viewerOpen) return;
+    if (phase !== "vm" || viewerOpen || !pageVisible) return;
     let alive = true;
     const shoot = async () => {
       if (vmInFlight.current) return;
@@ -448,12 +452,12 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       }
     };
     void shoot();
-    const timer = window.setInterval(() => void shoot(), 3000);
+    const timer = window.setInterval(() => void shoot(), bot.busy ? 3000 : 30_000);
     return () => {
       alive = false;
       window.clearInterval(timer);
     };
-  }, [phase, bot.id, viewerOpen]);
+  }, [phase, bot.id, viewerOpen, pageVisible, bot.busy]);
 
   // local preview: frames from the Electron main process. The FIRST capture
   // attempt is what makes macOS show the Screen Recording prompt (there is
@@ -461,7 +465,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   // the user denied — surface the Settings repair path instead of spinning.
   const [localMisses, setLocalMisses] = useState(0);
   useEffect(() => {
-    if (phase !== "local" || !window.ogb || isLinux) return;
+    if (phase !== "local" || !window.ogb || isLinux || !pageVisible) return;
     let alive = true;
     setLocalMisses(0);
     const shoot = async () => {
@@ -474,12 +478,14 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       }
     };
     void shoot();
-    const timer = setInterval(shoot, 3000);
+    // A real ScreenCaptureKit capture + PNG encode per tick: idle bots get a
+    // slow heartbeat, working ones the live cadence.
+    const timer = setInterval(shoot, bot.busy ? 3000 : 30_000);
     return () => {
       alive = false;
       clearInterval(timer);
     };
-  }, [phase, isLinux]);
+  }, [phase, isLinux, pageVisible, bot.busy]);
 
   const lastScreenMessage = [...bot.messages].reverse().find((m) => m.kind === "screen" && m.png);
   const cloudFrame =

--- a/src/components/CursorAvatar.tsx
+++ b/src/components/CursorAvatar.tsx
@@ -1436,6 +1436,7 @@ export const CursorAvatar = React.forwardRef<CursorAvatarHandle, CursorAvatarPro
 
     useEffect(() => {
       let frame = 0
+      let wake: ReturnType<typeof setTimeout> | undefined
       engine.current.last = performance.now()
 
       const draw = (e: typeof engine.current, now: number, spinTurn: number) => {
@@ -1532,12 +1533,21 @@ export const CursorAvatar = React.forwardRef<CursorAvatarHandle, CursorAvatarPro
       }
 
       const step = (now: number) => {
-        frame = requestAnimationFrame(step)
         const e = engine.current
         const p = e.props
+        // A paused mascot must not wake at display rate: re-arming BEFORE the
+        // pause check once had N idle sidebar faces ticking at 60fps forever.
+        // While paused, poll for unpause at 4Hz — no springs, no DOM writes.
+        if (p.paused) {
+          e.last = now
+          wake = setTimeout(() => {
+            frame = requestAnimationFrame(step)
+          }, 250)
+          return
+        }
+        frame = requestAnimationFrame(step)
         const dt = Math.min((now - e.last) / 1000, 0.1)
         e.last = now
-        if (p.paused) return
 
         const f = p.spring ?? 7
         e.velocity += (-2 * f * e.velocity - f * f * (e.morph - 1)) * dt
@@ -1558,7 +1568,10 @@ export const CursorAvatar = React.forwardRef<CursorAvatarHandle, CursorAvatarPro
       }
 
       frame = requestAnimationFrame(step)
-      return () => cancelAnimationFrame(frame)
+      return () => {
+        cancelAnimationFrame(frame)
+        if (wake !== undefined) clearTimeout(wake)
+      }
     }, [])
 
     const paint = `url(#${uid}-grad)`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -179,7 +179,7 @@ function StackedMauses({ members, density }: { members: Bot[]; density: SidebarD
     const b = members[0];
     return (
       <div className={cn("flex shrink-0 items-center justify-center", slotSize)}>
-        {b ? <BotAvatar bot={b} state="happy" size={singleSize} /> : <Users size={24} className="text-ink-secondary" />}
+        {b ? <BotAvatar bot={b} state="happy" size={singleSize} animated={false} /> : <Users size={24} className="text-ink-secondary" />}
       </div>
     );
   }
@@ -189,7 +189,7 @@ function StackedMauses({ members, density }: { members: Bot[]; density: SidebarD
     <div className={cn("flex shrink-0 items-center justify-center", slotSize)}>
       <div className="flex items-center -space-x-3">
         {shown.map((b) => (
-          <BotAvatar key={b.id} bot={b} state="happy" size={30} />
+          <BotAvatar key={b.id} bot={b} state="happy" size={30} animated={false} />
         ))}
         {extra > 0 && (
           <span className="z-10 flex size-[22px] items-center justify-center rounded-full border border-hairline/40 bg-raised text-[10px] font-medium text-ink-secondary">
@@ -773,6 +773,11 @@ function BotListItem({
         size={avatarSize}
         motion={mascotMotion?.kind ?? "none"}
         motionKey={mascotMotion?.nonce ?? 0}
+        // Motion means something is happening. A resting bot holds a resting
+        // pose — N idle rows bobbing at display rate was most of the app's
+        // visible-idle CPU (states are keyword-derived, so "working" can be
+        // decorative; busy/unread/motion are the real signals).
+        animated={Boolean(bot.busy) || Boolean(bot.unread) || (mascotMotion?.kind ?? "none") !== "none"}
       />
       <div className={cn("min-w-0 flex-1", iconOnly && "hidden")}>
         <div className="flex items-baseline justify-between gap-2">
@@ -977,7 +982,7 @@ function ArchivedBotsPanel({
           <div className="grid grid-cols-1 gap-x-8 md:grid-cols-2">
             {bots.map((bot) => (
               <div key={bot.id} className="flex min-h-[82px] items-center gap-3 border-b border-hairline/35 px-1 py-3">
-                <BotAvatar bot={bot} state="happy" size={42} />
+                <BotAvatar bot={bot} state="happy" size={42} animated={false} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-[14px] font-medium text-ink">{bot.name}</div>
                   <div className="mt-0.5 truncate text-[12.5px] text-ink-secondary">{bot.title || "Bot"}</div>

--- a/src/lib/page-visible.ts
+++ b/src/lib/page-visible.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+/** Whether the document is visible. Poll-style effects include this in their
+ * deps so a hidden window tears its interval down instead of capturing
+ * screenshots nobody can see. */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(() => document.visibilityState === "visible");
+  useEffect(() => {
+    const onChange = () => setVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onChange);
+    return () => document.removeEventListener("visibilitychange", onChange);
+  }, []);
+  return visible;
+}


### PR DESCRIPTION
## Why

An iPhone 17 Pro simulator left on the roster overnight sat at **~41% CPU** (OpenMausCompanion) with **SimRenderServer at ~38%** for 8 hours. Two audits traced it: every mounted mascot face was an always-on animation loop — 30fps `TimelineView`+`Canvas` per chat row on iOS, a 60fps rAF loop per avatar on desktop whose `paused` check ran *after* re-arming — and the computer drawer's preview polls ran at full cadence regardless of visibility or bot activity. On a real phone this is battery, not just heat.

## What changed

**Motion is now signal, not decoration — animation is opt-in on both platforms.**

- **iOS**: `animated` defaults to `false` in `MausAvatar`/`BotAvatarView`/`ChatAvatarView`. Opt-in sites: roster rows and the chat header only while the bot's state shows activity (listening/thinking/searching/working — new `MausState.showsActivity`), the open profile sheet, and the needs-you island. Opted-in faces also stop when `scenePhase != .active`, and the island's comet orbit (the costliest draw path) goes still 30s after appearing, so an unattended approval can't keep a 30fps orbit running until morning.
- **Desktop**: the rAF loop parks on a 4Hz wake-poll while paused instead of ticking at display rate; sidebar rows animate only for busy/unread/motion-beat bots (states are keyword-derived, so "working" can be decorative — busy/unread are the real signals); decorative avatar strips are still.
- **Computer drawer**: cloud (4s), Local VM (3s), host ScreenCaptureKit (3s), `adb devices` (2s), and phone screencap (850ms) polls all gate on `document.visibilityState` and drop to a 30s heartbeat when the bot is idle.
- **Companion sidecar**: interface-table poll 5s → 30s (its only recurring wakeup).

## Deliberately deferred

Pausing idle **Local VM containers** (the other big idle burner: a full Linux desktop per bot runs for 8h after last use). `docker pause` reports paused containers as `Running`, so the status parser and the turn/screenshot/panel choke points all need to learn the state and unpause lazily — that deserves its own PR against the fresh #332 lease fences, not a rider here. Design notes in the commit message.

## Verification

- Renderer + companion: typecheck clean, 377 tests green locally.
- iOS: compile-checked by CI's Swift job (behavioral change is prop defaults + a scenePhase gate).
- Audit reports (two independent agents, one per platform) available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar animations now appear selectively for active, busy, or attention-needed states.
  * Avatars pause when the app is inactive or the page is hidden, while respecting Reduce Motion settings.
  * Activity indicators can remain animated briefly when attention is needed.
* **Performance**
  * Background polling and screen previews pause when the page is hidden.
  * Idle devices and bots use less frequent polling, while active bots remain responsive.
  * Address monitoring now checks every 30 seconds instead of every 5 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->