### PR TITLE
fix(diagnostics): redact OpenAI-compatible environment

### DIFF
--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -11,6 +11,8 @@
 // asserts the two lists never drift apart.
 export const CREDENTIAL_ENV_NAMES = [
   "XAI_API_KEY",
+  "OPENAI_COMPAT_API_KEY",
+  "OPENAI_COMPAT_URL",
   "BOX_TOKEN",
   "OPENCODE_API_KEY",
   "OMB_TTS_KEY",


### PR DESCRIPTION
Follow-up to #482. Keep the Electron diagnostics redaction list in parity with `WORKSPACE_CREDENTIAL_ENV` after adding the OpenAI-compatible provider environment.

Verified: 24 diagnostics tests, Electron syntax checks, and TypeScript checks pass.