### PR TITLE
Let pasted text return to the chat box

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -188,9 +188,9 @@ export function Composer({
     (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
     [setAttachments],
   );
-  /** Moves one pasted attachment into the editable draft and restores focus. */
   const displayPasteInChatBox = useCallback(
-    (attachment: PasteAttachment) => {
+    /** Moves one pasted attachment into the editable draft and restores focus. */
+    function displayPasteInChatBox(attachment: PasteAttachment) {
       const nextText = appendPastedText(text, attachment.text);
       setText(nextText);
       setAttachments((prev) => prev.filter((a) => a.id !== attachment.id));

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -8,6 +8,7 @@ import { MausAvatar } from "./Avatar";
 import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import {
+  appendPastedText,
   composeMessage,
   imageAttachmentFromFile,
   intakeFiles,
@@ -15,6 +16,7 @@ import {
   isLongPaste,
   pasteAttachment,
   type Attachment,
+  type PasteAttachment,
 } from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
 import { groupComposerHint, roomRespondersForComposer } from "@/lib/group-routing";
@@ -184,6 +186,22 @@ export function Composer({
   const removeAttachment = useCallback(
     (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
     [setAttachments],
+  );
+  const displayPasteInChatBox = useCallback(
+    (attachment: PasteAttachment) => {
+      const nextText = appendPastedText(text, attachment.text);
+      setText(nextText);
+      setAttachments((prev) => prev.filter((a) => a.id !== attachment.id));
+      setCaret(nextText.length);
+      setDismissedAt(null);
+      requestAnimationFrame(() => {
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.setSelectionRange(nextText.length, nextText.length);
+      });
+    },
+    [text, setText, setAttachments],
   );
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
@@ -468,6 +486,7 @@ export function Composer({
           items={attachments}
           onAdd={addAttachments}
           onRemove={removeAttachment}
+          onDisplayInChatBox={displayPasteInChatBox}
           allowImages={engineSupportsImages}
           notice={attachmentNotice}
           onNotice={setAttachmentNotice}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -133,6 +133,7 @@ function PermissionModeSelector({ bot, onSetAuto }: { bot: Bot; onSetAuto: (auto
   );
 }
 
+/** Renders the editable message composer and its pending attachments. */
 export function Composer({
   bot,
   group,
@@ -187,6 +188,7 @@ export function Composer({
     (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
     [setAttachments],
   );
+  /** Moves one pasted attachment into the editable draft and restores focus. */
   const displayPasteInChatBox = useCallback(
     (attachment: PasteAttachment) => {
       const nextText = appendPastedText(text, attachment.text);

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -3,7 +3,7 @@
 // first lines instead of flooding the composer; a file dropped anywhere
 // on the window attaches by path.
 import { useEffect, useRef, useState } from "react";
-import { ClipboardPaste, File as FileIcon, Image as ImageIcon, X } from "lucide-react";
+import { ClipboardPaste, File as FileIcon, Image as ImageIcon, MessageSquareText, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 import {
   attachmentImageUrl,
@@ -12,6 +12,7 @@ import {
   imageAttachmentFromFile,
   pasteSummary,
   type Attachment,
+  type PasteAttachment,
 } from "@/lib/composer-attachments";
 import { AttachmentPreviewDialog, previewImage, type PreviewImage } from "./AttachmentPreview";
 
@@ -24,6 +25,7 @@ export function ComposerAttachments({
   items,
   onAdd,
   onRemove,
+  onDisplayInChatBox,
   allowImages = true,
   notice,
   onNotice,
@@ -31,6 +33,7 @@ export function ComposerAttachments({
   items: Attachment[];
   onAdd: (attachments: Attachment[]) => void;
   onRemove: (id: string) => void;
+  onDisplayInChatBox: (attachment: PasteAttachment) => void;
   allowImages?: boolean;
   notice: string | null;
   onNotice: (notice: string | null) => void;
@@ -133,6 +136,16 @@ export function ComposerAttachments({
                   <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-raised" />
                 </div>
                 <div className="mt-1 text-[10.5px] text-ink-secondary/70">{pasteSummary(a)}</div>
+                <button
+                  type="button"
+                  onClick={() => onDisplayInChatBox(a)}
+                  className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-accent/25 bg-accent/5 px-2 py-1.5 text-[10.5px] font-medium text-accent-text transition-colors hover:border-accent/50 hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/60"
+                  aria-label="Display pasted text in chat box"
+                  title="Display in chat box"
+                >
+                  <MessageSquareText size={12} aria-hidden="true" />
+                  <span>Display in chat box</span>
+                </button>
               </Chip>
             ) : a.kind === "image" ? (
               <Chip key={a.id} label="IMAGE" title={a.name} onRemove={() => onRemove(a.id)}>

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -21,6 +21,7 @@ export function pathForFile(file: File): string {
   return window.ogb?.getPathForFile?.(file) ?? "";
 }
 
+/** Renders pending attachments and their composer actions. */
 export function ComposerAttachments({
   items,
   onAdd,

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -27,14 +27,16 @@ describe("appendPastedText", () => {
 });
 
 /** Builds a stable image attachment fixture for prompt and preview tests. */
-const image = (path: string): ImageAttachment => ({
-  kind: "image",
-  id: "i1",
-  path,
-  name: "shot.png",
-  size: 1234,
-  mime: "image/png",
-});
+function image(path: string): ImageAttachment {
+  return {
+    kind: "image",
+    id: "i1",
+    path,
+    name: "shot.png",
+    size: 1234,
+    mime: "image/png",
+  };
+}
 
 describe("composeMessage with images", () => {
   it("emits an attached-image tag carrying the server path", () => {

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -12,19 +12,29 @@ import {
   type ImageAttachment,
 } from "./composer-attachments";
 
-describe("appendPastedText", () => {
-  it("adds pasted content after an existing draft", () => {
+/** Exercises the spacing and empty-draft cases for pasted text insertion. */
+function appendPastedTextTests() {
+  /** Keeps an existing draft ahead of newly inserted pasted content. */
+  function addsPastedContentAfterDraft() {
     expect(appendPastedText("Keep this", "Edit this too")).toBe("Keep this\n\nEdit this too");
-  });
+  }
 
-  it("does not add a second separator when the draft ends with a newline", () => {
+  /** Avoids duplicating a separator when the draft already ends with a newline. */
+  function preservesExistingTrailingNewline() {
     expect(appendPastedText("Keep this\n", "Edit this too")).toBe("Keep this\nEdit this too");
-  });
+  }
 
-  it("uses the pasted content directly for an empty draft", () => {
+  /** Inserts pasted content directly when no draft exists yet. */
+  function insertsIntoEmptyDraft() {
     expect(appendPastedText("", "Edit this too")).toBe("Edit this too");
-  });
-});
+  }
+
+  it("adds pasted content after an existing draft", addsPastedContentAfterDraft);
+  it("does not add a second separator when the draft ends with a newline", preservesExistingTrailingNewline);
+  it("uses the pasted content directly for an empty draft", insertsIntoEmptyDraft);
+}
+
+describe("appendPastedText", appendPastedTextTests);
 
 /** Builds a stable image attachment fixture for prompt and preview tests. */
 function image(path: string): ImageAttachment {

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  appendPastedText,
   attachmentBasename,
   attachmentImageUrl,
   composeMessage,
@@ -10,6 +11,20 @@ import {
   splitAttachedImages,
   type ImageAttachment,
 } from "./composer-attachments";
+
+describe("appendPastedText", () => {
+  it("adds pasted content after an existing draft", () => {
+    expect(appendPastedText("Keep this", "Edit this too")).toBe("Keep this\n\nEdit this too");
+  });
+
+  it("does not add a second separator when the draft ends with a newline", () => {
+    expect(appendPastedText("Keep this\n", "Edit this too")).toBe("Keep this\nEdit this too");
+  });
+
+  it("uses the pasted content directly for an empty draft", () => {
+    expect(appendPastedText("", "Edit this too")).toBe("Edit this too");
+  });
+});
 
 const image = (path: string): ImageAttachment => ({
   kind: "image",

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -26,6 +26,7 @@ describe("appendPastedText", () => {
   });
 });
 
+/** Builds a stable image attachment fixture for prompt and preview tests. */
 const image = (path: string): ImageAttachment => ({
   kind: "image",
   id: "i1",

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -122,6 +122,13 @@ export function pasteAttachment(text: string): PasteAttachment {
   return { kind: "paste", id, text, size: byteLength(text), lines: countLines(text) };
 }
 
+/** Move a pasted attachment into the editable composer draft without
+ * running the text back through the paste threshold. */
+export function appendPastedText(text: string, pasted: string): string {
+  if (!text) return pasted;
+  return `${text}${text.endsWith("\n") ? "" : "\n\n"}${pasted}`;
+}
+
 export const INLINE_DROP_LIMIT = 512 * 1024;
 
 export type DroppedFile = Pick<File, "name" | "size" | "type" | "text">;


### PR DESCRIPTION
## What changed

- Added a “Display in chat box” action to long pasted-text cards.
- Moved the full pasted text into the editable composer draft, preserving existing text with a blank-line separator.
- Removed the card after insertion and restored focus and the caret at the end.

## Why

Long pasted text was preview-only. This lets people place it in the composer and edit it before sending without changing the paste threshold behavior.

## How it was verified

- `pnpm typecheck` passed.
- The clean-environment full test suite passed: 1,923 tests passed and 18 skipped.
- `pnpm build` passed.
- CI passed on Ubuntu, Windows, macOS, iOS, packaging, and control-plane checks.
- No dependency or lockfile changes.

## Screenshots (UI changes)

The action uses the existing attachment-card palette and compact layout. Before/after images could not be attached because this workspace does not provide the browser or desktop capture permission needed to capture the running UI.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally.
- [x] Server behavior changes come with tests (not applicable; this is a client-side composer change with focused tests).
- [x] No `dist-server/` edits.
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building.
- [x] No secrets in logs, responses, events, or argv.
- [ ] UI changes include before/after screenshots; capture permission was unavailable in this workspace.

## Status

All code and package checks are green. The Vercel status remains blocked by repository-team authorization for fork deployments.