### PR TITLE
fix(openai-compat): support reasoning models and fix openaiCompat con…

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -139,6 +139,24 @@ describe("default fleet", () => {
     });
   });
 
+  it("does not retain an injected OpenAI-compatible URL across config refreshes", () => {
+    const config: AppConfig = {
+      openaiCompat: { url: "https://first.example.test/v1" },
+      instances: {
+        custom: { driver: "openai-compat" },
+      },
+    };
+
+    expect(instanceConfigs(config).custom.config).toEqual({
+      url: "https://first.example.test/v1",
+    });
+    config.openaiCompat = { url: "https://second.example.test/v1" };
+    expect(instanceConfigs(config).custom.config).toEqual({
+      url: "https://second.example.test/v1",
+    });
+    expect(config.instances?.custom.config).toBeUndefined();
+  });
+
   it("adds missing custom-only engines onto an existing product fleet", () => {
     const map = instanceConfigs({ instances: { claude: { driver: "claudeAgent" } } });
     expect(map.claude.driver).toBe("claudeAgent");

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -112,6 +112,33 @@ describe("default fleet", () => {
     expect(map.cursor).toEqual({ driver: "cursorAgent", environment: {} });
   });
 
+  it("carries the saved OpenAI-compatible URL into the live default instance", () => {
+    const map = instanceConfigs({
+      openaiCompat: { key: "secret", url: "https://models.example.test/v1" },
+    });
+    expect(map.openaiCompat.config).toEqual({ url: "https://models.example.test/v1" });
+    expect(map.openaiCompat.environment).toEqual({
+      OPENAI_COMPAT_API_KEY: "secret",
+      OPENAI_COMPAT_URL: "https://models.example.test/v1",
+    });
+  });
+
+  it("preserves a per-instance OpenAI-compatible URL override", () => {
+    const map = instanceConfigs({
+      openaiCompat: { url: "https://workspace.example.test/v1" },
+      instances: {
+        custom: {
+          driver: "openai-compat",
+          config: { url: "https://instance.example.test/v1", apiKeyEnv: "CUSTOM_KEY" },
+        },
+      },
+    });
+    expect(map.custom.config).toEqual({
+      url: "https://instance.example.test/v1",
+      apiKeyEnv: "CUSTOM_KEY",
+    });
+  });
+
   it("adds missing custom-only engines onto an existing product fleet", () => {
     const map = instanceConfigs({ instances: { claude: { driver: "claudeAgent" } } });
     expect(map.claude.driver).toBe("claudeAgent");
@@ -246,7 +273,16 @@ describe("credential env narrowing", () => {
 });
 
 describe("credential env preference", () => {
-  const VARS = ["XAI_API_KEY", "BOX_TOKEN", "OPENCODE_API_KEY", "OMB_TTS_KEY", "OMB_OPENAI_IMAGE_KEY", "COMPOSIO_API_KEY"] as const;
+  const VARS = [
+    "XAI_API_KEY",
+    "OPENAI_COMPAT_API_KEY",
+    "OPENAI_COMPAT_URL",
+    "BOX_TOKEN",
+    "OPENCODE_API_KEY",
+    "OMB_TTS_KEY",
+    "OMB_OPENAI_IMAGE_KEY",
+    "COMPOSIO_API_KEY",
+  ] as const;
   let saved: Record<string, string | undefined>;
 
   beforeEach(() => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -440,6 +440,21 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     const environment = { ...entry.environment };
     for (const [key, value] of injectedEnvironment(cfg, entry.driver)) environment[key] = value;
     entry.environment = environment;
+    // The driver URL is configuration, not a credential. Environment is
+    // intentionally not consulted by ProviderRegistry when it decodes a
+    // driver's config, so carry the workspace default into the transient
+    // instance map while preserving a per-instance override.
+    if (entry.driver === "openai-compat" && cfg.openaiCompat?.url) {
+      const raw = entry.config;
+      if (raw === undefined) {
+        entry.config = { url: cfg.openaiCompat.url };
+      } else if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+        const current = raw as Record<string, unknown>;
+        if (typeof current.url !== "string" || !current.url.trim()) {
+          entry.config = { ...current, url: cfg.openaiCompat.url };
+        }
+      }
+    }
   }
   return map;
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -187,6 +187,9 @@ export function loadConfig(): AppConfig {
   // shadow the save until the next launch.
   cfg.xai = { ...cfg.xai };
   if (process.env.XAI_API_KEY !== undefined) cfg.xai.key = process.env.XAI_API_KEY;
+  cfg.openaiCompat = { ...cfg.openaiCompat };
+  if (process.env.OPENAI_COMPAT_API_KEY !== undefined) cfg.openaiCompat.key = process.env.OPENAI_COMPAT_API_KEY;
+  if (process.env.OPENAI_COMPAT_URL !== undefined) cfg.openaiCompat.url = process.env.OPENAI_COMPAT_URL;
   cfg.composio = { ...cfg.composio };
   if (process.env.COMPOSIO_API_KEY !== undefined) cfg.composio.apiKey = process.env.COMPOSIO_API_KEY;
   cfg.box = { ...cfg.box };
@@ -210,6 +213,7 @@ export function loadConfig(): AppConfig {
 export function syncCredentialEnv(patch: Partial<AppConfig>): void {
   const secrets: Array<[value: string | undefined, name: string]> = [
     [patch.xai?.key, "XAI_API_KEY"],
+    [patch.openaiCompat?.key, "OPENAI_COMPAT_API_KEY"],
     [patch.composio?.apiKey, "COMPOSIO_API_KEY"],
     [patch.box?.token, "BOX_TOKEN"],
     [patch.opencodeGo?.apiKey, "OPENCODE_API_KEY"],
@@ -221,6 +225,10 @@ export function syncCredentialEnv(patch: Partial<AppConfig>): void {
     if (value) process.env[name] = value;
     else delete process.env[name];
   }
+  if (patch.openaiCompat?.url !== undefined) {
+    if (patch.openaiCompat.url) process.env["OPENAI_COMPAT_URL"] = patch.openaiCompat.url;
+    else delete process.env["OPENAI_COMPAT_URL"];
+  }
 }
 
 /** Env names of every workspace credential this process may be holding —
@@ -230,6 +238,8 @@ export function syncCredentialEnv(patch: Partial<AppConfig>): void {
  * child these are someone else's keys riding along in `...process.env`. */
 export const WORKSPACE_CREDENTIAL_ENV = [
   "XAI_API_KEY",
+  "OPENAI_COMPAT_API_KEY",
+  "OPENAI_COMPAT_URL",
   "BOX_TOKEN",
   "OPENCODE_API_KEY",
   "OMB_TTS_KEY",
@@ -274,7 +284,7 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     /* first write */
   }
   const checkedPatch = appConfigSchema.partial().parse(patch);
-  for (const key of ["xai", "composio", "box", "opencodeGo", "tts", "imageGen", "profile", "rooms", "localVm", "features"] as const) {
+  for (const key of ["xai", "openaiCompat", "composio", "box", "opencodeGo", "tts", "imageGen", "profile", "rooms", "localVm", "features"] as const) {
     const section = checkedPatch[key];
     if (!section) continue;
     const current = jsonObjectSchema.safeParse(disk[key]);

--- a/server/config.ts
+++ b/server/config.ts
@@ -436,7 +436,12 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
       if (!Object.hasOwn(map, id)) map[id] = { ...entry };
     }
   }
-  for (const entry of Object.values(map)) {
+  for (const [id, sourceEntry] of Object.entries(map)) {
+    // instanceConfigs() builds a transient runtime map. Never mutate the
+    // caller's persisted entries while injecting workspace defaults: doing so
+    // would turn the first workspace URL into a stale per-instance override.
+    const entry = { ...sourceEntry };
+    map[id] = entry;
     const environment = { ...entry.environment };
     for (const [key, value] of injectedEnvironment(cfg, entry.driver)) environment[key] = value;
     entry.environment = environment;

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -118,4 +118,67 @@ describe("OpenAICompatDriver", () => {
     recorder.stop();
     await inst.dispose();
   });
+
+  it("streams reasoning separately and completes only actual assistant text", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input).endsWith("/models")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        return new Response(
+          'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n' +
+            'data: {"choices":[{"delta":{"content":"answer"}}]}\n' +
+            "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-reasoning-stream",
+      displayName: "Reasoning",
+      enabled: true,
+      config: { url: "https://example.test/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "reasoning-thread", text: "question", model: "vendor/model" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    expect(recorder.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "content.delta", streamKind: "reasoning_text", delta: "thinking" }),
+      expect.objectContaining({ type: "content.delta", streamKind: "assistant_text", delta: "answer" }),
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "answer" }),
+    ]));
+    expect(recorder.events).not.toContainEqual(
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "thinking" }),
+    );
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("uses reasoning as a helper-model fallback when normal content is whitespace", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input).endsWith("/models")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: "  ", reasoning_content: "usable result" } }],
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-reasoning-helper",
+      displayName: "Reasoning helper",
+      enabled: true,
+      config: { url: "https://example.test/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+
+    await expect(inst.generateText?.("question")).resolves.toBe("usable result");
+    await inst.dispose();
+  });
 });

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -113,7 +113,11 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
         signal?: AbortSignal;
         onDelta?: (d: string, streamKind?: "assistant_text" | "reasoning_text") => void;
       },
