### PR TITLE
chore(release): bump version to 0.1.36

### DIFF
--- a/ios/AppStore/RELEASE.md
+++ b/ios/AppStore/RELEASE.md
@@ -5,7 +5,7 @@ The app is native Swift and uses XcodeGen; EAS commands do not apply.
 ## One-time Apple setup
 
 1. Enrol in the Apple Developer Program.
-2. Register the bundle ID `com.openmausbot.companion` (or change it in `project.yml` before the first upload).
+2. Register the bundle IDs `com.openmausbot.app` and `com.openmausbot.app.widgets` (or change them in `project.yml` before the first upload).
 3. Create the matching app in App Store Connect with the name **OpenMaus Mobile**, primary category **Productivity**, and a unique SKU.
 4. Create or select an Apple Distribution certificate and App Store provisioning profile.
 5. Add the review contact details in App Store Connect; do not commit private contact data or App Store Connect keys.

--- a/ios/AppStore/review-notes.md
+++ b/ios/AppStore/review-notes.md
@@ -9,7 +9,7 @@ not present a login screen.
 To review the primary flow:
 
 1. Install and start OpenMausBot on a Mac, Windows, or Linux computer.
-2. Open **Settings → Companion**, enable Companion, and choose **Start pairing**.
+2. Open **Settings → Phone**, enable Companion, and choose **Start pairing**.
 3. On the iPhone, choose **Scan QR Code**, scan the code shown by the desktop,
    review the computer and address, and confirm pairing.
 4. If the camera is unavailable, select the discovered computer or enter the
@@ -18,7 +18,7 @@ To review the primary flow:
    then send a message.
 
 To review optional cross-network HTTPS access, enter an email in **Settings →
-Companion → Use your phone anywhere** on the desktop, enter the eight-digit
+Phone → Use your phone anywhere** on the desktop, enter the eight-digit
 email code, enable Companion, and scan a newly generated QR code. The hosted
 service authenticates and provisions the desktop; the phone still pairs to that
 specific computer and receives no universal OpenMausBot account credential.
@@ -27,7 +27,7 @@ OpenMausBot-managed Cloudflare Tunnel and does not require Tailscale.
 
 Optional cloud-desktop review requires an ascii.dev Box configured on the
 computer. For the paired phone, enable **Cloud desktop** under **Settings →
-Companion**, open a bot configured for **Cloud box**, choose its computer
+Phone**, open a bot configured for **Cloud box**, choose its computer
 preview on iPhone, and confirm **Open live cloud desktop**. The app requests a
 fresh HTTPS viewer session and does not use or store the provider API key.
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -33,7 +33,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "1"
+        CURRENT_PROJECT_VERSION: "2"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         # The catalog lives in App/, which is already a source path. Generated
@@ -120,7 +120,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app.widgets
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "1"
+        CURRENT_PROJECT_VERSION: "2"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         SKIP_INSTALL: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop app from 0.1.35 to 0.1.36
- increment both native iOS build numbers from 1 to 2
- correct the App Store bundle IDs and Settings → Phone review copy

## Validation

- exact four-file release scope verified
- package and iOS version assertions pass
- App Store bundle IDs and review-note wording verified
- pnpm lockfile unchanged
- `git diff --check` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Apple setup instructions to reference the main app and widget bundle IDs.
  - Revised App Store review steps to use **Settings → Phone** for pairing, HTTPS access, and cloud-desktop review.

- **Chores**
  - Incremented the iOS app and widget build versions.
  - Updated the package release version to 0.1.36 while retaining the 1.0.0 marketing version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->