### PR TITLE
feat(ios): simplify phone onboarding and settings

### DIFF
--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -25,10 +25,12 @@ The first version includes:
   Box computer view. The loopback-only VPS SSH viewer remains desktop-only.
 - Markdown rendering and Keychain storage for the phone's pairing trust.
 
-It is foreground-only. Push notifications, closed-app background delivery,
-voice, and App Store release automation are not part of this version. The
-optional hosted transport connects to the user's own computer; it is not a
-cloud transcript store and cannot wake a terminated iOS app.
+Alerts work while the app is open or for the short period it remains connected
+after moving to the background. Once iOS suspends or closes the app, new alerts
+cannot arrive. Closed-app push delivery, voice, and App Store release
+automation are not part of this version. The optional hosted transport connects
+to the user's own computer; it is not a cloud transcript store and cannot wake
+a terminated iOS app.
 
 The Mac must be running OpenMausBot and must not be asleep. Desktop
 **Settings → Phone** offers an off-by-default **Keep this computer awake**
@@ -223,10 +225,11 @@ the requested gap was replayed. The client:
 Unknown message and frame kinds degrade safely instead of failing an entire
 response, and one malformed fleet record does not hide every healthy chat.
 Screen frames are off by default and enabled only while a computer view is
-visible. Backgrounding deliberately closes the stream; foregrounding
-reconnects from the saved cursor. A hello cursor is committed only after a
-cold hydration succeeds; replayed streams advance it one folded frame at a
-time, so a disconnect during recovery cannot skip the remaining gap.
+visible. Backgrounding keeps the stream for only the short grace period iOS
+allows, then closes it; foregrounding reconnects from the saved cursor. A hello
+cursor is committed only after a cold hydration succeeds; replayed streams
+advance it one folded frame at a time, so a disconnect during recovery cannot
+skip the remaining gap.
 
 ## Source layout
 
@@ -282,9 +285,9 @@ distribution scope:
    search with exact-message landing, transcript export/share, reactions, and
    edit/version controls. Archived or hidden chat management remains desktop-only.
 3. **Notifications:** native permission, live/replayed alerts, time-sensitive
-   approvals, badges, and background reconciliation are in the app. Closed-app
-   delivery still requires project-owned APNs credentials and a hosted relay;
-   Tailscale cannot wake a terminated iOS process.
+   approvals, badges, and a brief background grace period are in the app.
+   Closed-app delivery still requires project-owned APNs credentials and a
+   hosted relay; Tailscale cannot wake a terminated iOS process.
 4. **Distribution:** signing, bundle ownership, privacy declarations,
    TestFlight, and App Store review material. Swift tests and an unsigned
    simulator build already run in the repository CI.

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -2,41 +2,45 @@
 
 The iOS app is a thin, native client for the OpenMausBot instance running on
 your Mac. The Mac remains the only machine that owns agent processes,
-credentials, SQLite data, transcripts, and computers. The phone discovers or
-is told how to reach the Mac, pairs once, and then uses the same HTTP and SSE
-contract as the desktop client through a restricted sidecar.
+credentials, SQLite data, transcripts, and computers. The iPhone trusts a Mac
+by scanning the QR code shown in desktop **Settings → Phone**; it does not need
+an OpenMausBot account of its own.
 
 ## Current status
 
 The first version includes:
 
-- Bonjour discovery on the same LAN and manual address entry.
-- Remote access through a Tailscale MagicDNS name or an optional
-  account-provisioned HTTPS address.
-- QR-first pairing with a short-lived, single-use credential and a six-digit
-  manual fallback, plus per-device tokens, device listing, and revocation.
+- QR-first pairing from desktop **Settings → Phone**, with the computer name
+  confirmed on the iPhone before it connects.
+- Automatic routing through the address carried by the QR. This can include a
+  Tailscale MagicDNS name when both devices share a tailnet, or hosted HTTPS
+  when the desktop owner has enabled it.
+- Nearby computers, a manual address, and a six-digit code under **Other ways
+  to connect** when the QR path is unavailable.
+- Secure per-device trust, device listing, and revocation.
 - Bot and room lists, paged transcripts, sending, interruption, and unread
   state.
 - Approvals and questions, including narrow “always allow” grants.
 - Resumable SSE, streamed reply text, reconnect hydration, and an opt-in live
   Box computer view. The loopback-only VPS SSH viewer remains desktop-only.
-- Markdown rendering and Keychain storage for the device token.
+- Markdown rendering and Keychain storage for the phone's pairing trust.
 
 It is foreground-only. Push notifications, closed-app background delivery,
 voice, and App Store release automation are not part of this version. The
 optional hosted transport connects to the user's own computer; it is not a
 cloud transcript store and cannot wake a terminated iOS app.
 
