### PR TITLE
fix(control-plane): support Worker redirect handling

### DIFF
--- a/cloudflare/control-plane/src/cloudflare-api.ts
+++ b/cloudflare/control-plane/src/cloudflare-api.ts
@@ -154,7 +154,10 @@ export class CloudflareAPI {
         body,
         headers,
         method: init.method ?? "GET",
-        redirect: "error",
+        // Workers only implements `follow` and `manual`. Keep redirects manual
+        // so the bearer token is never forwarded to a redirect destination;
+        // the non-2xx response checks below reject the 3xx response.
+        redirect: "manual",
         signal: AbortSignal.timeout(API_TIMEOUT_MS),
       });
     } catch (error) {

--- a/cloudflare/control-plane/test/managed-endpoints.test.ts
+++ b/cloudflare/control-plane/test/managed-endpoints.test.ts
@@ -291,6 +291,34 @@ class FakeCloudflare {
 }
 
 describe("Cloudflare API response contracts", () => {
+  it("keeps redirects manual and rejects them without forwarding credentials", async () => {
+    const fetcher = vi.fn<CloudflareFetch>(async (_input, init) => {
+      expect(init?.redirect).toBe("manual");
+      return new Response(null, {
+        headers: { location: "https://redirect.invalid/capture-token" },
+        status: 302,
+      });
+    });
+    const api = new CloudflareAPI(readConfig(env).cloudflare, fetcher);
+
+    await expect(api.listTunnels("redirect-probe")).rejects.toMatchObject({
+      code: "cf_http_302",
+      status: 302,
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the network error contract for genuine fetch rejection", async () => {
+    const api = new CloudflareAPI(readConfig(env).cloudflare, async () => {
+      throw new TypeError("simulated connection failure");
+    });
+
+    await expect(api.listTunnels("network-probe")).rejects.toMatchObject({
+      code: "cf_network",
+      status: null,
+    });
+  });
+
   it("accepts the documented result-only DNS delete response and validates its ID", async () => {
     const api = new CloudflareAPI(readConfig(env).cloudflare, async () => (
       Response.json({ result: { id: "dns-record-1" } })


### PR DESCRIPTION
## What changed
- use Cloudflare Workers-supported manual redirect handling for API requests
- keep bearer credentials from being forwarded to redirect destinations
- add regression coverage for 3xx and genuine network failures

## Root cause
Workers rejects `redirect: "error"` before issuing a request. The catch block mapped that runtime TypeError to `cf_network`, so managed companion endpoint provisioning always failed before reaching the Cloudflare API.

## Validation
- control-plane tests: 40 passed
- control-plane typecheck: passed
- Wrangler deploy dry-run: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of redirected API requests to prevent credentials from being forwarded unexpectedly.
  * Redirect responses now produce consistent errors instead of being followed automatically.
  * Network failures continue to be reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->