### PR TITLE
feat(computer): add secure VPS parity and companion uptime

### DIFF
--- a/apps/docs/content/docs/computers/cloud-and-vps.mdx
+++ b/apps/docs/content/docs/computers/cloud-and-vps.mdx
@@ -6,7 +6,7 @@ icon: Cloud
 
 ## Box cloud computer
 
-Add a Box API key in App Settings to provision an isolated hosted Linux desktop. The computer can sleep and wake, and supported sessions provide a live viewer for temporary human control.
+Add a Box API key in App Settings to provision an isolated hosted Linux desktop. The computer can sleep and wake, and supported sessions provide a live viewer for temporary human control. Trial accounts automatically retry creation with the provider's shorter auto-stop ceiling when required.
 
 Box is a third-party paid service after its trial. OpenMausBot stores the configured credential locally and does not expose it to the renderer.
 
@@ -24,3 +24,7 @@ docker -H ssh://my-vps info
 The SSH user needs Docker access, which is root-equivalent on that server. Use a dedicated VPS and firewall inbound traffic to SSH only.
 
 The managed container publishes no ports, has no host mounts, and is checked before every attach. Its filesystem should be treated as disposable; move important results out before deleting or upgrading the container.
+
+**Take control** opens the VPS desktop inside OpenMausBot through a temporary SSH tunnel. noVNC remains on the container's private bridge network; only a random loopback port is opened on your computer, and the tunnel closes with the viewer.
+
+Auto reuses an already-ready VPS without changing its lifecycle. To let Auto create or wake this bot's managed container, enable **Start VPS automatically** for that bot. This permission is off by default. When neither the VPS nor a local fallback is available, OpenMausBot shows the exact VPS failure instead of silently omitting computer tools.

--- a/apps/docs/content/docs/mobile/ios-companion.mdx
+++ b/apps/docs/content/docs/mobile/ios-companion.mdx
@@ -12,7 +12,7 @@ The native iOS companion is a thin client. Your computer remains the only machin
 - List bots and rooms, read paged transcripts, send messages, and interrupt work
 - Answer approvals and questions, including narrow always-allow grants
 - Search, manage tasks, react, share, and navigate message versions
-- Follow resumable live updates and optionally view a bot's cloud computer
+- Follow resumable live updates and optionally view a bot's managed Box cloud computer. The loopback-only VPS SSH viewer currently opens in the desktop app.
 
 ## Pairing
 
@@ -26,6 +26,8 @@ The computer stores only a digest of the device token. Revoking the phone from d
 - **Away from home:** Tailscale on both devices with the computer's MagicDNS name.
 
 There is no hosted OpenMausBot relay. Bonjour does not cross Tailscale, so remote connections use manual address entry.
