### PR TITLE
fix(ios): a linger sleeper may not close a window it does not own

### DIFF
--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -376,6 +376,9 @@ final class Session: ObservableObject {
     }
 
     private var lingerTask: UIBackgroundTaskIdentifier = .invalid
+    /// Identifies the background window currently allowed to end the stream.
+    /// A sleeper from an earlier window may wake after a newer one has opened.
+    private var lingerGeneration = 0
 
     /// Leaving the screen: keep the stream alive for the grace period iOS
     /// allows (~30 s) rather than cutting it at once, so an approval that
@@ -384,13 +387,22 @@ final class Session: ObservableObject {
     /// the cursor is written down at a known point.
     func linger() {
         guard streamTask != nil, lingerTask == .invalid else { disconnect(); return }
+        lingerGeneration += 1
+        let generation = lingerGeneration
         lingerTask = UIApplication.shared.beginBackgroundTask(withName: "companion.linger") { [weak self] in
             // time is up before our own timer — the system wants us gone now
-            self?.disconnect()
+            guard let self,
+                  self.lingerGeneration == generation,
+                  self.lingerTask != .invalid
+            else { return }
+            self.disconnect()
         }
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(25))
-            guard let self, self.lingerTask != .invalid else { return }
+            guard let self,
+                  self.lingerGeneration == generation,
+                  self.lingerTask != .invalid
+            else { return }
             self.disconnect()
         }
     }


### PR DESCRIPTION
Fixes #469.

## What happens

`linger()` starts a 25-second sleeper and `endLinger()` does not cancel it. A round trip near the end of one window — leave, come back, leave again — lets the first window's sleeper wake up during the second one and end it early. The stream drops while the user believes they still have the grace period, so an approval or a finished-turn notification arriving in those seconds never lands.

The UIKit expiration handler had the same shape: it captured no window identity, so an expiration belonging to a finished window could disconnect a live one.

## The fix

A generation counter, incremented only when a window actually opens. Both the sleeper and the expiration handler capture it and act only if it is still current and a window is still open. A sleeper from window A wakes during window B, sees a generation that is no longer its own, and returns.

`Session` is `@MainActor`, so there is no suspension point between the guard and `disconnect()` — the check cannot be raced. The old `Task` is deliberately left to finish its sleep rather than being stored and cancelled: with the guard in place it is inert, and keeping a handle would add state to buy nothing but an earlier wake-up.

## About tests

There are none, and I would rather say so than imply otherwise.

`Session.swift` lives in `ios/App/`, and `ios/Package.swift` builds and tests only `ios/Sources/CompanionCore`, so `swift test` cannot reach it. The `xcodebuild` step compiles it but does not exercise it. Moving the lifecycle policy into `CompanionCore` purely to make it testable would be a much larger change than the fix, in a shipped app, and that is your call rather than mine.

The scenario a test would need to drive, if that ever happens: open window A and suspend its sleeper near 25s; call `connect()` to end A; open window B before A's sleeper resumes; resume A and assert the stream and B are still alive; then let B expire on its own schedule and assert only that disconnects.

Found while porting this behaviour to Android, where the same rule is covered by tests because the equivalent code sits in a testable module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkWZ3y7iKQMjH6tHNFBte7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background session handling to prevent older expiration events from disconnecting an active session.
  * Increased reliability when transitioning between consecutive background tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->