### PR TITLE
feat(companion): carry secure endpoints from desktop to iOS

### DIFF
--- a/companion/src/control.ts
+++ b/companion/src/control.ts
@@ -15,6 +15,7 @@
 import { createServer, type Server, type ServerResponse } from "node:http";
 
 import type { DeviceRegistry } from "./devices.ts";
+import { companionEndpointCandidates } from "./endpoints.ts";
 import { lanAddresses, tailnetName, tailscaleAddress } from "./listener.ts";
 import { defaultHostName } from "./mdns.ts";
 
@@ -23,6 +24,8 @@ export interface ControlOptions {
   devices: DeviceRegistry;
   /** Where a phone connects — for display, and for the pairing instructions. */
   companionPort: number;
+  /** Stable HTTPS route provisioned for this computer, when available. */
+  hostedUrl?: string | null;
   /** Whether Bonjour came up, and under what name. */
   discovery: () => { advertising: boolean; name: string };
 }
@@ -130,6 +133,9 @@ export function companionState(options: ControlOptions) {
     // The ordered fallback list the pairing QR hands the phone, so it can
     // walk to the next address when the first stops resolving.
     hosts: hostCandidates(addresses, name),
+    // Complete URLs for new clients. Unlike `hosts`, this can represent an
+    // HTTPS route on its natural port without teaching the client to guess.
+    endpoints: companionEndpointCandidates(options.companionPort, addresses, name, options.hostedUrl),
     pairing: pairing ? { code: pairing.code, token: pairing.token, expiresAt: pairing.expiresAt } : null,
     devices: options.devices.list(),
     discovery: options.discovery(),

--- a/companion/src/endpoints.ts
+++ b/companion/src/endpoints.ts
@@ -1,0 +1,95 @@
+import { lanAddresses, tailnetName, tailscaleAddress } from "./listener.ts";
+import { defaultHostName } from "./mdns.ts";
+
+export const COMPANION_ENDPOINT_KINDS = ["hosted", "tailnet", "lan", "bonjour"] as const;
+
+export type CompanionEndpointKind = (typeof COMPANION_ENDPOINT_KINDS)[number];
+
+/** A complete base URL the mobile app can dial, independent of the port and
+ * transport assumptions made by the original `hosts` contract. */
+export interface CompanionEndpoint {
+  url: string;
+  kind: CompanionEndpointKind;
+  priority: number;
+}
+
+export const MAX_COMPANION_ENDPOINTS = 8;
+
+/** Read the deliberately narrow hosted-route setting.
+ *
+ * A hosted endpoint is public internet infrastructure, so accepting a typo
+ * as though it were a local route is worse than refusing to start. It must be
+ * an HTTPS origin: paths, credentials, queries, and fragments have no place
+ * in a base URL and make request construction ambiguous. */
+export function hostedCompanionUrl(value: string | undefined): string | null {
+  const configured = value?.trim();
+  if (!configured) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(configured);
+  } catch {
+    throw new Error("OMB_COMPANION_HOSTED_URL must be an absolute HTTPS origin");
+  }
+
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    (parsed.pathname !== "" && parsed.pathname !== "/") ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error("OMB_COMPANION_HOSTED_URL must be an HTTPS origin without a path, credentials, query, or fragment");
+  }
+
+  return parsed.origin;
+}
+
+const httpOrigin = (host: string, port: number): string => {
+  const authority = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `http://${authority}:${port}`;
+};
+
+/** Every complete URL a new mobile build can dial, best first.
+ *
+ * The hosted HTTPS route wins when configured. Direct routes remain in the
+ * same order as the legacy host list so the app can fall back without an
+ * account, relay, or Tailscale dependency. The final cap bounds both QR size
+ * and connection-walk latency; Bonjour is retained as the last fallback even
+ * on a machine with an unusually large interface table. */
+export function companionEndpointCandidates(
+  port: number,
+  addresses: string[] = lanAddresses(),
+  magicDnsName: string | null = tailnetName(),
+  hostedUrl: string | null = null,
+  bonjourHost: string = defaultHostName(),
+): CompanionEndpoint[] {
+  const tailscale = tailscaleAddress(addresses);
+  const candidates: CompanionEndpoint[] = [];
+
+  if (hostedUrl) candidates.push({ url: hostedUrl, kind: "hosted", priority: 0 });
+  if (tailscale && magicDnsName) {
+    candidates.push({ url: httpOrigin(magicDnsName, port), kind: "tailnet", priority: 100 });
+  }
+  addresses.forEach((address, index) => {
+    if (address !== tailscale) {
+      candidates.push({ url: httpOrigin(address, port), kind: "lan", priority: 200 + index });
+    }
+  });
+  candidates.push({ url: httpOrigin(bonjourHost, port), kind: "bonjour", priority: 300 });
+
+  const seen = new Set<string>();
+  const ordered = candidates
+    .sort((left, right) => left.priority - right.priority)
+    .filter((endpoint) => {
+      if (seen.has(endpoint.url)) return false;
+      seen.add(endpoint.url);
+      return true;
+    });
+
+  if (ordered.length <= MAX_COMPANION_ENDPOINTS) return ordered;
+  const bonjour = ordered.find((endpoint) => endpoint.kind === "bonjour");
+  const head = ordered.filter((endpoint) => endpoint.kind !== "bonjour").slice(0, MAX_COMPANION_ENDPOINTS - 1);
+  return bonjour ? [...head, bonjour] : ordered.slice(0, MAX_COMPANION_ENDPOINTS);
+}

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -22,6 +22,7 @@ import { createServer } from "node:http";
 import { createAddressWatcher } from "./advertise-watch.ts";
 import { createControlServer, hostCandidates } from "./control.ts";
 import { DeviceRegistry } from "./devices.ts";
+import { companionEndpointCandidates, hostedCompanionUrl } from "./endpoints.ts";
 import { lanAddresses, refreshTailnetName, tailnetName, tailscaleAddress } from "./listener.ts";
 import {
   advertisableAddresses,
@@ -45,6 +46,7 @@ const WEBHOOK_PORT = num(process.env.OMB_WEBHOOK_PORT, HARNESS_PORT + 1);
 const COMPANION_PORT = num(process.env.OMB_COMPANION_PORT, 8810);
 const CONTROL_PORT = num(process.env.OMB_CONTROL_PORT, 8811);
 const SERVICE_TYPE = "_openmausbot._tcp";
+const HOSTED_URL = hostedCompanionUrl(process.env.OMB_COMPANION_HOSTED_URL);
 
 /** Ports the harness takes for itself, and what it uses each for.
  *
@@ -137,12 +139,14 @@ const companion = createServer(
     // machine joins another network, and a pairing is exactly the moment the
     // list has to be right.
     hosts: () => hostCandidates(),
+    endpoints: () => companionEndpointCandidates(COMPANION_PORT, undefined, undefined, HOSTED_URL),
   }),
 );
 
 const control = createControlServer({
   devices,
   companionPort: COMPANION_PORT,
+  hostedUrl: HOSTED_URL,
   discovery: () => ({ advertising: mdns.advertising, name: service().name }),
 });
 

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -14,6 +14,7 @@
 import { request as httpRequest, type IncomingMessage, type ServerResponse } from "node:http";
 
 import { bearerToken } from "./devices.ts";
+import type { CompanionEndpoint } from "./endpoints.ts";
 import { denyReason, isCloudDesktopJoin } from "./routes.ts";
 import { createSseScrubber, isJson, scrub } from "./wire.ts";
 
@@ -38,6 +39,9 @@ export interface ProxyOptions {
    * stops resolving. Optional and advisory: a phone that never receives it
    * simply keeps dialing the one host it paired with. */
   hosts?: () => string[];
+  /** Complete connection URLs for current mobile clients. `hosts` remains
+   * alongside this field for builds that predate typed endpoints. */
+  endpoints?: () => CompanionEndpoint[];
   /** How long the harness may take to produce response *headers*. Optional,
    * and only ever set by tests — the default is the one that ships. */
   headersTimeoutMs?: number;
@@ -178,11 +182,17 @@ export function createProxyHandler(options: ProxyOptions) {
           // empty, when there is nothing to offer: absent is what a sidecar
           // predating the field sends, and one decode path beats two.
           const hosts = options.hosts?.() ?? [];
-          const response: typeof result & { serverName: string; hosts?: string[] } = {
+          const endpoints = options.endpoints?.() ?? [];
+          const response: typeof result & {
+            serverName: string;
+            hosts?: string[];
+            endpoints?: CompanionEndpoint[];
+          } = {
             ...result,
             serverName: options.serverName(),
           };
           if (hosts.length) response.hosts = hosts;
+          if (endpoints.length) response.endpoints = endpoints;
           return sendJson(res, 201, response);
         },
         (error: Error) => sendJson(res, 400, { error: error.message }),

--- a/companion/test/control.test.ts
+++ b/companion/test/control.test.ts
@@ -164,9 +164,12 @@ describe("hostCandidates", () => {
     const { status, body } = await ask("GET", "/state");
     expect(status).toBe(200);
     expect(Array.isArray(body.hosts)).toBe(true);
+    expect(Array.isArray(body.endpoints)).toBe(true);
     // Whatever this machine's interfaces are, the mDNS fallback is always
     // present and always last.
     expect(body.hosts.at(-1)).toMatch(/^openmausbot-[0-9a-f]{8}\.local$/);
+    expect(body.endpoints.at(-1)).toMatchObject({ kind: "bonjour", priority: 300 });
+    expect(body.endpoints.at(-1).url).toMatch(/^http:\/\/openmausbot-[0-9a-f]{8}\.local:8810$/);
   });
 });
 

