### PR TITLE
fix(desktop): stop the recorder helper during the Accessibility prompt

### DIFF
--- a/electron/resources/recorder-helper.swift
+++ b/electron/resources/recorder-helper.swift
@@ -445,6 +445,19 @@ guard let stopFile = argument("--stop-file") else {
     fputs("missing --stop-file\n", stderr)
     exit(2)
 }
+// LaunchServices gives the helper its TCC identity, but it also means the
+// parent cannot terminate us by killing the `open -W` waiter. Poll the stop
+// marker from process start — including during Accessibility's blocking
+// prompt — so a quit, a 5s ready-timeout, or a cancelled Teach-a-skill
+// session cannot leave a global event tap behind.
+var stopWatcher: DispatchSourceTimer?
+let stopTimer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+stopTimer.schedule(deadline: .now() + .milliseconds(100), repeating: .milliseconds(100))
+stopTimer.setEventHandler {
+    if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
+}
+stopWatcher = stopTimer
+stopTimer.resume()
 let trustOptions = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
 guard AXIsProcessTrustedWithOptions(trustOptions) else {
     fputs("Allow OpenMausBot Recorder in Privacy & Security → Accessibility, then try again. Input Monitoring may also be requested.\n", stderr)

--- a/electron/resources/recorder-helper.swift
+++ b/electron/resources/recorder-helper.swift
@@ -463,6 +463,12 @@ guard AXIsProcessTrustedWithOptions(trustOptions) else {
     fputs("Allow OpenMausBot Recorder in Privacy & Security → Accessibility, then try again. Input Monitoring may also be requested.\n", stderr)
     exit(3)
 }
+// Recording has its own stop-file timer, which flushes any pending typing
+// before stopping the run loop. Hand off to that graceful path now that the
+// blocking Accessibility prompt is finished.
+if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
+stopTimer.cancel()
+stopWatcher = nil
 let recorder = Recorder(stopFile: stopFile)
 guard recorder.start() else {
     fputs("input monitoring permission is required\n", stderr)

--- a/electron/resources/recorder-helper.swift
+++ b/electron/resources/recorder-helper.swift
@@ -452,10 +452,12 @@ guard let stopFile = argument("--stop-file") else {
 // session cannot leave a global event tap behind.
 var stopWatcher: DispatchSourceTimer?
 let stopTimer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+let stopWatcherStopped = DispatchSemaphore(value: 0)
 stopTimer.schedule(deadline: .now() + .milliseconds(100), repeating: .milliseconds(100))
 stopTimer.setEventHandler {
     if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
 }
+stopTimer.setCancelHandler { stopWatcherStopped.signal() }
 stopWatcher = stopTimer
 stopTimer.resume()
 let trustOptions = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
@@ -468,6 +470,7 @@ guard AXIsProcessTrustedWithOptions(trustOptions) else {
 // blocking Accessibility prompt is finished.
 if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
 stopTimer.cancel()
+stopWatcherStopped.wait()
 stopWatcher = nil
 let recorder = Recorder(stopFile: stopFile)
 guard recorder.start() else {


### PR DESCRIPTION
## What changed

Polls the recorder helper's stop-file from process start, before the blocking Accessibility prompt, so a cancelled or timed-out Teach-a-skill session cannot leave a global event tap behind.

```swift
stopTimer.setEventHandler {
    if FileManager.default.fileExists(atPath: stopFile) { exit(0) }
}
```

This matches the dictation helper (`electron/resources/speech-helper.swift`), which already watches its stop marker on a background queue before authorization.

## Why

**Problem:** `startRecorder()` in `electron/skill-recorder.mjs` launches the helper through LaunchServices (`open -n -W`). The helper only started polling `--stop-file` inside `Recorder.start()`'s 0.25s `Timer`, which runs **after** `AXIsProcessTrustedWithOptions` (a blocking prompt). Two reachable paths then orphan it:

1. The 5s ready-timeout in `startRecorder()` writes the stop file and rejects (`skill-recorder.mjs`, the `setTimeout` around the ready promise). If the user is still looking at the Accessibility prompt, nobody is watching that file. When they later click Allow, the helper installs a session event tap for a recording the app already abandoned — `active` is null, so the UI has no Stop control.
2. Quit (`before-quit` already calls `stopRecorder()`) during the same prompt writes the stop file and then exits Electron. Killing the `open -W` waiter does not terminate the LaunchServices process (this is documented in `speech-helper.swift`). The helper survives, then may tap after the app is gone.

**Triage / root cause:** stop intent is a stop-file, not SIGTERM, because LaunchServices children are not in Electron's process tree. The speech helper polls that file from process start for exactly this reason. The recorder helper did not.

**Fix:** install the same GCD timer (100ms, background queue) immediately after parsing `--stop-file`, before the Accessibility prompt. `exit(0)` during the prompt is the correct abort — there is no typing buffer to flush yet. The existing 0.25s `Timer` keeps doing its in-session work (typing flush, clipboard, downloads).

## How it was verified

- `pnpm typecheck` — clean.
- `pnpm check:electron` — syntax-checked 62 Electron modules.
- `pnpm exec vitest run electron/skill-recorder.test.mjs` — pass (compiler/save path unchanged).
- `pnpm broker:test`, `pnpm test:updater`, `pnpm test:desktop-viewer`, `pnpm test:package-link`, `pnpm test:save-file`, `pnpm test:packaged-server` — pass.
- Full `node scripts/test-floor.mjs`: 2059 passed / 8 skipped / 4 failed, all unrelated to this Swift file:
  - `scripts/linux-after-install.test.mjs` (2) — this clone lives at `/tmp/oss-g4-openmausbot`, so the hook's temp-root guard reports a missing package dir instead of the expected "must stay under /tmp" string.
  - `server/index.test.ts` team-import (2) — 20s timeout / name-suffix flake; the same file passed 88/88 on an earlier run in this session.
- Deterministic reproduction of the JS side of the timeout path (the helper never gets a chance to see the marker until this change):

```
# electron/skill-recorder.mjs — if ready does not settle in 5s:
stopRecorder();  // writes session.stopPath, clears `active`
# electron/resources/recorder-helper.swift (before):
# AXIsProcessTrustedWithOptions(...)  // blocked here, no stop-file poller yet
# Timer in Recorder.start() is the first poller
```

Electron shell / Swift helpers are not launched by the vitest suite (same as #24/#25). This host is Linux, so the Swift helper was not recompiled here; `pnpm build:recorder` / the next `package:mac` picks up the source. Dev builds compile it lazily when the helper is stale.

## Screenshots (UI changes)

N/A — helper lifecycle, no UI.

## Notes / Risks

- Packaged macOS builds ship a pre-built `OpenMausBot Recorder.app`; this lands for users on the next mac package that runs `pnpm build:recorder`.
- Self-sourced, same family as #25 (LaunchServices helper not actually stopped). Not a duplicate: #25 stopped dictation on quit; this makes the *recorder* helper honor that stop during the Accessibility prompt.
- Overlap: no open PR touches `electron/resources/recorder-helper.swift`.

## Checklist

- [x] `pnpm typecheck` and targeted/desktop tests pass locally (full floor: 4 unrelated failures, see Verification)
- [x] No server behavior changed (electron-shell helper only) — no new tests needed per CONTRIBUTING
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording reliability when stopping during startup or initialization.
  * Stop requests are now handled more consistently before recording begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->