### PR TITLE
ci: stop retaining disposable Linux packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,6 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: openmausbot-ubuntu-x64
-          path: |
-            release/*.deb
-            release/*.AppImage
-          if-no-files-found: error
 
   ios:
     name: Swift tests + iOS build


### PR DESCRIPTION
Ordinary CI builds and smoke-tests the Ubuntu package but has no downstream consumer for its binaries. The unconditional upload retained a roughly 240 MB artifact for 90 days on every PR run, accumulating more than 200 GiB.

This removes only that successful-package upload. Failure diagnostics remain available for seven days, and the dedicated release workflows keep their release artifacts.

Validation: YAML parse and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to stop automatically uploading generated Linux package artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->