### PR TITLE
Big support badge under the download buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Talk to them like contacts. Watch them work. Approve what matters.
 <sub>macOS: Apple silicon & Intel · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
 
 <br>
+
+<a href="https://buy.polar.sh/polar_cl_EEzWmormSVBD151HkmkyId9j0GPXina0KurfS1fYYcO">
+  <img src="https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F%20%20Support%20OpenMausBot-any%20amount%20%C2%B7%20or%20monthly-38d591?style=for-the-badge&labelColor=070707" alt="Support OpenMausBot — one-time any amount or monthly, via Polar" height="40">
+</a>
+
+<br>
 <br>
 
 <img src="docs/screenshots/hero.png" alt="OpenMausBot — a Telegram-style chat app where every chat is a real AI agent" width="900">


### PR DESCRIPTION
Re-lands the badge that missed #460's merge: 40px for-the-badge Support button in the download cluster, linking the Polar checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a support button to the README, with options for one-time and monthly contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->