### PR TITLE
chore(release): bump version to 0.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the desktop release version from `0.1.33` to `0.1.34`
- leave the iOS marketing/build versions unchanged because this is the cross-platform Electron release

## Validation
- `pnpm install --frozen-lockfile`
- release workflow version extraction returns `0.1.34`
- confirmed `v0.1.34` does not already exist in `openmausbot-releases`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->