### PR TITLE
fix(phone): keep automatic pairing on HTTPS

### DIFF
--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -12,9 +12,9 @@ The first version includes:
 
 - QR-first pairing from desktop **Settings → Phone**, with the computer name
   confirmed on the iPhone before it connects.
-- Automatic routing through the address carried by the QR. This can include a
-  Tailscale MagicDNS name when both devices share a tailnet, or hosted HTTPS
-  when the desktop owner has enabled it.
+- Hosted HTTPS for the default QR after the desktop owner enables it, with
+  dedicated Tailscale and trusted-local QR routes only after an explicit
+  choice.
 - Nearby computers, a manual address, and a six-digit code under **Other ways
   to connect** when the QR path is unavailable.
 - Secure per-device trust, device listing, and revocation.
@@ -116,11 +116,11 @@ direct LAN requires choosing that computer or address again.
 
 ### Tailscale
 
-Tailscale is the recommended route away from home and on Wi-Fi networks that
-isolate clients. When both devices share a tailnet, OpenMausBot can place the
-Mac's MagicDNS name in the pairing QR automatically. Scan the QR normally; no
-address entry is required. Manual entry remains available only as a fallback
-when a QR invitation is unavailable or does not contain that route.
+Tailscale is an optional route away from home and on Wi-Fi networks that
+isolate clients. When both devices share a tailnet, choose **Pair over
+Tailscale** in the desktop setup alternatives. OpenMausBot then places the
+Mac's MagicDNS name in that dedicated QR; it never silently replaces the
+default hosted HTTPS route. Manual entry remains available as a fallback.
 
 The URL is still `http`, but the path is encrypted and authenticated by
 WireGuard inside the tailnet. Use the MagicDNS name rather than the
@@ -140,7 +140,9 @@ connections continue to work without an account.
 
 The desktop runs an outbound connector to Cloudflare, so no inbound router
 configuration or Tailscale installation is required. The hosted address is
-included in a pairing invitation only after it is ready.
+included in a pairing invitation only after it is ready. The default setup
+waits for that HTTPS address instead of silently substituting Tailscale;
+Tailscale pairing remains an explicit choice under the alternative routes.
 
 Cloudflare terminates and proxies the encrypted connection to the connector.
 The OpenMausBot control plane stores account and installation metadata plus
@@ -160,8 +162,9 @@ local port cannot inherit the public route.
 1. On the Mac, open **Settings → Phone**, turn on phone access, and choose
    **Set up a phone**.
 2. On the iPhone, choose **Connect my computer** and scan the QR.
