### PR TITLE
fix: remove redundant ready to pair status

### DIFF
--- a/src/components/CompanionSection.test.ts
+++ b/src/components/CompanionSection.test.ts
@@ -40,6 +40,13 @@ describe("companion account action errors", () => {
 });
 
 describe("companion status refresh", () => {
+  it("omits the redundant status pill when phone access is ready for its first pairing", () => {
+    expect(deriveCompanionPanelStatus({
+      enabled: true,
+      devices: [],
+    })).toBeNull();
+  });
+
   it("does not show a healthy status when the enabled sidecar reports an error", () => {
     expect(deriveCompanionPanelStatus({
       enabled: true,

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -34,14 +34,13 @@ export interface CompanionPanelStatus {
 
 export function deriveCompanionPanelStatus(
   state: Pick<CompanionState, "enabled" | "devices" | "error">,
-): CompanionPanelStatus {
+): CompanionPanelStatus | null {
   if (state.error) return { label: "Phone access needs attention", good: false };
   if (!state.enabled) return { label: "Phone access off", good: false };
   const pairedCount = state.devices.length;
+  if (!pairedCount) return null;
   return {
-    label: pairedCount
-      ? `${pairedCount} ${pairedCount === 1 ? "phone" : "phones"} paired`
-      : "Ready to pair",
+    label: `${pairedCount} ${pairedCount === 1 ? "phone" : "phones"} paired`,
     good: true,
   };
 }
@@ -86,7 +85,7 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
   }
 
   const pairedCount = state.devices.length;
-  const { label: statusLabel, good: statusGood } = deriveCompanionPanelStatus(state);
+  const panelStatus = deriveCompanionPanelStatus(state);
   const accountActionError = companionAccountActionError(c.account, c.accountError);
   const hosted = state.endpoints?.find((endpoint) => endpoint.kind === "hosted");
   const localRoutes = [
@@ -103,21 +102,25 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
   return (
     <div className="flex flex-col gap-4">
       <Card>
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <div
-            className={`flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] ${
-              statusGood ? "bg-success/10 text-success" : "bg-control text-ink-secondary"
-            }`}
-          >
-            <span className={`size-1.5 rounded-full ${statusGood ? "bg-success" : "bg-ink-secondary/50"}`} />
-            {statusLabel}
+        {(panelStatus || (pairedCount > 0 && c.hostedReady)) && (
+          <div className="mb-4 flex items-center justify-between gap-3">
+            {panelStatus && (
+              <div
+                className={`flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] ${
+                  panelStatus.good ? "bg-success/10 text-success" : "bg-control text-ink-secondary"
+                }`}
+              >
+                <span className={`size-1.5 rounded-full ${panelStatus.good ? "bg-success" : "bg-ink-secondary/50"}`} />
+                {panelStatus.label}
+              </div>
+            )}
+            {pairedCount > 0 && c.hostedReady && (
+              <div className="flex items-center gap-1.5 text-[11.5px] text-ink-secondary">
+                <ShieldCheck size={13} className="text-accent" /> Works away from home
+              </div>
+            )}
           </div>
-          {pairedCount > 0 && c.hostedReady && (
-            <div className="flex items-center gap-1.5 text-[11.5px] text-ink-secondary">
-              <ShieldCheck size={13} className="text-accent" /> Works away from home
-            </div>
-          )}
-        </div>
+        )}
         <PhoneSetupFlowView controller={c} variant="settings" />
       </Card>
 


### PR DESCRIPTION
## Summary
- hide the healthy zero-device “Ready to pair” status pill
- keep off, error, and paired-phone status indicators
- remove the empty header spacing with the hidden state

## Validation
- `pnpm exec vitest run src/components/CompanionSection.test.ts` (14/14)
- `pnpm typecheck`
- focused Oxlint
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “Ready to pair” status when phone access is enabled but no phones are paired.
  * Status messaging now appears only when relevant, preventing empty or misleading indicators.
  * Hosted connectivity information remains visible only when paired phones are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->