### PR TITLE
fix(ios): keep a protected companion route first after restart

### DIFF
--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -312,6 +312,12 @@ extension Connection {
     /// legacy fields because they can represent hosted HTTPS. A connection
     /// either walks that complete typed set or, for an older desktop, derives
     /// direct routes from the legacy fields — never a lossy mixture of both.
+    ///
+    /// A protected route that already carried the bearer leads regardless of
+    /// a lower advertised priority. Otherwise a hand-typed LAN origin
+    /// (`priority: 0`) would win the sort after restart and the rotation
+    /// would hand the token to cleartext again. Typing a local address
+    /// resets `activeEndpoint`, so the priority order remains the escape hatch.
     public var orderedEndpoints: [CompanionEndpoint] {
         var candidates = endpoints ?? []
         if !candidates.isEmpty {
@@ -323,6 +329,9 @@ extension Connection {
                     ? $0.offset < $1.offset
                     : $0.element.priority < $1.element.priority
             }.map(\.element)
+            if let activeEndpoint, activeEndpoint.protectsCredentials {
+                candidates = [activeEndpoint] + candidates.filter { $0.url != activeEndpoint.url }
+            }
         } else {
             candidates = orderedHosts.enumerated().compactMap { offset, candidate in
                 CompanionEndpoint.direct(host: candidate, port: port, priority: offset)

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -313,11 +313,15 @@ extension Connection {
     /// either walks that complete typed set or, for an older desktop, derives
     /// direct routes from the legacy fields — never a lossy mixture of both.
     ///
-    /// A protected route that already carried the bearer leads regardless of
-    /// a lower advertised priority. Otherwise a hand-typed LAN origin
-    /// (`priority: 0`) would win the sort after restart and the rotation
-    /// would hand the token to cleartext again. Typing a local address
-    /// resets `activeEndpoint`, so the priority order remains the escape hatch.
+    /// A protected route that already carried the bearer leads when — and
+    /// only when — the priority sort would otherwise hand the rotation to a
+    /// cleartext route. Without this, a hand-typed LAN origin (`priority: 0`)
+    /// wins the sort after restart and the rotation hands the token to
+    /// cleartext again. But when the sort's head is itself protected (a
+    /// tailnet invite whose active tailnet route sits behind an advertised
+    /// hosted HTTPS), the advertised priority order stands. Typing a local
+    /// address resets `activeEndpoint`, so the priority order remains the
+    /// escape hatch.
     public var orderedEndpoints: [CompanionEndpoint] {
         var candidates = endpoints ?? []
         if !candidates.isEmpty {
@@ -329,7 +333,8 @@ extension Connection {
                     ? $0.offset < $1.offset
                     : $0.element.priority < $1.element.priority
             }.map(\.element)
-            if let activeEndpoint, activeEndpoint.protectsCredentials {
+            if let activeEndpoint, activeEndpoint.protectsCredentials,
+               let sortedHead = candidates.first, !sortedHead.protectsCredentials {
                 candidates = [activeEndpoint] + candidates.filter { $0.url != activeEndpoint.url }
             }
         } else {

--- a/ios/Sources/CompanionCore/Failover.swift
+++ b/ios/Sources/CompanionCore/Failover.swift
@@ -328,12 +328,17 @@ extension Connection {
             if let activeEndpoint, !candidates.contains(where: { $0.url == activeEndpoint.url }) {
                 candidates.append(activeEndpoint)
             }
-            candidates = candidates.enumerated().sorted {
+            // Route policy is part of candidate selection, not a final display
+            // filter. A disallowed cleartext route must not trigger the trust
+            // ratchet and hoist an otherwise lower-priority protected route.
+            candidates = endpointsAllowedByRoutePolicy(candidates).enumerated().sorted {
                 $0.element.priority == $1.element.priority
                     ? $0.offset < $1.offset
                     : $0.element.priority < $1.element.priority
             }.map(\.element)
-            if let activeEndpoint, activeEndpoint.protectsCredentials,
+            if let activeEndpoint = activeEndpoint.flatMap({ active in
+                candidates.first(where: { $0.url == active.url })
+            }), activeEndpoint.protectsCredentials,
                let sortedHead = candidates.first, !sortedHead.protectsCredentials {
                 candidates = [activeEndpoint] + candidates.filter { $0.url != activeEndpoint.url }
             }

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -328,6 +328,38 @@ final class FailoverTests: XCTestCase {
         XCTAssertEqual(connection.automaticEndpoints.map(\.kind), [.hosted, .tailnet])
     }
 
+    func testADisallowedCleartextHeadCannotHoistTheActiveProtectedRoute() throws {
+        let lan = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 0
+        ))
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 50
+        ))
+        let tailnet = try XCTUnwrap(CompanionEndpoint(
+            url: "http://mac.tail1234.ts.net:8810",
+            kind: .tailnet,
+            priority: 100
+        ))
+        let connection = Connection(
+            name: "Mac",
+            host: tailnet.host,
+            port: tailnet.port,
+            activeEndpoint: tailnet,
+            endpoints: [lan, hosted, tailnet],
+            allowedRouteKinds: [.hosted, .tailnet]
+        )
+
+        XCTAssertEqual(
+            connection.orderedEndpoints.map(\.kind),
+            [.hosted, .tailnet],
+            "a route forbidden by policy must not influence protected-route ordering"
+        )
+    }
+
     func testPromotingAWorkingLegacyEndpointKeepsEveryLegacyFallback() throws {
         var connection = Connection(
             name: "Mac",

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -244,6 +244,59 @@ final class FailoverTests: XCTestCase {
         XCTAssertEqual(connection.orderedEndpoints.map(\.url), [hosted.url, lan.url])
     }
 
+    func testPromotingAProtectedRouteLeadsAfterRestartDespiteAPriorityZeroLocalRoute() throws {
+        let local = try XCTUnwrap(CompanionEndpoint(
+            url: "http://192.168.1.42:8810",
+            kind: .lan,
+            priority: 0
+        ))
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 100
+        ))
+        var connection = Connection(
+            name: "Mac",
+            host: local.host,
+            port: local.port,
+            activeEndpoint: local,
+            endpoints: [local, hosted]
+        )
+
+        XCTAssertEqual(
+            connection.orderedEndpoints.map(\.kind),
+            [.lan, .hosted],
+            "a hand-typed local route leads until a protected route wins"
+        )
+
+        connection.promote(hosted)
+
+        XCTAssertEqual(connection.activeEndpoint, hosted)
+        XCTAssertEqual(
+            connection.orderedEndpoints.map(\.kind),
+            [.hosted, .lan],
+            "the upgrade must live in the stored order, not only this process's rotation"
+        )
+        XCTAssertEqual(
+            connection.automaticEndpoints.map(\.kind),
+            [.hosted],
+            "the next launch must not retry the superseded cleartext route"
+        )
+
+        var persisted = try JSONDecoder().decode(
+            Connection.self,
+            from: try JSONEncoder().encode(connection)
+        )
+        XCTAssertEqual(persisted.orderedEndpoints.map(\.kind), [.hosted, .lan])
+        let rotation = CandidateRotation(endpoints: persisted.orderedEndpoints)
+        XCTAssertEqual(rotation.currentEndpoint?.kind, .hosted)
+        XCTAssertTrue(rotation.endpoints.allSatisfy(\.protectsCredentials))
+
+        // Typing the LAN address again is the escape hatch when hosted is down.
+        persisted.resetRoutePolicy(selecting: local)
+        XCTAssertEqual(persisted.orderedEndpoints.map(\.kind), [.lan, .hosted])
+    }
+
     func testPromotingAWorkingLegacyEndpointKeepsEveryLegacyFallback() throws {
         var connection = Connection(
             name: "Mac",

--- a/ios/Tests/CompanionCoreTests/FailoverTests.swift
+++ b/ios/Tests/CompanionCoreTests/FailoverTests.swift
@@ -297,6 +297,37 @@ final class FailoverTests: XCTestCase {
         XCTAssertEqual(persisted.orderedEndpoints.map(\.kind), [.lan, .hosted])
     }
 
+    func testAPriorityPreferredProtectedHeadOutranksTheActiveProtectedRoute() throws {
+        // A tailnet invite keeps the active tailnet route protected, but the
+        // desktop advertises its hosted HTTPS with a better priority: the
+        // trust ratchet must not hoist the active route above another
+        // protected head — only above a cleartext one.
+        let hosted = try XCTUnwrap(CompanionEndpoint(
+            url: "https://mac.companion.example",
+            kind: .hosted,
+            priority: 0
+        ))
+        let tailnet = try XCTUnwrap(CompanionEndpoint(
+            url: "http://mac.tail1234.ts.net:8810",
+            kind: .tailnet,
+            priority: 100
+        ))
+        let connection = Connection(
+            name: "Mac",
+            host: tailnet.host,
+            port: tailnet.port,
+            activeEndpoint: tailnet,
+            endpoints: [tailnet, hosted]
+        )
+
+        XCTAssertEqual(
+            connection.orderedEndpoints.map(\.kind),
+            [.hosted, .tailnet],
+            "an advertised protected head keeps its priority lead over the active route"
+        )
+        XCTAssertEqual(connection.automaticEndpoints.map(\.kind), [.hosted, .tailnet])
+    }
+
     func testPromotingAWorkingLegacyEndpointKeepsEveryLegacyFallback() throws {
         var connection = Connection(
             name: "Mac",


### PR DESCRIPTION
## What changed

`Connection.orderedEndpoints` now leads with a protected `activeEndpoint` after a successful hosted/tailnet upgrade, so the trust ratchet survives process restart. A regression test encodes/decodes the saved connection and rebuilds `CandidateRotation` the way `Session` does on launch.

Fixes #479.

## Why

A hand-typed LAN origin is stored at `priority: 0`. `CandidateRotation.advance` already drops that cleartext route once a protected route answers, and `promote` records the winner as `activeEndpoint`. The stored order still sorted by priority, so the next launch rebuilt the rotation from LAN-first `orderedEndpoints`, treated that address as the explicit local choice, and sent the long-lived bearer there again. Endpoint refresh is best-effort and does not cover this: a 404, failure, or cancel leaves the broken order on disk.

## How it was verified

Deterministic reproduction of `orderedEndpoints` + `automaticCandidates` (the functions `Session` uses on restore). LAN at priority 0, hosted at priority 100, `activeEndpoint = hosted`:

```
before kinds ['lan', 'hosted'] auto ['lan', 'hosted']
after kinds  ['hosted', 'lan'] auto ['hosted']
```

- Before: restart retries the superseded LAN route with the bearer.
- After: restart starts on hosted HTTPS and drops cleartext from automatic candidates.
- `promote(lan)` still leaves hosted first when hosted has the better advertised priority (existing `testTypedRoutesKeepHostedHTTPSAheadOfAnActiveLANFallback`).
- Typing a LAN address again still leads (`resetRoutePolicy`); that remains the escape hatch when hosted is down.

New XCTest: `testPromotingAProtectedRouteLeadsAfterRestartDespiteAPriorityZeroLocalRoute` in `ios/Tests/CompanionCoreTests/FailoverTests.swift`. This Linux host has no Swift toolchain; CI `swift test` in `ios/` will run it.

No server/JS change; `pnpm typecheck` / `pnpm test` are not applicable to this diff.

## Screenshots (UI changes)

n/a — CompanionCore routing only.

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

## Problem

Hand-typed local address (`priority: 0`) → rotation upgrades to hosted/tailnet and prunes LAN in memory → `promote(hosted)` saves `activeEndpoint` but does not reorder → next launch `CandidateRotation(endpoints: saved.orderedEndpoints)` starts at LAN again and carries the device token onto cleartext.

## Triage / Root cause

`orderedEndpoints` sorts only by `priority` then original offset, and appends `activeEndpoint` only when it is missing. `promote(_: CompanionEndpoint)` assigns `activeEndpoint` and never reprioritises. The ratchet therefore lived only inside one `CandidateRotation` value.

## Fix

After the priority sort, if `activeEndpoint` already protects credentials, put it first. The superseded LAN origin stays in `endpoints` for display and a later manual choice. Typing a local address again sets `activeEndpoint` to that explicit-local route, so priority order applies once more.

## Verification

Python reproduction of the sort + `automaticCandidates` as quoted above (before/after). New `FailoverTests` case round-trips the `Connection` through `JSONEncoder`/`JSONDecoder` and asserts the restored rotation starts on hosted and contains only protected candidates.

## Notes / Risks

Does not touch `ios/App/Session.swift` (open #499 is on that file). Does not change invite policy, `resetRoutePolicy`, or the existing “don't let LAN jump ahead of a better-priority hosted route” case. Android #349 is diverging on this path by design; this PR is the Swift store only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection failover after restart by prioritizing an eligible active protected route when a cleartext route would otherwise lead.
  * Prevented automatic selection of disallowed or cleartext routes when a protected route is available.
  * Preserved route priority ordering when protected routes are already preferred.
  * Kept eligible hosted protected routes ahead of lower-priority LAN routes while retaining automatic failover options.
  * Explicit LAN route selection remains available as a fallback when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->