### PR TITLE
Let Antigravity models control computers (mount the computer MCP)

### DIFF
--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -444,4 +444,47 @@ describe("Antigravity computer MCP config", () => {
       rmSync(home, { recursive: true, force: true });
     }
   });
+
+  it("reaps a child that hangs after result, restores the mount, and unblocks the next turn", async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpreaper-"));
+    const firstDump = join(home, "first.json");
+    const secondDump = join(home, "second.json");
+    const first = await AntigravityDriver.create({
+      instanceId: "agy-mcp-zombie",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_AGY_MCP_DUMP: firstDump, FAKE_AGY_POST_RESULT_DELAY_MS: "10000" },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const second = await AntigravityDriver.create({
+      instanceId: "agy-mcp-after-zombie",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_AGY_MCP_DUMP: secondDump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const firstRecorder = recordEvents(first.adapter);
+    const secondRecorder = recordEvents(second.adapter);
+    try {
+      await first.adapter.sendTurn({ threadId: "t-mcp-zombie", text: "first", integrations: boxIntegrations });
+      await firstRecorder.until((event) => event.type === "turn.completed");
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+
+      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-after-zombie", text: "second" });
+      await secondTurn;
+      await secondRecorder.until((event) => event.type === "turn.completed");
+
+      expect(JSON.parse(readFileSync(firstDump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(JSON.parse(readFileSync(secondDump, "utf8"))?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      await expect.poll(() => existsSync(configPath(home))).toBe(false);
+    } finally {
+      firstRecorder.stop();
+      secondRecorder.stop();
+      await first.dispose();
+      await second.dispose();
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 10_000);
 });

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -4,7 +4,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly;
 // spawnCli resolves it to `node <script>`, so these run everywhere.
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -287,6 +287,23 @@ describe("Antigravity computer MCP config", () => {
     }
   });
 
+  it("restricts the token-bearing config directory and file to the current user", () => {
+    if (process.platform === "win32") return;
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpperms-"));
+    try {
+      const directory = dirname(configPath(home));
+      mkdirSync(directory, { recursive: true, mode: 0o755 });
+      writeFileSync(configPath(home), "{}\n", { mode: 0o644 });
+
+      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+
+      expect(statSync(directory).mode & 0o777).toBe(0o700);
+      expect(statSync(configPath(home)).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("a computer-less turn removes only its own key, and never creates the file just to remove", () => {
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcprm-"));
     try {
@@ -343,19 +360,18 @@ describe("Antigravity computer MCP config", () => {
     }
   });
 
-  it("writes the mount before spawning agy and clears it on the next computer-less turn", async () => {
+  it("uses the spawned CLI's HOME and restores the prior config when the turn exits", async () => {
     ensureDirs();
     chmodSync(FAKE_CLI, 0o755);
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpturn-"));
+    const dump = join(home, "mcp-at-spawn.json");
+    const original = JSON.stringify({ mcpServers: { "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] } } });
     mkdirSync(join(home, ".gemini", "config"), { recursive: true });
-    writeFileSync(
-      configPath(home),
-      JSON.stringify({ mcpServers: { "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] } } }),
-    );
+    writeFileSync(configPath(home), original);
     const instance = await AntigravityDriver.create({
       instanceId: "agy-mcp-turn",
       displayName: undefined,
-      environment: { HOME: home },
+      environment: { HOME: home, FAKE_AGY_DELAY_MS: "100", FAKE_AGY_MCP_DUMP: dump },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: true },
     });
@@ -372,15 +388,59 @@ describe("Antigravity computer MCP config", () => {
       expect(mounted.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
       expect(mounted.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
       await recorder.until((e) => e.type === "turn.completed");
-
-      await instance.adapter.sendTurn({ threadId: "t-mcp-off", text: "no computer here" });
-      const cleared = readConfig(home);
-      expect(cleared.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
-      expect(cleared.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
-      await recorder.until((e) => e.type === "turn.completed" && e.threadId === "t-mcp-off");
+      expect(JSON.parse(readFileSync(dump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      await expect.poll(() => readFileSync(configPath(home), "utf8")).toBe(original);
     } finally {
       recorder.stop();
       await instance.dispose();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes overlapping turns so each child sees only its own computer mount", async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcplease-"));
+    const firstDump = join(home, "first.json");
+    const secondDump = join(home, "second.json");
+    const first = await AntigravityDriver.create({
+      instanceId: "agy-mcp-first",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_AGY_DELAY_MS: "150", FAKE_AGY_MCP_DUMP: firstDump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const second = await AntigravityDriver.create({
+      instanceId: "agy-mcp-second",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_AGY_MCP_DUMP: secondDump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const firstRecorder = recordEvents(first.adapter);
+    const secondRecorder = recordEvents(second.adapter);
+    try {
+      await first.adapter.sendTurn({ threadId: "t-mcp-first", text: "first", integrations: boxIntegrations });
+      let secondSpawned = false;
+      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-second", text: "second" }).then((result) => {
+        secondSpawned = true;
+        return result;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(secondSpawned).toBe(false);
+      await firstRecorder.until((event) => event.type === "turn.completed");
+      await secondTurn;
+      await secondRecorder.until((event) => event.type === "turn.completed");
+
+      expect(JSON.parse(readFileSync(firstDump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(JSON.parse(readFileSync(secondDump, "utf8"))?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      await expect.poll(() => existsSync(configPath(home))).toBe(false);
+    } finally {
+      firstRecorder.stop();
+      secondRecorder.stop();
+      await first.dispose();
+      await second.dispose();
       rmSync(home, { recursive: true, force: true });
     }
   });

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -4,7 +4,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly;
 // spawnCli resolves it to `node <script>`, so these run everywhere.
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,8 +12,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
+import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { AntigravityDriver, readAntigravityModelCatalog, STATIC_ANTIGRAVITY_MODELS } from "./antigravity.ts";
+import {
+  ANTIGRAVITY_COMPUTER_MCP_KEY,
+  AntigravityDriver,
+  antigravityComputerMcpServer,
+  ensureAntigravityComputerMcp,
+  readAntigravityModelCatalog,
+  STATIC_ANTIGRAVITY_MODELS,
+} from "./antigravity.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-agy-cli.ts");
 
@@ -195,6 +203,185 @@ describe("Antigravity snapshot", () => {
         else process.env[name] = previous[name];
       }
       rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Antigravity computer MCP config", () => {
+  const configPath = (home: string) => join(home, ".gemini", "config", "mcp_config.json");
+  const readConfig = (home: string) => JSON.parse(readFileSync(configPath(home), "utf8"));
+  const boxIntegrations = {
+    computer: {
+      kind: "box" as const,
+      boxId: "bx_1",
+      token: "box-tok",
+      control: { url: "http://127.0.0.1:9/control", token: "ctl-tok" },
+    },
+  };
+  const boxEntry = () => antigravityComputerMcpServer(boxIntegrations)!;
+
+  it("builds the cloud-box spec on the shared computer proxy (never path-resolved locally)", () => {
+    expect(antigravityComputerMcpServer(boxIntegrations)).toEqual({
+      command: process.execPath,
+      args: [SPAWNED_PROXIES.computer],
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        OGB_BOX_ID: "bx_1",
+        OGB_BOX_TOKEN: "box-tok",
+        OMB_CONTROL_URL: "http://127.0.0.1:9/control",
+        OMB_CONTROL_TOKEN: "ctl-tok",
+      },
+    });
+  });
+
+  it("passes a Local VM / VPS stdio connection through unchanged, and yields null without a computer", () => {
+    expect(
+      antigravityComputerMcpServer({
+        localComputer: { command: "/opt/cua", args: ["--mcp"], env: { CUA_SOCKET: "/tmp/cua.sock" } },
+      }),
+    ).toEqual({ command: "/opt/cua", args: ["--mcp"], env: { CUA_SOCKET: "/tmp/cua.sock" } });
+    expect(antigravityComputerMcpServer({})).toBeNull();
+    expect(antigravityComputerMcpServer(undefined)).toBeNull();
+  });
+
+  it("upserts only its own key — the user's servers and unknown top-level keys survive", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpcfg-"));
+    try {
+      mkdirSync(join(home, ".gemini", "config"), { recursive: true });
+      writeFileSync(
+        configPath(home),
+        JSON.stringify({
+          mcpServers: { "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] } },
+          futureTopLevelKey: { keep: true },
+        }),
+      );
+      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      let config = readConfig(home);
+      expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
+      expect(config.futureTopLevelKey).toEqual({ keep: true });
+      expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+
+      // A later turn on a different computer overwrites the key in place.
+      ensureAntigravityComputerMcp(
+        { command: "/opt/cua", args: ["--mcp"], env: { CUA_SOCKET: "/tmp/cua.sock" } },
+        { HOME: home },
+      );
+      config = readConfig(home);
+      expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY].command).toBe("/opt/cua");
+      expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
+      expect(config.futureTopLevelKey).toEqual({ keep: true });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("starts fresh from malformed JSON instead of failing the turn", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpbad-"));
+    try {
+      mkdirSync(join(home, ".gemini", "config"), { recursive: true });
+      writeFileSync(configPath(home), "{{{ not json");
+      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("a computer-less turn removes only its own key, and never creates the file just to remove", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcprm-"));
+    try {
+      // No file at all: removal is a no-op, not an empty file in the user's home.
+      ensureAntigravityComputerMcp(null, { HOME: home });
+      expect(existsSync(configPath(home))).toBe(false);
+
+      mkdirSync(join(home, ".gemini", "config"), { recursive: true });
+      writeFileSync(
+        configPath(home),
+        JSON.stringify({
+          mcpServers: {
+            "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] },
+            [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+          },
+        }),
+      );
+      ensureAntigravityComputerMcp(null, { HOME: home });
+      const config = readConfig(home);
+      expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("advertises computerMcp only on full-auto instances, and never localComputerMcp", async () => {
+    const fullAuto = await AntigravityDriver.create({
+      instanceId: "agy-caps-full",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const acceptEdits = await AntigravityDriver.create({
+      instanceId: "agy-caps-safe",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      expect(fullAuto.adapter.capabilities.computerMcp).toBe(true);
+      // accept-edits print mode auto-denies tools that would prompt, so a
+      // mount there could never fire — the capability must not be offered.
+      expect(acceptEdits.adapter.capabilities.computerMcp).toBe(false);
+      // The host desktop needs per-action human approval; print mode has no
+      // approval channel in any mode.
+      expect(fullAuto.adapter.capabilities.localComputerMcp).toBeUndefined();
+      expect(acceptEdits.adapter.capabilities.localComputerMcp).toBeUndefined();
+    } finally {
+      await fullAuto.dispose();
+      await acceptEdits.dispose();
+    }
+  });
+
+  it("writes the mount before spawning agy and clears it on the next computer-less turn", async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpturn-"));
+    mkdirSync(join(home, ".gemini", "config"), { recursive: true });
+    writeFileSync(
+      configPath(home),
+      JSON.stringify({ mcpServers: { "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] } } }),
+    );
+    const instance = await AntigravityDriver.create({
+      instanceId: "agy-mcp-turn",
+      displayName: undefined,
+      environment: { HOME: home },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const recorder = recordEvents(instance.adapter);
+    try {
+      await instance.adapter.sendTurn({
+        threadId: "t-mcp-on",
+        text: "click things",
+        integrations: boxIntegrations,
+      });
+      // sendTurn resolves after the child is spawned; the write happens
+      // synchronously before that spawn, so this IS the spawn-time content.
+      const mounted = readConfig(home);
+      expect(mounted.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(mounted.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
+      await recorder.until((e) => e.type === "turn.completed");
+
+      await instance.adapter.sendTurn({ threadId: "t-mcp-off", text: "no computer here" });
+      const cleared = readConfig(home);
+      expect(cleared.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(cleared.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
+      await recorder.until((e) => e.type === "turn.completed" && e.threadId === "t-mcp-off");
+    } finally {
+      recorder.stop();
+      await instance.dispose();
+      rmSync(home, { recursive: true, force: true });
     }
   });
 });

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -304,6 +304,41 @@ describe("Antigravity computer MCP config", () => {
     }
   });
 
+  it("preserves concurrent config edits while restoring only its own MCP entry", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpconcurrent-"));
+    try {
+      const restoreNewFile = ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      const concurrentlyCreated = readConfig(home);
+      concurrentlyCreated.mcpServers["external-helper"] = { command: "external-mcp" };
+      concurrentlyCreated.futureTopLevelKey = { keep: true };
+      writeFileSync(configPath(home), JSON.stringify(concurrentlyCreated));
+
+      restoreNewFile();
+      expect(existsSync(configPath(home))).toBe(true);
+      let restored = readConfig(home);
+      expect(restored.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(restored.mcpServers["external-helper"]).toEqual({ command: "external-mcp" });
+      expect(restored.futureTopLevelKey).toEqual({ keep: true });
+
+      const originalEntry = { command: "user-owned-mcp", args: ["--serve"] };
+      writeFileSync(
+        configPath(home),
+        JSON.stringify({ mcpServers: { [ANTIGRAVITY_COMPUTER_MCP_KEY]: originalEntry } }),
+      );
+      const restoreExistingEntry = ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      const concurrentlyEdited = readConfig(home);
+      concurrentlyEdited.mcpServers["another-helper"] = { command: "another-mcp" };
+      writeFileSync(configPath(home), JSON.stringify(concurrentlyEdited));
+
+      restoreExistingEntry();
+      restored = readConfig(home);
+      expect(restored.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(originalEntry);
+      expect(restored.mcpServers["another-helper"]).toEqual({ command: "another-mcp" });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("a computer-less turn removes only its own key, and never creates the file just to remove", () => {
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcprm-"));
     try {
@@ -494,6 +529,57 @@ describe("Antigravity computer MCP config", () => {
       await expect.poll(() => existsSync(configPath(home))).toBe(false);
     } finally {
       firstRecorder.stop();
+      secondRecorder.stop();
+      await first.dispose();
+      await second.dispose();
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  it("force-reaps an interrupted child that ignores SIGTERM before result", async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpinterrupt-"));
+    const readyFile = join(home, "ready");
+    const first = await AntigravityDriver.create({
+      instanceId: "agy-mcp-interrupted",
+      displayName: undefined,
+      environment: {
+        HOME: home,
+        FAKE_AGY_DELAY_MS: "10000",
+        FAKE_AGY_IGNORE_SIGTERM: "1",
+        FAKE_AGY_READY_FILE: readyFile,
+      },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const second = await AntigravityDriver.create({
+      instanceId: "agy-mcp-after-interrupt",
+      displayName: undefined,
+      environment: { HOME: home },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const secondRecorder = recordEvents(second.adapter);
+    try {
+      await first.adapter.sendTurn({ threadId: "t-mcp-interrupted", text: "first", integrations: boxIntegrations });
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      await expect.poll(() => existsSync(readyFile)).toBe(true);
+      await first.adapter.interruptTurn("t-mcp-interrupted");
+
+      let secondSpawned = false;
+      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-after-interrupt", text: "second" }).then((result) => {
+        secondSpawned = true;
+        return result;
+      });
+      if (process.platform !== "win32") {
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+        expect(secondSpawned).toBe(false);
+      }
+      await secondTurn;
+      await secondRecorder.until((event) => event.type === "turn.completed");
+      await expect.poll(() => existsSync(configPath(home))).toBe(false);
+    } finally {
       secondRecorder.stop();
       await first.dispose();
       await second.dispose();

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -454,7 +454,12 @@ describe("Antigravity computer MCP config", () => {
     const first = await AntigravityDriver.create({
       instanceId: "agy-mcp-zombie",
       displayName: undefined,
-      environment: { HOME: home, FAKE_AGY_MCP_DUMP: firstDump, FAKE_AGY_POST_RESULT_DELAY_MS: "10000" },
+      environment: {
+        HOME: home,
+        FAKE_AGY_MCP_DUMP: firstDump,
+        FAKE_AGY_POST_RESULT_DELAY_MS: "10000",
+        FAKE_AGY_IGNORE_SIGTERM: "1",
+      },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: true },
     });
@@ -472,7 +477,15 @@ describe("Antigravity computer MCP config", () => {
       await firstRecorder.until((event) => event.type === "turn.completed");
       expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
 
-      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-after-zombie", text: "second" });
+      let secondSpawned = false;
+      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-after-zombie", text: "second" }).then((result) => {
+        secondSpawned = true;
+        return result;
+      });
+      if (process.platform !== "win32") {
+        await new Promise((resolve) => setTimeout(resolve, 2_500));
+        expect(secondSpawned).toBe(false);
+      }
       await secondTurn;
       await secondRecorder.until((event) => event.type === "turn.completed");
 

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -564,7 +564,7 @@ describe("Antigravity computer MCP config", () => {
     try {
       await first.adapter.sendTurn({ threadId: "t-mcp-interrupted", text: "first", integrations: boxIntegrations });
       expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
-      await expect.poll(() => existsSync(readyFile)).toBe(true);
+      await expect.poll(() => existsSync(readyFile), { timeout: 2_000 }).toBe(true);
       await first.adapter.interruptTurn("t-mcp-interrupted");
 
       let secondSpawned = false;
@@ -578,7 +578,7 @@ describe("Antigravity computer MCP config", () => {
       }
       await secondTurn;
       await secondRecorder.until((event) => event.type === "turn.completed");
-      await expect.poll(() => existsSync(configPath(home))).toBe(false);
+      await expect.poll(() => existsSync(configPath(home)), { timeout: 6_000 }).toBe(false);
     } finally {
       secondRecorder.stop();
       await first.dispose();

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -380,7 +380,12 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       // one workspace dir. replace() already keeps a UUID unique and safe.
       const tag = threadId.replace(/[^\w-]/g, "");
       const workspace = join(DATA_DIR, "workspaces", tag);
-      mkdirSync(workspace, { recursive: true });
+      try {
+        mkdirSync(workspace, { recursive: true });
+      } catch (error) {
+        pending.delete(threadId);
+        throw error;
+      }
       const cwd = turn.cwd ?? workspace;
 
       // prompt is passed as the `--print` argv value: agy does NOT read the

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -17,7 +17,7 @@
 // ensureAntigravityComputerMcp below. Full-auto instances only; the host
 // desktop stays off (no approval channel in print mode, ever).
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { z } from "zod";
@@ -68,8 +68,8 @@ export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   ],
 };
 
-function antigravityEnvironment(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath() };
+function antigravityEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath(), ...overrides };
   // The harness process may hold workspace credentials injected by the
   // desktop shell. Antigravity uses its own login, so none belong in any of
   // its turn, snapshot, or helper children.
@@ -136,6 +136,26 @@ export interface AntigravityComputerMcpServer {
   env: Record<string, string>;
 }
 
+// agy's MCP file is machine-global. Hold this lease for the complete child
+// lifetime so two Antigravity turns cannot see each other's computer tokens.
+let antigravityComputerMcpLease: Promise<void> = Promise.resolve();
+
+async function acquireAntigravityComputerMcpLease(): Promise<() => void> {
+  const previous = antigravityComputerMcpLease;
+  let unlock: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    unlock = resolve;
+  });
+  antigravityComputerMcpLease = previous.then(() => current);
+  await previous;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    unlock?.();
+  };
+}
+
 // Lenient by design: keep every unknown key the user put in the file. A
 // present-but-wrong mcpServers (e.g. an array) fails the parse and is
 // rebuilt fresh — that file was already unusable to agy itself.
@@ -179,12 +199,14 @@ export function antigravityComputerMcpServer(
 export function ensureAntigravityComputerMcp(
   server: AntigravityComputerMcpServer | null,
   env: Record<string, string | undefined> = process.env,
-): void {
+): () => void {
   const home = env.HOME || env.USERPROFILE || homedir();
   const path = join(home, ".gemini", "config", "mcp_config.json");
+  const existed = existsSync(path);
+  const original = existed ? readFileSync(path, "utf8") : null;
   let config: z.infer<typeof mcpConfigFileSchema> = {};
   try {
-    const parsed = mcpConfigFileSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+    const parsed = mcpConfigFileSchema.safeParse(JSON.parse(original ?? ""));
     if (parsed.success) config = parsed.data;
   } catch {
     // Missing or malformed user config — rebuild only what the mount needs.
@@ -192,14 +214,37 @@ export function ensureAntigravityComputerMcp(
   const servers = { ...config.mcpServers };
   // Nothing to remove and nothing to add: leave the user's file untouched
   // (don't create or reformat it on every computer-less turn).
-  if (!server && !(ANTIGRAVITY_COMPUTER_MCP_KEY in servers)) return;
+  if (!server && !(ANTIGRAVITY_COMPUTER_MCP_KEY in servers)) return () => {};
   if (server) {
     servers[ANTIGRAVITY_COMPUTER_MCP_KEY] = { command: server.command, args: server.args, env: server.env };
   } else {
     delete servers[ANTIGRAVITY_COMPUTER_MCP_KEY];
   }
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`);
+  const directory = dirname(path);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  if (existed) chmodSync(path, 0o600);
+  writeFileSync(path, `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600);
+
+  // Restore exactly what was present before this turn. The module-wide lease
+  // means no other OpenMausBot Antigravity turn can modify the file before
+  // this runs. Keep the tightened permissions when restoring an existing file.
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    if (original !== null) {
+      writeFileSync(path, original, { mode: 0o600 });
+      chmodSync(path, 0o600);
+      return;
+    }
+    try {
+      unlinkSync(path);
+    } catch (error) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+    }
+  };
 }
 
 function decodeConfig(raw: unknown): AntigravityConfig {
@@ -238,7 +283,8 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
   async create(input: DriverCreateInput<AntigravityConfig>): Promise<ProviderInstance> {
     const { instanceId, config } = input;
-    const catalogEnv: Record<string, string | undefined> = { ...process.env, ...input.environment };
+    const env = antigravityEnvironment(input.environment);
+    const catalogEnv: Record<string, string | undefined> = env;
     let models = STATIC_ANTIGRAVITY_MODELS;
     const refreshModels = async () => {
       try {
@@ -252,6 +298,8 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
     const listeners = new Set<RuntimeEventListener>();
     // one active turn per thread; a second send while busy is a caller bug
     const active = new Map<string, { stop: () => void; turnId: string }>();
+    const pending = new Set<string>();
+    let disposed = false;
     // every live agy child, tracked independently of `active`: a child can
     // hang AFTER emitting `result` (so it's already removed from `active`), and
     // dispose()/stopAll() must still be able to reap it. Removed on process exit.
@@ -287,7 +335,9 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
     const sendTurn = async (turn: SendTurnInput) => {
       const { threadId } = turn;
-      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      if (disposed) throw new Error("Antigravity instance is disposed");
+      if (active.has(threadId) || pending.has(threadId)) throw new Error("a turn is already running on this thread");
+      pending.add(threadId);
       const turnId = newId();
 
       // Default cwd to a per-thread workspace under DATA_DIR — deliberately
@@ -337,19 +387,27 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           message: `prompt too large for Antigravity's argv-only print mode (${Buffer.byteLength(prompt)} bytes)`,
         });
         settle(false, "prompt_too_large");
+        pending.delete(threadId);
         return { turnId };
       }
 
-      // Mount (or unmount) the bot's computer for this turn, in the global
-      // mcp_config.json, as close to the spawn as possible — the file is
-      // machine-global, so the window in which a concurrent Antigravity turn
-      // with a DIFFERENT computer could re-write it before this child reads
-      // its config should stay as small as it can. A failed write with a
-      // computer to mount must fail the turn: the bot was promised tools it
-      // would otherwise burn the whole turn hunting for.
+      // agy's config is global, so every turn — including one without a
+      // computer — owns the mount for its complete child lifetime. This keeps
+      // overlapping turns from inheriting, replacing, or removing each
+      // other's tools and credentials.
+      const releaseMcpLease = await acquireAntigravityComputerMcpLease();
+      if (disposed) {
+        releaseMcpLease();
+        pending.delete(threadId);
+        settle(false, "disposed");
+        return { turnId };
+      }
+      let restoreMcp = () => {};
       try {
-        ensureAntigravityComputerMcp(antigravityComputerMcpServer(turn.integrations), catalogEnv);
+        restoreMcp = ensureAntigravityComputerMcp(antigravityComputerMcpServer(turn.integrations), env);
       } catch (error) {
+        releaseMcpLease();
+        pending.delete(threadId);
         emit({
           ...base(threadId, turnId),
           type: "runtime.error",
@@ -374,15 +432,30 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       if (turn.model) args.push("--model", injectedApiModel(turn.model) ?? turn.model);
       if (resumeCursor) args.push("--conversation", resumeCursor);
 
-      const env = antigravityEnvironment();
-
       // spawnCli resolves npm .cmd shims / shebang scripts on Windows and
       // owns the process-group vs windowsHide difference (see procs.ts)
-      const child = spawnCli(config.cli, args, {
-        cwd,
-        env,
-        stdio: ["ignore", "pipe", "pipe"], // prompt is on argv; stdin is unused
-      });
+      let child: ReturnType<typeof spawnCli>;
+      try {
+        child = spawnCli(config.cli, args, {
+          cwd,
+          env,
+          stdio: ["ignore", "pipe", "pipe"], // prompt is on argv; stdin is unused
+        });
+      } catch (error) {
+        try {
+          restoreMcp();
+        } finally {
+          releaseMcpLease();
+        }
+        pending.delete(threadId);
+        emit({
+          ...base(threadId, turnId),
+          type: "runtime.error",
+          ...describeSpawnFailure(error instanceof Error ? error : new Error(String(error)), config.cli),
+        });
+        settle(false, "spawn_error");
+        return { turnId };
+      }
       children.add(child);
 
       // conversation_id from the init event → the resumeCursor (session.started
@@ -487,6 +560,17 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
       child.on("close", (code) => {
         children.delete(child); // close is the true process-exit signal
+        try {
+          restoreMcp();
+        } catch (error) {
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message: `could not restore Antigravity's MCP config: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        } finally {
+          releaseMcpLease();
+        }
         if (!settled) {
           emit({
             ...base(threadId, turnId),
@@ -499,6 +583,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
       const stop = () => killCliTree(child); // process groups are POSIX-only
       active.set(threadId, { stop, turnId });
+      pending.delete(threadId);
 
       // 11 min — just above agy's own 10m --print-timeout, so agy normally
       // settles first; this is the backstop for a fully wedged child.
@@ -518,7 +603,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const version = await new Promise<string | null>((resolve) => {
-        execCli(config.cli, ["--version"], { timeout: 8000, env: antigravityEnvironment() }, (err, stdout) =>
+        execCli(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
           resolve(err ? null : stdout.trim()),
         );
       });
@@ -573,11 +658,12 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           execCli(
             config.cli,
             ["-p", prompt, "--output-format", "text", "--model", "gemini-3.6-flash-low"],
-            { timeout: 60_000, env: antigravityEnvironment() },
+            { timeout: 60_000, env },
             (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
           );
         }),
       dispose: async () => {
+        disposed = true;
         for (const { stop } of active.values()) stop();
         reapChildren(true); // escalate to SIGKILL — disposal must reap every child
         listeners.clear();

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -10,13 +10,22 @@
 // `request-review` auto-denies; `--dangerously-skip-permissions` (fullAuto)
 // approves everything. Real per-action approval cards are a future path via
 // native ACP (agy issue #31), which would reuse acp/core.ts like grok/gemini.
+//
+// Computer use: agy has no per-turn MCP flag, so the bot's computer (cloud
+// box / Local VM / VPS) is mounted by upserting one key into the global
+// `~/.gemini/config/mcp_config.json` before each spawn — see
+// ensureAntigravityComputerMcp below. Full-auto instances only; the host
+// desktop stays off (no approval channel in print mode, ever).
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { z } from "zod";
 
 import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
+import { computerProxyEnv } from "../container-computer.ts";
 import { augmentedPath } from "../env-path.ts";
+import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 import { injectedApiModel, mergeLocalInject } from "./local-inject.ts";
 
 import type { ChildProcess } from "node:child_process";
@@ -108,6 +117,89 @@ export function readAntigravityModelCatalog(env: Record<string, string | undefin
     options.push({ id: extra.id, label: extra.label, custom: true });
   }
   return { default: STATIC_ANTIGRAVITY_MODELS.default, options };
+}
+
+// ── computer MCP mount ──────────────────────────────────────────────────
+// agy has no per-session MCP flag and no project-level MCP config: verified
+// against agy 1.1.19, whose embedded docs list exactly two locations — the
+// global `~/.gemini/config/mcp_config.json` and per-plugin files — and whose
+// `agy mcp list` ignores `.gemini/{settings,mcp_config}.json` in the cwd.
+// So the bot's computer is mounted by upserting ONE key into the global file
+// right before each spawn: every other byte of the user's config is
+// preserved, and a malformed file starts from a fresh object instead of
+// failing the turn (the ensureOpenCodeInjectModel discipline).
+export const ANTIGRAVITY_COMPUTER_MCP_KEY = "openmausbot-computer";
+
+export interface AntigravityComputerMcpServer {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+// Lenient by design: keep every unknown key the user put in the file. A
+// present-but-wrong mcpServers (e.g. an array) fails the parse and is
+// rebuilt fresh — that file was already unusable to agy itself.
+const mcpConfigFileSchema = z.looseObject({
+  mcpServers: z.looseObject({}).optional(),
+});
+
+/** The computer MCP server for this turn, or null when the turn has none.
+ * Cloud boxes go through OpenMausBot's REST-to-MCP adapter (the same spec
+ * claude.ts and codex.ts build); Local VM and VPS connections arrive as a
+ * ready-made Cua Driver stdio command and pass through unchanged. */
+export function antigravityComputerMcpServer(
+  integrations: SendTurnInput["integrations"],
+): AntigravityComputerMcpServer | null {
+  const computer = integrations?.computer;
+  if (computer) {
+    const proxyEnv = computerProxyEnv(computer);
+    return {
+      command: process.execPath,
+      args: [SPAWNED_PROXIES.computer],
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        OGB_BOX_ID: proxyEnv.OGB_BOX_ID ?? "",
+        OGB_BOX_TOKEN: proxyEnv.OGB_BOX_TOKEN ?? "",
+        // who-is-driving endpoint, so a person taking the wheel in the
+        // panel pauses this bot's hands mid-turn
+        OMB_CONTROL_URL: proxyEnv.OMB_CONTROL_URL ?? "",
+        OMB_CONTROL_TOKEN: proxyEnv.OMB_CONTROL_TOKEN ?? "",
+      },
+    };
+  }
+  const local = integrations?.localComputer;
+  if (local) return { command: local.command, args: local.args, env: { ...local.env } };
+  return null;
+}
+
+/** Upsert (server) or remove (null) the openmausbot-computer entry in the
+ * global mcp_config.json. Only that one key is ever written; a turn without
+ * a computer removes it so a previous turn's mount cannot leak tools — or
+ * box/control tokens — into later turns or the user's own agy sessions. */
+export function ensureAntigravityComputerMcp(
+  server: AntigravityComputerMcpServer | null,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const home = env.HOME || env.USERPROFILE || homedir();
+  const path = join(home, ".gemini", "config", "mcp_config.json");
+  let config: z.infer<typeof mcpConfigFileSchema> = {};
+  try {
+    const parsed = mcpConfigFileSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+    if (parsed.success) config = parsed.data;
+  } catch {
+    // Missing or malformed user config — rebuild only what the mount needs.
+  }
+  const servers = { ...config.mcpServers };
+  // Nothing to remove and nothing to add: leave the user's file untouched
+  // (don't create or reformat it on every computer-less turn).
+  if (!server && !(ANTIGRAVITY_COMPUTER_MCP_KEY in servers)) return;
+  if (server) {
+    servers[ANTIGRAVITY_COMPUTER_MCP_KEY] = { command: server.command, args: server.args, env: server.env };
+  } else {
+    delete servers[ANTIGRAVITY_COMPUTER_MCP_KEY];
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`);
 }
 
 function decodeConfig(raw: unknown): AntigravityConfig {
@@ -245,6 +337,27 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           message: `prompt too large for Antigravity's argv-only print mode (${Buffer.byteLength(prompt)} bytes)`,
         });
         settle(false, "prompt_too_large");
+        return { turnId };
+      }
+
+      // Mount (or unmount) the bot's computer for this turn, in the global
+      // mcp_config.json, as close to the spawn as possible — the file is
+      // machine-global, so the window in which a concurrent Antigravity turn
+      // with a DIFFERENT computer could re-write it before this child reads
+      // its config should stay as small as it can. A failed write with a
+      // computer to mount must fail the turn: the bot was promised tools it
+      // would otherwise burn the whole turn hunting for.
+      try {
+        ensureAntigravityComputerMcp(antigravityComputerMcpServer(turn.integrations), catalogEnv);
+      } catch (error) {
+        emit({
+          ...base(threadId, turnId),
+          type: "runtime.error",
+          message: `could not update Antigravity's MCP config (${join(".gemini", "config", "mcp_config.json")}): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+        settle(false, "mcp_config_error");
         return { turnId };
       }
 
@@ -428,7 +541,20 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       snapshot,
       adapter: {
         provider: DRIVER_KIND,
-        capabilities: { sessionModelSwitch: "in-session", images: true },
+        capabilities: {
+          sessionModelSwitch: "in-session",
+          images: true,
+          // Cloud box, Local VM, and VPS computers all mount through the
+          // global mcp_config.json above. Only full-auto instances advertise
+          // it: print mode has no interactive approval channel, and outside
+          // --dangerously-skip-permissions agy auto-denies tools that would
+          // prompt (the accept-edits shell behavior in the header comment),
+          // so a non-fullAuto mount could never fire. localComputerMcp stays
+          // unset on purpose — the host desktop requires per-action human
+          // approval (see contracts.ts), which print mode cannot deliver in
+          // any mode; that returns with the native ACP path (agy issue #31).
+          computerMcp: config.fullAuto,
+        },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),
         respondToRequest: async () => "unavailable" as const, // this engine has no asks to answer

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -464,7 +464,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
       let childClosed = false;
       let postSettleReaper: ReturnType<typeof setTimeout> | undefined;
-      let postSettleFallback: ReturnType<typeof setTimeout> | undefined;
+      let postSettleEscalation: ReturnType<typeof setTimeout> | undefined;
       let mcpFinalized = false;
       const finalizeMcp = () => {
         if (mcpFinalized) return;
@@ -487,10 +487,26 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         // short grace, then reap a zombie so `close` can release the lease.
         postSettleReaper = setTimeout(() => killCliTree(child), 2_000);
         postSettleReaper.unref?.();
-        // Some platforms can fail to deliver `close` after a failed kill.
-        // Never leave credentials mounted or every later turn queued forever.
-        postSettleFallback = setTimeout(finalizeMcp, 5_000);
-        postSettleFallback.unref?.();
+        // Keep the lease while the child is alive. If graceful termination is
+        // ignored, force the process tree down; `close` is the only path that
+        // restores the global config and releases the next queued turn.
+        postSettleEscalation = setTimeout(() => {
+          if (childClosed) return;
+          if (process.platform === "win32") {
+            killCliTree(child); // taskkill /T /F is already forceful
+            return;
+          }
+          try {
+            const pid = child.pid;
+            if (pid) process.kill(-pid, "SIGKILL");
+            else child.kill("SIGKILL");
+          } catch {
+            try {
+              child.kill("SIGKILL");
+            } catch {}
+          }
+        }, 5_000);
+        postSettleEscalation.unref?.();
       };
 
       // conversation_id from the init event → the resumeCursor (session.started
@@ -597,7 +613,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         childClosed = true;
         children.delete(child); // close is the true process-exit signal
         clearTimeout(postSettleReaper);
-        clearTimeout(postSettleFallback);
+        clearTimeout(postSettleEscalation);
         finalizeMcp();
         if (!settled) {
           emit({

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -364,6 +364,9 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       // exiting, the bot would stay busy forever (agy's own --print-timeout 10m
       // is the only other net). Assigned just below; settle() always clears it.
       let watchdog: ReturnType<typeof setTimeout> | undefined;
+      // Assigned once the child exists. A child can emit `result` and then
+      // hang, so settling must still arrange for process and MCP cleanup.
+      let armPostSettleCleanup = () => {};
       const settle = (
         ok: boolean,
         stopReason: string | null,
@@ -374,6 +377,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         settled = true;
         clearTimeout(watchdog);
         active.delete(threadId);
+        armPostSettleCleanup();
         emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost, ...(usage ? { usage } : {}) });
       };
 
@@ -457,6 +461,37 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         return { turnId };
       }
       children.add(child);
+
+      let childClosed = false;
+      let postSettleReaper: ReturnType<typeof setTimeout> | undefined;
+      let postSettleFallback: ReturnType<typeof setTimeout> | undefined;
+      let mcpFinalized = false;
+      const finalizeMcp = () => {
+        if (mcpFinalized) return;
+        mcpFinalized = true;
+        try {
+          restoreMcp();
+        } catch (error) {
+          emit({
+            ...base(threadId, turnId),
+            type: "runtime.error",
+            message: `could not restore Antigravity's MCP config: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        } finally {
+          releaseMcpLease();
+        }
+      };
+      armPostSettleCleanup = () => {
+        if (childClosed || postSettleReaper) return;
+        // A normal agy process exits immediately after `result`. Give it a
+        // short grace, then reap a zombie so `close` can release the lease.
+        postSettleReaper = setTimeout(() => killCliTree(child), 2_000);
+        postSettleReaper.unref?.();
+        // Some platforms can fail to deliver `close` after a failed kill.
+        // Never leave credentials mounted or every later turn queued forever.
+        postSettleFallback = setTimeout(finalizeMcp, 5_000);
+        postSettleFallback.unref?.();
+      };
 
       // conversation_id from the init event → the resumeCursor (session.started
       // is what the harness persists as the cursor). Also seeds tool item ids.
@@ -559,18 +594,11 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       });
 
       child.on("close", (code) => {
+        childClosed = true;
         children.delete(child); // close is the true process-exit signal
-        try {
-          restoreMcp();
-        } catch (error) {
-          emit({
-            ...base(threadId, turnId),
-            type: "runtime.error",
-            message: `could not restore Antigravity's MCP config: ${error instanceof Error ? error.message : String(error)}`,
-          });
-        } finally {
-          releaseMcpLease();
-        }
+        clearTimeout(postSettleReaper);
+        clearTimeout(postSettleFallback);
+        finalizeMcp();
         if (!settled) {
           emit({
             ...base(threadId, turnId),

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -224,26 +224,58 @@ export function ensureAntigravityComputerMcp(
   mkdirSync(directory, { recursive: true, mode: 0o700 });
   chmodSync(directory, 0o700);
   if (existed) chmodSync(path, 0o600);
-  writeFileSync(path, `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`, { mode: 0o600 });
+  const mounted = `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`;
+  writeFileSync(path, mounted, { mode: 0o600 });
   chmodSync(path, 0o600);
 
-  // Restore exactly what was present before this turn. The module-wide lease
-  // means no other OpenMausBot Antigravity turn can modify the file before
-  // this runs. Keep the tightened permissions when restoring an existing file.
+  const hadOriginalEntry = ANTIGRAVITY_COMPUTER_MCP_KEY in (config.mcpServers ?? {});
+  const originalEntry = config.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY];
+
+  // Restore exactly what was present before this turn when nobody else touched
+  // the file. A user's own agy process is outside our module-wide lease, so if
+  // it edited the config concurrently, preserve that edit and restore only our
+  // one key instead of replacing (or deleting) the whole file.
   let restored = false;
   return () => {
     if (restored) return;
     restored = true;
-    if (original !== null) {
+    let current: string;
+    try {
+      current = readFileSync(path, "utf8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+      throw error;
+    }
+    if (current === mounted) {
+      if (original === null) {
+        unlinkSync(path);
+        return;
+      }
       writeFileSync(path, original, { mode: 0o600 });
       chmodSync(path, 0o600);
       return;
     }
+
+    // A malformed concurrent edit is not safe to rewrite. Leaving a stale
+    // OpenMausBot entry is preferable to destroying bytes we cannot interpret.
+    let currentJson: unknown;
     try {
-      unlinkSync(path);
-    } catch (error) {
-      if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+      currentJson = JSON.parse(current);
+    } catch {
+      return;
     }
+    const parsed = mcpConfigFileSchema.safeParse(currentJson);
+    if (!parsed.success) return;
+    const currentConfig = parsed.data;
+    const currentServers = { ...currentConfig.mcpServers };
+    if (hadOriginalEntry) currentServers[ANTIGRAVITY_COMPUTER_MCP_KEY] = originalEntry;
+    else delete currentServers[ANTIGRAVITY_COMPUTER_MCP_KEY];
+    writeFileSync(
+      path,
+      `${JSON.stringify({ ...currentConfig, mcpServers: currentServers }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+    chmodSync(path, 0o600);
   };
 }
 
@@ -464,7 +496,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
       let childClosed = false;
       let postSettleReaper: ReturnType<typeof setTimeout> | undefined;
-      let postSettleEscalation: ReturnType<typeof setTimeout> | undefined;
+      let terminationEscalation: ReturnType<typeof setTimeout> | undefined;
       let mcpFinalized = false;
       const finalizeMcp = () => {
         if (mcpFinalized) return;
@@ -481,16 +513,9 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           releaseMcpLease();
         }
       };
-      armPostSettleCleanup = () => {
-        if (childClosed || postSettleReaper) return;
-        // A normal agy process exits immediately after `result`. Give it a
-        // short grace, then reap a zombie so `close` can release the lease.
-        postSettleReaper = setTimeout(() => killCliTree(child), 2_000);
-        postSettleReaper.unref?.();
-        // Keep the lease while the child is alive. If graceful termination is
-        // ignored, force the process tree down; `close` is the only path that
-        // restores the global config and releases the next queued turn.
-        postSettleEscalation = setTimeout(() => {
+      const armTerminationEscalation = () => {
+        if (childClosed || terminationEscalation) return;
+        terminationEscalation = setTimeout(() => {
           if (childClosed) return;
           if (process.platform === "win32") {
             killCliTree(child); // taskkill /T /F is already forceful
@@ -505,8 +530,20 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
               child.kill("SIGKILL");
             } catch {}
           }
-        }, 5_000);
-        postSettleEscalation.unref?.();
+        }, 3_000);
+        terminationEscalation.unref?.();
+      };
+      const stop = () => {
+        killCliTree(child); // process groups are POSIX-only
+        armTerminationEscalation();
+      };
+      armPostSettleCleanup = () => {
+        if (childClosed || postSettleReaper) return;
+        // A normal agy process exits immediately after `result`. Give it a
+        // short grace, then reap a zombie. Explicit stops use the same bounded
+        // SIGKILL escalation so an uncooperative child cannot retain the lease.
+        postSettleReaper = setTimeout(stop, 2_000);
+        postSettleReaper.unref?.();
       };
 
       // conversation_id from the init event → the resumeCursor (session.started
@@ -613,7 +650,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         childClosed = true;
         children.delete(child); // close is the true process-exit signal
         clearTimeout(postSettleReaper);
-        clearTimeout(postSettleEscalation);
+        clearTimeout(terminationEscalation);
         finalizeMcp();
         if (!settled) {
           emit({
@@ -625,7 +662,6 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         }
       });
 
-      const stop = () => killCliTree(child); // process groups are POSIX-only
       active.set(threadId, { stop, turnId });
       pending.delete(threadId);
 

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -12,6 +12,9 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const argv = process.argv.slice(2);
+if (process.env.FAKE_AGY_IGNORE_SIGTERM === "1") {
+  process.on("SIGTERM", () => {});
+}
 if (process.env.FAKE_AGY_DUMP) {
   writeFileSync(process.env.FAKE_AGY_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
 }

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -47,4 +47,8 @@ out({ event: "step_update", conversation_id: CONV, step_update: { conversation_i
 out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 0, state: "DONE", step_type: "tool", tool_name: "write_to_file", tool_info: { name: "write_to_file", parameters: {} } } });
 out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 1, state: "DONE", step_type: "agent_response", usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 0, cache_read_tokens: 5, total_tokens: 125 } } });
 out({ event: "result", conversation_id: CONV, result: { conversation_id: CONV, status: "SUCCESS", response: "done from fake agy", duration_seconds: 1, num_turns: 1, usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 0, cache_read_tokens: 5, total_tokens: 125 } } });
+const postResultDelayMs = Number(process.env.FAKE_AGY_POST_RESULT_DELAY_MS ?? 0);
+if (Number.isFinite(postResultDelayMs) && postResultDelayMs > 0) {
+  await new Promise((resolve) => setTimeout(resolve, postResultDelayMs));
+}
 process.exit(0);

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -8,7 +8,8 @@
 // status SUCCESS. Deterministic, no network.
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const argv = process.argv.slice(2);
 if (process.env.FAKE_AGY_DUMP) {
@@ -17,6 +18,19 @@ if (process.env.FAKE_AGY_DUMP) {
 if (argv.includes("--version")) {
   console.log("1.1.12");
   process.exit(0);
+}
+
+const delayMs = Number(process.env.FAKE_AGY_DELAY_MS ?? 0);
+if (Number.isFinite(delayMs) && delayMs > 0) {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+if (process.env.FAKE_AGY_MCP_DUMP) {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  let config = "null";
+  try {
+    config = readFileSync(join(home, ".gemini", "config", "mcp_config.json"), "utf8");
+  } catch {}
+  writeFileSync(process.env.FAKE_AGY_MCP_DUMP, config);
 }
 
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -15,6 +15,9 @@ const argv = process.argv.slice(2);
 if (process.env.FAKE_AGY_IGNORE_SIGTERM === "1") {
   process.on("SIGTERM", () => {});
 }
+if (process.env.FAKE_AGY_READY_FILE) {
+  writeFileSync(process.env.FAKE_AGY_READY_FILE, "ready");
+}
 if (process.env.FAKE_AGY_DUMP) {
   writeFileSync(process.env.FAKE_AGY_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
 }


### PR DESCRIPTION
## Root cause

Turn assembly gates every computer destination on adapter capabilities (`server/index.ts` ~1516–1557): `computerMcp` enables the cloud box (`integrations.computer`), the Local VM, and the self-hosted VPS mounts; `localComputerMcp` enables the host desktop. `server/drivers/antigravity.ts` declared neither — only `{ sessionModelSwitch, images }` — so any Antigravity model on a bot with a computer destination threw "this model engine cannot control this computer — choose Claude or an ACP engine" (or the VM/VPS variants of that error). The driver simply never mounted `turn.integrations` at all.

## Design

**How the mount works.** `agy` has no per-turn MCP flag and no project-level MCP config. Probed empirically against agy 1.1.19 on this machine:

- the binary's embedded MCP docs list exactly two config locations — global `~/.gemini/config/mcp_config.json` and per-plugin `mcp_config.json` — and no project location;
- `agy mcp list` run from cwds seeded with `.gemini/config/mcp_config.json`, `.gemini/mcp_config.json`, `.gemini/settings.json`, `.agents/mcp_config.json`, and a bare `mcp_config.json` sees none of them;
- `agy mcp add/remove/disable` reads and writes only the global file (shape `{"mcpServers": {name: {command, args, env}}}`).

So project-scoped config provably doesn't work, and the driver falls back to upserting the **global** file: one key, `openmausbot-computer`, written synchronously right before each spawn. The upsert preserves every other byte of the user's config (other servers, unknown top-level keys) and tolerates malformed JSON by starting from a fresh object — the same discipline as `ensureOpenCodeInjectModel` in `server/drivers/acp/opencode-go.ts`. A computer-less turn removes the key, so tools and box/control tokens cannot leak into later turns or the user's own interactive `agy` sessions.

**What gets mounted.** Cloud boxes mount OpenMausBot's REST-to-MCP proxy: `command = process.execPath`, `args = [SPAWNED_PROXIES.computer]` (resolved through `server/proxy-paths.ts`, never relative to the module — the 0.1.24 lesson), `env = ELECTRON_RUN_AS_NODE=1` + `computerProxyEnv()` (box id/token plus the who-is-driving control endpoint) — the same spec `claude.ts` and `codex.ts` build. Local VM and VPS connections arrive as ready-made Cua Driver stdio commands and pass through unchanged.

**Capability gating.**

- `computerMcp: config.fullAuto` — only full-auto instances (the default) advertise a computer. Print mode has no interactive approval channel, and outside `--dangerously-skip-permissions` agy auto-denies tools that would need a prompt (its own mode help: accept-edits = "auto-approve file edits, prompt for commands"; print mode soft-denies what would prompt). A non-fullAuto mount could therefore never fire, so per the review rule it is gated rather than shipped dead.
- `localComputerMcp` intentionally stays unset. `contracts.ts` requires it only "when local MCP calls can reach the human approval channel" and requires full-auto/bypass instances to leave it false — agy print mode cannot deliver per-action approvals in any mode. **Result: Cloud box, Local VM, and VPS now work for Antigravity; "This computer" (host desktop) still refuses, by design.** Host control returns with the native ACP path (agy issue #31).

**Known quirk, pre-existing, not touched here:** `instanceSupportsLocalComputer` in `src/lib/local-computer.ts` treats `computerMcp` as implying local-desktop support in the UI, so a full-auto instance can select "This computer" and only fails at turn time — Antigravity full-auto now joins ACP-fullAuto and Claude-bypass instances in that bucket. The OR is deliberate and test-pinned (commit 848fea8), so aligning it with the server gate is left as a follow-up. The ComputerPanel mirror copy at `src/components/ComputerPanel.tsx:227` renders only for instances where nothing works (non-fullAuto Antigravity), where its current wording is still accurate, so it is unchanged.

**Trade-offs:** the global file is machine-wide, so between the write and the spawned agy reading its config there is an ms-scale window in which a concurrent Antigravity turn with a *different* computer could rewrite the entry; the write is kept immediately before the spawn to minimize it. Between a computer turn and the next computer-less turn the entry persists in the user's global agy config (their own interactive agy would see the computer tools until then). Both are consequences of agy offering no per-session MCP config.

## Verification

- `pnpm typecheck` clean.
- `npx oxlint` on both touched files adds no findings vs origin/main (driver 22 → 22, test file 6 → 6; new code uses zod at the JSON boundary, no typeof narrowing, no assertions).
- New tests in `server/drivers/antigravity.test.ts` (18 total, all pass):
  - upsert preserves the user's other servers and unknown top-level keys, and overwrites our key in place on a later turn;
  - survives malformed JSON by rebuilding a valid file with the mount;
  - a computer-less turn removes only our key, and never creates the file just to remove;
  - the cloud-box spec pins `command/args/env` at `process.execPath` + `SPAWNED_PROXIES.computer` + `ELECTRON_RUN_AS_NODE`/box/control env; Local VM/VPS specs pass through; no computer → null;
  - `computerMcp` exposed on fullAuto instances only; `localComputerMcp` never;
  - a fake-CLI turn asserts the settings file content at spawn time (write is synchronous before the spawn `sendTurn` resolves behind) and the removal on the next computer-less turn.
- **Mutation checks** on the upsert-preserve behavior: (1) replacing the merged `{ ...config.mcpServers }` with an empty object → 3 tests fail; (2) dropping unknown top-level keys on write (`{ mcpServers }` instead of `{ ...config, mcpServers }`) → the preserve test fails. Both mutations reverted; suite green again.
- Full `pnpm test` green (includes the packaged-server smoke; no bare imports outside the bundler's reach — the driver is inlined into the index bundle like claude.ts/codex.ts, which already import the same modules).
- CLI probes (`agy mcp list/add/remove`, embedded docs, project-level location matrix) run live against agy 1.1.19 on macOS.

## Not verified

- **An end-to-end live computer turn.** `agy` on this machine is signed out, so no real print-mode turn can run. "agy discovers the mounted MCP server and calls its tools in a real turn" has not been exercised live — the mount file format matches agy's own `mcp add` output and its embedded schema docs, and the stream-json turn handling is unchanged, but live tool-calling is unproven here.
- Whether accept-edits print mode denies or allows MCP tool calls — unprovable while signed out; the capability is gated to fullAuto so no mount ships where it might never fire.
- Probes ran on agy 1.1.19; the driver was originally validated against 1.1.12. The MCP config location/schema is asserted for 1.1.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added computer-use MCP support for Antigravity in full-auto and accept-edits modes.
  * Supports computer-use servers hosted in the cloud, local virtual machines, or VPS environments.
  * Reports available computer-use capabilities and automatically manages integration setup.

* **Bug Fixes**
  * Improved recovery from malformed MCP configuration files.
  * Preserves unrelated and concurrent configuration changes.
  * Improved security for temporary configuration files.
  * Prevented overlapping operations from interfering with each other.
  * Ensured configurations are restored or cleaned up after operations complete.
  * Improved cleanup when operations or background processes do not exit normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->