### PR TITLE
Paint the resting face when a mascot mounts paused

### DIFF
--- a/src/components/CursorAvatar.tsx
+++ b/src/components/CursorAvatar.tsx
@@ -1338,6 +1338,9 @@ export const CursorAvatar = React.forwardRef<CursorAvatarHandle, CursorAvatarPro
       stateStart: 0,
       lastState,
       lastBodyTransform: '',
+      // what the parked loop last painted; '' means "never" so a mascot that
+      // mounts paused still gets its one resting-face paint
+      pausedPaint: '',
       props: {
         state,
         expression,
@@ -1537,14 +1540,23 @@ export const CursorAvatar = React.forwardRef<CursorAvatarHandle, CursorAvatarPro
         const p = e.props
         // A paused mascot must not wake at display rate: re-arming BEFORE the
         // pause check once had N idle sidebar faces ticking at 60fps forever.
-        // While paused, poll for unpause at 4Hz — no springs, no DOM writes.
+        // While paused, poll for unpause at 4Hz — but the resting face must
+        // still be PAINTED: the SVG layers hold no expression until the first
+        // draw, so a mascot that mounts paused would otherwise stay blank.
+        // One draw per change of what the still face shows, then park.
         if (p.paused) {
           e.last = now
+          const still = `${p.state}|${p.expression ?? ''}|${paintRef.current}`
+          if (e.pausedPaint !== still) {
+            e.pausedPaint = still
+            draw(e, now, 0)
+          }
           wake = setTimeout(() => {
             frame = requestAnimationFrame(step)
           }, 250)
           return
         }
+        e.pausedPaint = ''
         frame = requestAnimationFrame(step)
         const dt = Math.min((now - e.last) / 1000, 0.1)
         e.last = now


### PR DESCRIPTION
## Why

#425 made sidebar mascots mount paused (animation is now opt-in) — which exposed a latent gap: the avatar's SVG layers hold no expression until the first `draw()` positions them, and the parked loop never drew. Idle bots' avatars rendered blank. Before #425 nothing ever mounted paused, so the gap never showed.

## What

The paused branch paints the resting face once on park, and re-paints only when what the still face shows changes (state, pinned expression, gradient) — tracked by a tiny signature checked on the existing 4Hz wake-poll. No springs, no continuous DOM writes; animation stays opt-in.

## Verification

Typecheck clean, 216 renderer tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paused avatars now consistently display their resting expression when first shown.
  * Avatar visuals update correctly when pause state, expression, or appearance changes.
  * Avatars resume animation detection reliably after being unpaused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->