-    ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
+    ): Promise<{
+      text: string;
+      reasoning: string;
+      usage: { input: number; output: number } | null;
+    }> => {
       const res = await fetch(`${config.url}/chat/completions`, {
         method: "POST",
         headers: {
@@ -135,7 +139,8 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
         const mainContent = typeof msg?.content === "string" ? msg.content : "";
         const reasoningContent = typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "";
         return {
-          text: mainContent || reasoningContent || "",
+          text: mainContent,
+          reasoning: reasoningContent,
           usage: json.usage
             ? {
                 input: json.usage.prompt_tokens ?? 0,
@@ -186,11 +191,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           }
         }
       }
-      // If content was empty but reasoning was emitted, fall back to reasoning text
-      if (!text.trim() && reasoning.trim()) {
-        text = reasoning;
-      }
-      return { text, usage };
+      return { text, reasoning, usage };
     };
 
     const fetchModels = async (): Promise<void> => {
@@ -268,7 +269,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
 
       (async () => {
         try {
-          const { text, usage } = await complete(
+          const { text, reasoning, usage } = await complete(
             messages,
             turn.model || catalog.default,
             {
@@ -286,7 +287,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           appendNative(threadId, {
             dir: "in",
             source: "openai-compat.chat.completions",
-            msg: { textLength: text.length, usage },
+            msg: { textLength: text.length, reasoningLength: reasoning.length, usage },
           });
           if (text.trim()) {
             emit({
@@ -371,12 +372,12 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
         },
       },
       generateText: async (prompt: string) => {
-        const { text } = await complete(
+        const { text, reasoning } = await complete(
           [{ role: "user", content: prompt }],
           catalog.default,
           { stream: false },
         );
-        return text;
+        return text.trim() ? text : reasoning;
       },
       dispose: async () => {
         for (const { abort } of active.values()) abort.abort();

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -37,6 +37,8 @@ export interface OpenAICompatConfig {
   url: string;
   /** Env var (instance environment or process.env) carrying the API key. */
   apiKeyEnv: string;
+  /** Direct API key if configured */
+  key?: string;
 }
 
 function decodeConfig(raw: unknown): OpenAICompatConfig {
@@ -50,6 +52,7 @@ function decodeConfig(raw: unknown): OpenAICompatConfig {
           ? envUrl.replace(/\/+$/, "")
           : "https://openrouter.ai/api/v1",
     apiKeyEnv: typeof o.apiKeyEnv === "string" && o.apiKeyEnv ? o.apiKeyEnv : "OPENAI_COMPAT_API_KEY",
+    key: typeof o.key === "string" && o.key ? o.key : undefined,
   };
 }
 
@@ -81,7 +84,12 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
   async create(input: DriverCreateInput<OpenAICompatConfig>): Promise<ProviderInstance> {
     const { instanceId, config } = input;
     const apiKey =
-      input.environment[config.apiKeyEnv] ?? process.env[config.apiKeyEnv] ?? "";
+      config.key ??
+      input.environment[config.apiKeyEnv] ??
+      input.environment["OPENAI_COMPAT_API_KEY"] ??
+      process.env[config.apiKeyEnv] ??
+      process.env["OPENAI_COMPAT_API_KEY"] ??
+      "";
     const listeners = new Set<RuntimeEventListener>();
     const active = new Map<string, { abort: AbortController; turnId: string }>();
     let catalog = DEFAULT_MODELS;
@@ -100,7 +108,11 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
     const complete = async (
       messages: Array<{ role: string; content: string }>,
       model: string,
-      opts: { stream: boolean; signal?: AbortSignal; onDelta?: (d: string) => void },
+      opts: {
+        stream: boolean;
+        signal?: AbortSignal;
+        onDelta?: (d: string, streamKind?: "assistant_text" | "reasoning_text") => void;
+      },
     ): Promise<{ text: string; usage: { input: number; output: number } | null }> => {
       const res = await fetch(`${config.url}/chat/completions`, {
         method: "POST",
@@ -119,8 +131,11 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
       }
       if (!opts.stream) {
         const json: any = await res.json();
+        const msg = json.choices?.[0]?.message;
+        const mainContent = typeof msg?.content === "string" ? msg.content : "";
+        const reasoningContent = typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "";
         return {
-          text: json.choices?.[0]?.message?.content ?? "",
+          text: mainContent || reasoningContent || "",
           usage: json.usage
             ? {
                 input: json.usage.prompt_tokens ?? 0,
@@ -130,6 +145,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
         };
       }
       let text = "";
+      let reasoning = "";
       let usage: { input: number; output: number } | null = null;
       const reader = res.body!.getReader();
       const decoder = new TextDecoder();
@@ -151,10 +167,16 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           } catch {
             continue;
           }
-          const delta = chunk.choices?.[0]?.delta?.content;
-          if (delta) {
-            text += delta;
-            opts.onDelta?.(delta);
+          const delta = chunk.choices?.[0]?.delta;
+          const contentDelta = typeof delta?.content === "string" ? delta.content : undefined;
+          const reasoningDelta = typeof delta?.reasoning_content === "string" ? delta.reasoning_content : undefined;
+          if (reasoningDelta) {
+            reasoning += reasoningDelta;
+            opts.onDelta?.(reasoningDelta, "reasoning_text");
+          }
+          if (contentDelta) {
+            text += contentDelta;
+            opts.onDelta?.(contentDelta, "assistant_text");
           }
           if (chunk.usage) {
             usage = {
@@ -163,6 +185,10 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
             };
           }
         }
+      }
+      // If content was empty but reasoning was emitted, fall back to reasoning text
+      if (!text.trim() && reasoning.trim()) {
+        text = reasoning;
       }
       return { text, usage };
     };
@@ -248,11 +274,11 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
             {
               stream: true,
               signal: abort.signal,
-              onDelta: (delta) =>
+              onDelta: (delta, streamKind = "assistant_text") =>
                 emit({
                   ...base(threadId, turnId),
                   type: "content.delta",
-                  streamKind: "assistant_text",
+                  streamKind,
                   delta,
                 }),
             },


### PR DESCRIPTION
<!--
Please read CONTRIBUTING.md first — it's short. One concern per PR;
big changes should have an issue agreeing on the approach before code.
-->

## What changed

1. **Reasoning / Thinking Model Support (`server/drivers/openai-compat.ts`)**:
   - Captured `delta.reasoning_content` in SSE streams and emitted live thinking chunks under `streamKind: "reasoning_text"`.
   - Added automatic fallback logic: if a reasoning model consumes its tokens in thinking and returns an empty `content` string, `text` falls back to `reasoning_content` (preventing `(the bot finished without a text reply)` errors).
   - Hardened API key resolution to check `config.key`, `input.environment`, and `process.env`.

2. **Config Persistence & Environment Synchronization (`server/config.ts`)**:
   - Added `"openaiCompat"` to the section merge whitelist in `saveConfig()`.
   - Added `OPENAI_COMPAT_API_KEY` and `OPENAI_COMPAT_URL` environment synchronization across `loadConfig()`, `syncCredentialEnv()`, and `WORKSPACE_CREDENTIAL_ENV`.

## Why

1. **Thinking Model Failures**:
   - Modern reasoning models (GLM-4.5 Flash, DeepSeek-R1, QwQ, Grok) emit their primary chain of thought in `reasoning_content`. When `content` arrived empty, bots failed silently with empty replies.
2. **Config Loss Bug**:
   - `saveConfig()` previously stripped the `openaiCompat` block whenever user settings (such as profile edits) were saved, silently deleting user-configured endpoints and API keys from `~/.openmausbot/config.json`.

## How it was verified

- **Unit Tests**: Ran `npx vitest run server/drivers/openai-compat.test.ts` (6/6 tests passing).
- **Type Checking**: Ran `pnpm typecheck` (`tsc -b && tsc -p tsconfig.server.json`) — clean compile with 0 errors.
- **End-to-End Test**: Verified live multi-turn chat streaming with `glm-4.5-flash` thinking model (full reasoning and text reply generated).
- **Config Persistence**: Verified `openaiCompat` survives successive user profile and room settings saves.

## Screenshots (UI changes)

*N/A — Driver and backend configuration changes only.*

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OpenAI-compatible providers with API keys and URLs.
  * Automatically applies saved provider settings to matching instances.
  * Added reasoning content support for streaming and non-streaming responses.
  * Falls back to reasoning text when standard assistant content is unavailable.

* **Bug Fixes**
  * Preserved instance-specific provider URL and API key overrides.
  * Improved synchronization of provider settings after configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->