### PR TITLE
chore: configure the production control plane

### DIFF
--- a/cloudflare/control-plane/test/managed-endpoints.test.ts
+++ b/cloudflare/control-plane/test/managed-endpoints.test.ts
@@ -346,7 +346,9 @@ describe("managed companion endpoints", () => {
     }>();
     expect(firstPayload.connectorToken).toBe(CONNECTOR_TOKEN);
     expect(firstPayload.endpoint).toMatchObject({ status: "ready" });
-    expect(firstPayload.endpoint.hostname).toMatch(/^c-[0-9a-f]{32}\.openmausbot\.test$/);
+    const [opaqueLabel, ...suffixLabels] = firstPayload.endpoint.hostname.split(".");
+    expect(opaqueLabel).toMatch(/^c-[0-9a-f]{32}$/);
+    expect(suffixLabels.join(".")).toBe(readConfig(env).cloudflare.companionHostSuffix);
     expect(firstPayload.endpoint.url).toBe(`https://${firstPayload.endpoint.hostname}`);
 
     const tunnel = [...cloudflare.tunnels.values()][0];

--- a/cloudflare/control-plane/wrangler.jsonc
+++ b/cloudflare/control-plane/wrangler.jsonc
@@ -2,16 +2,23 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "openmausbot-control-plane",
   "main": "src/index.ts",
+  "account_id": "0c92969a82eb9e173b013a7e7a02333d",
   "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
+  "routes": [
+    {
+      "pattern": "accounts.openmausbot.com",
+      "custom_domain": true
+    }
+  ],
   "vars": {
-    "BETTER_AUTH_URL": "https://auth.openmausbot.test",
-    "EMAIL_FROM": "noreply@openmausbot.test",
+    "BETTER_AUTH_URL": "https://accounts.openmausbot.com",
+    "EMAIL_FROM": "noreply@openmausbot.com",
     "ALLOWED_ORIGINS": "",
-    "CLOUDFLARE_ACCOUNT_ID": "00000000000000000000000000000000",
-    "CLOUDFLARE_ZONE_ID": "00000000000000000000000000000000",
-    "COMPANION_HOST_SUFFIX": "openmausbot.test"
+    "CLOUDFLARE_ACCOUNT_ID": "0c92969a82eb9e173b013a7e7a02333d",
+    "CLOUDFLARE_ZONE_ID": "bae08399bb6f96eb7266c65ac0057eee",
+    "COMPANION_HOST_SUFFIX": "openmausbot.com"
   },
   "secrets": {
     "required": ["BETTER_AUTH_SECRET", "CLOUDFLARE_API_TOKEN"]
@@ -20,14 +27,14 @@
     {
       "binding": "DB",
       "database_name": "openmausbot-control-plane",
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "8a7c34ed-5428-4ae2-8722-fef2fe9bf160",
       "migrations_dir": "migrations"
     }
   ],
   "send_email": [
     {
       "name": "EMAIL",
-      "allowed_sender_addresses": ["noreply@openmausbot.test"]
+      "allowed_sender_addresses": ["noreply@openmausbot.com"]
     }
   ],
   "triggers": {


### PR DESCRIPTION
## Summary
- bind the control-plane Worker to `accounts.openmausbot.com`
- configure the production Cloudflare account, zone, D1 database, sender, and companion hostname suffix
- make the managed-endpoint test follow the configured hostname suffix instead of a `.test` fixture

## Cloudflare state
- created `openmausbot-control-plane` D1 in APAC
- applied migrations `0001` through `0005`
- deployment remains intentionally pending until Email Sending is enabled, the stale `accounts` DNS record is removed, and the least-privilege runtime token is available

## Validation
- `pnpm control-plane:check`
- `pnpm control-plane:test` (38 passed)
- `pnpm control-plane:dry-run`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed endpoint validation to support the configured companion host format.

* **Configuration**
  * Updated production deployment settings, including domains, routing, database, Cloudflare account details, and allowed sender address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->