### PR TITLE
fix(connectors): never show a connected app as disconnected

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -220,6 +220,12 @@ async function loadSecureCredentials() {
 }
 
 async function saveSecureCredentials(credentials) {
+  // A failed read means we do not know what the existing encrypted document
+  // contains. Never derive a replacement from that incomplete view: boot
+  // migrations must leave plaintext in place so a later launch can retry.
+  if (credentialStoreUnavailable) {
+    throw new Error("The operating-system credential store could not be read this launch");
+  }
   if (!(await safeStorage.isAsyncEncryptionAvailable())) {
     throw new Error("The operating-system credential store is unavailable");
   }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -37,6 +37,7 @@ import {
   withoutManagedCompanionTunnelAccess,
 } from "./managed-companion-tunnel.mjs";
 import { createSecureCredentialState } from "./secure-credential-state.mjs";
+import { readSecureCredentials } from "./secure-credentials.mjs";
 import { createControlPlaneClient } from "./control-plane-client.mjs";
 import {
   companionAccountCleanupPending,
@@ -195,22 +196,27 @@ let secureCredentialState = null;
 
 const CREDENTIALS_FILE = path.join(app.getPath("userData"), "credentials.bin");
 
+/** Set once per launch: true when the store could not be READ, which is not
+ * the same as the user having saved nothing. Everything downstream — the
+ * server's view of "configured", and whether we may register a fresh
+ * installation — keys off this rather than off an empty object. */
+let credentialStoreUnavailable = false;
+
 async function loadSecureCredentials() {
-  if (!fs.existsSync(CREDENTIALS_FILE)) return {};
-  if (!(await safeStorage.isAsyncEncryptionAvailable())) {
-    // Returning nothing here looks identical to "the user never saved keys".
-    // Say why, so an OS-store hiccup is diagnosable instead of reading as
-    // wiped credentials.
-    slog("OS credential store unavailable; saved credentials are not loaded this launch");
-    return {};
+  const result = await readSecureCredentials({
+    exists: () => fs.existsSync(CREDENTIALS_FILE),
+    isAvailable: () => safeStorage.isAsyncEncryptionAvailable(),
+    readFile: () => fs.readFileSync(CREDENTIALS_FILE),
+    decrypt: (buffer) => safeStorage.decryptStringAsync(buffer),
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  });
+  credentialStoreUnavailable = result.status === "unavailable";
+  if (credentialStoreUnavailable) {
+    // Deliberately loud. A silent {} here is what made a keychain hiccup
+    // look like "your connected apps are gone".
+    slog(`credential store unreadable after retries (${result.error}); saved keys are not loaded this launch`);
   }
-  try {
-    const decrypted = await safeStorage.decryptStringAsync(fs.readFileSync(CREDENTIALS_FILE));
-    return JSON.parse(decrypted.result);
-  } catch (error) {
-    slog(`credential load failed: ${error?.message ?? error}`);
-    return {};
-  }
+  return result.credentials;
 }
 
 async function saveSecureCredentials(credentials) {
@@ -647,6 +653,8 @@ async function startServerOn(port) {
     ...(secureCredentials.composioApiKey
       ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }
       : {}),
+    // "we could not read your keys" must not reach the UI as "you have none"
+    OMB_CREDENTIAL_STORE: credentialStoreUnavailable ? "unavailable" : "ok",
     // one env var per stored workspace secret (xai/box/voice/OpenCode Go);
     // the server prefers these over config.json, whose plaintext fields
     // the boot migration has deleted
@@ -1415,7 +1423,10 @@ app.whenReady().then(async () => {
   }
   // Boot migrations above are deliberately sequential. From this point on,
   // every account/API-key writer must use the shared serialized state.
-  secureCredentialState = createSecureCredentialState(secureCredentials, saveSecureCredentials);
+  // An unreadable store must not become a WRITE of an empty document.
+  secureCredentialState = createSecureCredentialState(secureCredentials, saveSecureCredentials, {
+    writable: !credentialStoreUnavailable,
+  });
   secureCredentials = secureCredentialState.read();
   const hostedAccount = ensureCompanionAccountService();
   // Display capture remains user-initiated. The renderer first sends a
@@ -1499,7 +1510,13 @@ app.whenReady().then(async () => {
   // Registration is optional network work. Start it only after the local
   // server and first window are usable, then update the server child over its
   // private parent port so Connected Apps becomes available without restart.
-  if (app.isPackaged && composioBrokerUrl()) {
+  // Registering while the store is unreadable would mint a SECOND installation
+  // identity for a user who already has one — the first thing they would
+  // notice is every connected app gone, permanently.
+  if (credentialStoreUnavailable) {
+    slog("skipping connected-apps registration: the credential store was unreadable this launch");
+  }
+  if (app.isPackaged && composioBrokerUrl() && !credentialStoreUnavailable) {
     void updateSecureCredentialDocument(async (credentials) => {
       await ensureManagedComposioCredentials({
         brokerUrl: composioBrokerUrl(),

--- a/electron/secure-credential-state.mjs
+++ b/electron/secure-credential-state.mjs
@@ -41,9 +41,19 @@ const copy = (credentials) => {
  * snapshot over the other two. `afterPersist` supports changes that must also
  * be accepted by the local server: if that second phase fails, the encrypted
  * file is restored before another mutation may begin. */
-export function createSecureCredentialState(initialCredentials, persist) {
+export function createSecureCredentialState(initialCredentials, persist, { writable = true } = {}) {
   let current = copy(initialCredentials);
   let transition = Promise.resolve();
+
+  // A launch that could not READ the store starts from {}. Deriving a new
+  // document from {} and writing it would not add a secret — it would replace
+  // every secret in the file with nothing, stranding the connected-apps
+  // identity the user already authorized. Reads still work (callers get an
+  // honest empty view); writes refuse, loudly, until a launch can read again.
+  const assertWritable = () => {
+    if (writable) return;
+    throw new Error("The credential store could not be read on this launch, so credentials cannot be saved");
+  };
 
   const serialize = (work) => {
     const next = transition.then(work, work);
@@ -61,6 +71,7 @@ export function createSecureCredentialState(initialCredentials, persist) {
 
     update(derive, afterPersist) {
       return serialize(async () => {
+        assertWritable();
         const previous = copy(current);
         const next = copy(await derive(copy(previous)));
         await persist(copy(next));

--- a/electron/secure-credential-state.test.mjs
+++ b/electron/secure-credential-state.test.mjs
@@ -5,6 +5,40 @@ import { describe, expect, it, vi } from "vitest";
 import { createSecureCredentialState } from "./secure-credential-state.mjs";
 
 describe("serialized secure credential state", () => {
+  // A launch that could not READ credentials.bin starts from {}. Writing a
+  // document derived from {} would not "add a key" — it would replace every
+  // secret in the file with nothing, and orphan the connected-apps identity
+  // the user already authorized. So such a state does not write at all.
+  it("refuses to persist when it was built from an unreadable store", async () => {
+    const persist = vi.fn();
+    const state = createSecureCredentialState({}, persist, { writable: false });
+
+    await expect(state.update((credentials) => ({ ...credentials, xaiApiKey: "new" }))).rejects.toThrow(
+      /credential store/i,
+    );
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("still answers reads when it cannot write, so callers see an empty view rather than a crash", async () => {
+    const state = createSecureCredentialState({}, vi.fn(), { writable: false });
+    expect(state.read()).toEqual({});
+  });
+
+  it("writes normally when the store was readable", async () => {
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const state = createSecureCredentialState({ boxToken: "old" }, persist, { writable: true });
+
+    await state.update((credentials) => ({ ...credentials, boxToken: "new" }));
+    expect(persist).toHaveBeenCalledWith({ boxToken: "new" });
+  });
+
+  it("writes normally when no options are passed at all", async () => {
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const state = createSecureCredentialState({}, persist);
+    await state.update(() => ({ boxToken: "x" }));
+    expect(persist).toHaveBeenCalled();
+  });
+
   it("derives concurrent changes from the latest committed copy", async () => {
     const writes = [];
     let releaseFirst;

--- a/electron/secure-credentials.mjs
+++ b/electron/secure-credentials.mjs
@@ -1,0 +1,59 @@
+// Reading the OS-encrypted credential store (credentials.bin via safeStorage).
+//
+// The whole point of this module is one distinction main.mjs used to lose:
+//
+//   empty        the store was read, and the user has saved nothing
+//   ok           the store was read, here is what is in it
+//   unavailable  the store could NOT be read — we know nothing
+//
+// Those first two are facts. The third is ignorance, and it must not be
+// spelled the same way as "empty": a caller that cannot tell them apart
+// starts the app as though the user had never connected anything, and — far
+// worse — registers a fresh installation over the top of the real one.
+//
+// macOS says "temporarily unavailable. Please try again." for a keychain that
+// is merely busy at that instant, which is exactly what happens when the app
+// asks a few hundred milliseconds too early. So we try again, briefly, before
+// admitting ignorance.
+export const CREDENTIAL_READ_DELAYS_MS = [100, 200, 400, 800];
+
+const message = (error) => (error instanceof Error ? error.message : String(error));
+
+export async function readSecureCredentials({
+  exists,
+  isAvailable,
+  readFile,
+  decrypt,
+  sleep,
+  delays = CREDENTIAL_READ_DELAYS_MS,
+}) {
+  if (!exists()) return { status: "empty", credentials: {} };
+
+  let lastError = "the operating-system credential store is unavailable";
+  // delays.length retries AFTER the first attempt
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    if (attempt > 0) await sleep(delays[attempt - 1]);
+    try {
+      if (!(await isAvailable())) {
+        lastError = "the operating-system credential store is unavailable";
+        continue;
+      }
+      const decrypted = await decrypt(readFile());
+      const text = typeof decrypted === "string" ? decrypted : decrypted?.result;
+      try {
+        const parsed = JSON.parse(text);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return { status: "unavailable", credentials: {}, error: "the credential store is not readable" };
+        }
+        return { status: "ok", credentials: parsed };
+      } catch {
+        // Corruption is not a timing problem; retrying only delays the
+        // report. It is still ignorance, never emptiness.
+        return { status: "unavailable", credentials: {}, error: "the credential store is not readable" };
+      }
+    } catch (error) {
+      lastError = message(error);
+    }
+  }
+  return { status: "unavailable", credentials: {}, error: lastError };
+}

--- a/electron/secure-credentials.test.mjs
+++ b/electron/secure-credentials.test.mjs
@@ -1,0 +1,74 @@
+// The rule this module exists to enforce: "I could not read the store" and
+// "the store is empty" are DIFFERENT ANSWERS. Collapsing them is what made a
+// keychain hiccup look like the user had never connected anything.
+import { describe, expect, it, vi } from "vitest";
+
+import { readSecureCredentials } from "./secure-credentials.mjs";
+
+const transient = () =>
+  new Error("safeStorage.decryptStringAsync is temporarily unavailable. Please try again.");
+
+/** deps with sane defaults; each test overrides the one thing it is about */
+const deps = (over = {}) => ({
+  exists: () => true,
+  isAvailable: async () => true,
+  readFile: () => Buffer.from("cipher"),
+  decrypt: async () => JSON.stringify({ composioApiKey: "ak_live" }),
+  sleep: async () => {},
+  ...over,
+});
+
+describe("readSecureCredentials", () => {
+  it("reports an empty store when no file was ever written", async () => {
+    const result = await readSecureCredentials(deps({ exists: () => false }));
+    expect(result).toEqual({ status: "empty", credentials: {} });
+  });
+
+  it("returns the stored credentials when the store opens", async () => {
+    const result = await readSecureCredentials(deps());
+    expect(result.status).toBe("ok");
+    expect(result.credentials).toEqual({ composioApiKey: "ak_live" });
+  });
+
+  it("tries again when the OS says the store is temporarily unavailable", async () => {
+    const decrypt = vi
+      .fn()
+      .mockRejectedValueOnce(transient())
+      .mockRejectedValueOnce(transient())
+      .mockResolvedValue(JSON.stringify({ composioApiKey: "ak_live" }));
+    const result = await readSecureCredentials(deps({ decrypt }));
+    expect(decrypt).toHaveBeenCalledTimes(3);
+    expect(result.status).toBe("ok");
+    expect(result.credentials).toEqual({ composioApiKey: "ak_live" });
+  });
+
+  it("waits between attempts instead of hammering the keychain", async () => {
+    const slept = [];
+    const decrypt = vi.fn().mockRejectedValueOnce(transient()).mockResolvedValue("{}");
+    await readSecureCredentials(deps({ decrypt, sleep: async (ms) => slept.push(ms) }));
+    expect(slept).toEqual([100]);
+  });
+
+  it("says UNAVAILABLE — never empty — when every attempt fails", async () => {
+    const decrypt = vi.fn().mockRejectedValue(transient());
+    const result = await readSecureCredentials(deps({ decrypt }));
+    expect(result.status).toBe("unavailable");
+    expect(result.credentials).toEqual({});
+    expect(result.error).toMatch(/temporarily unavailable/);
+    expect(decrypt.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("says UNAVAILABLE when the OS store itself is switched off", async () => {
+    const result = await readSecureCredentials(deps({ isAvailable: async () => false }));
+    expect(result.status).toBe("unavailable");
+  });
+
+  it("says UNAVAILABLE for a file it cannot parse, rather than pretending it is empty", async () => {
+    // retrying cannot fix corruption, but calling it "empty" would invite the
+    // caller to register a fresh identity over the top of it
+    const decrypt = vi.fn().mockResolvedValue("not json");
+    const result = await readSecureCredentials(deps({ decrypt }));
+    expect(result.status).toBe("unavailable");
+    expect(decrypt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/composio-availability.test.ts
+++ b/server/composio-availability.test.ts
@@ -1,0 +1,31 @@
+// "You have not set this up" and "I could not read your key" produce the same
+// empty screen today. They are opposite situations: the first is the truth,
+// the second is ignorance the UI must be told about so it can keep showing
+// what it already knew.
+import { describe, expect, it } from "vitest";
+
+import { connectorAvailability } from "./composio.ts";
+import type { AppConfig } from "./config.ts";
+
+const cfg = (over: Partial<AppConfig> = {}): AppConfig => ({ ...over }) as AppConfig;
+
+describe("connectorAvailability", () => {
+  it("is configured when a project key is present", () => {
+    expect(connectorAvailability(cfg({ composio: { apiKey: "ak_live" } }), undefined)).toBe("configured");
+  });
+
+  it("is unconfigured when there is no key and the store read fine", () => {
+    expect(connectorAvailability(cfg(), undefined)).toBe("unconfigured");
+    expect(connectorAvailability(cfg({ composio: { apiKey: "" } }), "ok")).toBe("unconfigured");
+  });
+
+  it("is unreadable when the desktop shell could not open the credential store", () => {
+    expect(connectorAvailability(cfg(), "unavailable")).toBe("unreadable");
+  });
+
+  it("prefers a working key over a store that failed earlier in the launch", () => {
+    // the key arrived some other way (env, self-hosted config): what the user
+    // can actually do matters more than how the shell felt about it
+    expect(connectorAvailability(cfg({ composio: { apiKey: "ak_live" } }), "unavailable")).toBe("configured");
+  });
+});

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -170,6 +170,20 @@ export function configured(cfg: AppConfig): boolean {
   return connectionMode(cfg) !== "unavailable";
 }
 
+/** Three answers, not two. The desktop shell sets OMB_CREDENTIAL_STORE to
+ * "unavailable" when it could not read credentials.bin this launch; without
+ * that signal an unreadable store is indistinguishable from a user who never
+ * connected anything, and the UI wipes a list it should have kept. */
+export type ConnectorAvailability = "configured" | "unconfigured" | "unreadable";
+
+export function connectorAvailability(
+  cfg: AppConfig,
+  storeState: string | undefined = process.env.OMB_CREDENTIAL_STORE,
+): ConnectorAvailability {
+  if (configured(cfg)) return "configured";
+  return storeState === "unavailable" ? "unreadable" : "unconfigured";
+}
+
 async function brokerRequest(path: string, init?: RequestInit): Promise<Response> {
   const broker = brokerAccess();
   if (!broker) throw new Error("The connected-apps service is unavailable");

--- a/server/index.ts
+++ b/server/index.ts
@@ -4931,15 +4931,28 @@ const server = createServer(async (req, res) => {
       return json(res, 200, { configured: composio.configured(cfg), mode: composio.connectionMode(cfg), source, cards });
     }
     if (method === "GET" && path === "/api/connectors/connected") {
-      if (!composio.configured(cfg)) {
-        return json(res, 200, { configured: false, services: {} });
+      const availability = composio.connectorAvailability(cfg);
+      if (availability !== "configured") {
+        // `credentialStore` is what stops the panel treating this empty list
+        // as authoritative: an unreadable store means we do not KNOW what is
+        // connected, which is not the same as knowing nothing is.
+        return json(res, 200, {
+          configured: false,
+          credentialStore: availability === "unreadable" ? "unavailable" : "ok",
+          services: {},
+        });
       }
-      return json(res, 200, { configured: true, services: await composio.connectedServices(cfg) });
+      return json(res, 200, { configured: true, credentialStore: "ok", services: await composio.connectedServices(cfg) });
     }
     if (method === "GET" && path === "/api/connectors") {
       const services = (url.searchParams.get("services") ?? "").split(",").filter(Boolean);
-      if (!composio.configured(cfg)) {
-        return json(res, 200, { configured: false, services: {} });
+      const availability = composio.connectorAvailability(cfg);
+      if (availability !== "configured") {
+        return json(res, 200, {
+          configured: false,
+          credentialStore: availability === "unreadable" ? "unavailable" : "ok",
+          services: {},
+        });
       }
       const status = await composio.connectionStatus(cfg, services.length ? services : composio.CURATED_SLUGS);
       return json(res, 200, { configured: true, services: status });

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -162,3 +162,30 @@ describe("connected-app status races", () => {
     })).toBe("Unavailable");
   });
 });
+
+describe("an answer the server was not sure about", () => {
+  const connectedGmail = {
+    gmail: { connected: true, pending: false, status: "ACTIVE", accounts: [{ id: "ca_1", status: "ACTIVE" }] },
+  } satisfies Record<string, ConnectorStatus>;
+
+  it("keeps a connected app when the response was not authoritative", () => {
+    // the credential store was unreadable, so the server sent {} — that is
+    // ignorance, and clearing on it is how a connected app turns into a
+    // Connect button the user never asked for
+    const merged = mergeCompleteConnectorStatus(connectedGmail, {}, new Map(), new Map(), false);
+    expect(merged.gmail.connected).toBe(true);
+  });
+
+  it("still clears an app the server authoritatively no longer lists", () => {
+    // disconnection has to remain possible: revoking from Composio's
+    // dashboard must show up here on the next successful check
+    const merged = mergeCompleteConnectorStatus(connectedGmail, {}, new Map(), new Map(), true);
+    expect(merged.gmail.connected).toBe(false);
+    expect(merged.gmail.status).toBe("not_connected");
+  });
+
+  it("treats a missing authority flag as authoritative, preserving today's behaviour", () => {
+    const merged = mergeCompleteConnectorStatus(connectedGmail, {}, new Map(), new Map());
+    expect(merged.gmail.connected).toBe(false);
+  });
+});

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -3,9 +3,10 @@
 // Composio API key is configured, a curated set otherwise. Icons resolve
 // logo → favicon → monogram.
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, Loader2, RefreshCw, Search, X } from "lucide-react";
+import { Check, Loader2, RefreshCw, Search, TriangleAlert, X } from "lucide-react";
 import { api, useStore } from "@/state/store";
 import { cn } from "@/lib/cn";
+import { readCachedInventory, writeCachedInventory } from "@/lib/connected-apps-cache";
 
 interface ToolkitCard {
   slug: string;
@@ -32,23 +33,37 @@ export interface ConnectorStatus {
 // as disconnected while a fresh secure status check runs in the background.
 let cachedConnectorStatus: Record<string, ConnectorStatus> | null = null;
 let cachedConnectorStatusAt = 0;
-let connectorStatusRequest: Promise<Record<string, ConnectorStatus>> | null = null;
+let connectorStatusRequest: Promise<ConnectorInventory> | null = null;
 const CONNECTOR_STATUS_CACHE_MS = 30_000;
+
+export interface ConnectorInventory {
+  services: Record<string, ConnectorStatus>;
+  /** false when the server could not read the credential store: the list is
+   * then "we do not know", and nothing may be cleared on the strength of it */
+  authoritative: boolean;
+}
 
 /** Warm the account inventory once the app server is ready. Concurrent panel
  * opens share the same request, and recent data survives modal unmounts. */
-export function preloadConnectedApps(force = false): Promise<Record<string, ConnectorStatus>> {
+export function preloadConnectedApps(force = false): Promise<ConnectorInventory> {
   if (!force && cachedConnectorStatus !== null && Date.now() - cachedConnectorStatusAt < CONNECTOR_STATUS_CACHE_MS) {
-    return Promise.resolve(cachedConnectorStatus);
+    return Promise.resolve({ services: cachedConnectorStatus, authoritative: true });
   }
   if (connectorStatusRequest) return connectorStatusRequest;
   connectorStatusRequest = api("/api/connectors/connected")
     .then((response) => {
       const services: Record<string, ConnectorStatus> = response.services ?? {};
+      // An unreadable credential store tells us nothing about what is
+      // connected. Keep the last inventory we were sure about instead.
+      if (response.credentialStore === "unavailable") {
+        return { services: readCachedInventory()?.services ?? {}, authoritative: false };
+      }
       cachedConnectorStatus = services;
       cachedConnectorStatusAt = Date.now();
-      return services;
+      writeCachedInventory(services, Date.now());
+      return { services, authoritative: true };
     })
+    .catch(() => ({ services: readCachedInventory()?.services ?? {}, authoritative: false }))
     .finally(() => {
       connectorStatusRequest = null;
     });
@@ -117,8 +132,15 @@ export function mergeCompleteConnectorStatus(
   incoming: Record<string, ConnectorStatus>,
   latestGenerations: ReadonlyMap<string, number>,
   requestGenerations: ReadonlyMap<string, number>,
+  /** Did the server actually KNOW the full picture? A response sent while the
+   * credential store was unreadable carries no information about what is
+   * connected, so it must not be allowed to clear anything — an empty list
+   * from an ignorant server is exactly how a connected app became a Connect
+   * button. Disconnection still shows up on the next authoritative answer. */
+  authoritative = true,
 ) {
   const next = { ...current };
+  if (!authoritative) return mergeCurrentConnectorStatus(next, incoming, latestGenerations, requestGenerations);
   for (const [slug, state] of Object.entries(current)) {
     if (incoming[slug]) continue;
     if (!state.connected && !state.accounts?.length) continue;
@@ -170,9 +192,14 @@ export function PluginsPanel() {
   const [source, setSource] = useState<"api" | "curated">("curated");
   const [configured, setConfigured] = useState(true);
   const [mode, setMode] = useState<"managed" | "self-hosted" | "unavailable">("unavailable");
+  // Paint what we last knew before any request goes out: the module cache if
+  // this window already fetched, otherwise the inventory saved on disk. An
+  // empty panel is never the first thing a connected user sees.
   const [status, setStatus] = useState<Record<string, ConnectorStatus>>(
-    () => cachedConnectorStatus ?? {},
+    () => cachedConnectorStatus ?? readCachedInventory()?.services ?? {},
   );
+  /** true when what is on screen is remembered rather than confirmed */
+  const [stale, setStale] = useState(false);
   const [pendingUrls, setPendingUrls] = useState<Record<string, string>>({});
   const [aliasSlug, setAliasSlug] = useState<string | null>(null);
   const [aliasDraft, setAliasDraft] = useState("");
@@ -231,12 +258,14 @@ export function PluginsPanel() {
     const requestGenerations = new Map(statusGenerations.current);
     setRefreshing(true);
     return preloadConnectedApps(force)
-      .then((services) => {
+      .then(({ services, authoritative }) => {
+        setStale(!authoritative);
         setStatus((current) => mergeCompleteConnectorStatus(
           current,
           services,
           statusGenerations.current,
           requestGenerations,
+          authoritative,
         ));
         for (const [slug, state] of Object.entries(services)) {
           const isCurrent = (statusGenerations.current.get(slug) ?? 0) === (requestGenerations.get(slug) ?? 0);
@@ -467,6 +496,18 @@ export function PluginsPanel() {
           </div>
         </header>
 
+        {stale && (
+          // Say which of the two things is true. Silence here is what makes a
+          // remembered list indistinguishable from a confirmed one.
+          <div className="mx-6 mb-1 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[12.5px] text-warning sm:mx-8">
+            <TriangleAlert size={14} className="mt-px shrink-0" />
+            <span>
+              Showing what was connected last time — this Mac's credential store could not be opened just now, so these
+              could not be re-checked. Your apps are still connected; restarting OpenMausBot usually clears this.
+            </span>
+          </div>
+        )}
+
         <div className="flex flex-col gap-3 px-6 pb-4 pt-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
           <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Connected apps view">
             <button
@@ -504,7 +545,10 @@ export function PluginsPanel() {
           </label>
         </div>
 
-        {!configured && (
+        {/* Two notices about the same fact is one too many: the stale banner
+            above already explains this launch, and "configure your own
+            connection service" is advice for someone who never set one up. */}
+        {!configured && !stale && (
           <div className="mx-6 mb-1 rounded-xl bg-warning/10 px-4 py-3 text-[13px] text-warning sm:mx-8">
             Connected apps are temporarily unavailable. You can retry after restarting, or configure your own connection service.{" "}
             <button

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -33,6 +33,7 @@ export interface ConnectorStatus {
 // as disconnected while a fresh secure status check runs in the background.
 let cachedConnectorStatus: Record<string, ConnectorStatus> | null = null;
 let cachedConnectorStatusAt = 0;
+let cachedConnectorStatusAuthoritative = true;
 let connectorStatusRequest: Promise<ConnectorInventory> | null = null;
 const CONNECTOR_STATUS_CACHE_MS = 30_000;
 
@@ -47,7 +48,10 @@ export interface ConnectorInventory {
  * opens share the same request, and recent data survives modal unmounts. */
 export function preloadConnectedApps(force = false): Promise<ConnectorInventory> {
   if (!force && cachedConnectorStatus !== null && Date.now() - cachedConnectorStatusAt < CONNECTOR_STATUS_CACHE_MS) {
-    return Promise.resolve({ services: cachedConnectorStatus, authoritative: true });
+    return Promise.resolve({
+      services: cachedConnectorStatus,
+      authoritative: cachedConnectorStatusAuthoritative,
+    });
   }
   if (connectorStatusRequest) return connectorStatusRequest;
   connectorStatusRequest = api("/api/connectors/connected")
@@ -60,6 +64,7 @@ export function preloadConnectedApps(force = false): Promise<ConnectorInventory>
       }
       cachedConnectorStatus = services;
       cachedConnectorStatusAt = Date.now();
+      cachedConnectorStatusAuthoritative = true;
       writeCachedInventory(services, Date.now());
       return { services, authoritative: true };
     })
@@ -199,7 +204,9 @@ export function PluginsPanel() {
     () => cachedConnectorStatus ?? readCachedInventory()?.services ?? {},
   );
   /** true when what is on screen is remembered rather than confirmed */
-  const [stale, setStale] = useState(false);
+  const [stale, setStale] = useState(
+    cachedConnectorStatus !== null && !cachedConnectorStatusAuthoritative,
+  );
   const [pendingUrls, setPendingUrls] = useState<Record<string, string>>({});
   const [aliasSlug, setAliasSlug] = useState<string | null>(null);
   const [aliasDraft, setAliasDraft] = useState("");
@@ -306,7 +313,8 @@ export function PluginsPanel() {
     if (inventoryPhase !== "ready") return;
     cachedConnectorStatus = status;
     cachedConnectorStatusAt = Date.now();
-  }, [inventoryPhase, status]);
+    cachedConnectorStatusAuthoritative = !stale;
+  }, [inventoryPhase, stale, status]);
 
   useEffect(() => {
     let alive = true;

--- a/src/lib/connected-apps-cache.test.ts
+++ b/src/lib/connected-apps-cache.test.ts
@@ -40,6 +40,20 @@ describe("connected apps cache", () => {
     expect(readCachedInventory(fakeStorage({ [CONNECTED_APPS_CACHE_KEY]: '"a string"' }))).toBeNull();
   });
 
+  it("rejects malformed service and account records before the panel paints them", () => {
+    const cached = (services: unknown) => fakeStorage({
+      [CONNECTED_APPS_CACHE_KEY]: JSON.stringify({ at: 1, services }),
+    });
+    expect(readCachedInventory(cached({ gmail: { connected: "yes" } }))).toBeNull();
+    expect(readCachedInventory(cached({ gmail: { connected: true, accounts: "invalid" } }))).toBeNull();
+    expect(readCachedInventory(cached({
+      gmail: { connected: true, accounts: [{ id: "ca_1", status: 42 }] },
+    }))).toBeNull();
+    expect(readCachedInventory(cached({
+      gmail: { connected: true, accounts: [{ id: "ca_1", status: "ACTIVE", alias: 7 }] },
+    }))).toBeNull();
+  });
+
   it("survives storage that throws, which a private window does", () => {
     const throwing = {
       getItem: () => {

--- a/src/lib/connected-apps-cache.test.ts
+++ b/src/lib/connected-apps-cache.test.ts
@@ -1,0 +1,70 @@
+// Why this exists: the panel is a modal, so its in-memory inventory dies the
+// moment it closes. Reopening then paints an empty list until the network
+// answers — and if the answer is "I could not read your key", it stays empty.
+// A user reads that as "my connections are gone". This remembers the last
+// thing we were SURE about, so the panel opens showing it.
+import { describe, expect, it, vi } from "vitest";
+
+import { CONNECTED_APPS_CACHE_KEY, readCachedInventory, writeCachedInventory } from "./connected-apps-cache";
+
+const fakeStorage = (seed: Record<string, string> = {}): Storage => {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  } as Storage;
+};
+
+const gmail = { connected: true, pending: false, status: "ACTIVE", accounts: [{ id: "ca_1", status: "ACTIVE" }] };
+
+describe("connected apps cache", () => {
+  it("round-trips an inventory", () => {
+    const storage = fakeStorage();
+    writeCachedInventory({ gmail }, 1_700_000_000_000, storage);
+    expect(readCachedInventory(storage)).toEqual({ at: 1_700_000_000_000, services: { gmail } });
+  });
+
+  it("returns nothing when the user has no cache yet", () => {
+    expect(readCachedInventory(fakeStorage())).toBeNull();
+  });
+
+  it("ignores a cache it cannot make sense of, rather than throwing at paint time", () => {
+    expect(readCachedInventory(fakeStorage({ [CONNECTED_APPS_CACHE_KEY]: "{{{" }))).toBeNull();
+    expect(readCachedInventory(fakeStorage({ [CONNECTED_APPS_CACHE_KEY]: '{"services":"nope"}' }))).toBeNull();
+    expect(readCachedInventory(fakeStorage({ [CONNECTED_APPS_CACHE_KEY]: '"a string"' }))).toBeNull();
+  });
+
+  it("survives storage that throws, which a private window does", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    } as unknown as Storage;
+    expect(readCachedInventory(throwing)).toBeNull();
+    expect(() => writeCachedInventory({ gmail }, 1, throwing)).not.toThrow();
+  });
+
+  it("keeps only what the panel paints, never a credential", () => {
+    const storage = fakeStorage();
+    writeCachedInventory({ gmail }, 1, storage);
+    const raw = storage.getItem(CONNECTED_APPS_CACHE_KEY) ?? "";
+    expect(raw).toContain("gmail");
+    expect(raw).toContain("ca_1");
+    expect(raw).not.toMatch(/ak_|token|secret|key"\s*:/i);
+  });
+
+  it("does not blow up when storage is missing entirely", () => {
+    const spy = vi.fn();
+    expect(readCachedInventory(undefined)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/connected-apps-cache.ts
+++ b/src/lib/connected-apps-cache.ts
@@ -34,13 +34,49 @@ function store(explicit?: Storage): Storage | undefined {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+function parseConnectorStatus(value: unknown): ConnectorStatus | null {
+  if (!isRecord(value) || typeof value.connected !== "boolean") return null;
+  if (value.pending !== undefined && typeof value.pending !== "boolean") return null;
+  if (value.status !== undefined && typeof value.status !== "string") return null;
+
+  const status: ConnectorStatus = { connected: value.connected };
+  if (value.pending !== undefined) status.pending = value.pending;
+  if (value.status !== undefined) status.status = value.status;
+
+  if (value.accounts !== undefined) {
+    if (!Array.isArray(value.accounts)) return null;
+    const accounts = value.accounts.map((account) => {
+      if (
+        !isRecord(account) ||
+        typeof account.id !== "string" ||
+        typeof account.status !== "string" ||
+        (account.alias !== undefined && typeof account.alias !== "string")
+      ) return null;
+      return {
+        id: account.id,
+        status: account.status,
+        ...(account.alias === undefined ? {} : { alias: account.alias }),
+      };
+    });
+    if (accounts.some((account) => account === null)) return null;
+    status.accounts = accounts as NonNullable<ConnectorStatus["accounts"]>;
+  }
+  return status;
+}
+
 export function readCachedInventory(explicit?: Storage): CachedInventory | null {
   try {
     const raw = store(explicit)?.getItem(CONNECTED_APPS_CACHE_KEY);
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed) || !isRecord(parsed.services)) return null;
-    return { at: typeof parsed.at === "number" ? parsed.at : 0, services: parsed.services as Record<string, ConnectorStatus> };
+    const services: Record<string, ConnectorStatus> = {};
+    for (const [slug, value] of Object.entries(parsed.services)) {
+      const status = parseConnectorStatus(value);
+      if (!status) return null;
+      services[slug] = status;
+    }
+    return { at: typeof parsed.at === "number" ? parsed.at : 0, services };
   } catch {
     // A cache we cannot read is the same as no cache; it must never be the
     // reason the panel fails to paint.

--- a/src/lib/connected-apps-cache.ts
+++ b/src/lib/connected-apps-cache.ts
@@ -1,0 +1,61 @@
+// The last connected-apps inventory we were SURE about.
+//
+// The panel is a modal: its in-memory inventory dies when it closes, so
+// reopening paints an empty list until the network answers. When the answer
+// is "the credential store was unreadable", it stays empty — and an empty
+// list reads as "my connections are gone", which is never what happened.
+//
+// So the last authoritative inventory is kept where it survives a relaunch,
+// and the panel opens showing it. Nothing secret goes in: app slugs, the
+// connected-account ids the panel already displays, and a timestamp.
+//
+// This is for the HUMAN's view only. A bot's tool call always uses live
+// state — a cached list may be optimistic, and acting on it would be wrong.
+import type { ConnectorStatus } from "@/components/PluginsPanel";
+
+export interface CachedInventory {
+  at: number;
+  services: Record<string, ConnectorStatus>;
+}
+
+export const CONNECTED_APPS_CACHE_KEY = "omb-connected-apps";
+
+/** Reaching for localStorage is itself a failure point: a private window or
+ * blocked site data throws on access, and a cache is never worth a crash. */
+function store(explicit?: Storage): Storage | undefined {
+  if (explicit) return explicit;
+  try {
+    return typeof localStorage === "undefined" ? undefined : localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export function readCachedInventory(explicit?: Storage): CachedInventory | null {
+  try {
+    const raw = store(explicit)?.getItem(CONNECTED_APPS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || !isRecord(parsed.services)) return null;
+    return { at: typeof parsed.at === "number" ? parsed.at : 0, services: parsed.services as Record<string, ConnectorStatus> };
+  } catch {
+    // A cache we cannot read is the same as no cache; it must never be the
+    // reason the panel fails to paint.
+    return null;
+  }
+}
+
+export function writeCachedInventory(
+  services: Record<string, ConnectorStatus>,
+  now: number,
+  explicit?: Storage,
+): void {
+  try {
+    store(explicit)?.setItem(CONNECTED_APPS_CACHE_KEY, JSON.stringify({ at: now, services }));
+  } catch {
+    /* a cache is never worth a crash */
+  }
+}


### PR DESCRIPTION
## What changed

A user reported their connected apps vanishing. They were never disconnected — the app lost the ability to *see* them, and expressed that by rendering the screen it shows someone who has never connected anything.

The trigger is in the desktop log, twice on my machine, most recently the day this was filed:

```
credential load failed: safeStorage.decryptStringAsync is temporarily unavailable. Please try again.
connected-apps registration failed: Error while encrypting the text provided to safeStorage.encryptStringAsync
```

macOS is saying the keychain is momentarily busy and asking to be retried. `loadSecureCredentials` caught that and returned `{}` — the same value it returns for "the user has saved nothing". From there it is mechanical:

`{}` → no `COMPOSIO_API_KEY` in the server env → `connectionMode()` is `"unavailable"` → `/api/connectors/connected` answers `configured:false` with no services → the panel, which clears any app missing from a fresh response, turns every connected app into a Connect button.

**One conflation, four places.** "I don't know" is now different from "nothing is connected" at each:

| Layer | Before | After |
|---|---|---|
| Credential read | transient error → `{}` | retries a busy keychain (100/200/400/800ms), then reports **unavailable** |
| Credential writes | any writer derives from `{}` | a state built from an unreadable store **refuses to write** |
| Server API | `configured: true/false` | `configured` **plus** `credentialStore: ok/unavailable` |
| Panel | clears apps missing from any response | keeps the last inventory it was **sure** about; clears only on an authoritative answer |

## The serious one

Every credential writer derives its next document from the current one. During an unreadable-store launch that current document is `{}`, so a single save would have replaced **every stored secret with nothing** — and the managed-Composio path would have registered a *second* installation identity, permanently orphaning the accounts the user had already authorized.

On the logged occurrences the encrypt also failed, which is the only reason no data was lost. That is luck, not design. Registration is now skipped outright when the store was unreadable, and the shared state refuses the write regardless of caller.

## Known trade-off

A remembered list can be optimistic: an app revoked from Composio's dashboard keeps showing until a successful check. That is the right way round — briefly stale beats telling someone their connections are gone — and it is **display only**. A bot's tool call still resolves against live state, never the cache.

## How it was verified

- **7 unit tests** for the credential read (`electron/secure-credentials.test.mjs`): retry-then-succeed, waits between attempts, unavailable-never-empty, store switched off, unparseable file. Written against a stub and watched failing first.
- **4 tests** for the write guard (`electron/secure-credential-state.test.mjs`), including that a readable store still writes normally and that omitting the option preserves today's behaviour.
- **4 tests** for the server's three states, and **3** for the panel's merge — including that an authoritative empty response *still* clears, so disconnecting genuinely works.
- **6 tests** for the persisted inventory, including storage that throws (private window) and that no credential can end up in it.
- **End to end in a browser against a server started with `OMB_CREDENTIAL_STORE=unavailable`** — the exact failing launch. Gmail, Google Calendar and Notion stay listed with their accounts and Disconnect buttons, the banner explains why, and apps that were never connected still correctly say Connect. Before this change that same launch produced the reporter's screenshot: everything saying Connect.
- `pnpm typecheck` clean, 1958 tests pass, `oxlint` count identical to main (1601).

## Screenshots

Panel on a launch where the credential store could not be opened: connected apps still present, with a banner saying they are remembered rather than re-checked. (Adding the image in a follow-up comment.)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure file saving with save-dialog support, cancellation handling, and file reveal behavior.
  - Added persistent connected-app status caching for more reliable display.
  - Added clear status handling for configured, unconfigured, and unavailable credential storage.
  - Added warnings when displaying cached connection information that could not be verified.

- **Bug Fixes**
  - Prevented unavailable credential storage from overwriting confirmed connected apps.
  - Added retries for temporary credential-read failures.
  - Improved handling of corrupted or invalid credential data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->