### PR TITLE
fix(redact): content-redact ACP env entries whose name is not secret-shaped

### DIFF
--- a/server/redact.test.ts
+++ b/server/redact.test.ts
@@ -74,6 +74,35 @@ describe("redactSecrets", () => {
     expect(out).toContain('"1"'); // a non-secret value is untouched
   });
 
+  it("still content-redacts an ACP env entry whose name is not secret-shaped", () => {
+    // A credential can land under an ordinary-looking variable name (a
+    // custom env var, a feature flag someone repurposed) — the ACP
+    // {name,value} shortcut must not skip the content pass just because
+    // the NAME alone doesn't scream "secret".
+    const alpha = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const leaked = `sk-ant-api03-${alpha}`;
+    const sessionNew = {
+      params: {
+        mcpServers: [
+          {
+            name: "custom",
+            env: [
+              { name: "SESSION_CONFIG", value: leaked },
+              { name: "FEATURE_FLAG", value: "enabled" },
+            ],
+          },
+        ],
+      },
+    };
+
+    const out = flat(redactSecrets(sessionNew));
+    expect(out).not.toContain(leaked);
+    expect(out).toContain("SESSION_CONFIG");
+    expect(out).toContain("FEATURE_FLAG");
+    expect(out).toContain("enabled");
+    expect(out).toMatch(/«redacted \d+ chars»/);
+  });
+
   it("leaves ordinary protocol traffic alone", () => {
     const update = {
       method: "session/update",

--- a/server/redact.ts
+++ b/server/redact.ts
@@ -79,7 +79,13 @@ export function redactSecrets(input: unknown, depth = 0): unknown {
         typeof (item as { value?: unknown }).value === "string"
       ) {
         const entry = item as { name: string; value: string };
-        return isSecretName(entry.name) ? { ...entry, value: mask(entry.value) } : entry;
+        // A non-secret-shaped name (a custom env var, a feature flag) does
+        // not clear the value of suspicion — the same content pass every
+        // other string in this tree gets is what catches a credential
+        // someone stashed under an ordinary-looking name.
+        return isSecretName(entry.name)
+          ? { ...entry, value: mask(entry.value) }
+          : { ...entry, value: redactSecretsInText(entry.value) };
       }
       return redactSecrets(item, depth + 1);
     });


### PR DESCRIPTION
## Problem

The native protocol log (`~/.openmausbot/native/<threadId>.ndjson`) redacts credentials from session-setup messages, but ACP wire-shape env entries (`{name, value}`) whose `name` is not secret-shaped bypass the content redaction pass entirely.

`redactSecrets` in `server/redact.ts` has two paths for env entries:
- **Secret-named** (e.g. `OMB_COMMS_TOKEN`): the value is fully masked.
- **Non-secret-named** (e.g. `SESSION_CONFIG`, `FEATURE_FLAG`): the entry is returned **as-is** — no content scan is applied to the value.

Every other string in the tree gets a content pass (`redactSecretsInText`) that catches credential-shaped values (API key prefixes, bearer tokens, PEM blocks). The ACP env shortcut skips that pass, so a credential stashed under an ordinary-looking variable name appears verbatim in the log.

## Triage / Root cause

`server/redact.ts`, the `Array.isArray` branch of `redactSecrets`:

```ts
return isSecretName(entry.name)
  ? { ...entry, value: mask(entry.value) }
  : entry;  // ← value returned untouched, no content pass
```

The shortcut was intended to avoid redundant work on non-secret values, but it also skips the content scan that would catch a credential value under a benign name.

## Fix

Apply `redactSecretsInText` to the value of every ACP env entry whose name is not secret-shaped, instead of returning it untouched:

```ts
return isSecretName(entry.name)
  ? { ...entry, value: mask(entry.value) }
  : { ...entry, value: redactSecretsInText(entry.value) };
```

Secret-named entries still get the full mask (the value is replaced regardless of content). Non-secret entries now get the same content scan every other string in the tree already receives — a harmless value like `"enabled"` passes through unchanged, while a credential-shaped value is redacted.

## Verification

```
pnpm typecheck          # passes
vitest run server/redact.test.ts   # 11/11 pass
```

A new regression test (`still content-redacts an ACP env entry whose name is not secret-shaped`) places an `sk-ant-api03-` key under the env name `SESSION_CONFIG` and asserts it is redacted, while a harmless `FEATURE_FLAG=enabled` value is untouched.

## Notes / Risks

- The fix adds one function call per non-secret ACP env entry per log write. `redactSecretsInText` short-circuits on strings shorter than 8 chars, so the common case (short env values) is unchanged.
- No existing test assertions changed — all 10 original tests pass unmodified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of sensitive values in environment entries, including variables with non-secret-looking names.
  * Secret-shaped variables continue to be fully masked.
  * Redacted values now preserve variable names and non-sensitive content while indicating the removed secret length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->