### PR TITLE
fix(pi): harden MCP extension schema conversion and tool lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "esbuild": "^0.28.2",
     "oxlint": "1.78.0",
     "tailwindcss": "^4.1.11",
+    "typebox": "1.3.7",
     "typescript": "^5.8.3",
     "vite": "^7.1.0",
     "vitest": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.11
         version: 4.3.3
+      typebox:
+        specifier: 1.3.7
+        version: 1.3.7
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -3941,6 +3944,9 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -8152,6 +8158,8 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  typebox@1.3.7: {}
 
   typescript@5.9.3: {}
 

--- a/server/drivers/pi-mcp-extension.test.ts
+++ b/server/drivers/pi-mcp-extension.test.ts
@@ -1,0 +1,321 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import extension, {
+  allocateToolName,
+  StdioMcp,
+  toTypebox,
+  truncateToolText,
+} from "./pi-mcp-extension.ts";
+
+const tempDirs: string[] = [];
+const clients: StdioMcp[] = [];
+const originalMcpConfig = process.env.OMB_MCP_CONFIG;
+
+type ExtensionApi = Parameters<typeof extension>[0];
+type RegisteredTool = Parameters<ExtensionApi["registerTool"]>[0];
+type ShutdownHandler = Parameters<ExtensionApi["on"]>[1];
+
+interface SchemaNode {
+  type?: string;
+  const?: unknown;
+  enum?: unknown[];
+  anyOf?: SchemaNode[];
+  required?: string[];
+  additionalProperties?: boolean | SchemaNode;
+  properties?: Record<string, SchemaNode>;
+}
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omb-pi-mcp-ext-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function fakeMcpScript(source: string): string {
+  const dir = tempDir();
+  const path = join(dir, "fake-mcp.mjs");
+  writeFileSync(path, source, "utf8");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function createClient(source: string, env: Record<string, string> = {}): StdioMcp {
+  const client = new StdioMcp({ command: process.execPath, args: [fakeMcpScript(source)], env });
+  clients.push(client);
+  return client;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const client of clients.splice(0)) client.dispose();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  if (originalMcpConfig === undefined) delete process.env.OMB_MCP_CONFIG;
+  else process.env.OMB_MCP_CONFIG = originalMcpConfig;
+});
+
+describe("Pi MCP JSON Schema conversion", () => {
+  it("keeps the cua browser_prepare regression schema object-shaped at the root", () => {
+    const schema = toTypebox({
+      type: "object",
+      additionalProperties: true,
+      anyOf: [
+        { required: ["pid"] },
+        {
+          properties: {
+            allow_launch: { const: true },
+            profile: { properties: { mode: { enum: ["isolated_new", "isolated_named"] } } },
+          },
+          required: ["allow_launch", "profile"],
+        },
+      ],
+      properties: {
+        allow_launch: { type: "boolean" },
+        pid: { type: "integer" },
+        profile: {
+          type: "object",
+          properties: { mode: { type: "string", enum: ["isolated_new", "isolated_named"] } },
+          required: ["mode"],
+        },
+      },
+      required: [],
+    });
+    // SAFETY: toTypebox returns a TypeBox JSON Schema; this test reads only
+    // standard JSON Schema fields represented by SchemaNode.
+    const inspected = schema as SchemaNode;
+
+    expect(inspected.type).toBe("object");
+    expect(inspected.additionalProperties).toBe(true);
+    expect(inspected.properties?.pid.type).toBe("integer");
+    expect(inspected.properties?.profile.type).toBe("object");
+    expect(inspected.properties?.profile.required).toEqual(["mode"]);
+  });
+
+  it("preserves nested combinators, nullability, const and Google-compatible string enums", () => {
+    const schema = toTypebox({
+      type: "object",
+      properties: {
+        value: { anyOf: [{ type: "string" }, { type: "null" }] },
+        flag: { type: ["boolean", "null"] },
+        mode: { type: "string", enum: ["ax", "vision"] },
+        enabled: { const: true },
+      },
+      required: ["value"],
+    });
+    // SAFETY: toTypebox returns a TypeBox JSON Schema; this test reads only
+    // standard JSON Schema fields represented by SchemaNode.
+    const inspected = schema as SchemaNode;
+
+    expect(inspected.type).toBe("object");
+    expect(inspected.required).toEqual(["value"]);
+    expect(inspected.properties?.value.anyOf?.map((item) => item.type)).toEqual(["string", "null"]);
+    expect(inspected.properties?.flag.anyOf?.map((item) => item.type)).toEqual(["boolean", "null"]);
+    expect(inspected.properties?.mode).toMatchObject({ type: "string", enum: ["ax", "vision"] });
+    expect(inspected.properties?.enabled).toMatchObject({ type: "boolean", const: true });
+  });
+
+  it("collects properties declared only inside root combinator branches", () => {
+    const schema = toTypebox({
+      oneOf: [
+        { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+        { type: "object", properties: { id: { type: "integer" } }, required: ["id"] },
+      ],
+    });
+    // SAFETY: toTypebox returns a TypeBox JSON Schema; this test reads only
+    // standard JSON Schema fields represented by SchemaNode.
+    const inspected = schema as SchemaNode;
+
+    expect(inspected.type).toBe("object");
+    expect(Object.keys(inspected.properties ?? {})).toEqual(["query", "id"]);
+    // A field required by only one choice cannot be globally required.
+    expect(inspected.required).toBeUndefined();
+  });
+
+  it("always returns an object schema for malformed, nullable or absent root schemas", () => {
+    expect(toTypebox(undefined)).toMatchObject({ type: "object" });
+    expect(toTypebox({ anyOf: [] })).toMatchObject({ type: "object" });
+    expect(toTypebox({ type: "object", nullable: true })).toMatchObject({ type: "object" });
+  });
+});
+
+describe("Pi MCP tool names and output bounds", () => {
+  it("keeps collision suffixes inside the provider 64-character limit", () => {
+    const used = new Set<string>();
+    const long = "x".repeat(100);
+    const names = Array.from({ length: 12 }, () => {
+      const name = allocateToolName("computer", long, used);
+      used.add(name);
+      return name;
+    });
+
+    expect(new Set(names).size).toBe(names.length);
+    expect(names.every((name) => name.length <= 64)).toBe(true);
+    expect(names.at(-1)).toMatch(/_12$/);
+  });
+
+  it("truncates by lines and UTF-8 bytes without splitting a code point", () => {
+    const manyLines = Array.from({ length: 2_100 }, (_, index) => `line ${index}`).join("\n");
+    expect(truncateToolText(manyLines)).toContain("2000-line limit");
+
+    const manyAccents = "á".repeat(30_000);
+    const truncated = truncateToolText(manyAccents);
+    expect(truncated).toContain("50KB limit");
+    expect(truncated).not.toContain("�");
+  });
+});
+
+describe("StdioMcp", () => {
+  it("initializes, paginates tools/list, preserves images and truncates text", async () => {
+    const client = createClient(`
+      let buffer = "";
+      process.stdin.setEncoding("utf8");
+      const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+      process.stdin.on("data", (chunk) => {
+        buffer += chunk;
+        let newline;
+        while ((newline = buffer.indexOf("\\n")) !== -1) {
+          const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+          if (!line.trim()) continue;
+          const msg = JSON.parse(line);
+          if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { tools: {} } } });
+          else if (msg.method === "tools/list" && !msg.params?.cursor) send({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "first", inputSchema: { type: "object" } }], nextCursor: "page-2" } });
+          else if (msg.method === "tools/list") send({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "second", inputSchema: { type: "object" } }] } });
+          else if (msg.method === "tools/call") send({ jsonrpc: "2.0", id: msg.id, result: { content: [
+            { type: "text", text: "x".repeat(60 * 1024) },
+            { type: "image", data: "aW1hZ2U=", mimeType: "image/png" }
+          ] } });
+        }
+      });
+    `);
+
+    await client.init();
+    await expect(client.listTools()).resolves.toMatchObject([{ name: "first" }, { name: "second" }]);
+    const result = await client.callTool("first", {});
+    expect(result.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("50KB limit") });
+    expect(result.content[1]).toEqual({ type: "image", data: "aW1hZ2U=", mimeType: "image/png" });
+  });
+
+  it("propagates abort and sends MCP notifications/cancelled", async () => {
+    const dir = tempDir();
+    const dump = join(dir, "cancel.json");
+    const client = createClient(
+      `
+        import { writeFileSync } from "node:fs";
+        let buffer = "";
+        process.stdin.setEncoding("utf8");
+        const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+        process.stdin.on("data", (chunk) => {
+          buffer += chunk;
+          let newline;
+          while ((newline = buffer.indexOf("\\n")) !== -1) {
+            const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+            if (!line.trim()) continue;
+            const msg = JSON.parse(line);
+            if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { tools: {} } } });
+            else if (msg.method === "notifications/cancelled") writeFileSync(process.env.DUMP, JSON.stringify(msg.params));
+          }
+        });
+      `,
+      { DUMP: dump },
+    );
+    await client.init();
+    const controller = new AbortController();
+    const pending = client.callTool("slow", {}, controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/);
+    await vi.waitFor(() => expect(JSON.parse(readFileSync(dump, "utf8"))).toMatchObject({ requestId: 2 }));
+  });
+});
+
+describe("Pi MCP extension registration", () => {
+  it("keeps earlier tools alive when a later registration fails", async () => {
+    const script = fakeMcpScript(`
+      let buffer = "";
+      process.stdin.setEncoding("utf8");
+      const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+      process.stdin.on("data", (chunk) => {
+        buffer += chunk;
+        let newline;
+        while ((newline = buffer.indexOf("\\n")) !== -1) {
+          const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+          if (!line.trim()) continue;
+          const msg = JSON.parse(line);
+          if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { tools: {} } } });
+          else if (msg.method === "tools/list") send({ jsonrpc: "2.0", id: msg.id, result: { tools: [
+            { name: "good", inputSchema: { type: "object", properties: {} } },
+            { name: "bad", inputSchema: { type: "object", properties: {} } }
+          ] } });
+          else if (msg.method === "tools/call") send({ jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "still alive" }] } });
+        }
+      });
+    `);
+    const dir = tempDir();
+    const config = join(dir, "mcp.json");
+    writeFileSync(config, JSON.stringify({ mcpServers: { test: { command: process.execPath, args: [script] } } }));
+    process.env.OMB_MCP_CONFIG = config;
+
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const tools: RegisteredTool[] = [];
+    const handlers = new Map<string, ShutdownHandler>();
+    await extension({
+      registerTool(tool) {
+        if (tool.name.endsWith("_bad")) throw new Error("synthetic registration failure");
+        tools.push(tool);
+      },
+      on(event, handler) {
+        handlers.set(event, handler);
+      },
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("synthetic registration failure"));
+    await expect(
+      tools[0].execute("call-1", {}, undefined, undefined, { ui: { confirm: async () => true } }),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "still alive" }] });
+    await handlers.get("session_shutdown")?.();
+  });
+
+  it("throws when an MCP tool result declares isError", async () => {
+    const script = fakeMcpScript(`
+      let buffer = "";
+      process.stdin.setEncoding("utf8");
+      const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+      process.stdin.on("data", (chunk) => {
+        buffer += chunk;
+        let newline;
+        while ((newline = buffer.indexOf("\\n")) !== -1) {
+          const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+          if (!line.trim()) continue;
+          const msg = JSON.parse(line);
+          if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { tools: {} } } });
+          else if (msg.method === "tools/list") send({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "fail", inputSchema: { type: "object", properties: {} } }] } });
+          else if (msg.method === "tools/call") send({ jsonrpc: "2.0", id: msg.id, result: { isError: true, content: [{ type: "text", text: "remote failure" }] } });
+        }
+      });
+    `);
+    const dir = tempDir();
+    const config = join(dir, "mcp.json");
+    writeFileSync(config, JSON.stringify({ mcpServers: { test: { command: process.execPath, args: [script] } } }));
+    process.env.OMB_MCP_CONFIG = config;
+
+    const tools: RegisteredTool[] = [];
+    const handlers = new Map<string, ShutdownHandler>();
+    await extension({
+      registerTool(tool) {
+        tools.push(tool);
+      },
+      on(event, handler) {
+        handlers.set(event, handler);
+      },
+    });
+
+    expect(tools).toHaveLength(1);
+    await expect(
+      tools[0].execute("call-1", {}, undefined, undefined, { ui: { confirm: async () => true } }),
+    ).rejects.toThrow("remote failure");
+    await handlers.get("session_shutdown")?.();
+  });
+});

