### PR TITLE
chore(release): bump version to 0.1.37

### DIFF
--- a/ios/AppStore/en-US/release_notes.txt
+++ b/ios/AppStore/en-US/release_notes.txt
@@ -1,6 +1,7 @@
 Welcome to OpenMausMobile 1.0.
 
 • Pair securely with your OpenMausBot computer
+• Default QR pairing now stays on hosted HTTPS; Tailscale and local routes remain explicit choices
 • Chat with bots and rooms
 • Answer approvals and questions
 • Search, manage tasks, edit versions, react, and share transcripts

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -33,7 +33,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "2"
+        CURRENT_PROJECT_VERSION: "3"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         # The catalog lives in App/, which is already a source path. Generated
@@ -120,7 +120,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app.widgets
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "2"
+        CURRENT_PROJECT_VERSION: "3"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         SKIP_INSTALL: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop release from 0.1.36 to 0.1.37
- bump the iOS/TestFlight build from 2 to 3 while keeping marketing version 1.0.0
- document HTTPS-only automatic QR pairing in the iOS release notes

## Validation

- `pnpm install --frozen-lockfile`
- regenerated the Xcode project and confirmed `1.0.0 (3)`
- `git diff --check`

After merge, dispatch the Release workflow from `main` with publishing enabled. TestFlight remains a separate App Store Connect upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR pairing now defaults to a hosted HTTPS connection, with Tailscale and local routes available as explicit options.

* **Chores**
  * Updated the app and widget build numbers.
  * Incremented the package version to 0.1.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->