### PR TITLE
chore(release): bump version to 0.1.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop release version from 0.1.34 to 0.1.35
- prepare a fresh cross-platform release containing the hosted companion connectivity fixes

## Validation

- parsed `package.json` and asserted version `0.1.35`
- confirmed `v0.1.35` does not already exist in `milind-soni/openmausbot-releases`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.1.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->