--- a/server/drivers/pi-mcp-extension.ts
+++ b/server/drivers/pi-mcp-extension.ts
@@ -11,8 +11,7 @@
 // frame per line (no MCP SDK, no Content-Length framing) — see
 // server/mcp-bridge.ts and server/drivers/agents-proxy.ts. This client matches
 // that exactly.
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
+import { Type, type TObjectOptions, type TSchema, type TSchemaOptions } from "typebox";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { readFileSync } from "node:fs";
 
@@ -35,12 +34,62 @@ interface McpTool {
   inputSchema?: unknown;
 }
 
+interface McpTextContent {
+  type: "text";
+  text: unknown;
+}
+
+interface McpImageContent {
+  type: "image";
+  data: unknown;
+  mimeType: unknown;
+}
+
+type PiToolContent = { type: "text"; text: string } | { type: "image"; data: string; mimeType: string };
+
+interface PiToolContext {
+  ui: {
+    confirm(title: string, message: string): Promise<boolean>;
+  };
+}
+
+interface PiToolDefinition {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TSchema;
+  execute(
+    toolCallId: string,
+    params: unknown,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    context: PiToolContext,
+  ): Promise<{ content: PiToolContent[]; details: Record<string, never> }>;
+}
+
+/** Structural slice of Pi 0.84's ExtensionAPI used by this standalone file.
+ * Keeping it local avoids bundling Pi into OpenMausBot; the extension is
+ * loaded by the user's installed Pi, which supplies the real implementation. */
+interface PiExtensionApi {
+  registerTool(definition: PiToolDefinition): void;
+  on(event: "session_shutdown", handler: () => void): void;
+}
+
+const MCP_STARTUP_TIMEOUT_MS = 8_000;
+const MCP_TOOL_TIMEOUT_MS = 10 * 60_000;
+const MCP_MAX_LIST_PAGES = 100;
+const MCP_MAX_FRAME_BYTES = 32 * 1024 * 1024;
+const TOOL_OUTPUT_MAX_BYTES = 50 * 1024;
+const TOOL_OUTPUT_MAX_LINES = 2_000;
+const TOOL_NAME_MAX_LENGTH = 64;
+
 /** A minimal stdio JSON-RPC 2.0 MCP client, matched to OpenMausBot's
  * newline-delimited house protocol. */
