### PR TITLE
fix(chat): keep jump-to-latest control stationary

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1133,7 +1133,7 @@ export function ChatView({ bot }: { bot: Bot }) {
       {/* Messages */}
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto px-5 [overflow-anchor:none]"
+        className="flex-1 overflow-x-hidden overflow-y-auto px-5 [overflow-anchor:none]"
         onWheel={(e) => {
           if (e.deltaY < 0) setBottomFollow(false);
           else if (atEnd()) setBottomFollow(true);

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -1076,7 +1076,7 @@ export function GroupView({ group }: { group: Group }) {
       {/* Transcript */}
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto px-5 [overflow-anchor:none]"
+        className="flex-1 overflow-x-hidden overflow-y-auto px-5 [overflow-anchor:none]"
         onWheel={(e) => {
           if (e.deltaY < 0) setBottomFollow(false);
           else if (atEnd()) setBottomFollow(true);


### PR DESCRIPTION
## What changed

- Prevent chat and room transcript containers from scrolling horizontally.
- Keep horizontal scrolling scoped to nested code blocks and tables, so the floating **Jump to latest** control stays stationary.

## Why

Fixes #497.

The transcript container was implicitly allowed to scroll on the x-axis. Long nested content could therefore move the entire transcript layer, including the absolutely positioned jump control.

## How it was verified

- `pnpm typecheck`
- `pnpm build`
- `pnpm vitest run src/lib/bottom-follow.test.ts` (4 passed)
- `pnpm test` (197 test files passed, 1 skipped; 2053 tests passed, 18 skipped; all additional package and packaged-server checks passed)
- `git diff --check`

## Screenshots (UI changes)

Before (from the issue report):

![The Jump to latest control moving while a code block scrolls horizontally](https://github.com/user-attachments/assets/feb96cd4-0d1b-4d53-ad68-5e7bc478438b)

After: the outer transcript has no horizontal scroll range; code blocks and tables retain their existing nested horizontal scrolling.

## Checklist

- [x] The change is focused and does not add unrelated refactors.
- [x] Type checking, build, and tests pass locally.
- [x] No dependency or lockfile changes.
- [x] No server behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unwanted horizontal scrolling in chat messages and group transcripts.
  - Preserved vertical scrolling for easier navigation through lengthy conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->