### PR TITLE
fix(ios): cancel the linger sleeper when the companion reconnects

### DIFF
--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -376,6 +376,7 @@ final class Session: ObservableObject {
     }
 
     private var lingerTask: UIBackgroundTaskIdentifier = .invalid
+    private var lingerSleep: Task<Void, Never>?
 
     /// Leaving the screen: keep the stream alive for the grace period iOS
     /// allows (~30 s) rather than cutting it at once, so an approval that
@@ -388,14 +389,16 @@ final class Session: ObservableObject {
             // time is up before our own timer — the system wants us gone now
             self?.disconnect()
         }
-        Task { [weak self] in
+        lingerSleep = Task { [weak self] in
             try? await Task.sleep(for: .seconds(25))
-            guard let self, self.lingerTask != .invalid else { return }
+            guard !Task.isCancelled, let self, self.lingerTask != .invalid else { return }
             self.disconnect()
         }
     }
 
     private func endLinger() {
+        lingerSleep?.cancel()
+        lingerSleep = nil
         guard lingerTask != .invalid else { return }
         UIApplication.shared.endBackgroundTask(lingerTask)
         lingerTask = .invalid

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -385,10 +385,17 @@ final class Session: ObservableObject {
     /// the cursor is written down at a known point.
     func linger() {
         guard streamTask != nil, lingerTask == .invalid else { disconnect(); return }
-        lingerTask = UIApplication.shared.beginBackgroundTask(withName: "companion.linger") { [weak self] in
+        // A previous request can leave a sleeper behind when iOS refuses the
+        // background assertion. Never let it outlive the assertion it belongs
+        // to or disconnect a later linger window.
+        lingerSleep?.cancel()
+        lingerSleep = nil
+        let task = UIApplication.shared.beginBackgroundTask(withName: "companion.linger") { [weak self] in
             // time is up before our own timer — the system wants us gone now
             self?.disconnect()
         }
+        guard task != .invalid else { disconnect(); return }
+        lingerTask = task
         lingerSleep = Task { [weak self] in
             try? await Task.sleep(for: .seconds(25))
             guard !Task.isCancelled, let self, self.lingerTask != .invalid else { return }


### PR DESCRIPTION
## What changed

`Session.linger()` kept a detached 25s sleeper after `endLinger()`. Cancel that Task when the companion reconnects so a stale timer cannot end the next background window.

Fixes #469.

## Why

**Problem:** `endLinger()` cleared `lingerTask` and ended the UIKit background task, but the `Task.sleep(for: .seconds(25))` started in `linger()` was never cancelled.

**Sequence (from #469):**

1. t=0 — background. linger() starts sleeper A.
2. t=24 — foreground. connect() → endLinger(); sleeper A still asleep.
3. t=24.5 — background again. linger() starts sleeper B (lingerTask was invalid).
4. t=25 — sleeper A wakes, sees lingerTask != .invalid (now B's), calls disconnect() and kills the new window ~0.5s in.

**Fix:** store the sleeper as `lingerSleep` and cancel it in `endLinger()`.

## How it was verified

- Inspected `ios/App/Session.swift` on current `upstream/main` (`667af71`): the detached Task is still uncancelled.
- `gh pr list` / issue search: no open PR for linger / #469.
- Linux host cannot compile the iOS target; this is the same constraint as #24/#25. The change is local to `linger`/`endLinger` and does not touch UI.

## Screenshots (UI changes)

N/A

## Notes / Risks

- If `sleep` throws because of cancellation, `try?` swallows it and the guard returns — same as a cancelled linger.
- Sibling of the desktop helper-lifecycle work (#24/#25/#498), iOS companion session this time.

## Checklist

- [x] No server behavior changed
- [x] No `dist-server/` edits
- [x] iOS-only companion session code
- [x] No secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream reconnection reliability by preventing outdated linger timers from disconnecting newer streams.
  * Ensured linger timers are properly cancelled and cleared when lingering ends or restarts.
  * Improved background task handling during stream transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->