### PR TITLE
feat(claude): add per-bot tool scoping

### DIFF
--- a/apps/docs/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/content/docs/getting-started/configuration.mdx
@@ -32,6 +32,26 @@ Local agent chat works without these credentials.
 
 Source and headless runs can set supported environment variables before starting the harness. The app-level settings are preferable for normal packaged use because they validate inputs and keep secret values out of the renderer.
 
+### Per-instance Claude tool scope
+
+Source and headless installations can give separate Claude instances different built-in tool sets in `~/.openmausbot/config.json`:
+
+```json
+{
+  "instances": {
+    "claude-browser": {
+      "driver": "claudeAgent",
+      "config": {
+        "tools": ["Read", "WebFetch", "WebSearch"],
+        "disallowedTools": ["Bash(git *)", "Edit", "Write"]
+      }
+    }
+  }
+}
+```
+
+`tools` selects Claude's available built-ins; an explicit empty array disables every built-in, while omitting it keeps Claude's default set. `disallowedTools` applies Claude tool-name patterns as an additional deny list. These settings do not grant or pre-approve MCP integrations, which remain controlled by the instance's mounted integrations and OpenMausBot permission flow.
+
 <Callout type="warn" title="Do not put secrets in prompts">
   A prompt becomes conversation history and may be sent to an agent provider. Use App Settings or environment configuration for credentials.
 </Callout>

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { ClaudeDriver, permissionSocketPath } from "./claude.ts";
+import { ClaudeDriver, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
@@ -86,6 +86,27 @@ describe("ClaudeDriver.decodeConfig", () => {
     expect(() => ClaudeDriver.decodeConfig({ permissionMode: "yolo" })).toThrow(/permissionMode/);
   });
 
+  it("normalizes and deduplicates built-in tool lists", () => {
+    expect(
+      ClaudeDriver.decodeConfig({
+        tools: [" Read ", "WebFetch", "Read"],
+        disallowedTools: [" Bash(git *) ", "Bash(git *)"],
+      }),
+    ).toMatchObject({
+      tools: ["Read", "WebFetch"],
+      disallowedTools: ["Bash(git *)"],
+    });
+    expect(ClaudeDriver.decodeConfig({ tools: [] }).tools).toEqual([]);
+  });
+
+  it.each([
+    ["tools", "Read"],
+    ["tools", ["Read", " "]],
+    ["disallowedTools", [42]],
+  ])("rejects invalid %s configuration", (field, value) => {
+    expect(() => ClaudeDriver.decodeConfig({ [field]: value })).toThrow(new RegExp(field));
+  });
+
   it.skipIf(process.platform !== "win32")("names permission pipes per harness process", () => {
     expect(permissionSocketPath("thread-abc")).toMatch(
       new RegExp(`^\\\\\\\\\\.\\\\pipe\\\\openmausbot-perm-${process.pid}-thre[0-9a-f]{4}$`),
@@ -136,14 +157,22 @@ describe("ClaudeDriver turns (fake CLI)", () => {
   let recorder: EventRecorder;
   let scratch: string;
 
-  const create = async (mode?: string, environment: Record<string, string> = {}) => {
+  const create = async (
+    mode?: string,
+    environment: Record<string, string> = {},
+    config: Partial<ClaudeConfig> = {},
+  ) => {
     if (mode) process.env.FAKE_CLAUDE_MODE = mode;
     instance = await ClaudeDriver.create({
       instanceId: "claude-test",
       displayName: "Claude Test",
       environment,
       enabled: true,
-      config: { cli: FAKE_CLI, permissionMode: "acceptEdits" },
+      config: {
+        ...config,
+        cli: config.cli ?? FAKE_CLI,
+        permissionMode: config.permissionMode ?? "acceptEdits",
+      },
     });
     recorder = recordEvents(instance.adapter);
   };
@@ -323,6 +352,35 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(JSON.stringify(seen.argv)).not.toContain("tok");
     const allowed = seen.argv[seen.argv.indexOf("--allowedTools") + 1];
     expect(allowed).toContain("mcp__agents");
+  });
+
+  it("passes normalized available and denied built-in tool sets to Claude", async () => {
+    await create(undefined, {}, {
+      tools: ["Read", "WebFetch"],
+      disallowedTools: ["Bash(git *)", "Edit"],
+    });
+    const dump = join(scratch, "tool-scope.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-tool-scope", text: "inspect" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv[seen.argv.indexOf("--tools") + 1]).toBe("Read,WebFetch");
+    expect(seen.argv[seen.argv.indexOf("--disallowedTools") + 1]).toBe("Bash(git *),Edit");
+  });
+
+  it("passes an explicit empty available set to disable every Claude built-in", async () => {
+    await create(undefined, {}, { tools: [], disallowedTools: [] });
+    const dump = join(scratch, "no-builtins.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-no-builtins", text: "reply only" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv[seen.argv.indexOf("--tools") + 1]).toBe("");
+    expect(seen.argv).not.toContain("--disallowedTools");
   });
 
   it("mounts the dweb proxy from the drivers directory and pre-allows its tools", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -94,6 +94,10 @@ const DRIVER_KIND = "claudeAgent";
 export interface ClaudeConfig {
   cli: string;
   permissionMode: "acceptEdits" | "auto" | "bypassPermissions";
+  /** Available Claude built-ins. An empty list passes `--tools ""`. */
+  tools?: string[];
+  /** Claude tool patterns to deny after the available set is selected. */
+  disallowedTools?: string[];
 }
 
 // model catalog ported from upstream packages/contracts/src/model.ts
@@ -376,15 +380,36 @@ function createPermissionBroker(opts: {
   };
 }
 
+function decodeToolList(value: unknown, field: "tools" | "disallowedTools"): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error(`claude: ${field} must be an array of non-empty strings`);
+  const decoded: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string" || !entry.trim()) {
+      throw new Error(`claude: ${field} must be an array of non-empty strings`);
+    }
+    const normalized = entry.trim();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    decoded.push(normalized);
+  }
+  return decoded;
+}
+
 function decodeConfig(raw: unknown): ClaudeConfig {
   const o = (raw ?? {}) as Record<string, unknown>;
   const mode = o.permissionMode;
   if (mode !== undefined && mode !== "acceptEdits" && mode !== "auto" && mode !== "bypassPermissions") {
     throw new Error(`claude: invalid permissionMode ${JSON.stringify(mode)}`);
   }
+  const tools = decodeToolList(o.tools, "tools");
+  const disallowedTools = decodeToolList(o.disallowedTools, "disallowedTools");
   return {
     cli: typeof o.cli === "string" ? o.cli : "claude",
     permissionMode: (mode as ClaudeConfig["permissionMode"]) ?? "acceptEdits",
+    ...(tools !== undefined ? { tools } : {}),
+    ...(disallowedTools !== undefined ? { disallowedTools } : {}),
   };
 }
 
@@ -550,6 +575,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         "--include-partial-messages",
         "--permission-mode", config.permissionMode === "auto" ? "acceptEdits" : config.permissionMode,
       ];
+      if (config.tools !== undefined) args.push("--tools", config.tools.join(","));
+      if (config.disallowedTools?.length) {
+        args.push("--disallowedTools", config.disallowedTools.join(","));
+      }
       const turnEnvironment: NodeJS.ProcessEnv = { ...process.env, ...input.environment };
       const turnModel = await resolveClaudeTurnModel(turn.model, turnEnvironment);
       const injected = applyClaudeInject({ ...turnEnvironment }, turnModel);


### PR DESCRIPTION
## Summary

- add per-instance Claude `tools[]` and `disallowedTools[]` configuration
- narrow and validate both arrays when decoding instance config
- emit the exact Claude CLI flags without changing other provider drivers
- document how to allow a subset or explicitly withhold built-in tools per bot

## Verification

- 56 focused Claude driver tests pass, 1 skipped
- Node 24 / pnpm 10 typecheck passes
- production build passes
- exact diff and working tree are clean

Closes #478.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Claude’s allowed and disallowed tool scopes per instance.
  - Tool selections and exclusions are applied to each Claude interaction, including the option to disable all built-in tools.
  - Configuration values are validated, trimmed, and deduplicated.

- **Documentation**
  - Added setup guidance covering tool patterns, defaults, and how tool scopes differ from MCP integrations and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->