### PR TITLE
feat: add live Team Map for agent handoffs

### DIFF
--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -12,6 +12,7 @@ import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
 import {
   drainDelegations,
+  pendingDelegationSnapshot,
   queueDelegation,
   _pendingCount,
 } from "./delegations.ts";
@@ -129,6 +130,20 @@ describe("queueDelegation", () => {
         (b as { threadId?: string }).threadId === from.threadId,
     );
     expect(broadcast).toBeTruthy();
+  });
+
+  it("projects routing metadata without exposing the delegated task prompt", () => {
+    queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "private customer task details",
+      reason: "followup",
+      depth: 0,
+    }, 1);
+    const ownSnapshot = pendingDelegationSnapshot().filter((item) => item.sourceThreadId === from.threadId);
+    expect(ownSnapshot).toEqual([
+      { sourceThreadId: from.threadId, toBotId: target.id, reason: "followup" },
+    ]);
+    expect(JSON.stringify(ownSnapshot)).not.toContain("private customer task details");
   });
 
   it("keys detached routine delegations to their real source thread", async () => {

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -91,6 +91,22 @@ export function pendingThreads(): string[] {
   return [...pendingDelegations.keys()];
 }
 
+/** Read-only metadata for the local Team Map. Task prompts stay private;
+ * the UI only needs to know who handed work to whom and the optional label. */
+export function pendingDelegationSnapshot(): Array<{
+  sourceThreadId: string;
+  toBotId: string;
+  reason?: string;
+}> {
+  return [...pendingDelegations.entries()].flatMap(([sourceThreadId, items]) =>
+    items.map((item) => ({
+      sourceThreadId,
+      toBotId: item.toBotId,
+      ...(item.reason ? { reason: item.reason } : {}),
+    })),
+  );
+}
+
 /** How many handoffs one turn may queue. Small on purpose: this is the only
  * thing standing between a confused bot and a fan-out of real turns. */
 const MAX_QUEUED_PER_THREAD = 4;

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -317,6 +317,21 @@ describe("harness HTTP API", () => {
     expect(body.bots[0].messages.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("projects privacy-safe live team-map metadata", async () => {
+    const response = await api("GET", "/api/team-map");
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ collaborations: expect.any(Array), queued: [], running: [] });
+    for (const collaboration of response.body.collaborations) {
+      expect(collaboration).toEqual({
+        groupId: expect.any(String),
+        botIds: [expect.any(String), expect.any(String)],
+        lastAt: expect.any(Number),
+      });
+    }
+    expect(JSON.stringify(response.body)).not.toContain("messages");
+    expect(JSON.stringify(response.body)).not.toContain("prompt");
+  });
+
   it("adds and removes room members through PATCH", async () => {
     const [first, second, third] = await Promise.all([
       api("POST", "/api/bots"),

--- a/server/index.ts
+++ b/server/index.ts
@@ -75,7 +75,7 @@ import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
-import { _loadPending, discardDelegations, drainDelegations, pendingThreads, queueDelegation, type QueueResult } from "./delegations.ts";
+import { _loadPending, discardDelegations, drainDelegations, pendingDelegationSnapshot, pendingThreads, queueDelegation, type QueueResult } from "./delegations.ts";
 import { drainSteeredMessages, queueSteeredMessage } from "./steer-queue.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
@@ -2961,6 +2961,39 @@ const server = createServer(async (req, res) => {
         return json(res, 200, { messageIds });
       }
       return json(res, 404, { error: "unknown internal endpoint" });
+    }
+
+    // Live Team Map metadata. Prompts and replies never leave their
+    // transcripts: this projection carries only ids, status relationships,
+    // optional delegation labels, and timestamps.
+    if (method === "GET" && path === "/api/team-map") {
+      const visible = new Set(store.bots.filter((bot) => !bot.hidden).map((bot) => bot.id));
+      const collaborations = store.groups
+        .filter(
+          (group) =>
+            group.dm === true &&
+            group.memberIds.length === 2 &&
+            group.memberIds.every((botId) => visible.has(botId)),
+        )
+        .map((group) => ({
+          groupId: group.id,
+          botIds: [group.memberIds[0], group.memberIds[1]] as [string, string],
+          lastAt: store.messagesFor(group.threadId).at(-1)?.at ?? group.createdAt,
+        }))
+        .sort((a, b) => b.lastAt - a.lastAt);
+      const queued = pendingDelegationSnapshot().flatMap((item) => {
+        const source = store.botByThread(item.sourceThreadId);
+        if (!source || !visible.has(source.id) || !visible.has(item.toBotId)) return [];
+        return [{ sourceBotId: source.id, targetBotId: item.toBotId, reason: item.reason }];
+      });
+      const running = [...delegationWatch.entries()].flatMap(([threadId, watch]) => {
+        if (!visible.has(watch.toBotId)) return [];
+        const channel = watch.channelId ? store.group(watch.channelId) : undefined;
+        const sourceBotId = channel?.memberIds.find((botId) => botId !== watch.toBotId);
+        if (!sourceBotId || !visible.has(sourceBotId)) return [];
+        return [{ sourceBotId, targetBotId: watch.toBotId, threadId, groupId: channel?.id }];
+      });
+      return json(res, 200, { collaborations, queued, running });
     }
 
     // ── routines calendar ────────────────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { RoutinesPage } from "@/components/RoutinesPage";
 import { NoEngines } from "@/components/NoEngines";
 import { CommandPalette } from "@/components/CommandPalette";
 import { SkillRecorderPage } from "@/components/SkillRecorderPage";
+import { TeamMapPage } from "@/components/TeamMapPage";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -132,7 +133,9 @@ function Shell() {
           menuButtonRef.current?.focus();
         }}
       />
-      {state.activeView === "routines" ? (
+      {state.activeView === "team-map" ? (
+        <TeamMapPage />
+      ) : state.activeView === "routines" ? (
         <RoutinesPage />
       ) : state.activeView === "skill-recorder" ? (
         <SkillRecorderPage />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   FolderPlus,
   Library,
   Loader2,
+  Network,
   Pencil,
   PanelLeftClose,
   PanelLeftOpen,
@@ -1482,6 +1483,19 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
 
       {/* Footer */}
       <div className={cn("pb-3 pt-2", density === "icons" ? "px-2" : "px-3")}>
+        <button
+          onClick={() => dispatch({ type: "showTeamMap" })}
+          aria-label={density === "icons" ? "Team map" : undefined}
+          title={density === "icons" ? "Team map" : undefined}
+          className={cn(
+            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+            state.activeView === "team-map" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+          )}
+        >
+          <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
+          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
+        </button>
         {skillRecorderEnabled(state.config) && (
           <button
             onClick={() => dispatch({ type: "showSkillRecorder" })}

--- a/src/components/TeamMapPage.tsx
+++ b/src/components/TeamMapPage.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowRight, Crown, Network, Radio, RefreshCw } from "lucide-react";
+
+import { MausAvatar } from "./Avatar";
+import { api, formatTime, useStore, type Bot } from "@/state/store";
+import { normalizeState } from "@/lib/mascot";
+import {
+  EMPTY_TEAM_MAP_SNAPSHOT,
+  buildTeamMapEdges,
+  buildTeamMapSections,
+  teamMapStatus,
+  type TeamMapEdge,
+  type TeamMapSnapshot,
+} from "@/lib/team-map";
+import { cn } from "@/lib/cn";
+
+const statusTone = {
+  success: "bg-success",
+  warning: "bg-warning",
+  danger: "bg-danger",
+  idle: "bg-ink-secondary/35",
+} as const;
+
+function BotNode({ bot, chief = false }: { bot: Bot; chief?: boolean }) {
+  const { dispatch } = useStore();
+  const status = teamMapStatus(bot);
+  return (
+    <button
+      onClick={() => dispatch({ type: "select", id: bot.id })}
+      className="group relative flex min-w-0 items-center gap-3 rounded-xl border border-hairline/50 bg-card px-3 py-3 text-left shadow-sm transition hover:border-accent/35 hover:bg-raised/50"
+    >
+      <MausAvatar
+        color={bot.color}
+        state={normalizeState(bot.mascotExpression) ?? "idle"}
+        size={34}
+        motion="none"
+        motionKey={0}
+        animated={false}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-[13.5px] font-semibold text-ink">{bot.name}</span>
+          {chief && <Crown size={12} className="shrink-0 text-warning" aria-label="Chief of Staff" />}
+        </span>
+        <span className="block truncate text-[11.5px] text-ink-secondary">{bot.title || bot.modelSelection.model}</span>
+      </span>
+      <span className="flex shrink-0 items-center gap-1.5 text-[10.5px] text-ink-secondary">
+        <span className={cn("size-1.5 rounded-full", statusTone[status.tone], status.label === "Working" && "animate-pulse")} />
+        {status.label}
+      </span>
+    </button>
+  );
+}
+
+function EdgeRow({ edge, bots }: { edge: TeamMapEdge; bots: Bot[] }) {
+  const { dispatch } = useStore();
+  const source = bots.find((bot) => bot.id === edge.sourceBotId);
+  const target = bots.find((bot) => bot.id === edge.targetBotId);
+  if (!source || !target) return null;
+  const live = edge.state !== "connected";
+  return (
+    <button
+      onClick={() => dispatch({ type: "select", id: edge.groupId ?? target.id })}
+      className="flex w-full items-center gap-3 rounded-xl border border-hairline/40 bg-card px-3 py-2.5 text-left transition hover:bg-raised/50"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="truncate text-[13px] font-medium text-ink">{source.name}</span>
+        <ArrowRight size={13} className={cn("shrink-0", live ? "text-accent" : "text-ink-secondary")} />
+        <span className="truncate text-[13px] font-medium text-ink">{target.name}</span>
+      </div>
+      {edge.reason && <span className="max-w-[220px] truncate text-[11.5px] text-ink-secondary">{edge.reason}</span>}
+      <span
+        className={cn(
+          "rounded-full px-2 py-0.5 text-[10.5px] font-medium",
+          edge.state === "running"
+            ? "bg-success/15 text-success"
+            : edge.state === "queued"
+              ? "bg-warning/15 text-warning"
+              : "bg-control text-ink-secondary",
+        )}
+      >
+        {edge.state === "running" ? "Running" : edge.state === "queued" ? "Queued" : edge.lastAt ? formatTime(edge.lastAt) : "Connected"}
+      </span>
+    </button>
+  );
+}
+
+export function TeamMapPage() {
+  const { state } = useStore();
+  const [snapshot, setSnapshot] = useState<TeamMapSnapshot>(EMPTY_TEAM_MAP_SNAPSHOT);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bots = useMemo(() => state.bots.filter((bot) => !bot.hidden), [state.bots]);
+  const sections = useMemo(() => buildTeamMapSections(bots), [bots]);
+  const edges = useMemo(() => buildTeamMapEdges(bots, snapshot), [bots, snapshot]);
+
+  const refresh = useCallback(async (showSpinner = false) => {
+    if (showSpinner) setRefreshing(true);
+    try {
+      setSnapshot(await api("/api/team-map"));
+      setError(null);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      if (showSpinner) setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, 3_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  const working = bots.filter((bot) => bot.busy || bot.activity === "working").length;
+  const waiting = bots.filter((bot) => bot.activity === "waiting-on-you").length;
+
+  return (
+    <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-app text-ink">
+      <header className="flex shrink-0 items-center justify-between border-b border-hairline/40 px-7 py-5 max-md:pl-12">
+        <div>
+          <div className="flex items-center gap-2.5">
+            <Network size={20} className="text-accent" />
+            <h1 className="text-[18px] font-semibold">Team map</h1>
+            <span className="flex items-center gap-1 rounded-full bg-success/10 px-2 py-0.5 text-[10.5px] font-medium text-success">
+              <Radio size={10} /> Live
+            </span>
+          </div>
+          <p className="mt-1 text-[12.5px] text-ink-secondary">
+            See every section, who is working, and where tasks are moving.
+          </p>
+        </div>
+        <button
+          onClick={() => void refresh(true)}
+          disabled={refreshing}
+          className="rounded-lg border border-hairline/50 bg-card p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+          aria-label="Refresh team map"
+          title="Refresh"
+        >
+          <RefreshCw size={15} className={refreshing ? "animate-spin" : ""} />
+        </button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
+        <div className="mb-5 grid max-w-[620px] grid-cols-3 gap-2">
+          {[
+            [bots.length, "Bots"],
+            [working, "Working"],
+            [waiting, "Waiting on you"],
+          ].map(([value, label]) => (
+            <div key={label} className="rounded-xl border border-hairline/40 bg-panel px-3.5 py-3">
+              <div className="text-[18px] font-semibold tabular-nums text-ink">{value}</div>
+              <div className="text-[11.5px] text-ink-secondary">{label}</div>
+            </div>
+          ))}
+        </div>
+
+        {error && <div className="mb-4 rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">{error}</div>}
+
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-4">
+          {sections.map((section) => (
+            <section key={section.name} className="rounded-2xl border border-hairline/50 bg-panel p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="text-[12px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">{section.name}</h2>
+                <span className="text-[11px] tabular-nums text-ink-secondary">{section.chiefs.length + section.members.length}</span>
+              </div>
+              <div className="space-y-2">
+                {section.chiefs.map((bot) => <BotNode key={bot.id} bot={bot} chief />)}
+                {section.chiefs.length > 0 && section.members.length > 0 && (
+                  <div className="ml-5 h-3 w-px bg-hairline" aria-hidden />
+                )}
+                {section.members.length > 0 && (
+                  <div className={cn("space-y-2", section.chiefs.length > 0 && "border-l border-hairline/60 pl-3")}>
+                    {section.members.map((bot) => <BotNode key={bot.id} bot={bot} />)}
+                  </div>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-6 max-w-[900px]">
+          <div className="mb-2.5 flex items-center justify-between">
+            <h2 className="text-[12px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">Agent handoffs</h2>
+            <span className="text-[11px] text-ink-secondary">Running and queued first</span>
+          </div>
+          <div className="space-y-2">
+            {edges.slice(0, 12).map((edge) => (
+              <EdgeRow key={`${edge.sourceBotId}:${edge.targetBotId}`} edge={edge} bots={bots} />
+            ))}
+            {edges.length === 0 && (
+              <div className="rounded-xl border border-dashed border-hairline bg-panel px-4 py-6 text-center text-[12.5px] text-ink-secondary">
+                No bot-to-bot handoffs yet. Ask a Chief of Staff to delegate a task and it will appear here live.
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/team-map.test.ts
+++ b/src/lib/team-map.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTeamMapEdges, buildTeamMapSections, teamMapStatus, type TeamMapSnapshot } from "./team-map";
+
+const bots = [
+  { id: "chief", name: "Atlas", section: "Work", chiefOfStaff: true, busy: true },
+  { id: "maker", name: "Pixel", section: "Work" },
+  { id: "home", name: "Mochi" },
+  { id: "archived", name: "Old", hidden: true },
+];
+
+describe("team map projection", () => {
+  it("groups visible bots by section and separates chiefs", () => {
+    expect(buildTeamMapSections(bots)).toEqual([
+      { name: "Work", chiefs: [bots[0]], members: [bots[1]] },
+      { name: "General", chiefs: [], members: [bots[2]] },
+    ]);
+  });
+
+  it("keeps one edge per pair and gives live work priority", () => {
+    const snapshot: TeamMapSnapshot = {
+      collaborations: [{ groupId: "channel", botIds: ["chief", "maker"], lastAt: 10 }],
+      queued: [{ sourceBotId: "chief", targetBotId: "maker", reason: "design" }],
+      running: [{ sourceBotId: "chief", targetBotId: "maker", threadId: "task" }],
+    };
+    expect(buildTeamMapEdges(bots, snapshot)).toEqual([
+      { sourceBotId: "chief", targetBotId: "maker", state: "running", groupId: undefined },
+    ]);
+  });
+
+  it("filters archived endpoints and explains live states", () => {
+    const snapshot: TeamMapSnapshot = {
+      collaborations: [{ groupId: "old", botIds: ["chief", "archived"], lastAt: 10 }],
+      queued: [],
+      running: [],
+    };
+    expect(buildTeamMapEdges(bots, snapshot)).toEqual([]);
+    expect(teamMapStatus(bots[0])).toEqual({ label: "Working", tone: "success" });
+    expect(teamMapStatus({ id: "x", name: "X", activity: "waiting-on-you" })).toEqual({
+      label: "Waiting for you",
+      tone: "warning",
+    });
+  });
+});

--- a/src/lib/team-map.ts
+++ b/src/lib/team-map.ts
@@ -1,0 +1,98 @@
+export interface TeamMapBot {
+  id: string;
+  name: string;
+  hidden?: boolean;
+  section?: string;
+  chiefOfStaff?: boolean;
+  busy?: boolean;
+  activity?: "working" | "waiting-on-you" | "idle" | "no-signal" | "dead";
+}
+
+export interface TeamMapSnapshot {
+  collaborations: Array<{ groupId: string; botIds: [string, string]; lastAt: number }>;
+  queued: Array<{ sourceBotId: string; targetBotId: string; reason?: string }>;
+  running: Array<{ sourceBotId: string; targetBotId: string; threadId: string; groupId?: string }>;
+}
+
+export interface TeamMapSection<T extends TeamMapBot = TeamMapBot> {
+  name: string;
+  chiefs: T[];
+  members: T[];
+}
+
+export type TeamMapEdge = {
+  sourceBotId: string;
+  targetBotId: string;
+  state: "running" | "queued" | "connected";
+  reason?: string;
+  groupId?: string;
+  lastAt?: number;
+};
+
+export const EMPTY_TEAM_MAP_SNAPSHOT: TeamMapSnapshot = {
+  collaborations: [],
+  queued: [],
+  running: [],
+};
+
+export function buildTeamMapSections<T extends TeamMapBot>(bots: T[]): TeamMapSection<T>[] {
+  const sections = new Map<string, T[]>();
+  for (const bot of bots) {
+    if (bot.hidden) continue;
+    const section = bot.section?.trim() || "General";
+    sections.set(section, [...(sections.get(section) ?? []), bot]);
+  }
+  return [...sections].map(([name, sectionBots]) => ({
+    name,
+    chiefs: sectionBots.filter((bot) => bot.chiefOfStaff),
+    members: sectionBots.filter((bot) => !bot.chiefOfStaff),
+  }));
+}
+
+/** One visible edge per pair. A running handoff outranks a queued one,
+ * which outranks the durable connection left by an earlier conversation. */
+export function buildTeamMapEdges(bots: TeamMapBot[], snapshot: TeamMapSnapshot): TeamMapEdge[] {
+  const visible = new Set(bots.filter((bot) => !bot.hidden).map((bot) => bot.id));
+  const edges = new Map<string, TeamMapEdge>();
+  const key = (sourceBotId: string, targetBotId: string) => [sourceBotId, targetBotId].sort().join(":");
+  for (const collaboration of snapshot.collaborations) {
+    const [sourceBotId, targetBotId] = collaboration.botIds;
+    if (!visible.has(sourceBotId) || !visible.has(targetBotId)) continue;
+    edges.set(key(sourceBotId, targetBotId), {
+      sourceBotId,
+      targetBotId,
+      state: "connected",
+      groupId: collaboration.groupId,
+      lastAt: collaboration.lastAt,
+    });
+  }
+  for (const delegation of snapshot.queued) {
+    if (!visible.has(delegation.sourceBotId) || !visible.has(delegation.targetBotId)) continue;
+    edges.set(key(delegation.sourceBotId, delegation.targetBotId), {
+      sourceBotId: delegation.sourceBotId,
+      targetBotId: delegation.targetBotId,
+      state: "queued",
+      reason: delegation.reason,
+    });
+  }
+  for (const delegation of snapshot.running) {
+    if (!visible.has(delegation.sourceBotId) || !visible.has(delegation.targetBotId)) continue;
+    edges.set(key(delegation.sourceBotId, delegation.targetBotId), {
+      sourceBotId: delegation.sourceBotId,
+      targetBotId: delegation.targetBotId,
+      state: "running",
+      groupId: delegation.groupId,
+    });
+  }
+  return [...edges.values()].sort((a, b) => {
+    const priority = { running: 0, queued: 1, connected: 2 } as const;
+    return priority[a.state] - priority[b.state] || (b.lastAt ?? 0) - (a.lastAt ?? 0);
+  });
+}
+
+export function teamMapStatus(bot: TeamMapBot): { label: string; tone: "success" | "warning" | "danger" | "idle" } {
+  if (bot.activity === "waiting-on-you") return { label: "Waiting for you", tone: "warning" };
+  if (bot.activity === "dead" || bot.activity === "no-signal") return { label: "No signal", tone: "danger" };
+  if (bot.busy || bot.activity === "working") return { label: "Working", tone: "success" };
+  return { label: "Ready", tone: "idle" };
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -348,7 +348,7 @@ export interface AppState {
   config: ConfigStatus | null;
   /** selected chat — a bot id OR a group id */
   selectedId: string;
-  activeView: "chat" | "routines" | "skill-recorder";
+  activeView: "chat" | "team-map" | "routines" | "skill-recorder";
   routines: Routine[];
   routineRuns: RoutineRun[];
   webhooks: WebhookTrigger[];
@@ -408,6 +408,7 @@ export type Action =
       computerControl: Record<string, { held: boolean; helpReason: string | null }>;
     }
   | { type: "showRoutines" }
+  | { type: "showTeamMap" }
   | { type: "showSkillRecorder" }
   | { type: "routinesHydrated"; routines: Routine[]; runs: RoutineRun[] }
   | { type: "routinePatched"; routine: Routine }
@@ -572,6 +573,16 @@ export function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         activeView: "routines",
+        settingsOpen: false,
+        computerOpen: false,
+        inspectorOpen: false,
+        appSettingsOpen: false,
+        pluginsOpen: false,
+      };
+    case "showTeamMap":
+      return {
+        ...state,
+        activeView: "team-map",
         settingsOpen: false,
         computerOpen: false,
         inspectorOpen: false,


### PR DESCRIPTION
## What this adds

- a live Team Map view grouped by the existing workspace sections
- Chief of Staff hierarchy and per-bot Ready / Working / Waiting / No signal states
- running, queued, and recent bot-to-bot handoffs with live refresh
- click-through from bots to their chats and from handoffs to the relevant channel
- a privacy-safe `/api/team-map` projection that omits prompts and replies

## Safety and provenance

This is an independent clean-room implementation using OpenMausBot’s existing sections, activities, DM channels, and delegation queue. No code or assets were copied from the reconstructed Grok Bot repository. The endpoint exposes only local routing/status metadata; delegated task prompts and chat replies are never included.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/lib/team-map.test.ts server/delegations.test.ts server/index.test.ts` (110 tests)
- `pnpm build`
- full `pnpm test` passed before the final rebase (1,753 tests counted); the PR matrix will re-run it on current main