### PR TITLE
fix(drivers): scope local-computer approvals to real desktop-control tools only

### DIFF
--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -715,18 +715,38 @@ describe("ClaudeDriver turns (fake CLI)", () => {
       tool: "Bash",
       summary: "rm -rf scratch",
       requestId: "ask-1",
-      approvalScope: "local-computer",
     });
+    // a plain CLI tool never carries the desktop-control approval scope,
+    // so the UI can offer a remembered grant for it
+    expect(opened).toHaveProperty("approvalScope", undefined);
 
     // the outcome names exactly what was granted: this action, once
     await expect(instance.adapter.respondToRequest("t-perm-abc", "ask-1", { behavior: "allow" })).resolves.toBe("allowed-once");
     expect(await answered).toMatchObject({ behavior: "allow" });
     const resolved = await recorder.until((e) => e.type === "request.resolved");
-    expect(resolved).toMatchObject({
-      behavior: "allow",
-      source: "user",
-      approvalScope: "local-computer",
+    expect(resolved).toMatchObject({ behavior: "allow", source: "user" });
+    expect(resolved).toHaveProperty("approvalScope", undefined);
+
+    // a real desktop-control tool keeps the local-computer scope, which
+    // suppresses remembered grants — desktop actions must be approved
+    // one at a time
+    const answered2 = new Promise<{ behavior: string }>((resolve) => {
+      let buf = "";
+      conn.on("data", (c) => {
+        buf += c;
+        const nl = buf.indexOf("\n");
+        if (nl !== -1) resolve(JSON.parse(buf.slice(0, nl)));
+      });
     });
+    conn.write(
+      JSON.stringify({ t: "ask", id: "ask-2", tool: "mcp__computer__screenshot", input: {} }) + "\n",
+    );
+    const opened2 = await recorder.until((e) => e.requestId === "ask-2" && e.type === "request.opened");
+    expect(opened2).toHaveProperty("approvalScope", "local-computer");
+    await expect(instance.adapter.respondToRequest("t-perm-abc", "ask-2", { behavior: "allow" })).resolves.toBe("allowed-once");
+    expect(await answered2).toMatchObject({ behavior: "allow" });
+    const resolved2 = await recorder.until((e) => e.requestId === "ask-2" && e.type === "request.resolved");
+    expect(resolved2).toHaveProperty("approvalScope", "local-computer");
 
     conn.end();
     await instance.adapter.interruptTurn("t-perm-abc");

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -704,6 +704,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               approvalScope:
                 controlsHost && typeof askTools.get(resolved.id) === "string" && askTools.get(resolved.id)!.startsWith("mcp__computer") ? "local-computer" : undefined,
             });
+            askTools.delete(resolved.id);
           },
         });
       }

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -678,7 +678,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           isActive: () => Boolean(sessions.get(threadId)?.turn),
           onAsk: (ask) => {
             const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
-            askTools.set(ask.id, ask.tool);
+            askTools.set(ask.id, typeof ask.tool === "string" ? ask.tool : undefined);
             emit({
               ...base(threadId, eventTurnId),
               type: "request.opened",
@@ -686,7 +686,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               requestType: ask.kind,
               tool: ask.tool,
               summary: askSummary(ask),
-              approvalScope: controlsHost && ask.tool?.startsWith("mcp__computer") ? "local-computer" : undefined,
+              approvalScope:
+                typeof ask.tool === "string" && controlsHost && ask.tool.startsWith("mcp__computer")
+                  ? "local-computer"
+                  : undefined,
               choices: Array.isArray(ask.input?.choices) ? (ask.input.choices as string[]).slice(0, 5) : undefined,
             });
           },
@@ -699,7 +702,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               behavior: resolved.behavior,
               source: resolved.source,
               approvalScope:
-                controlsHost && askTools.get(resolved.id)?.startsWith("mcp__computer") ? "local-computer" : undefined,
+                controlsHost && typeof askTools.get(resolved.id) === "string" && askTools.get(resolved.id)!.startsWith("mcp__computer") ? "local-computer" : undefined,
             });
           },
         });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -670,11 +670,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // Only create a broker for a new process. A compatible retained process
       // keeps its existing proxy connection and broker across turns.
       if (socketPath) {
+        // remembers which tool each pending ask came from, so the resolved
+        // event can scope approvals to real desktop-control tools only
+        const askTools = new Map<string, string | undefined>();
         broker = createPermissionBroker({
           socketPath,
           isActive: () => Boolean(sessions.get(threadId)?.turn),
           onAsk: (ask) => {
             const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
+            askTools.set(ask.id, ask.tool);
             emit({
               ...base(threadId, eventTurnId),
               type: "request.opened",
@@ -682,7 +686,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               requestType: ask.kind,
               tool: ask.tool,
               summary: askSummary(ask),
-              approvalScope: controlsHost ? "local-computer" : undefined,
+              approvalScope: controlsHost && ask.tool?.startsWith("mcp__computer") ? "local-computer" : undefined,
               choices: Array.isArray(ask.input?.choices) ? (ask.input.choices as string[]).slice(0, 5) : undefined,
             });
           },
@@ -694,7 +698,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               requestId: resolved.id,
               behavior: resolved.behavior,
               source: resolved.source,
-              approvalScope: controlsHost ? "local-computer" : undefined,
+              approvalScope:
+                controlsHost && askTools.get(resolved.id)?.startsWith("mcp__computer") ? "local-computer" : undefined,
             });
           },
         });


### PR DESCRIPTION
## What changed

`server/drivers/claude.ts`: the permission broker stamped `approvalScope: "local-computer"` onto **every** `request.opened` / `request.resolved` event whenever a bot had "This computer" enabled — including plain `Bash`, `Edit`, and `Write` asks. The server (`server/index.ts`) suppresses `allowKey` whenever an approval carries a scope, which is correct for desktop control but meant the **"Always allow" button never rendered for any tool** on any bot with local computer-use enabled.

Now:
- only tools whose name starts with `mcp__computer` (the real desktop-control namespace) carry the scope on `request.opened`;
- `request.resolved` looks up the ask's tool from a small per-turn map, so resolved events carry the same scoped logic.

## Why

Desktop-control approvals must stay one-at-a-time (no remembered grants), but ordinary CLI/file asks should be rememberable. Conflating them made a core UX affordance unreachable in a very common configuration.

Closes nothing — filed independently as a bug fix.

## How it was verified

- `pnpm typecheck` ✅
- `pnpm test` — full suite green: 163 files, 1,699 passed, 12 skipped ✅
- Updated `server/drivers/claude.test.ts` contract test: a `Bash` ask now asserts `approvalScope === undefined` (so the UI can offer a remembered grant), and a new `mcp__computer__screenshot` ask asserts the scope is still `"local-computer"` on both `opened` and `resolved`.
- Manually verified end-to-end on macOS against a live bot: "Always allow" renders for Bash/Edit cards and remembered grants stick; computer-use cards still prompt every time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission approval handling for desktop-control tools.
  * Standard command-line tools no longer receive unnecessary computer-access approval prompts.
  * Follow-up approval requests now consistently use the correct access scope and status.
  * Improved handling of approval requests when tool information is incomplete or invalid, helping prevent incorrect access prompts or unresolved approval states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->