### PR TITLE
fix: surface companion authentication errors

### DIFF
--- a/cloudflare/control-plane/src/index.ts
+++ b/cloudflare/control-plane/src/index.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { accountSession, createAuth } from "./auth";
 import { readConfig, type ControlPlaneConfig } from "./config";
 import { errorResponse, HTTPError, json, preflight, secureResponse, withBoundedRequestBody } from "./http";
@@ -21,6 +23,43 @@ import {
 const ROTATE_ROUTE = /^\/v1\/installations\/([^/]+)\/credentials\/rotate$/;
 const INSTALLATION_ROUTE = /^\/v1\/installations\/([^/]+)$/;
 
+const BETTER_AUTH_ERROR_CODES = new Map([
+  ["INVALID_EMAIL", "invalid_email"],
+  ["INVALID_OTP", "invalid_otp"],
+  ["OTP_EXPIRED", "otp_expired"],
+  ["TOO_MANY_ATTEMPTS", "rate_limited"],
+  ["USER_NOT_FOUND", "invalid_otp"],
+  ["VALIDATION_ERROR", "invalid_request"],
+]);
+const betterAuthErrorSchema = z.object({ code: z.string() }).loose();
+
+function authStatusErrorCode(status: number): string {
+  if (status === 400 || status === 422) return "invalid_request";
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
+  if (status === 404) return "not_found";
+  if (status === 405) return "method_not_allowed";
+  if (status === 409) return "conflict";
+  if (status === 413) return "request_too_large";
+  if (status === 415) return "unsupported_media_type";
+  if (status === 429) return "rate_limited";
+  return "request_failed";
+}
+
+async function canonicalAuthResponse(response: Response): Promise<Response> {
+  if (response.status >= 500) return errorResponse(500, "internal_error");
+  if (response.status < 400 || response.status > 499) return response;
+
+  // Better Auth error bodies are dependency-owned and may contain prose or
+  // change shape between releases (its rate limiter currently returns only a
+  // `message`). Publish only OpenMausBot's stable, lowercase error contract.
+  const payload: unknown = await response.json().catch(() => null);
+  const parsed = betterAuthErrorSchema.safeParse(payload);
+  const dependencyCode = parsed.success ? parsed.data.code : "";
+  const code = BETTER_AUTH_ERROR_CODES.get(dependencyCode) ?? authStatusErrorCode(response.status);
+  return errorResponse(response.status, code);
+}
+
 async function route(
   request: Request,
   env: Env,
@@ -36,7 +75,7 @@ async function route(
     const limited = await limitedOTPResponse(request, env);
     if (limited) return limited;
     const response = await createAuth(env, ctx, config, requestId).handler(request);
-    return response.status >= 500 ? errorResponse(500, "internal_error") : response;
+    return canonicalAuthResponse(response);
   }
 
   const auth = createAuth(env, ctx, config, requestId);

--- a/cloudflare/control-plane/test/control-plane.test.ts
+++ b/cloudflare/control-plane/test/control-plane.test.ts
@@ -237,6 +237,29 @@ describe("Better Auth email OTP and bearer boundary", () => {
     expect(rateLimit?.attempts).toBe(3);
   });
 
+  it("canonicalizes Better Auth's message-only rate limit response", async () => {
+    const responses = [];
+    for (let index = 0; index < 6; index += 1) {
+      responses.push(await call("/api/auth/email-otp/send-verification-otp", {
+        method: "POST",
+        headers: { "cf-connecting-ip": "198.51.100.42" },
+        body: { email: `better-auth-limit-${index}@example.com`, type: "sign-in" },
+      }));
+    }
+
+    expect(responses.slice(0, 5).map((response) => response.status)).toEqual([
+      200,
+      200,
+      200,
+      200,
+      200,
+    ]);
+    const limited = responses[5];
+    expect(limited.status).toBe(429);
+    await expect(limited.json()).resolves.toEqual({ error: "rate_limited" });
+    expect(limited.headers.get("x-request-id")).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
   it("completes email OTP registration once and authenticates a bearer", async () => {
     const account = await signIn("ada@example.com");
     const me = await call("/v1/me", { token: account.token });
@@ -267,6 +290,7 @@ describe("Better Auth email OTP and bearer boundary", () => {
       body: { email: invalidEmail, otp: "00000000", name: "Invalid" },
     });
     expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toEqual({ error: "invalid_otp" });
 
     const accepted = await call("/api/auth/sign-in/email-otp", {
       method: "POST",
@@ -280,6 +304,7 @@ describe("Better Auth email OTP and bearer boundary", () => {
       body: { email: invalidEmail, otp: validOTP, name: "Replay" },
     });
     expect(replayed.status).toBe(400);
+    await expect(replayed.json()).resolves.toEqual({ error: "invalid_otp" });
 
     const expiredEmail = "expired-otp@example.com";
     const expiredContext = createExecutionContext();
@@ -296,6 +321,7 @@ describe("Better Auth email OTP and bearer boundary", () => {
       body: { email: expiredEmail, otp: expiredOTP, name: "Expired" },
     });
     expect(expired.status).toBe(400);
+    await expect(expired.json()).resolves.toEqual({ error: "otp_expired" });
 
     const signedOut = await call("/api/auth/sign-out", {
       method: "POST",

--- a/electron/companion-account-service.mjs
+++ b/electron/companion-account-service.mjs
@@ -126,9 +126,11 @@ function withAuthenticatedAccount(
 
 const FRIENDLY_MESSAGES = Object.freeze({
   invalid_email: "Enter a valid email address.",
+  invalid_request: "The secure connection request was not accepted. Check the details and try again.",
   invalid_otp: "That code is not valid. Check the email and try again.",
   otp_expired: "That code expired. Email yourself a new one.",
   unauthorized: "Your sign-in expired. Email yourself a new code to reconnect.",
+  forbidden: "The secure connection request was not allowed. Try signing in again.",
   signed_out: "Your sign-in expired. Email yourself a new code to reconnect.",
   network_unavailable: "OpenMausBot could not reach its secure connection service. Check your internet and try again.",
   rate_limited: "Too many attempts were made. Wait a little, then try again.",
@@ -139,12 +141,18 @@ const FRIENDLY_MESSAGES = Object.freeze({
   endpoint_unavailable: "The secure connection service could not finish setup. Local pairing still works; try again shortly.",
   endpoint_cleanup_pending: "The secure connection is still being removed. Try signing out again shortly.",
   control_plane_unavailable: "Secure access is not available right now. Local pairing still works.",
+  internal_error: "The secure connection service had a problem. Local pairing still works; try again.",
   invalid_response: "The secure connection service returned an unexpected response. Try again.",
+  request_failed: "The secure connection request could not be completed. Local pairing still works; try again.",
 });
 
 export function friendlyCompanionAccountError(error) {
   const code = error instanceof ControlPlaneError ? error.code : "";
-  return FRIENDLY_MESSAGES[code] ?? "Secure access could not be updated. Local pairing still works; try again.";
+  const message = FRIENDLY_MESSAGES[code] ?? FRIENDLY_MESSAGES.request_failed;
+  const reference = error instanceof ControlPlaneError && error.requestId
+    ? ` Reference: ${error.requestId}.`
+    : "";
+  return `${message}${reference}`;
 }
 
 function publicState({ available, status, email, endpoint, message }) {
@@ -467,18 +475,19 @@ export function createCompanionAccountService({
   const requestCode = (rawEmail) => serialize(async () => {
     if (!configured) throw new Error(FRIENDLY_MESSAGES.control_plane_unavailable);
     const email = normalizeAccountEmail(rawEmail);
+    let requested;
     try {
       await requireHealthyControlPlane();
-      const requested = await client.requestOTP(email);
-      phase = {
-        status: "signed-out",
-        email: requested.email,
-      };
-      return settledState();
+      requested = await client.requestOTP(email);
     } catch (error) {
       const message = failAction(error, { email, signedOut: true });
       throw new Error(message);
     }
+    phase = {
+      status: "signed-out",
+      email: requested.email,
+    };
+    return settledState();
   });
 
   const verifyCode = (rawEmail, rawCode) => serialize(async () => {

--- a/electron/companion-account-service.test.mjs
+++ b/electron/companion-account-service.test.mjs
@@ -185,6 +185,36 @@ describe("Companion account service", () => {
     await expect(service.state()).resolves.toEqual({ available: true, status: "signed-out" });
   });
 
+  it("shows a specific rate-limit message instead of the generic secure-access error", async () => {
+    const requestId = "44444444-4444-4444-8444-444444444444";
+    const client = readyClient({
+      requestOTP: vi.fn(async () => {
+        throw new ControlPlaneError("rate_limited", 429, requestId);
+      }),
+    });
+    const { service } = serviceFixture({ client });
+
+    const request = service.requestCode("ada@example.com");
+    await expect(request).rejects.toThrow("Too many attempts were made");
+    await expect(request).rejects.toThrow(`Reference: ${requestId}`);
+    await expect(request).rejects.not.toThrow("Secure access could not be updated");
+  });
+
+  it("does not classify local settled-state failures as request failures", async () => {
+    const client = readyClient();
+    const service = createCompanionAccountService({
+      client,
+      readCredentials: () => {
+        throw new Error("credential store unavailable");
+      },
+    });
+
+    await expect(service.requestCode("ada@example.com")).rejects.toThrow(
+      "credential store unavailable",
+    );
+    expect(client.requestOTP).toHaveBeenCalledOnce();
+  });
+
   it("persists one stable identity and the complete provision atomically", async () => {
     const activatePersistedEndpoint = vi.fn(async () => ({ status: "ready", ready: true }));
     const { client, service, store } = serviceFixture({ activatePersistedEndpoint });

--- a/electron/control-plane-client.mjs
+++ b/electron/control-plane-client.mjs
@@ -3,6 +3,7 @@ const INSTALLATION_CREDENTIAL =
 const INSTALLATION_ID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const CLIENT_INSTANCE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const REQUEST_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const stringValue = (value) => (typeof value === "string" ? value : null);
 
@@ -52,12 +53,27 @@ const boundedSecret = (value, maximum = 8_192) =>
     : null;
 
 export class ControlPlaneError extends Error {
-  constructor(code, status = 0) {
+  constructor(code, status = 0, requestId = "") {
     super(code);
     this.name = "ControlPlaneError";
     this.code = code;
     this.status = status;
+    this.requestId = REQUEST_ID.test(requestId) ? requestId : "";
   }
+}
+
+function statusErrorCode(status) {
+  if (status === 400 || status === 422) return "invalid_request";
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
+  if (status === 404) return "not_found";
+  if (status === 405) return "method_not_allowed";
+  if (status === 409) return "conflict";
+  if (status === 413) return "request_too_large";
+  if (status === 415) return "unsupported_media_type";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "control_plane_unavailable";
+  return "request_failed";
 }
 
 /** Production accepts HTTPS only. A loopback HTTP origin remains available
@@ -189,8 +205,9 @@ export function createControlPlaneClient({
         ? rawCode
         : null;
       throw new ControlPlaneError(
-        code ?? "request_failed",
+        code ?? statusErrorCode(response.status),
         response.status,
+        response.headers.get("x-request-id") ?? "",
       );
     }
     if (!allowEmpty && !plainObject(payload)) {

--- a/electron/control-plane-client.test.mjs
+++ b/electron/control-plane-client.test.mjs
@@ -237,6 +237,40 @@ describe("control-plane desktop client", () => {
     });
   });
 
+  it("falls back from Better Auth's message-only 429 without exposing its prose", async () => {
+    const requestId = "44444444-4444-4444-8444-444444444444";
+    const client = createControlPlaneClient({
+      baseURL: "https://accounts.openmausbot.com",
+      fetchImpl: vi.fn(async () => jsonResponse(
+        { message: "Too many requests. Please try again later." },
+        { status: 429, headers: { "x-request-id": requestId } },
+      )),
+    });
+
+    await expect(client.requestOTP("ada@example.com")).rejects.toMatchObject({
+      name: "ControlPlaneError",
+      code: "rate_limited",
+      status: 429,
+      requestId,
+    });
+  });
+
+  it("uses stable status errors when a response has no public error contract", async () => {
+    const client = createControlPlaneClient({
+      baseURL: "https://accounts.openmausbot.com",
+      fetchImpl: vi.fn(async () => jsonResponse(
+        { code: "INTERNAL_DEPENDENCY_DETAIL", message: "do not expose this" },
+        { status: 400, headers: { "x-request-id": "not-a-safe-request-id" } },
+      )),
+    });
+
+    await expect(client.requestOTP("ada@example.com")).rejects.toMatchObject({
+      code: "invalid_request",
+      status: 400,
+      requestId: "",
+    });
+  });
+
   it("fails closed on redirects and network errors", async () => {
     const client = createControlPlaneClient({
       baseURL: "https://accounts.openmausbot.com",


### PR DESCRIPTION
## What changed
- normalize Better Auth 4xx responses to the stable OpenMausBot error contract
- map message-only rate limits and HTTP fallback statuses correctly in Electron
- show actionable messages and safe request references instead of the generic secure-access error
- keep local credential-store failures separate from network failures

## Validation
- root tests: 1,920 passed
- control-plane tests: 39 passed
- control-plane typecheck: passed
- changed-file checks and diff validation: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in and one-time passcode error messages with consistent, user-friendly guidance.
  * Rate-limit errors are now clearly identified after repeated code requests.
  * Invalid, expired, or reused passcodes now return distinct error messages.
  * Unexpected server failures are presented safely without exposing internal details.
  * Error messages may include a request reference to help with support investigations.
  * Account request handling now updates sign-in status only after successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->