--- a/companion/test/endpoints.test.ts
+++ b/companion/test/endpoints.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  companionEndpointCandidates,
+  hostedCompanionUrl,
+  MAX_COMPANION_ENDPOINTS,
+} from "../src/endpoints.ts";
+
+describe("hostedCompanionUrl", () => {
+  it("normalizes one explicit HTTPS origin", () => {
+    expect(hostedCompanionUrl("  https://Maus.Example/  ")).toBe("https://maus.example");
+    expect(hostedCompanionUrl(undefined)).toBeNull();
+    expect(hostedCompanionUrl("  ")).toBeNull();
+  });
+
+  it("refuses insecure or ambiguous hosted routes", () => {
+    for (const value of [
+      "http://maus.example",
+      "https://user:secret@maus.example",
+      "https://maus.example/companion",
+      "https://maus.example?device=one",
+      "https://maus.example#pair",
+      "not a URL",
+    ]) {
+      expect(() => hostedCompanionUrl(value)).toThrow(/OMB_COMPANION_HOSTED_URL/);
+    }
+  });
+});
+
+describe("companionEndpointCandidates", () => {
+  it("puts hosted HTTPS first, followed by tailnet, LAN, and Bonjour routes", () => {
+    expect(
+      companionEndpointCandidates(
+        8810,
+        ["100.121.5.6", "192.168.1.42", "10.0.0.7"],
+        "macbook.tail1234.ts.net",
+        "https://device-123.companion.example",
+        "openmausbot-abcd1234.local",
+      ),
+    ).toEqual([
+      { url: "https://device-123.companion.example", kind: "hosted", priority: 0 },
+      { url: "http://macbook.tail1234.ts.net:8810", kind: "tailnet", priority: 100 },
+      { url: "http://192.168.1.42:8810", kind: "lan", priority: 201 },
+      { url: "http://10.0.0.7:8810", kind: "lan", priority: 202 },
+      { url: "http://openmausbot-abcd1234.local:8810", kind: "bonjour", priority: 300 },
+    ]);
+  });
+
+  it("keeps direct routes when no hosted route exists", () => {
+    expect(
+      companionEndpointCandidates(8810, ["192.168.1.42"], null, null, "openmausbot-abcd1234.local"),
+    ).toEqual([
+      { url: "http://192.168.1.42:8810", kind: "lan", priority: 200 },
+      { url: "http://openmausbot-abcd1234.local:8810", kind: "bonjour", priority: 300 },
+    ]);
+  });
+
+  it("caps pathological interface lists without losing the Bonjour fallback", () => {
+    const addresses = Array.from({ length: 20 }, (_, index) => `192.168.1.${index + 1}`);
+    const endpoints = companionEndpointCandidates(
+      8810,
+      addresses,
+      null,
+      "https://device-123.companion.example",
+      "openmausbot-abcd1234.local",
+    );
+    expect(endpoints).toHaveLength(MAX_COMPANION_ENDPOINTS);
+    expect(endpoints[0]).toMatchObject({ kind: "hosted", priority: 0 });
+    expect(endpoints.at(-1)).toEqual({
+      url: "http://openmausbot-abcd1234.local:8810",
+      kind: "bonjour",
+      priority: 300,
+    });
+  });
+});

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -552,6 +552,10 @@ describe("pairing, end to end", () => {
         redeem: (code, deviceName, pairRequestId) => registry.redeem(code, deviceName, pairRequestId),
         serverName: () => "Ada's computer",
         hosts: () => ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"],
+        endpoints: () => [
+          { url: "https://device-123.companion.example", kind: "hosted", priority: 0 },
+          { url: "http://192.168.1.42:8810", kind: "lan", priority: 200 },
+        ],
       }),
     );
     await new Promise<void>((r) => paired.listen(0, "127.0.0.1", r));
