### PR TITLE
feat(pi): image attachments and reasoning-effort levels

### DIFF
--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -255,6 +255,51 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-exit")).toBe(false);
   });
 
+  it("advertises images and every harness effort level", async () => {
+    await create();
+    expect(instance.adapter.capabilities.images).toBe(true);
+    expect(instance.adapter.capabilities.effortLevels).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
+  });
+
+  it("pins reasoning effort via set_thinking_level after the model", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-pi-effort-"));
+    const dump = join(dir, "dump.jsonl");
+    await create(undefined, { FAKE_PI_DUMP: dump });
+    const { turnId } = await instance.adapter.sendTurn({
+      threadId: "t-effort",
+      text: "hi",
+      model: "ollama-cloud/glm-5.2",
+      effort: "high",
+    });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+    const levels = readFileSync(dump, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { thinkingLevel?: string })
+      .filter((record) => record.thinkingLevel !== undefined)
+      .map((record) => record.thinkingLevel!);
+    expect(levels).toEqual(["high"]);
+  });
+
+  it("maps the none effort to pi's off and sends nothing without effort", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-pi-effort-"));
+    const dump = join(dir, "dump.jsonl");
+    await create(undefined, { FAKE_PI_DUMP: dump });
+    const none = await instance.adapter.sendTurn({ threadId: "t-none", text: "hi", effort: "none" });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === none.turnId);
+    const plain = await instance.adapter.sendTurn({ threadId: "t-plain", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === plain.turnId);
+    const levels = readFileSync(dump, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { thinkingLevel?: string })
+      .filter((record) => record.thinkingLevel !== undefined)
+      .map((record) => record.thinkingLevel!);
+    // exactly one pin across both turns: the "none" turn's off — a plain turn
+    // must not touch the thinking level at all
+    expect(levels).toEqual(["off"]);
+  });
+
   it("scrubs provider and workspace credentials from every pi child env", async () => {
     const dir = mkdtempSync(join(tmpdir(), "omb-pi-dump-"));
     const dump = join(dir, "dump.jsonl");

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -29,6 +29,7 @@ import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 
 import type {
   DriverCreateInput,
+  EffortLevel,
   ModelCatalog,
   ProviderDriver,
   ProviderInstance,
@@ -37,12 +38,19 @@ import type {
   RuntimeEventListener,
   SendTurnInput,
 } from "../contracts.ts";
-import { newEventId, newId } from "../contracts.ts";
+import { EFFORT_LEVELS, newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "piAgent";
 const PI_ARGS = ["--mode", "rpc", "--no-session"];
 const NODE_ENV_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
+
+/** Harness effort → pi thinking level (`set_thinking_level`). The sets match
+ * one-for-one except for the name of the lowest rung: the harness calls it
+ * "none", pi calls it "off". Exported for the test. */
+export function piThinkingLevel(effort: EffortLevel): (typeof EFFORT_LEVELS)[number] | "off" {
+  return effort === "none" ? "off" : effort;
+}
 
 /** Mirror of the Claude driver's integration → stdio MCP mount: every entry is
  * a JSON-RPC 2.0 stdio server the pi-mcp-extension consumes. Returns null when
@@ -581,6 +589,18 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         }
       }
 
+      // pin reasoning effort after the model (the supported level set is
+      // model-dependent); a rejection keeps the engine default
+      if (turn.effort) {
+        try {
+          const levelPromise = awaitResponse("set_thinking_level");
+          send({ type: "set_thinking_level", level: piThinkingLevel(turn.effort) });
+          await levelPromise;
+        } catch {
+          /* keep going on the engine default */
+        }
+      }
+
       const message = turn.system ? `${turn.system}\n\n${turn.text}` : turn.text;
       try {
         send({ type: "prompt", message });
@@ -650,7 +670,14 @@ export const PiDriver: ProviderDriver<PiConfig> = {
           // extension, so it is offered exactly when the other engines offer
           // it: enabled unless the bot is in full-auto.
           localComputerMcp: !config.fullAuto,
-          images: false,
+          // Images ride the ordinary prompt as <attached-image path> refs the
+          // agent opens with its read tool — no native image blocks needed,
+          // same as every other CLI engine.
+          images: true,
+          // Reasoning effort pins pi's thinking level per turn (none → off).
+          // xhigh/max only land on models that expose them; pi rejects an
+          // unsupported level and the turn keeps the engine default.
+          effortLevels: EFFORT_LEVELS,
         },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -170,6 +170,17 @@ function handle(cmd: any) {
       send({ type: "response", command: "set_model", success: true, data: { id: cmd.modelId, provider: cmd.provider } });
       return;
     }
+    case "set_thinking_level":
+      // record the level so a test can assert what the driver pinned
+      if (process.env.FAKE_PI_DUMP) {
+        try {
+          appendFileSync(process.env.FAKE_PI_DUMP, JSON.stringify({ thinkingLevel: cmd.level }) + "\n");
+        } catch {
+          /* never let dumping break a run */
+        }
+      }
+      send({ type: "response", command: "set_thinking_level", success: true });
+      return;
     case "prompt":
       // acknowledge acceptance; the completion comes via events
       send({ type: "response", command: "prompt", success: true });


### PR DESCRIPTION
## What

Two small capability gaps between the pi engine and the other CLI engines:

### Images
The composer gates image paste on `capabilities.images`, and pi reads images fine — flip the flag so pi bots accept attachments like Claude, Codex, and Antigravity. No native plumbing needed: images already ride the prompt as `<attached-image path>` refs the agent opens with its own read tool.

### Reasoning effort
Declare `effortLevels` and pin each turn's reasoning effort via pi's `set_thinking_level` RPC, sent right after `set_model` (the supported level set is model-dependent). The harness and pi level sets match one-for-one except the lowest rung's name — harness `none` is pi's `off`. A rejected/unsupported level (e.g. `xhigh` on a model that lacks it) keeps the engine default instead of failing the turn.

## Testing

- Fake CLI extended to answer `set_thinking_level` and record the pinned level in the `FAKE_PI_DUMP` stream.
- New tests: capabilities advertise images + all six effort levels; a turn with `effort: "high"` pins exactly one level; `none` maps to `off`; a plain turn sends no thinking-level command.
- `pnpm typecheck` clean; full suite green (173 files, 1781 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pi now supports configurable effort levels, including disabling extended thinking.
  * Pi advertises image input support.
  * Thinking-level settings are applied automatically after model selection.
* **Bug Fixes**
  * Unsupported or unsuccessful thinking-level updates now safely preserve Pi’s default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->