-3. Confirm the computer name and **Secure connection**. The phone stores its
-   trust securely in Keychain; no iPhone account is required.
+3. Confirm the computer name and the displayed transport — **HTTPS connection**,
+   **Tailscale connection**, or **Trusted local connection**. The phone stores
+   its trust securely in Keychain; no iPhone account is required.
 4. If scanning is unavailable, open **Other ways to connect** for a nearby
    computer, manual address, or six-digit code.
 5. Revoking the phone on the Mac removes its access and lets it pair again.

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -247,6 +247,7 @@ struct PairingView: View {
 
     @ViewBuilder
     private func confirmationView(for connection: Connection) -> some View {
+        let badge = connectionBadge(for: connection)
         VStack(spacing: 22) {
             ZStack {
                 Circle()
@@ -262,8 +263,7 @@ struct PairingView: View {
                 Text(connection.name)
                     .font(.title2.bold())
                     .multilineTextAlignment(.center)
-                Label(connectionIsProtected(connection) ? "Secure connection" : "Trusted local connection",
-                      systemImage: connectionIsProtected(connection) ? "lock.shield.fill" : "checkmark.shield.fill")
+                Label(badge.title, systemImage: badge.systemImage)
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MausPalette.color("green"))
             }
@@ -456,6 +456,17 @@ struct PairingView: View {
         connection.activeEndpoint?.protectsCredentials
             ?? connection.automaticEndpoints.first?.protectsCredentials
             ?? false
+    }
+
+    private func connectionBadge(for connection: Connection) -> (title: String, systemImage: String) {
+        let kind = connection.activeEndpoint?.kind ?? connection.automaticEndpoints.first?.kind
+        if kind == .hosted {
+            return ("HTTPS connection", "lock.shield.fill")
+        }
+        if kind == .tailnet {
+            return ("Tailscale connection", "lock.shield.fill")
+        }
+        return ("Trusted local connection", "checkmark.shield.fill")
     }
 
     static func deviceName() -> String {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -170,8 +170,15 @@ final class Session: ObservableObject {
         deviceName: String,
         pairRequestId: String
     ) async throws {
+        var invited = connection
+        // QR invites already carry this policy. Manual entry reaches the
+        // session as a parsed Connection, so establish the same consent
+        // boundary here before any health probe or credential redemption.
+        if invited.allowedRouteKinds == nil {
+            invited.establishRoutePolicyFromInvite()
+        }
         let outcome = try await CompanionClient.pairFirstReachable(
-            connection: connection,
+            connection: invited,
             credential: credential,
             deviceName: deviceName,
             pairRequestId: pairRequestId
@@ -180,14 +187,9 @@ final class Session: ObservableObject {
         // prefer the name the computer calls itself over the Bonjour label
         var stored = outcome.connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
-        // The computer knows every address it answers on, and what it says at
-        // redeem time beats whatever the invite carried. The route that just
-        // redeemed leads this live session; future launches return to the
-        // desktop's security-prioritized typed order.
-        if let hosts = paired.hosts, !hosts.isEmpty { stored.hosts = Array(hosts.prefix(8)) }
-        if let endpoints = paired.endpoints, !endpoints.isEmpty {
-            stored.endpoints = Array(endpoints.prefix(8))
-        }
+        // The computer knows every address it answers on, but redemption may
+        // not widen the explicit route consent carried by the invite.
+        stored.applyPairingAdvertisement(hosts: paired.hosts, endpoints: paired.endpoints)
         let winner = outcome.connection.activeEndpoint ?? CompanionEndpoint.direct(
             host: outcome.connection.host,
             port: outcome.connection.port,
@@ -570,19 +572,15 @@ final class Session: ObservableObject {
     @discardableResult
     func updateAddress(_ text: String) -> Bool {
         guard var updated = connection, let parsed = Connection.parse(text) else { return false }
-        let existingRoutes = updated.orderedEndpoints
         guard let endpoint = parsed.activeEndpoint ?? CompanionEndpoint.direct(
             host: parsed.host,
             port: parsed.port,
             priority: 0
         ) else { return false }
-        updated.promote(endpoint)
-        updated.endpoints = [endpoint] + existingRoutes.filter { $0.url != endpoint.url }
+        updated.resetRoutePolicy(selecting: endpoint)
         connection = updated
         UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
-        rotation = CandidateRotation(
-            endpoints: [endpoint] + updated.orderedEndpoints.filter { $0.url != endpoint.url }
-        )
+        rotation = CandidateRotation(endpoints: updated.orderedEndpoints)
         if let token {
             client = CompanionClient(connection: updated.dialing(endpoint), token: token)
         }

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -18,8 +18,9 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     public var port: Int
     /// Every other address the computer answered on at pairing time, best
     /// first — the tailnet name, the LAN address, the sidecar's mDNS name.
-    /// Optional so connections saved before fallbacks existed still decode;
-    /// read through `orderedHosts`, which is never empty.
+    /// Optional so connections saved before fallbacks existed still decode.
+    /// Read through `orderedHosts`; policy-bound hosted connections may have
+    /// no legacy HTTP host because their complete route lives in `endpoints`.
     public var hosts: [String]?
     /// Complete route currently being dialed. Absent on connections saved by
     /// older app builds, where `host` + `port` still mean direct HTTP.
@@ -27,6 +28,16 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// Full routes advertised by a newer desktop. Each carries its own scheme
     /// and port so hosted HTTPS can coexist with local HTTP fallbacks.
     public var endpoints: [CompanionEndpoint]?
+    /// The route kinds this pairing explicitly authorized. `nil` is reserved
+    /// for connections saved by older app versions and retains their legacy
+    /// failover behavior. New pairings always persist a non-nil policy, with
+    /// hosted HTTPS included as the one universally safe future upgrade.
+    public var allowedRouteKinds: Set<CompanionEndpointKind>?
+    /// Exact cleartext origins the pairing consent screen authorized. New
+    /// policies persist an empty set for hosted/Tailscale and one selected
+    /// LAN or Bonjour origin for local pairing. Absent alongside a nil kind
+    /// policy on connections saved before route consent existed.
+    public var allowedLocalRouteURLs: Set<String>?
 
     public init(
         id: String = UUID().uuidString,
@@ -35,7 +46,9 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         port: Int,
         hosts: [String]? = nil,
         activeEndpoint: CompanionEndpoint? = nil,
-        endpoints: [CompanionEndpoint]? = nil
+        endpoints: [CompanionEndpoint]? = nil,
+        allowedRouteKinds: Set<CompanionEndpointKind>? = nil,
+        allowedLocalRouteURLs: Set<String>? = nil
     ) {
         self.id = id
         self.name = name
@@ -44,6 +57,8 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         self.hosts = hosts
         self.activeEndpoint = activeEndpoint
         self.endpoints = endpoints
+        self.allowedRouteKinds = allowedRouteKinds
+        self.allowedLocalRouteURLs = allowedLocalRouteURLs
     }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
@@ -132,13 +147,14 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// The bearer token goes out in a header on every request, so anyone who
     /// can observe the path between phone and computer can lift it and use it
     /// until the device is revoked. What that means in practice depends
-    /// entirely on how you reach the computer, and the two supported routes
-    /// are not equivalent:
+    /// entirely on how you reach the computer, and the supported routes are
+    /// not equivalent:
     ///
-    /// - **Over a tailnet** — the recommended route, and the only one that
-    ///   works away from home — the traffic is inside WireGuard before it
-    ///   reaches any network, so it is encrypted and authenticated end to end
-    ///   even though this URL says `http`.
+    /// - **Over hosted HTTPS** — the default remote route — ordinary TLS
+    ///   encrypts the connection and authenticates the public endpoint.
+    /// - **Over a tailnet**, the traffic is inside WireGuard before it reaches
+    ///   any network, so it is encrypted and authenticated end to end even
+    ///   though this URL says `http`.
     /// - **Over a LAN**, it is cleartext on that network. Trust it exactly as
     ///   far as you trust everyone on the wifi: fine at home, not fine on a
     ///   café or conference network — pair over the tailnet there instead.
@@ -147,19 +163,21 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// switched on. A self-signed certificate on a LAN address is a
     /// certificate nothing can validate, so it would have to be pinned at
     /// pairing time and re-pinned whenever the sidecar regenerates it — a
-    /// meaningful amount of machinery whose benefit, on the tailnet path, is
-    /// zero. The honest position is: the tailnet carries the encryption, the
-    /// LAN path is documented as trusted-network-only, and pinned TLS is what
-    /// this needs before it could claim otherwise. See `docs/ios-companion.md`.
+    /// meaningful amount of machinery. Hosted HTTPS and the tailnet carry
+    /// encryption; the LAN path is documented as trusted-network-only, and
+    /// pinned TLS is what it needs before it could claim otherwise. See
+    /// `docs/ios-companion.md`.
     public var baseURL: URL? {
-        if let endpoint = activeEndpoint?.baseURL { return endpoint }
-        var components = URLComponents()
-        components.scheme = "http"
-        // Normalize here too so connections saved by older builds with an
-        // unbracketed IPv6 host remain usable after an update.
-        components.host = Self.urlHost(host)
-        components.port = port
-        return components.url
+        if let activeEndpoint {
+            guard allowsEndpoint(activeEndpoint) else { return nil }
+            return activeEndpoint.baseURL
+        }
+        guard let direct = CompanionEndpoint.direct(
+            host: host,
+            port: port,
+            priority: 0
+        ), allowsEndpoint(direct) else { return nil }
+        return direct.baseURL
     }
 }
 
@@ -217,6 +235,7 @@ public struct PairingInvite: Equatable, Sendable {
             connection.endpoints = endpoints
             connection = connection.dialing(endpoints[0])
         }
+        connection.establishRoutePolicyFromInvite()
         return PairingInvite(connection: connection, credential: credential)
     }
 

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -6,11 +6,12 @@
 // moment either device leaves the tailnet. The connection still carries every
 // address the computer advertised, but a bearer credential cannot safely be
 // sprayed onto whatever LAN happens to use the same private address later.
-// Automatic walking is therefore a trust ratchet: protected routes can walk
-// to other protected routes, while a user-selected cleartext route can be
-// tried exactly once and can only move to a stronger transport. Both halves
-// are pure — no sockets, no clocks — so the rules can be tested without a
-// network; `Session` owns when they run.
+// New pairings also persist the route kinds the person chose: hosted never
+// grows a Tailscale fallback, while an explicit Tailscale or local selection
+// may still upgrade to hosted HTTPS. Connections saved before that policy was
+// introduced retain the legacy protected-route ratchet. Both layers are pure
+// — no sockets, no clocks — so the rules can be tested without a network;
+// `Session` owns when they run.
 import Foundation
 
 /// The ordered walk through a connection's stored hosts.
@@ -176,14 +177,132 @@ public enum ConnectionAdvice {
 }
 
 extension Connection {
-    /// Every host this connection may dial, best first and never empty: the
-    /// stored `host` leads, then the pairing-time fallbacks, deduplicated
-    /// after the same normalization dialing applies.
+    /// `nil` is the compatibility policy for connections persisted before
+    /// route consent existed. Once a policy is present, only an explicitly
+    /// selected kind and hosted HTTPS may receive the pairing/device token.
+    public func allowsRouteKind(_ kind: CompanionEndpointKind) -> Bool {
+        guard let allowedRouteKinds else { return true }
+        return kind == .hosted || allowedRouteKinds.contains(kind)
+    }
+
+    /// Kind consent is sufficient for protected transports. A cleartext
+    /// route additionally has to be the exact origin shown for confirmation;
+    /// another address of the same LAN/Bonjour kind is not interchangeable.
+    public func allowsEndpoint(_ endpoint: CompanionEndpoint) -> Bool {
+        guard allowsRouteKind(endpoint.kind) else { return false }
+        guard endpoint.securityClass == .explicitLocal,
+              allowedRouteKinds != nil
+        else { return true }
+        return allowedLocalRouteURLs?.contains(endpoint.url) == true
+    }
+
+    public func endpointsAllowedByRoutePolicy(
+        _ candidates: [CompanionEndpoint]
+    ) -> [CompanionEndpoint] {
+        candidates.filter(allowsEndpoint)
+    }
+
+    /// Bind a new pairing to the route the QR/manual choice actually selected.
+    /// Other fallback addresses in a typed invite are advisory, not fresh
+    /// consent. Hosted HTTPS is always retained as a safe future upgrade.
+    public mutating func establishRoutePolicyFromInvite() {
+        let selected = activeEndpoint ?? CompanionEndpoint.direct(
+            host: host,
+            port: port,
+            priority: 0
+        )
+        switch selected {
+        case let endpoint? where endpoint.kind == .hosted:
+            allowedRouteKinds = [.hosted]
+            allowedLocalRouteURLs = []
+        case let endpoint? where endpoint.kind == .tailnet:
+            allowedRouteKinds = [.tailnet, .hosted]
+            allowedLocalRouteURLs = []
+        case let endpoint?:
+            allowedRouteKinds = [endpoint.kind, .hosted]
+            allowedLocalRouteURLs = [endpoint.url]
+        case nil:
+            // A valid Connection always has a direct representation, but
+            // fail closed to hosted if a corrupted value reaches this helper.
+            allowedRouteKinds = [.hosted]
+            allowedLocalRouteURLs = []
+        }
+        if let endpoints {
+            self.endpoints = Array(endpointsAllowedByRoutePolicy(endpoints).prefix(8))
+        }
+        if let hosts {
+            self.hosts = Array(advertisedHostsAllowedByRoutePolicy(hosts).prefix(8))
+        }
+    }
+
+    /// Apply the routes returned when a pairing credential is redeemed. The
+    /// response may advertise every interface on the Mac, but it cannot widen
+    /// the consent recorded from the invite which carried that credential.
+    public mutating func applyPairingAdvertisement(
+        hosts advertisedHosts: [String]?,
+        endpoints advertisedEndpoints: [CompanionEndpoint]?
+    ) {
+        if let advertisedHosts, !advertisedHosts.isEmpty {
+            hosts = Array(advertisedHostsAllowedByRoutePolicy(advertisedHosts).prefix(8))
+        }
+        if let advertisedEndpoints, !advertisedEndpoints.isEmpty {
+            let accepted = endpointsAllowedByRoutePolicy(advertisedEndpoints)
+            // Keep the invite's known-good selected route if a newer or
+            // compromised response contains only disallowed alternatives.
+            if !accepted.isEmpty { endpoints = Array(accepted.prefix(8)) }
+        }
+    }
+
+    /// A hand-entered replacement is fresh, explicit consent. Reset rather
+    /// than widening the old policy: selected Tailscale permits Tailscale and
+    /// hosted, selected LAN/Bonjour permits that one kind and hosted.
+    public mutating func resetRoutePolicy(selecting endpoint: CompanionEndpoint) {
+        let previousEndpoints = orderedEndpoints
+        allowedRouteKinds = [endpoint.kind, .hosted]
+        allowedLocalRouteURLs = endpoint.securityClass == .explicitLocal ? [endpoint.url] : []
+        activeEndpoint = endpoint
+        host = endpoint.host
+        port = endpoint.port
+        endpoints = [endpoint] + endpointsAllowedByRoutePolicy(previousEndpoints)
+            .filter { $0.url != endpoint.url }
+        hosts = Array(advertisedHostsAllowedByRoutePolicy(
+            [endpoint.host] + (hosts ?? [])
+        ).prefix(8))
+    }
+
+    private func advertisedHostsAllowedByRoutePolicy(_ candidates: [String]) -> [String] {
+        var seen = Set<String>()
+        return candidates.compactMap { raw -> String? in
+            let candidate = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !candidate.isEmpty,
+                  candidate.utf8.count <= 253,
+                  !candidate.contains(where: { $0.isWhitespace || "/?#".contains($0) })
+            else { return nil }
+            let normalized = Self.urlHost(candidate)
+            guard let endpoint = CompanionEndpoint.direct(
+                host: normalized,
+                port: port,
+                priority: 0
+            ), allowsEndpoint(endpoint) else { return nil }
+            return seen.insert(normalized).inserted ? normalized : nil
+        }
+    }
+
+    /// Every legacy host this connection may dial, best first. A policy-bound
+    /// hosted connection can legitimately return an empty list because its
+    /// complete HTTPS endpoint lives in `orderedEndpoints` instead.
     public var orderedHosts: [String] {
         var seen = Set<String>()
         var out: [String] = []
         for candidate in [host] + (hosts ?? []) {
             let normalized = Self.urlHost(candidate)
+            guard let endpoint = CompanionEndpoint.direct(
+                host: normalized,
+                port: port,
+                priority: 0
+            ), allowsEndpoint(endpoint) else {
+                continue
+            }
             if seen.insert(normalized).inserted { out.append(normalized) }
         }
         return out
@@ -210,12 +329,14 @@ extension Connection {
             }
         }
         var seen = Set<String>()
-        return candidates.filter { seen.insert($0.url).inserted }.prefix(8).map { $0 }
+        return endpointsAllowedByRoutePolicy(candidates)
+            .filter { seen.insert($0.url).inserted }
+            .prefix(8).map { $0 }
     }
 
     /// The subset an automatic pairing or authenticated reconnect may try.
-    /// The complete advertised list remains persisted in `orderedEndpoints`
-    /// so a person can explicitly choose a local route later.
+    /// A policy-bound connection first removes route kinds the person did not
+    /// select; the transport ratchet then removes unsafe cleartext fallbacks.
     public var automaticEndpoints: [CompanionEndpoint] {
         CompanionEndpoint.automaticCandidates(from: orderedEndpoints)
     }
@@ -234,24 +355,16 @@ extension Connection {
         if !cleanedName.isEmpty { name = String(cleanedName.prefix(80)) }
 
         if let advertisedHosts = metadata.hosts {
-            var seen = Set<String>()
-            hosts = advertisedHosts.compactMap { raw -> String? in
-                let candidate = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !candidate.isEmpty,
-                      candidate.utf8.count <= 253,
-                      !candidate.contains(where: { $0.isWhitespace || "/?#".contains($0) })
-                else { return nil }
-                let normalized = Self.urlHost(candidate)
-                return seen.insert(normalized).inserted ? normalized : nil
-            }.prefix(8).map { $0 }
+            hosts = Array(advertisedHostsAllowedByRoutePolicy(advertisedHosts).prefix(8))
         }
 
-        let previousActive = activeEndpoint
-        endpoints = metadata.endpoints
+        let previousActive = activeEndpoint.flatMap { allowsEndpoint($0) ? $0 : nil }
+        let refreshedEndpoints = endpointsAllowedByRoutePolicy(metadata.endpoints)
+        endpoints = refreshedEndpoints
         if let previousActive,
-           let refreshedActive = metadata.endpoints.first(where: { $0.url == previousActive.url }) {
+           let refreshedActive = refreshedEndpoints.first(where: { $0.url == previousActive.url }) {
             activeEndpoint = refreshedActive
-        } else if let protectedReplacement = metadata.endpoints.first(where: \.protectsCredentials) {
+        } else if let protectedReplacement = refreshedEndpoints.first(where: \.protectsCredentials) {
             activeEndpoint = protectedReplacement
         } else if let previousActive,
                   let retained = CompanionEndpoint(
@@ -260,11 +373,11 @@ extension Connection {
                       priority: 0
                   ) {
             activeEndpoint = retained
-            endpoints = [retained] + metadata.endpoints
+            endpoints = [retained] + refreshedEndpoints
                 .filter { $0.url != retained.url }
                 .prefix(7)
         } else {
-            activeEndpoint = metadata.endpoints.first
+            activeEndpoint = refreshedEndpoints.first
         }
         if let activeEndpoint {
             host = activeEndpoint.host
@@ -285,6 +398,7 @@ extension Connection {
     /// A copy dialing one complete route without changing its stored policy
     /// order or keychain identity.
     public func dialing(_ candidate: CompanionEndpoint) -> Connection {
+        guard allowsEndpoint(candidate) else { return self }
         var copy = self
         copy.activeEndpoint = candidate
         copy.host = candidate.host
@@ -296,15 +410,21 @@ extension Connection {
     /// carried traffic, or the one the user typed in by hand.
     public mutating func promote(_ winner: String) {
         let normalized = Self.urlHost(winner)
+        guard let endpoint = CompanionEndpoint.direct(
+            host: normalized,
+            port: port,
+            priority: 10_000
+        ), allowsEndpoint(endpoint) else { return }
         let rest = orderedHosts.filter { $0 != normalized }
         host = normalized
         hosts = [normalized] + rest
-        activeEndpoint = CompanionEndpoint.direct(host: normalized, port: port, priority: 10_000)
+        activeEndpoint = endpoint
     }
 
     /// Remember the route that worked without letting a cleartext fallback
     /// jump ahead of a lower-priority hosted/tailnet route on the next launch.
     public mutating func promote(_ winner: CompanionEndpoint) {
+        guard allowsEndpoint(winner) else { return }
         activeEndpoint = winner
         host = winner.host
         port = winner.port

--- a/ios/TESTING.md
+++ b/ios/TESTING.md
@@ -247,16 +247,17 @@ so this is also how the phone reaches the Mac over cellular.
    App Store build) and sign in.
 2. **On the phone:** install Tailscale from the App Store, sign in to the *same*
    account, and turn the VPN on.
-3. **In OpenMausBot → Settings → Companion:** with the toggle on, the panel now
+3. **In OpenMausBot → Settings → Phone:** with Phone access on, the panel now
    prints the tailnet name — something like `macbook.tail1234.ts.net:8810`, with
    the LAN address listed separately underneath. If it still only shows a
    `192.168.x.x` address, the sidecar could not find the Tailscale CLI — it
    asks once at startup, so turn the Companion toggle off and on again (or
    restart `pnpm companion` if running it by hand) after Tailscale is up.
-4. **On the phone:** scan the Companion panel's QR code, which carries that
-   MagicDNS name, or pair by typing the name. Discovery does not help here —
-   Bonjour is multicast and a tailnet does not carry it — so the QR/manual
-   address is the path, and it is the one path that works from anywhere.
+4. **In the desktop setup alternatives, choose Pair over Tailscale.** Scan its
+   dedicated QR, which carries that MagicDNS name, or pair by typing the name.
+   Discovery does not help here — Bonjour is multicast and a tailnet does not
+   carry it — so the Tailscale QR/manual address is the path, and it is the one
+   path that works from anywhere.
 
 **Use the name, not the address.** Both reach the harness, but only the name
 gets past App Transport Security. iOS exempts local networking, and `100.64/10`

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -99,18 +99,23 @@ final class ConnectionTests: XCTestCase {
 
     func testParsesAnOlderCodeOnlyPairingInvite() throws {
         let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=004209"))
-        XCTAssertEqual(PairingInvite.parse(url)?.credential, "004209")
+        let invite = try XCTUnwrap(PairingInvite.parse(url))
+        XCTAssertEqual(invite.credential, "004209")
+        XCTAssertEqual(invite.connection.allowedRouteKinds, [.bonjour, .hosted])
+        XCTAssertEqual(invite.connection.allowedLocalRouteURLs, ["http://mac.local:8810"])
     }
 
-    func testCarriesTheFallbackHostsFromTheInvite() throws {
+    func testLegacyTailnetInviteDropsUnselectedLocalFallbackKinds() throws {
         let url = try XCTUnwrap(URL(string:
             "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&code=004209" +
             "&hosts=macbook.tail1234.ts.net,192.168.1.42,openmausbot-aa.local"))
         let invite = try XCTUnwrap(PairingInvite.parse(url))
-        XCTAssertEqual(invite.connection.hosts, ["macbook.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"])
+        XCTAssertEqual(invite.connection.hosts, ["macbook.tail1234.ts.net"])
+        XCTAssertEqual(invite.connection.allowedRouteKinds, [.tailnet, .hosted])
+        XCTAssertEqual(invite.connection.allowedLocalRouteURLs, [])
     }
 
-    func testCarriesHostedAndDirectTypedEndpointsFromTheInvite() throws {
+    func testHostedTypedInviteCannotRetainDirectFallbacks() throws {
         let routes = [
             ["url": "http://192.168.1.42:8810", "kind": "lan", "priority": 200] as [String: Any],
             ["url": "https://mac.companion.example", "kind": "hosted", "priority": 0] as [String: Any],
@@ -125,8 +130,10 @@ final class ConnectionTests: XCTestCase {
 
         XCTAssertEqual(invite.connection.baseURL?.absoluteString, "https://mac.companion.example")
         XCTAssertEqual(invite.connection.activeEndpoint?.kind, .hosted)
-        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.kind), [.hosted, .tailnet, .lan])
-        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.priority), [0, 100, 200])
+        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.kind), [.hosted])
+        XCTAssertEqual(invite.connection.orderedEndpoints.map(\.priority), [0])
+        XCTAssertEqual(invite.connection.allowedRouteKinds, [.hosted])
+        XCTAssertEqual(invite.connection.allowedLocalRouteURLs, [])
     }
 
     func testRejectsMalformedOrDowngradedTypedEndpoints() throws {
@@ -146,13 +153,13 @@ final class ConnectionTests: XCTestCase {
         XCTAssertNil(PairingInvite.parse(invalidBase64))
     }
 
-    func testDropsUnusableFallbackHostsWithoutRefusingTheInvite() throws {
+    func testSanitizesFallbackHostsAndKeepsOnlyTheConfirmedLocalOrigin() throws {
         // Fallbacks are advisory: a bad one costs a single failed dial when
         // its turn comes, so it is filtered rather than fatal.
         let url = try XCTUnwrap(URL(string:
-            "openmausbot://pair?address=mac.local&code=004209&hosts=%20192.168.1.42%20,,bad%2Fslash,has%20space"))
+            "openmausbot://pair?address=mac.local&code=004209&hosts=%20mac.local%20,other.local,,bad%2Fslash,has%20space"))
         let invite = try XCTUnwrap(PairingInvite.parse(url))
-        XCTAssertEqual(invite.connection.hosts, ["192.168.1.42"])
+        XCTAssertEqual(invite.connection.hosts, ["mac.local"])
 
         // and an invite with no usable candidate keeps the single address
         let empty = try XCTUnwrap(URL(string: "openmausbot://pair?address=mac.local&code=004209&hosts=bad%2Fslash"))
@@ -165,7 +172,23 @@ final class ConnectionTests: XCTestCase {
         let data = Data(#"{"id":"saved","name":"Mac","host":"mac.tail1234.ts.net","port":8810}"#.utf8)
         let saved = try JSONDecoder().decode(Connection.self, from: data)
         XCTAssertNil(saved.hosts)
+        XCTAssertNil(saved.allowedRouteKinds)
+        XCTAssertNil(saved.allowedLocalRouteURLs)
         XCTAssertEqual(saved.orderedHosts, ["mac.tail1234.ts.net"])
+    }
+
+    func testRouteConsentPolicyPersistsAcrossEncoding() throws {
+        var connection = try XCTUnwrap(Connection.parse("mac.tail1234.ts.net"))
+        connection.establishRoutePolicyFromInvite()
+
+        let restored = try JSONDecoder().decode(
+            Connection.self,
+            from: JSONEncoder().encode(connection)
+        )
+
+        XCTAssertEqual(restored.allowedRouteKinds, [.tailnet, .hosted])
+        XCTAssertEqual(restored.allowedLocalRouteURLs, [])
+        XCTAssertEqual(restored.automaticEndpoints.map(\.kind), [.tailnet])
     }
 
     func testAPairResponseWithAndWithoutHostsDecodes() throws {

--- a/ios/Tests/CompanionCoreTests/EndpointRefreshTests.swift
+++ b/ios/Tests/CompanionCoreTests/EndpointRefreshTests.swift
@@ -146,6 +146,131 @@ final class EndpointRefreshTests: XCTestCase {
         XCTAssertTrue(liveRotation.endpoints.allSatisfy(\.protectsCredentials))
     }
 
+    func testHostedInviteFiltersPairResponseAndRefreshToHTTPSOnly() throws {
+        let routes = try Self.routes()
+        var connection = Connection(
+            name: "Mac",
+            host: routes.hosted.host,
+            port: routes.hosted.port,
+            activeEndpoint: routes.hosted,
+            endpoints: [routes.hosted]
+        )
+        connection.establishRoutePolicyFromInvite()
+
+        connection.applyPairingAdvertisement(
+            hosts: [routes.tailnet.host, routes.local.host],
+            endpoints: [routes.hosted, routes.tailnet, routes.local]
+        )
+        XCTAssertEqual(connection.allowedRouteKinds, [.hosted])
+        XCTAssertEqual(connection.allowedLocalRouteURLs, [])
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.hosted])
+        XCTAssertEqual(connection.hosts, [])
+
+        connection.reconcile(try Self.metadata())
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.hosted])
+        XCTAssertEqual(connection.automaticEndpoints.map(\.kind), [.hosted])
+        XCTAssertEqual(connection.hosts, [])
+    }
+
+    func testExplicitTailscaleInviteAllowsTailnetAndHostedAfterRefresh() throws {
+        let routes = try Self.routes()
+        var connection = Connection(
+            name: "Mac",
+            host: routes.tailnet.host,
+            port: routes.tailnet.port,
+            activeEndpoint: routes.tailnet,
+            endpoints: [routes.tailnet, routes.hosted]
+        )
+        connection.establishRoutePolicyFromInvite()
+
+        connection.applyPairingAdvertisement(
+            hosts: [routes.tailnet.host, routes.local.host],
+            endpoints: [routes.hosted, routes.tailnet, routes.local]
+        )
+        connection.reconcile(try Self.metadata())
+
+        XCTAssertEqual(connection.allowedRouteKinds, [.tailnet, .hosted])
+        XCTAssertEqual(connection.allowedLocalRouteURLs, [])
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.hosted, .tailnet])
+        XCTAssertEqual(connection.automaticEndpoints.map(\.kind), [.hosted, .tailnet])
+        XCTAssertEqual(connection.hosts, [routes.tailnet.host])
+    }
+
+    func testExplicitLocalInviteNeverLearnsTailscaleOrAnotherLANOrigin() throws {
+        let routes = try Self.routes()
+        var connection = Connection(
+            name: "Mac",
+            host: routes.local.host,
+            port: routes.local.port,
+            activeEndpoint: routes.local,
+            endpoints: [routes.local, routes.tailnet, routes.hosted, routes.otherLocal]
+        )
+        connection.establishRoutePolicyFromInvite()
+
+        connection.applyPairingAdvertisement(
+            hosts: [routes.tailnet.host, routes.local.host],
+            endpoints: [routes.hosted, routes.tailnet, routes.otherLocal, routes.local]
+        )
+        let refreshed = try JSONDecoder().decode(
+            CompanionConnectionMetadata.self,
+            from: Data(#"{"serverName":"Mac","hosts":["192.168.1.99","192.168.1.42","mac.tail1234.ts.net"],"endpoints":[{"url":"http://192.168.1.99:8810","kind":"lan","priority":50},{"url":"http://mac.tail1234.ts.net:8810","kind":"tailnet","priority":100},{"url":"http://192.168.1.42:8810","kind":"lan","priority":200},{"url":"https://mac.companion.example","kind":"hosted","priority":0}]}"#.utf8)
+        )
+        connection.reconcile(refreshed)
+
+        XCTAssertEqual(connection.allowedRouteKinds, [.lan, .hosted])
+        XCTAssertEqual(connection.allowedLocalRouteURLs, [routes.local.url])
+        XCTAssertFalse(connection.orderedEndpoints.contains { $0.kind == .tailnet })
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.hosted, .lan])
+        XCTAssertFalse(connection.orderedEndpoints.contains { $0.url == routes.otherLocal.url })
+        XCTAssertEqual(connection.hosts, [routes.local.host])
+    }
+
+    func testSavedConnectionWithoutPolicyRetainsLegacyProtectedFailover() throws {
+        let data = Data(#"""
+        {
+          "id":"legacy","name":"Mac","host":"mac.companion.example","port":443,
+          "activeEndpoint":{"url":"https://mac.companion.example","kind":"hosted","priority":0},
+          "endpoints":[
+            {"url":"https://mac.companion.example","kind":"hosted","priority":0},
+            {"url":"http://mac.tail1234.ts.net:8810","kind":"tailnet","priority":100}
+          ]
+        }
+        """#.utf8)
+        var connection = try JSONDecoder().decode(Connection.self, from: data)
+        XCTAssertNil(connection.allowedRouteKinds)
+        XCTAssertNil(connection.allowedLocalRouteURLs)
+
+        connection.reconcile(try Self.metadata())
+
+        XCTAssertEqual(connection.automaticEndpoints.map(\.kind), [.hosted, .tailnet])
+    }
+
+    private static func metadata() throws -> CompanionConnectionMetadata {
+        try JSONDecoder().decode(CompanionConnectionMetadata.self, from: fullMetadata)
+    }
+
+    private static func routes() throws -> (
+        hosted: CompanionEndpoint,
+        tailnet: CompanionEndpoint,
+        local: CompanionEndpoint,
+        otherLocal: CompanionEndpoint
+    ) {
+        (
+            try XCTUnwrap(CompanionEndpoint(
+                url: "https://mac.companion.example", kind: .hosted, priority: 0
+            )),
+            try XCTUnwrap(CompanionEndpoint(
+                url: "http://mac.tail1234.ts.net:8810", kind: .tailnet, priority: 100
+            )),
+            try XCTUnwrap(CompanionEndpoint(
+                url: "http://192.168.1.42:8810", kind: .lan, priority: 200
+            )),
+            try XCTUnwrap(CompanionEndpoint(
+                url: "http://192.168.1.99:8810", kind: .lan, priority: 150
+            ))
+        )
+    }
+
     private static let fullMetadata = Data(
         #"{"serverName":"Milind's computer","hosts":["mac.tail1234.ts.net","192.168.1.42"],"endpoints":[{"url":"http://192.168.1.42:8810","kind":"lan","priority":200},{"url":"http://not-a-tailnet.example:8810","kind":"tailnet","priority":50},{"url":"http://mac.tail1234.ts.net:8810","kind":"tailnet","priority":100},{"url":"https://mac.companion.example","kind":"hosted","priority":0}]}"#.utf8
     )

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -295,4 +295,43 @@ final class FailoverTests: XCTestCase {
             priority: 100
         ))
     }
+
+    func testManualAddressSelectionResetsInsteadOfWidensRoutePolicy() throws {
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example", kind: .hosted, priority: 0
+        ))
+        let tailnet = try XCTUnwrap(CompanionEndpoint(
+            url: "http://mac.tail1234.ts.net:8810", kind: .tailnet, priority: 0
+        ))
+        let local = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810", kind: .lan, priority: 0
+        ))
+        let otherLocal = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.99:8810", kind: .lan, priority: 0
+        ))
+        var connection = Connection(
+            name: "Mac",
+            host: hosted.host,
+            port: hosted.port,
+            activeEndpoint: hosted,
+            endpoints: [hosted],
+            allowedRouteKinds: [.hosted]
+        )
+
+        connection.resetRoutePolicy(selecting: tailnet)
+        XCTAssertEqual(connection.allowedRouteKinds, [.tailnet, .hosted])
+        XCTAssertEqual(connection.allowedLocalRouteURLs, [])
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.tailnet, .hosted])
+
+        connection.resetRoutePolicy(selecting: local)
+        XCTAssertEqual(connection.allowedRouteKinds, [.lan, .hosted])
+        XCTAssertEqual(connection.allowedLocalRouteURLs, [local.url])
+        XCTAssertEqual(connection.orderedEndpoints.map(\.kind), [.lan, .hosted])
+        XCTAssertFalse(connection.orderedEndpoints.contains { $0.kind == .tailnet })
+
+        let refused = connection.dialing(tailnet)
+        XCTAssertEqual(refused.activeEndpoint, local)
+        XCTAssertEqual(refused.baseURL?.absoluteString, local.url)
+        XCTAssertEqual(connection.dialing(otherLocal).activeEndpoint, local)
+    }
 }

--- a/src/components/PhoneSetupFlow.tsx
+++ b/src/components/PhoneSetupFlow.tsx
@@ -95,7 +95,7 @@ type StateBridge<T> = { state: () => Promise<T> };
 const DIRECT_PAIRING_UNAVAILABLE =
   "Direct Wi-Fi pairing isn’t available on this computer right now. Connect this computer to Wi-Fi, then try again.";
 const PROTECTED_PAIRING_UNAVAILABLE =
-  "The protected pairing route became unavailable. Check your secure connection or Tailscale, then create a new code.";
+  "The HTTPS pairing route became unavailable. Check secure access, then create a new code.";
 
 interface OwnedCompanionPairingRoutePin extends CompanionPairingRoutePin {
   generation: number;

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -122,7 +122,7 @@ describe("companionPairingLink", () => {
     expect(new URL(none!).searchParams.get("hosts")).toBeNull();
   });
 
-  it("preserves protected priority without exposing a LAN legacy fallback", () => {
+  it("makes the automatic QR hosted-only even when Tailscale and LAN are advertised", () => {
     const endpoints = [
       { url: "https://device.openmausbot.com", kind: "hosted" as const, priority: 0 },
       { url: "http://mac.tail1234.ts.net:8810", kind: "tailnet" as const, priority: 100 },
@@ -139,17 +139,16 @@ describe("companionPairingLink", () => {
     expect(route).toEqual({
       address: "device.openmausbot.com",
       port: 443,
-      hosts: ["device.openmausbot.com", "mac.tail1234.ts.net"],
-      endpoints,
+      hosts: ["device.openmausbot.com"],
+      endpoints: [endpoints[0]],
     });
     const link = companionPairingLink({ ...route!, code: "004209", token });
     const url = new URL(link!);
     expect(url.searchParams.get("address")).toBe("device.openmausbot.com:443");
-    expect(url.searchParams.get("hosts")).toBe(
-      "device.openmausbot.com,mac.tail1234.ts.net",
-    );
+    expect(url.searchParams.get("hosts")).toBe("device.openmausbot.com");
     expect(url.searchParams.get("hosts")).not.toContain("192.168.1.42");
-    expect(decodedEndpoints(link!)).toEqual(endpoints);
+    expect(url.searchParams.get("hosts")).not.toContain("tail1234.ts.net");
+    expect(decodedEndpoints(link!)).toEqual([endpoints[0]]);
     expect(companionPairingRoutePin({
       port: 8810,
       tailnetName: "mac.tail1234.ts.net",
@@ -159,25 +158,20 @@ describe("companionPairingLink", () => {
     }, "automatic")?.protectedEndpoint?.kind).toBe("hosted");
   });
 
-  it("keeps a tailnet-first automatic QR on MagicDNS legacy hosts", () => {
-    const route = companionPairingRoute({
+  it("refuses automatic pairing when hosted HTTPS is not ready", () => {
+    const source = {
       port: 8810,
       tailnetName: "mac.tail1234.ts.net",
       lan: "192.168.1.42",
       hosts: ["mac.tail1234.ts.net", "192.168.1.42", "openmausbot-aa.local"],
       endpoints: [
-        { url: "http://mac.tail1234.ts.net:8810", kind: "tailnet", priority: 0 },
-        { url: "http://192.168.1.42:8810", kind: "lan", priority: 100 },
+        { url: "http://mac.tail1234.ts.net:8810", kind: "tailnet" as const, priority: 0 },
+        { url: "http://192.168.1.42:8810", kind: "lan" as const, priority: 100 },
       ],
-    }, "automatic");
+    };
 
-    expect(route).toMatchObject({
-      address: "mac.tail1234.ts.net",
-      port: 8810,
-      hosts: ["mac.tail1234.ts.net"],
-    });
-    const link = companionPairingLink({ ...route!, code: "004209", token });
-    expect(new URL(link!).searchParams.get("hosts")).toBe("mac.tail1234.ts.net");
+    expect(companionPairingRoute(source, "automatic")).toBeNull();
+    expect(companionPairingRoutePin(source, "automatic")).toBeNull();
   });
 
   it("pins the protected automatic transport instead of downgrading the live QR to LAN", () => {
@@ -206,9 +200,9 @@ describe("companionPairingLink", () => {
       ...opened,
       endpoints: [{ url: "http://192.168.1.42:8810", kind: "lan" as const, priority: 200 }],
     };
-    expect(companionPairingRoute(withdrawn, "automatic")?.address).toBe("192.168.1.42");
+    expect(companionPairingRoute(withdrawn, "automatic")).toBeNull();
     expect(companionPairingRoutePinAvailable(withdrawn, pin!)).toBe(false);
-    expect(pin?.route.endpoints?.map((endpoint) => endpoint.kind)).toEqual(["hosted", "lan"]);
+    expect(pin?.route.endpoints?.map((endpoint) => endpoint.kind)).toEqual(["hosted"]);
   });
 
   it("does not substitute a different protected transport for the pinned one", () => {
@@ -227,7 +221,7 @@ describe("companionPairingLink", () => {
     }, pin!)).toBe(false);
   });
 
-  it("fails automatic pinning closed when a LAN endpoint would be encoded first", () => {
+  it("selects hosted HTTPS regardless of an unprotected endpoint's priority", () => {
     expect(companionPairingRoutePin({
       port: 8810,
       lan: "192.168.1.42",
@@ -235,7 +229,14 @@ describe("companionPairingLink", () => {
         { url: "http://192.168.1.42:8810", kind: "lan", priority: 0 },
         { url: "https://device.openmausbot.com", kind: "hosted", priority: 100 },
       ],
-    }, "automatic")).toBeNull();
+    }, "automatic")?.route).toEqual({
+      address: "device.openmausbot.com",
+      port: 443,
+      hosts: ["device.openmausbot.com"],
+      endpoints: [
+        { url: "https://device.openmausbot.com", kind: "hosted", priority: 100 },
+      ],
+    });
   });
 
   it("makes the explicitly selected LAN route first without losing protected upgrades", () => {
@@ -256,7 +257,6 @@ describe("companionPairingLink", () => {
     expect(route?.port).toBe(8810);
     expect(route?.hosts).toEqual([
       "192.168.1.42",
-      "mac.tail1234.ts.net",
       "openmausbot-aa.local",
     ]);
     const link = companionPairingLink({ ...route!, code: "004209", token });
@@ -264,8 +264,7 @@ describe("companionPairingLink", () => {
     expect(decodedEndpoints(link!)).toEqual([
       { url: "http://192.168.1.42:8810", kind: "lan", priority: 0 },
       { url: "https://device.openmausbot.com", kind: "hosted", priority: 100 },
-      { url: "http://mac.tail1234.ts.net:8810", kind: "tailnet", priority: 200 },
-      { url: "http://openmausbot-aa.local:8810", kind: "bonjour", priority: 300 },
+      { url: "http://openmausbot-aa.local:8810", kind: "bonjour", priority: 200 },
     ]);
   });
 

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -119,59 +119,35 @@ const directHTTPOrigin = (host: string, port: number): string => {
   return `http://${authority}:${port}`;
 };
 
-/** Select the route policy encoded into a QR. Automatic setup preserves the
- * sidecar's hosted/Tailscale-first order. Explicit local setup promotes one
- * exact LAN/Bonjour endpoint, followed only by protected upgrades; iOS then
+/** Select the route policy encoded into a QR. Automatic setup is deliberately
+ * hosted-HTTPS only: Tailscale must be chosen explicitly and never replaces a
+ * hosted route that is still provisioning. Explicit local setup promotes one
+ * exact LAN/Bonjour endpoint, followed only by hosted upgrades; iOS then
  * refuses to spray the pairing credential onto any other cleartext route. */
 export function companionPairingRoute(
   source: CompanionPairingRouteSource,
   mode: CompanionPairingRouteMode,
 ): CompanionPairingRoute | null {
   if (mode === "automatic") {
-    const advertised = qrEndpoints(source.endpoints);
-    const preferred = advertised[0] ?? null;
-    if (preferred?.kind === "hosted" || preferred?.kind === "tailnet") {
-      const parsed = new URL(preferred.url);
-      const address = parsed.hostname;
-      const port = parsed.port ? Number(parsed.port) : preferred.kind === "hosted" ? 443 : 80;
-      const tailnetHosts = deduplicatedHosts([
-        source.tailnetName ?? "",
-        ...(source.hosts ?? []),
-      ]).filter((host) => host.toLowerCase().replace(/\.$/, "").endsWith(".ts.net"));
-      const hosts = preferred.kind === "tailnet"
-        ? deduplicatedHosts([address, ...tailnetHosts])
-        : deduplicatedHosts([
-            address,
-            ...advertised
-              .filter((endpoint) => endpoint.kind === "hosted")
-              .map((endpoint) => new URL(endpoint.url).hostname),
-            ...tailnetHosts,
-          ]);
-      return {
-        address,
-        port,
-        // Older phone builds ignore typed endpoints and assume cleartext HTTP
-        // for every legacy host. A hosted authority on its TLS port therefore
-        // fails closed instead of replaying the six-digit credential to LAN;
-        // a tailnet-first QR retains only MagicDNS legacy fallbacks.
-        hosts,
-        endpoints: source.endpoints,
-      };
-    }
+    const hosted = qrEndpoints(source.endpoints).filter((endpoint) => endpoint.kind === "hosted");
+    const preferred = hosted[0] ?? null;
+    if (!preferred) return null;
 
-    const address =
-      source.tailnetName
-      ?? source.lan
-      ?? source.addresses?.find((candidate) => candidate !== source.tailscale)
-      ?? source.hosts?.[0];
-    return address
-      ? {
-          address,
-          port: source.port,
-          hosts: source.hosts,
-          endpoints: source.endpoints,
-        }
-      : null;
+    const parsed = new URL(preferred.url);
+    const address = parsed.hostname;
+    const port = parsed.port ? Number(parsed.port) : 443;
+    return {
+      address,
+      port,
+      // Older phone builds ignore typed endpoints and assume cleartext HTTP
+      // for every legacy host. A hosted authority on its TLS port therefore
+      // fails closed instead of replaying the credential to Tailscale or LAN.
+      hosts: deduplicatedHosts([
+        address,
+        ...hosted.map((endpoint) => new URL(endpoint.url).hostname),
+      ]),
+      endpoints: hosted,
+    };
   }
 
   const advertised = qrEndpoints(source.endpoints);
@@ -235,7 +211,7 @@ export function companionPairingRoute(
   const address = parsed.hostname;
   const port = parsed.port ? Number(parsed.port) : 80;
   const protectedRoutes = advertised.filter(
-    (endpoint) => endpoint.url !== preferred.url && ["hosted", "tailnet"].includes(endpoint.kind),
+    (endpoint) => endpoint.url !== preferred.url && endpoint.kind === "hosted",
   );
   const otherLocalRoutes = advertised.filter(
     (endpoint) => endpoint.url !== preferred.url && !["hosted", "tailnet"].includes(endpoint.kind),
@@ -247,14 +223,21 @@ export function companionPairingRoute(
   return {
     address,
     port,
-    hosts: deduplicatedHosts([address, ...(source.hosts ?? [])]),
+    // Choosing local must not smuggle a tailnet route into legacy clients.
+    // Tailscale has its own explicit mode and consent copy.
+    hosts: deduplicatedHosts([
+      address,
+      ...(source.hosts ?? []).filter((host) =>
+        !host.trim().toLowerCase().replace(/\.$/, "").endsWith(".ts.net")
+      ),
+    ]),
     endpoints,
   };
 }
 
 /** Freeze the route represented by one pairing QR. Automatic setup must have
- * a validated hosted or tailnet endpoint; otherwise a later state refresh can
- * reinterpret the same one-time credential as a plain LAN QR. */
+ * a validated hosted endpoint; otherwise a later state refresh cannot
+ * reinterpret the same one-time credential as Tailscale or plain LAN. */
 export function companionPairingRoutePin(
   source: CompanionPairingRouteSource,
   mode: CompanionPairingRouteMode,
@@ -268,7 +251,7 @@ export function companionPairingRoutePin(
     ? null
     : mode === "tailscale"
       ? endpoints.find((endpoint) => endpoint.kind === "tailnet") ?? null
-      : firstEndpoint && (firstEndpoint.kind === "hosted" || firstEndpoint.kind === "tailnet")
+      : firstEndpoint?.kind === "hosted"
         ? firstEndpoint
         : null;
   if (mode !== "local" && !protectedEndpoint) return null;

--- a/src/lib/phone-setup.test.ts
+++ b/src/lib/phone-setup.test.ts
@@ -93,11 +93,21 @@ describe("phone setup flow", () => {
     ).toBe("sign-in");
   });
 
-  it("never opens local pairing while hosted access is provisioning", () => {
-    const companion = { enabled: true, endpoints: [] };
+  it("waits for hosted HTTPS even when Tailscale is already available", () => {
+    const companion = {
+      enabled: true,
+      endpoints: [{
+        kind: "tailnet" as const,
+        url: "http://mac.tail1234.ts.net:8810",
+        priority: 0,
+      }],
+    };
     expect(phonePairingGate(account("connecting"), companion, false)).toBe("wait");
     expect(phonePairingGate(account("ready"), companion, false)).toBe("wait");
     expect(phonePairingGate(account("signed-out"), companion, false)).toBe("account-required");
+    expect(
+      phonePairingGate({ available: false, status: "signed-out" }, companion, false),
+    ).toBe("account-required");
   });
 
   it("opens local pairing only after the explicit Wi-Fi fallback", () => {
@@ -130,7 +140,7 @@ describe("phone setup flow", () => {
     ).toBe("open");
   });
 
-  it("opens pairing over a protected tailnet without requiring a hosted account", () => {
+  it("opens Tailscale only after the explicit fallback is selected", () => {
     const tailnet = {
       enabled: true,
       endpoints: [{
@@ -139,10 +149,11 @@ describe("phone setup flow", () => {
         priority: 100,
       }],
     };
-    expect(phonePairingGate(account("signed-out"), tailnet, false)).toBe("open");
+    expect(phonePairingGate(account("signed-out"), tailnet, false)).toBe("account-required");
     expect(
       phonePairingGate({ available: false, status: "signed-out" }, tailnet, false),
-    ).toBe("open");
+    ).toBe("account-required");
+    expect(phonePairingGate(account("signed-out"), tailnet, true)).toBe("open");
   });
 
   it("arms the timeout during account IPC and explicit local setup", () => {

--- a/src/lib/phone-setup.ts
+++ b/src/lib/phone-setup.ts
@@ -114,7 +114,6 @@ export function derivePhoneSetupPhase(
 
 export type CompanionPairingMode =
   | "local-only"
-  | "tailnet-ready"
   | "hosted-startable"
   | "hosted-connecting"
   | "hosted-ready";
@@ -124,19 +123,15 @@ export interface PhoneSetupCompanionSnapshot {
   endpoints?: CompanionEndpoint[];
 }
 
-/** Protected hosted and Tailscale endpoints are automatic routes. Plain
- * local pairing requires an explicit user choice, which prevents
- * provisioning races from showing a QR that cannot work on an isolated
- * Wi-Fi network. */
+/** Automatic setup is hosted-HTTPS only. Tailscale and plain local pairing
+ * remain explicit user choices, so a tailnet route cannot silently replace
+ * hosted access while the account connection is still being prepared. */
 export const companionPairingMode = (
   account: CompanionAccountState | null,
   companion: PhoneSetupCompanionSnapshot | null,
 ): CompanionPairingMode => {
   if (companion?.endpoints?.some((endpoint) => endpoint.kind === "hosted")) {
     return "hosted-ready";
-  }
-  if (companion?.endpoints?.some((endpoint) => endpoint.kind === "tailnet")) {
-    return "tailnet-ready";
   }
   if (!account?.available || account.status === "signed-out" || account.status === "error") {
     return "local-only";
@@ -150,12 +145,14 @@ export type PhonePairingGate = "open" | "start" | "wait" | "account-required";
 export function phonePairingGate(
   account: CompanionAccountState | null,
   companion: PhoneSetupCompanionSnapshot | null,
-  localFallback: boolean,
+  explicitRoute: boolean,
 ): PhonePairingGate {
-  if (localFallback) return "open";
+  // The caller already validated which explicit route the person selected.
+  // This bypass is shared by Wi-Fi and Tailscale; neither is an automatic
+  // alternative to the hosted route.
+  if (explicitRoute) return "open";
   switch (companionPairingMode(account, companion)) {
     case "hosted-ready":
-    case "tailnet-ready":
       return "open";
     case "hosted-startable":
       return "start";


### PR DESCRIPTION
## Summary

- make the default phone-pairing QR wait for and contain only hosted HTTPS
- keep Tailscale and trusted-local pairing available only through their explicit choices
- persist the selected iOS route policy so pair responses, refreshes, and reconnects cannot silently widen it
- show HTTPS, Tailscale, and trusted-local labels on the iPhone confirmation screen
- update pairing docs and add regression coverage for every route

## Validation

- `pnpm test` — 2049 passed, 18 skipped
- `pnpm typecheck`
- Oxlint on changed TypeScript files
- focused pairing tests — 38 passed
- `swift test` — 182 passed
- unsigned iOS Simulator build
- signed physical-iPhone build, install, and launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic phone pairing now uses hosted HTTPS only.
  * Tailscale and trusted-local pairing require explicit route selection.
  * Pairing confirmations identify the connection type: HTTPS, Tailscale, or trusted local.
  * Tailscale pairing now supports a dedicated QR invitation and MagicDNS setup.
* **Bug Fixes**
  * Prevented pairing and failover from switching to unapproved routes.
  * Improved route handling when manually changing connection addresses.
* **Documentation**
  * Updated iOS setup and Tailscale testing instructions.
* **Tests**
  * Expanded coverage for route selection, fallback, and saved connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->