### PR TITLE
fix(settings): keep long setup commands inside the Local VM panel

### DIFF
--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -66,7 +66,7 @@ function Step({ n, title, done, children }: { n: number; title: string; done: bo
       </div>
       <div className="min-w-0 flex-1">
         <div className={cn("text-[14px]", done ? "text-ink-secondary line-through" : "text-ink")}>{title}</div>
-        {!done && children && <div className="mt-2 flex flex-col items-start gap-2">{children}</div>}
+        {!done && children && <div className="mt-2 flex flex-col items-start gap-2 [&>*]:max-w-full">{children}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #443.

## What changed

One class on the wrapper that lays out a setup step's children in `Step`
(`src/components/LocalComputerSection.tsx`), so those children can no longer grow
wider than the step's column.

## Why

The setup steps arrange their children with `flex flex-col items-start`. In a
column flex container that aligns each child to its own content width rather than
to the column, so a child holding one long unbreakable string takes the string's
full width.

Step 4's `docker run` line is exactly that: a single ~950-character token stream
with `whitespace-nowrap`. Measured in the running app against a real
`/api/local-computer` payload, the `<details>` wrapper around it grew to **5204px**
inside a **668px** column, which pushed the settings pane **4604px** wider than the
dialog. The pane then scrolled horizontally, clipping the panel's left edge, and
the command boxes lost their copy button off the right side. That is what the
issue screenshot shows.

`CommandLine` already carries `min-w-0 overflow-x-auto`, so it is built to scroll
a long command inside its own box — it just never got the chance, because nothing
stopped it from growing first.

Two notes on the shape of the fix:

- **It belongs on the step, not on `CommandLine`.** In steps 3 and 4 the direct
  child of the flex container is the `<details>` wrapper, not the command box, so
  bounding the primitive alone would have left those two steps broken. Steps 1
  and 2 render `CommandLine` directly and have the same latent problem, and one
  constraint on the container covers all four.
- **`items-start` is kept deliberately.** Switching the container to
  `items-stretch` also removes the overflow, but it stretches the action buttons
  to the full column width. Constraining the children instead leaves the buttons
  shrink-wrapped, which is what `items-start` was there for.

## How it was verified

macOS 26.6, Node 26, Docker as the detected runtime, `pnpm dev` + `pnpm dev:server`.
Opened Settings → Local VM and expanded both "Show base-image download" and
"Show command", then measured the scroll pane and the step children in the page:

| | before | after |
|---|---|---|
| settings pane horizontal overflow | 4604px | **0px** |
| `<details>` widths (steps 3, 4) | 840px, 5204px | 564px, 564px |
| "Prepare Cua desktop" button width | 150px | 150px |

The unchanged button width is the regression check for keeping `items-start`.

Also confirmed that `flex-col` combined with `items-start` does not occur anywhere
else in the settings UI — the other `items-start` uses in `CompanionSection` are on
row containers, where it controls vertical alignment and not width.

```
pnpm typecheck   # clean
pnpm test        # 197 files, 2053 tests passed, 1 file / 18 tests skipped
```

No test is added: every test under `src/` is a pure-logic test on exported
functions, with no DOM or layout harness in the repo, and CONTRIBUTING asks UI
changes for screenshots instead. Adding a rendering stack to assert one
`max-width` did not seem like the trade this change should make — happy to
revisit if you'd rather have it.

## Screenshots (UI changes)

**Before** — both commands run past the right edge, copy buttons pushed out of the
panel, and the pane is scrolled sideways so the left edge of the content is clipped:

![before](https://raw.githubusercontent.com/Maksim-Burtsev/OpenMausBot/pr-443-assets/before.png)

**After** — both commands are bounded by the column and scroll inside their own
boxes, copy buttons are back, and the button is untouched:

![after](https://raw.githubusercontent.com/Maksim-Burtsev/OpenMausBot/pr-443-assets/after.png)

<sub>Screenshots live on a separate branch of my fork so they stay out of this PR's diff.</sub>

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — n/a, no server change; this is CSS only
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building — n/a
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved layout behavior by ensuring content within steps stays within the available container width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->