@@ -605,12 +609,21 @@ describe("pairing, end to end", () => {
       expect(res.status).toBe(201);
       // SAFETY: a 201 from /api/pair carries exactly this shape — the
       // sidecar's own contract, pinned by the expects that follow.
-      const body = (await res.json()) as { token: string; serverName: string; hosts: string[] };
+      const body = (await res.json()) as {
+        token: string;
+        serverName: string;
+        hosts: string[];
+        endpoints: Array<{ url: string; kind: string; priority: number }>;
+      };
       expect(body.serverName).toBe("Ada's computer");
       expect(body.token).toMatch(/^omb_/);
       // The fallback list rides on the redeem response so a phone that paired
       // by typed address learns the other ways to reach this computer too.
       expect(body.hosts).toEqual(["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-abcd1234.local"]);
+      expect(body.endpoints).toEqual([
+        { url: "https://device-123.companion.example", kind: "hosted", priority: 0 },
+        { url: "http://192.168.1.42:8810", kind: "lan", priority: 200 },
+      ]);
 
       // Losing the first response after it reached the Mac must not strand an
       // orphan device. The same logical request can arrive through a fallback

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -346,7 +346,7 @@ struct PairingView: View {
                             .font(.system(size: 14))
                             .foregroundColor(isDark ? Color(hex: "#64748B") : Color(hex: "#94A3B8"))
 
-                        TextField("192.168.1.42:8810 or mac.ts.net:8810", text: $manualAddress)
+                        TextField("https://mac.example or 192.168.1.42:8810", text: $manualAddress)
                             .font(.system(size: 14, design: .monospaced))
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
@@ -364,7 +364,7 @@ struct PairingView: View {
                         Haptics.selection()
                         failure = nil
                         guard let connection = Self.parse(manualAddress) else {
-                            failure = "That should look like 192.168.1.42:8810 or host.ts.net:8810."
+                            failure = "Enter a secure https:// address, 192.168.1.42:8810, or host.ts.net:8810."
                             return
                         }
                         choiceGeneration += 1
@@ -413,13 +413,15 @@ struct PairingView: View {
                 Text(connection.name)
                     .font(.title2.weight(.bold))
                     .foregroundColor(isDark ? .white : Color(hex: "#0F172A"))
-                Text("\(connection.host):\(connection.port)")
+                Text(connection.displayAddress)
                     .font(.system(size: 13, design: .monospaced))
                     .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
             }
 
             if let credential = scannedCredential {
-                Text("Confirm this computer to establish an authenticated companion connection. Use a trusted Wi-Fi network or a tailnet; OpenMausBot does not encrypt local Wi-Fi traffic.")
+                Text(connection.activeEndpoint?.isSecure == true
+                    ? "Confirm this computer to establish an authenticated HTTPS companion connection."
+                    : "Confirm this computer to establish an authenticated companion connection. Use a trusted Wi-Fi network or a tailnet; OpenMausBot does not encrypt local Wi-Fi traffic.")
                     .font(.caption)
                     .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
                     .multilineTextAlignment(.center)

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -436,26 +436,33 @@ final class Session: ObservableObject {
     /// A 401 never reaches here: the unauthorized path returns above, which
     /// is what keeps a token problem from masquerading as an address walk.
     private func failureMessage(for error: Error) -> String {
-        guard let urlError = error as? URLError, let connection else {
-            return error.localizedDescription
-        }
+        guard let connection else { return error.localizedDescription }
         let failed = rotation.currentEndpoint ?? connection.activeEndpoint ??
             CompanionEndpoint.direct(host: connection.host, port: connection.port, priority: 10_000)
         var next: String?
-        if ConnectionAdvice.shouldTryAnotherHost(urlError.code), rotation.count > 1 {
-            let candidate = rotation.advanceEndpoint()
-            if let candidate, let token {
-                client = CompanionClient(connection: connection.dialing(candidate), token: token)
-                next = candidate.displayAddress
-                log.info("advancing to companion route \(candidate.url, privacy: .public)")
-            }
+        if let candidate = rotation.advanceEndpoint(after: error), let token {
+            client = CompanionClient(connection: connection.dialing(candidate), token: token)
+            next = candidate.displayAddress
+            log.info("advancing to companion route \(candidate.url, privacy: .public)")
         }
-        return ConnectionAdvice.message(
-            for: urlError.code,
-            host: failed?.displayAddress ?? connection.host,
-            port: failed?.port ?? connection.port,
-            tryingNext: next
-        )
+        if let urlError = error as? URLError {
+            return ConnectionAdvice.message(
+                for: urlError.code,
+                host: failed?.displayAddress ?? connection.host,
+                port: failed?.port ?? connection.port,
+                tryingNext: next
+            )
+        }
+        if let apiError = error as? APIError,
+           case let .status(code, _) = apiError,
+           ConnectionAdvice.shouldTryAnotherRoute(after: error) {
+            return ConnectionAdvice.message(
+                forGatewayStatus: code,
+                host: failed?.displayAddress ?? connection.host,
+                tryingNext: next
+            )
+        }
+        return error.localizedDescription
     }
 
     /// Persist the route that carried a live stream. Legacy host lists promote

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -146,10 +146,12 @@ final class Session: ObservableObject {
 
         connection = saved
         token = stored
-        // `orderedHosts` puts the stored host first, so the address that
-        // worked last time is the one dialed first this time.
-        rotation = CandidateRotation(hosts: saved.orderedHosts)
-        client = CompanionClient(connection: saved, token: stored)
+        // New connections honor the desktop's transport policy (hosted HTTPS,
+        // tailnet, LAN, Bonjour). Older saved connections retain their
+        // last-working-host-first behavior through the legacy list.
+        rotation = CandidateRotation(endpoints: saved.orderedEndpoints)
+        let first = rotation.currentEndpoint.map(saved.dialing) ?? saved
+        client = CompanionClient(connection: first, token: stored)
         status = .connecting
     }
 
@@ -173,19 +175,36 @@ final class Session: ObservableObject {
         var stored = outcome.connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
         // The computer knows every address it answers on, and what it says at
-        // redeem time beats whatever the invite carried. Then the host that
-        // just redeemed the code leads: it demonstrably works from here.
+        // redeem time beats whatever the invite carried. The route that just
+        // redeemed leads this live session; future launches return to the
+        // desktop's security-prioritized typed order.
         if let hosts = paired.hosts, !hosts.isEmpty { stored.hosts = Array(hosts.prefix(8)) }
-        stored.promote(outcome.connection.host)
-        stored.hosts = Array(stored.orderedHosts.prefix(8))
+        if let endpoints = paired.endpoints, !endpoints.isEmpty {
+            stored.endpoints = Array(endpoints.prefix(8))
+        }
+        let winner = outcome.connection.activeEndpoint ?? CompanionEndpoint.direct(
+            host: outcome.connection.host,
+            port: outcome.connection.port,
+            priority: 10_000
+        )
+        if let winner { stored.promote(winner) }
+        if stored.endpoints?.isEmpty != false {
+            stored.hosts = Array(stored.orderedHosts.prefix(8))
+        }
 
         try Keychain.save(paired.token, for: stored.id)
         UserDefaults.standard.set(try? JSONEncoder().encode(stored), forKey: Self.connectionKey)
 
         self.connection = stored
         self.token = paired.token
-        self.rotation = CandidateRotation(hosts: stored.orderedHosts)
-        self.client = CompanionClient(connection: stored, token: paired.token)
+        let liveRoutes = winner.map { route in
+            [route] + stored.orderedEndpoints.filter { $0.url != route.url }
+        } ?? stored.orderedEndpoints
+        self.rotation = CandidateRotation(endpoints: liveRoutes)
+        self.client = CompanionClient(
+            connection: winner.map(stored.dialing) ?? stored,
+            token: paired.token
+        )
         self.state = CompanionState()
         // A fresh pairing settles any restore that was still waiting on the
         // keychain — the token is in hand, so there is nothing left to retry.
@@ -362,9 +381,10 @@ final class Session: ObservableObject {
                             state.resetCursor(cursor)
                         }
                         status = .live
-                        // this candidate carried a live stream — dial it
-                        // first from now on, including next launch
-                        promoteWorkingHost()
+                        // Remember what actually carried the stream for
+                        // display and legacy ordering. Typed routes retain
+                        // their explicit security priority next launch.
+                        rememberWorkingRoute()
                         continue
                     }
                     state.apply(frame)
@@ -419,26 +439,30 @@ final class Session: ObservableObject {
         guard let urlError = error as? URLError, let connection else {
             return error.localizedDescription
         }
-        let failed = rotation.current.isEmpty ? connection.host : rotation.current
+        let failed = rotation.currentEndpoint ?? connection.activeEndpoint ??
+            CompanionEndpoint.direct(host: connection.host, port: connection.port, priority: 10_000)
         var next: String?
         if ConnectionAdvice.shouldTryAnotherHost(urlError.code), rotation.count > 1 {
-            let candidate = rotation.advance()
-            if let token {
+            let candidate = rotation.advanceEndpoint()
+            if let candidate, let token {
                 client = CompanionClient(connection: connection.dialing(candidate), token: token)
+                next = candidate.displayAddress
+                log.info("advancing to companion route \(candidate.url, privacy: .public)")
             }
-            next = candidate
-            log.info("advancing to candidate host \(candidate, privacy: .public)")
         }
-        return ConnectionAdvice.message(for: urlError.code, host: failed, port: connection.port, tryingNext: next)
+        return ConnectionAdvice.message(
+            for: urlError.code,
+            host: failed?.displayAddress ?? connection.host,
+            port: failed?.port ?? connection.port,
+            tryingNext: next
+        )
     }
 
-    /// The candidate that just carried a live stream dials first from now on.
-    /// Persisted, so the next launch starts from the address that works
-    /// rather than re-walking the list from a stale front-runner.
-    private func promoteWorkingHost() {
-        let winner = rotation.current
-        guard !winner.isEmpty, var updated = connection,
-              updated.host != Connection.urlHost(winner) else { return }
+    /// Persist the route that carried a live stream. Legacy host lists promote
+    /// it for the next launch; typed lists keep their explicit policy order.
+    private func rememberWorkingRoute() {
+        guard let winner = rotation.currentEndpoint, var updated = connection,
+              updated.activeEndpoint?.url != winner.url else { return }
         updated.promote(winner)
         connection = updated
         UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
@@ -449,12 +473,20 @@ final class Session: ObservableObject {
     @discardableResult
     func updateAddress(_ text: String) -> Bool {
         guard var updated = connection, let parsed = Connection.parse(text) else { return false }
-        updated.port = parsed.port
-        updated.promote(parsed.host)
+        let existingRoutes = updated.orderedEndpoints
+        guard let endpoint = parsed.activeEndpoint ?? CompanionEndpoint.direct(
+            host: parsed.host,
+            port: parsed.port,
+            priority: 0
+        ) else { return false }
+        updated.promote(endpoint)
+        updated.endpoints = [endpoint] + existingRoutes.filter { $0.url != endpoint.url }
         connection = updated
         UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
-        rotation = CandidateRotation(hosts: updated.orderedHosts)
-        if let token { client = CompanionClient(connection: updated, token: token) }
+        rotation = CandidateRotation(endpoints: updated.orderedEndpoints)
+        if let token {
+            client = CompanionClient(connection: updated.dialing(endpoint), token: token)
+        }
         // Dial the new address now rather than on the next backoff tick —
         // someone who just typed an address is watching the banner.
         restartStream()

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -17,14 +17,14 @@ struct SettingsView: View {
             Section("Computer") {
                 if let connection = session.connection {
                     LabeledContent("Name", value: connection.name)
-                    LabeledContent("Address", value: "\(connection.host):\(connection.port)")
+                    LabeledContent("Address", value: connection.displayAddress)
                     // The stored address can simply go stale — a tailnet name
                     // on a phone that left the tailnet, a LAN address after
                     // the router reshuffled. Editing it here keeps the
                     // pairing; the alternative is a walk to the computer for
                     // a new code.
                     Button("Edit address") {
-                        addressText = "\(connection.host):\(connection.port)"
+                        addressText = connection.displayAddress
                         editingAddress = true
                     }
                 }
@@ -76,12 +76,12 @@ struct SettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task { await session.refreshNotificationAuthorization() }
         .alert("Edit address", isPresented: $editingAddress) {
-            TextField("192.168.1.42:8810", text: $addressText)
+            TextField("https://mac.example or 192.168.1.42:8810", text: $addressText)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
             Button("Save") {
                 if !session.updateAddress(addressText) {
-                    session.actionError = "That should look like 192.168.1.42:8810, or a name like macbook.tail1234.ts.net."
+                    session.actionError = "Enter a secure https:// address, 192.168.1.42:8810, or a name like macbook.tail1234.ts.net."
                 }
             }
             Button("Cancel", role: .cancel) {}

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -21,13 +21,29 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// Optional so connections saved before fallbacks existed still decode;
     /// read through `orderedHosts`, which is never empty.
     public var hosts: [String]?
+    /// Complete route currently being dialed. Absent on connections saved by
+    /// older app builds, where `host` + `port` still mean direct HTTP.
+    public var activeEndpoint: CompanionEndpoint?
+    /// Full routes advertised by a newer desktop. Each carries its own scheme
+    /// and port so hosted HTTPS can coexist with local HTTP fallbacks.
+    public var endpoints: [CompanionEndpoint]?
 
-    public init(id: String = UUID().uuidString, name: String, host: String, port: Int, hosts: [String]? = nil) {
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        host: String,
+        port: Int,
+        hosts: [String]? = nil,
+        activeEndpoint: CompanionEndpoint? = nil,
+        endpoints: [CompanionEndpoint]? = nil
+    ) {
         self.id = id
         self.name = name
         self.host = Self.urlHost(host)
         self.port = port
         self.hosts = hosts
+        self.activeEndpoint = activeEndpoint
+        self.endpoints = endpoints
     }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
@@ -57,9 +73,20 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// same unambiguous form browsers and command-line tools use.
     public static func parse(_ text: String, defaultPort: Int = 8810) -> Connection? {
         var trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        for prefix in ["http://", "https://"] where trimmed.lowercased().hasPrefix(prefix) {
-            trimmed.removeFirst(prefix.count)
-            break
+        let lowercased = trimmed.lowercased()
+        if lowercased.hasPrefix("http://") || lowercased.hasPrefix("https://") {
+            guard let endpoint = CompanionEndpoint(
+                url: trimmed,
+                kind: lowercased.hasPrefix("https://") ? .hosted : .lan,
+                priority: 0
+            ) else { return nil }
+            return Connection(
+                name: endpoint.host,
+                host: endpoint.host,
+                port: endpoint.port,
+                activeEndpoint: endpoint,
+                endpoints: [endpoint]
+            )
         }
         while trimmed.hasSuffix("/") { trimmed.removeLast() }
         guard !trimmed.isEmpty else { return nil }
@@ -92,7 +119,8 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         return Connection(name: host, host: host, port: port)
     }
 
-    /// Plain HTTP, and that is a real limitation rather than an oversight.
+    /// Hosted routes use ordinary certificate-validated HTTPS. A connection
+    /// saved by an older app still falls back to direct HTTP below.
     ///
     /// The bearer token goes out in a header on every request, so anyone who
     /// can observe the path between phone and computer can lift it and use it
@@ -117,6 +145,7 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// LAN path is documented as trusted-network-only, and pinned TLS is what
     /// this needs before it could claim otherwise. See `docs/ios-companion.md`.
     public var baseURL: URL? {
+        if let endpoint = activeEndpoint?.baseURL { return endpoint }
         var components = URLComponents()
         components.scheme = "http"
         // Normalize here too so connections saved by older builds with an
@@ -176,7 +205,43 @@ public struct PairingInvite: Equatable, Sendable {
                 }
             if !candidates.isEmpty { connection.hosts = Array(candidates.prefix(8)) }
         }
+        if let encoded = values["endpoints"] {
+            guard let endpoints = Self.decodeEndpoints(encoded) else { return nil }
+            connection.endpoints = endpoints
+            connection = connection.dialing(endpoints[0])
+        }
         return PairingInvite(connection: connection, credential: credential)
+    }
+
+    /// Unpadded base64url JSON keeps the typed array in one unambiguous query
+    /// value. A present-but-invalid value rejects the invite instead of
+    /// quietly downgrading a hosted HTTPS QR to its legacy HTTP address.
+    private static func decodeEndpoints(_ encoded: String) -> [CompanionEndpoint]? {
+        guard !encoded.isEmpty,
+              encoded.utf8.count <= 8_192,
+              encoded.utf8.allSatisfy({
+                  (48...57).contains($0) || (65...90).contains($0) ||
+                  (97...122).contains($0) || $0 == 45 || $0 == 95
+              })
+        else { return nil }
+
+        var base64 = encoded.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        guard let data = Data(base64Encoded: base64),
+              let decoded = try? JSONDecoder().decode([CompanionEndpoint].self, from: data),
+              !decoded.isEmpty,
+              decoded.count <= 8
+        else { return nil }
+
+        let stable = decoded.enumerated().sorted {
+            $0.element.priority == $1.element.priority
+                ? $0.offset < $1.offset
+                : $0.element.priority < $1.element.priority
+        }.map(\.element)
+        var seen = Set<String>()
+        let unique = stable.filter { seen.insert($0.url).inserted }
+        return unique.isEmpty ? nil : unique
     }
 
     private static func credential(from values: [String: String]) -> String? {
@@ -392,11 +457,12 @@ public struct CompanionClient: Sendable {
         pairRequestId: String = UUID().uuidString,
         session: URLSession = .shared
     ) async throws -> PairingOutcome {
-        let candidates = connection.orderedHosts.map(connection.dialing)
+        let candidates = connection.orderedEndpoints.map(connection.dialing)
+        let attemptedRoutes = connection.orderedEndpoints.map(\.url)
         var remaining = candidates
         while !remaining.isEmpty {
             guard let winner = await firstHealthy(in: remaining, session: session) else {
-                throw PairingRouteError(attemptedHosts: connection.orderedHosts)
+                throw PairingRouteError(attemptedHosts: attemptedRoutes)
             }
             remaining.remove(at: winner.offset)
             do {
@@ -422,7 +488,7 @@ public struct CompanionClient: Sendable {
                 continue
             }
         }
-        throw PairingRouteError(attemptedHosts: connection.orderedHosts)
+        throw PairingRouteError(attemptedHosts: attemptedRoutes)
     }
 
     /// Probe every candidate together, but respect the advertised security

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -475,12 +475,13 @@ public struct CompanionClient: Sendable {
                 )
                 return PairingOutcome(response: response, connection: winner.connection)
             } catch let error as APIError {
-                // An HTTP response is authoritative: a rejected or expired
-                // credential must not be sprayed at another address. A
-                // transport failure is ambiguous, though — the Mac may have
-                // committed the device before the route died. New desktops
+                // Credential/client errors are authoritative and must not be
+                // sprayed at another address. Transport failures and gateway
+                // errors belong to this route, though — the Mac may even have
+                // committed the device before the proxy failed. New desktops
                 // replay this exact request id safely through a fallback.
                 if case .transport = error { continue }
+                if ConnectionAdvice.shouldTryAnotherRoute(after: error) { continue }
                 throw error
             } catch {
                 // URL loading and decoding failures are likewise ambiguous.

--- a/ios/Sources/CompanionCore/Endpoint.swift
+++ b/ios/Sources/CompanionCore/Endpoint.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Why an address exists. The kind is display and policy metadata; the URL
+/// remains the complete dialing authority, so hosted HTTPS and local HTTP can
+/// live in the same fallback list without guessing a scheme from a hostname.
+public enum CompanionEndpointKind: String, Codable, CaseIterable, Sendable {
+    case hosted
+    case tailnet
+    case lan
+    case bonjour
+}
+
+/// One validated route to the desktop companion.
+public struct CompanionEndpoint: Codable, Hashable, Sendable {
+    public let url: String
+    public let kind: CompanionEndpointKind
+    public let priority: Int
+
+    public init?(url: String, kind: CompanionEndpointKind, priority: Int) {
+        guard (0...1_000_000).contains(priority),
+              let normalized = Self.normalizedURL(url, kind: kind)
+        else { return nil }
+        self.url = normalized
+        self.kind = kind
+        self.priority = priority
+    }
+
+    public var baseURL: URL? { URL(string: url) }
+
+    public var host: String {
+        guard let host = URLComponents(string: url)?.host else { return "" }
+        return Connection.urlHost(host)
+    }
+
+    public var port: Int {
+        guard let components = URLComponents(string: url) else { return 0 }
+        return components.port ?? (components.scheme?.lowercased() == "https" ? 443 : 80)
+    }
+
+    public var isSecure: Bool {
+        URLComponents(string: url)?.scheme?.lowercased() == "https"
+    }
+
+    /// Host-only for the old direct routes, full HTTPS authority for hosted
+    /// routes. Used in status copy, never for dialing.
+    public var displayAddress: String {
+        if kind == .hosted || isSecure { return url }
+        return port == 8810 ? host : "\(host):\(port)"
+    }
+
+    /// Construct the legacy HTTP route represented by `host` + `port`.
+    public static func direct(
+        host: String,
+        port: Int,
+        kind: CompanionEndpointKind = .lan,
+        priority: Int
+    ) -> CompanionEndpoint? {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = Connection.urlHost(host)
+        components.port = port
+        guard let value = components.url?.absoluteString else { return nil }
+        return CompanionEndpoint(url: value, kind: kind, priority: priority)
+    }
+
+    private static func normalizedURL(_ raw: String, kind: CompanionEndpointKind) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.utf8.count <= 2_048,
+              var components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/",
+              kind == .hosted ? scheme == "https" : scheme == "http"
+        else { return nil }
+
+        components.scheme = scheme
+        components.host = host.lowercased()
+        components.path = ""
+        if let port = components.port, !(1...65_535).contains(port) { return nil }
+        return components.url?.absoluteString
+    }
+
+    private enum CodingKeys: String, CodingKey { case url, kind, priority }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let url = try values.decode(String.self, forKey: .url)
+        let kind = try values.decode(CompanionEndpointKind.self, forKey: .kind)
+        let priority = try values.decode(Int.self, forKey: .priority)
+        guard let accepted = CompanionEndpoint(url: url, kind: kind, priority: priority) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .url,
+                in: values,
+                debugDescription: "Companion endpoints must be absolute HTTP(S) authorities; hosted routes require HTTPS."
+            )
+        }
+        self = accepted
+    }
+}
+
+extension Connection {
+    public var displayAddress: String {
+        activeEndpoint?.displayAddress ?? "\(host):\(port)"
+    }
+}

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -16,36 +16,60 @@ import Foundation
 /// rather than giving up, because the retry loop it lives in already backs
 /// off between attempts and a network that comes back deserves a second lap.
 public struct CandidateRotation: Equatable, Sendable {
-    public private(set) var hosts: [String]
+    public private(set) var endpoints: [CompanionEndpoint]
     private var index: Int
 
     public init(hosts: [String]) {
-        self.hosts = hosts
+        endpoints = hosts.enumerated().compactMap { offset, host in
+            CompanionEndpoint.direct(host: host, port: 8810, priority: offset)
+        }
         index = 0
+    }
+
+    public init(endpoints: [CompanionEndpoint]) {
+        self.endpoints = endpoints
+        index = 0
+    }
+
+    /// Compatibility view for tests and callers that only understand the old
+    /// host list. New dialing code uses `currentEndpoint` so it never loses a
+    /// route's HTTPS scheme or distinct port.
+    public var hosts: [String] { endpoints.map(\.displayAddress) }
+
+    public var currentEndpoint: CompanionEndpoint? {
+        endpoints.indices.contains(index) ? endpoints[index] : nil
     }
 
     /// The host the next attempt should dial. Empty only when there are no
     /// hosts at all, which a real connection never produces.
     public var current: String {
-        hosts.indices.contains(index) ? hosts[index] : ""
+        currentEndpoint?.displayAddress ?? ""
     }
 
-    public var count: Int { hosts.count }
+    public var count: Int { endpoints.count }
 
     /// Move to the next candidate and return it, wrapping past the end.
     @discardableResult
     public mutating func advance() -> String {
-        guard !hosts.isEmpty else { return "" }
-        index = (index + 1) % hosts.count
-        return current
+        advanceEndpoint()?.displayAddress ?? ""
     }
 
-    /// The stored order after a success: the host that just worked first, so
-    /// the next launch dials it before anything that was failing, and the
-    /// rest keeping their relative order.
+    @discardableResult
+    public mutating func advanceEndpoint() -> CompanionEndpoint? {
+        guard !endpoints.isEmpty else { return nil }
+        index = (index + 1) % endpoints.count
+        return currentEndpoint
+    }
+
+    public func promotedEndpoints() -> [CompanionEndpoint] {
+        guard endpoints.indices.contains(index) else { return endpoints }
+        return [endpoints[index]] + endpoints.enumerated()
+            .filter { $0.offset != index }
+            .map(\.element)
+    }
+
     public func promoted() -> [String] {
-        guard hosts.indices.contains(index) else { return hosts }
-        return [hosts[index]] + hosts.enumerated().filter { $0.offset != index }.map(\.element)
+        promotedEndpoints().map(\.displayAddress)
     }
 }
 
@@ -109,12 +133,47 @@ extension Connection {
         return out
     }
 
+    /// Every complete route in policy order. Typed endpoints win over the
+    /// legacy fields because they can represent hosted HTTPS. A connection
+    /// either walks that complete typed set or, for an older desktop, derives
+    /// direct routes from the legacy fields — never a lossy mixture of both.
+    public var orderedEndpoints: [CompanionEndpoint] {
+        var candidates = endpoints ?? []
+        if !candidates.isEmpty {
+            if let activeEndpoint, !candidates.contains(where: { $0.url == activeEndpoint.url }) {
+                candidates.append(activeEndpoint)
+            }
+            candidates = candidates.enumerated().sorted {
+                $0.element.priority == $1.element.priority
+                    ? $0.offset < $1.offset
+                    : $0.element.priority < $1.element.priority
+            }.map(\.element)
+        } else {
+            candidates = orderedHosts.enumerated().compactMap { offset, candidate in
+                CompanionEndpoint.direct(host: candidate, port: port, priority: offset)
+            }
+        }
+        var seen = Set<String>()
+        return candidates.filter { seen.insert($0.url).inserted }.prefix(8).map { $0 }
+    }
+
     /// A copy dialing `candidate` — same pairing, same port, different
     /// address. The stored order is untouched; committing a winner is
     /// `promote`, and only success earns it.
     public func dialing(_ candidate: String) -> Connection {
+        guard let endpoint = CompanionEndpoint.direct(host: candidate, port: port, priority: 10_000) else {
+            return self
+        }
+        return dialing(endpoint)
+    }
+
+    /// A copy dialing one complete route without changing its stored policy
+    /// order or keychain identity.
+    public func dialing(_ candidate: CompanionEndpoint) -> Connection {
         var copy = self
-        copy.host = Self.urlHost(candidate)
+        copy.activeEndpoint = candidate
+        copy.host = candidate.host
+        copy.port = candidate.port
         return copy
     }
 
@@ -125,5 +184,22 @@ extension Connection {
         let rest = orderedHosts.filter { $0 != normalized }
         host = normalized
         hosts = [normalized] + rest
+        activeEndpoint = CompanionEndpoint.direct(host: normalized, port: port, priority: 10_000)
+    }
+
+    /// Remember the route that worked without letting a cleartext fallback
+    /// jump ahead of a lower-priority hosted/tailnet route on the next launch.
+    public mutating func promote(_ winner: CompanionEndpoint) {
+        activeEndpoint = winner
+        host = winner.host
+        port = winner.port
+        if let existing = endpoints,
+           !existing.contains(where: { $0.url == winner.url }) {
+            endpoints = existing + [winner]
+        }
+        if winner.kind != .hosted {
+            let rest = orderedHosts.filter { $0 != winner.host }
+            hosts = [winner.host] + rest
+        }
     }
 }

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -61,6 +61,17 @@ public struct CandidateRotation: Equatable, Sendable {
         return currentEndpoint
     }
 
+    /// Move only when the failure belongs to this route rather than to the
+    /// pairing or the phone as a whole. Keeping that decision beside the
+    /// rotation makes reconnects handle URL and HTTP gateway failures alike.
+    @discardableResult
+    public mutating func advanceEndpoint(after error: Error) -> CompanionEndpoint? {
+        guard endpoints.count > 1,
+              ConnectionAdvice.shouldTryAnotherRoute(after: error)
+        else { return nil }
+        return advanceEndpoint()
+    }
+
     public func promotedEndpoints() -> [CompanionEndpoint] {
         guard endpoints.indices.contains(index) else { return endpoints }
         return [endpoints[index]] + endpoints.enumerated()
@@ -82,11 +93,34 @@ public enum ConnectionAdvice {
     /// "offline" fails identically wherever the dial points.
     public static func shouldTryAnotherHost(_ code: URLError.Code) -> Bool {
         switch code {
-        case .cannotFindHost, .cannotConnectToHost, .timedOut, .secureConnectionFailed:
+        case .cannotFindHost,
+             .cannotConnectToHost,
+             .timedOut,
+             .secureConnectionFailed,
+             .serverCertificateHasBadDate,
+             .serverCertificateUntrusted,
+             .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid,
+             .clientCertificateRejected,
+             .clientCertificateRequired:
             return true
         default:
             return false
         }
+    }
+
+    /// Classify errors which another advertised route can actually repair.
+    /// 502–504 are ordinary reverse-proxy failures; 520–530 are the gateway
+    /// family Cloudflare can return when a tunnel or its origin is unhealthy.
+    /// Application errors such as 400/401/500 deliberately stay put.
+    public static func shouldTryAnotherRoute(after error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            return shouldTryAnotherHost(urlError.code)
+        }
+        guard let apiError = error as? APIError,
+              case let .status(code, _) = apiError
+        else { return false }
+        return (502...504).contains(code) || (520...530).contains(code)
     }
 
     /// The offline banner as advice rather than an NSURLError string.
@@ -116,6 +150,16 @@ public enum ConnectionAdvice {
         }
         let fallback = next.map { " Trying \($0) next." } ?? ""
         return advice + fallback + " The app keeps retrying automatically."
+    }
+
+    public static func message(
+        forGatewayStatus code: Int,
+        host: String,
+        tryingNext next: String? = nil
+    ) -> String {
+        let fallback = next.map { " Trying \($0) next." } ?? ""
+        return "The route through \(host) is temporarily unavailable (HTTP \(code))." +
+            fallback + " The app keeps retrying automatically."
     }
 }
 

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -318,6 +318,9 @@ public struct PairResponse: Codable, Sendable {
     /// connection so the app can walk to the next one when the address it
     /// paired on stops resolving. Absent from older sidecars.
     public var hosts: [String]?
+    /// Full HTTPS/HTTP routes from newer sidecars. Absent during a staggered
+    /// rollout; `hosts` remains the compatibility path for older builds.
+    public var endpoints: [CompanionEndpoint]?
 }
 
 /// A freshly minted provider viewer. It is deliberately not Codable for

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -321,6 +321,36 @@ public struct PairResponse: Codable, Sendable {
     /// Full HTTPS/HTTP routes from newer sidecars. Absent during a staggered
     /// rollout; `hosts` remains the compatibility path for older builds.
     public var endpoints: [CompanionEndpoint]?
+
+    private enum CodingKeys: String, CodingKey {
+        case token, device, serverName, hosts, endpoints
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        token = try container.decode(String.self, forKey: .token)
+        device = try container.decode(PairedDevice.self, forKey: .device)
+        serverName = try container.decode(String.self, forKey: .serverName)
+        hosts = try container.decodeIfPresent([String].self, forKey: .hosts)
+        if container.contains(.endpoints) {
+            // These routes are advisory and the credential may already have
+            // been redeemed. One malformed or future-kind entry must not
+            // discard the valid token and legacy host fallback with it.
+            endpoints = (try? container.decode([Lossy<CompanionEndpoint>].self, forKey: .endpoints))?
+                .compactMap(\.value) ?? []
+        } else {
+            endpoints = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(token, forKey: .token)
+        try container.encode(device, forKey: .device)
+        try container.encode(serverName, forKey: .serverName)
+        try container.encodeIfPresent(hosts, forKey: .hosts)
+        try container.encodeIfPresent(endpoints, forKey: .endpoints)
+    }
 }
 
 /// A freshly minted provider viewer. It is deliberately not Codable for

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -10,6 +10,11 @@ final class ConnectionTests: XCTestCase {
         let explicit = Connection.parse("http://192.168.1.42:9910/")
         XCTAssertEqual(explicit?.host, "192.168.1.42")
         XCTAssertEqual(explicit?.port, 9910)
+
+        let hosted = Connection.parse("https://companion.example.com")
+        XCTAssertEqual(hosted?.host, "companion.example.com")
+        XCTAssertEqual(hosted?.port, 443)
+        XCTAssertEqual(hosted?.baseURL?.absoluteString, "https://companion.example.com")
     }
 
     func testParsesIPv6WithAndWithoutAnExplicitPort() {
@@ -79,6 +84,42 @@ final class ConnectionTests: XCTestCase {
         XCTAssertEqual(invite.connection.hosts, ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"])
     }
 
+    func testCarriesHostedAndDirectTypedEndpointsFromTheInvite() throws {
+        let routes = [
+            ["url": "http://192.168.1.42:8810", "kind": "lan", "priority": 200] as [String: Any],
+            ["url": "https://mac.companion.example", "kind": "hosted", "priority": 0] as [String: Any],
+            ["url": "http://mac.tail1234.ts.net:8810", "kind": "tailnet", "priority": 100] as [String: Any],
+        ]
+        let encoded = try Self.base64URL(JSONSerialization.data(withJSONObject: routes))
+        let token = "omb_pair_" + String(repeating: "a", count: 43)
+        let url = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=192.168.1.42%3A8810&token=\(token)&endpoints=\(encoded)"))
+
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+
+        XCTAssertEqual(invite.connection.baseURL?.absoluteString, "https://mac.companion.example")
+        XCTAssertEqual(invite.connection.activeEndpoint?.kind, .hosted)
+        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.kind), [.hosted, .tailnet, .lan])
+        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.priority), [0, 100, 200])
+    }
+
+    func testRejectsMalformedOrDowngradedTypedEndpoints() throws {
+        let token = "omb_pair_" + String(repeating: "a", count: 43)
+        for routes in [
+            [["url": "http://public.example", "kind": "hosted", "priority": 0]],
+            [["url": "https://user:secret@public.example", "kind": "hosted", "priority": 0]],
+            [["url": "https://public.example/path", "kind": "hosted", "priority": 0]],
+        ] {
+            let encoded = try Self.base64URL(JSONSerialization.data(withJSONObject: routes))
+            let url = try XCTUnwrap(URL(string:
+                "openmausbot://pair?address=192.168.1.42%3A8810&token=\(token)&endpoints=\(encoded)"))
+            XCTAssertNil(PairingInvite.parse(url))
+        }
+        let invalidBase64 = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=192.168.1.42%3A8810&token=\(token)&endpoints=not-json"))
+        XCTAssertNil(PairingInvite.parse(invalidBase64))
+    }
+
     func testDropsUnusableFallbackHostsWithoutRefusingTheInvite() throws {
         // Fallbacks are advisory: a bad one costs a single failed dial when
         // its turn comes, so it is filtered rather than fatal.
@@ -107,6 +148,11 @@ final class ConnectionTests: XCTestCase {
 
         let newer = Data(#"{"token":"omb_x","device":{"id":"d","name":"p","createdAt":1,"lastSeenAt":1},"serverName":"Mac","hosts":["a.ts.net","192.168.1.42"]}"#.utf8)
         XCTAssertEqual(try JSONDecoder().decode(PairResponse.self, from: newer).hosts, ["a.ts.net", "192.168.1.42"])
+
+        let typed = Data(#"{"token":"omb_x","device":{"id":"d","name":"p","createdAt":1,"lastSeenAt":1},"serverName":"Mac","endpoints":[{"url":"https://mac.example","kind":"hosted","priority":0}]}"#.utf8)
+        let response = try JSONDecoder().decode(PairResponse.self, from: typed)
+        XCTAssertEqual(response.endpoints?.first?.url, "https://mac.example")
+        XCTAssertEqual(response.endpoints?.first?.kind, .hosted)
     }
 
     func testRejectsAnUntrustedOrMalformedPairingInvite() throws {
@@ -131,5 +177,12 @@ final class ConnectionTests: XCTestCase {
             let data = try JSONSerialization.data(withJSONObject: ["joinUrl": value])
             XCTAssertThrowsError(try JSONDecoder().decode(CloudDesktopSession.self, from: data))
         }
+    }
+
+    private static func base64URL(_ data: Data) throws -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -288,6 +288,28 @@ final class DecodingTests: XCTestCase {
         XCTAssertFalse(paired.serverName.isEmpty)
     }
 
+    func testMalformedAdvisoryEndpointDoesNotDiscardAPairedToken() throws {
+        let json = """
+        {
+          "token":"omb_device",
+          "device":{"id":"d1","name":"Ada's iPhone","createdAt":1,"lastSeenAt":1},
+          "serverName":"Ada's Mac",
+          "hosts":["192.168.1.42"],
+          "endpoints":[
+            {"url":"https://mac.example","kind":"hosted","priority":0},
+            {"url":"https://future.example","kind":"future-transport","priority":10},
+            {"url":"http://192.168.1.42:8810","kind":"lan","priority":200}
+          ]
+        }
+        """
+
+        let paired = try JSONDecoder().decode(PairResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(paired.token, "omb_device")
+        XCTAssertEqual(paired.hosts, ["192.168.1.42"])
+        XCTAssertEqual(paired.endpoints?.map(\.kind), [.hosted, .lan])
+    }
+
     func testDecodesTheHarnessErrorBodies() throws {
         // these strings are written for people, and the client shows them
         // rather than inventing its own

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -41,11 +41,68 @@ final class FailoverTests: XCTestCase {
         XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.cannotConnectToHost)) // -1004
         XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.timedOut)) // -1001
         XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.secureConnectionFailed)) // -1200
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.serverCertificateHasBadDate)) // -1201
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.serverCertificateUntrusted)) // -1202
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.serverCertificateHasUnknownRoot)) // -1203
+        XCTAssertTrue(ConnectionAdvice.shouldTryAnotherHost(.serverCertificateNotYetValid)) // -1204
 
         // Offline fails on every address, and cancellation is deliberate.
         XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.notConnectedToInternet)) // -1009
         XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.cancelled))
         XCTAssertFalse(ConnectionAdvice.shouldTryAnotherHost(.networkConnectionLost))
