### PR TITLE
fix(ios): read the two fields the server already sends

### DIFF
--- a/ios/App/AgentProfileView.swift
+++ b/ios/App/AgentProfileView.swift
@@ -43,6 +43,10 @@ struct AgentProfileView: View {
     private var voiceConfigured: Bool { config?.isTTSConfigured == true }
     private var hasWorkspaceDefaultVoice: Bool { config?.hasWorkspaceDefaultVoice == true }
     private var selectedVoiceCanSpeak: Bool { config?.canSpeak(agentVoice: voice) == true }
+    /// Which engine's words to use. An unloaded status is ElevenLabs for the
+    /// same reason a missing `provider` is: that is the server's own fallback,
+    /// and the copy that shipped.
+    private var usesSystemVoices: Bool { config?.voiceProvider == .system }
 
     var body: some View {
         NavigationStack {
@@ -134,6 +138,9 @@ struct AgentProfileView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
+                    } else if usesSystemVoices {
+                        Label("Built-in Mac voices are unavailable", systemImage: "speaker.slash")
+                            .foregroundStyle(.secondary)
                     } else {
                         Label("ElevenLabs is not configured", systemImage: "speaker.slash")
                             .foregroundStyle(.secondary)
@@ -142,9 +149,22 @@ struct AgentProfileView: View {
                     Text("Voice")
                 } footer: {
                     if !voiceConfigured {
-                        Text("Add the shared ElevenLabs key in this agent's profile on the computer. The key is never returned to iOS.")
+                        // Under the built-in engine "not configured" is not a
+                        // missing credential — there is none — so the remedy
+                        // cannot be a key. `providerConfigured` in
+                        // `server/tts/index.ts` is reporting that this
+                        // computer has no built-in voices to speak with.
+                        if usesSystemVoices {
+                            Text("Built-in Mac voices need no key, and this computer has none available. Switch the voice engine to ElevenLabs in this agent's profile on the computer to keep using voice.")
+                        } else {
+                            Text("Add the shared ElevenLabs key in this agent's profile on the computer. The key is never returned to iOS.")
+                        }
                     } else if !hasWorkspaceDefaultVoice {
-                        Text("No workspace default voice is selected. Choose an agent-specific voice above; synthesis still uses the shared ElevenLabs key on your computer.")
+                        if usesSystemVoices {
+                            Text("No workspace default voice is selected. Choose an agent-specific voice above; synthesis still uses the built-in Mac voices on your computer.")
+                        } else {
+                            Text("No workspace default voice is selected. Choose an agent-specific voice above; synthesis still uses the shared ElevenLabs key on your computer.")
+                        }
                     } else {
                         Text("The voice choice belongs to this agent. Workspace default uses the shared voice selected on your computer.")
                     }

--- a/ios/App/ConnectedAppsView.swift
+++ b/ios/App/ConnectedAppsView.swift
@@ -12,7 +12,15 @@ struct ConnectedAppsView: View {
     @EnvironmentObject private var session: Session
     @Environment(\.scenePhase) private var scenePhase
     @State private var catalog: ConnectorCatalog?
-    @State private var statuses: [String: ConnectorStatus] = [:]
+    /// The last inventory the computer vouched for, or `nil` if it never has.
+    /// An empty dictionary is a real answer — "nothing is connected". `nil` is
+    /// the absence of an answer, and drawing the two the same way is the whole
+    /// bug: it turns "we could not find out" into "you are disconnected".
+    @State private var statuses: [String: ConnectorStatus]?
+    /// Whether the newest answer withdrew its own authority. `PluginsPanel.tsx`
+    /// keeps the same flag for the same reason: silence makes a remembered
+    /// list indistinguishable from a confirmed one.
+    @State private var credentialStoreUnreadable = false
     @State private var query = ""
     @State private var aliasCard: ConnectorCard?
     @State private var alias = ""
@@ -30,7 +38,29 @@ struct ConnectedAppsView: View {
 
     var body: some View {
         List {
-            if catalog?.configured == false {
+            if credentialStoreUnreadable {
+                Section {
+                    Label("Accounts could not be re-checked", systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                    if statuses == nil {
+                        Text("Your computer could not open its credential store, so it cannot say which accounts are connected. Nothing has been disconnected — restarting OpenMausBot on your computer usually clears this.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Showing what was connected last time. Your computer could not open its credential store just now, so these could not be re-checked. Nothing has been disconnected — restarting OpenMausBot on your computer usually clears this.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            // Two notices about one fact is one too many, and only the banner
+            // above is true during a failed read: `configured` comes from
+            // `composio.configured(cfg)` (server/index.ts:4993), which an
+            // unreadable store also drives to false, so "needs setup" would be
+            // advice for someone who never set this up. Same rule the panel on
+            // the computer applies — `!configured && !stale`.
+            if catalog?.configured == false, !credentialStoreUnreadable {
                 Section {
                     ContentUnavailableView(
                         "Connected apps need setup",
@@ -81,13 +111,19 @@ struct ConnectedAppsView: View {
 
     @ViewBuilder
     private func connectorSection(_ card: ConnectorCard) -> some View {
-        let status = statuses[card.slug]
+        let status = statuses?[card.slug]
         let accounts = status?.accounts ?? []
         let isConnected = status?.connected == true
         let isPending = status?.pending == true
 
         Section {
-            if accounts.isEmpty, !isConnected, !isPending {
+            if statuses == nil {
+                // No inventory has ever been confirmed, so this app's state is
+                // not known. "Connect" would assert that it is disconnected —
+                // the one claim we are in no position to make.
+                Label("Connection unknown", systemImage: "questionmark.circle")
+                    .foregroundStyle(.secondary)
+            } else if accounts.isEmpty, !isConnected, !isPending {
                 Button("Connect \(card.label)", systemImage: "plus.circle") {
                     Task { await authorize(card, alias: nil) }
                 }
@@ -148,6 +184,15 @@ struct ConnectedAppsView: View {
         if showProgress { refreshing = true }
         defer { if showProgress { refreshing = false } }
         guard let response = await session.loadAllConnectorStatuses() else { return }
+        credentialStoreUnreadable = !response.isAuthoritative
+        // An unreadable credential store answers with an empty map that means
+        // "we could not find out", not "nothing is connected". Replacing the
+        // inventory with it would show live accounts as disconnected — and
+        // this runs on every foregrounding, so one transient failure would be
+        // enough. Keep the last answer we were sure about; when there is none
+        // to keep, `statuses` stays nil and the view says so rather than
+        // guessing on the user's behalf.
+        guard response.isAuthoritative else { return }
         statuses = response.services
     }
 

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -452,11 +452,22 @@ public struct InstanceList: Codable, Sendable {
     public var instances: [Instance]
 }
 
+/// Which engine actually speaks — `VoiceProvider` in `server/tts/index.ts`.
+/// Derived from `ConfigFlag.provider`, never decoded straight off the wire.
+public enum VoiceProvider: Hashable, Sendable {
+    case elevenlabs
+    case system
+}
+
 public struct ConfigFlag: Codable, Hashable, Sendable {
     public var configured: Bool
     public var apiKeyConfigured: Bool?
     public var ready: Bool?
     public var voice: String?
+    /// The voice engine, absent on a computer that predates the choice. Read
+    /// it through `ConfigStatus.voiceProvider`, which applies the server's own
+    /// fallback; nothing should compare this string directly.
+    public var provider: String?
 }
 
 public struct Profile: Codable, Hashable, Sendable {
@@ -471,8 +482,13 @@ public struct ConfigStatus: Codable, Sendable {
     public var imageGen: ConfigFlag?
     public var profile: Profile?
 
-    /// Whether the shared synthesis credential exists on the paired
-    /// computer. The credential itself never appears in this response.
+    /// Whether synthesis is available on the paired computer. Deliberately
+    /// provider-neutral: under ElevenLabs this is a key on file, while under
+    /// the built-in engine `providerConfigured` in `server/tts/index.ts`
+    /// reports whether the computer has voices it can use and no credential
+    /// exists at all. Only the reason behind the flag changes — so anything
+    /// that *explains* a false here has to ask `voiceProvider` first.
+    /// Either way the credential itself never appears in this response.
     public var isTTSConfigured: Bool {
         tts?.configured == true || tts?.apiKeyConfigured == true
     }
@@ -486,6 +502,16 @@ public struct ConfigStatus: Codable, Sendable {
     public func canSpeak(agentVoice: String?) -> Bool {
         let hasAgentVoice = !(agentVoice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         return isTTSConfigured && (hasAgentVoice || hasWorkspaceDefaultVoice)
+    }
+
+    /// `voiceProvider(cfg)` in `server/tts/index.ts`: only the exact string
+    /// `"system"` selects the built-in engine. A missing field — a computer
+    /// older than the choice — and an engine this build has never heard of
+    /// both fall back to ElevenLabs, which is the server's own rule and what
+    /// keeps an unrecognised engine from being explained to the user with
+    /// copy written for a different one.
+    public var voiceProvider: VoiceProvider {
+        tts?.provider == "system" ? .system : .elevenlabs
     }
 }
 
@@ -757,6 +783,26 @@ public struct ConnectorCatalog: Codable, Sendable {
 public struct ConnectorStatuses: Codable, Sendable {
     public var configured: Bool
     public var services: [String: ConnectorStatus]
+    /// `"ok"`, `"unavailable"`, or absent on a computer that predates the
+    /// field. Read it through `isAuthoritative`; nothing should compare it
+    /// directly.
+    public var credentialStore: String?
+
+    /// Whether `services` is an inventory or an admission of ignorance.
+    ///
+    /// `server/index.ts` answers an unreadable Composio credential store with
+    /// an empty map *and* `credentialStore: "unavailable"`, because failing to
+    /// read the store means we do not know what is connected — which is not
+    /// the same as knowing nothing is. An empty map arriving that way must
+    /// never be shown as "nothing is connected": every account may still be
+    /// live on the computer.
+    ///
+    /// Only that exact string withdraws the claim. `"ok"` is authoritative,
+    /// and so is a missing field — a computer old enough not to send it would
+    /// otherwise have every answer treated as unknowable.
+    public var isAuthoritative: Bool {
+        credentialStore != "unavailable"
+    }
 }
 
 /// The harness's error body. Every non-2xx response carries one.

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -175,6 +175,35 @@ final class DecodingTests: XCTestCase {
         XCTAssertNil(pending.accounts)
     }
 
+    func testAnUnreadableCredentialStoreIsNotAnEmptyInventory() throws {
+        func statuses(_ json: String) throws -> ConnectorStatuses {
+            try JSONDecoder().decode(ConnectorStatuses.self, from: Data(json.utf8))
+        }
+
+        // The one answer that withdraws its own authority: an empty map the
+        // server explicitly labels as "we could not read the store".
+        let unreadable = try statuses(#"{"configured":false,"credentialStore":"unavailable","services":{}}"#)
+        XCTAssertTrue(unreadable.services.isEmpty)
+        XCTAssertFalse(unreadable.isAuthoritative)
+
+        // The three ways of still being authoritative. Each is asserted
+        // separately because a rule that only recognised the case above would
+        // pass a test that only checked the case above — and every one of
+        // these would then start hiding accounts that really are gone.
+        XCTAssertTrue(
+            try statuses(#"{"configured":true,"credentialStore":"ok","services":{}}"#).isAuthoritative,
+            "an empty list from a readable store really does mean nothing is connected"
+        )
+        XCTAssertTrue(
+            try statuses(#"{"configured":true,"services":{}}"#).isAuthoritative,
+            "a computer older than the field would otherwise have every answer treated as unknowable"
+        )
+        XCTAssertTrue(
+            try statuses(#"{"configured":false,"credentialStore":"Unavailable","services":{}}"#).isAuthoritative,
+            "only the exact string server/index.ts writes withdraws the claim; anything else is as unknown as an absent field"
+        )
+    }
+
     func testOneMalformedBotDoesNotHideTheRestOfTheFleet() throws {
         let json = """
         {
@@ -337,6 +366,14 @@ final class DecodingTests: XCTestCase {
         let config = try decode(ConfigStatus.self, "config")
         XCTAssertEqual(config.profile?.name, "Ada Lovelace")
         XCTAssertEqual(config.box?.configured, false)
+        // Captured bytes, not our idea of them: `describeVoice` always sends
+        // the engine, so a sidecar that stopped forwarding it fails here
+        // instead of quietly sending every built-in-voices user back to an
+        // explanation about an ElevenLabs key. The captured value is stable on
+        // any platform — the fabricated config selects no provider, so the
+        // server's own fallback decides it.
+        XCTAssertEqual(config.tts?.provider, "elevenlabs")
+        XCTAssertEqual(config.voiceProvider, .elevenlabs)
     }
 
     // MARK: - Frames

--- a/ios/Tests/CompanionCoreTests/Fixtures/config.json
+++ b/ios/Tests/CompanionCoreTests/Fixtures/config.json
@@ -4,18 +4,38 @@
   },
   "composio": {
     "configured": false,
-    "apiKeyConfigured": false
+    "mode": "unavailable"
   },
   "box": {
+    "configured": false
+  },
+  "vps": {
+    "configured": false
+  },
+  "opencodeGo": {
     "configured": false
   },
   "tts": {
     "configured": false,
     "ready": false,
-    "voice": ""
+    "voice": "",
+    "provider": "elevenlabs"
+  },
+  "imageGen": {
+    "configured": false
   },
   "profile": {
     "name": "Ada Lovelace",
     "email": "ada@example.com"
+  },
+  "rooms": {
+    "turnTimeoutMinutes": 5
+  },
+  "localVm": {
+    "mode": "shared",
+    "maxInstances": 2
+  },
+  "features": {
+    "skillRecorder": false
   }
 }

--- a/ios/Tests/CompanionCoreTests/ProfileRoutinePolicyTests.swift
+++ b/ios/Tests/CompanionCoreTests/ProfileRoutinePolicyTests.swift
@@ -47,6 +47,47 @@ final class ProfileRoutinePolicyTests: XCTestCase {
         XCTAssertTrue(withDefault.canSpeak(agentVoice: nil))
     }
 
+    func testOnlyTheEngineTheServerNamesGetsItsOwnExplanation() throws {
+        // The built-in engine is the reason "configured" stopped meaning "a
+        // key is on file" — so the copy that explains a false has to know
+        // which engine it is talking about.
+        XCTAssertEqual(try decodeConfig(#"{"tts":{"configured":false,"provider":"system"}}"#).voiceProvider, .system)
+
+        // Everything else is ElevenLabs: `voiceProvider(cfg)` in
+        // `server/tts/index.ts` matches that one exact string and falls back
+        // for the rest. Each case is asserted on its own, because a rule that
+        // merely matched "system" loosely would still pass the assertion
+        // above while explaining someone's ElevenLabs setup as a Mac voice.
+        XCTAssertEqual(
+            try decodeConfig(#"{"tts":{"configured":true,"ready":true,"voice":"v"}}"#).voiceProvider, .elevenlabs,
+            "a computer older than the choice does not send the field at all"
+        )
+        XCTAssertEqual(
+            try decodeConfig(#"{"tts":{"configured":true,"provider":"elevenlabs"}}"#).voiceProvider, .elevenlabs
+        )
+        XCTAssertEqual(
+            try decodeConfig(#"{"tts":{"configured":false,"provider":"System"}}"#).voiceProvider, .elevenlabs,
+            "only the exact string the server writes selects the built-in engine"
+        )
+        XCTAssertEqual(
+            try decodeConfig(#"{"tts":{"configured":false,"provider":"cartesia"}}"#).voiceProvider, .elevenlabs,
+            "an engine this build has never heard of must not borrow another engine's copy"
+        )
+        XCTAssertEqual(
+            try decodeConfig(#"{"tts":{"configured":false,"provider":"system-voices"}}"#).voiceProvider, .elevenlabs,
+            "a future engine whose name merely contains the old one is still unknown: matching loosely would explain it with Mac-voice copy and a Mac-voice remedy"
+        )
+        XCTAssertEqual(
+            try decodeConfig("{}").voiceProvider, .elevenlabs,
+            "no voice block at all is not the built-in engine either"
+        )
+
+        // The flag itself stays provider-neutral: the meaning of a true moved,
+        // not its shape, and nothing above may quietly change who can speak.
+        XCTAssertTrue(try decodeConfig(#"{"tts":{"configured":true,"provider":"system","voice":"Albert"}}"#).canSpeak(agentVoice: nil))
+        XCTAssertFalse(try decodeConfig(#"{"tts":{"configured":false,"provider":"system","voice":"Albert"}}"#).canSpeak(agentVoice: nil))
+    }
+
     private func routine(schedule: RoutineSchedule) -> Routine {
         Routine(
             id: "routine-1",


### PR DESCRIPTION
Fixes #504. Fixes #505.

Two defects with the same shape: the server already sends a field, and the phone ignores it. Both touch `Models.swift`, so they come together.

## #504 — an unreadable credential store reads as "nothing is connected"

`server/index.ts:4995-5008` answers an unreadable Composio store with `services: {}` **and** `credentialStore: "unavailable"`, and says why in place:

> an unreadable store means we do not KNOW what is connected, which is not the same as knowing nothing is

`PluginsPanel.tsx:60-71` honours that and keeps the last confirmed inventory. iOS did not model the field, so it wrote the empty map into view state and rendered **Connect** for accounts that were still connected — inviting the user to re-authorize something that never went away. `refreshStatuses()` also runs on scene activation and pull-to-refresh, so a transient failure could blank the list at any foregrounding.

The fix distinguishes the two states that were conflated: `statuses` is now optional, where `[:]` means *a real answer that is empty* and `nil` means *no answer*. With no answer a card reads **Connection unknown** rather than Connect, and the "Connected apps need setup" banner is suppressed — the rule `PluginsPanel.tsx:559` already applies (`!configured && !stale`), for the reason its own comment at `:556-558` gives. Nothing is hidden: the cards stay listed, searchable and refreshable; only the false claim is gone.

One deliberate side effect: during the first load, cards briefly read "Connection unknown" instead of "Connect". If you would rather have the panel's cached inventory instead, that `nil` is exactly where it would attach.

## #505 — the phone blames ElevenLabs for the Mac's own voice

`server/tts/index.ts:57-63` sends `provider`, and documents that under `system` the meaning of `configured` moves with it: *"this engine can speak", not "a key is on file"*. `systemVoicesAvailable()` is `platform === "darwin"` (`system-voices.ts:26-28`), so `provider: "system"` with `configured: false` means *this computer has no built-in voice engine* — nothing to do with a key.

iOS ignored `provider` and told the user to add a shared ElevenLabs key: a remedy for a state that has no key in it, pointing at a setting that would change nothing.

`provider` is now decoded, and the copy follows it. **Under ElevenLabs the three sentences are byte-identical to what shipped** — that is what the desktop expects and what your users have seen. Only the `system` branch is new, and it names the engine actually in use. A missing `provider` means ElevenLabs, matching the server's own fallback, so an older desktop keeps today's behaviour exactly.

## Fixture

`Fixtures/config.json` did not carry `provider`, even though `describeVoice` sends it — so the new path would only ever have been exercised by hand-written JSON, which `DecodingTests.swift` itself calls the weaker option. I re-ran `scripts/capture-companion-fixtures.mjs` rather than editing bytes by hand; only `config.json` changed, and the other seven fixtures are byte-identical to `main`. (They are stale in other ways — ids and timestamps — but that is not this PR's business.)

## What CI covers here, and what it does not

The decoding rules and the fixture contract are pinned by tests in `CompanionCoreTests`. The view changes — the copy branch and the unknown-inventory state — are outside the test target; `xcodebuild` compiles them, nothing exercises them.

I could not run `swift test` locally (no Swift toolchain on the machine this was written on), so CI is the first execution. Opened as a draft for that reason.

Both defects were found while porting the companion to Android, where the same two contracts are now honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkWZ3y7iKQMjH6tHNFBte7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing built-in system voices from ElevenLabs voices, with provider-specific setup guidance.
  * Connected apps now show confirmed connection statuses and clearly identify when connection details are unavailable.
  * Added support for recognizing voice provider settings and additional configuration options.

* **Bug Fixes**
  * Prevented misleading setup prompts when credential status cannot be verified.
  * Preserved previously confirmed connection statuses during temporary read failures.

* **Tests**
  * Expanded coverage for voice provider selection and unavailable credential-store scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->