### PR TITLE
feat: remember window state and show native unread badges

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, nativeImage, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
 import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
@@ -28,6 +28,7 @@ const { createDisplayMediaGuard, invokeDisplayMediaCallback, selectCaptureSource
 );
 const { STAGE_PREFIX: APPIMAGE_CUA_STAGE_PREFIX } = require("./cua-linux-bundle.cjs");
 const { desktopViewerUrl, sameDesktopViewerOrigin } = require("./desktop-viewer.cjs");
+const { normalizeUnreadCount, parseWindowState, resolveWindowState } = require("./window-state.cjs");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
@@ -39,6 +40,74 @@ const APP_ICON = path.join(__dirname, "resources/app-icon.png");
 let desktopViewerWindow = null;
 let desktopViewerOwner = null;
 let desktopViewerContextId = null;
+let mainWindow = null;
+let unreadCount = 0;
+let unreadOverlayIcon = null;
+
+function windowStateFile() {
+  return path.join(app.getPath("userData"), "window-state.json");
+}
+
+function readWindowState() {
+  try {
+    return parseWindowState(fs.readFileSync(windowStateFile(), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeWindowState(win) {
+  if (!win || win.isDestroyed()) return;
+  const file = windowStateFile();
+  const temporary = `${file}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      temporary,
+      JSON.stringify({ bounds: win.getNormalBounds(), maximized: win.isMaximized() }),
+      { mode: 0o600 },
+    );
+    fs.renameSync(temporary, file);
+  } catch (error) {
+    try {
+      fs.rmSync(temporary, { force: true });
+    } catch {}
+    slog(`window state save failed: ${error?.message ?? error}`);
+  }
+}
+
+function installWindowStatePersistence(win) {
+  let timer = null;
+  const flush = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    writeWindowState(win);
+  };
+  const schedule = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(flush, 250);
+    timer.unref?.();
+  };
+  win.on("resize", schedule);
+  win.on("move", schedule);
+  win.on("maximize", schedule);
+  win.on("unmaximize", schedule);
+  win.on("close", flush);
+}
+
+function applyUnreadBadge(win = mainWindow) {
+  const count = normalizeUnreadCount(unreadCount);
+  if (process.platform === "win32") {
+    if (!win || win.isDestroyed()) return;
+    unreadOverlayIcon ??= nativeImage.createFromPath(APP_ICON).resize({ width: 16, height: 16 });
+    win.setOverlayIcon(
+      count > 0 && !unreadOverlayIcon.isEmpty() ? unreadOverlayIcon : null,
+      count > 0 ? `${count} unread conversation${count === 1 ? "" : "s"}` : "No unread conversations",
+    );
+    return;
+  }
+  if (process.platform === "darwin" || process.platform === "linux") app.setBadgeCount(count);
+}
 
 // GNOME groups the window with its installed desktop entry only when both
 // identities match. This must run before Electron becomes ready.
@@ -517,11 +586,20 @@ ipcMain.on("screen:preview-intent", (event) => {
   event.returnValue = displayMediaGuard.begin(event.senderFrame);
 });
 
+ipcMain.on("desktop:unread-count", (event, value) => {
+  const sender = BrowserWindow.fromWebContents(event.sender);
+  if (!sender || sender !== mainWindow || sender.isDestroyed()) return;
+  unreadCount = normalizeUnreadCount(value);
+  applyUnreadBadge(sender);
+});
+
 function createWindow() {
   const isMac = process.platform === "darwin";
+  const primary = screen.getPrimaryDisplay();
+  const displays = [primary, ...screen.getAllDisplays().filter((display) => display.id !== primary.id)];
+  const restored = resolveWindowState(readWindowState(), displays.map((display) => display.workArea));
   const win = new BrowserWindow({
-    width: 1440,
-    height: 920,
+    ...restored.bounds,
     minWidth: 900,
     minHeight: 600,
     icon: APP_ICON,
@@ -545,6 +623,13 @@ function createWindow() {
       contextIsolation: true,
       preload: path.join(__dirname, "preload.cjs"),
     },
+  });
+  mainWindow = win;
+  installWindowStatePersistence(win);
+  applyUnreadBadge(win);
+  if (restored.maximized) win.maximize();
+  win.on("closed", () => {
+    if (mainWindow === win) mainWindow = null;
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -100,6 +100,8 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Open a web link in the default browser. Unlike renderer window.open,
    * this remains reliable after an asynchronous API request. */
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
+  /** Mirrors durable unread state into the native Dock/taskbar badge. */
+  setUnreadCount: (count) => ipcRenderer.send("desktop:unread-count", count),
   /** Live VNC/noVNC in a sandboxed window owned by the app window. */
   desktopViewer: {
     open: (url, title, contextId) => ipcRenderer.invoke("desktop-viewer:open", url, title, contextId),

--- a/electron/window-state.cjs
+++ b/electron/window-state.cjs
@@ -1,0 +1,98 @@
+const DEFAULT_BOUNDS = Object.freeze({ width: 1440, height: 920 });
+const MIN_BOUNDS = Object.freeze({ width: 900, height: 600 });
+
+const integer = (value) => Number.isFinite(value) && Number.isInteger(value);
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+function parseWindowState(raw) {
+  let value;
+  try {
+    value = typeof raw === "string" ? JSON.parse(raw) : raw;
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || !value.bounds || typeof value.bounds !== "object") return null;
+  const { x, y, width, height } = value.bounds;
+  if (![x, y, width, height].every(integer) || width <= 0 || height <= 0) return null;
+  return {
+    bounds: { x, y, width, height },
+    maximized: value.maximized === true,
+  };
+}
+
+function intersectionArea(a, b) {
+  const width = Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x));
+  const height = Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y));
+  return width * height;
+}
+
+function validWorkAreas(workAreas) {
+  return workAreas.filter(
+    (area) =>
+      area &&
+      [area.x, area.y, area.width, area.height].every(integer) &&
+      area.width > 0 &&
+      area.height > 0,
+  );
+}
+
+/** Keep restored windows reachable after monitor, resolution, or DPI changes.
+ * workAreas must put the primary display first. */
+function resolveWindowState(state, workAreas, defaults = DEFAULT_BOUNDS) {
+  const areas = validWorkAreas(workAreas);
+  const primary = areas[0];
+  const defaultBounds = {
+    width: primary ? Math.min(defaults.width, primary.width) : defaults.width,
+    height: primary ? Math.min(defaults.height, primary.height) : defaults.height,
+  };
+  const parsed = parseWindowState(state);
+  if (!parsed || !primary) return { bounds: defaultBounds, maximized: false };
+
+  let target = primary;
+  let bestArea = 0;
+  for (const area of areas) {
+    const overlap = intersectionArea(parsed.bounds, area);
+    if (overlap > bestArea) {
+      bestArea = overlap;
+      target = area;
+    }
+  }
+
+  const minWidth = Math.min(MIN_BOUNDS.width, target.width);
+  const minHeight = Math.min(MIN_BOUNDS.height, target.height);
+  const width = clamp(parsed.bounds.width, minWidth, target.width);
+  const height = clamp(parsed.bounds.height, minHeight, target.height);
+  if (bestArea === 0) {
+    return {
+      bounds: {
+        x: target.x + Math.round((target.width - width) / 2),
+        y: target.y + Math.round((target.height - height) / 2),
+        width,
+        height,
+      },
+      maximized: parsed.maximized,
+    };
+  }
+  return {
+    bounds: {
+      x: clamp(parsed.bounds.x, target.x, target.x + target.width - width),
+      y: clamp(parsed.bounds.y, target.y, target.y + target.height - height),
+      width,
+      height,
+    },
+    maximized: parsed.maximized,
+  };
+}
+
+function normalizeUnreadCount(value) {
+  if (!Number.isFinite(value)) return 0;
+  return clamp(Math.trunc(value), 0, 999);
+}
+
+module.exports = {
+  DEFAULT_BOUNDS,
+  MIN_BOUNDS,
+  normalizeUnreadCount,
+  parseWindowState,
+  resolveWindowState,
+};

--- a/electron/window-state.test.mjs
+++ b/electron/window-state.test.mjs
@@ -1,0 +1,48 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { normalizeUnreadCount, parseWindowState, resolveWindowState } = require("./window-state.cjs");
+
+const primary = { x: 0, y: 0, width: 1920, height: 1080 };
+const left = { x: -1600, y: 0, width: 1600, height: 900 };
+
+describe("desktop window state", () => {
+  it("rejects corrupt and incomplete saved state", () => {
+    expect(parseWindowState("not json")).toBeNull();
+    expect(parseWindowState({ bounds: { x: 1, y: 2, width: 0, height: 700 } })).toBeNull();
+    expect(parseWindowState({ bounds: { x: 1, y: 2, width: 1000 } })).toBeNull();
+  });
+
+  it("restores a reachable window on the display where it was saved", () => {
+    expect(
+      resolveWindowState(
+        { bounds: { x: -1500, y: 40, width: 1200, height: 760 }, maximized: true },
+        [primary, left],
+      ),
+    ).toEqual({ bounds: { x: -1500, y: 40, width: 1200, height: 760 }, maximized: true });
+  });
+
+  it("centers an off-screen window on the primary display and clamps its size", () => {
+    expect(
+      resolveWindowState(
+        { bounds: { x: 7000, y: 7000, width: 4000, height: 200 }, maximized: false },
+        [primary, left],
+      ),
+    ).toEqual({ bounds: { x: 0, y: 240, width: 1920, height: 600 }, maximized: false });
+  });
+
+  it("uses safe default dimensions when there is no saved state", () => {
+    expect(resolveWindowState(null, [primary])).toEqual({
+      bounds: { width: 1440, height: 920 },
+      maximized: false,
+    });
+  });
+
+  it("bounds native unread counts", () => {
+    expect(normalizeUnreadCount(-4)).toBe(0);
+    expect(normalizeUnreadCount(3.9)).toBe(3);
+    expect(normalizeUnreadCount(10_000)).toBe(999);
+    expect(normalizeUnreadCount("3")).toBe(0);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Loader2, Menu } from "lucide-react";
 import { StoreProvider, useStore } from "@/state/store";
 import { Onboarding } from "@/components/Onboarding";
 import { emailGateDone, initAnalytics } from "@/lib/analytics";
+import { unreadConversationCount } from "@/lib/unread";
 import { Sidebar } from "@/components/Sidebar";
 import { ChatView } from "@/components/ChatView";
 import { GroupView } from "@/components/GroupView";
@@ -20,6 +21,7 @@ import { SkillRecorderPage } from "@/components/SkillRecorderPage";
 
 function Shell() {
   const { state, dispatch } = useStore();
+  const unreadCount = unreadConversationCount(state.bots, state.groups);
   // Mobile-only drawer state. Above md, none of these properties are emitted
   // at all — Sidebar scopes every mobile class with max-md: rather than
   // cancelling them with md:, which would still emit a translate value and
@@ -67,6 +69,10 @@ function Shell() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [state.bots, state.selectedId, dispatch]);
+
+  useEffect(() => {
+    window.ogb?.setUnreadCount?.(unreadCount);
+  }, [unreadCount]);
 
   // Picking a conversation closes the drawer: on a phone the chat is what you
   // asked for, and leaving the list up would hide it. Watching activeView too

--- a/src/lib/unread.test.ts
+++ b/src/lib/unread.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { unreadConversationCount } from "./unread";
+
+describe("unreadConversationCount", () => {
+  it("counts visible bot and room conversations but ignores archived bots", () => {
+    expect(
+      unreadConversationCount(
+        [{ unread: true }, { unread: false }, { unread: true, hidden: true }],
+        [{ unread: true }, { unread: false }],
+      ),
+    ).toBe(2);
+  });
+});

--- a/src/lib/unread.ts
+++ b/src/lib/unread.ts
@@ -1,0 +1,6 @@
+export function unreadConversationCount(
+  bots: Array<{ hidden?: boolean; unread?: boolean }>,
+  groups: Array<{ unread?: boolean }>,
+): number {
+  return bots.filter((bot) => !bot.hidden && bot.unread).length + groups.filter((group) => group.unread).length;
+}

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -152,6 +152,8 @@ type SkillRecordingPayload = {
       openInstallTerminal?(command: string): Promise<boolean>;
       /** Opens an http(s) link in the user's default browser. */
       openExternal?(url: string): Promise<boolean>;
+      /** Updates the native Dock/taskbar unread indicator. */
+      setUnreadCount?(count: number): void;
       /** Opens a live desktop as a sandboxed window owned by OpenMausBot. */
       desktopViewer?: {
         open(url: string, title: string, contextId: string): Promise<boolean>;


### PR DESCRIPTION
## What this adds

- restores the main window’s normal bounds and maximized state between launches
- keeps restored windows reachable after monitor, resolution, or DPI changes
- mirrors visible unread conversations to the macOS/Linux app badge and a Windows taskbar overlay
- validates renderer IPC and caps the native unread count

## Safety and provenance

This is an independent clean-room implementation based on OpenMausBot’s existing Electron shell and the public Electron APIs. No code or assets were copied from the reconstructed Grok Bot repository. The saved file contains only window geometry and maximized state.

## Validation

- `pnpm typecheck`
- `pnpm vitest run electron/window-state.test.mjs src/lib/unread.test.ts` (6 tests)
- `pnpm build`
- `pnpm check:electron` (42 Electron modules)