### PR TITLE
chore(release): bump version to 0.1.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop release version from `0.1.32` to `0.1.33`.

The `v0.1.33` tag is not currently published in `openmausbot-releases`, so the release workflow can safely pin and publish this version after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->