### PR TITLE
fix(computer): close VPS viewer review gaps

### DIFF
--- a/src/components/CloudBackendPicker.tsx
+++ b/src/components/CloudBackendPicker.tsx
@@ -19,7 +19,7 @@ export function CloudBackendPicker({
       <div className="text-[12px] font-medium text-ink">Cloud backend</div>
       <div className="mt-0.5 text-[11.5px] text-ink-secondary">
         {value === "vps"
-          ? "Auto only attaches to a VPS container that is already running — a stopped or missing one is never provisioned or started, and the bot quietly works as if no cloud computer existed. Choose Cloud to provision or start it. No interactive desktop tunnel is exposed."
+          ? "Auto reuses a running VPS by default. Enable Start VPS automatically to let Auto create or wake its managed container, or choose Cloud to do it explicitly. Open the live desktop securely from the computer panel."
           : "Box is the default hosted computer. Choose Self-hosted VPS to use your SSH-configured Linux Docker host."}
       </div>
       <div className="mt-2 flex overflow-hidden rounded-lg border border-hairline/40">

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -591,11 +591,12 @@ export function ComputerPanel({ bot }: { bot: Bot }) {
       }
     } catch (e) {
       fallbackTab?.close();
+      // Release the bot before waiting on best-effort tunnel cleanup. A sick
+      // SSH process must never leave the agent paused indefinitely.
+      if (tookControl) await requestControl("release").catch(() => {});
       if (phase === "ready" && cloudBackend === "vps") {
         await api(`/api/bots/${bot.id}/computer/viewer-close`, { method: "POST", body: "{}" }).catch(() => {});
       }
-      // A failed viewer must not leave the bot's hands paused indefinitely.
-      if (tookControl) await requestControl("release").catch(() => {});
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setPending(null);


### PR DESCRIPTION
## Summary

Follow-up to #458 after review identified two still-relevant UI edge cases:

- release bot control before waiting for best-effort VPS tunnel cleanup, so a stuck cleanup request cannot leave the bot paused
- replace the stale VPS backend copy with the shipped Auto opt-in and secure live-desktop behavior

The Companion-exit finding from #458 is already covered more comprehensively on current main by the new lifecycle listener, so this follow-up deliberately does not duplicate that implementation.

## Verification

- pnpm typecheck
- focused VPS renderer test
- clean rebase on current main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified that Auto can create or wake its managed VPS when automatic startup is enabled.
  * Clarified that the live desktop is accessible through the computer panel.

* **Bug Fixes**
  * Improved control release and cleanup when opening the desktop viewer fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->