+    }
+
+    func testRotatesPastTunnelGatewayFailuresButNotApplicationErrors() {
+        for code in [502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530] {
+            XCTAssertTrue(ConnectionAdvice.shouldTryAnotherRoute(
+                after: APIError.status(code: code, message: nil)
+            ), "expected HTTP \(code) to move to another route")
+        }
+        for code in [400, 401, 403, 404, 409, 500, 501] {
+            XCTAssertFalse(ConnectionAdvice.shouldTryAnotherRoute(
+                after: APIError.status(code: code, message: nil)
+            ), "expected HTTP \(code) to stay on the current route")
+        }
+    }
+
+    func testTunnelGatewayFailureAdvancesFromHostedToLAN() throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 200
+        ))
+        var rotation = CandidateRotation(endpoints: [hosted, lan])
+
+        let next = rotation.advanceEndpoint(
+            after: APIError.status(code: 502, message: nil)
+        )
+
+        XCTAssertEqual(next, lan)
+        XCTAssertEqual(rotation.currentEndpoint, lan)
+    }
+
+    func testAuthenticationFailureDoesNotAdvanceTheRoute() throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 200
+        ))
+        var rotation = CandidateRotation(endpoints: [hosted, lan])
+
+        XCTAssertNil(rotation.advanceEndpoint(
+            after: APIError.status(code: 401, message: nil)
+        ))
+        XCTAssertEqual(rotation.currentEndpoint, hosted)
     }
 
     // MARK: - The advice strings
