### PR TITLE
fix(control-plane): preserve Worker fetch receiver

### DIFF
--- a/cloudflare/control-plane/src/cloudflare-api.ts
+++ b/cloudflare/control-plane/src/cloudflare-api.ts
@@ -150,7 +150,11 @@ export class CloudflareAPI {
 
     let response: Response;
     try {
-      response = await this.fetcher(new URL(path, API_BASE), {
+      // Calling a stored global fetch as `this.fetcher(...)` rebinds its
+      // receiver to this API instance. Workers rejects that with an illegal
+      // invocation, so detach the function before invoking it.
+      const fetcher = this.fetcher;
+      response = await fetcher(new URL(path, API_BASE), {
         body,
         headers,
         method: init.method ?? "GET",

--- a/cloudflare/control-plane/test/managed-endpoints.test.ts
+++ b/cloudflare/control-plane/test/managed-endpoints.test.ts
@@ -291,6 +291,18 @@ class FakeCloudflare {
 }
 
 describe("Cloudflare API response contracts", () => {
+  it("does not rebind the Worker fetch receiver", async () => {
+    let receiver: unknown = "not-called";
+    const fetcher: CloudflareFetch = function (this: unknown) {
+      receiver = this;
+      return Promise.resolve(jsonResult([]));
+    };
+    const api = new CloudflareAPI(readConfig(env).cloudflare, fetcher);
+
+    await expect(api.listTunnels("receiver-probe")).resolves.toEqual([]);
+    expect(receiver).toBeUndefined();
+  });
+
   it("keeps redirects manual and rejects them without forwarding credentials", async () => {
     const fetcher = vi.fn<CloudflareFetch>(async (_input, init) => {
       expect(init?.redirect).toBe("manual");


### PR DESCRIPTION
## What changed
- invoke the stored Worker `fetch` function without rebinding it to the `CloudflareAPI` instance
- add a regression test with a receiver-sensitive fetch implementation

## Root cause
Calling the stored global as `this.fetcher(...)` changed its receiver. Cloudflare Workers rejected every API request with `Illegal invocation`, which the endpoint layer surfaced as `cf_network`.

## Live validation
After deploying this focused change, the existing desktop installation provisioned successfully: endpoint status `ready`, tunnel and DNS IDs persisted, the managed connector launched, and the public `/api/health` returned direct HTTP 200 JSON.

## Automated validation
- control-plane tests: 42 passed
- control-plane typecheck: passed
- Wrangler deploy dry-run: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could prevent Cloudflare API requests from completing in Workers environments.
  - Tunnel list results now load successfully without invocation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->