### PR TITLE
fix(openai-compat): fall back to reasoning text in streaming turns wh…

### DIFF
--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -181,4 +181,47 @@ describe("OpenAICompatDriver", () => {
     await expect(inst.generateText?.("question")).resolves.toBe("usable result");
     await inst.dispose();
   });
+
+  it("falls back to reasoning_content when content is empty (streaming)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input).endsWith("/models")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        return new Response(
+          'data: {"choices":[{"delta":{"reasoning_content":"thinking through the problem"}}]}\n' +
+            'data: {"choices":[{"delta":{"content":""}}]}\n' +
+            'data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}\n' +
+            "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-reasoning-fallback-stream",
+      displayName: "Reasoning Fallback",
+      enabled: true,
+      config: { url: "https://example.test/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread-rf", text: "prompt", model: "vendor/model" });
+    const item = await recorder.until((e) => e.type === "item.completed");
+    const completed = await recorder.until((e) => e.type === "turn.completed");
+
+    expect(item).toMatchObject({
+      type: "item.completed",
+      itemType: "assistant_text",
+      text: "thinking through the problem",
+    });
+    expect(completed).toMatchObject({ ok: true, usage: { input: 10, output: 5 } });
+
+    const deltas = recorder.events.filter((e) => e.type === "content.delta");
+    expect(deltas.some((d: any) => d.streamKind === "reasoning_text" && d.delta === "thinking through the problem")).toBe(true);
+
+    recorder.stop();
+    await inst.dispose();
+  });
 });

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -289,12 +289,13 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
             source: "openai-compat.chat.completions",
             msg: { textLength: text.length, reasoningLength: reasoning.length, usage },
           });
-          if (text.trim()) {
+          const replyText = text.trim() ? text : reasoning;
+          if (replyText.trim()) {
             emit({
               ...base(threadId, turnId),
               type: "item.completed",
               itemType: "assistant_text",
-              text,
+              text: replyText,
             });
           }
           if (usage) {


### PR DESCRIPTION
## What changed

- When an OpenAI-compatible provider/model (such as reasoning models) returns streaming chunks with `reasoning_content` while emitting empty `content`, the `openai-compat` driver now promotes the reasoning output into the final assistant response (`item.completed`).
- Standard models that stream content deltas continue to take full precedence.
- Added a dedicated unit test in `server/drivers/openai-compat.test.ts` asserting fallback to `reasoning_content` when content deltas are empty.

## Why

- Certain OpenAI-compatible reasoning models route their output stream into `delta.reasoning_content` and leave `delta.content` blank.
- While live `content.delta` events were already emitted for UI streaming, the turn completion check required non-empty `text`, resulting in the bot finishing with `"(the bot finished without a text reply)"` in chat and storing an empty assistant turn.
- Promoting the reasoning text when standard content is empty ensures these models produce valid, persistent replies.

## How it was verified

- Executed vitest driver test suite: `npx vitest run server/drivers/openai-compat.test.ts` (9/9 passed).
- Ran full workspace typecheck: `pnpm typecheck` passed cleanly across client and server.
- Verified live turns end-to-end with an OpenAI-compatible thinking model.

## Screenshots (UI changes)

N/A (backend driver and test change only; no UI modifications).

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed assistant responses when standard message content is empty.
  * Reasoning content is now correctly included in the completed response while remaining available through reasoning updates.
  * Streamed input and output token usage is now reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->