@@ -81,6 +138,16 @@ final class FailoverTests: XCTestCase {
             port: 8810,
             tryingNext: "192.168.1.42"
         )
+        XCTAssertTrue(message.contains("Trying 192.168.1.42 next."))
+    }
+
+    func testGatewayAdviceNamesTheFallbackRoute() {
+        let message = ConnectionAdvice.message(
+            forGatewayStatus: 502,
+            host: "https://mac.companion.example",
+            tryingNext: "192.168.1.42"
+        )
+        XCTAssertTrue(message.contains("HTTP 502"))
         XCTAssertTrue(message.contains("Trying 192.168.1.42 next."))
     }
 

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -133,4 +133,68 @@ final class FailoverTests: XCTestCase {
         XCTAssertEqual(connection.hosts?.first, "10.0.0.7")
         XCTAssertEqual(connection.hosts?.count, 4)
     }
+
+    func testTypedRoutesKeepHostedHTTPSAheadOfAnActiveLANFallback() throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 200
+        ))
+        var connection = Connection(
+            name: "Mac",
+            host: hosted.host,
+            port: hosted.port,
+            activeEndpoint: hosted,
+            endpoints: [lan, hosted]
+        )
+
+        connection.promote(lan)
+
+        XCTAssertEqual(connection.baseURL?.absoluteString, lan.url)
+        XCTAssertEqual(connection.orderedEndpoints.map(\.url), [hosted.url, lan.url])
+    }
+
+    func testPromotingAWorkingLegacyEndpointKeepsEveryLegacyFallback() throws {
+        var connection = Connection(
+            name: "Mac",
+            host: "mac.tail1234.ts.net",
+            port: 8810,
+            hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"]
+        )
+        let lan = try XCTUnwrap(CompanionEndpoint.direct(
+            host: "192.168.1.42",
+            port: 8810,
+            priority: 1
+        ))
+
+        connection.promote(lan)
+
+        XCTAssertNil(connection.endpoints)
+        XCTAssertEqual(connection.orderedEndpoints.map(\.host), [
+            "192.168.1.42", "mac.tail1234.ts.net", "openmausbot-aa.local",
+        ])
+    }
+
+    func testTypedRotationPreservesSchemesAndPorts() throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let direct = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:9910",
+            kind: .lan,
+            priority: 200
+        ))
+        var rotation = CandidateRotation(endpoints: [hosted, direct])
+
+        XCTAssertEqual(rotation.currentEndpoint, hosted)
+        XCTAssertEqual(rotation.advanceEndpoint(), direct)
+        XCTAssertEqual(rotation.promotedEndpoints(), [direct, hosted])
+    }
 }

