### PR TITLE
fix(pi): make always-allow approvals reach the running turn

### DIFF
--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -434,6 +434,26 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(recorder.events.some((e) => e.type === "request.resolved")).toBe(true);
   });
 
+  it("registers an ask before emitting it so synchronous auto-approval works", async () => {
+    await create("permission");
+    let unsubscribe = () => {};
+    const outcome = new Promise<string>((resolve) => {
+      unsubscribe = instance.adapter.onEvent((event) => {
+        if (event.type !== "request.opened" || !event.requestId) return;
+        // This mirrors the harness's auto-approve listener: emit() invokes it
+        // synchronously, so the ask must already be in pending here.
+        void instance.adapter
+          .respondToRequest(event.threadId, event.requestId, { behavior: "allow" })
+          .then(resolve);
+      });
+    });
+    await instance.adapter.sendTurn({ threadId: "t-sync-auto", text: "go" });
+    expect(await outcome).toBe("allowed-once");
+    unsubscribe();
+    const done = await recorder.until((event) => event.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true, stopReason: "end_turn" });
+  });
+
   it("respondToRequest is unavailable for an ask that is not pending", async () => {
     await create();
     await expect(instance.adapter.respondToRequest("t-none", "nope", { behavior: "allow" })).resolves.toBe("unavailable");

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -494,6 +494,15 @@ export const PiDriver: ProviderDriver<PiConfig> = {
               flushAssistantText();
               const reqId = evt.id ?? newId();
               const isQuestion = evt.method === "input";
+              // Register BEFORE emitting: the harness may auto-approve from
+              // inside its synchronous request.opened listener. Emitting first
+              // made respondToRequest see no pending ask, return unavailable,
+              // then fall back to a human card on every "Always allow" call.
+              pending.set(reqId, (decision) => {
+                if (decision.behavior === "deny") send({ type: "extension_ui_response", id: reqId, cancelled: true });
+                else if (isQuestion) send({ type: "extension_ui_response", id: reqId, value: decision.message ?? "" });
+                else send({ type: "extension_ui_response", id: reqId, confirmed: true });
+              });
               emit({
                 ...base(threadId, turnId),
                 requestId: reqId,
@@ -501,11 +510,6 @@ export const PiDriver: ProviderDriver<PiConfig> = {
                 requestType: isQuestion ? "question" : "permission",
                 tool: String(evt.title ?? "pi"),
                 summary: String(evt.title ?? "pi wants confirmation"),
-              });
-              pending.set(reqId, (decision) => {
-                if (decision.behavior === "deny") send({ type: "extension_ui_response", id: reqId, cancelled: true });
-                else if (isQuestion) send({ type: "extension_ui_response", id: reqId, value: decision.message ?? "" });
-                else send({ type: "extension_ui_response", id: reqId, confirmed: true });
               });
             }
             return;


### PR DESCRIPTION
## Problem

Pi emitted `request.opened` before registering the matching extension-UI responder. The harness can auto-approve synchronously from that event (including a remembered **Always allow** grant), so `respondToRequest` saw no pending ask and returned `unavailable`. The harness then showed the fallback card: `Auto mode couldn't answer this one.` The person could approve it manually, but the next equivalent request repeated the same failure.

## Fix

Register the pending extension-UI responder before emitting `request.opened`. The running turn can now receive a synchronous auto-approval.

No UI or approval-policy changes are included.

## Regression coverage

Adds a pi-driver contract test that mirrors the harness's synchronous auto-approval listener. It verifies `respondToRequest` returns `allowed-once` and the turn completes, instead of returning `unavailable`.

## Validation

- `pnpm typecheck`
- `pnpm vitest run server/drivers/pi.test.ts` — 30 passed
- `pnpm vitest run` — 197 files, 2054 passed (18 skipped)

Rebased onto current `origin/main` (`667af71`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission requests can now be approved immediately when they are opened, preventing timing-related failures in approval workflows.

* **Tests**
  * Added coverage to verify that requests are available for approval before the open event is emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->