### PR TITLE
feat(electron): right-click context menu with clipboard and spellcheck actions

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -640,6 +640,9 @@ function createWindow() {
   // Native context menu for text inputs — without this, right-click does
   // nothing in the Electron window (no Cut/Copy/Paste/Select All).
   win.webContents.on("context-menu", (_event, params) => {
+    // nothing actionable here — no menu at all, rather than a wall of
+    // disabled items
+    if (!params.isEditable && !params.linkURL && !params.misspelledWord && !params.selectionText) return;
     const menuItems = [];
     if (params.misspelledWord) {
       for (const suggestion of params.dictionarySuggestions.slice(0, 5)) {
@@ -667,7 +670,7 @@ function createWindow() {
       { type: "separator" },
       { label: "Select All", role: "selectAll", enabled: params.editFlags.canSelectAll },
     );
-    Menu.buildFromTemplate(menuItems).popup({ window: win });
+    Menu.buildFromTemplate(menuItems).popup({ window: win, frame: params.frame });
   });
 
   // Packaged CI smoke hook. It validates the real renderer/preload bridge and

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, nativeImage, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, Menu, nativeImage, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
 import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
@@ -635,6 +635,39 @@ function createWindow() {
   win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
     return { action: "deny" };
+  });
+
+  // Native context menu for text inputs — without this, right-click does
+  // nothing in the Electron window (no Cut/Copy/Paste/Select All).
+  win.webContents.on("context-menu", (_event, params) => {
+    const menuItems = [];
+    if (params.misspelledWord) {
+      for (const suggestion of params.dictionarySuggestions.slice(0, 5)) {
+        menuItems.push({
+          label: suggestion,
+          click: () => win.webContents.replaceMisspelling(suggestion),
+        });
+      }
+      if (menuItems.length) menuItems.push({ type: "separator" });
+    }
+    if (params.linkURL) {
+      menuItems.push(
+        { label: "Copy Link", click: () => clipboard.writeText(params.linkURL) },
+        { type: "separator" },
+      );
+    }
+    menuItems.push(
+      { label: "Undo", role: "undo", enabled: params.editFlags.canUndo },
+      { label: "Redo", role: "redo", enabled: params.editFlags.canRedo },
+      { type: "separator" },
+      { label: "Cut", role: "cut", enabled: params.editFlags.canCut },
+      { label: "Copy", role: "copy", enabled: params.editFlags.canCopy },
+      { label: "Paste", role: "paste", enabled: params.editFlags.canPaste },
+      { label: "Paste and Match Style", role: "pasteAndMatchStyle", enabled: params.editFlags.canPaste },
+      { type: "separator" },
+      { label: "Select All", role: "selectAll", enabled: params.editFlags.canSelectAll },
+    );
+    Menu.buildFromTemplate(menuItems).popup({ window: win });
   });
 
   // Packaged CI smoke hook. It validates the real renderer/preload bridge and


### PR DESCRIPTION
## What changed

`electron/main.mjs`: adds a `context-menu` handler on the main `BrowserWindow`'s `webContents` that pops a native menu on right-click:

- spellcheck suggestions (top 5) + separator when a misspelled word is clicked
- "Copy Link" when a link is right-clicked
- Undo / Redo / Cut / Copy / Paste / Paste and Match Style / Select All using Electron's built-in roles, enabled/disabled from `params.editFlags`

## Why

Right-click currently does nothing in text inputs — no Cut/Copy/Paste/Select All. This makes the renderer behave like a native macOS app with ~30 lines of standard Electron wiring; no new dependencies.

## How it was verified

- `pnpm check:electron` ✅
- Manually on macOS: right-click in the composer shows Cut/Copy/Paste/Select All (correctly disabled per state), misspelling shows suggestions, right-clicking a link offers Copy Link.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [ ] Server behavior changes come with tests — N/A (Electron shell only)
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening install links through the `openmausbot://` protocol.
  * Install links now work when launching the app from a link or opening them while the app is already running.
  * Added a native context menu with spelling suggestions, link copying, text editing, paste formatting, and select-all actions.
  * Contextual editing options adapt to the current selection and input area.
  * Added improved shutdown handling and Linux startup compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->