### PR TITLE
fix(composio): accept empty first-account authorization bodies

### DIFF
--- a/cloudflare/composio-broker/src/index.test.ts
+++ b/cloudflare/composio-broker/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   ensureSession,
   normalizeAccountAlias,
   parseSession,
+  requestAlias,
   sha256,
 } from "./index";
 
@@ -53,6 +54,17 @@ function testEnv(fetchCalls: Array<{ url: string; init?: RequestInit }>) {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("connected-apps broker boundaries", () => {
+  it("accepts an empty authorize body as a first-account request", async () => {
+    await expect(requestAlias(new Request("https://broker.test/v1/connectors/gmail/authorize", {
+      method: "POST",
+      body: "",
+    }))).resolves.toBeUndefined();
+    await expect(requestAlias(new Request("https://broker.test/v1/connectors/gmail/authorize", {
+      method: "POST",
+      body: "  \n",
+    }))).resolves.toBeUndefined();
+  });
+
   it("accepts only HTTPS Composio MCP endpoints", () => {
     expect(parseSession({
       session_id: "session-1",

--- a/cloudflare/composio-broker/src/index.ts
+++ b/cloudflare/composio-broker/src/index.ts
@@ -552,6 +552,10 @@ async function requestAlias(request: Request) {
     if (new TextEncoder().encode(raw).byteLength > 2048) {
       throw new Response(JSON.stringify({ error: "request body is too large" }), { status: 413, headers: JSON_HEADERS });
     }
+    // Some Fetch implementations expose a zero-length POST as a non-null
+    // ReadableStream. First-account authorization intentionally has no alias,
+    // so accept that wire representation exactly like a missing body.
+    if (!raw.trim()) return undefined;
     body = aliasRequestSchema.parse(JSON.parse(raw));
   } catch (error) {
     if (error instanceof Response) throw error;
@@ -607,5 +611,6 @@ export {
   ensureSession,
   normalizeAccountAlias,
   parseSession,
+  requestAlias,
   sha256,
 };


### PR DESCRIPTION
Fixes the hosted broker rejecting first-account connection requests with `invalid JSON body`.

Some Fetch runtimes expose a zero-length POST as a non-null stream; treat empty/whitespace-only authorization bodies as a request without an alias.

Tests:
- `pnpm broker:test`
- `pnpm broker:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - First-account authorization requests with empty or whitespace-only POST bodies are now accepted instead of being rejected as invalid JSON.

- **Tests**
  - Added coverage to verify authorization behavior for empty and whitespace-only request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->