### PR TITLE
fix(voice): keep system runner testable cross-platform

### DIFF
--- a/server/tts/index.ts
+++ b/server/tts/index.ts
@@ -79,7 +79,9 @@ export async function listVoices(cfg: AppConfig, run?: systemVoices.Runner): Pro
 export function speak(cfg: AppConfig, text: string, voiceId?: string, run?: systemVoices.Runner) {
   if (voiceProvider(cfg) === "system") {
     const voice = voiceId || cfg.tts?.voice;
-    if (!systemVoices.systemVoicesAvailable()) throw new NoVoiceConfigured("key");
+    // An injected runner is the cross-platform test seam for `/usr/bin/say`;
+    // production calls omit it and remain strictly Darwin-gated.
+    if (!systemVoices.systemVoicesAvailable() && !run) throw new NoVoiceConfigured("key");
     if (!voice) throw new NoVoiceConfigured("voice");
     return systemVoices.synthesizeSystem(text, voice, run);
   }


### PR DESCRIPTION
Follow-up to #415. Keep production system voices Darwin-only while allowing the explicitly injected fake `say` runner to exercise synthesis in Linux and Windows CI.

Verified: 14 TTS tests and TypeScript checks pass.