### PR TITLE
fix(mdns): keep the cache-flush bit off shared PTRs and legacy replies

### DIFF
--- a/companion/src/mdns.ts
+++ b/companion/src/mdns.ts
@@ -184,9 +184,48 @@ export function decodeMessage(buf: Buffer): DnsMessage | null {
   }
 }
 
+/**
+ * May this record tell a client to discard what it already holds?
+ *
+ * The cache-flush bit means "everything else you have cached for this name
+ * and type is stale, drop it" (RFC 6762 §10.2), and two rules keep it off a
+ * record here:
+ *
+ * - **Shared records (§10.2).** The PTR of `_openmausbot._tcp.local` is
+ *   shared: every computer running the companion answers that same name with
+ *   its own instance, and the service-type enumeration PTR is shared wider
+ *   still. Flushing one tells the client to throw away the instances the
+ *   other machines advertised, so the bit is forbidden on both.
+ * - **Legacy-unicast replies (§6.7).** They go to a resolver with no mDNS
+ *   cache to invalidate, which reads the top class bit as part of the class,
+ *   so nothing in such a response may carry it.
+ *
+ * The rrtype test below is a shorthand that holds *for the records this file
+ * builds*, and not a general rule: §2 defines shared versus unique over the
+ * RRset, not over the type, so a PTR is not inherently shared nor an SRV
+ * inherently unique. `serviceRecords` emits exactly four RRsets — two shared
+ * PTRs, and SRV/TXT/A on names derived from this machine — and no other
+ * shared type is constructed anywhere here, which is what makes the
+ * shorthand safe. Add a record type and this predicate is the thing to
+ * revisit.
+ *
+ * Nor does "unique" mean *verified* unique: §8.3 and §10.2 want the bit only
+ * on a name defended by probing, and this responder deliberately does not
+ * probe (see the note at the top of this file). Marking SRV/TXT/A is how a
+ * client learns an address changed instead of holding the old one alongside
+ * the new for its TTL — but the claim of sole ownership rests on the hashed
+ * host name, not on §8.1. That gap predates this function and is unchanged
+ * by it; the bit simply stopped going where the RFC forbids it outright.
+ */
+function mayFlush(record: ResourceRecord, legacy: boolean): boolean {
+  return !legacy && record.type !== TYPE.PTR;
+}
+
 /** One resource record on the wire. `ttlOverride` is how a goodbye is sent:
- * the same records, TTL 0, meaning "forget what I told you". */
-function encodeRecord(record: ResourceRecord, ttlOverride?: number): Buffer {
+ * the same records, TTL 0, meaning "forget what I told you". `flush` is the
+ * caller's answer to `mayFlush` — stated at every call site rather than
+ * defaulted, because the default that used to be here was "always". */
+function encodeRecord(record: ResourceRecord, ttlOverride: number | undefined, flush: boolean): Buffer {
   let rdata: Buffer;
   let ttl: number;
   switch (record.type) {
@@ -228,7 +267,7 @@ function encodeRecord(record: ResourceRecord, ttlOverride?: number): Buffer {
   const name = encodeName(record.name);
   const fixed = Buffer.alloc(10);
   fixed.writeUInt16BE(record.type, 0);
-  fixed.writeUInt16BE(CLASS_IN | FLUSH, 2);
+  fixed.writeUInt16BE(flush ? CLASS_IN | FLUSH : CLASS_IN, 2);
   fixed.writeUInt32BE(ttlOverride ?? ttl, 4);
   fixed.writeUInt16BE(rdata.length, 8);
   return Buffer.concat([name, fixed, rdata]);
@@ -237,9 +276,13 @@ function encodeRecord(record: ResourceRecord, ttlOverride?: number): Buffer {
 export function encodeResponse(
   answers: ResourceRecord[],
   additionals: ResourceRecord[] = [],
-  opts: { id?: number; ttl?: number; questions?: Question[] } = {},
+  opts: { id?: number; ttl?: number; questions?: Question[]; legacy?: boolean } = {},
 ): Buffer {
   const questions = opts.questions ?? [];
+  // Carried explicitly rather than inferred from the echoed questions: the
+  // echo is what §6.7 asks for, the flush policy is a separate rule of the
+  // same section, and tying one to the other hides the second.
+  const legacy = opts.legacy ?? false;
   const header = Buffer.alloc(12);
   header.writeUInt16BE(opts.id ?? 0, 0);
   header.writeUInt16BE(0x8400, 2); // QR=1 (response), AA=1 (authoritative)
@@ -258,8 +301,8 @@ export function encodeResponse(
   return Buffer.concat([
     header,
     ...questionBytes,
-    ...answers.map((record) => encodeRecord(record, opts.ttl)),
-    ...additionals.map((record) => encodeRecord(record, opts.ttl)),
+    ...answers.map((record) => encodeRecord(record, opts.ttl, mayFlush(record, legacy))),
+    ...additionals.map((record) => encodeRecord(record, opts.ttl, mayFlush(record, legacy))),
   ]);
 }
 
@@ -630,7 +673,7 @@ export class MdnsResponder {
     const packet = encodeResponse(
       answers,
       additionals,
-      legacy ? { id: message.id, questions: message.questions } : {},
+      legacy ? { id: message.id, questions: message.questions, legacy: true } : {},
     );
     try {
       // A unicast answer goes back the way the question came — the kernel

--- a/companion/test/mdns.test.ts
+++ b/companion/test/mdns.test.ts
@@ -148,8 +148,13 @@ describe("wire format", () => {
     expect(parsed.answerCount).toBe(4);
 
     const [ptrRec, srvRec, txtRec, aRec] = parsed.records;
-    // every record sets the cache-flush bit and class IN
-    for (const record of parsed.records) expect(record.klass).toBe(0x8001);
+    // Class IN throughout, but the cache-flush bit is not an invariant: the
+    // service PTR is a shared record and RFC 6762 §10.2 forbids the bit on
+    // one, because flushing it discards the instances *other* computers
+    // advertised under the same name. The records named after this machine
+    // are ours to replace.
+    expect(ptrRec.klass).toBe(0x0001);
+    for (const record of [srvRec, txtRec, aRec]) expect(record.klass).toBe(0x8001);
 
     expect(ptrRec).toMatchObject({ name: SERVICE_NAME, type: TYPE.PTR, ttl: 4500 });
 
@@ -170,6 +175,30 @@ describe("wire format", () => {
     const parsed = parseResponse(encodeResponse(announcement(service), [], { ttl: 0 }));
     expect(parsed.records).toHaveLength(4);
     for (const record of parsed.records) expect(record.ttl).toBe(0);
+    // TTL 0 is how a shared record is withdrawn (§10.1); the flush bit is
+    // still not the way to do it, and the goodbye uses the same encoder.
+    expect(parsed.records.find((r) => r.type === TYPE.PTR)!.klass).toBe(0x0001);
+  });
+
+  it("keeps the cache-flush bit off every record of a legacy-unicast reply", () => {
+    const { ptr, srv, txt, addresses } = serviceRecords(service);
+    const { id, questions } = decodeMessage(query(SERVICE_NAME, TYPE.PTR, { id: 42 }))!;
+    const parsed = parseResponse(encodeResponse([ptr], [srv, txt, ...addresses], { id, questions, legacy: true }));
+
+    // RFC 6762 §6.7: the asker is a plain DNS resolver. It has no mDNS cache
+    // to invalidate, and it reads the top class bit as part of the class —
+    // so not one record here may set it, unique or shared.
+    expect(parsed.id).toBe(42);
+    expect(parsed.questionCount).toBe(1);
+    expect(parsed.records).toHaveLength(4);
+    for (const record of parsed.records) expect(record.klass).toBe(0x0001);
+  });
+
+  it("leaves the enumeration PTR unflushed too — it is shared widest of all", () => {
+    const { answers } = answersFor(decodeMessage(query(SERVICE_ENUMERATION, TYPE.PTR))!, service);
+    const [record] = parseResponse(encodeResponse(answers)).records;
+    // every service type on the network answers this name, not just ours
+    expect(record).toMatchObject({ name: SERVICE_ENUMERATION, type: TYPE.PTR, klass: 0x0001 });
   });
 
   it("encodes an empty TXT as one empty string, not zero bytes", () => {
@@ -296,6 +325,27 @@ describe("MdnsResponder", () => {
     }
   });
 
+  it("answers a legacy resolver with the cache-flush bit nowhere in the packet", async () => {
+    const responder = new MdnsResponder({ port: 0, multicast: false });
+    expect(await responder.advertise(service)).toBe(true);
+    try {
+      const port = responder.address()!;
+      const parsed = parseResponse(await askResponder(port, query(SERVICE_NAME, TYPE.PTR, { id: 42 })));
+
+      // The id/question echo is one of §6.7's requirements of a legacy reply
+      // and this is another — among others the responder does not yet meet,
+      // the section also caps a legacy reply's TTL at 10 s and this one still
+      // sends 120/4500. That is filed separately, not asserted here. What is
+      // asserted: the reply leaves through the same encoder as a multicast
+      // one, so the caller must pass the policy down rather than let the
+      // encoder decide on its own.
+      expect(parsed.records.length).toBeGreaterThan(1);
+      for (const record of parsed.records) expect(record.klass).toBe(0x0001);
+    } finally {
+      await responder.stop();
+    }
+  });
+
   it("says nothing at all about a service that is not ours", async () => {
     const responder = new MdnsResponder({ port: 0, multicast: false });
     await responder.advertise(service);
@@ -351,37 +401,48 @@ describe("MdnsResponder", () => {
   });
 });
 
+/** A socket that logs what the responder does to it, and keeps the packets.
+ * Satisfies `ResponderSocket` structurally — no casting required. Shared by
+ * the two describes below: one reads `ops` to check interface pinning, the
+ * other reads `packets` to check what went on the wire. */
+class FakeSocket extends EventEmitter {
+  readonly ops: Array<{ op: "pin" | "send"; address: string; port?: number }> = [];
+  /** Kept beside `ops` rather than in it: the ops log is asserted with
+   * `toEqual` below, and a packet field would drown those assertions. */
+  readonly packets: Buffer[] = [];
+  bind(_port: number, callback?: () => void) {
+    callback?.();
+  }
+  setMulticastTTL(_ttl: number) {}
+  addMembership(_group: string, _membershipInterface?: string) {}
+  setMulticastInterface(multicastInterface: string) {
+    this.ops.push({ op: "pin", address: multicastInterface });
+  }
+  send(packet: Buffer, port: number, address: string, callback?: (error: Error | null) => void) {
+    this.ops.push({ op: "send", address, port });
+    this.packets.push(packet);
+    callback?.(null);
+  }
+  close(callback?: () => void) {
+    callback?.();
+  }
+  address() {
+    return { port: 5353 };
+  }
+}
+
+const homes = ["192.168.1.42", "10.0.0.7"];
+
+// The fake's callbacks fire synchronously, so the first announcement (the
+// 0 ms timer) has fully drained once one later macrotask runs.
+const drained = () => new Promise((resolve) => setTimeout(resolve, 25));
+
 // The outbound half of multicast. Joining the group per interface only fixes
 // what we *hear*; every group send must also be pinned per interface, or the
 // kernel routes 224.0.0.251 out of exactly one interface of its choosing —
 // with a VPN or VM bridge up, a network the phone is not on. None of this
 // reaches the wire in CI, so a recording socket is where it gets asserted.
 describe("multicast interface pinning", () => {
-  /** A socket that logs what the responder does to it. Satisfies
-   * `ResponderSocket` structurally — no casting required. */
-  class FakeSocket extends EventEmitter {
-    readonly ops: Array<{ op: "pin" | "send"; address: string; port?: number }> = [];
-    bind(_port: number, callback?: () => void) {
-      callback?.();
-    }
-    setMulticastTTL(_ttl: number) {}
-    addMembership(_group: string, _membershipInterface?: string) {}
-    setMulticastInterface(multicastInterface: string) {
-      this.ops.push({ op: "pin", address: multicastInterface });
-    }
-    send(_packet: Buffer, port: number, address: string, callback?: (error: Error | null) => void) {
-      this.ops.push({ op: "send", address, port });
-      callback?.(null);
-    }
-    close(callback?: () => void) {
-      callback?.();
-    }
-    address() {
-      return { port: 5353 };
-    }
-  }
-
-  const homes = ["192.168.1.42", "10.0.0.7"];
   /** One announcement burst, as the ops log should show it: pin, send, pin,
    * send — the pin *before* each send, per advertised interface, because
    * `setMulticastInterface` redirects the sends that come after it. */
@@ -389,10 +450,6 @@ describe("multicast interface pinning", () => {
     { op: "pin", address },
     { op: "send", address: "224.0.0.251", port: 5353 },
   ]);
-
-  // The fake's callbacks fire synchronously, so the first announcement (the
-  // 0 ms timer) has fully drained once one later macrotask runs.
-  const drained = () => new Promise((resolve) => setTimeout(resolve, 25));
 
   it("pins every announcement and goodbye to each advertised interface, in order", async () => {
     const socket = new FakeSocket();
@@ -461,6 +518,64 @@ describe("multicast interface pinning", () => {
     } finally {
       await responder.stop();
     }
+  });
+});
+
+// Which records claim to replace a cache entry, read off the packets the
+// responder actually emitted. The policy is decided in `mayFlush` and carried
+// by the caller, so the encoder unit tests above cannot show that the caller
+// passed it — only a packet off the socket can.
+describe("cache-flush policy on the wire", () => {
+  it("flushes what this machine owns on multicast, and never the shared PTR", async () => {
+    const socket = new FakeSocket();
+    const responder = new MdnsResponder({ socketFactory: () => socket });
+    await responder.advertise({ ...service, addresses: homes });
+    await drained();
+    try {
+      const parsed = parseResponse(socket.packets[0]);
+      const klassOf = (type: number) => parsed.records.find((r) => r.type === type)!.klass;
+      // the other half of the rule: dropping the bit everywhere would be a
+      // client holding a stale address for the whole 120 s of its TTL
+      expect(klassOf(TYPE.PTR)).toBe(0x0001);
+      for (const type of [TYPE.SRV, TYPE.TXT, TYPE.A]) expect(klassOf(type)).toBe(0x8001);
+    } finally {
+      await responder.stop();
+    }
+  });
+
+  // A QU query and a legacy query are both answered directly to the asker, so
+  // "went out unicast" is the wrong thing to hang the policy on. What splits
+  // them is the source port: §6.7 is about a resolver with no mDNS cache, and
+  // a QU asker on 5353 is a full mDNS client that has one — §5.4 leaves it
+  // under the same cache-flush rules as a multicast answer. The two cases
+  // below differ in nothing but that port.
+  const askDirectly = async (fromPort: number) => {
+    const socket = new FakeSocket();
+    const responder = new MdnsResponder({ socketFactory: () => socket });
+    // one address, so the reply is exactly SRV + its A and the classes below
+    // can be read as a pair rather than counted
+    await responder.advertise(service);
+    await drained();
+    socket.packets.length = 0;
+    try {
+      socket.emit("message", query(INSTANCE, TYPE.SRV, { id: 9, unicast: true }), {
+        address: "127.0.0.1",
+        port: fromPort,
+      });
+      await drained();
+      return parseResponse(socket.packets[0]).records.map((record) => record.klass);
+    } finally {
+      await responder.stop();
+    }
+  };
+
+  it("keeps flushing for a QU asker on 5353, which has a cache to replace", async () => {
+    expect(await askDirectly(5353)).toEqual([0x8001, 0x8001]);
+  });
+
+  it("drops the bit for the same QU question from a legacy port", async () => {
+    // QU set and all: the source port is what makes it legacy, not the bit
+    expect(await askDirectly(40404)).toEqual([0x0001, 0x0001]);
   });
 });
 


### PR DESCRIPTION
Fixes #467.

`encodeRecord` set `CLASS_IN | FLUSH` unconditionally, and it is the only encoding path, so the cache-flush bit rode on every record — PTR included — in multicast and unicast answers both. RFC 6762 forbids it in two cases that occur here.

**Shared PTR (§10.2).** `_openmausbot._tcp.local` PTR is shared: every computer running the companion advertises the same name legitimately. The bit tells a receiver to discard other cached records with that name, so whichever machine answers second tells listening phones to drop the first one's PTR.

**Legacy-unicast replies (§6.7).** A query whose source port is not 5353 comes from a resolver with no mDNS cache to flush. The code already knew about this section — `handle()` computes `legacy` and echoes the id and questions as required — but the reply was still built through the same encoder.

### The change

`mayFlush(record, legacy)` decides per record. `encodeRecord`'s flush argument is required rather than defaulted, because the default it replaces was "always", and adding a new one would trade a silent wrong value for a different silent wrong value. `encodeResponse` takes `legacy` and applies it to answers and additionals; `handle()` passes the flag it already had.

Announcements and the goodbye stay multicast and keep flushing what this host owns. The goodbye withdraws the shared PTR by TTL 0, which is what §10.1 asks for. The QU bit is untouched: a question carrying QU from port 5353 is not a legacy resolver, and its answer still flushes the unique records.

### On the tests

The assertion that had to change was pinning the bug as an invariant:

```ts
// every record sets the cache-flush bit and class IN
for (const record of parsed.records) expect(record.klass).toBe(0x8001);
```

It is now a distinction, and the suite gained a legacy-unicast case, the enumeration PTR, an end-to-end exchange over the responder's own socket, a QU pair that varies only the source port, and the inverse — that multicast still flushes SRV/TXT/A — without which "never flag anything" would have passed.

Checked by mutation rather than by reading, because a test that passes either way proves nothing:

- old encoder restored, new tests in place → **7 of 41 fail**;
- all unicast answers treated as legacy → **exactly the QU-on-5353 case fails**, nothing else.

`companion/test` is green at 195, `tsc --noEmit` is clean, and `oxlint` reports the same 9 pre-existing findings as the base.

### Deliberately not in scope

Two neighbouring gaps, both noted on the issue rather than folded in here:

- this responder does not probe (`mdns.ts:12` says so), so two machines belonging to one person can still advertise the same Service Instance Name — RFC 6763 Appendix D territory, and independent of the flush bit;
- legacy replies still carry TTLs of 120/4500 where §6.7 asks for no more than 10 seconds.

Happy to fold either in if you would rather have them together.

---

Found while porting the companion to Android and working out why an emulator on API 26 saw no service. It turned out **not** to be the cause of that — Android 8's bundled `mDNSResponder` masks the flush bit off the class and carries on parsing, so no packet is rejected over it. Reporting and fixing it separately because the multi-computer consequence is real on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multicast service discovery responses by applying cache-flush behavior correctly to different record types.
  - Updated legacy unicast responses to preserve request identifiers and questions while avoiding inappropriate cache flushing.
  - Improved compatibility across multicast, QU, and legacy-port discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->