+
+Your computer must remain on, awake, and running OpenMausBot. In desktop Companion Settings, **Keep this computer awake** can prevent system sleep while Companion is enabled; it is off by default, allows the screen to turn off, and may use more battery. A sleeping or powered-off computer cannot be reached without a future hosted relay.
 
 ## Security boundary
 

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -116,7 +116,13 @@ const sendJson = (res: ServerResponse, status: number, body: unknown): void => {
  * is the sidecar's credential and means nothing to the harness, and hop-by-hop
  * headers are by definition not ours to relay. */
 const forwardHeaders = (req: IncomingMessage): Record<string, string> => {
-  const out: Record<string, string> = { accept: String(req.headers.accept ?? "*/*") };
+  const out: Record<string, string> = {
+    accept: String(req.headers.accept ?? "*/*"),
+    // Lets a response whose URL is intentionally loopback-only (the VPS SSH
+    // viewer) fail before opening a tunnel a phone cannot reach. This header
+    // carries no authority; it only narrows behavior at the harness.
+    "x-openmausbot-companion": "1",
+  };
   const contentType = req.headers["content-type"];
   if (contentType) out["content-type"] = String(contentType);
   // Last-Event-ID is how a reconnecting client asks for the gap. Dropping it

--- a/companion/test/proxy-response.test.ts
+++ b/companion/test/proxy-response.test.ts
@@ -24,6 +24,7 @@ let harness: Server;
 let sidecar: Server;
 let sidecarPort = 0;
 let cloudDesktopAccess = true;
+let companionMarker = "";
 /** What the stub harness answers with next. Set per test. */
 let respond: (res: ServerResponse) => void = (res) => res.end();
 
@@ -43,7 +44,10 @@ const device = async (path = "/api/bots", method = "GET"): Promise<{ status: num
 };
 
 beforeAll(async () => {
-  harness = createServer((_req, res) => respond(res));
+  harness = createServer((req, res) => {
+    companionMarker = String(req.headers["x-openmausbot-companion"] ?? "");
+    respond(res);
+  });
   const harnessPort = await listen(harness);
 
   sidecar = createServer(
@@ -82,6 +86,7 @@ describe("preparing a harness response for a device", () => {
     const { status, text } = await device("/api/bots/b1/computer/join", "POST");
     expect(status).toBe(200);
     expect(JSON.parse(text).joinUrl).toBe("https://desktop.example/session/fresh");
+    expect(companionMarker).toBe("1");
   });
 
   it("never forwards a body it could not scrub", async () => {

--- a/docs/byo-vps.md
+++ b/docs/byo-vps.md
@@ -3,18 +3,18 @@
 OpenMausBot can turn a Linux server you already own into a bot's computer. The agent process stays on your
 machine; Docker's own SSH transport reaches the daemon on the VPS, and each bot gets one managed, hardened
 Cua container there — a Linux desktop it can see and control. SSH is the only credential involved and the
-only surface exposed: OpenMausBot never opens a port on the VPS, never stores a key or password, and never
-runs an agent remotely.
+only surface exposed: OpenMausBot never opens a public port on the VPS, never stores your SSH key or
+passphrase, and never runs an agent remotely.
 
 ## What works
 
 - A per-bot Linux desktop in a managed container on your VPS, driven through the official Cua tools.
 - Live screen preview in the Computer panel and in transcripts, same as a Box.
-- Explicit **Cloud** with the **Self-hosted VPS** backend provisions or starts the container; **Auto** only
-  reuses one that is already running and verified.
-
-Deliberately not offered: an interactive desktop tunnel. There is no "Open desktop" for a VPS bot — the
-container publishes no ports, so there is nothing to tunnel to, by design.
+- Explicit **Cloud** with the **Self-hosted VPS** backend provisions or starts the container. **Auto** reuses
+  a ready container by default; an off-by-default **Start VPS automatically** switch lets that bot prepare
+  or wake its managed container when needed.
+- Interactive **Take control** through a temporary SSH tunnel. The app binds noVNC only to a random
+  `127.0.0.1` port on your computer, closes the tunnel with the viewer, and never publishes VNC on the VPS.
 
 ## Prerequisites
 
@@ -66,7 +66,8 @@ host is unknown simply fails until you have done this once.
 ## Security
 
 - **No public ports.** The managed container is created with no published ports, and OpenMausBot refuses to
-  use a container that publishes any — the check runs before every attach, not just at creation.
+  use a container that publishes any — the check runs before every attach, not just at creation. Live view
+  reaches the container's private bridge address through SSH and is loopback-only on your computer.
 - **Firewall the VPS to SSH only**, ideally from your IP. Nothing OpenMausBot does needs any other inbound
   port open, so anything else open is pure attack surface.
 - **Nothing sensitive is stored.** The only thing OpenMausBot persists is the alias name itself
@@ -93,8 +94,10 @@ follows a Cua image upgrade, since a container pinned to an old image is refused
 it. Treat the container filesystem as **disposable**: anything a bot must keep should leave the VPS (pushed,
 uploaded, or pasted back into chat) before the container is removed.
 
-A bot set to **Auto** never touches this lifecycle. It attaches only when the container is already running
-and verified; otherwise it behaves as if no cloud computer existed.
+A bot set to **Auto** is lifecycle-read-only by default. It attaches only when the container is already
+running and verified. If no local fallback exists, the turn now explains why the VPS was unavailable instead
+of silently running without a computer. Enable **Start VPS automatically** per bot to let Auto prepare or wake
+that bot's managed container; the switch is deliberately off by default.
 
 ## Troubleshooting
 

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -18,11 +18,17 @@ The first version includes:
   state.
 - Approvals and questions, including narrow “always allow” grants.
 - Resumable SSE, streamed reply text, reconnect hydration, and an opt-in live
-  computer view.
+  Box computer view. The loopback-only VPS SSH viewer remains desktop-only.
 - Markdown rendering and Keychain storage for the device token.
 
 It is foreground-only. Push notifications, background delivery, voice, App
 Store release automation, and a hosted relay are not part of this version.
+
+The Mac must be running OpenMausBot and must not be asleep. Companion Settings
+offers an off-by-default **Keep this computer awake** switch that prevents
+system sleep while Companion is on; the display may still turn off. Without a
+hosted relay, a sleeping or powered-off Mac cannot receive phone requests or
+run its local routines.
 
 ## Runtime architecture
 

--- a/electron/companion.mjs
+++ b/electron/companion.mjs
@@ -54,25 +54,35 @@ const entryPoint = (resourcesPath) =>
 
 const settingsFile = () => path.join(app.getPath("userData"), "companion-settings.json");
 
+function companionSettings() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(settingsFile(), "utf8"));
+    return { enabled: parsed?.enabled === true, keepAwake: parsed?.keepAwake === true };
+  } catch {
+    return { enabled: false, keepAwake: false };
+  }
+}
+
 /** Whether the user left the companion on. Anything unreadable is "off" —
  * the flag opens a network listener, so it fails closed. */
 export function companionEnabledAtRest() {
-  try {
-    return JSON.parse(fs.readFileSync(settingsFile(), "utf8"))?.enabled === true;
-  } catch {
-    return false;
-  }
+  return companionSettings().enabled;
+}
+
+export function companionKeepAwakeAtRest() {
+  return companionSettings().keepAwake;
 }
 
 /** Remember the toggle's position. Written via temp-and-rename so a crash
  * mid-write cannot leave a truncated file; a failed write costs auto-start
  * on the next launch, never the toggle itself. */
-export function rememberCompanionEnabled(enabled) {
+function rememberCompanionSettings(patch) {
   const file = settingsFile();
   const temporary = `${file}.${process.pid}.tmp`;
   try {
+    const next = { ...companionSettings(), ...patch };
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(temporary, JSON.stringify({ enabled }, null, 2));
+    fs.writeFileSync(temporary, JSON.stringify(next, null, 2));
     fs.renameSync(temporary, file);
   } catch {
     try {
@@ -81,6 +91,15 @@ export function rememberCompanionEnabled(enabled) {
       /* never created, or already renamed */
     }
   }
+}
+
+
+export function rememberCompanionEnabled(enabled) {
+  rememberCompanionSettings({ enabled });
+}
+
+export function rememberCompanionKeepAwake(keepAwake) {
+  rememberCompanionSettings({ keepAwake });
 }
 
 /** Ask the sidecar's own control server, which is the same API the standalone
@@ -245,15 +264,18 @@ async function stop() {
 /** Everything the panel renders. Shaped so "off" is a complete answer rather
  * than an absence — the panel should never have to guess. */
 export async function companionState() {
+  const keepAwake = companionKeepAwakeAtRest();
   if (!proc) {
-    return { enabled: false, port: COMPANION_PORT, devices: [], pairing: null, ...(lastError ? { error: lastError } : {}) };
+    const state = { enabled: false, keepAwake, port: COMPANION_PORT, devices: [], pairing: null };
+    if (lastError) state.error = lastError;
+    return state;
   }
   try {
     const state = await control("GET", "/state");
-    return { enabled: true, ...state };
+    return { enabled: true, keepAwake, ...state };
   } catch {
     // running but unreachable: report it rather than claiming health
-    return { enabled: true, port: COMPANION_PORT, devices: [], pairing: null, error: "the companion is not responding" };
+    return { enabled: true, keepAwake, port: COMPANION_PORT, devices: [], pairing: null, error: "the companion is not responding" };
   }
 }
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, Menu, nativeImage, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, dialog, ipcMain, Menu, nativeImage, powerSaveBlocker, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
 import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
@@ -283,14 +283,28 @@ const LOG_DIR = app.getPath("logs");
 let logStream = null;
 import {
   companionEnabledAtRest,
+  companionKeepAwakeAtRest,
   companionPairing,
   companionCloudDesktopAccess,
   companionRevoke,
   companionState,
   rememberCompanionEnabled,
+  rememberCompanionKeepAwake,
   startCompanion,
   stopCompanion,
 } from "./companion.mjs";
+
+let companionPowerBlocker = null;
+
+function syncCompanionKeepAwake(companionEnabled, keepAwake) {
+  const shouldBlock = companionEnabled && keepAwake;
+  if (shouldBlock && companionPowerBlocker === null) {
+    companionPowerBlocker = powerSaveBlocker.start("prevent-app-suspension");
+  } else if (!shouldBlock && companionPowerBlocker !== null) {
+    if (powerSaveBlocker.isStarted(companionPowerBlocker)) powerSaveBlocker.stop(companionPowerBlocker);
+    companionPowerBlocker = null;
+  }
+}
 
 function slog(line) {
   try {
@@ -966,7 +980,13 @@ ipcMain.handle("skill-recorder:save", (_event, payload) => saveSkillRecording(pa
 // The renderer gets these five and nothing else: it can turn the companion
 // on and off, look at it, open or cancel a pairing window, and remove a
 // device. It cannot reach the sidecar's control port itself.
-ipcMain.handle("companion:state", () => companionState());
+ipcMain.handle("companion:state", async () => {
+  const state = await companionState();
+  // The panel polls this state, so a sidecar that exited on its own releases
+  // the blocker within one poll instead of keeping the computer awake forever.
+  syncCompanionKeepAwake(state.enabled && !state.error, state.keepAwake === true);
+  return state;
+});
 ipcMain.handle("companion:start", async () => {
   const state = await startCompanion({
     resourcesPath: process.resourcesPath,
@@ -977,11 +997,20 @@ ipcMain.handle("companion:start", async () => {
   // one would greet every launch with the same error for a toggle the panel
   // showed as off.
   if (state.enabled && !state.error) rememberCompanionEnabled(true);
+  syncCompanionKeepAwake(state.enabled && !state.error, state.keepAwake === true);
   return state;
 });
-ipcMain.handle("companion:stop", () => {
+ipcMain.handle("companion:stop", async () => {
   rememberCompanionEnabled(false);
+  syncCompanionKeepAwake(false, false);
   return stopCompanion();
+});
+ipcMain.handle("companion:keep-awake", async (_event, enabled) => {
+  const keepAwake = Boolean(enabled);
+  rememberCompanionKeepAwake(keepAwake);
+  const state = await companionState();
+  syncCompanionKeepAwake(state.enabled && !state.error, keepAwake);
+  return companionState();
 });
 ipcMain.handle("companion:pairing", (_event, open) => companionPairing(Boolean(open)));
 ipcMain.handle("companion:cloud-desktop", (_event, deviceId, allowed) =>
@@ -1169,7 +1198,9 @@ app.whenReady().then(async () => {
   // (the panel shows the error) rather than retrying; and it never delays
   // the window.
   if (serverReady && companionEnabledAtRest()) {
-    void startCompanion({ resourcesPath: process.resourcesPath, harnessPort: SERVER_PORT, log: slog });
+    void startCompanion({ resourcesPath: process.resourcesPath, harnessPort: SERVER_PORT, log: slog }).then((state) => {
+      syncCompanionKeepAwake(state.enabled && !state.error, companionKeepAwakeAtRest());
+    });
   }
   const win = createWindow();
   // Registration is optional network work. Start it only after the local
@@ -1225,6 +1256,7 @@ app.on("before-quit", (e) => {
   // the sidecar holds a socket that is reachable from off this machine —
   // it should not outlive the window by even a moment
   void stopCompanion();
+  syncCompanionKeepAwake(false, false);
   // a live dictation session runs its own helper child that holds the mic —
   // stop it here so quitting never orphans a recording process
   if (nativeActions.appleSpeech) stopSpeech();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -27,6 +27,7 @@ contextBridge.exposeInMainWorld("ogb", {
     state: () => ipcRenderer.invoke("companion:state"),
     start: () => ipcRenderer.invoke("companion:start"),
     stop: () => ipcRenderer.invoke("companion:stop"),
+    keepAwake: (enabled) => ipcRenderer.invoke("companion:keep-awake", enabled),
     pairing: (open) => ipcRenderer.invoke("companion:pairing", open),
     cloudDesktop: (deviceId, allowed) => ipcRenderer.invoke("companion:cloud-desktop", deviceId, allowed),
     revoke: (deviceId) => ipcRenderer.invoke("companion:revoke", deviceId),

--- a/server/box-trial.test.ts
+++ b/server/box-trial.test.ts
@@ -1,0 +1,71 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("Box trial provisioning", () => {
+  let api: Server;
+  let provisionBox: typeof import("./box.ts").provisionBox;
+  const createBodies: Array<{ ttlSeconds: number; noEnv: boolean }> = [];
+
+  beforeAll(async () => {
+    api = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://box.test");
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        res.setHeader("content-type", "application/json");
+        if (url.pathname === "/api/box/v1/boxes" && req.method === "GET") {
+          return res.end(JSON.stringify({ ok: true, boxes: [] }));
+        }
+        if (url.pathname === "/api/box/v1/boxes" && req.method === "POST") {
+          const body = JSON.parse(raw);
+          createBodies.push(body);
+          if (createBodies.length === 1) {
+            res.writeHead(400);
+            return res.end(JSON.stringify({
+              ok: false,
+              error: { code: "trial_auto_stop_required", details: { maxTtlSeconds: 7200 } },
+            }));
+          }
+          res.writeHead(201);
+          return res.end(JSON.stringify({ ok: true, box: { id: "trial-box", state: "ready" } }));
+        }
+        if (url.pathname === "/api/box/v1/boxes/trial-box" && req.method === "PATCH") {
+          return res.end(JSON.stringify({ ok: true }));
+        }
+        if (url.pathname === "/api/box/v1/boxes/trial-box" && req.method === "GET") {
+          return res.end(JSON.stringify({ ok: true, box: { id: "trial-box", state: "ready" } }));
+        }
+        if (url.pathname.endsWith("/commands")) {
+          return res.end(JSON.stringify({ ok: true, exitCode: 0, stdout: "", stderr: "" }));
+        }
+        if (url.pathname.endsWith("/desktop")) {
+          return res.end(JSON.stringify({ ok: true, desktopUrl: "https://desktop.example/vnc" }));
+        }
+        res.writeHead(404).end(JSON.stringify({ ok: false, message: "unexpected request" }));
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
+    // SAFETY: the test server was bound as TCP above, not to a Unix socket.
+    const port = (api.address() as AddressInfo).port;
+    vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
+    vi.resetModules();
+    ({ provisionBox } = await import("./box.ts"));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve) => api.close(() => resolve()));
+  });
+
+  it("retries the structured trial TTL refusal exactly once at the allowed ceiling", async () => {
+    // SAFETY: AppConfig's remaining sections are optional; this test supplies
+    // the only credential the Box path reads.
+    const result = await provisionBox({ box: { token: "box_trial" } } as any, "trial-bot", "Trial Bot");
+    expect(result.boxId).toBe("trial-box");
+    expect(createBodies).toEqual([
+      { ttlSeconds: 8 * 60 * 60, noEnv: true },
+      { ttlSeconds: 2 * 60 * 60, noEnv: true },
+    ]);
+  });
+});

--- a/server/box.ts
+++ b/server/box.ts
@@ -16,6 +16,8 @@ import { ensureRemoteCuaCommand, remoteComputerBootstrapCommand } from "./remote
 // overridable so tests can point at a stub instead of the live provider
 const BOX_API = process.env.OMB_BOX_API || "https://ascii.dev/api/box/v1";
 const READY = new Set(["idle", "ready", "running"]);
+const DEFAULT_BOX_TTL_SECONDS = 8 * 60 * 60;
+const TRIAL_BOX_TTL_SECONDS = 2 * 60 * 60;
 
 function boxFetch(cfg: AppConfig, path: string, opts: RequestInit = {}) {
   return fetch(`${BOX_API}${path}`, {
@@ -171,6 +173,35 @@ export function boxErrorMessage(status: number, what: string, body?: any): strin
   return theirs ? `${what} failed: ${theirs}` : `${what} failed (${status})`;
 }
 
+/** ascii.dev trial accounts reject the normal eight-hour auto-stop with a
+ * structured `trial_auto_stop_required` refusal. Retry that one condition
+ * once at the provider's advertised maximum (or the documented two-hour
+ * trial ceiling). Other create failures must retain their original error. */
+function trialBoxTtlSeconds(body: any): number | null {
+  const code = body?.error?.code ?? body?.code;
+  if (code !== "trial_auto_stop_required") return null;
+  const details = body?.error?.details ?? body?.details ?? {};
+  for (const value of [details.maxTtlSeconds, details.maximumTtlSeconds, details.maxAutoStopSeconds]) {
+    if (Number.isInteger(value) && value > 0 && value <= DEFAULT_BOX_TTL_SECONDS) return value;
+  }
+  return TRIAL_BOX_TTL_SECONDS;
+}
+
+async function createBox(cfg: AppConfig) {
+  const request = (ttlSeconds: number) =>
+    boxJson(cfg, "/boxes", {
+      method: "POST",
+      // The computer needs the user's desktop session, not the account
+      // owner's host credentials. Keep provider-side env injection off so
+      // API keys cannot silently appear inside the guest.
+      body: JSON.stringify({ ttlSeconds, noEnv: true }),
+    });
+  const first = await request(DEFAULT_BOX_TTL_SECONDS);
+  if (first.ok) return first;
+  const trialTtl = trialBoxTtlSeconds(first.body);
+  return trialTtl === null ? first : request(trialTtl);
+}
+
 /** Box state for the Computer panel. */
 export async function boxStatus(cfg: AppConfig, botId: string) {
   if (!boxConfigured(cfg)) return { configured: false, box: null };
@@ -195,15 +226,10 @@ export async function provisionBox(cfg: AppConfig, botId: string, botName: strin
   let created = false;
   try {
     if (!box) {
-      const createRes = await boxJson(cfg, "/boxes", {
-        method: "POST",
-        // substrate-side backstop: archives itself (billing pauses, disk
-        // survives) if every stop path dies
-        // The computer needs the user's desktop session, not the account
-        // owner's host credentials. Keep provider-side env injection off so
-        // API keys cannot silently appear inside the guest.
-        body: JSON.stringify({ ttlSeconds: 8 * 60 * 60, noEnv: true }),
-      });
+      // Provider-side backstop: archives itself (billing pauses, disk
+      // survives) if every stop path dies. Trial accounts get one narrower
+      // retry when ascii.dev reports their shorter TTL ceiling.
+      const createRes = await createBox(cfg);
       if (!createRes.ok || !createRes.body?.box?.id) {
         throw new Error(boxErrorMessage(createRes.status, "box create", createRes.body));
       }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1789,6 +1789,10 @@ describe("harness HTTP API", () => {
     const patched = await api("PATCH", `/api/bots/${bot.id}`, { cloudBackend: "vps" });
     expect(patched.status).toBe(200);
     expect(patched.body.bot.cloudBackend).toBe("vps");
+    const autoStart = await api("PATCH", `/api/bots/${bot.id}`, { autoStartVps: true });
+    expect(autoStart.status).toBe(200);
+    expect(autoStart.body.bot.autoStartVps).toBe(true);
+    expect((await api("PATCH", `/api/bots/${bot.id}`, { autoStartVps: "yes" })).status).toBe(400);
     const invalid = await api("PATCH", `/api/bots/${bot.id}`, { cloudBackend: "daytona" });
     expect(invalid.status).toBe(400);
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1535,6 +1535,7 @@ async function startTurn(
       const mountsLocalComputer = instance.adapter.capabilities.localComputerMcp === true;
       let previewCapture: (() => Promise<{ png: string; format: string }>) | null = null;
       let computerKind: "box" | "vps" | "vm" | "local" | null = null;
+      let autoVpsProblem: string | null = null;
 
       // Explicit destinations are strict. In particular, Local VM must never
       // fall through to host CUA and accidentally click on the user's Mac.
@@ -1580,16 +1581,17 @@ async function startTurn(
       }
 
       // A VPS is a local-agent computer mount, never a remote agent runner.
-      // Explicit Cloud may prepare/start it; Auto is read-only and can only
-      // attach to an already-running, verified container.
+      // Explicit Cloud may prepare/start it. Auto remains read-only unless
+      // the person explicitly opted this bot into remote lifecycle actions.
       if ((wants === "cloud" || wants === undefined) && cloudBackend === "vps") {
         const unsupported = vps.vpsDriverError(instance.driverKind, mountsComputerMcp);
         if (unsupported && wants === "cloud") throw new Error(unsupported);
+        if (unsupported && wants === undefined) autoVpsProblem = unsupported;
         if (!unsupported) {
           activeVpsThreads.set(bot.id, threadId);
-          const remote = wants === "cloud"
+          const remote = wants === "cloud" || bot.autoStartVps
             ? await vps.vpsComputerAction("provision", cfg, bot.id)
-            : await vps.reuseVps(cfg, bot.id);
+            : await vps.inspectVpsForAuto(cfg, bot.id);
           if (remote?.ready && remote.sshAlias) {
             const targetCfg = { ...cfg, vps: { sshAlias: remote.sshAlias } };
             const vpsMcp = vps.vpsComputerMcp(targetCfg, bot.id, remote.container_id ?? undefined);
@@ -1605,6 +1607,7 @@ async function startTurn(
             if (wants === "cloud") {
               throw new Error(remote?.problem ?? "the VPS computer could not be created or reached");
             }
+            autoVpsProblem = remote?.problem ?? "the VPS computer could not be reached";
           }
         }
       }
@@ -1668,6 +1671,18 @@ async function startTurn(
           integrations.localComputer = cua;
           computerKind = "local";
         }
+      }
+      if (
+        wants === undefined &&
+        cloudBackend === "vps" &&
+        !integrations.computer &&
+        !integrations.localComputer &&
+        autoVpsProblem
+      ) {
+        const hint = bot.autoStartVps
+          ? "Check the VPS connection in App Settings → Connections."
+          : "Open Computer and enable Start VPS automatically, or choose Cloud to start it manually.";
+        throw new Error(`${autoVpsProblem}. ${hint}`);
       }
       // Agent control tools include peer comms and the secure credential
       // request card. A comms-invoked turn (depth ≥ cap) gets none — hard recursion
@@ -4039,6 +4054,10 @@ const server = createServer(async (req, res) => {
       if (body.cloudBackend !== undefined && !["box", "vps"].includes(String(body.cloudBackend))) {
         return json(res, 400, { error: "cloudBackend must be box or vps" });
       }
+      if (body.autoStartVps !== undefined) {
+        if (typeof body.autoStartVps !== "boolean") return json(res, 400, { error: "autoStartVps must be true or false" });
+        patch.autoStartVps = body.autoStartVps;
+      }
       if (body.chiefOfStaff !== undefined && typeof body.chiefOfStaff !== "boolean") {
         return json(res, 400, { error: "chiefOfStaff must be true or false" });
       }
@@ -5048,6 +5067,15 @@ const server = createServer(async (req, res) => {
       }
       return json(res, 405, { error: "method not allowed" });
     }
+    m = path.match(/^\/api\/bots\/([\w-]+)\/computer\/viewer-close$/);
+    if (m && method === "POST") {
+      const bot = store.bot(m[1]);
+      if (!bot) return json(res, 404, { error: "no such bot" });
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      return json(res, 200, bot.cloudBackend === "vps" ? vps.closeVpsDesktopTunnel(bot.id) : { closed: false });
+    }
     m = path.match(/^\/api\/bots\/([\w-]+)\/computer\/(provision|join|sleep|exec|screenshot|remove)$/);
     if (m && method === "POST") {
       const botId = m[1];
@@ -5062,14 +5090,22 @@ const server = createServer(async (req, res) => {
         return json(res, 415, { error: "content-type must be application/json" });
       }
       if (bot.cloudBackend === "vps") {
-        if (m[2] === "join" || m[2] === "exec") {
-          return json(res, 409, { error: "interactive VPS desktop access is not supported" });
+        if (m[2] === "exec") {
+          return json(res, 409, { error: "the VPS console is available to the bot through its scoped computer tools" });
         }
-        if (m[2] === "provision" && bot.computer !== "cloud") {
-          return json(res, 409, { error: "Auto mode will not provision a VPS; choose Cloud for this bot first" });
+        if (m[2] === "provision" && bot.computer !== "cloud" && !bot.autoStartVps) {
+          return json(res, 409, { error: "Auto may start this VPS only after Start VPS automatically is enabled" });
         }
         if ((m[2] === "sleep" || m[2] === "remove") && (bot.busy || activeVpsThreads.has(botId))) {
           return json(res, 409, { error: "the VPS computer is being used by this bot — interrupt the turn first" });
+        }
+        if (m[2] === "join") {
+          if (req.headers["x-openmausbot-companion"] === "1") {
+            return json(res, 409, {
+              error: "VPS live desktop control is currently available in the desktop app; the SSH viewer is loopback-only",
+            });
+          }
+          return json(res, 200, await vps.vpsComputerJoin(cfg, botId));
         }
         if (m[2] === "screenshot") return json(res, 200, await vps.vpsComputerScreenshot(cfg, botId));
         const action = m[2] === "provision" ? "provision" : m[2] === "remove" ? "remove" : "stop";
@@ -5130,6 +5166,7 @@ server.listen(PORT, "127.0.0.1", () => {
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
     for (const idle of localVmIdles.values()) idle.cancel();
+    vps.closeAllVpsDesktopTunnels();
     watchdog.stop();
     routines?.stop();
     webhookIngress?.server.close();

--- a/server/store.ts
+++ b/server/store.ts
@@ -299,6 +299,9 @@ export interface BotRecord {
   computer?: "cloud" | "vm" | "local" | "off";
   /** Which cloud computer backs `computer: "cloud"`; absent means Box. */
   cloudBackend?: CloudBackend;
+  /** Auto mode may prepare/start this bot's managed VPS container. Off by
+   * default because starting remote infrastructure is an external action. */
+  autoStartVps?: boolean;
   /** where NEW tasks run their shell tools; each task pins its own copy
    * on its first turn (TaskRecord.cwd). Absent = the home folder. */
   cwd?: string;
@@ -509,6 +512,10 @@ export class Store {
       b.activity = "idle";
       if (b.cloudBackend !== undefined && b.cloudBackend !== "box" && b.cloudBackend !== "vps") {
         delete b.cloudBackend;
+        botsMigrated = true;
+      }
+      if (b.autoStartVps !== undefined && b.autoStartVps !== true && b.autoStartVps !== false) {
+        delete b.autoStartVps;
         botsMigrated = true;
       }
       const avatar = botAvatarProfile(b);

--- a/server/vps-computer.test.ts
+++ b/server/vps-computer.test.ts
@@ -16,6 +16,7 @@ import {
   VPS_CONTAINER_LABEL,
   VPS_IMAGE,
   VPS_MANAGED_LABEL,
+  VPS_VIEWER_LABEL,
   vpsComputerAction,
   vpsComputerScreenshot,
   vpsComputerStatus,
@@ -25,6 +26,7 @@ import {
   vpsContainerRunArgs,
   vpsDockerArgs,
   vpsDriverError,
+  vpsSshTunnelArgs,
   reuseVps,
   type VpsCommandRunner,
 } from "./vps-computer.ts";
@@ -127,6 +129,7 @@ function fixture({
         stdout: JSON.stringify([{
           Config: {
             Image: state.image ? VPS_IMAGE : "old-image",
+            Env: [`VNC_PW=${argValue("VNC_PW") || "viewer-secret"}`],
             Labels: {
               [VPS_MANAGED_LABEL]: managed ? "1" : "0",
               [VPS_CONTAINER_LABEL]: managed ? name : "other-container",
@@ -134,6 +137,7 @@ function fixture({
               [DRIVER_LABEL]: CUA_DRIVER_VERSION,
               [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
               [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+              [VPS_VIEWER_LABEL]: "1",
             },
           },
            Id: containerId,
@@ -165,7 +169,7 @@ function fixture({
             RestartPolicy: { Name: restartPolicyName, MaximumRetryCount: 0 },
           },
           NetworkSettings: {
-            Networks: { [networkMode === "default" ? "bridge" : networkMode]: {} },
+            Networks: { [networkMode === "default" ? "bridge" : networkMode]: { IPAddress: "172.17.0.5" } },
           },
           Mounts: mounts ? [{ Source: "/host", Destination: "/container" }] : [],
           State: { Running: state.running },
@@ -238,6 +242,15 @@ describe("VPS computer", () => {
       expect(() => vpsDockerArgs(alias, ["info"])).toThrow(/alias/);
     }
     expect(() => vpsContainerMcpArgs("production-vps", "not a container")).toThrow(/connection/);
+  });
+
+  it("keeps the live desktop behind a validated loopback SSH forward", () => {
+    const args = vpsSshTunnelArgs("production-vps", 45678, "172.17.0.5");
+    expect(args).toContain("127.0.0.1:45678:172.17.0.5:6901");
+    expect(args.at(-1)).toBe("production-vps");
+    expect(args).toContain("ExitOnForwardFailure=yes");
+    expect(() => vpsSshTunnelArgs("production-vps", 80, "172.17.0.5")).toThrow(/port/);
+    expect(() => vpsSshTunnelArgs("production-vps", 45678, "203.0.113.8")).toThrow(/private/);
   });
 
   it("reports a ready container only when image, labels, limits, mounts, network, and Cua pass", async () => {
@@ -371,7 +384,10 @@ describe("VPS computer", () => {
     expect(run.at(-1)).toBe(IMAGE_ID);
     expect(run.join(" ")).toContain(`--label ${VPS_MANAGED_LABEL}=1`);
     expect(run.join(" ")).toContain(`--label ${IMAGE_LAYER_LABEL}=${IMAGE_LAYER_VERSION}`);
+    expect(run.join(" ")).toContain(`--label ${VPS_VIEWER_LABEL}=1`);
     expect(run.join(" ")).toContain("--restart unless-stopped");
+    expect(run).toContain("-e");
+    expect(run.some((arg) => /^VNC_PW=[A-Za-z0-9_-]{8,}$/.test(arg))).toBe(true);
     expect(run).not.toContain("--mount");
     expect(run).not.toContain("-p");
     expect(provision.calls.some(({ args }) => args[2] === "build")).toBe(true);

--- a/server/vps-computer.ts
+++ b/server/vps-computer.ts
@@ -1,8 +1,9 @@
 // BYO Linux VPS computer. The agent process stays local; Docker's own SSH
 // transport reaches the user's daemon and the official Cua MCP server stays
 // inside one managed container per bot.
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
+import { createConnection, createServer, type AddressInfo } from "node:net";
 
 import {
   BASE_IMAGE,
@@ -29,6 +30,7 @@ import { SPAWNED_PROXIES } from "./proxy-paths.ts";
 export const VPS_IMAGE = CUA_IMAGE;
 export const VPS_MANAGED_LABEL = "com.openmausbot.vps";
 export const VPS_CONTAINER_LABEL = "com.openmausbot.container";
+export const VPS_VIEWER_LABEL = "com.openmausbot.vps-viewer";
 export const VPS_CONTAINER_PREFIX = "openmausbot-vps";
 // SIGTERM must give ssh + docker time to tear down the remote exec before the
 // SIGKILL escalation; 1s was routinely too short over a WAN round-trip, and an
@@ -40,6 +42,8 @@ const CONTAINER_ID = /^[a-f0-9]{12,64}$/i;
 const IMAGE_ID = /^sha256:[a-f0-9]{64}$/i;
 const PIDS_LIMIT = 512;
 const SCREENSHOT_PATH = "/tmp/openmausbot-vps-preview.png";
+const INTERNAL_VIEWER_PORT = 6901;
+const VIEWER_VERSION = "1";
 const lifecycleLocks = new Map<string, Promise<void>>();
 // A held lock means a lifecycle mutation (worst case: a 10-minute image
 // build) is running. Waiting it out would wedge Sleep and the screenshot
@@ -50,6 +54,11 @@ const LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
 // pattern as container-computer's screenshotStatusCache, and the same TTL.
 const STATUS_CACHE_TTL_MS = 10_000;
 const statusCache = new Map<string, { status: VpsComputerStatus; expiresAt: number }>();
+const viewerConnections = new Map<string, { privateIp: string; password: string }>();
+const desktopTunnels = new Map<
+  string,
+  { child: ReturnType<typeof spawn>; joinUrl: string; expiry: ReturnType<typeof setTimeout> }
+>();
 
 export interface VpsCommandOptions {
   input?: string;
@@ -101,6 +110,84 @@ export function vpsDockerArgs(alias: string, args: string[]): string[] {
     throw new Error("invalid VPS SSH config alias");
   }
   return ["-H", `ssh://${alias}`, ...args];
+}
+
+/** A live VPS desktop is never published by Docker. SSH binds one temporary
+ * loopback port on this computer and forwards it to noVNC on the container's
+ * private bridge address. Every caller-controlled component is validated
+ * before it becomes an argv value. */
+export function vpsSshTunnelArgs(alias: string, localPort: number, privateIp: string): string[] {
+  if (!isValidSshAlias(alias)) throw new Error("invalid VPS SSH config alias");
+  if (!Number.isInteger(localPort) || localPort < 1024 || localPort > 65535) {
+    throw new Error("invalid VPS viewer port");
+  }
+  if (!privateDockerIpv4(privateIp)) throw new Error("invalid VPS private container address");
+  return [
+    "-N",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "PermitLocalCommand=no",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
+    "-L",
+    `127.0.0.1:${localPort}:${privateIp}:${INTERNAL_VIEWER_PORT}`,
+    alias,
+  ];
+}
+
+function unusedLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      // SAFETY: this server was bound to an IPv4 TCP address above, so Node
+      // returns AddressInfo here rather than a Unix-socket string.
+      const port = (probe.address() as AddressInfo).port;
+      probe.close((error) => {
+        if (error) reject(error);
+        else if (port >= 1024) resolve(port);
+        else reject(new Error("could not reserve a VPS viewer port"));
+      });
+    });
+  });
+}
+
+function loopbackAnswers(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    let settled = false;
+    const finish = (answer: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(answer);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(250, () => finish(false));
+  });
+}
+
+function stopDesktopTunnel(botId: string): boolean {
+  const tunnel = desktopTunnels.get(botId);
+  if (!tunnel) return false;
+  desktopTunnels.delete(botId);
+  clearTimeout(tunnel.expiry);
+  if (tunnel.child.exitCode === null && !tunnel.child.killed) tunnel.child.kill("SIGTERM");
+  return true;
+}
+
+export function closeVpsDesktopTunnel(botId: string) {
+  return { closed: stopDesktopTunnel(botId) };
+}
+
+export function closeAllVpsDesktopTunnels(): void {
+  for (const botId of desktopTunnels.keys()) stopDesktopTunnel(botId);
 }
 
 const STREAM_CAP_CHARS = 16 * 1024 * 1024;
@@ -234,6 +321,22 @@ function transportFailure(message: string): string {
   return `Docker over SSH failed while checking the VPS: ${message.trim().slice(0, 200) || "unknown transport error"}`;
 }
 
+function privateDockerIpv4(value: string | undefined): boolean {
+  if (!value) return false;
+  const parts = value.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  return (
+    parts[0] === 10 ||
+    (parts[0] === 172 && parts[1]! >= 16 && parts[1]! <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  );
+}
+
+function viewerPassword(env: string[] | undefined): string | null {
+  const value = env?.find((entry) => entry.startsWith("VNC_PW="))?.slice("VNC_PW=".length);
+  return value && /^[A-Za-z0-9_-]{8,128}$/.test(value) ? value : null;
+}
+
 function hasNoHostMounts(detail: {
   Mounts?: unknown;
   HostConfig?: { Binds?: string[] | null; VolumesFrom?: string[] | null };
@@ -295,6 +398,7 @@ async function computeVpsComputerStatus(
   const alias = vpsSshAlias(cfg);
   const status = emptyStatus(botId, alias);
   if (!alias) return status;
+  viewerConnections.delete(`${alias}:${status.container_name}`);
   const run = (args: string[], timeoutMs = 10_000, input?: string) =>
     runner(vpsDockerArgs(alias, args), { timeoutMs, input });
 
@@ -326,7 +430,7 @@ async function computeVpsComputerStatus(
 
   try {
     const inspected = JSON.parse((await run(["inspect", status.container_name])).stdout) as Array<{
-      Config?: { Image?: string; Labels?: Record<string, string> };
+      Config?: { Image?: string; Labels?: Record<string, string>; Env?: string[] };
       HostConfig?: DockerHardeningConfig & {
         Binds?: string[] | null;
         VolumesFrom?: string[] | null;
@@ -337,7 +441,7 @@ async function computeVpsComputerStatus(
       Id?: string;
       id?: string;
       Image?: string;
-      NetworkSettings?: { Networks?: Record<string, unknown> | null };
+      NetworkSettings?: { Networks?: Record<string, { IPAddress?: string }> | null };
       Mounts?: unknown;
       State?: { Running?: boolean };
     }>;
@@ -352,7 +456,8 @@ async function computeVpsComputerStatus(
       (detail?.Config?.Image === VPS_IMAGE || detail?.Config?.Image === inspectedImageId) &&
       Boolean(inspectedImageId) &&
       detail?.Image === inspectedImageId &&
-      imageLabelsMatch(labels);
+      imageLabelsMatch(labels) &&
+      labels?.[VPS_VIEWER_LABEL] === VIEWER_VERSION;
     status.managed =
       labels?.[VPS_MANAGED_LABEL] === "1" && labels?.[VPS_CONTAINER_LABEL] === status.container_name;
     status.network = hasNoPublishedPorts(detail?.HostConfig, detail?.NetworkSettings?.Networks) ? "private" : "unsafe";
@@ -360,6 +465,15 @@ async function computeVpsComputerStatus(
     status.security = dockerSecurityIsHardened(detail?.HostConfig, { restartPolicy: "unless-stopped" })
       ? "hardened"
       : "unsafe";
+
+    const connectionKey = `${alias}:${status.container_name}`;
+    const privateIp = Object.values(detail?.NetworkSettings?.Networks ?? {})[0]?.IPAddress;
+    const password = viewerPassword(detail?.Config?.Env);
+    if (status.managed && privateIp && privateDockerIpv4(privateIp) && password) {
+      viewerConnections.set(connectionKey, { privateIp, password });
+    } else {
+      viewerConnections.delete(connectionKey);
+    }
 
     const containerRef = status.container_id;
     const canProbe =
@@ -456,10 +570,15 @@ export async function vpsComputerStatus(
   return status;
 }
 
-export function vpsContainerRunArgs(containerName: string, imageRef = VPS_IMAGE): string[] {
+export function vpsContainerRunArgs(
+  containerName: string,
+  imageRef = VPS_IMAGE,
+  viewerSecret = randomBytes(18).toString("base64url"),
+): string[] {
   if (!CONTAINER_NAME.test(containerName) || (imageRef !== VPS_IMAGE && !IMAGE_ID.test(imageRef))) {
     throw new Error("invalid managed VPS container or image reference");
   }
+  if (!/^[A-Za-z0-9_-]{8,128}$/.test(viewerSecret)) throw new Error("invalid managed VPS viewer secret");
   return [
     "run",
     "-d",
@@ -469,6 +588,8 @@ export function vpsContainerRunArgs(containerName: string, imageRef = VPS_IMAGE)
     `${VPS_MANAGED_LABEL}=1`,
     "--label",
     `${VPS_CONTAINER_LABEL}=${containerName}`,
+    "--label",
+    `${VPS_VIEWER_LABEL}=${VIEWER_VERSION}`,
     "--label",
     `${MANAGED_LABEL}=1`,
     "--label",
@@ -507,6 +628,8 @@ export function vpsContainerRunArgs(containerName: string, imageRef = VPS_IMAGE)
     // whose desktop cannot safely resume).
     "--restart",
     "unless-stopped",
+    "-e",
+    `VNC_PW=${viewerSecret}`,
     imageRef,
   ];
 }
@@ -639,6 +762,10 @@ export async function vpsComputerAction(
     try {
       const before = await computeVpsComputerStatus(cfg, botId, runner);
       if (!before.daemonUp) throw Object.assign(new Error(before.problem ?? "Docker over SSH is not reachable"), { status: 409 });
+      // A real lifecycle change invalidates the remote endpoint. Provision
+      // is also the turn-start idempotency path, so leave an already-running
+      // viewer alone when no start/replacement will occur.
+      if (action !== "provision" || before.container !== "running") stopDesktopTunnel(botId);
       const run = (args: string[], timeoutMs = 2 * 60_000) => runner(vpsDockerArgs(alias, args), { timeoutMs });
 
       const containerRef = before.container_id ?? before.container_name;
@@ -698,11 +825,99 @@ export async function reuseVps(
   botId: string,
   runner: VpsCommandRunner = defaultRunner,
 ): Promise<VpsComputerStatus | null> {
-  const key = vpsLockKey(cfg, botId);
-  const status = await (key
-    ? withVpsLifecycleLock(key, () => computeVpsComputerStatus(cfg, botId, runner))
-    : computeVpsComputerStatus(cfg, botId, runner));
+  const status = await inspectVpsForAuto(cfg, botId, runner);
   return status.ready ? status : null;
+}
+
+/** Auto needs the complete fresh status to explain a failed attach, while
+ * retaining reuseVps's no-cache/no-mutation routing guarantee. */
+export async function inspectVpsForAuto(
+  cfg: AppConfig,
+  botId: string,
+  runner: VpsCommandRunner = defaultRunner,
+): Promise<VpsComputerStatus> {
+  const key = vpsLockKey(cfg, botId);
+  return key
+    ? withVpsLifecycleLock(key, () => computeVpsComputerStatus(cfg, botId, runner))
+    : computeVpsComputerStatus(cfg, botId, runner);
+}
+
+/** Open a temporary noVNC connection through the configured SSH alias. The
+ * returned URL is loopback-only and contains the per-container password in
+ * its fragment (never sent in HTTP). Closing the app viewer calls the paired
+ * close endpoint, and process shutdown closes every remaining child. */
+export async function vpsComputerJoin(
+  cfg: AppConfig,
+  botId: string,
+  runner: VpsCommandRunner = defaultRunner,
+): Promise<{ joinUrl: string; state: "running" }> {
+  const alias = vpsSshAlias(cfg);
+  if (!alias) throw Object.assign(new Error("VPS is not configured"), { status: 409 });
+
+  const existing = desktopTunnels.get(botId);
+  if (existing && existing.child.exitCode === null && !existing.child.killed) {
+    return { joinUrl: existing.joinUrl, state: "running" };
+  }
+  stopDesktopTunnel(botId);
+
+  // Always re-inspect here. A cached IP or password from before a container
+  // replacement is exactly the sort of secret-bearing stale state a viewer
+  // endpoint must not reuse.
+  const status = await computeVpsComputerStatus(cfg, botId, runner);
+  if (!status.ready) {
+    throw Object.assign(new Error(status.problem ?? "The VPS computer is not ready"), { status: 409 });
+  }
+  const connection = viewerConnections.get(`${alias}:${status.container_name}`);
+  if (!connection) {
+    throw Object.assign(
+      new Error("This VPS computer predates secure live desktop access — replace its managed container once"),
+      { status: 409 },
+    );
+  }
+
+  const localPort = await unusedLoopbackPort();
+  const child = spawn("ssh", vpsSshTunnelArgs(alias, localPort, connection.privateIp), {
+    shell: false,
+    env: { ...process.env, PATH: augmentedPath() },
+    stdio: ["ignore", "ignore", "pipe"],
+    windowsHide: true,
+  });
+  let failure: string | null = null;
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr = `${stderr}${chunk}`.slice(-1000);
+  });
+  child.once("error", (error) => {
+    failure = error.message;
+  });
+  child.once("close", (code) => {
+    const active = desktopTunnels.get(botId);
+    if (active?.child === child) {
+      clearTimeout(active.expiry);
+      desktopTunnels.delete(botId);
+    }
+    if (!failure) failure = stderr.trim() || `SSH viewer tunnel exited ${code ?? "without a status"}`;
+  });
+
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline && !failure) {
+    if (await loopbackAnswers(localPort)) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (failure || !(await loopbackAnswers(localPort))) {
+    if (child.exitCode === null && !child.killed) child.kill("SIGTERM");
+    const detail = failure || stderr.trim() || "the SSH port forward did not become ready";
+    throw Object.assign(new Error(`Could not open the VPS live desktop: ${detail}`), { status: 502 });
+  }
+
+  const joinUrl = `http://127.0.0.1:${localPort}/vnc.html#autoconnect=true&resize=scale&password=${encodeURIComponent(connection.password)}`;
+  // Viewer-close is the normal cleanup. This unref'd ceiling is a backstop
+  // for a renderer crash or an old browser client that cannot signal close.
+  const expiry = setTimeout(() => stopDesktopTunnel(botId), 8 * 60 * 60_000);
+  expiry.unref?.();
+  desktopTunnels.set(botId, { child, joinUrl, expiry });
+  return { joinUrl, state: "running" };
 }
 
 export function vpsContainerMcpArgs(alias: string, containerName: string): string[] {

--- a/server/vps-routing.test.ts
+++ b/server/vps-routing.test.ts
@@ -27,7 +27,7 @@ import {
   IMAGE_LAYER_VERSION,
   MANAGED_LABEL,
 } from "./container-computer.ts";
-import { VPS_CONTAINER_LABEL, VPS_IMAGE, VPS_MANAGED_LABEL } from "./vps-computer.ts";
+import { VPS_CONTAINER_LABEL, VPS_IMAGE, VPS_MANAGED_LABEL, VPS_VIEWER_LABEL } from "./vps-computer.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +65,7 @@ function containerInspectTemplate(): string {
       Image: IMAGE_ID,
       Config: {
         Image: VPS_IMAGE,
+        Env: ["VNC_PW=test-viewer-secret"],
         Labels: {
           [VPS_MANAGED_LABEL]: "1",
           [VPS_CONTAINER_LABEL]: "__NAME__",
@@ -72,10 +73,11 @@ function containerInspectTemplate(): string {
           [DRIVER_LABEL]: CUA_DRIVER_VERSION,
           [BASE_IMAGE_LABEL]: BASE_IMAGE_DIGEST,
           [IMAGE_LAYER_LABEL]: IMAGE_LAYER_VERSION,
+          [VPS_VIEWER_LABEL]: "1",
         },
       },
       State: { Running: true },
-      NetworkSettings: { Networks: { bridge: {} } },
+      NetworkSettings: { Networks: { bridge: { IPAddress: "172.17.0.5" } } },
       Mounts: [],
       HostConfig: {
         Binds: [],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,11 @@ function Shell() {
           if (snap) dispatch({ type: "computerControl", botId, held: snap.held === true, helpReason: snap.helpReason ?? null });
         })
         .catch(() => {});
+      void fetch(`/api/bots/${botId}/computer/viewer-close`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }).catch(() => {});
     });
   }, [dispatch]);
 

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -28,6 +28,7 @@ interface Device {
 
 interface CompanionState {
   enabled: boolean;
+  keepAwake: boolean;
   port: number;
   devices: Device[];
   pairing: { code: string; token: string; expiresAt: number } | null;
@@ -57,6 +58,7 @@ type Bridge = {
   state: () => Promise<CompanionState>;
   start: () => Promise<CompanionState>;
   stop: () => Promise<CompanionState>;
+  keepAwake: (enabled: boolean) => Promise<CompanionState>;
   pairing: (open: boolean) => Promise<CompanionState>;
   cloudDesktop: (deviceId: string, allowed: boolean) => Promise<CompanionState>;
   revoke: (deviceId: string) => Promise<CompanionState>;
@@ -258,6 +260,24 @@ export function CompanionSection() {
         {(error || state.error) && (
           <div className="mt-3 text-[13px] text-danger">{error ?? state.error}</div>
         )}
+        <div className="mt-4 flex items-center justify-between gap-4 border-t border-hairline/30 pt-4">
+          <div className="min-w-0">
+            <div className="text-[13px] text-ink">Keep this computer awake</div>
+            <div className="mt-0.5 text-[11.5px] text-ink-secondary">
+              While Companion is on, prevent system sleep so your phone and scheduled work stay reachable. The screen may still turn off and battery use may increase.
+            </div>
+          </div>
+          <button
+            role="switch"
+            aria-checked={state.keepAwake}
+            aria-label="Keep this computer awake while Companion is on"
+            disabled={busy || !state.enabled}
+            onClick={() => void act((c) => c.keepAwake(!state.keepAwake))}
+            className={cnSwitch(state.keepAwake)}
+          >
+            <span className={cnKnob(state.keepAwake)} />
+          </button>
+        </div>
       </Card>
 
       <Card

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -344,7 +344,11 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             return;
           }
           setBoxState(status.container ?? null);
-          setError(`${status.problem ?? "No ready VPS container"}. Auto will not create or start it; choose Cloud to provision it.`);
+          setError(
+            bot.autoStartVps
+              ? `${status.problem ?? "No ready VPS container"}. Auto will prepare or wake it when this bot next works.`
+              : `${status.problem ?? "No ready VPS container"}. Enable Start VPS automatically below, or choose Cloud to provision it.`,
+          );
           setPhase(status.container === "stopped" ? "vps-stopped" : "vps-unconfigured");
         })
         .catch((e) => {
@@ -392,6 +396,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
   }, [
     bot.id,
     bot.computer,
+    bot.autoStartVps,
     cloudBackend,
     retry,
     capabilitiesReady,
@@ -503,7 +508,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
         : null;
   const previewOpensDesktop = Boolean(
     frameSrc &&
-      ((phase === "vm" && vmViewerUrl) || (phase === "ready" && cloudBackend === "box")),
+      ((phase === "vm" && vmViewerUrl) || phase === "ready"),
   );
 
   // who-is-driving: SSE keeps this fresh; the mount fetch covers a panel
@@ -586,6 +591,9 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       }
     } catch (e) {
       fallbackTab?.close();
+      if (phase === "ready" && cloudBackend === "vps") {
+        await api(`/api/bots/${bot.id}/computer/viewer-close`, { method: "POST", body: "{}" }).catch(() => {});
+      }
       // A failed viewer must not leave the bot's hands paused indefinitely.
       if (tookControl) await requestControl("release").catch(() => {});
       setError(e instanceof Error ? e.message : String(e));
@@ -849,17 +857,19 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                   Open VPS settings
                 </button>
               )}
-              {phase === "vps-stopped" && bot.computer === "cloud" && (
+              {(phase === "vps-stopped" || (phase === "vps-unconfigured" && vpsStatus?.configured)) &&
+                (bot.computer === "cloud" || bot.autoStartVps) && (
                 <button
                   onClick={() => run("provision")}
                   disabled={pending === "provision"}
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover disabled:opacity-50"
                 >
                   {pending === "provision" && <Loader2 size={13} className="mr-1.5 inline animate-spin" />}
-                  Start VPS computer
+                  {phase === "vps-stopped" ? "Start VPS computer" : "Prepare VPS computer"}
                 </button>
               )}
-              {phase === "vps-incompatible" && vpsStatus?.managed && (
+              {phase === "vps-incompatible" && vpsStatus?.managed &&
+                (bot.computer === "cloud" || bot.autoStartVps) && (
                 <button
                   onClick={() => void replaceVpsComputer()}
                   disabled={pending === "vps-replace"}
@@ -912,7 +922,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             <div className="mt-2 flex gap-2">
               <button
                 onClick={() =>
-                  phase === "vm" || cloudBackend === "box" ? void openDesktop() : controlAction("take")
+                  phase === "vm" || phase === "ready" ? void openDesktop() : controlAction("take")
                 }
                 disabled={controlPending || pending === "join"}
                 className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-accent py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-50"
@@ -934,7 +944,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
           <div className="mt-3 rounded-xl border border-accent/25 bg-accent/10 p-4">
             <div className="text-[13px] leading-relaxed text-ink">
               You have the wheel — the bot's clicks and keystrokes are refused until you hand it back.
-              {phase === "ready" && cloudBackend === "box" && " Use Open desktop to drive."}
+              {phase === "ready" && " Use Open desktop to drive."}
               {phase === "vm" && " Use Open desktop to drive — the preview here is watch-only."}
             </div>
             <button
@@ -989,7 +999,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             {!control.held && !control.helpReason && (
               <button
                 onClick={() =>
-                  cloudBackend === "box" ? void openDesktop() : controlAction("take")
+                  void openDesktop()
                 }
                 disabled={controlPending || pending === "join"}
                 className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-control py-2 text-[13px] text-ink hover:bg-raised-hover disabled:opacity-50"
@@ -999,7 +1009,7 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
                 Take control
               </button>
             )}
-            {cloudBackend === "box" && control.held && (
+            {control.held && (
               <button
                 onClick={() => void openDesktop()}
                 disabled={pending === "join"}
@@ -1091,11 +1101,44 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
             ))}
           </div>
           {(!bot.computer || bot.computer === "cloud") && (
-            <CloudBackendPicker
-              value={cloudBackend}
-              vpsSupported={vpsSupported}
-              onChange={(backend) => dispatch({ type: "updateBot", botId: bot.id, patch: { cloudBackend: backend } })}
-            />
+            <>
+              <CloudBackendPicker
+                value={cloudBackend}
+                vpsSupported={vpsSupported}
+                onChange={(backend) => dispatch({ type: "updateBot", botId: bot.id, patch: { cloudBackend: backend } })}
+              />
+              {!bot.computer && cloudBackend === "vps" && (
+                <div className="mt-3 flex items-center justify-between gap-4 rounded-lg bg-inset px-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="text-[13px] text-ink">Start VPS automatically</div>
+                    <div className="mt-0.5 text-[11.5px] text-ink-secondary">
+                      Off by default. When enabled, Auto may create or wake this bot's managed container.
+                    </div>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={Boolean(bot.autoStartVps)}
+                    aria-label="Start VPS automatically"
+                    onClick={() => dispatch({
+                      type: "updateBot",
+                      botId: bot.id,
+                      patch: { autoStartVps: !bot.autoStartVps },
+                    })}
+                    className={cn(
+                      "relative h-6 w-11 shrink-0 rounded-full transition-colors",
+                      bot.autoStartVps ? "bg-accent" : "bg-control",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-[3px] size-[18px] rounded-full bg-white transition-all",
+                        bot.autoStartVps ? "left-[22px]" : "left-[4px]",
+                      )}
+                    />
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -331,6 +331,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "notifications"
         | "computer"
         | "cloudBackend"
+        | "autoStartVps"
         | "color"
         | "mascotExpression"
         | "avatarUrl"
@@ -625,11 +626,40 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               ))}
             </div>
             {(!bot.computer || bot.computer === "cloud") && (
-              <CloudBackendPicker
-                value={bot.cloudBackend ?? "box"}
-                vpsSupported={canUseVps}
-                onChange={(backend) => patch({ cloudBackend: backend })}
-              />
+              <>
+                <CloudBackendPicker
+                  value={bot.cloudBackend ?? "box"}
+                  vpsSupported={canUseVps}
+                  onChange={(backend) => patch({ cloudBackend: backend })}
+                />
+                {!bot.computer && bot.cloudBackend === "vps" && (
+                  <div className="mt-3 flex items-center justify-between gap-4 rounded-lg bg-inset px-3 py-2.5">
+                    <div className="min-w-0">
+                      <div className="text-[13px] text-ink">Start VPS automatically</div>
+                      <div className="mt-0.5 text-[11.5px] text-ink-secondary">
+                        Allow Auto to create or wake this bot's managed container when needed.
+                      </div>
+                    </div>
+                    <button
+                      role="switch"
+                      aria-checked={Boolean(bot.autoStartVps)}
+                      aria-label="Start VPS automatically"
+                      onClick={() => patch({ autoStartVps: !bot.autoStartVps })}
+                      className={cn(
+                        "relative h-6 w-11 shrink-0 rounded-full transition-colors",
+                        bot.autoStartVps ? "bg-accent" : "bg-control",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "absolute top-[3px] size-[18px] rounded-full bg-white transition-all",
+                          bot.autoStartVps ? "left-[22px]" : "left-[4px]",
+                        )}
+                      />
+                    </button>
+                  </div>
+                )}
+              </>
             )}
           </div>
 

--- a/src/state/bot-patch-queue.ts
+++ b/src/state/bot-patch-queue.ts
@@ -10,6 +10,7 @@ export type BotUpdatePatch = Partial<
     | "notifications"
     | "computer"
     | "cloudBackend"
+    | "autoStartVps"
     | "color"
     | "mascotExpression"
     | "avatarUrl"

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -191,6 +191,8 @@ export interface Bot {
   computer?: "cloud" | "vm" | "local" | "off";
   /** Which cloud computer backs `computer: "cloud"`; absent means Box. */
   cloudBackend?: CloudBackend;
+  /** Allow Auto to prepare/start the managed VPS container. Off by default. */
+  autoStartVps?: boolean;
   /** where new tasks run their shell tools; absent = the private bot workspace */
   cwd?: string;
   /** auto mode: the bot approves its own tool permissions */
@@ -1368,6 +1370,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             modelSelection: source.modelSelection,
             computer: source.computer,
             cloudBackend: source.cloudBackend,
+            autoStartVps: source.autoStartVps,
             avatarUrl: source.avatarUrl,
             avatarCrop: source.avatarCrop,
           };


### PR DESCRIPTION
## Summary

- retry Box creation once with the provider-advertised free-trial TTL limit
- add an off-by-default per-bot option that lets Auto start/provision its VPS, with actionable errors instead of silent no-computer turns
- add a password-protected VPS desktop viewer over a temporary loopback-only SSH tunnel, including deterministic cleanup
- add an off-by-default Companion setting that keeps the desktop runtime awake, and document the desktop-attached mobile model

## VPS viewer migration

Existing OpenMaus-managed VPS containers predate the private viewer password marker. The UI asks for one explicit **Replace** before live desktop viewing is available. Replacement deletes files inside that disposable container, so it remains user-confirmed.

The VPS viewer is intentionally desktop-only: the temporary URL is bound to the desktop's loopback interface and is never exposed to the LAN or internet.

## Verification

- 1,831 behavioral tests passed (18 skipped)
- broker, updater, desktop-viewer, package-link, and packaged-server checks passed
- desktop production build passed
- Companion build passed
- Electron syntax check passed (46 modules)
- documentation production build passed (111 pages)

Closes #424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live VPS desktop access through a temporary, secure SSH tunnel.
  * Added an optional **Start VPS automatically** setting for Auto mode.
  * Added a Companion **Keep this computer awake** setting with status visibility.
  * Added cleanup when closing VPS desktop viewers.
* **Bug Fixes**
  * Trial cloud computers now retry provisioning with supported shorter time limits when required.
  * Improved error reporting when VPS or local computer fallback is unavailable.
* **Documentation**
  * Clarified VPS viewer, SSH credential, auto-start, and Companion sleep behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->