-class StdioMcp {
+export class StdioMcp {
   private child: ChildProcessWithoutNullStreams;
   private buf = "";
   private nextId = 1;
+  private disposed = false;
   private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
 
   constructor(def: McpServerDef) {
@@ -53,20 +102,31 @@ class StdioMcp {
     });
     this.child.stdout.setEncoding("utf8");
     this.child.stdout.on("data", (chunk: string) => this.onData(chunk));
-    this.child.on("error", (err) => this.failAll(err));
+    this.child.on("error", (err) => this.closeWithError(err));
     // A server that starts and then dies emits `exit`, never `error`; without
     // settling on it, an in-flight init/listTools would hang the extension
     // load for the whole turn.
-    this.child.on("exit", (code) => this.failAll(new Error(`MCP server exited (code ${code ?? "?"})`)));
+    this.child.on("exit", (code) => this.closeWithError(new Error(`MCP server exited (code ${code ?? "?"})`)));
     // A write to a dead child errors asynchronously on the stream; an
     // unhandled stream error would kill the pi process (the same hazard
     // spawnCli documents for driver-spawned children in procs.ts).
-    this.child.stdin.on("error", () => this.failAll(new Error("MCP server stdin closed")));
+    this.child.stdin.on("error", () => this.closeWithError(new Error("MCP server stdin closed")));
   }
 
   private failAll(err: Error): void {
     for (const [, p] of this.pending) p.reject(err);
     this.pending.clear();
+  }
+
+  private closeWithError(err: Error): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.failAll(err);
+    try {
+      this.child.kill();
+    } catch {
+      /* already gone */
+    }
   }
 
   private onData(chunk: string): void {
@@ -76,84 +136,166 @@ class StdioMcp {
       const line = this.buf.slice(0, nl).trim();
       this.buf = this.buf.slice(nl + 1);
       if (!line) continue;
-      let msg: { id?: unknown; error?: { message?: string }; result?: unknown };
+      if (Buffer.byteLength(line, "utf8") > MCP_MAX_FRAME_BYTES) {
+        this.closeWithError(new Error(`MCP frame exceeded ${MCP_MAX_FRAME_BYTES} bytes`));
+        return;
+      }
+      let msg: { id?: unknown; method?: unknown; error?: { message?: string }; result?: unknown };
       try {
         msg = JSON.parse(line);
       } catch {
         continue;
       }
-      if (msg.id !== undefined && this.pending.has(msg.id as number)) {
-        const p = this.pending.get(msg.id as number)!;
-        this.pending.delete(msg.id as number);
+      if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+        const p = this.pending.get(msg.id)!;
+        this.pending.delete(msg.id);
         if (msg.error) p.reject(new Error(msg.error.message ?? "MCP error"));
         else p.resolve(msg.result);
+        continue;
       }
-      // Server notifications/requests (e.g. notifications/tools/list_changed)
-      // carry no id and are intentionally ignored for this single-shot mount.
+      // This minimal client does not implement server→client requests. Reply
+      // explicitly instead of leaving a conforming server waiting forever.
+      if (msg.id !== undefined && typeof msg.method === "string") {
+        try {
+          this.write({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "Client method not supported" } });
+        } catch (err) {
+          this.closeWithError(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
+      }
+      // Notifications (e.g. notifications/tools/list_changed) are intentionally
+      // ignored for this single-shot mount.
+    }
+    if (Buffer.byteLength(this.buf, "utf8") > MCP_MAX_FRAME_BYTES) {
+      this.closeWithError(new Error(`MCP frame exceeded ${MCP_MAX_FRAME_BYTES} bytes without a newline`));
     }
   }
 
-  private call(method: string, params?: unknown, timeoutMs = 30_000): Promise<unknown> {
+  private write(frame: unknown): void {
+    if (this.disposed || this.child.stdin.destroyed || !this.child.stdin.writable) {
+      throw new Error("MCP server stdin is closed");
+    }
+    this.child.stdin.write(JSON.stringify(frame) + "\n");
+  }
+
+  private call(method: string, params: unknown, timeoutMs: number, signal?: AbortSignal): Promise<unknown> {
+    if (this.disposed) return Promise.reject(new Error("MCP client is closed"));
+    if (signal?.aborted) return Promise.reject(new Error(`MCP ${method} aborted`));
+
     const id = this.nextId++;
     return new Promise<unknown>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      let settled = false;
+      const cleanup = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn();
+      };
+      const cancel = (reason: string) => {
         this.pending.delete(id);
-        reject(new Error(`MCP ${method} timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
+        try {
+          this.notify("notifications/cancelled", { requestId: id, reason });
+        } catch {
+          /* the transport may already be gone */
+        }
+        settle(() => reject(new Error(reason)));
+      };
+      const onAbort = () => cancel(`MCP ${method} aborted`);
+      const timer = setTimeout(() => cancel(`MCP ${method} timed out after ${timeoutMs}ms`), timeoutMs);
       timer.unref?.();
+      signal?.addEventListener("abort", onAbort, { once: true });
       this.pending.set(id, {
-        resolve: (v) => (clearTimeout(timer), resolve(v)),
-        reject: (e) => (clearTimeout(timer), reject(e)),
+        resolve: (value) => settle(() => resolve(value)),
+        reject: (err) => settle(() => reject(err)),
       });
       try {
-        this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+        this.write({ jsonrpc: "2.0", id, method, params });
       } catch (err) {
-        clearTimeout(timer);
         this.pending.delete(id);
-        reject(err instanceof Error ? err : new Error(String(err)));
+        settle(() => reject(err instanceof Error ? err : new Error(String(err))));
       }
     });
   }
 
   private notify(method: string, params?: unknown): void {
-    this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+    this.write({ jsonrpc: "2.0", method, params });
   }
 
   async init(): Promise<void> {
-    await this.call("initialize", {
-      protocolVersion: "2024-11-05",
-      capabilities: {},
-      clientInfo: { name: "openmausbot-pi", version: "1" },
-    });
+    await this.call(
+      "initialize",
+      {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "openmausbot-pi", version: "1" },
+      },
+      MCP_STARTUP_TIMEOUT_MS,
+    );
     this.notify("notifications/initialized");
   }
 
   async listTools(): Promise<McpTool[]> {
-    const res = (await this.call("tools/list", {})) as { tools?: McpTool[] } | undefined;
-    return res?.tools ?? [];
+    const tools: McpTool[] = [];
+    const seenCursors = new Set<string>();
+    const deadline = Date.now() + MCP_STARTUP_TIMEOUT_MS;
+    let cursor: string | undefined;
+    for (let page = 0; page < MCP_MAX_LIST_PAGES; page += 1) {
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const res = (await this.call(
+        "tools/list",
+        cursor ? { cursor } : {},
+        remainingMs,
+      )) as { tools?: unknown; nextCursor?: unknown } | undefined;
+      if (!Array.isArray(res?.tools)) throw new Error("MCP tools/list returned no tools array");
+      tools.push(...(res.tools as McpTool[]));
+      if (typeof res.nextCursor !== "string" || !res.nextCursor) return tools;
+      if (seenCursors.has(res.nextCursor)) throw new Error("MCP tools/list repeated a pagination cursor");
+      seenCursors.add(res.nextCursor);
+      cursor = res.nextCursor;
+    }
+    throw new Error(`MCP tools/list exceeded ${MCP_MAX_LIST_PAGES} pages`);
   }
 
-  /** tools/call → pi text result. Non-text content (screenshots, etc.) is
-   * folded into a marker so the agent still gets the structured state the
-   * proxies return alongside it. */
-  async callTool(name: string, args: unknown): Promise<{ text: string; isError: boolean }> {
-    const res = (await this.call("tools/call", { name, arguments: args ?? {} })) as
-      | { content?: unknown[]; isError?: boolean }
-      | undefined;
-    const content = Array.isArray(res?.content) ? res.content : [];
-    const text = content
-      .filter((c): c is { type: "text"; text: unknown } => (c as { type?: string })?.type === "text")
+  /** tools/call → Pi content, preserving screenshots and bounding text so a
+   * remote server cannot flood the model context. */
+  async callTool(name: string, args: unknown, signal?: AbortSignal): Promise<{ content: PiToolContent[]; isError: boolean }> {
+    const res = (await this.call(
+      "tools/call",
+      { name, arguments: args ?? {} },
+      MCP_TOOL_TIMEOUT_MS,
+      signal,
+    )) as { content?: unknown; isError?: boolean } | undefined;
+    const rawContent = Array.isArray(res?.content) ? res.content : [];
+    const text = rawContent
+      .filter((c): c is McpTextContent => Boolean(c) && (c as { type?: unknown }).type === "text")
       .map((c) => String(c.text ?? ""))
       .join("\n");
-    const other = content.filter((c) => (c as { type?: string })?.type !== "text");
-    const note = other.length ? `\n[${other.length} non-text content item(s) omitted]` : "";
+    const images = rawContent
+      .filter(
+        (c): c is McpImageContent =>
+          Boolean(c) &&
+          (c as { type?: unknown }).type === "image" &&
+          typeof (c as McpImageContent).data === "string" &&
+          typeof (c as McpImageContent).mimeType === "string",
+      )
+      .map((c) => ({ type: "image" as const, data: String(c.data), mimeType: String(c.mimeType) }));
+    const unsupported = rawContent.length - rawContent.filter((c) => (c as { type?: unknown })?.type === "text").length - images.length;
+    let boundedText = truncateToolText(text || (images.length ? "" : "(empty result)"));
+    if (unsupported > 0) boundedText += `${boundedText ? "\n" : ""}[${unsupported} unsupported MCP content item(s) omitted]`;
     return {
-      text: (text || "(empty result)") + note,
+      content: [...(boundedText ? [{ type: "text" as const, text: boundedText }] : []), ...images],
       isError: Boolean(res?.isError),
     };
   }
 
   dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.failAll(new Error("MCP client disposed"));
     try {
       this.child.kill();
     } catch {
@@ -162,53 +304,188 @@ class StdioMcp {
   }
 }
 
-/** Best-effort JSON Schema → typebox for the common MCP tool shapes.
- * Anything unrecognized degrades to a permissive record rather than failing
- * the mount: a tool that works loosely beats one that never registers. */
-function toTypebox(schema: unknown): unknown {
-  if (!schema || typeof schema !== "object") return Type.Record(Type.String(), Type.Any());
-  const s = schema as {
-    type?: string;
-    enum?: unknown[];
-    anyOf?: unknown;
-    oneOf?: unknown;
-    allOf?: unknown;
-    items?: unknown;
-    properties?: Record<string, unknown>;
-    required?: string[];
-  };
-  if (Array.isArray(s.enum)) {
-    const lits = s.enum.filter((v) => ["string", "number", "boolean"].includes(typeof v));
-    if (lits.length === s.enum.length && lits.length > 0) {
-      return Type.Union(lits.map((v) => Type.Literal(v as string | number | boolean)));
-    }
-    return Type.Any();
+interface JsonSchema {
+  type?: string | string[];
+  title?: unknown;
+  description?: unknown;
+  default?: unknown;
+  const?: unknown;
+  enum?: unknown[];
+  nullable?: unknown;
+  anyOf?: unknown[];
+  oneOf?: unknown[];
+  allOf?: unknown[];
+  items?: unknown | unknown[];
+  prefixItems?: unknown[];
+  properties?: Record<string, unknown>;
+  required?: unknown;
+  additionalProperties?: unknown;
+  minimum?: unknown;
+  maximum?: unknown;
+  exclusiveMinimum?: unknown;
+  exclusiveMaximum?: unknown;
+  multipleOf?: unknown;
+  minLength?: unknown;
+  maxLength?: unknown;
+  pattern?: unknown;
+  format?: unknown;
+  minItems?: unknown;
+  maxItems?: unknown;
+  uniqueItems?: unknown;
+  minProperties?: unknown;
+  maxProperties?: unknown;
+}
+
+const SCHEMA_OPTION_KEYS = [
+  "title",
+  "description",
+  "default",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "format",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minProperties",
+  "maxProperties",
+] as const;
+
+function schemaOptions(schema: JsonSchema): TSchemaOptions {
+  const options: TSchemaOptions = {};
+  for (const key of SCHEMA_OPTION_KEYS) {
+    const value = schema[key];
+    if (value !== undefined) Reflect.set(options, key, value);
   }
-  if (s.anyOf || s.oneOf || s.allOf) return Type.Any();
-  switch (s.type) {
+  return options;
+}
+
+function isSchemaObject(value: unknown): value is JsonSchema {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function primitiveLiteral(value: unknown): TSchema | null {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return Type.Literal(value);
+  }
+  if (value === null) return Type.Null();
+  return null;
+}
+
+function withNullable(schema: TSchema, nullable: unknown): TSchema {
+  return nullable === true ? Type.Union([schema, Type.Null()]) : schema;
+}
+
+function collectObjectShape(schema: JsonSchema): { properties: Record<string, unknown>; required: Set<string> } {
+  const properties: Record<string, unknown> = {};
+  const required = new Set<string>();
+
+  const visit = (candidate: unknown, mode: "root" | "all" | "choice") => {
+    if (!isSchemaObject(candidate)) return;
+    for (const branch of candidate.allOf ?? []) visit(branch, mode === "choice" ? "choice" : "all");
+    for (const branch of [...(candidate.anyOf ?? []), ...(candidate.oneOf ?? [])]) visit(branch, "choice");
+    for (const [key, value] of Object.entries(candidate.properties ?? {})) {
+      // The root declaration is authoritative; branch-only properties are
+      // still retained so the model knows which arguments exist.
+      if (mode === "root" || properties[key] === undefined) properties[key] = value;
+    }
+    if (mode !== "choice" && Array.isArray(candidate.required)) {
+      for (const key of candidate.required) if (typeof key === "string") required.add(key);
+    }
+  };
+
+  visit(schema, "root");
+  return { properties, required };
+}
+
+function objectSchema(schema: JsonSchema, root = false): TSchema {
+  const { properties, required } = collectObjectShape(schema);
+  const converted: Record<string, TSchema> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    const nested = nestedTypebox(value);
+    converted[key] = required.has(key) ? nested : Type.Optional(nested);
+  }
+  const options: TObjectOptions = schemaOptions(schema);
+  if (typeof schema.additionalProperties === "boolean") {
+    options.additionalProperties = schema.additionalProperties;
+  } else if (isSchemaObject(schema.additionalProperties)) {
+    options.additionalProperties = nestedTypebox(schema.additionalProperties);
+  }
+  const object = Type.Object(converted, options);
+  return root ? object : withNullable(object, schema.nullable);
+}
+
+function nestedTypebox(schema: unknown): TSchema {
+  if (!isSchemaObject(schema)) return Type.Any();
+  const options = schemaOptions(schema);
+
+  const literal = primitiveLiteral(schema.const);
+  if (literal) return withNullable(literal, schema.nullable);
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    if (schema.enum.every((value) => typeof value === "string")) {
+      // `{type:"string", enum:[...]}` works across Google/OpenAI/Anthropic;
+      // Type.Union(Type.Literal(...)) does not work with Google's tool API.
+      return withNullable(Type.String({ ...options, enum: schema.enum }), schema.nullable);
+    }
+    const literals = schema.enum.map(primitiveLiteral).filter((value): value is TSchema => value !== null);
+    if (literals.length === schema.enum.length) {
+      const union = literals.length === 1 ? literals[0] : Type.Union(literals, options);
+      return withNullable(union, schema.nullable);
+    }
+  }
+
+  if (Array.isArray(schema.type)) {
+    const variants = schema.type.map((type) => nestedTypebox({ ...schema, type, nullable: false }));
+    return variants.length === 1 ? variants[0] : Type.Union(variants, options);
+  }
+
+  if (schema.type === "object" || schema.properties) return objectSchema(schema);
+
+  const choice = schema.anyOf ?? schema.oneOf;
+  if (Array.isArray(choice) && choice.length > 0) {
+    const variants = choice.map(nestedTypebox);
+    return withNullable(variants.length === 1 ? variants[0] : Type.Union(variants, options), schema.nullable);
+  }
+  if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    const variants = schema.allOf.map(nestedTypebox);
+    return withNullable(variants.length === 1 ? variants[0] : Type.Intersect(variants, options), schema.nullable);
+  }
+
+  switch (schema.type) {
     case "string":
-      return Type.String();
+      return withNullable(Type.String(options), schema.nullable);
     case "number":
-      return Type.Number();
+      return withNullable(Type.Number(options), schema.nullable);
     case "integer":
-      return Type.Integer();
+      return withNullable(Type.Integer(options), schema.nullable);
     case "boolean":
-      return Type.Boolean();
+      return withNullable(Type.Boolean(options), schema.nullable);
     case "null":
       return Type.Null();
-    case "array":
-      return Type.Array(s.items ? toTypebox(s.items) : Type.Any());
-    case "object": {
-      const props: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(s.properties ?? {})) {
-        const required = Array.isArray(s.required) && s.required.includes(k);
-        props[k] = required ? toTypebox(v) : Type.Optional(toTypebox(v));
-      }
-      return Type.Object(props);
+    case "array": {
+      const tupleItems = schema.prefixItems ?? (Array.isArray(schema.items) ? schema.items : undefined);
+      const value = tupleItems
+        ? Type.Tuple(tupleItems.map(nestedTypebox), options)
+        : Type.Array(schema.items ? nestedTypebox(schema.items) : Type.Any(), options);
+      return withNullable(value, schema.nullable);
     }
     default:
-      return Type.Record(Type.String(), Type.Any());
+      return Type.Any();
   }
+}
+
+/** Best-effort JSON Schema → TypeBox. MCP tool parameters must always expose
+ * an object at the root; Pi/provider tool serialization rejects a root schema
+ * without `type: "object"`. Nested schemas retain unions, nullability and
+ * constraints instead of being incorrectly rewritten as objects. */
+export function toTypebox(schema: unknown): TSchema {
+  return objectSchema(isSchemaObject(schema) ? schema : {}, true);
 }
 
 /** pi tool names are lowercase snake identifiers; MCP tool names are not
@@ -216,7 +493,36 @@ function toTypebox(schema: unknown): unknown {
  * with the server so two servers can never collide. */
 function sanitizeToolName(server: string, tool: string): string {
   const raw = `${server}_${tool}`.toLowerCase().replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
-  return raw.slice(0, 64) || `mcp_tool`;
+  return raw.slice(0, TOOL_NAME_MAX_LENGTH) || "mcp_tool";
+}
+
+export function allocateToolName(server: string, tool: string, used: Set<string>): string {
+  const base = sanitizeToolName(server, tool);
+  let candidate = base;
+  for (let suffixNumber = 2; used.has(candidate); suffixNumber += 1) {
+    const suffix = `_${suffixNumber}`;
+    candidate = `${base.slice(0, Math.max(1, TOOL_NAME_MAX_LENGTH - suffix.length))}${suffix}`;
+  }
+  return candidate;
+}
+
+export function truncateToolText(text: string): string {
+  const lines = text.split("\n");
+  const lineLimited = lines.slice(0, TOOL_OUTPUT_MAX_LINES).join("\n");
+  const bytes = Buffer.from(lineLimited, "utf8");
+  let byteEnd = Math.min(bytes.length, TOOL_OUTPUT_MAX_BYTES);
+  // Avoid returning a replacement character when the byte limit lands in the
+  // middle of a UTF-8 code point.
+  while (byteEnd > 0 && byteEnd < bytes.length && (bytes[byteEnd] & 0xc0) === 0x80) byteEnd -= 1;
+  const content = bytes.subarray(0, byteEnd).toString("utf8");
+  const truncatedByLines = lines.length > TOOL_OUTPUT_MAX_LINES;
+  const truncatedByBytes = bytes.length > TOOL_OUTPUT_MAX_BYTES;
+  if (!truncatedByLines && !truncatedByBytes) return content;
+  const reasons = [
+    ...(truncatedByLines ? [`${TOOL_OUTPUT_MAX_LINES}-line limit`] : []),
+    ...(truncatedByBytes ? [`${TOOL_OUTPUT_MAX_BYTES / 1024}KB limit`] : []),
+  ];
+  return `${content}\n\n[MCP output truncated: ${reasons.join(" and ")}. Refine the request for less output.]`;
 }
 
 /** A short human-readable line for the permission card's detail. */
@@ -229,7 +535,7 @@ function summarizeParams(params: unknown): string {
   }
 }
 
-export default async function (pi: ExtensionAPI): Promise<void> {
+export default async function (pi: PiExtensionApi): Promise<void> {
   const configPath = process.env.OMB_MCP_CONFIG;
   if (!configPath) return;
 
@@ -242,52 +548,87 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   const used = new Set<string>();
   const clients: StdioMcp[] = [];
+  const serverEntries = Object.entries(config.mcpServers ?? {});
 
-  for (const [serverName, def] of Object.entries(config.mcpServers ?? {})) {
-    if (!def || typeof def.command !== "string") continue;
+  // Mount independent servers concurrently so one slow integration cannot
+  // consume the startup timeout once per server. Registration remains in
+  // config order below for deterministic tool names and collision suffixes.
+  const mounts = await Promise.all(
+    serverEntries.map(async ([serverName, def]) => {
+      if (!def || typeof def.command !== "string" || !def.command.trim()) return { serverName };
+      let client: StdioMcp | undefined;
+      try {
+        client = new StdioMcp(def);
+        await client.init();
+        return { serverName, def, client, tools: await client.listTools() };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[openmausbot-pi-mcp] ${serverName}: ${message}\n`);
+        client?.dispose();
+        return { serverName };
+      }
+    }),
+  );
+
+  for (const mount of mounts) {
+    if (!mount.client || !mount.def || !mount.tools) continue;
+    const { serverName, def, client, tools } = mount;
     const gated = def.scope === "local-computer";
-    let client: StdioMcp | undefined;
-    try {
-      client = new StdioMcp(def);
-      await client.init();
-      const tools = await client.listTools();
-      for (const tool of tools) {
-        let name = sanitizeToolName(serverName, tool.name);
-        while (used.has(name)) name = `${name}_2`;
-        used.add(name);
+    let registered = 0;
+
+    for (const tool of tools) {
+      if (!tool || typeof tool.name !== "string" || !tool.name.trim()) {
+        process.stderr.write(`[openmausbot-pi-mcp] ${serverName}: skipped a tool with no valid name\n`);
+        continue;
+      }
+      const toolName = tool.name;
+      const name = allocateToolName(serverName, toolName, used);
+      try {
+        const parameters = toTypebox(tool.inputSchema);
         pi.registerTool({
           name,
-          label: `${serverName}:${tool.name}`,
-          description: tool.description ?? `${tool.name} (MCP tool from ${serverName})`,
-          parameters: toTypebox(tool.inputSchema),
-          async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+          label: `${serverName}:${toolName}`,
+          description: typeof tool.description === "string" ? tool.description : `${toolName} (MCP tool from ${serverName})`,
+          parameters,
+          async execute(_toolCallId, params, signal, _onUpdate, ctx) {
             // Host tools ask first, using pi's native permission card
             // (ctx.ui.confirm → extension_ui_request → Allow/Deny card). This
             // mirrors ACP's session/request_permission and Codex's elicitation.
             if (gated) {
               const detail = summarizeParams(params);
               const allowed = await ctx.ui.confirm(
-                `Allow ${tool.name} on your computer?`,
-                detail || `Run ${serverName}:${tool.name}`,
+                `Allow ${toolName} on your computer?`,
+                detail || `Run ${serverName}:${toolName}`,
               );
               if (!allowed) {
                 return { content: [{ type: "text", text: "Blocked by the user." }], details: {} };
               }
             }
-            const res = await client.callTool(tool.name, params);
-            const text = res.isError ? `(tool returned an error)\n${res.text}` : res.text;
-            return { content: [{ type: "text", text }], details: {} };
+            const res = await client.callTool(toolName, params, signal);
+            if (res.isError) {
+              const message = res.content
+                .filter((item): item is { type: "text"; text: string } => item.type === "text")
+                .map((item) => item.text)
+                .join("\n");
+              // Pi marks a custom tool as failed only when execute throws;
+              // returning error-looking text incorrectly produces isError=false.
+              throw new Error(message || `MCP tool ${serverName}:${toolName} returned an error`);
+            }
+            return { content: res.content, details: {} };
           },
         });
+        used.add(name);
+        registered += 1;
+      } catch (err) {
+        // One malformed tool must not dispose the client behind tools that
+        // were already registered from the same server.
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[openmausbot-pi-mcp] ${serverName}:${toolName}: ${message}\n`);
       }
-      clients.push(client);
-    } catch (err) {
-      // A server that fails to initialize must not take the whole turn down:
-      // skip its tools and let the agent work with whatever else mounted.
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[openmausbot-pi-mcp] ${serverName}: ${message}\n`);
-      client?.dispose();
     }
+
+    if (registered > 0) clients.push(client);
+    else client.dispose();
   }
 
   pi.on("session_shutdown", () => {

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -255,6 +255,17 @@ describe("PiDriver turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-exit")).toBe(false);
   });
 
+  it("surfaces a pi turn error instead of reporting an empty success", async () => {
+    await create("turn-error");
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-turn-error", text: "hi" });
+    const done = await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+    expect(done).toMatchObject({ ok: false, stopReason: "failed", usage: { input: 0, output: 0 } });
+    expect(recorder.events.find((e) => e.type === "runtime.error")).toMatchObject({
+      message: "Invalid schema for function 'computer_browser_prepare'",
+    });
+    expect(instance.adapter.hasSession("t-turn-error")).toBe(false);
+  });
+
   it("advertises images and every harness effort level", async () => {
     await create();
     expect(instance.adapter.capabilities.images).toBe(true);

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -229,7 +229,7 @@ interface PiEvent {
   toolName?: string;
   isError?: boolean;
   // turn_end / message_end
-  message?: { stopReason?: string; usage?: { input?: number; output?: number } };
+  message?: { stopReason?: string; errorMessage?: string; usage?: { input?: number; output?: number } };
   usage?: { input?: number; output?: number };
   // extension_ui_request
   id?: string;
@@ -517,7 +517,16 @@ export const PiDriver: ProviderDriver<PiConfig> = {
             // answer — settling now would drop the final reply.
             if (sr === "toolUse" || sr === "tool_use" || sr === "tool_calls") return;
             const usage = evt.usage ?? evt.message?.usage;
-            settle(true, sr === "cancelled" ? "cancelled" : "end_turn", usage);
+            if (sr === "error" || sr === "failed") {
+              emit({
+                ...base(threadId, turnId),
+                type: "runtime.error",
+                message: String(evt.message?.errorMessage ?? "pi turn failed").slice(0, 2_000),
+              });
+              settle(false, "failed", usage);
+              return;
+            }
+            settle(true, sr === "cancelled" || sr === "aborted" ? "cancelled" : "end_turn", usage);
             return;
           }
           default:

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -5,7 +5,7 @@
 // / set_model, and streams a scripted turn in response to `prompt`. Failure
 // modes mirror how the real CLI misbehaves:
 //
-//   FAKE_PI_MODE   happy (default) | tooluse | permission | interleave | no-models | exit-early
+//   FAKE_PI_MODE   happy (default) | tooluse | permission | interleave | turn-error | no-models | exit-early
 //   FAKE_PI_MODELS comma-separated provider/model pairs (default "ollama-cloud/glm-5.2,openai/gpt-4o")
 //   FAKE_PI_DUMP   path to append {argv, env} JSON, so a test can assert argv shape
 //                  and env hygiene (no leaked secrets into the pi child).
@@ -77,6 +77,21 @@ const streamTurn = () => {
     send({ type: "message_update", usage: { input: 0, output: 0 }, assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta } });
   }
   send({ type: "turn_end", message: { stopReason: "end_turn", usage: { input: 12, output: 3 } }, usage: { input: 12, output: 3 } });
+  send({ type: "agent_end" });
+};
+
+const streamErrorTurn = () => {
+  send({ type: "agent_start" });
+  send({ type: "turn_start" });
+  send({
+    type: "turn_end",
+    message: {
+      stopReason: "error",
+      errorMessage: "Invalid schema for function 'computer_browser_prepare'",
+      usage: { input: 0, output: 0 },
+    },
+    usage: { input: 0, output: 0 },
+  });
   send({ type: "agent_end" });
 };
 
@@ -187,6 +202,7 @@ function handle(cmd: any) {
       if (mode === "tooluse") streamToolTurn();
       else if (mode === "permission") streamPermissionTurn();
       else if (mode === "interleave") streamInterleaveTurn();
+      else if (mode === "turn-error") streamErrorTurn();
       else streamTurn();
       return;
     case "extension_ui_response":


### PR DESCRIPTION
## Problem

Bots using the `pi` engine with a local computer (`computer: "local"`, i.e. Cua Driver) stopped answering — every turn completed in ~1s with `usage: 0/0` and an empty reply.

Root cause: the pi MCP extension (`server/drivers/pi-mcp-extension.ts`) converts each MCP tool's JSON Schema into a TypeBox schema. A schema with a **root-level `anyOf`/`oneOf`/`allOf`** — like Cua Driver's `browser_prepare` — was mapped to `Type.Any()`. pi 0.84 rejects `Type.Any()` as a tool parameter schema and aborts the turn with `stopReason: "error"` and empty content. The pi driver then normalized that into `turn.completed { ok: true }` with zero tokens, so the failure was invisible.

## What changed

`server/drivers/pi-mcp-extension.ts`
- Rewrote JSON Schema → TypeBox conversion: always object at the root, preserving nested unions, `nullable`, `const`, string enums (Google-compatible `{type:"string", enum:[...]}`), tuples, `allOf` intersections, and constraints. Properties declared only inside root combinator branches are collected too.
- Timeouts split by phase: 8s for initialize/list, 10min for `tools/call` (Composio and dweb legitimately run minutes). Tool calls now propagate the abort signal and emit `notifications/cancelled`.
- Preserved MCP image content (screenshots) and added text truncation (50KB / 2000 lines, UTF-8-safe) so a remote server can't flood context.
- `isError` tool results now throw so pi reports them as real failures instead of success text.
- Collision-safe tool names within the 64-char limit; each tool registers independently so one malformed tool no longer disposes the client behind earlier tools from the same server.
- Paginated `tools/list`, bounded frame size, explicit reply to unsupported server→client requests, and concurrent server mount (bounded total startup).

`server/drivers/pi.ts`
- Surface `turn_end`/`agent_end` with `stopReason: "error"`/`"failed"` as `runtime.error` + `ok:false` instead of an empty success.

`server/testing/fake-pi-cli.ts` + `server/drivers/pi.test.ts`
- Added a `turn-error` mode and an assertion that pi turn errors fail the turn.

`server/drivers/pi-mcp-extension.test.ts` (new)
- Schema conversion (the `browser_prepare` regression, nested combinators, nullability, const, branch-only properties), tool-name allocation, output truncation, stdio pagination + abort/cancel, `isError` handling, and partial-registration survival.

`package.json` / `pnpm-lock.yaml`
- `typebox@1.3.7` as a devDependency (the same version pi 0.84 ships), so the previously-excluded extension file is now type-checked.

## Testing

- `pnpm typecheck` — passes
- `node scripts/test-floor.mjs` — 2083 tests, floor 1070 ✓
- Manual smoke: pi 0.84.2 + Cua Driver (56 tools) via the extension → `stopReason: "stop"`, correct reply, no stderr.

## Notes

- This is independent of #512 (the always-allow approval race) — separate branch, no overlap.
- No pi core changes: the extension is OpenMausBot-owned code loaded into the pi process via `-e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP support improvements, including paginated tool discovery, richer schema handling, image-preserving output, cancellation, and safer tool naming.
  * Added clearer handling for failed and aborted Pi turns, including surfaced runtime error messages.

* **Bug Fixes**
  * MCP tool errors now propagate correctly, while unavailable or invalid tools are handled more safely.

* **Tests**
  * Expanded coverage for MCP initialization, limits, pagination, cancellation, images, errors, and failed Pi turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->