-The Mac must be running OpenMausBot and must not be asleep. Companion Settings
-offers an off-by-default **Keep this computer awake** switch that prevents
-system sleep while Companion is on; the display may still turn off. A sleeping
-or powered-off computer cannot receive phone requests or run its local
-routines, including through the optional hosted transport.
+The Mac must be running OpenMausBot and must not be asleep. Desktop
+**Settings → Phone** offers an off-by-default **Keep this computer awake**
+switch that prevents system sleep while phone access is on; the display may
+still turn off. A sleeping or powered-off computer cannot receive phone
+requests or run its local routines, including through the optional hosted
+transport.
 
 ## Runtime architecture
 
 ```text
- iPhone (bearer token in Keychain)
+ iPhone (pairing trust in Keychain)
        │                         │
        │ trusted LAN/Tailscale   │ optional hosted HTTPS
        ▼                         ▼
@@ -95,45 +99,46 @@ not belong in the message database.
 
 ### Same Wi-Fi
 
-The sidecar advertises `_openmausbot._tcp` over Bonjour. The app browses with
-`NWBrowser`, resolves the chosen service, and connects directly. If multicast
-is unavailable, the desktop shows the LAN address for manual entry.
+The QR code is still the primary path on the same Wi-Fi. If it is unavailable,
+the user can open **Other ways to connect** and choose a nearby computer or
+enter the address shown in desktop Phone settings. Nearby discovery does not
+run until the user opens that fallback.
 
-LAN traffic is plain HTTP. Use it only on a network you trust. Device tokens
-are bearer credentials, so someone able to observe that LAN traffic could copy
-one until the device is revoked.
+Nearby discovery uses Bonjour and direct LAN traffic. Use it only on a network
+you trust.
 
-Choosing a LAN or Bonjour address is therefore explicit. Once the app is using
-a hosted or Tailscale route, automatic reconnection stays within those
-protected transports and never sends a pairing credential or device bearer to
-an old private address on the current Wi-Fi. Moving back to cleartext LAN
-requires choosing that computer/address again.
+Choosing a nearby computer or manually entering a LAN address is therefore an
+explicit fallback. Once the app is using a hosted or Tailscale route,
+automatic reconnection stays within those protected transports. Moving back to
+direct LAN requires choosing that computer or address again.
 
 ### Tailscale
 
 Tailscale is the recommended route away from home and on Wi-Fi networks that
-isolate clients. Both devices join the same tailnet and the phone uses the
-Mac’s MagicDNS name, such as `macbook.example.ts.net:8810`.
+isolate clients. When both devices share a tailnet, OpenMausBot can place the
+Mac's MagicDNS name in the pairing QR automatically. Scan the QR normally; no
+address entry is required. Manual entry remains available only as a fallback
+when a QR invitation is unavailable or does not contain that route.
 
 The URL is still `http`, but the path is encrypted and authenticated by
 WireGuard inside the tailnet. Use the MagicDNS name rather than the
 `100.64.0.0/10` address: App Transport Security exceptions are domain-based,
 and `ios/project.yml` narrowly allows insecure HTTP for `ts.net` subdomains.
-Bonjour does not cross the tailnet, so remote pairing uses manual address
-entry.
 
 Tailscale is optional. The direct path does not use an OpenMausBot-operated
 relay or create a cloud copy of local transcript data.
 
 ### Optional hosted HTTPS
 
-In desktop **Settings → Companion**, **Use your phone anywhere** accepts a
-passwordless email code and provisions one opaque HTTPS address for that
-computer. The desktop runs a pinned `cloudflared` connector outbound to
-Cloudflare; no inbound router configuration or Tailscale installation is
-required. The sidecar advertises the hosted address in pairing invitations only
-after the route has passed an end-to-end health check. LAN, Bonjour, manual
-addresses, and Tailscale continue to work without signing in.
+In desktop **Settings → Phone**, **Use your phone anywhere** accepts a
+passwordless email code and provisions one HTTPS address for that computer.
+This desktop sign-in is only for hosted HTTPS. The iPhone never signs in; it
+trusts the computer through the same pairing QR. Nearby, manual, and Tailscale
+connections continue to work without an account.
+
+The desktop runs an outbound connector to Cloudflare, so no inbound router
+configuration or Tailscale installation is required. The hosted address is
+included in a pairing invitation only after it is ready.
 
 Cloudflare terminates and proxies the encrypted connection to the connector.
 The OpenMausBot control plane stores account and installation metadata plus
@@ -150,21 +155,17 @@ local port cannot inherit the public route.
 
 ## Pairing and device security
 
-1. The user enables Companion in desktop Settings and starts pairing.
-2. The desktop opens a two-minute pairing window. Its QR contains the reachable
-   address and a high-entropy, single-use credential; the visible six-digit code
-   remains available for manual entry and older app builds.
-3. The phone scans and validates the invitation, shows the computer and address,
-   and asks the user to confirm before it connects. Scanning never auto-pairs.
-4. The phone sends the one-time credential and a device name to `POST /api/pair`.
-   Redeeming either the QR credential or manual code closes the entire window,
-   so neither can be replayed.
-5. The sidecar returns a separate random device token once and stores only its
-   SHA-256 digest.
-6. The phone stores the device token in Keychain and sends it as a bearer token.
-   It never persists the QR credential or manual code.
-7. Revoking the device on the Mac invalidates future requests and sends the
-   phone back to pairing.
+1. On the Mac, open **Settings → Phone**, turn on phone access, and choose
+   **Set up a phone**.
+2. On the iPhone, choose **Connect my computer** and scan the QR.
+3. Confirm the computer name and **Secure connection**. The phone stores its
+   trust securely in Keychain; no iPhone account is required.
+4. If scanning is unavailable, open **Other ways to connect** for a nearby
+   computer, manual address, or six-digit code.
+5. Revoking the phone on the Mac removes its access and lets it pair again.
+
+The Mac must remain awake with OpenMausBot running for chats, approvals, and
+routines to work, including through hosted HTTPS or Tailscale.
 
 After pairing, the phone periodically reads the authenticated, sidecar-owned
 `GET /api/companion/endpoints` snapshot. This lets an existing phone learn a
@@ -172,12 +173,9 @@ new hosted address—or its withdrawal—without another pairing ceremony. The
 route never reaches the harness and returns only the computer name plus a
 bounded list of connection origins.
 
-This mirrors the direct-pairing security shape used by T3 Code: a high-entropy
-bootstrap credential, explicit confirmation of the scanned target, and a
-one-time exchange for a securely stored long-lived credential. An OpenMausBot
-account is not required for LAN or Tailscale. The optional hosted route requires
-the desktop owner to authenticate before provisioning, while the phone still
-uses the same per-computer pairing credential.
+An OpenMausBot account is not required for nearby, manual, or Tailscale
+connections. Only the desktop owner signs in when enabling the optional hosted
+HTTPS route; the iPhone always uses the same QR trust flow.
 
 The device-facing socket rejects browser `Origin` headers before reading a
 token. Its route policy in `companion/src/routes.ts` is default-deny: a new

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -164,17 +164,15 @@ struct ChatListView: View {
 
     // MARK: - Header
 
-    /// You (the computer you are paired with) on the left, settings on the
-    /// right, and where you are in between. Glass tiles, like the system's.
+    /// The paired computer's profile on the left, one settings action on the
+    /// right, and where you are in between. The avatar is identity, not a
+    /// second hidden route to the same screen.
     private var header: some View {
         HStack(alignment: .center) {
-            NavigationLink { SettingsView() } label: {
-                ProfileAvatar(name: session.connection?.name ?? "You", size: 30)
-                    .frame(width: 44, height: 44)
-            }
-            .buttonStyle(.plain)
-            .glassCapsule()
-            .accessibilityLabel("Settings")
+            ProfileAvatar(name: session.connection?.name ?? "You", size: 30)
+                .frame(width: 44, height: 44)
+                .glassCapsule(interactive: false)
+                .accessibilityLabel("Connected to \(session.connection?.name ?? "your computer")")
 
             Spacer(minLength: 8)
 

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -68,11 +68,18 @@ struct RootView: View {
             case .notificationPrompt:
                 NotificationOnboardingView {
                     hasSeenNotificationPrompt = true
+                    pairingRequested = false
                 }
                 .onAppear { hasSeenWelcome = true }
             case .chats:
                 ChatListView()
-                    .onAppear { hasSeenWelcome = true }
+                    .onAppear {
+                        hasSeenWelcome = true
+                        // This is either an existing pairing or a new pairing
+                        // which needed no notification education. Do not let
+                        // a later voluntary unpair reopen Pairing by itself.
+                        pairingRequested = false
+                    }
             case .revoked:
                 UnpairedView {
                     session.signOut()
@@ -113,6 +120,7 @@ struct RootView: View {
             hasSeenWelcome: hasSeenWelcome,
             pairingRequested: pairingRequested,
             hasPendingPairingInvite: session.pairingInvite != nil,
+            notificationOnboardingRequested: pairingRequested,
             hasSeenNotificationPrompt: hasSeenNotificationPrompt,
             notificationPermissionIsUndetermined: shouldOfferNotificationOnboarding
         ))

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -1,9 +1,10 @@
 // App entry, and the one place that decides when the event stream lives.
 //
 // A phone is not a desktop: the stream is torn down the moment the app
-// leaves the screen, because iOS is going to kill it anyway and doing it
-// deliberately means the cursor is written down at a known point. Coming
-// back asks the harness what was missed rather than asking for everything.
+// leaves the screen's short background grace period, because iOS is going to
+// suspend it anyway and doing it deliberately means the cursor is written
+// down at a known point. Coming back asks the harness what was missed rather
+// than asking for everything.
 import SwiftUI
 import CompanionCore
 import UserNotifications
@@ -41,6 +42,8 @@ struct RootView: View {
     @EnvironmentObject private var session: Session
     @AppStorage("companion.onboarding.welcomeSeen") private var hasSeenWelcome = false
     @AppStorage("companion.onboarding.notificationsSeen") private var hasSeenNotificationPrompt = false
+    @AppStorage(CompanionOnboardingPreferences.pendingNotificationOnboardingKey)
+    private var notificationOnboardingPending = false
     @State private var pairingRequested = false
 
     var body: some View {
@@ -68,6 +71,7 @@ struct RootView: View {
             case .notificationPrompt:
                 NotificationOnboardingView {
                     hasSeenNotificationPrompt = true
+                    notificationOnboardingPending = false
                     pairingRequested = false
                 }
                 .onAppear { hasSeenWelcome = true }
@@ -79,6 +83,7 @@ struct RootView: View {
                         // which needed no notification education. Do not let
                         // a later voluntary unpair reopen Pairing by itself.
                         pairingRequested = false
+                        reconcileNotificationOnboarding()
                     }
             case .revoked:
                 UnpairedView {
@@ -91,6 +96,16 @@ struct RootView: View {
             guard invite != nil else { return }
             hasSeenWelcome = true
             pairingRequested = true
+        }
+        .onAppear { reconcileNotificationOnboarding() }
+        .onChange(of: session.notificationAuthorizationResolved) { _, _ in
+            reconcileNotificationOnboarding()
+        }
+        .onChange(of: session.notificationAuthorization) { _, _ in
+            reconcileNotificationOnboarding()
+        }
+        .onChange(of: notificationOnboardingPending) { _, isPending in
+            if isPending { reconcileNotificationOnboarding() }
         }
         .alert(
             "Something went wrong",
@@ -120,20 +135,28 @@ struct RootView: View {
             hasSeenWelcome: hasSeenWelcome,
             pairingRequested: pairingRequested,
             hasPendingPairingInvite: session.pairingInvite != nil,
-            notificationOnboardingRequested: pairingRequested,
+            notificationOnboardingPending: notificationOnboardingPending,
             hasSeenNotificationPrompt: hasSeenNotificationPrompt,
-            notificationPermissionIsUndetermined: shouldOfferNotificationOnboarding
+            notificationAuthorization: notificationAuthorizationState
         ))
     }
 
-    private var shouldOfferNotificationOnboarding: Bool {
+    private var notificationAuthorizationState: CompanionNotificationAuthorizationState {
         #if DEBUG
         // Store-preview runs are deterministic screenshot fixtures, not a
         // first pairing, and must keep landing on the requested chat surface.
-        if ProcessInfo.processInfo.arguments.contains("-store-preview") { return false }
+        if ProcessInfo.processInfo.arguments.contains("-store-preview") { return .determined }
         #endif
-        return session.notificationAuthorizationResolved &&
-            session.notificationAuthorization == .notDetermined
+        guard session.notificationAuthorizationResolved else { return .unresolved }
+        return session.notificationAuthorization == .notDetermined ? .notDetermined : .determined
+    }
+
+    private func reconcileNotificationOnboarding() {
+        notificationOnboardingPending = CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: notificationOnboardingPending,
+            hasCompletedStep: hasSeenNotificationPrompt,
+            authorization: notificationAuthorizationState
+        )
     }
 
     private func startPairing() {

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -5,6 +5,8 @@
 // deliberately means the cursor is written down at a known point. Coming
 // back asks the harness what was missed rather than asking for everything.
 import SwiftUI
+import CompanionCore
+import UserNotifications
 
 @main
 struct CompanionApp: App {
@@ -37,17 +39,51 @@ struct CompanionApp: App {
 
 struct RootView: View {
     @EnvironmentObject private var session: Session
+    @AppStorage("companion.onboarding.welcomeSeen") private var hasSeenWelcome = false
+    @AppStorage("companion.onboarding.notificationsSeen") private var hasSeenNotificationPrompt = false
+    @State private var pairingRequested = false
 
     var body: some View {
         Group {
-            switch session.status {
-            case .unpaired:
-                PairingView()
-            case .unauthorized:
-                UnpairedView()
-            default:
+            switch route {
+            case .welcome:
+                CompanionWelcomeView(
+                    onConnect: startPairing,
+                    onSkip: {
+                        hasSeenWelcome = true
+                        pairingRequested = false
+                    }
+                )
+            case .pairing:
+                PairingView {
+                    hasSeenWelcome = true
+                    pairingRequested = false
+                }
+                .onAppear {
+                    hasSeenWelcome = true
+                    pairingRequested = true
+                }
+            case .unpairedHome:
+                UnpairedHomeView(onConnect: startPairing)
+            case .notificationPrompt:
+                NotificationOnboardingView {
+                    hasSeenNotificationPrompt = true
+                }
+                .onAppear { hasSeenWelcome = true }
+            case .chats:
                 ChatListView()
+                    .onAppear { hasSeenWelcome = true }
+            case .revoked:
+                UnpairedView {
+                    session.signOut()
+                    startPairing()
+                }
             }
+        }
+        .onChange(of: session.pairingInvite) { _, invite in
+            guard invite != nil else { return }
+            hasSeenWelcome = true
+            pairingRequested = true
         }
         .alert(
             "Something went wrong",
@@ -62,22 +98,59 @@ struct RootView: View {
             Text(message)
         }
     }
+
+    private var route: CompanionOnboardingRoute {
+        let pairingState: CompanionPairingState
+        if session.status == .unauthorized {
+            pairingState = .revoked
+        } else if session.connection != nil {
+            pairingState = .paired
+        } else {
+            pairingState = .unpaired
+        }
+        return CompanionOnboardingRouter.route(for: .init(
+            pairingState: pairingState,
+            hasSeenWelcome: hasSeenWelcome,
+            pairingRequested: pairingRequested,
+            hasPendingPairingInvite: session.pairingInvite != nil,
+            hasSeenNotificationPrompt: hasSeenNotificationPrompt,
+            notificationPermissionIsUndetermined: shouldOfferNotificationOnboarding
+        ))
+    }
+
+    private var shouldOfferNotificationOnboarding: Bool {
+        #if DEBUG
+        // Store-preview runs are deterministic screenshot fixtures, not a
+        // first pairing, and must keep landing on the requested chat surface.
+        if ProcessInfo.processInfo.arguments.contains("-store-preview") { return false }
+        #endif
+        return session.notificationAuthorizationResolved &&
+            session.notificationAuthorization == .notDetermined
+    }
+
+    private func startPairing() {
+        hasSeenWelcome = true
+        pairingRequested = true
+    }
 }
 
 /// The token stopped working. Almost always because someone revoked this
 /// phone on the computer — which is exactly what that button is for, so the
 /// honest thing is to say so and offer to pair again.
 struct UnpairedView: View {
-    @EnvironmentObject private var session: Session
+    let onPairAgain: () -> Void
 
     var body: some View {
-        ContentUnavailableView {
-            Label("This phone was unpaired", systemImage: "lock.slash")
-        } description: {
-            Text("It was removed from the computer's companion settings, or the pairing was reset.")
-        } actions: {
-            Button("Pair again") { session.signOut() }
-                .buttonStyle(.borderedProminent)
+        NavigationStack {
+            ContentUnavailableView {
+                Label("This phone was unpaired", systemImage: "lock.slash")
+            } description: {
+                Text("The connection was removed on your computer. Pair again to keep using your chats here.")
+            } actions: {
+                Button("Pair again", action: onPairAgain)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+            }
         }
     }
 }

--- a/ios/App/ComputerView.swift
+++ b/ios/App/ComputerView.swift
@@ -86,7 +86,7 @@ struct ComputerView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(openingDesktop)
-                    Text("Interactive VNC session. Access must be enabled for this phone in the Mac's Companion settings.")
+                    Text("Interactive VNC session. Access must be enabled for this phone in the Mac's Phone settings.")
                         .font(.caption)
                         .foregroundStyle(Color.white.opacity(0.6))
                         .multilineTextAlignment(.center)

--- a/ios/App/Discovery.swift
+++ b/ios/App/Discovery.swift
@@ -134,7 +134,7 @@ final class Discovery: ObservableObject {
            Int(code) == kDNSServiceErr_PolicyDenied {
             return "Local Network access is off. Enable it in iPhone Settings, or enter a Tailscale address below."
         }
-        return "Local discovery isn't available right now. Enter the address shown by Companion below."
+        return "Local discovery isn't available right now. Enter the address shown in Phone settings."
     }
 
     /// Resolve a browse result to something `Connection` can hold.

--- a/ios/App/OnboardingViews.swift
+++ b/ios/App/OnboardingViews.swift
@@ -134,7 +134,7 @@ struct UnpairedHomeView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    Text("On your computer, open OpenMausBot → Settings → Companion.")
+                    Text("On your computer, open OpenMausBot → Settings → Phone.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)

--- a/ios/App/OnboardingViews.swift
+++ b/ios/App/OnboardingViews.swift
@@ -194,7 +194,7 @@ struct NotificationOnboardingView: View {
                 VStack(spacing: 10) {
                     Text("Stay in the loop")
                         .font(.largeTitle.bold())
-                    Text("Get an alert when a bot needs approval or finishes important work.")
+                    Text("Get alerts while OpenMausBot is open or was recently in the background. Alerts stop after iOS fully suspends or closes the app.")
                         .font(.title3)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)

--- a/ios/App/OnboardingViews.swift
+++ b/ios/App/OnboardingViews.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+struct CompanionWelcomeView: View {
+    let onConnect: () -> Void
+    let onSkip: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 28) {
+                Spacer(minLength: 28)
+
+                ZStack {
+                    RoundedRectangle(cornerRadius: 32, style: .continuous)
+                        .fill(MausPalette.color("blue").opacity(0.12))
+                        .frame(width: 148, height: 148)
+                    MausAvatar(color: "blue", size: 108, state: .happy, animated: false)
+                        .accessibilityHidden(true)
+                }
+
+                VStack(spacing: 12) {
+                    Text("Take your bots with you")
+                        .font(.largeTitle.bold())
+                        .multilineTextAlignment(.center)
+                    Text("Open chats, approve actions, and send new work from your iPhone.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+
+                VStack(spacing: 18) {
+                    WelcomeBenefit(
+                        icon: "bubble.left.and.bubble.right.fill",
+                        title: "Your chats, in your pocket",
+                        detail: "Pick up the same conversations from your computer."
+                    )
+                    WelcomeBenefit(
+                        icon: "checkmark.circle.fill",
+                        title: "Respond when a bot needs you",
+                        detail: "Review approvals without going back to your desk."
+                    )
+                    WelcomeBenefit(
+                        icon: "lock.shield.fill",
+                        title: "Private by design",
+                        detail: "You choose which trusted computer this phone connects to."
+                    )
+                }
+                .padding(.top, 4)
+
+                Spacer(minLength: 10)
+            }
+            .padding(.horizontal, 28)
+            .frame(maxWidth: 560)
+            .frame(maxWidth: .infinity)
+        }
+        .background {
+            LinearGradient(
+                colors: [MausPalette.color("blue").opacity(0.10), Color.clear],
+                startPoint: .top,
+                endPoint: .center
+            )
+            .ignoresSafeArea()
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 10) {
+                Button(action: onConnect) {
+                    Text("Connect my computer")
+                        .frame(maxWidth: .infinity)
+                }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                Button("Not now", action: onSkip)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 14)
+            .padding(.bottom, 8)
+            .background(.ultraThinMaterial)
+        }
+    }
+}
+
+private struct WelcomeBenefit: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(MausPalette.color("blue"))
+                .frame(width: 30, height: 30)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+struct UnpairedHomeView: View {
+    let onConnect: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    Spacer(minLength: 72)
+
+                    ZStack {
+                        Circle()
+                            .fill(MausPalette.color("blue").opacity(0.12))
+                            .frame(width: 112, height: 112)
+                        Image(systemName: "laptopcomputer.and.iphone")
+                            .font(.system(size: 42, weight: .medium))
+                            .foregroundStyle(MausPalette.color("blue"))
+                    }
+                    .accessibilityHidden(true)
+
+                    VStack(spacing: 8) {
+                        Text("Connect when you're ready")
+                            .font(.title2.bold())
+                        Text("Pair this iPhone with OpenMausBot to see your chats and respond to your bots.")
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Text("On your computer, open OpenMausBot → Settings → Companion.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    Spacer(minLength: 30)
+                }
+                .padding(28)
+                .frame(maxWidth: 520)
+                .frame(maxWidth: .infinity)
+            }
+            .safeAreaInset(edge: .bottom) {
+                Button(action: onConnect) {
+                    Text("Connect computer")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 14)
+                .background(.ultraThinMaterial)
+            }
+            .navigationTitle("OpenMausBot")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        SettingsView(onConnect: onConnect)
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                    .accessibilityLabel("Settings")
+                }
+            }
+        }
+    }
+}
+
+struct NotificationOnboardingView: View {
+    @EnvironmentObject private var session: Session
+    @State private var enabling = false
+    let onContinue: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 10) {
+                Spacer(minLength: 36)
+
+                ZStack {
+                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                        .fill(MausPalette.color("green").opacity(0.12))
+                        .frame(width: 132, height: 132)
+                    Image(systemName: "bell.badge.fill")
+                        .font(.system(size: 48, weight: .medium))
+                        .foregroundStyle(MausPalette.color("green"))
+                }
+                .accessibilityHidden(true)
+
+                VStack(spacing: 10) {
+                    Text("Stay in the loop")
+                        .font(.largeTitle.bold())
+                    Text("Get an alert when a bot needs approval or finishes important work.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.top, 18)
+
+                VStack(alignment: .leading, spacing: 14) {
+                    Label("Approvals that are waiting for you", systemImage: "checkmark.circle")
+                    Label("Finished work and important updates", systemImage: "sparkles")
+                }
+                .font(.headline)
+                .padding(.top, 18)
+
+                Spacer(minLength: 24)
+            }
+            .padding(28)
+            .frame(maxWidth: 560)
+            .frame(maxWidth: .infinity)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 10) {
+                Button {
+                    enabling = true
+                    Task {
+                        await session.enableNotifications()
+                        enabling = false
+                        onContinue()
+                    }
+                } label: {
+                    HStack {
+                        if enabling { ProgressView().tint(.white) }
+                        Text("Enable notifications")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(enabling)
+
+                Button("Not now", action: onContinue)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .disabled(enabling)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+            .background(.ultraThinMaterial)
+        }
+    }
+}

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -17,7 +17,7 @@ struct PairingView: View {
     /// was lost, repeating this same logical request recovers its token.
     @State private var pairRequestId: String?
     @State private var chosen: Connection?
-    @State private var pairing = false
+    @State private var submission = CompanionPairingSubmissionState()
     @State private var failure: String?
     @State private var showingScanner = false
     @State private var showingOtherWays = false
@@ -29,6 +29,8 @@ struct PairingView: View {
     init(onCancel: @escaping () -> Void = {}) {
         self.onCancel = onCancel
     }
+
+    private var pairing: Bool { submission.isInFlight }
 
     var body: some View {
         NavigationStack {
@@ -57,6 +59,7 @@ struct PairingView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Not now", action: onCancel)
+                        .disabled(!submission.allowsNavigation)
                 }
             }
             .onAppear {
@@ -83,6 +86,7 @@ struct PairingView: View {
                     return nil
                 }
             }
+            .interactiveDismissDisabled(pairing)
         }
     }
 
@@ -264,15 +268,23 @@ struct PairingView: View {
                     .foregroundStyle(MausPalette.color("green"))
             }
 
-            DisclosureGroup("Connection details") {
-                Text(connection.displayAddress)
+            VStack(alignment: .leading, spacing: 7) {
+                Text("Computer address")
+                    .font(.subheadline.weight(.semibold))
+                Text(connection.pairingConsentOrigin)
                     .font(.footnote.monospaced())
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 8)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Make sure this is the computer you expect before connecting.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
-            .font(.subheadline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(14)
+            .background(Color(uiColor: .tertiarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityElement(children: .combine)
 
             if let credential = scannedCredential {
                 if !connectionIsProtected(connection) {
@@ -285,7 +297,7 @@ struct PairingView: View {
 
                 Button {
                     Haptics.selection()
-                    Task { await submit(connection, credential: credential) }
+                    beginSubmission(connection, credential: credential)
                 } label: {
                     HStack {
                         if pairing { ProgressView().tint(.white) }
@@ -316,7 +328,7 @@ struct PairingView: View {
 
                     Button {
                         Haptics.selection()
-                        Task { await submit(connection, credential: code) }
+                        beginSubmission(connection, credential: code)
                     } label: {
                         HStack {
                             if pairing { ProgressView().tint(.white) }
@@ -339,6 +351,7 @@ struct PairingView: View {
                 failure = nil
             }
             .foregroundStyle(.secondary)
+            .disabled(!submission.allowsNavigation)
         }
         .padding(22)
         .background(Color(uiColor: .secondarySystemGroupedBackground))
@@ -377,10 +390,26 @@ struct PairingView: View {
         }
     }
 
+    @MainActor
+    private func beginSubmission(_ connection: Connection, credential: String) {
+        guard submission.begin() else { return }
+        Task { await submit(connection, credential: credential) }
+    }
+
+    @MainActor
     private func submit(_ connection: Connection, credential: String) async {
-        pairing = true
         failure = nil
-        defer { pairing = false }
+        defer {
+            submission.finish()
+            // A deep link received during the commit cannot replace the
+            // consent screen. If this request failed, present it only after
+            // the in-flight request has fully settled.
+            if session.connection == nil {
+                accept(session.pairingInvite)
+            } else {
+                session.consumePairingInvite()
+            }
+        }
         let cameFromScanner = scannedCredential != nil
         let requestId = pairRequestId ?? UUID().uuidString
         pairRequestId = requestId
@@ -413,7 +442,7 @@ struct PairingView: View {
     }
 
     private func accept(_ invite: PairingInvite?) {
-        guard let invite else { return }
+        guard submission.allowsNavigation, let invite else { return }
         choiceGeneration += 1
         chosen = invite.connection
         scannedCredential = invite.credential

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -1,10 +1,5 @@
-// Pairing: scan the computer's QR, confirm its identity, and connect.
-//
-// Two ways in, because discovery is allowed to fail. Bonjour finds the
-// computer by name when the network cooperates; when it does not — a guest
-// network with multicast off, a responder that could not take port 5353 —
-// the address the desktop panel prints is typed instead. Neither path is a
-// fallback bolted on: the desktop panel changes its own wording to match.
+// Pairing: make QR scanning the obvious path, then keep discovery and manual
+// entry available without making network plumbing part of onboarding.
 import SwiftUI
 import CompanionCore
 #if canImport(UIKit)
@@ -13,82 +8,72 @@ import UIKit
 
 struct PairingView: View {
     @EnvironmentObject private var session: Session
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var discovery = Discovery()
 
     @State private var manualAddress = ""
     @State private var code = ""
     @State private var scannedCredential: String?
     /// Stable across Retry. If the Mac committed a device but the response
-    /// was lost, repeating this same logical request recovers its token
-    /// instead of creating an orphan device.
+    /// was lost, repeating this same logical request recovers its token.
     @State private var pairRequestId: String?
     @State private var chosen: Connection?
     @State private var pairing = false
     @State private var failure: String?
     @State private var showingScanner = false
-    @State private var showManualInput = false
-    /// "Looking…" forever is not an answer. After a few seconds with nothing
-    /// found, say the thing that is almost always true.
-    @State private var searchedLongEnough = false
+    @State private var showingOtherWays = false
+    @State private var showingManualInput = false
     @State private var choiceGeneration = 0
 
-    // Radar pulse animation states
-    @State private var radarPulse = false
+    private let onCancel: () -> Void
 
-    private let accentTint = Color(hex: "#38BDF8")
+    init(onCancel: @escaping () -> Void = {}) {
+        self.onCancel = onCancel
+    }
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                backgroundColor
-                    .ignoresSafeArea()
-
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 20) {
-                        if let chosen {
-                            confirmationView(for: chosen)
-                        } else {
-                            // 1. Radar Discovery Hero
-                            radarHeroSection
-
-                            // 2. Discovered Computers
-                            discoveredHostsSection
-
-                            // 3. QR Scan Action CTA
-                            qrActionSection
-
-                            // 4. Manual IP Input Accordion
-                            manualEntrySection
-                        }
-
-                        if let failure {
-                            errorBanner(failure)
-                        }
+            ScrollView {
+                VStack(spacing: 24) {
+                    if let chosen {
+                        confirmationView(for: chosen)
+                    } else {
+                        pairingHero
+                        qrAction
+                        otherWays
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 14)
+
+                    if let failure {
+                        errorBanner(failure)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+                .frame(maxWidth: 560)
+                .frame(maxWidth: .infinity)
+            }
+            .background(Color(uiColor: .systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle("Connect computer")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Not now", action: onCancel)
                 }
             }
-            .navigationTitle("Pair Companion")
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
             .onAppear {
-                discovery.start()
                 accept(session.pairingInvite)
-                if !reduceMotion {
-                    withAnimation(.easeInOut(duration: 2.2).repeatForever(autoreverses: false)) {
-                        radarPulse = true
-                    }
-                }
             }
             .onDisappear {
                 choiceGeneration += 1
                 discovery.stop()
             }
             .onChange(of: session.pairingInvite) { _, invite in accept(invite) }
+            .onChange(of: showingOtherWays) { _, isShowing in
+                if isShowing {
+                    discovery.start()
+                } else {
+                    discovery.stop()
+                }
+            }
             .fullScreenCover(isPresented: $showingScanner) {
                 PairingScannerSheet { payload in
                     guard let url = URL(string: payload), let invite = PairingInvite.parse(url) else {
@@ -98,375 +83,233 @@ struct PairingView: View {
                     return nil
                 }
             }
-            .task {
-                searchedLongEnough = false
-                do {
-                    try await Task.sleep(nanoseconds: 7_000_000_000)
-                    try Task.checkCancellation()
-                    searchedLongEnough = true
-                } catch is CancellationError {
-                    return
-                } catch {
-                    return
-                }
-            }
         }
     }
 
-    private var isDark: Bool {
-        colorScheme == .dark
-    }
-
-    private var backgroundColor: Color {
-        isDark ? Color(hex: "#0B0F19") : Color(hex: "#F8FAFC")
-    }
-
-    private var cardBackground: Color {
-        isDark ? Color(hex: "#131C2E") : Color.white
-    }
-
-    private var cardBorder: Color {
-        isDark ? Color.white.opacity(0.08) : Color.black.opacity(0.06)
-    }
-
-    // MARK: - 1. Radar Hero Section
-
-    private var radarHeroSection: some View {
-        VStack(spacing: 14) {
+    private var pairingHero: some View {
+        VStack(spacing: 16) {
             ZStack {
-                // Radar orbital rings
-                Circle()
-                    .stroke(accentTint.opacity(0.12), lineWidth: 1.5)
-                    .frame(width: 140, height: 140)
-
-                Circle()
-                    .stroke(accentTint.opacity(radarPulse ? 0.0 : 0.4), lineWidth: 1.5)
-                    .frame(width: radarPulse ? 130 : 50, height: radarPulse ? 130 : 50)
-                    .scaleEffect(radarPulse ? 1.0 : 0.4)
-
-                Circle()
-                    .stroke(accentTint.opacity(0.25), lineWidth: 1)
-                    .frame(width: 90, height: 90)
-
-                // Center Beacon & Avatar
-                ZStack {
-                    Circle()
-                        .fill(accentTint.opacity(0.16))
-                        .frame(width: 58, height: 58)
-
-                    Image(systemName: "desktopcomputer")
-                        .font(.system(size: 24, weight: .semibold))
-                        .foregroundColor(accentTint)
-                }
-                .shadow(color: accentTint.opacity(0.3), radius: 10, y: 2)
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(MausPalette.color("blue").opacity(0.12))
+                    .frame(width: 124, height: 124)
+                Image(systemName: "laptopcomputer.and.iphone")
+                    .font(.system(size: 46, weight: .medium))
+                    .foregroundStyle(MausPalette.color("blue"))
             }
-            .frame(height: 120)
-            .padding(.top, 8)
+            .accessibilityHidden(true)
 
-            VStack(spacing: 4) {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(discovery.failure == nil ? accentTint : Color(hex: "#EF4444"))
-                        .frame(width: 7, height: 7)
-                    Text("LOCAL NETWORK RADAR")
-                        .font(.system(size: 11, weight: .heavy, design: .monospaced))
-                        .foregroundColor(isDark ? accentTint : Color(hex: "#0369A1"))
-                }
-
-                Text(discoveryStatus)
-                    .font(.headline)
-                    .foregroundColor(isDark ? .white : Color(hex: "#0F172A"))
-
-                Text("Ensure your phone and computer share the same Wi-Fi network.")
-                    .font(.caption)
-                    .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
+            VStack(spacing: 8) {
+                Text("Connect to your computer")
+                    .font(.title.bold())
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 16)
+                Text("Scan the QR code in OpenMausBot. We'll securely choose the best way to connect.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-        }
-        .padding(.vertical, 14)
-        .frame(maxWidth: .infinity)
-        .background(cardBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(cardBorder, lineWidth: 1)
-        )
-    }
-
-    // MARK: - 2. Discovered Hosts List
-
-    @ViewBuilder
-    private var discoveredHostsSection: some View {
-        if let discoveryFailure = discovery.failure {
-            errorBanner(discoveryFailure)
-        } else if !discovery.found.isEmpty {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("DISCOVERED COMPUTERS")
-                    .font(.system(size: 10, weight: .heavy, design: .monospaced))
-                    .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-                    .padding(.horizontal, 4)
-
-                VStack(spacing: 8) {
-                    ForEach(discovery.found) { service in
-                        Button {
-                            Haptics.selection()
-                            Task { await choose(service) }
-                        } label: {
-                            HStack(spacing: 12) {
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .fill(accentTint.opacity(0.12))
-                                        .frame(width: 40, height: 40)
-                                    Image(systemName: "laptopcomputer")
-                                        .font(.system(size: 18, weight: .semibold))
-                                        .foregroundColor(accentTint)
-                                }
-
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(service.name)
-                                        .font(.system(size: 15, weight: .semibold))
-                                        .foregroundColor(isDark ? .white : Color(hex: "#0F172A"))
-                                    Text("Ready for pairing")
-                                        .font(.caption2)
-                                        .foregroundColor(Color(hex: "#10B981"))
-                                }
-
-                                Spacer()
-
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 12, weight: .bold))
-                                    .foregroundColor(isDark ? Color(hex: "#475569") : Color(hex: "#94A3B8"))
-                            }
-                            .padding(12)
-                            .background(cardBackground)
-                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                    .stroke(cardBorder, lineWidth: 0.8)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-            }
-        } else if searchedLongEnough {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    Image(systemName: "info.circle")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(Color(hex: "#F59E0B"))
-                    Text("Can't find your computer?")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundColor(isDark ? .white : Color(hex: "#0F172A"))
-                }
-                Text("Guest networks and some router isolation settings block devices from seeing each other. Use the QR scanner below or enter your computer's address directly.")
-                    .font(.caption)
-                    .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-                    .lineSpacing(2)
-            }
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(hex: "#F59E0B").opacity(0.08))
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color(hex: "#F59E0B").opacity(0.2), lineWidth: 0.8)
-            )
         }
     }
 
-    // MARK: - 3. QR Scan CTA Section
-
-    private var qrActionSection: some View {
-        VStack(spacing: 8) {
+    private var qrAction: some View {
+        VStack(spacing: 12) {
             Button {
                 Haptics.selection()
                 failure = nil
                 showingScanner = true
             } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "qrcode.viewfinder")
-                        .font(.system(size: 18, weight: .bold))
-                    Text("Scan Pairing QR Code")
-                        .font(.system(size: 15, weight: .bold))
-                }
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 50)
-                .background(
-                    LinearGradient(
-                        colors: [Color(hex: "#0284C7"), Color(hex: "#0EA5E9")],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .shadow(color: Color(hex: "#0284C7").opacity(0.35), radius: 8, y: 3)
+                Label("Scan QR code", systemImage: "qrcode.viewfinder")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
 
-            Text("In OpenMausBot, open Settings → Companion → Set up a phone to view your QR code.")
-                .font(.caption2)
-                .foregroundColor(isDark ? Color(hex: "#64748B") : Color(hex: "#94A3B8"))
+            Text("On your computer, open Settings → Companion → Set up a phone.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 8)
         }
     }
 
-    // MARK: - 4. Manual Entry Section
+    private var otherWays: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            DisclosureGroup(isExpanded: $showingOtherWays) {
+                VStack(alignment: .leading, spacing: 18) {
+                    discoveredComputers
 
-    private var manualEntrySection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Button {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                    showManualInput.toggle()
-                }
-            } label: {
-                HStack {
-                    Image(systemName: "network")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-                    Text("Direct Host Address")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-                    Spacer()
-                    Image(systemName: showManualInput ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(isDark ? Color(hex: "#64748B") : Color(hex: "#94A3B8"))
-                }
-                .padding(.horizontal, 4)
-            }
-            .buttonStyle(.plain)
+                    Divider()
 
-            if showManualInput {
-                VStack(spacing: 10) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "link")
-                            .font(.system(size: 14))
-                            .foregroundColor(isDark ? Color(hex: "#64748B") : Color(hex: "#94A3B8"))
-
-                        TextField("https://mac.example or 192.168.1.42:8810", text: $manualAddress)
-                            .font(.system(size: 14, design: .monospaced))
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .keyboardType(.URL)
+                    DisclosureGroup(isExpanded: $showingManualInput) {
+                        manualEntry
+                            .padding(.top, 12)
+                    } label: {
+                        Label("Enter address and code", systemImage: "keyboard")
+                            .font(.subheadline.weight(.semibold))
                     }
-                    .padding(12)
-                    .background(isDark ? Color(hex: "#090D16") : Color(hex: "#F1F5F9"))
-                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(cardBorder, lineWidth: 0.8)
-                    )
+                }
+                .padding(.top, 18)
+            } label: {
+                Text("Other ways to connect")
+                    .font(.headline)
+            }
+        }
+        .padding(18)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
 
+    @ViewBuilder
+    private var discoveredComputers: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Nearby computers", systemImage: "desktopcomputer")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                if discovery.browsing && discovery.found.isEmpty {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Looking for computers")
+                }
+            }
+
+            if let discoveryFailure = discovery.failure {
+                Text(discoveryFailure)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if discovery.found.isEmpty {
+                Text("Computers running Companion will appear here.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(discovery.found) { service in
                     Button {
                         Haptics.selection()
-                        failure = nil
-                        guard let connection = Self.parse(manualAddress) else {
-                            failure = "Enter a secure https:// address, 192.168.1.42:8810, or host.ts.net:8810."
-                            return
-                        }
-                        choiceGeneration += 1
-                        scannedCredential = nil
-                        pairRequestId = nil
-                        chosen = connection
+                        Task { await choose(service) }
                     } label: {
-                        Text("Connect to Address")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(accentTint)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 42)
-                            .background(accentTint.opacity(0.12))
-                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        HStack(spacing: 12) {
+                            Image(systemName: "laptopcomputer")
+                                .foregroundStyle(MausPalette.color("blue"))
+                                .frame(width: 30, height: 30)
+                            Text(service.name)
+                                .font(.body.weight(.medium))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .disabled(manualAddress.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .accessibilityHint("Enter the code shown on this computer")
                 }
-                .padding(12)
-                .background(cardBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(cardBorder, lineWidth: 1)
-                )
             }
         }
     }
 
-    // MARK: - 5. Confirmation View
+    private var manualEntry: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Computer address", text: $manualAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .textContentType(.URL)
+                .padding(12)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            Text("Use the address shown in Companion settings on your computer.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Button("Continue") {
+                Haptics.selection()
+                failure = nil
+                guard let connection = Self.parse(manualAddress) else {
+                    failure = "That address doesn't look right. Copy it from Companion settings and try again."
+                    return
+                }
+                choiceGeneration += 1
+                scannedCredential = nil
+                pairRequestId = nil
+                chosen = connection
+            }
+            .buttonStyle(.bordered)
+            .disabled(manualAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
 
     @ViewBuilder
     private func confirmationView(for connection: Connection) -> some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 22) {
             ZStack {
                 Circle()
-                    .fill(Color(hex: "#10B981").opacity(0.15))
-                    .frame(width: 72, height: 72)
-                Image(systemName: "checkmark.shield.fill")
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundColor(Color(hex: "#10B981"))
+                    .fill(MausPalette.color("green").opacity(0.12))
+                    .frame(width: 92, height: 92)
+                Image(systemName: "desktopcomputer")
+                    .font(.system(size: 36, weight: .medium))
+                    .foregroundStyle(MausPalette.color("green"))
             }
-            .padding(.top, 10)
+            .accessibilityHidden(true)
 
-            VStack(spacing: 4) {
+            VStack(spacing: 8) {
                 Text(connection.name)
-                    .font(.title2.weight(.bold))
-                    .foregroundColor(isDark ? .white : Color(hex: "#0F172A"))
-                Text(connection.displayAddress)
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+                Label(connectionIsProtected(connection) ? "Secure connection" : "Trusted local connection",
+                      systemImage: connectionIsProtected(connection) ? "lock.shield.fill" : "checkmark.shield.fill")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MausPalette.color("green"))
             }
+
+            DisclosureGroup("Connection details") {
+                Text(connection.displayAddress)
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 8)
+            }
+            .font(.subheadline)
 
             if let credential = scannedCredential {
-                Text(connection.activeEndpoint?.isSecure == true
-                    ? "Confirm this computer to establish an authenticated HTTPS companion connection."
-                    : "Confirm this computer to establish an authenticated companion connection. Use a trusted Wi-Fi network or a tailnet; OpenMausBot does not encrypt local Wi-Fi traffic.")
-                    .font(.caption)
-                    .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 16)
+                if !connectionIsProtected(connection) {
+                    Text("Only continue on a network you trust. Local connections are authenticated but are not encrypted by OpenMausBot.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 Button {
                     Haptics.selection()
                     Task { await submit(connection, credential: credential) }
                 } label: {
-                    HStack(spacing: 8) {
-                        if pairing {
-                            ProgressView()
-                                .tint(.white)
-                        } else {
-                            Image(systemName: "link.badge.plus")
-                            Text("Pair with this Computer")
-                        }
+                    HStack {
+                        if pairing { ProgressView().tint(.white) }
+                        Text(pairing ? "Connecting…" : "Connect")
                     }
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(Color(hex: "#10B981"))
-                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                    .shadow(color: Color(hex: "#10B981").opacity(0.35), radius: 8, y: 3)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
                 .disabled(pairing)
             } else {
                 VStack(spacing: 12) {
-                    Text("Enter the 6-digit code shown on your desktop:")
-                        .font(.caption)
-                        .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
+                    Text("Enter the 6-digit code shown on your computer")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
 
                     TextField("000000", text: $code)
                         .keyboardType(.numberPad)
-                        .font(.system(size: 28, weight: .bold, design: .monospaced))
+                        .textContentType(.oneTimeCode)
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
                         .multilineTextAlignment(.center)
-                        .padding(.vertical, 8)
-                        .background(isDark ? Color(hex: "#090D16") : Color(hex: "#F1F5F9"))
-                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                .stroke(accentTint.opacity(0.4), lineWidth: 1)
-                        )
+                        .padding(.vertical, 12)
+                        .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .onChange(of: code) { _, value in
                             code = String(value.filter { $0.isASCII && $0.isNumber }.prefix(6))
                         }
@@ -475,22 +318,14 @@ struct PairingView: View {
                         Haptics.selection()
                         Task { await submit(connection, credential: code) }
                     } label: {
-                        HStack(spacing: 8) {
-                            if pairing {
-                                ProgressView()
-                                    .tint(.white)
-                            } else {
-                                Text("Connect")
-                            }
+                        HStack {
+                            if pairing { ProgressView().tint(.white) }
+                            Text(pairing ? "Connecting…" : "Connect")
                         }
-                        .font(.system(size: 15, weight: .bold))
-                        .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .background(code.count == 6 ? accentTint : Color.gray.opacity(0.4))
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                     .disabled(code.count != 6 || pairing)
                 }
             }
@@ -503,40 +338,27 @@ struct PairingView: View {
                 pairRequestId = nil
                 failure = nil
             }
-            .font(.caption.weight(.semibold))
-            .foregroundColor(isDark ? Color(hex: "#94A3B8") : Color(hex: "#64748B"))
-            .padding(.top, 4)
+            .foregroundStyle(.secondary)
         }
-        .padding(20)
-        .frame(maxWidth: .infinity)
-        .background(cardBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(cardBorder, lineWidth: 1)
-        )
+        .padding(22)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
     }
 
-    // MARK: - Error Banner
-
     private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(Color(hex: "#EF4444"))
+        Label {
             Text(message)
-                .font(.caption)
-                .foregroundColor(isDark ? Color(hex: "#F87171") : Color(hex: "#B91C1C"))
-                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "exclamationmark.triangle.fill")
         }
-        .padding(12)
+        .font(.footnote)
+        .foregroundStyle(.red)
+        .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(hex: "#EF4444").opacity(0.08))
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color(hex: "#EF4444").opacity(0.2), lineWidth: 0.8)
-        )
+        .background(Color.red.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .accessibilityElement(children: .combine)
     }
 
     @MainActor
@@ -573,9 +395,6 @@ struct PairingView: View {
         } catch {
             if cameFromScanner {
                 if error is PairingRouteError {
-                    // The same request id makes Retry safe whether no route
-                    // was reached or the Mac committed the device and its
-                    // response was lost while the route changed.
                     failure = error.localizedDescription
                 } else {
                     failure = "\(error.localizedDescription) Start pairing again on your computer and rescan the new QR code."
@@ -604,16 +423,10 @@ struct PairingView: View {
         session.consumePairingInvite()
     }
 
-    // MARK: - Helpers
-
-    private var discoveryStatus: String {
-        if discovery.failure != nil {
-            return "Local discovery needs attention"
-        }
-        if discovery.found.isEmpty {
-            return discovery.browsing ? "Searching for OpenMausBot hosts…" : "Starting local discovery…"
-        }
-        return "Found \(discovery.found.count) available host\(discovery.found.count == 1 ? "" : "s")"
+    private func connectionIsProtected(_ connection: Connection) -> Bool {
+        connection.activeEndpoint?.protectsCredentials
+            ?? connection.automaticEndpoints.first?.protectsCredentials
+            ?? false
     }
 
     static func deviceName() -> String {
@@ -624,7 +437,6 @@ struct PairingView: View {
         #endif
     }
 
-    /// "192.168.1.42:8810", or a bare host on the default companion port.
     static func parse(_ text: String) -> Connection? {
         Connection.parse(text)
     }

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -125,7 +125,7 @@ struct PairingView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
 
-            Text("On your computer, open Settings → Companion → Set up a phone.")
+            Text("On your computer, open Settings → Phone → Set up a phone.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -179,7 +179,7 @@ struct PairingView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             } else if discovery.found.isEmpty {
-                Text("Computers running Companion will appear here.")
+                Text("Computers ready to pair will appear here.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             } else {
@@ -220,7 +220,7 @@ struct PairingView: View {
                 .background(Color(uiColor: .tertiarySystemGroupedBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
 
-            Text("Use the address shown in Companion settings on your computer.")
+            Text("Use the address shown in Phone settings on your computer.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
 
@@ -228,7 +228,7 @@ struct PairingView: View {
                 Haptics.selection()
                 failure = nil
                 guard let connection = Self.parse(manualAddress) else {
-                    failure = "That address doesn't look right. Copy it from Companion settings and try again."
+                    failure = "That address doesn't look right. Copy it from Phone settings and try again."
                     return
                 }
                 choiceGeneration += 1

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -199,8 +199,28 @@ final class Session: ObservableObject {
         }
 
         try Keychain.save(paired.token, for: stored.id)
-        UserDefaults.standard.set(try? JSONEncoder().encode(stored), forKey: Self.connectionKey)
+        // Write the first-pair education marker before making the connection
+        // restorable. If the process stops between these writes, an orphan
+        // marker is harmless while unpaired; the reverse order could restore
+        // a pairing which permanently skipped this step.
+        // RootView may not have received iOS's notification status yet, and
+        // the app may be relaunched before that asynchronous lookup finishes.
+        CompanionPairingCommitSequence.persist {
+            UserDefaults.standard.set(
+                true,
+                forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+            )
+        } saveConnection: {
+            UserDefaults.standard.set(
+                try? JSONEncoder().encode(stored),
+                forKey: Self.connectionKey
+            )
+        }
 
+        pairingInvite = CompanionPairingInvitePolicy.nextInvite(
+            current: pairingInvite,
+            after: .pairingSucceeded
+        )
         self.connection = stored
         self.token = paired.token
         let liveRoutes = winner.map { route in
@@ -219,7 +239,10 @@ final class Session: ObservableObject {
     }
 
     func receivePairingURL(_ url: URL) {
-        guard status == .unpaired else {
+        guard CompanionPairingInvitePolicy.allowsIncomingInvite(
+            hasConnection: connection != nil,
+            pairingStateIsUnpaired: status == .unpaired
+        ) else {
             actionError = "This phone is already paired. Unpair it in Settings before connecting it to another computer."
             return
         }
@@ -227,11 +250,17 @@ final class Session: ObservableObject {
             actionError = "That pairing invitation is not valid. Start pairing again on your computer."
             return
         }
-        pairingInvite = invite
+        pairingInvite = CompanionPairingInvitePolicy.nextInvite(
+            current: pairingInvite,
+            after: .received(invite)
+        )
     }
 
     func consumePairingInvite() {
-        pairingInvite = nil
+        pairingInvite = CompanionPairingInvitePolicy.nextInvite(
+            current: pairingInvite,
+            after: .consumed
+        )
     }
 
     func signOut() {
@@ -241,8 +270,15 @@ final class Session: ObservableObject {
         endpointRefreshTask = nil
         restorePending = false
         pendingNotification = nil
+        pairingInvite = CompanionPairingInvitePolicy.nextInvite(
+            current: pairingInvite,
+            after: .signedOut
+        )
         if let id = connection?.id { Keychain.remove(id) }
         UserDefaults.standard.removeObject(forKey: Self.connectionKey)
+        UserDefaults.standard.removeObject(
+            forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+        )
         connection = nil
         client = nil
         token = nil

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -38,6 +38,9 @@ final class Session: ObservableObject {
     /// One exact message the next opened chat should reveal.
     @Published private(set) var focusedMessageId: String?
     @Published private(set) var notificationAuthorization: UNAuthorizationStatus = .notDetermined
+    /// Distinguishes a real `.notDetermined` result from the in-memory value
+    /// used while notification settings are still loading at launch.
+    @Published private(set) var notificationAuthorizationResolved = false
     /// A short-lived desktop handoff waiting for PairingView to present it.
     @Published private(set) var pairingInvite: PairingInvite?
 
@@ -994,6 +997,7 @@ final class Session: ObservableObject {
 
     func refreshNotificationAuthorization() async {
         notificationAuthorization = await NotificationCoordinator.shared.authorizationStatus()
+        notificationAuthorizationResolved = true
     }
 
     func enableNotifications() async {

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -277,12 +277,12 @@ struct ConnectionSecurityView: View {
                 .autocorrectionDisabled()
             Button("Save") {
                 if !session.updateAddress(addressText) {
-                    session.actionError = "That address doesn't look right. Copy it from Companion settings and try again."
+                    session.actionError = "That address doesn't look right. Copy it from Phone settings and try again."
                 }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Use the address shown in Companion settings on your computer. Your pairing is kept.")
+            Text("Use the address shown in Phone settings on your computer. Your pairing is kept.")
         }
         .confirmationDialog(
             "Unpair this phone?",

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -57,26 +57,30 @@ struct SettingsView: View {
                     .disabled(enablingNotifications)
                     .accessibilityHint(notificationAccessibilityHint)
                 }
+            } footer: {
+                Text("Alerts arrive while OpenMausBot is open or was recently in the background. Closed-app delivery is not available yet.")
             }
 
-            Section("Workspace") {
-                NavigationLink {
-                    TasksRoutinesView()
-                } label: {
-                    Label {
-                        Text("Tasks & Routines")
-                    } icon: {
-                        SettingsIcon(symbol: "calendar.badge.clock", color: .orange)
+            if session.connection != nil {
+                Section("Workspace") {
+                    NavigationLink {
+                        TasksRoutinesView()
+                    } label: {
+                        Label {
+                            Text("Tasks & Routines")
+                        } icon: {
+                            SettingsIcon(symbol: "calendar.badge.clock", color: .orange)
+                        }
                     }
-                }
 
-                NavigationLink {
-                    ConnectedAppsView()
-                } label: {
-                    Label {
-                        Text("Connected Apps")
-                    } icon: {
-                        SettingsIcon(symbol: "link", color: .blue)
+                    NavigationLink {
+                        ConnectedAppsView()
+                    } label: {
+                        Label {
+                            Text("Connected Apps")
+                        } icon: {
+                            SettingsIcon(symbol: "link", color: .blue)
+                        }
                     }
                 }
             }
@@ -261,7 +265,7 @@ struct ConnectionSecurityView: View {
                 }
 
                 Section {
-                    Button("Unpair this phone", role: .destructive) {
+                    Button("Remove connection from this iPhone", role: .destructive) {
                         confirmingSignOut = true
                     }
                 }
@@ -285,17 +289,17 @@ struct ConnectionSecurityView: View {
             Text("Use the address shown in Phone settings on your computer. Your pairing is kept.")
         }
         .confirmationDialog(
-            "Unpair this phone?",
+            "Remove this connection?",
             isPresented: $confirmingSignOut,
             titleVisibility: .visible
         ) {
-            Button("Unpair", role: .destructive) {
+            Button("Remove from this iPhone", role: .destructive) {
                 session.signOut()
                 dismiss()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("You'll need to scan a new QR code to connect again.")
+            Text("This removes the connection from this iPhone only. It does not revoke this phone on your Mac. To remove Mac-side access, open OpenMausBot → Settings → Phone and remove this device.")
         }
     }
 

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -1,112 +1,334 @@
-// Paired-device settings and safe workspace feature entry points.
-//
-// Credentials, revocation, Local VM and execution policy still live only on
-// the computer. The phone can manage renderer-neutral routines and connected-
-// account inventory/authorization without widening that boundary.
+// Settings stays status-first. Network details and destructive pairing
+// controls live one level deeper so the everyday screen remains calm.
 import SwiftUI
 import CompanionCore
+import UIKit
 
 struct SettingsView: View {
     @EnvironmentObject private var session: Session
-    @State private var confirmingSignOut = false
-    @State private var editingAddress = false
-    @State private var addressText = ""
+    @State private var enablingNotifications = false
+    private let onConnect: (() -> Void)?
+
+    init(onConnect: (() -> Void)? = nil) {
+        self.onConnect = onConnect
+    }
 
     var body: some View {
         Form {
             Section("Computer") {
                 if let connection = session.connection {
-                    LabeledContent("Name", value: connection.name)
-                    LabeledContent("Address", value: connection.displayAddress)
-                    // The stored address can simply go stale — a tailnet name
-                    // on a phone that left the tailnet, a LAN address after
-                    // the router reshuffled. Editing it here keeps the
-                    // pairing; the alternative is a walk to the computer for
-                    // a new code.
-                    Button("Edit address") {
-                        addressText = connection.displayAddress
-                        editingAddress = true
+                    NavigationLink {
+                        ConnectionSecurityView()
+                    } label: {
+                        ComputerSettingsRow(
+                            name: connection.name,
+                            status: statusText,
+                            connected: session.status == .live
+                        )
                     }
+                } else {
+                    Button {
+                        onConnect?()
+                    } label: {
+                        ComputerSettingsRow(
+                            name: "Connect a computer",
+                            status: "Not connected",
+                            connected: false
+                        )
+                    }
+                    .disabled(onConnect == nil)
                 }
-                LabeledContent("Connection", value: statusText)
             }
 
             Section {
-                LabeledContent("Status", value: session.notificationStatusText)
-                Button(session.notificationAuthorization == .denied ? "Open iPhone Settings" : "Enable notifications") {
-                    Task { await session.enableNotifications() }
+                if notificationsAreEnabled {
+                    notificationRow
+                        .accessibilityHint(notificationAccessibilityHint)
+                } else {
+                    Button {
+                        enablingNotifications = true
+                        Task {
+                            await session.enableNotifications()
+                            enablingNotifications = false
+                        }
+                    } label: {
+                        notificationRow
+                    }
+                    .disabled(enablingNotifications)
+                    .accessibilityHint(notificationAccessibilityHint)
                 }
-                .disabled(session.notificationAuthorization == .authorized)
-            } header: {
-                Text("Notifications")
-            } footer: {
-                Text("Approvals and finished work appear while OpenMausMobile is connected, including frames replayed after a short background pause. Closed-app push needs the separate APNs relay release.")
             }
 
-            Section {
+            Section("Workspace") {
                 NavigationLink {
                     TasksRoutinesView()
                 } label: {
-                    Label("Tasks & Routines", systemImage: "calendar.badge.clock")
+                    Label {
+                        Text("Tasks & Routines")
+                    } icon: {
+                        SettingsIcon(symbol: "calendar.badge.clock", color: .orange)
+                    }
                 }
+
                 NavigationLink {
                     ConnectedAppsView()
                 } label: {
-                    Label("Connected Apps", systemImage: "link")
+                    Label {
+                        Text("Connected Apps")
+                    } icon: {
+                        SettingsIcon(symbol: "link", color: .blue)
+                    }
                 }
-            } header: {
-                Text("Workspace")
-            } footer: {
-                Text("Manage routine schedules, view connected accounts, and add Work, Personal, or client aliases here. Provider keys, webhook secrets, account revocation, pairing, Local VM, and agent execution policy stay on your computer.")
-            }
-
-            Section {
-                Button("Unpair this phone", role: .destructive) { confirmingSignOut = true }
-            } footer: {
-                Text("Removes the pairing from this phone only. To stop it reaching the computer at all, remove the device in OpenMausBot → Settings → Companion.")
-            }
-
-            Section("Not here") {
-                Text("API keys, pairing and the Local VM are managed on the computer. This phone is deliberately not allowed to change them.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
             }
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .task { await session.refreshNotificationAuthorization() }
+    }
+
+    private var notificationsAreEnabled: Bool {
+        switch session.notificationAuthorization {
+        case .authorized, .provisional, .ephemeral: return true
+        default: return false
+        }
+    }
+
+    private var notificationAccessibilityHint: String {
+        if notificationsAreEnabled { return "Notifications are enabled" }
+        if session.notificationAuthorization == .denied { return "Opens iPhone Settings" }
+        return "Asks for permission to send notifications"
+    }
+
+    private var notificationRow: some View {
+        HStack(spacing: 12) {
+            SettingsIcon(symbol: "bell.fill", color: .red)
+            Text("Notifications")
+                .foregroundStyle(.primary)
+            Spacer()
+            if enablingNotifications {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Text(session.notificationStatusText)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var statusText: String { session.status.settingsText }
+}
+
+private struct ComputerSettingsRow: View {
+    let name: String
+    let status: String
+    let connected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(MausPalette.color("blue").opacity(0.14))
+                    .frame(width: 38, height: 38)
+                Image(systemName: "laptopcomputer")
+                    .foregroundStyle(MausPalette.color("blue"))
+            }
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(name)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(connected ? Color.green : Color.secondary)
+                        .frame(width: 7, height: 7)
+                    Text(status)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct SettingsIcon: View {
+    let symbol: String
+    let color: Color
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 28, height: 28)
+            .background(color, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .accessibilityHidden(true)
+    }
+}
+
+struct ConnectionSecurityView: View {
+    @EnvironmentObject private var session: Session
+    @Environment(\.dismiss) private var dismiss
+    @State private var confirmingSignOut = false
+    @State private var editingAddress = false
+    @State private var addressText = ""
+    @State private var showingFullAddress = false
+    @State private var copiedAddress = false
+    @State private var refreshing = false
+
+    var body: some View {
+        Form {
+            if let connection = session.connection {
+                Section {
+                    HStack(spacing: 14) {
+                        ProfileAvatar(name: connection.name, size: 46)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(connection.name)
+                                .font(.headline)
+                            Label(session.status.settingsText,
+                                  systemImage: session.status == .live ? "checkmark.circle.fill" : "circle.dotted")
+                                .font(.subheadline)
+                                .foregroundStyle(session.status == .live ? Color.green : Color.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                    .accessibilityElement(children: .combine)
+                }
+
+                Section {
+                    DisclosureGroup("Connection details") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Group {
+                                if showingFullAddress {
+                                    Text(connection.displayAddress)
+                                        .textSelection(.enabled)
+                                } else {
+                                    Text(shortened(connection.displayAddress))
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                            }
+                            .font(.footnote.monospaced())
+                            .foregroundStyle(.secondary)
+
+                            HStack(spacing: 16) {
+                                Button(showingFullAddress ? "Hide full address" : "Show full address") {
+                                    showingFullAddress.toggle()
+                                }
+                                Button(copiedAddress ? "Copied" : "Copy") {
+                                    UIPasteboard.general.string = connection.displayAddress
+                                    copiedAddress = true
+                                    Task {
+                                        try? await Task.sleep(for: .seconds(2))
+                                        copiedAddress = false
+                                    }
+                                }
+                            }
+                            .font(.subheadline.weight(.medium))
+                        }
+                        .padding(.top, 10)
+                    }
+
+                    Button("Edit address") {
+                        addressText = connection.displayAddress
+                        editingAddress = true
+                    }
+                }
+
+                Section("Troubleshooting") {
+                    Text(troubleshootingText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        refreshing = true
+                        Task {
+                            await session.refresh()
+                            refreshing = false
+                        }
+                    } label: {
+                        HStack {
+                            Text("Try reconnecting")
+                            if refreshing {
+                                Spacer()
+                                ProgressView().controlSize(.small)
+                            }
+                        }
+                    }
+                    .disabled(refreshing)
+                }
+
+                Section {
+                    Button("Unpair this phone", role: .destructive) {
+                        confirmingSignOut = true
+                    }
+                }
+            } else {
+                ContentUnavailableView("No computer connected", systemImage: "laptopcomputer.slash")
+            }
+        }
+        .navigationTitle("Connection & Security")
+        .navigationBarTitleDisplayMode(.inline)
         .alert("Edit address", isPresented: $editingAddress) {
-            TextField("https://mac.example or 192.168.1.42:8810", text: $addressText)
+            TextField("Computer address", text: $addressText)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
             Button("Save") {
                 if !session.updateAddress(addressText) {
-                    session.actionError = "Enter a secure https:// address, 192.168.1.42:8810, or a name like macbook.tail1234.ts.net."
+                    session.actionError = "That address doesn't look right. Copy it from Companion settings and try again."
                 }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Enter whatever the Companion panel on your computer shows. The pairing itself is kept.")
+            Text("Use the address shown in Companion settings on your computer. Your pairing is kept.")
         }
         .confirmationDialog(
             "Unpair this phone?",
             isPresented: $confirmingSignOut,
             titleVisibility: .visible
         ) {
-            Button("Unpair", role: .destructive) { session.signOut() }
+            Button("Unpair", role: .destructive) {
+                session.signOut()
+                dismiss()
+            }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("You'll need a new pairing code to connect again.")
+            Text("You'll need to scan a new QR code to connect again.")
         }
     }
 
-    private var statusText: String {
+    private var troubleshootingText: String {
         switch session.status {
+        case .live:
+            return "This computer is connected and responding normally."
+        case .connecting:
+            return "OpenMausBot is trying the saved connection automatically."
+        case let .offline(reason):
+            return reason
+        case .unauthorized:
+            return "This phone was removed from the computer. Pair it again to reconnect."
+        case .unpaired:
+            return "This phone is not paired with a computer."
+        }
+    }
+
+    private func shortened(_ address: String) -> String {
+        guard address.count > 14 else { return address }
+        let leadingCount = min(20, max(8, address.count - 8))
+        return "\(address.prefix(leadingCount))…\(address.suffix(6))"
+    }
+}
+
+private extension Session.Status {
+    var settingsText: String {
+        switch self {
         case .live: return "Connected"
         case .connecting: return "Connecting…"
         case .unpaired: return "Not paired"
-        case .unauthorized: return "Unpaired on the computer"
-        case let .offline(reason): return reason
+        case .unauthorized: return "Needs pairing"
+        case .offline: return "Offline"
         }
     }
 }

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -295,7 +295,7 @@ public struct PairingRouteError: Error, LocalizedError, Equatable, Sendable {
 
     public var errorDescription: String? {
         let routes = attemptedHosts.joined(separator: ", ")
-        return "Couldn’t reach this computer through any available route (\(routes)). Keep OpenMausBot’s Companion turned on, then try again."
+        return "Couldn’t reach this computer through any available route (\(routes)). Keep Phone access turned on in OpenMausBot, then try again."
     }
 }
 
@@ -410,7 +410,7 @@ public struct CompanionClient: Sendable {
 
     /// Turn a non-2xx into an `APIError` carrying the harness's own message.
     /// Those messages are written for people ("pair this device in
-    /// OpenMausBot → Settings → Companion"), so passing them through beats
+    /// OpenMausBot → Settings → Phone"), so passing them through beats
     /// inventing a worse one here.
     static func check(_ response: URLResponse, _ data: Data) throws {
         guard let http = response as? HTTPURLResponse else { return }

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -409,9 +409,9 @@ public struct CompanionClient: Sendable {
     }
 
     /// Turn a non-2xx into an `APIError` carrying the harness's own message.
-    /// Those messages are written for people ("pair this device in
-    /// OpenMausBot → Settings → Phone"), so passing them through beats
-    /// inventing a worse one here.
+    /// Those messages are written for people, so passing them through beats
+    /// inventing a different client-side explanation here. Captured fixtures
+    /// intentionally preserve the current server contract verbatim.
     static func check(_ response: URLResponse, _ data: Data) throws {
         guard let http = response as? HTTPURLResponse else { return }
         guard !(200...299).contains(http.statusCode) else { return }

--- a/ios/Sources/CompanionCore/Endpoint.swift
+++ b/ios/Sources/CompanionCore/Endpoint.swift
@@ -180,4 +180,16 @@ extension Connection {
     public var displayAddress: String {
         activeEndpoint?.displayAddress ?? "\(host):\(port)"
     }
+
+    /// The normalized network origin a person must consent to before pairing.
+    /// It deliberately contains no path, query, pairing code, or credential.
+    public var pairingConsentOrigin: String {
+        if let activeEndpoint { return activeEndpoint.url }
+
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = Self.urlHost(host.lowercased())
+        components.port = port
+        return components.url?.absoluteString ?? "\(host.lowercased()):\(port)"
+    }
 }

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -152,7 +152,7 @@ public enum ConnectionAdvice {
         case .cannotFindHost:
             advice = "\u{201C}\(host)\u{201D} didn't resolve. If that's a Tailscale name, this phone may not be on the tailnet."
         case .cannotConnectToHost:
-            advice = "Reached your computer, but the companion isn't answering on port \(port) — open OpenMausBot → Settings → Companion."
+            advice = "Reached your computer, but Phone access isn't answering on port \(port) — open OpenMausBot → Settings → Phone."
         case .timedOut:
             advice = "No route to your computer at \(host) — different network, or a firewall."
         case .notConnectedToInternet:

--- a/ios/Sources/CompanionCore/Onboarding.swift
+++ b/ios/Sources/CompanionCore/Onboarding.swift
@@ -24,6 +24,9 @@ public struct CompanionOnboardingContext: Equatable, Sendable {
     public var hasSeenWelcome: Bool
     public var pairingRequested: Bool
     public var hasPendingPairingInvite: Bool
+    /// True only while the current UI flow is completing a new pairing.
+    /// Existing paired users must not see first-pair education on upgrade.
+    public var notificationOnboardingRequested: Bool
     public var hasSeenNotificationPrompt: Bool
     public var notificationPermissionIsUndetermined: Bool
 
@@ -32,6 +35,7 @@ public struct CompanionOnboardingContext: Equatable, Sendable {
         hasSeenWelcome: Bool,
         pairingRequested: Bool = false,
         hasPendingPairingInvite: Bool = false,
+        notificationOnboardingRequested: Bool = false,
         hasSeenNotificationPrompt: Bool = false,
         notificationPermissionIsUndetermined: Bool = true
     ) {
@@ -39,6 +43,7 @@ public struct CompanionOnboardingContext: Equatable, Sendable {
         self.hasSeenWelcome = hasSeenWelcome
         self.pairingRequested = pairingRequested
         self.hasPendingPairingInvite = hasPendingPairingInvite
+        self.notificationOnboardingRequested = notificationOnboardingRequested
         self.hasSeenNotificationPrompt = hasSeenNotificationPrompt
         self.notificationPermissionIsUndetermined = notificationPermissionIsUndetermined
     }
@@ -50,7 +55,8 @@ public enum CompanionOnboardingRouter {
         case .revoked:
             return .revoked
         case .paired:
-            if !context.hasSeenNotificationPrompt,
+            if context.notificationOnboardingRequested,
+               !context.hasSeenNotificationPrompt,
                context.notificationPermissionIsUndetermined {
                 return .notificationPrompt
             }

--- a/ios/Sources/CompanionCore/Onboarding.swift
+++ b/ios/Sources/CompanionCore/Onboarding.swift
@@ -19,33 +19,134 @@ public enum CompanionOnboardingRoute: Equatable, Sendable {
     case revoked
 }
 
+/// The permission lookup is asynchronous at launch. Treating that short
+/// unresolved window as a final answer can skip first-pair education forever.
+public enum CompanionNotificationAuthorizationState: Equatable, Sendable {
+    case unresolved
+    case notDetermined
+    case determined
+}
+
+/// Durable preference names shared by the app's pairing commit and its root
+/// router. The pending marker is intentionally separate from the benign
+/// "already saw this" preference: a new pairing may finish before iOS returns
+/// the current notification authorization status.
+public enum CompanionOnboardingPreferences {
+    public static let pendingNotificationOnboardingKey =
+        "companion.onboarding.notificationPending"
+}
+
+/// Keeps the crash-sensitive part of a successful pairing commit explicit
+/// and testable. The notification marker must exist before the restorable
+/// connection: an orphan marker while unpaired is harmless, but a connection
+/// without its marker can permanently skip first-pair education.
+public enum CompanionPairingCommitSequence {
+    public static func persist(
+        markNotificationOnboardingPending: () -> Void,
+        saveConnection: () -> Void
+    ) {
+        markNotificationOnboardingPending()
+        saveConnection()
+    }
+}
+
+public enum CompanionPairingInviteEvent: Equatable, Sendable {
+    case received(PairingInvite)
+    case consumed
+    case pairingSucceeded
+    case signedOut
+}
+
+/// Pure invite lifecycle shared by Session and sequence tests. In particular,
+/// a connection published just before status changes must still reject a new
+/// invite, and terminal pairing/account events always empty the queue.
+public enum CompanionPairingInvitePolicy {
+    public static func allowsIncomingInvite(
+        hasConnection: Bool,
+        pairingStateIsUnpaired: Bool
+    ) -> Bool {
+        !hasConnection && pairingStateIsUnpaired
+    }
+
+    public static func nextInvite(
+        current: PairingInvite?,
+        after event: CompanionPairingInviteEvent
+    ) -> PairingInvite? {
+        switch event {
+        case .received(let invite):
+            return invite
+        case .consumed, .pairingSucceeded, .signedOut:
+            return nil
+        }
+    }
+}
+
+/// Pure lifecycle policy for the durable first-pair notification marker.
+public enum CompanionNotificationOnboardingPolicy {
+    public static func shouldKeepPending(
+        isPending: Bool,
+        hasCompletedStep: Bool,
+        authorization: CompanionNotificationAuthorizationState
+    ) -> Bool {
+        guard isPending else { return false }
+        // A relaunch can restore the pairing before UserNotifications has
+        // answered. Never spend the marker during that temporary state.
+        guard authorization != .unresolved else { return true }
+        // Once status is known, education is needed only when iOS can still
+        // ask and this user has not already completed or skipped the step.
+        return authorization == .notDetermined && !hasCompletedStep
+    }
+}
+
+/// A small state machine used by PairingView to make navigation mutually
+/// exclusive with a pairing commit. A second submit or reset cannot overtake
+/// the request which may already have persisted on the Mac and phone.
+public struct CompanionPairingSubmissionState: Equatable, Sendable {
+    public private(set) var isInFlight = false
+
+    public init() {}
+
+    public var allowsNavigation: Bool { !isInFlight }
+
+    @discardableResult
+    public mutating func begin() -> Bool {
+        guard !isInFlight else { return false }
+        isInFlight = true
+        return true
+    }
+
+    public mutating func finish() {
+        isInFlight = false
+    }
+}
+
 public struct CompanionOnboardingContext: Equatable, Sendable {
     public var pairingState: CompanionPairingState
     public var hasSeenWelcome: Bool
     public var pairingRequested: Bool
     public var hasPendingPairingInvite: Bool
-    /// True only while the current UI flow is completing a new pairing.
-    /// Existing paired users must not see first-pair education on upgrade.
-    public var notificationOnboardingRequested: Bool
+    /// Persisted only after a new pairing commits. Existing paired users do
+    /// not receive first-pair education merely because they upgraded.
+    public var notificationOnboardingPending: Bool
     public var hasSeenNotificationPrompt: Bool
-    public var notificationPermissionIsUndetermined: Bool
+    public var notificationAuthorization: CompanionNotificationAuthorizationState
 
     public init(
         pairingState: CompanionPairingState,
         hasSeenWelcome: Bool,
         pairingRequested: Bool = false,
         hasPendingPairingInvite: Bool = false,
-        notificationOnboardingRequested: Bool = false,
+        notificationOnboardingPending: Bool = false,
         hasSeenNotificationPrompt: Bool = false,
-        notificationPermissionIsUndetermined: Bool = true
+        notificationAuthorization: CompanionNotificationAuthorizationState = .notDetermined
     ) {
         self.pairingState = pairingState
         self.hasSeenWelcome = hasSeenWelcome
         self.pairingRequested = pairingRequested
         self.hasPendingPairingInvite = hasPendingPairingInvite
-        self.notificationOnboardingRequested = notificationOnboardingRequested
+        self.notificationOnboardingPending = notificationOnboardingPending
         self.hasSeenNotificationPrompt = hasSeenNotificationPrompt
-        self.notificationPermissionIsUndetermined = notificationPermissionIsUndetermined
+        self.notificationAuthorization = notificationAuthorization
     }
 }
 
@@ -55,9 +156,9 @@ public enum CompanionOnboardingRouter {
         case .revoked:
             return .revoked
         case .paired:
-            if context.notificationOnboardingRequested,
+            if context.notificationOnboardingPending,
                !context.hasSeenNotificationPrompt,
-               context.notificationPermissionIsUndetermined {
+               context.notificationAuthorization == .notDetermined {
                 return .notificationPrompt
             }
             return .chats

--- a/ios/Sources/CompanionCore/Onboarding.swift
+++ b/ios/Sources/CompanionCore/Onboarding.swift
@@ -1,0 +1,65 @@
+/// A small, platform-neutral decision seam for the companion's first-run flow.
+///
+/// Keeping this outside SwiftUI makes the important transitions explicit and
+/// testable: skipping setup must not look like a pairing, a pending deep link
+/// must still open pairing, and a revoked credential must never fall through
+/// to an ordinary empty state.
+public enum CompanionPairingState: Equatable, Sendable {
+    case unpaired
+    case paired
+    case revoked
+}
+
+public enum CompanionOnboardingRoute: Equatable, Sendable {
+    case welcome
+    case pairing
+    case unpairedHome
+    case notificationPrompt
+    case chats
+    case revoked
+}
+
+public struct CompanionOnboardingContext: Equatable, Sendable {
+    public var pairingState: CompanionPairingState
+    public var hasSeenWelcome: Bool
+    public var pairingRequested: Bool
+    public var hasPendingPairingInvite: Bool
+    public var hasSeenNotificationPrompt: Bool
+    public var notificationPermissionIsUndetermined: Bool
+
+    public init(
+        pairingState: CompanionPairingState,
+        hasSeenWelcome: Bool,
+        pairingRequested: Bool = false,
+        hasPendingPairingInvite: Bool = false,
+        hasSeenNotificationPrompt: Bool = false,
+        notificationPermissionIsUndetermined: Bool = true
+    ) {
+        self.pairingState = pairingState
+        self.hasSeenWelcome = hasSeenWelcome
+        self.pairingRequested = pairingRequested
+        self.hasPendingPairingInvite = hasPendingPairingInvite
+        self.hasSeenNotificationPrompt = hasSeenNotificationPrompt
+        self.notificationPermissionIsUndetermined = notificationPermissionIsUndetermined
+    }
+}
+
+public enum CompanionOnboardingRouter {
+    public static func route(for context: CompanionOnboardingContext) -> CompanionOnboardingRoute {
+        switch context.pairingState {
+        case .revoked:
+            return .revoked
+        case .paired:
+            if !context.hasSeenNotificationPrompt,
+               context.notificationPermissionIsUndetermined {
+                return .notificationPrompt
+            }
+            return .chats
+        case .unpaired:
+            if context.pairingRequested || context.hasPendingPairingInvite {
+                return .pairing
+            }
+            return context.hasSeenWelcome ? .unpairedHome : .welcome
+        }
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -75,6 +75,28 @@ final class ConnectionTests: XCTestCase {
         XCTAssertEqual(invite.credential, token)
     }
 
+    func testPairingConsentShowsNormalizedOriginInsteadOfTrustingQRName() throws {
+        let url = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=https%3A%2F%2FOTHER.Example%3A9443%2F" +
+            "&code=004209&name=Milind%27s%20Mac"))
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+
+        XCTAssertEqual(invite.connection.name, "Milind's Mac")
+        XCTAssertEqual(invite.connection.pairingConsentOrigin, "https://other.example:9443")
+        XCTAssertFalse(invite.connection.pairingConsentOrigin.contains("004209"))
+    }
+
+    func testPairingConsentNormalizesLegacyDNSAndIPv6Origins() throws {
+        let tailnet = try XCTUnwrap(Connection.parse("MacBook.Tail1234.TS.NET"))
+        XCTAssertEqual(
+            tailnet.pairingConsentOrigin,
+            "http://macbook.tail1234.ts.net:8810"
+        )
+
+        let ipv6 = try XCTUnwrap(Connection.parse("[2001:DB8::1]:9910"))
+        XCTAssertEqual(ipv6.pairingConsentOrigin, "http://[2001:db8::1]:9910")
+    }
+
     func testParsesAnOlderCodeOnlyPairingInvite() throws {
         let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=004209"))
         XCTAssertEqual(PairingInvite.parse(url)?.credential, "004209")

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -311,8 +311,8 @@ final class DecodingTests: XCTestCase {
     }
 
     func testDecodesTheHarnessErrorBodies() throws {
-        // these strings are written for people, and the client shows them
-        // rather than inventing its own
+        // These are captured server contracts. Keep them verbatim until the
+        // desktop changes in lockstep; the client passes them through.
         XCTAssertEqual(
             try decode(APIErrorBody.self, "unauthorized").error,
             "pair this device from Phone settings in OpenMausBot on your computer"

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -135,7 +135,7 @@ final class FailoverTests: XCTestCase {
     func testRefusedConnectionPointsAtTheCompanionToggle() {
         let message = ConnectionAdvice.message(for: .cannotConnectToHost, host: "192.168.1.42", port: 8810)
         XCTAssertTrue(message.contains("port 8810"))
-        XCTAssertTrue(message.contains("Settings → Companion"))
+        XCTAssertTrue(message.contains("Settings → Phone"))
     }
 
     func testTimeoutBlamesTheRouteNotTheApp() {

--- a/ios/Tests/CompanionCoreTests/OnboardingTests.swift
+++ b/ios/Tests/CompanionCoreTests/OnboardingTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import CompanionCore
+
+final class OnboardingTests: XCTestCase {
+    func testFirstLaunchShowsWelcome() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .unpaired,
+                hasSeenWelcome: false
+            )),
+            .welcome
+        )
+    }
+
+    func testSkipShowsUsefulUnpairedHome() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .unpaired,
+                hasSeenWelcome: true
+            )),
+            .unpairedHome
+        )
+    }
+
+    func testResumeAndPendingInviteBothOpenPairing() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .unpaired,
+                hasSeenWelcome: true,
+                pairingRequested: true
+            )),
+            .pairing
+        )
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .unpaired,
+                hasSeenWelcome: false,
+                hasPendingPairingInvite: true
+            )),
+            .pairing
+        )
+    }
+
+    func testPairedUserSeesNotificationExplanationOnceThenChats() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true
+            )),
+            .notificationPrompt
+        )
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true,
+                hasSeenNotificationPrompt: true
+            )),
+            .chats
+        )
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true,
+                notificationPermissionIsUndetermined: false
+            )),
+            .chats
+        )
+    }
+
+    func testRevokedPairingAlwaysShowsRecovery() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .revoked,
+                hasSeenWelcome: false,
+                pairingRequested: true,
+                hasPendingPairingInvite: true
+            )),
+            .revoked
+        )
+    }
+}

--- a/ios/Tests/CompanionCoreTests/OnboardingTests.swift
+++ b/ios/Tests/CompanionCoreTests/OnboardingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import CompanionCore
 
@@ -56,7 +57,8 @@ final class OnboardingTests: XCTestCase {
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true,
-                notificationOnboardingRequested: true
+                notificationOnboardingPending: true,
+                notificationAuthorization: .notDetermined
             )),
             .notificationPrompt
         )
@@ -64,7 +66,7 @@ final class OnboardingTests: XCTestCase {
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true,
-                notificationOnboardingRequested: true,
+                notificationOnboardingPending: true,
                 hasSeenNotificationPrompt: true
             )),
             .chats
@@ -73,11 +75,165 @@ final class OnboardingTests: XCTestCase {
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true,
-                notificationOnboardingRequested: true,
-                notificationPermissionIsUndetermined: false
+                notificationOnboardingPending: true,
+                notificationAuthorization: .determined
             )),
             .chats
         )
+    }
+
+    func testPendingNotificationEducationSurvivesUnresolvedLaunchAndRelaunch() {
+        let unresolved = CompanionOnboardingContext(
+            pairingState: .paired,
+            hasSeenWelcome: true,
+            notificationOnboardingPending: true,
+            notificationAuthorization: .unresolved
+        )
+        XCTAssertEqual(CompanionOnboardingRouter.route(for: unresolved), .chats)
+        XCTAssertTrue(CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: true,
+            hasCompletedStep: false,
+            authorization: .unresolved
+        ))
+
+        // A second process launch reads the same durable pending marker. Once
+        // iOS resolves to notDetermined, the education step must reappear.
+        let relaunchedAndResolved = CompanionOnboardingContext(
+            pairingState: .paired,
+            hasSeenWelcome: true,
+            notificationOnboardingPending: true,
+            notificationAuthorization: .notDetermined
+        )
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: relaunchedAndResolved),
+            .notificationPrompt
+        )
+        XCTAssertTrue(CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: true,
+            hasCompletedStep: false,
+            authorization: .notDetermined
+        ))
+    }
+
+    func testPendingNotificationPreferenceSurvivesAProcessRelaunch() throws {
+        let suiteName = "CompanionOnboardingTests.\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let firstLaunch = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        firstLaunch.set(
+            true,
+            forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+        )
+
+        let relaunched = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+
+        XCTAssertTrue(relaunched.bool(
+            forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+        ))
+    }
+
+    func testPairingCommitMarksNotificationStepBeforeSavingConnection() {
+        var writes: [String] = []
+
+        CompanionPairingCommitSequence.persist {
+            writes.append("notification-pending")
+        } saveConnection: {
+            writes.append("connection")
+        }
+
+        XCTAssertEqual(writes, ["notification-pending", "connection"])
+    }
+
+    func testResolvedOrCompletedNotificationEducationClearsPendingMarker() {
+        XCTAssertFalse(CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: true,
+            hasCompletedStep: false,
+            authorization: .determined
+        ))
+        XCTAssertFalse(CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: true,
+            hasCompletedStep: true,
+            authorization: .notDetermined
+        ))
+        XCTAssertTrue(CompanionNotificationOnboardingPolicy.shouldKeepPending(
+            isPending: true,
+            hasCompletedStep: true,
+            authorization: .unresolved
+        ))
+    }
+
+    func testPairingSubmissionBlocksResetUntilTheAttemptSettles() {
+        var submission = CompanionPairingSubmissionState()
+        XCTAssertTrue(submission.allowsNavigation)
+        XCTAssertTrue(submission.begin())
+        XCTAssertTrue(submission.isInFlight)
+        XCTAssertFalse(submission.allowsNavigation)
+        XCTAssertFalse(submission.begin(), "a second Connect cannot overtake the in-flight request")
+
+        submission.finish()
+
+        XCTAssertFalse(submission.isInFlight)
+        XCTAssertTrue(submission.allowsNavigation)
+        XCTAssertTrue(submission.begin(), "navigation and retry resume only after completion")
+    }
+
+    func testClearedDeferredInviteCannotReopenPairingAfterLaterUnpair() {
+        var submission = CompanionPairingSubmissionState()
+        XCTAssertTrue(submission.begin())
+        XCTAssertFalse(
+            submission.allowsNavigation,
+            "a second deep link stays deferred while the first pairing commits"
+        )
+        submission.finish()
+
+        let staleInviteRoute = CompanionOnboardingRouter.route(for: .init(
+            pairingState: .unpaired,
+            hasSeenWelcome: true,
+            hasPendingPairingInvite: true
+        ))
+        XCTAssertEqual(staleInviteRoute, .pairing)
+
+        let routeAfterSuccessfulPairClearsTheInvite = CompanionOnboardingRouter.route(for: .init(
+            pairingState: .unpaired,
+            hasSeenWelcome: true,
+            hasPendingPairingInvite: false
+        ))
+        XCTAssertEqual(routeAfterSuccessfulPairClearsTheInvite, .unpairedHome)
+    }
+
+    func testPairingInviteQueueClearsAcrossSuccessAndSignOutSequence() {
+        let first = PairingInvite(
+            connection: Connection(name: "First", host: "first.local", port: 8810),
+            credential: "first-code"
+        )
+        let deferred = PairingInvite(
+            connection: Connection(name: "Deferred", host: "deferred.local", port: 8810),
+            credential: "deferred-code"
+        )
+        var pending = CompanionPairingInvitePolicy.nextInvite(
+            current: nil,
+            after: .received(first)
+        )
+        pending = CompanionPairingInvitePolicy.nextInvite(
+            current: pending,
+            after: .received(deferred)
+        )
+        XCTAssertEqual(pending, deferred)
+
+        pending = CompanionPairingInvitePolicy.nextInvite(
+            current: pending,
+            after: .pairingSucceeded
+        )
+        XCTAssertNil(pending)
+        XCTAssertFalse(CompanionPairingInvitePolicy.allowsIncomingInvite(
+            hasConnection: true,
+            pairingStateIsUnpaired: true
+        ), "a published connection closes the deep-link race before status updates")
+
+        pending = CompanionPairingInvitePolicy.nextInvite(
+            current: deferred,
+            after: .signedOut
+        )
+        XCTAssertNil(pending)
     }
 
     func testRevokedPairingAlwaysShowsRecovery() {

--- a/ios/Tests/CompanionCoreTests/OnboardingTests.swift
+++ b/ios/Tests/CompanionCoreTests/OnboardingTests.swift
@@ -41,11 +41,22 @@ final class OnboardingTests: XCTestCase {
         )
     }
 
-    func testPairedUserSeesNotificationExplanationOnceThenChats() {
+    func testExistingPairedUserGoesStraightToChats() {
         XCTAssertEqual(
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true
+            )),
+            .chats
+        )
+    }
+
+    func testJustPairedUserSeesNotificationExplanationOnceThenChats() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true,
+                notificationOnboardingRequested: true
             )),
             .notificationPrompt
         )
@@ -53,6 +64,7 @@ final class OnboardingTests: XCTestCase {
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true,
+                notificationOnboardingRequested: true,
                 hasSeenNotificationPrompt: true
             )),
             .chats
@@ -61,6 +73,7 @@ final class OnboardingTests: XCTestCase {
             CompanionOnboardingRouter.route(for: .init(
                 pairingState: .paired,
                 hasSeenWelcome: true,
+                notificationOnboardingRequested: true,
                 notificationPermissionIsUndetermined: false
             )),
             .chats


### PR DESCRIPTION
## Summary

- make QR pairing the primary iPhone onboarding path, with nearby and manual entry as clear fallbacks
- add a useful skippable unpaired home and a status-first Settings experience
- show a destination/security confirmation before manual pairing and harden navigation against duplicate in-flight attempts
- explain notification limits and local-only removal accurately
- align every route and help string with the desktop `Settings → Phone` flow
- document desktop-only hosted sign-in, LAN/Tailscale pairing, and the requirement for the Mac to stay awake

## Safety and reliability

- clear stale invites and reject connected-state deep links
- persist the notification marker before committing a connection
- normalize the displayed destination so pairing tokens and paths are never shown
- preserve the desktop companion protocol fixtures and current Phone-settings errors

## Validation

- 176 Swift tests pass
- generated Xcode project builds for the iOS Simulator
- development-signed app builds and installs side-by-side on a physical iPhone
- fresh onboarding, skip/resume, Settings status, and local-only removal copy exercised through iPhone Mirroring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided iOS onboarding flow for connecting, pairing, notification permissions, and recovering revoked connections.
  - QR scanning is now the primary pairing method, with discovery and manual address entry available as alternatives.
  - Added connection management in Settings, including security details, address copying/editing, reconnection, troubleshooting, and removal.
  - Added clearer notification setup and support for time-sensitive approvals and badges.

- **Improvements**
  - Updated connection guidance and terminology throughout the app and documentation.
  - The connected computer is now shown as a non-interactive identity label in the chat header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->