### PR TITLE
fix(ios): pair through every trusted route

### DIFF
--- a/companion/src/devices.ts
+++ b/companion/src/devices.ts
@@ -45,6 +45,20 @@ export interface PairingWindow {
   attemptsLeft: number;
 }
 
+/** A successful redemption kept only long enough for the *same* phone request
+ * to recover from a lost HTTP response on another advertised address.
+ *
+ * The device token remains memory-only here (the durable file still contains
+ * only its digest), and a replay needs both the original high-entropy pairing
+ * credential and the client-generated request id. Older clients that omit a
+ * request id retain the original exactly-once behaviour. */
+interface PairingReplay {
+  requestId: string;
+  credentialHash: string;
+  expiresAt: number;
+  result: { device: PublicDevice; token: string };
+}
+
 const DEVICES_FILE = join(DATA_DIR, "devices.json");
 export const PAIRING_TTL_MS = 120_000;
 export const MAX_PAIRING_ATTEMPTS = 5;
@@ -113,6 +127,8 @@ function normalizeDevice(record: Partial<DeviceRecord> & { id: string; tokenHash
 export class DeviceRegistry {
   private devices: DeviceRecord[] = [];
   private window: PairingWindow | null = null;
+  private replay: PairingReplay | null = null;
+  private replayExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSeenWrites = new Map<string, number>();
 
   /** Load the paired fleet, normalising as it goes.
@@ -167,6 +183,7 @@ export class DeviceRegistry {
   /** Open a fresh window, replacing any that was already open. The code is
    * from `randomInt`, not `Math.random` — it is a credential for two minutes. */
   openPairing(): PairingWindow {
+    this.clearReplay();
     this.window = {
       code: String(randomInt(0, 1_000_000)).padStart(6, "0"),
       token: `omb_pair_${randomBytes(32).toString("base64url")}`,
@@ -178,16 +195,52 @@ export class DeviceRegistry {
 
   closePairing() {
     this.window = null;
+    this.clearReplay();
+  }
+
+  /** Erase the only in-memory copy of a successfully issued device token.
+   * The timer matters even if nobody ever calls `redeem` again: an expired
+   * recovery window must not leave a raw bearer sitting in a long-lived
+   * desktop process. */
+  private clearReplay() {
+    this.replay = null;
+    if (this.replayExpiryTimer) clearTimeout(this.replayExpiryTimer);
+    this.replayExpiryTimer = null;
   }
 
   /** Redeem either pairing credential for a device token.
    *
-   * The token is returned exactly once, here. There is no endpoint that can
-   * read it back — a phone that loses it pairs again. */
-  redeem(credential: string, name: unknown): { device: PublicDevice; token: string } | { error: string } {
+   * Old clients receive the token exactly once. A client that supplies a
+   * request id may repeat that same logical redemption until the pairing
+   * window's original expiry, which is just enough to survive losing the
+   * response while changing routes. There is no general token-read endpoint. */
+  redeem(
+    credential: string,
+    name: unknown,
+    pairRequestId?: unknown,
+  ): { device: PublicDevice; token: string } | { error: string } {
+    const presented = String(credential ?? "");
+    const requestId =
+      typeof pairRequestId === "string" && /^[A-Za-z0-9._-]{16,128}$/.test(pairRequestId)
+        ? pairRequestId
+        : null;
+
+    // A route can die after the registry committed the device but before the
+    // phone received the response. Retrying the same logical request through
+    // another advertised address must return the same device, not burn a
+    // second slot or turn a successful pairing into a misleading 401.
+    if (this.replay && this.replay.expiresAt <= Date.now()) this.clearReplay();
+    if (
+      requestId &&
+      this.replay &&
+      sameCredential(this.replay.requestId, requestId) &&
+      sameDigest(this.replay.credentialHash, sha256(presented))
+    ) {
+      return this.replay.result;
+    }
+
     const window = this.pairing();
     if (!window) return { error: "no pairing is in progress — open Companion settings on your computer" };
-    const presented = String(credential ?? "");
     if (!sameCredential(window.code, presented) && !sameCredential(window.token, presented)) {
       window.attemptsLeft -= 1;
       // A burned window is the whole point: without this, six digits is a
@@ -204,7 +257,9 @@ export class DeviceRegistry {
     // attempts. The window survives, so removing a phone and retyping the
     // same code still works.
     if (this.devices.length >= MAX_DEVICES) return { error: "too many paired devices — remove one first" };
-    this.closePairing();
+    // Consume the window without clearing a possible replay. `closePairing`
+    // is the explicit cancel operation and intentionally clears both.
+    this.window = null;
 
     const token = `omb_${randomBytes(32).toString("base64url")}`;
     const device: DeviceRecord = {
@@ -228,7 +283,23 @@ export class DeviceRegistry {
       return { error: `could not save the pairing: ${(e as Error).message}` };
     }
     const { tokenHash, ...pub } = device;
-    return { device: pub, token };
+    const result = { device: pub, token };
+    if (requestId) {
+      this.replay = {
+        requestId,
+        credentialHash: sha256(presented),
+        expiresAt: window.expiresAt,
+        result,
+      };
+      this.replayExpiryTimer = setTimeout(
+        () => this.clearReplay(),
+        Math.max(0, window.expiresAt - Date.now()),
+      );
+      // A two-minute recovery window is not a reason for a deliberately
+      // stopped companion process to stay alive.
+      this.replayExpiryTimer.unref?.();
+    }
+    return result;
   }
 
   /** Resolve a bearer token to its device, or null. */

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -131,7 +131,7 @@ const companion = createServer(
     // `authenticate` also stamps lastSeenAt, which is what makes the control
     // page able to say when a phone was last heard from.
     authenticate: (token) => devices.authenticate(token),
-    redeem: (code, deviceName) => devices.redeem(code, deviceName),
+    redeem: (code, deviceName, pairRequestId) => devices.redeem(code, deviceName, pairRequestId),
     serverName: machineName,
     // Recomputed per pairing rather than cached: addresses change when the
     // machine joins another network, and a pairing is exactly the moment the

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -29,6 +29,7 @@ export interface ProxyOptions {
   redeem: (
     code: string,
     deviceName: unknown,
+    pairRequestId?: unknown,
   ) => { token: string; device: unknown } | { error: string };
   /** What the phone should call this computer in its connection list. */
   serverName: () => string;
@@ -165,7 +166,11 @@ export function createProxyHandler(options: ProxyOptions) {
         (body) => {
           // New clients redeem the high-entropy credential carried by the QR.
           // `code` remains accepted for manual entry and older mobile builds.
-          const result = options.redeem(String(body.credential ?? body.code ?? ""), body.deviceName);
+          const result = options.redeem(
+            String(body.credential ?? body.code ?? ""),
+            body.deviceName,
+            body.pairRequestId,
+          );
           if ("error" in result) return sendJson(res, 401, { error: result.error });
           // `hosts` rides along whichever way the phone paired — QR, typed
           // address, or discovery — so every paired device learns the full

--- a/companion/test/devices.test.ts
+++ b/companion/test/devices.test.ts
@@ -128,6 +128,64 @@ describe("DeviceRegistry", () => {
     expect(registry.count()).toBe(1);
   });
 
+  it("replays one logical redemption without creating an orphan device", () => {
+    const registry = new DeviceRegistry();
+    const { token: credential } = registry.openPairing();
+    const requestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec";
+
+    const first = registry.redeem(credential, "iPhone", requestId);
+    const replay = registry.redeem(credential, "iPhone", requestId);
+
+    expect(first).toHaveProperty("token");
+    expect(replay).toEqual(first);
+    expect(registry.count()).toBe(1);
+    // Possessing only one half of the replay key is not enough.
+    expect(registry.redeem(credential, "iPhone", "different-request-id")).toMatchObject({
+      error: expect.stringContaining("no pairing"),
+    });
+    expect(registry.redeem("omb_pair_wrong", "iPhone", requestId)).toMatchObject({
+      error: expect.stringContaining("no pairing"),
+    });
+  });
+
+  it("forgets a redemption replay when a fresh pairing window opens", () => {
+    const registry = new DeviceRegistry();
+    const { token: firstCredential } = registry.openPairing();
+    const requestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec";
+    expect(registry.redeem(firstCredential, "iPhone", requestId)).toHaveProperty("token");
+
+    registry.openPairing();
+    expect(registry.redeem(firstCredential, "iPhone", requestId)).toMatchObject({
+      error: expect.stringContaining("not right"),
+    });
+  });
+
+  it("actively erases a redemption replay at the original window expiry", () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new DeviceRegistry();
+      const { token: credential } = registry.openPairing();
+      const requestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec";
+      expect(registry.redeem(credential, "iPhone", requestId)).toHaveProperty("token");
+      const memory = registry as unknown as {
+        replay: unknown;
+        replayExpiryTimer: unknown;
+      };
+      expect(memory.replay).not.toBeNull();
+      expect(memory.replayExpiryTimer).not.toBeNull();
+
+      vi.advanceTimersByTime(PAIRING_TTL_MS + 1);
+      expect(memory.replay).toBeNull();
+      expect(memory.replayExpiryTimer).toBeNull();
+      expect(registry.redeem(credential, "iPhone", requestId)).toMatchObject({
+        error: expect.stringContaining("no pairing"),
+      });
+      expect(registry.count()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps cloud desktop access off until enabled for that device", () => {
     const registry = new DeviceRegistry();
     const { token, device } = pair(registry);

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -549,7 +549,7 @@ describe("pairing, end to end", () => {
       createProxyHandler({
         harnessPort: HARNESS_PORT,
         authenticate: (t) => registry.authenticate(t ?? undefined),
-        redeem: (code, deviceName) => registry.redeem(code, deviceName),
+        redeem: (code, deviceName, pairRequestId) => registry.redeem(code, deviceName, pairRequestId),
         serverName: () => "Ada's computer",
         hosts: () => ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"],
       }),
@@ -591,10 +591,16 @@ describe("pairing, end to end", () => {
       expect(wrong.status).toBe(401);
 
       // The QR token is redeemed exactly once and never forwarded upstream.
+      const pairRequestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec";
+      const pairBody = JSON.stringify({
+        credential: opened.token,
+        deviceName: "Ada's iPhone",
+        pairRequestId,
+      });
       const res = await fetch(`${base}/api/pair`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ credential: opened.token, deviceName: "Ada's iPhone" }),
+        body: pairBody,
       });
       expect(res.status).toBe(201);
       // SAFETY: a 201 from /api/pair carries exactly this shape — the
@@ -605,6 +611,17 @@ describe("pairing, end to end", () => {
       // The fallback list rides on the redeem response so a phone that paired
       // by typed address learns the other ways to reach this computer too.
       expect(body.hosts).toEqual(["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"]);
+
+      // Losing the first response after it reached the Mac must not strand an
+      // orphan device. The same logical request can arrive through a fallback
+      // address and receives the exact token already committed to disk.
+      const replay = await fetch(`${base}/api/pair`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: pairBody,
+      });
+      expect(replay.status).toBe(201);
+      expect((await replay.json() as { token: string }).token).toBe(body.token);
 
       // and the token works on the real API, through the real proxy
       const bots = await fetch(`${base}/api/bots`, { headers: { authorization: `Bearer ${body.token}` } });

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -20,6 +20,10 @@ struct PairingView: View {
     @State private var manualAddress = ""
     @State private var code = ""
     @State private var scannedCredential: String?
+    /// Stable across Retry. If the Mac committed a device but the response
+    /// was lost, repeating this same logical request recovers its token
+    /// instead of creating an orphan device.
+    @State private var pairRequestId: String?
     @State private var chosen: Connection?
     @State private var pairing = false
     @State private var failure: String?
@@ -365,6 +369,7 @@ struct PairingView: View {
                         }
                         choiceGeneration += 1
                         scannedCredential = nil
+                        pairRequestId = nil
                         chosen = connection
                     } label: {
                         Text("Connect to Address")
@@ -493,6 +498,7 @@ struct PairingView: View {
                 chosen = nil
                 code = ""
                 scannedCredential = nil
+                pairRequestId = nil
                 failure = nil
             }
             .font(.caption.weight(.semibold))
@@ -536,6 +542,7 @@ struct PairingView: View {
         choiceGeneration += 1
         let generation = choiceGeneration
         failure = nil
+        pairRequestId = nil
         do {
             let resolved = try await discovery.resolve(service)
             guard generation == choiceGeneration else { return }
@@ -551,20 +558,35 @@ struct PairingView: View {
         failure = nil
         defer { pairing = false }
         let cameFromScanner = scannedCredential != nil
+        let requestId = pairRequestId ?? UUID().uuidString
+        pairRequestId = requestId
         do {
             try await session.pair(
                 with: connection,
                 credential: credential,
-                deviceName: Self.deviceName()
+                deviceName: Self.deviceName(),
+                pairRequestId: requestId
             )
+            pairRequestId = nil
         } catch {
             if cameFromScanner {
-                failure = "\(error.localizedDescription) Start pairing again on your computer and rescan the new QR code."
-                chosen = nil
-                scannedCredential = nil
+                if error is PairingRouteError {
+                    // The same request id makes Retry safe whether no route
+                    // was reached or the Mac committed the device and its
+                    // response was lost while the route changed.
+                    failure = error.localizedDescription
+                } else {
+                    failure = "\(error.localizedDescription) Start pairing again on your computer and rescan the new QR code."
+                    chosen = nil
+                    scannedCredential = nil
+                    pairRequestId = nil
+                }
             } else {
                 failure = error.localizedDescription
-                code = ""
+                if !(error is PairingRouteError) {
+                    code = ""
+                    pairRequestId = nil
+                }
             }
         }
     }
@@ -574,6 +596,7 @@ struct PairingView: View {
         choiceGeneration += 1
         chosen = invite.connection
         scannedCredential = invite.credential
+        pairRequestId = UUID().uuidString
         code = ""
         failure = nil
         session.consumePairingInvite()

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -156,20 +156,28 @@ final class Session: ObservableObject {
     /// Redeem a one-time pairing credential. On success the device token goes
     /// to the keychain and the connection to defaults — deliberately apart,
     /// so the thing that gets backed up is never the credential.
-    func pair(with connection: Connection, credential: String, deviceName: String) async throws {
-        let paired = try await CompanionClient.pair(
+    func pair(
+        with connection: Connection,
+        credential: String,
+        deviceName: String,
+        pairRequestId: String
+    ) async throws {
+        let outcome = try await CompanionClient.pairFirstReachable(
             connection: connection,
             credential: credential,
-            deviceName: deviceName
+            deviceName: deviceName,
+            pairRequestId: pairRequestId
         )
+        let paired = outcome.response
         // prefer the name the computer calls itself over the Bonjour label
-        var stored = connection
+        var stored = outcome.connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
         // The computer knows every address it answers on, and what it says at
         // redeem time beats whatever the invite carried. Then the host that
         // just redeemed the code leads: it demonstrably works from here.
-        if let hosts = paired.hosts, !hosts.isEmpty { stored.hosts = hosts }
-        stored.promote(stored.host)
+        if let hosts = paired.hosts, !hosts.isEmpty { stored.hosts = Array(hosts.prefix(8)) }
+        stored.promote(outcome.connection.host)
+        stored.hosts = Array(stored.orderedHosts.prefix(8))
 
         try Keychain.save(paired.token, for: stored.id)
         UserDefaults.standard.set(try? JSONEncoder().encode(stored), forKey: Self.connectionKey)

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -198,6 +198,35 @@ public struct PairingInvite: Equatable, Sendable {
     }
 }
 
+/// The server response together with the endpoint that actually answered.
+/// Pairing has to persist the winner, not merely the first address printed in
+/// a QR code, or the next launch repeats the same dead route.
+public struct PairingOutcome: Sendable {
+    public let response: PairResponse
+    public let connection: Connection
+
+    public init(response: PairResponse, connection: Connection) {
+        self.response = response
+        self.connection = connection
+    }
+}
+
+/// None of the addresses advertised for a computer answered the companion
+/// health check. Kept distinct from a pairing rejection: this invite is still
+/// valid and the UI can offer Retry without making someone scan it again.
+public struct PairingRouteError: Error, LocalizedError, Equatable, Sendable {
+    public let attemptedHosts: [String]
+
+    public init(attemptedHosts: [String]) {
+        self.attemptedHosts = attemptedHosts
+    }
+
+    public var errorDescription: String? {
+        let routes = attemptedHosts.joined(separator: ", ")
+        return "Couldn’t reach this computer through any available route (\(routes)). Keep OpenMausBot’s Companion turned on, then try again."
+    }
+}
+
 public enum APIError: Error, LocalizedError, Sendable {
     /// The harness answered, and said no.
     case status(code: Int, message: String?)
@@ -326,6 +355,7 @@ public struct CompanionClient: Sendable {
         connection: Connection,
         credential: String,
         deviceName: String,
+        pairRequestId: String? = nil,
         session: URLSession = .shared
     ) async throws -> PairResponse {
         let client = CompanionClient(connection: connection, token: nil, session: session)
@@ -335,12 +365,117 @@ public struct CompanionClient: Sendable {
         let key = credential.utf8.count == 6 && credential.utf8.allSatisfy({ (48...57).contains($0) })
             ? "code"
             : "credential"
-        let pairRequest = try client.makeRequest(
+        var body: [String: Any] = [key: credential, "deviceName": deviceName]
+        if let pairRequestId { body["pairRequestId"] = pairRequestId }
+        var pairRequest = try client.makeRequest(
             "POST",
             "/api/pair",
-            body: [key: credential, "deviceName": deviceName]
+            body: body
         )
+        // Pairing is allowed to move to another advertised route. One dead
+        // address must not consume the default twenty-second API deadline.
+        pairRequest.timeoutInterval = 8
         return try await client.send(pairRequest, as: PairResponse.self)
+    }
+
+    /// Resolve the multi-address invite before consuming its credential.
+    ///
+    /// Health probes are non-mutating and run together, so a dead MagicDNS
+    /// name cannot sit in front of a working LAN address for twenty seconds.
+    /// Only the first response that identifies itself as OpenMausBot receives
+    /// the one-time pairing POST. The request id makes that redemption safely
+    /// replayable by newer desktop builds if its response is lost in transit.
+    public static func pairFirstReachable(
+        connection: Connection,
+        credential: String,
+        deviceName: String,
+        pairRequestId: String = UUID().uuidString,
+        session: URLSession = .shared
+    ) async throws -> PairingOutcome {
+        let candidates = connection.orderedHosts.map(connection.dialing)
+        var remaining = candidates
+        while !remaining.isEmpty {
+            guard let winner = await firstHealthy(in: remaining, session: session) else {
+                throw PairingRouteError(attemptedHosts: connection.orderedHosts)
+            }
+            remaining.remove(at: winner.offset)
+            do {
+                let response = try await pair(
+                    connection: winner.connection,
+                    credential: credential,
+                    deviceName: deviceName,
+                    pairRequestId: pairRequestId,
+                    session: session
+                )
+                return PairingOutcome(response: response, connection: winner.connection)
+            } catch let error as APIError {
+                // An HTTP response is authoritative: a rejected or expired
+                // credential must not be sprayed at another address. A
+                // transport failure is ambiguous, though — the Mac may have
+                // committed the device before the route died. New desktops
+                // replay this exact request id safely through a fallback.
+                if case .transport = error { continue }
+                throw error
+            } catch {
+                // URL loading and decoding failures are likewise ambiguous.
+                // Keep the logical request id and try another verified route.
+                continue
+            }
+        }
+        throw PairingRouteError(attemptedHosts: connection.orderedHosts)
+    }
+
+    /// Probe every candidate together, but respect the advertised security
+    /// order. A quick cleartext LAN response must not outrank an encrypted
+    /// tailnet route that answers a moment later. A lower-priority result is
+    /// selected as soon as every route before it has conclusively failed.
+    private static func firstHealthy(
+        in candidates: [Connection],
+        session: URLSession
+    ) async -> (offset: Int, connection: Connection)? {
+        await withTaskGroup(
+            of: (Int, Bool).self,
+            returning: (offset: Int, connection: Connection)?.self
+        ) { group in
+            for (offset, candidate) in candidates.enumerated() {
+                group.addTask {
+                    (offset, await healthy(candidate, session: session))
+                }
+            }
+            var results = [Bool?](repeating: nil, count: candidates.count)
+            for await (offset, isHealthy) in group {
+                results[offset] = isHealthy
+                for priority in candidates.indices {
+                    guard let resolved = results[priority] else { break }
+                    if resolved {
+                        group.cancelAll()
+                        return (priority, candidates[priority])
+                    }
+                }
+            }
+            return nil
+        }
+    }
+
+    private struct HealthIdentity: Decodable {
+        let app: String
+    }
+
+    private static func healthy(_ connection: Connection, session: URLSession) async -> Bool {
+        do {
+            let client = CompanionClient(connection: connection, token: nil, session: session)
+            var request = try client.makeRequest("GET", "/api/health")
+            request.timeoutInterval = 4
+            let (data, response) = try await session.data(for: request)
+            guard !Task.isCancelled,
+                  let http = response as? HTTPURLResponse,
+                  (200...299).contains(http.statusCode),
+                  try JSONDecoder().decode(HealthIdentity.self, from: data).app == "openmausbot"
+            else { return false }
+            return true
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Reading

--- a/ios/Tests/CompanionCoreTests/PairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/PairingTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class PairingRequestStub: URLProtocol {
+    enum Action {
+        case response(Int, Data)
+        case delayedResponse(TimeInterval, Int, Data)
+        case failure(URLError.Code)
+    }
+
+    static let lock = NSLock()
+    static var requests: [URLRequest] = []
+    static var action: (URLRequest) -> Action = { _ in .failure(.cannotConnectToHost) }
+    private var delayed: DispatchWorkItem?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.requests.append(request)
+        let action = Self.action(request)
+        Self.lock.unlock()
+
+        switch action {
+        case let .failure(code):
+            client?.urlProtocol(self, didFailWithError: URLError(code))
+        case let .response(status, body):
+            respond(status: status, body: body)
+        case let .delayedResponse(delay, status, body):
+            let work = DispatchWorkItem { [weak self] in
+                guard let self, self.delayed?.isCancelled == false else { return }
+                self.respond(status: status, body: body)
+            }
+            delayed = work
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay, execute: work)
+        }
+    }
+
+    override func stopLoading() {
+        delayed?.cancel()
+        delayed = nil
+    }
+
+    private func respond(status: Int, body: Data) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    static func reset(_ handler: @escaping (URLRequest) -> Action) {
+        lock.lock()
+        requests = []
+        action = handler
+        lock.unlock()
+    }
+
+    static func captured() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    static func body(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            result.append(buffer, count: count)
+        }
+        return result
+    }
+}
+
+final class PairingTests: XCTestCase {
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [PairingRequestStub.self]
+        session = URLSession(configuration: configuration)
+    }
+
+    override func tearDown() {
+        session.invalidateAndCancel()
+        session = nil
+        super.tearDown()
+    }
+
+    func testProbesEveryRouteAndRedeemsOnlyOnTheHealthyLANAddress() async throws {
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" {
+                return request.url?.host == "192.168.1.42"
+                    ? .response(200, Self.health)
+                    : .failure(.cannotFindHost)
+            }
+            return .response(201, Self.paired)
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"]
+        )
+
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.host, "192.168.1.42")
+        let pairRequests = PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }
+        XCTAssertEqual(pairRequests.count, 1)
+        XCTAssertEqual(pairRequests.first?.url?.host, "192.168.1.42")
+        let data = try XCTUnwrap(pairRequests.first.flatMap(PairingRequestStub.body))
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(body["credential"] as? String, Self.credential)
+        XCTAssertNotNil(body["pairRequestId"] as? String)
+    }
+
+    func testAQuickLANResponseDoesNotOutrankThePreferredTailnetRoute() async throws {
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" {
+                return request.url?.host == "mac.tail1234.ts.net"
+                    ? .delayedResponse(0.08, 200, Self.health)
+                    : .response(200, Self.health)
+            }
+            return .response(201, Self.paired)
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["192.168.1.42"]
+        )
+
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.host, "mac.tail1234.ts.net")
+        XCTAssertEqual(
+            PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }.first?.url?.host,
+            "mac.tail1234.ts.net"
+        )
+    }
+
+    func testTransportFailureRetriesAHealthyFallbackWithTheSameRequestID() async throws {
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" { return .response(200, Self.health) }
+            return request.url?.host == "mac.tail1234.ts.net"
+                ? .failure(.networkConnectionLost)
+                : .response(201, Self.paired)
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["192.168.1.42"]
+        )
+        let requestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec"
+
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            pairRequestId: requestId,
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.host, "192.168.1.42")
+        let pairRequests = PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }
+        XCTAssertEqual(pairRequests.map(\.url?.host), ["mac.tail1234.ts.net", "192.168.1.42"])
+        let ids = try pairRequests.map { request in
+            let data = try XCTUnwrap(PairingRequestStub.body(of: request))
+            let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            return body["pairRequestId"] as? String
+        }
+        XCTAssertEqual(ids, [requestId, requestId])
+    }
+
+    func testRetryCanReuseTheLogicalRequestIDAfterTheOnlyRouteDropsItsResponse() async throws {
+        var pairAttempts = 0
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" { return .response(200, Self.health) }
+            pairAttempts += 1
+            return pairAttempts == 1 ? .failure(.networkConnectionLost) : .response(201, Self.paired)
+        }
+        let connection = Connection(name: "Mac", host: "192.168.1.42", port: 8810)
+        let requestId = "4c825d5b-cf40-4db7-aac5-2455f805a8ec"
+
+        await XCTAssertThrowsErrorAsync(
+            try await CompanionClient.pairFirstReachable(
+                connection: connection,
+                credential: Self.credential,
+                deviceName: "iPhone",
+                pairRequestId: requestId,
+                session: session
+            )
+        ) { error in
+            XCTAssertTrue(error is PairingRouteError)
+        }
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            pairRequestId: requestId,
+            session: session
+        )
+
+        XCTAssertEqual(outcome.response.token, "omb_device")
+        let pairRequests = PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }
+        XCTAssertEqual(pairRequests.count, 2)
+        let ids = try pairRequests.map { request in
+            let data = try XCTUnwrap(PairingRequestStub.body(of: request))
+            let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            return body["pairRequestId"] as? String
+        }
+        XCTAssertEqual(ids, [requestId, requestId])
+    }
+
+    func testAllFailedProbesLeaveTheCredentialUnspent() async throws {
+        PairingRequestStub.reset { _ in .failure(.timedOut) }
+        let connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["192.168.1.42"]
+        )
+
+        do {
+            _ = try await CompanionClient.pairFirstReachable(
+                connection: connection,
+                credential: Self.credential,
+                deviceName: "iPhone",
+                session: session
+            )
+            XCTFail("pairing should fail when no route answers")
+        } catch let error as PairingRouteError {
+            XCTAssertEqual(error.attemptedHosts, ["mac.tail1234.ts.net", "192.168.1.42"])
+        }
+        XCTAssertTrue(PairingRequestStub.captured().allSatisfy { $0.url?.path == "/api/health" })
+    }
+
+    func testRejectsAServiceThatDoesNotIdentifyAsOpenMausBot() async throws {
+        PairingRequestStub.reset { _ in .response(200, Data(#"{"app":"something-else"}"#.utf8)) }
+        let connection = Connection(name: "Mac", host: "192.168.1.42", port: 8810)
+
+        await XCTAssertThrowsErrorAsync(
+            try await CompanionClient.pairFirstReachable(
+                connection: connection,
+                credential: Self.credential,
+                deviceName: "iPhone",
+                session: session
+            )
+        ) { error in
+            XCTAssertTrue(error is PairingRouteError)
+        }
+        XCTAssertFalse(PairingRequestStub.captured().contains { $0.url?.path == "/api/pair" })
+    }
+
+    func testPairingRejectionIsNotSentToAnotherRoute() async throws {
+        PairingRequestStub.reset { request in
+            request.url?.path == "/api/health"
+                ? .response(200, Self.health)
+                : .response(401, Data(#"{"error":"pairing expired"}"#.utf8))
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: "192.168.1.42",
+            port: 8810,
+            hosts: ["openmausbot-aa.local"]
+        )
+
+        do {
+            _ = try await CompanionClient.pairFirstReachable(
+                connection: connection,
+                credential: Self.credential,
+                deviceName: "iPhone",
+                session: session
+            )
+            XCTFail("an expired credential should be rejected")
+        } catch let APIError.status(code, message) {
+            XCTAssertEqual(code, 401)
+            XCTAssertEqual(message, "pairing expired")
+        }
+        XCTAssertEqual(PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }.count, 1)
+    }
+
+    func testLegacySingleHostConnectionStillPairs() async throws {
+        PairingRequestStub.reset { request in
+            request.url?.path == "/api/health"
+                ? .response(200, Self.health)
+                : .response(201, Self.paired)
+        }
+        let connection = Connection(name: "Mac", host: "192.168.1.42", port: 8810)
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: "004209",
+            deviceName: "iPhone",
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.host, "192.168.1.42")
+        XCTAssertEqual(outcome.response.token, "omb_device")
+    }
+
+    private static let credential = "omb_pair_" + String(repeating: "a", count: 43)
+    private static let health = Data(#"{"app":"openmausbot","pid":42,"static":true}"#.utf8)
+    private static let paired = Data(
+        #"{"token":"omb_device","device":{"id":"d","name":"iPhone","createdAt":1,"lastSeenAt":1},"serverName":"Mac","hosts":["192.168.1.42"]}"#.utf8
+    )
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("expected expression to throw")
+    } catch {
+        errorHandler(error)
+    }
+}


### PR DESCRIPTION
## What changed

- probes every address in a pairing invite concurrently before spending its credential
- preserves the advertised security order, so a fast LAN response cannot outrank Tailscale
- sends the pairing POST only to a verified OpenMausBot endpoint
- safely replays one logical redemption after a lost response without creating an orphan device
- persists the route that actually worked and keeps the invite retryable
- actively erases the short-lived recovery token from desktop memory at expiry

## Why

Initial pairing previously tried only the first QR address. If that MagicDNS or Bonjour name did not resolve on the phone, a working LAN address in the same QR was never attempted. Fallback rotation only began after pairing, so it could not help.

## Verification

- `swift test`: 144 passed
- full iOS simulator app build: succeeded (iPhone 17 Pro, iOS 26.5)
- companion focused suite: 39 passed
- project TypeScript typecheck: passed
- companion production build: passed
- full repository suite before final review fixes: 1,839 tests counted, 18 skipped, 0 failed
- packaged-server smoke test: passed

## Compatibility

Older mobile clients still get exactly-once pairing. Older desktop companions remain supported; the iOS client does not retry an authoritative HTTP rejection. The wire change is one optional `pairRequestId` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pairing now retries safely using a stable request ID, preventing duplicate device registrations.
  * iOS pairing automatically checks available connection routes and falls back to the first reachable route.
  * Successful pairing preserves the preferred connection route and additional available hosts.
  * Existing clients continue to use the previous pairing behavior.

* **Bug Fixes**
  * Improved recovery from temporary connection, routing, and decoding failures during pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->