### PR TITLE
fix: stage companion connector for desktop development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ pnpm package:mac   # DMG + ZIP; requires Swift/Xcode tools
 pnpm package:linux # Ubuntu x64 .deb + AppImage; no Swift required
 ```
 
+`pnpm dev:desktop` downloads and verifies the pinned Cloudflare Tunnel connector for the current
+platform and architecture before Electron starts. Later launches re-verify and reuse the staged
+binary. Packaging continues to use `pnpm build:cloudflared`, which stages every architecture the
+host's desktop package build requires. To stage only the current development target without
+launching Electron, run `node scripts/prepare-cloudflared.mjs --current`.
+
 For Ubuntu installation and real desktop checks, see [`docs/linux-desktop.md`](docs/linux-desktop.md).
 
 ## Ubuntu release checklist

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "docs:preview": "pnpm --filter @openmausbot/docs preview",
     "companion": "node --experimental-strip-types companion/src/index.ts",
     "dev:server": "node --experimental-strip-types server/index.ts",
-    "dev:desktop": "electron .",
+    "dev:desktop": "node scripts/prepare-cloudflared.mjs --current && electron .",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
     "test": "node scripts/test-floor.mjs && pnpm broker:test && pnpm test:updater && pnpm test:desktop-viewer && pnpm test:package-link && pnpm test:save-file && pnpm test:packaged-server",

--- a/scripts/prepare-cloudflared.mjs
+++ b/scripts/prepare-cloudflared.mjs
@@ -1,6 +1,8 @@
 // Stage a pinned Cloudflare Tunnel connector for every desktop architecture
-// electron-builder will package on this host. The release asset is verified
-// before extraction and the executable is verified again on every reuse.
+// electron-builder will package on this host. Pass --current for development
+// to stage only the platform and architecture running this script. The release
+// asset is verified before extraction and the executable is verified again on
+// every reuse.
 // Nothing is installed globally and cloudflared's own updater stays disabled;
 // OpenMausBot updates this dependency with an ordinary reviewed app release.
 import { spawnSync } from "node:child_process";
@@ -54,6 +56,28 @@ export function targetsForHost(platform) {
   if (platform === "linux") return ["linux-x64"];
   if (platform === "win32") return ["win32-x64"];
   throw new Error(`Cloudflare Tunnel packaging is unsupported on ${platform}`);
+}
+
+export function targetForCurrentHost(platform = process.platform, arch = process.arch) {
+  const target = `${platform}-${arch}`;
+  if (!Object.hasOwn(CLOUDFLARED_ASSETS, target)) {
+    throw new Error(`Cloudflare Tunnel development is unsupported on ${target}`);
+  }
+  return target;
+}
+
+export function targetsForPreparation({
+  current = false,
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  return current ? [targetForCurrentHost(platform, arch)] : targetsForHost(platform);
+}
+
+export function parsePrepareCloudflaredArgs(args = []) {
+  if (args.length === 0) return { current: false };
+  if (args.length === 1 && args[0] === "--current") return { current: true };
+  throw new Error("Usage: node scripts/prepare-cloudflared.mjs [--current]");
 }
 
 export function sha256(value) {
@@ -249,10 +273,14 @@ async function stageTarget(root, target) {
 export async function prepareCloudflared({
   root = join(dirname(fileURLToPath(import.meta.url)), ".."),
   platform = process.platform,
+  arch = process.arch,
+  current = false,
 } = {}) {
-  for (const target of targetsForHost(platform)) await stageTarget(root, target);
+  for (const target of targetsForPreparation({ current, platform, arch })) {
+    await stageTarget(root, target);
+  }
 }
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
-  await prepareCloudflared();
+  await prepareCloudflared(parsePrepareCloudflaredArgs(process.argv.slice(2)));
 }

--- a/scripts/prepare-cloudflared.test.mjs
+++ b/scripts/prepare-cloudflared.test.mjs
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import {
   CLOUDFLARED_ASSETS,
   CLOUDFLARED_VERSION,
   executableTarget,
+  parsePrepareCloudflaredArgs,
   sha256,
+  targetForCurrentHost,
   targetsForHost,
+  targetsForPreparation,
   verifyPinnedBinary,
   verifySha256,
 } from "./prepare-cloudflared.mjs";
@@ -37,6 +41,8 @@ const PINNED_ASSETS = {
   },
 };
 
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
 function executableFixture(target) {
   const bytes = Buffer.alloc(128);
   if (target === "darwin-arm64" || target === "darwin-x64") {
@@ -60,6 +66,37 @@ describe("pinned cloudflared packaging", () => {
     expect(targetsForHost("linux")).toEqual(["linux-x64"]);
     expect(targetsForHost("win32")).toEqual(["win32-x64"]);
     expect(() => targetsForHost("freebsd")).toThrow(/unsupported/);
+  });
+
+  it("stages only the exact current desktop target in development mode", () => {
+    expect(targetForCurrentHost("darwin", "arm64")).toBe("darwin-arm64");
+    expect(targetForCurrentHost("darwin", "x64")).toBe("darwin-x64");
+    expect(targetForCurrentHost("linux", "x64")).toBe("linux-x64");
+    expect(targetForCurrentHost("win32", "x64")).toBe("win32-x64");
+    expect(targetsForPreparation({ current: true, platform: "darwin", arch: "arm64" })).toEqual([
+      "darwin-arm64",
+    ]);
+    expect(targetsForPreparation({ current: false, platform: "darwin", arch: "arm64" })).toEqual([
+      "darwin-arm64",
+      "darwin-x64",
+    ]);
+    expect(() => targetForCurrentHost("linux", "arm64")).toThrow(/unsupported/);
+  });
+
+  it("accepts only the documented current-target CLI option", () => {
+    expect(parsePrepareCloudflaredArgs([])).toEqual({ current: false });
+    expect(parsePrepareCloudflaredArgs(["--current"])).toEqual({ current: true });
+    expect(() => parsePrepareCloudflaredArgs(["--all"])).toThrow(/Usage:/);
+    expect(() => parsePrepareCloudflaredArgs(["--current", "--current"])).toThrow(/Usage:/);
+  });
+
+  it("stages the current target for development without narrowing package preparation", () => {
+    expect(packageJson.scripts["dev:desktop"]).toBe(
+      "node scripts/prepare-cloudflared.mjs --current && electron .",
+    );
+    expect(packageJson.scripts["build:cloudflared"]).toBe(
+      "node scripts/prepare-cloudflared.mjs",
+    );
   });
 
   it("pins a complete release asset and digest for every packaged target", () => {


### PR DESCRIPTION
## Summary
- stage the verified pinned Cloudflare connector before `pnpm dev:desktop` launches Electron
- add a strict `--current` mode so development downloads only the current architecture
- preserve full multi-architecture staging for package builds
- document the first-launch behavior and cover both modes

## Validation
- focused cloudflared tests (8/8)
- `pnpm typecheck`
- focused Oxlint
- `git diff --check`
- real darwin-arm64 staging and idempotent reuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop development now automatically prepares the connector required for the current operating system and architecture.
  * Added an option to prepare only the connector for the current development target.

* **Bug Fixes**
  * Improved validation and clearer handling of unsupported platforms, architectures, and command-line options.

* **Documentation**
  * Added setup guidance for connector preparation during development and packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->