--- a/ios/Tests/CompanionCoreTests/PairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/PairingTests.swift
@@ -241,6 +241,51 @@ final class PairingTests: XCTestCase {
         XCTAssertEqual(pair.url?.absoluteString, "http://192.168.1.42:8810/api/pair")
     }
 
+    func testHostedGatewayFailureRetriesPairingOverLANWithTheSameRequestID() async throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 200
+        ))
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" { return .response(200, Self.health) }
+            return request.url?.scheme == "https"
+                ? .response(502, Data())
+                : .response(201, Self.paired)
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: hosted.host,
+            port: hosted.port,
+            activeEndpoint: hosted,
+            endpoints: [hosted, lan]
+        )
+        let requestId = "d350b2ac-7f92-4f30-bf80-21e040c1494b"
+
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            pairRequestId: requestId,
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.activeEndpoint, lan)
+        let pairRequests = PairingRequestStub.captured().filter { $0.url?.path == "/api/pair" }
+        XCTAssertEqual(pairRequests.map(\.url?.scheme), ["https", "http"])
+        let ids = try pairRequests.map { request in
+            let data = try XCTUnwrap(PairingRequestStub.body(of: request))
+            let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            return body["pairRequestId"] as? String
+        }
+        XCTAssertEqual(ids, [requestId, requestId])
+    }
+
     func testRetryCanReuseTheLogicalRequestIDAfterTheOnlyRouteDropsItsResponse() async throws {
         var pairAttempts = 0
         PairingRequestStub.reset { request in

--- a/ios/Tests/CompanionCoreTests/PairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/PairingTests.swift
@@ -198,6 +198,49 @@ final class PairingTests: XCTestCase {
         XCTAssertEqual(ids, [requestId, requestId])
     }
 
+    func testTypedHostedRouteUsesHTTPSBeforeFallingBackToDirectHTTP() async throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 200
+        ))
+        PairingRequestStub.reset { request in
+            if request.url?.path == "/api/health" {
+                return request.url?.scheme == "https"
+                    ? .failure(.cannotConnectToHost)
+                    : .response(200, Self.health)
+            }
+            return .response(201, Self.paired)
+        }
+        let connection = Connection(
+            name: "Mac",
+            host: "192.168.1.42",
+            port: 8810,
+            activeEndpoint: hosted,
+            endpoints: [lan, hosted]
+        )
+
+        let outcome = try await CompanionClient.pairFirstReachable(
+            connection: connection,
+            credential: Self.credential,
+            deviceName: "iPhone",
+            session: session
+        )
+
+        XCTAssertEqual(outcome.connection.activeEndpoint, lan)
+        let requests = PairingRequestStub.captured()
+        XCTAssertTrue(requests.contains {
+            $0.url?.scheme == "https" && $0.url?.host == "mac.companion.example" && $0.url?.path == "/api/health"
+        })
+        let pair = try XCTUnwrap(requests.first { $0.url?.path == "/api/pair" })
+        XCTAssertEqual(pair.url?.absoluteString, "http://192.168.1.42:8810/api/pair")
+    }
+
     func testRetryCanReuseTheLogicalRequestIDAfterTheOnlyRouteDropsItsResponse() async throws {
         var pairAttempts = 0
         PairingRequestStub.reset { request in
@@ -256,7 +299,10 @@ final class PairingTests: XCTestCase {
             )
             XCTFail("pairing should fail when no route answers")
         } catch let error as PairingRouteError {
-            XCTAssertEqual(error.attemptedHosts, ["mac.tail1234.ts.net", "192.168.1.42"])
+            XCTAssertEqual(error.attemptedHosts, [
+                "http://mac.tail1234.ts.net:8810",
+                "http://192.168.1.42:8810",
+            ])
         }
         XCTAssertTrue(PairingRequestStub.captured().allSatisfy { $0.url?.path == "/api/health" })
     }

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -15,7 +15,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Loader2, Smartphone, Trash2 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { companionPairingLink } from "../lib/companion-pairing";
+import { companionPairingLink, type CompanionEndpoint } from "../lib/companion-pairing";
 import { Card } from "./SettingsPrimitives";
 
 interface Device {
@@ -43,6 +43,8 @@ interface CompanionState {
   lan?: string | null;
   /** Ordered fallback hosts for the phone — tailnet name, LAN, mDNS last. */
   hosts?: string[];
+  /** Complete URLs for current mobile builds, hosted HTTPS first. */
+  endpoints?: CompanionEndpoint[];
   /** Bonjour: when advertising, the phone finds this computer by name. */
   discovery?: { advertising: boolean; name: string };
   /** Why it is not running, or not answering. */
@@ -72,6 +74,14 @@ const relative = (at: number) => {
   const hours = Math.round(minutes / 60);
   if (hours < 24) return `${hours} h ago`;
   return `${Math.round(hours / 24)} d ago`;
+};
+
+const endpointHost = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
 };
 
 export function CompanionSection() {
@@ -155,7 +165,14 @@ export function CompanionSection() {
   // clients. A bare 100.64/10 address is not dialable by the iOS app over
   // HTTP, so fall back to LAN instead of putting a broken address in the QR.
   const tailnet = state.tailnetName;
-  const address = tailnet ?? state.lan ?? state.addresses?.find((candidate) => candidate !== state.tailscale);
+  const hosted = state.endpoints?.find((endpoint) => endpoint.kind === "hosted");
+  // `address` is deliberately still a direct host. Older iOS builds assume
+  // this field means host:port over HTTP and would corrupt an HTTPS URL.
+  const address =
+    tailnet ??
+    state.lan ??
+    state.addresses?.find((candidate) => candidate !== state.tailscale) ??
+    state.hosts?.[0];
   const pairingLink =
     state.pairing && address
       ? companionPairingLink({
@@ -165,6 +182,7 @@ export function CompanionSection() {
           token: state.pairing.token,
           name: state.discovery?.name,
           hosts: state.hosts,
+          endpoints: state.endpoints,
         })
       : null;
 
@@ -187,6 +205,8 @@ export function CompanionSection() {
             <div className="mt-0.5 text-[13px] text-ink-secondary">
               {!state.enabled
                 ? "Nothing on this computer is reachable from the network."
+                : hosted
+                  ? `Secure connection ready at ${endpointHost(hosted.url)} — your phone can connect from any network.`
                 : !address
                   ? `Listening on port ${state.port} — no network address yet.`
                   : tailnet
@@ -221,7 +241,7 @@ export function CompanionSection() {
         {/* A tailnet address with no name is workable on a laptop and not on
             a phone, so say so rather than letting pairing fail with an
             unexplained policy error. */}
-        {state.enabled && state.tailscale && !state.tailnetName && (
+        {state.enabled && !hosted && state.tailscale && !state.tailnetName && (
           <div className="mt-3 text-[13px] text-ink-secondary">
             You're on a tailnet, but this computer's MagicDNS name couldn't be read from the
             Tailscale app — either MagicDNS is off, or the Tailscale command line tool isn't
@@ -229,7 +249,7 @@ export function CompanionSection() {
             OpenMausBot log for which paths were tried.
           </div>
         )}
-        {state.enabled && !state.tailscale && (
+        {state.enabled && !hosted && !state.tailscale && (
           <div className="mt-3 text-[13px] text-ink-secondary">
             Only reachable on this network. Install Tailscale on both this computer and your phone
             to reach it from anywhere — including networks that stop devices from seeing each other.

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -89,6 +89,8 @@ describe("companionPairingLink", () => {
         { url: "http://hosted.example", kind: "hosted", priority: 0 },
         { url: "https://192.168.1.42:8810", kind: "lan", priority: 200 },
         { url: "http://mac.local:8810/path", kind: "bonjour", priority: 300 },
+        { url: "http://mac.local:0", kind: "bonjour", priority: 300 },
+        { url: "http://mac.local:65536", kind: "bonjour", priority: 300 },
         { url: "http://mac.local:8810", kind: "bonjour", priority: 300 },
       ],
     });

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -4,6 +4,13 @@ import { companionPairingLink } from "./companion-pairing";
 describe("companionPairingLink", () => {
   const token = `omb_pair_${"a".repeat(43)}`;
 
+  const decodedEndpoints = (link: string) => {
+    const encoded = new URL(link).searchParams.get("endpoints");
+    if (!encoded) return null;
+    const padded = encoded.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(encoded.length / 4) * 4, "=");
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+  };
+
   it("carries the dialable address, one-time token, fallback code, and display name", () => {
     const link = companionPairingLink({
       address: "macbook.tail1234.ts.net",
@@ -45,6 +52,49 @@ describe("companionPairingLink", () => {
     expect(new URL(link!).searchParams.get("hosts")).toBe(
       "macbook.tail1234.ts.net,192.168.1.42,openmausbot-abcd1234.local",
     );
+  });
+
+  it("carries sorted typed endpoints as URL-safe base64 JSON while preserving legacy fields", () => {
+    const link = companionPairingLink({
+      address: "192.168.1.42",
+      port: 8810,
+      code: "004209",
+      token,
+      hosts: ["192.168.1.42", "openmausbot-abcd1234.local"],
+      endpoints: [
+        { url: "http://192.168.1.42:8810", kind: "lan", priority: 200 },
+        { url: "https://Device-123.Companion.Example/", kind: "hosted", priority: 0 },
+        { url: "http://openmausbot-abcd1234.local:8810", kind: "bonjour", priority: 300 },
+      ],
+    });
+
+    const url = new URL(link!);
+    expect(url.searchParams.get("address")).toBe("192.168.1.42:8810");
+    expect(url.searchParams.get("hosts")).toBe("192.168.1.42,openmausbot-abcd1234.local");
+    expect(url.searchParams.get("endpoints")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(decodedEndpoints(link!)).toEqual([
+      { url: "https://device-123.companion.example", kind: "hosted", priority: 0 },
+      { url: "http://192.168.1.42:8810", kind: "lan", priority: 200 },
+      { url: "http://openmausbot-abcd1234.local:8810", kind: "bonjour", priority: 300 },
+    ]);
+  });
+
+  it("filters malformed or transport-mismatched typed endpoints", () => {
+    const link = companionPairingLink({
+      address: "mac.local",
+      port: 8810,
+      code: "004209",
+      token,
+      endpoints: [
+        { url: "http://hosted.example", kind: "hosted", priority: 0 },
+        { url: "https://192.168.1.42:8810", kind: "lan", priority: 200 },
+        { url: "http://mac.local:8810/path", kind: "bonjour", priority: 300 },
+        { url: "http://mac.local:8810", kind: "bonjour", priority: 300 },
+      ],
+    });
+    expect(decodedEndpoints(link!)).toEqual([
+      { url: "http://mac.local:8810", kind: "bonjour", priority: 300 },
+    ]);
   });
 
   it("drops unusable fallback hosts without breaking the link", () => {

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -9,19 +9,92 @@ interface CompanionPairingLinkOptions {
    * — a tailnet name is unreachable the moment the phone leaves the tailnet,
    * while the LAN address keeps working. Older mobile builds ignore it. */
   hosts?: string[];
+  /** Complete base URLs for current mobile builds. Encoded separately from
+   * the legacy address/hosts fields so HTTPS and port 443 stay unambiguous. */
+  endpoints?: CompanionEndpoint[];
+}
+
+export type CompanionEndpointKind = "hosted" | "tailnet" | "lan" | "bonjour";
+
+export interface CompanionEndpoint {
+  url: string;
+  kind: CompanionEndpointKind;
+  priority: number;
 }
 
 /** How many fallback hosts a link will carry. The list is tiny in practice
  * (tailnet name, a LAN address or two, the mDNS name); the cap only keeps a
  * pathological interface list from bloating the QR code. */
 const MAX_HOSTS = 8;
+const ENDPOINT_KINDS = new Set<CompanionEndpointKind>(["hosted", "tailnet", "lan", "bonjour"]);
+
+/** Keep the QR contract strict even though its input came from our own
+ * sidecar. A public URL with credentials or a path is not a companion base
+ * URL, and filtering it is safer than teaching the phone to reinterpret it. */
+function qrEndpoints(endpoints: CompanionEndpoint[] | undefined): CompanionEndpoint[] {
+  const seen = new Set<string>();
+  const valid: CompanionEndpoint[] = [];
+
+  for (const endpoint of endpoints ?? []) {
+    if (
+      !endpoint ||
+      !ENDPOINT_KINDS.has(endpoint.kind) ||
+      !Number.isInteger(endpoint.priority) ||
+      endpoint.priority < 0 ||
+      endpoint.priority > 1_000_000
+    ) {
+      continue;
+    }
+
+    try {
+      const parsed = new URL(endpoint.url);
+      const expectedProtocol = endpoint.kind === "hosted" ? "https:" : "http:";
+      if (
+        parsed.protocol !== expectedProtocol ||
+        parsed.username ||
+        parsed.password ||
+        parsed.pathname !== "/" ||
+        parsed.search ||
+        parsed.hash ||
+        seen.has(parsed.origin)
+      ) {
+        continue;
+      }
+      seen.add(parsed.origin);
+      valid.push({ url: parsed.origin, kind: endpoint.kind, priority: endpoint.priority });
+    } catch {
+      // One malformed advisory route must not invalidate an otherwise usable
+      // pairing QR. It is simply omitted from the route walk.
+    }
+  }
+
+  return valid.sort((left, right) => left.priority - right.priority).slice(0, MAX_HOSTS);
+}
+
+/** URL-safe, unpadded base64 keeps the structured JSON smaller than query
+ * escaping every quote and slash while remaining straightforward to decode
+ * with Foundation on iOS. */
+function encodeEndpoints(endpoints: CompanionEndpoint[]): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(endpoints));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
 
 /**
  * A short-lived handoff from the trusted desktop pairing panel to the mobile
  * app. The code still has to be redeemed with the companion; putting it in
  * the link does not create or expose the long-lived device token.
  */
-export function companionPairingLink({ address, port, code, token, name, hosts }: CompanionPairingLinkOptions): string | null {
+export function companionPairingLink({
+  address,
+  port,
+  code,
+  token,
+  name,
+  hosts,
+  endpoints,
+}: CompanionPairingLinkOptions): string | null {
   const host = address.trim();
   if (
     !host ||
@@ -49,5 +122,7 @@ export function companionPairingLink({ address, port, code, token, name, hosts }
     .filter((candidate) => candidate && !/[\s/?#,[\]]/.test(candidate))
     .slice(0, MAX_HOSTS);
   if (candidates.length) url.searchParams.set("hosts", candidates.join(","));
+  const routes = qrEndpoints(endpoints);
+  if (routes.length) url.searchParams.set("endpoints", encodeEndpoints(routes));
   return url.toString();
 }

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -49,8 +49,10 @@ function qrEndpoints(endpoints: CompanionEndpoint[] | undefined): CompanionEndpo
     try {
       const parsed = new URL(endpoint.url);
       const expectedProtocol = endpoint.kind === "hosted" ? "https:" : "http:";
+      const explicitPort = parsed.port ? Number(parsed.port) : null;
       if (
         parsed.protocol !== expectedProtocol ||
+        (explicitPort !== null && (!Number.isInteger(explicitPort) || explicitPort < 1 || explicitPort > 65_535)) ||
         parsed.username ||
         parsed.password ||
         parsed.pathname !== "/" ||


### PR DESCRIPTION
## What this changes

- advertises typed hosted, tailnet, LAN, and Bonjour endpoints in pair responses and QR invites
- preserves the legacy address and hosts fields for staggered desktop/mobile upgrades
- makes iOS preserve each routes scheme, port, and priority instead of rebuilding everything as HTTP
- prefers certificate-validated hosted HTTPS while retaining direct fallbacks
- falls through to a verified fallback when a tunnel, proxy, or TLS route fails during pairing or reconnect
- preserves the same idempotent pairing request ID across route failure

## Compatibility and safety

- hosted endpoints must be HTTPS origins
- direct endpoints remain HTTP origins and retain the existing trusted-network warning
- malformed typed endpoint payloads are rejected rather than silently downgraded
- credential errors and application errors remain authoritative; only narrow route-specific failures trigger fallback

## Verification

- 155 Swift tests passed
- full iOS simulator app build passed
- 1,858 TypeScript/Node tests passed, 18 skipped, 0 failed
- companion production build passed
- packaged-server smoke checks passed, including all 9 proxy paths
- focused endpoint lint passed with 0 diagnostics
- independent review found no remaining blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companion pairing supports secure hosted HTTPS connections alongside Tailnet, LAN, and Bonjour routes.
  * Pairing links include prioritized connection options for improved connectivity.
  * iOS users can enter HTTPS addresses and view clearer connection details.
* **Improvements**
  * Connections automatically try, remember, and prioritize alternate routes.
  * Hosted connections reduce unnecessary local-network diagnostics.
* **Bug Fixes**
  * Improved handling of gateway errors, invalid addresses, and connection failover.
  * Preserved compatibility with older pairing links and legacy connection formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->