### PR TITLE
fix(routines): preserve original scheduled time for past once routines

### DIFF
--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -330,4 +330,34 @@ describe("RoutineManager", () => {
     expect(h.manager.listRuns()[0]).toMatchObject({ status: "missed" });
     expect(h.started).toHaveLength(0);
   });
+
+  it("records a missed receipt for a once routine created with a long-past time", async () => {
+    const h = harness();
+    const staleAt = new Date(2026, 7, 16, 6, 0, 0).getTime();
+    const routine = h.manager.create({
+      name: "Stale check",
+      prompt: "Do the stale thing",
+      botId: "maus-6",
+      schedule: { type: "once", at: staleAt },
+    });
+    expect(routine.nextRunAt).toBe(staleAt);
+    await h.manager.tick();
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "missed", scheduledFor: staleAt });
+    expect(h.started).toHaveLength(0);
+  });
+
+  it("runs a once routine created slightly late and records the original scheduled time", async () => {
+    const h = harness();
+    const lateAt = new Date(2026, 7, 17, 7, 55, 0).getTime();
+    const routine = h.manager.create({
+      name: "Late check",
+      prompt: "Do the late thing",
+      botId: "maus-7",
+      schedule: { type: "once", at: lateAt },
+    });
+    expect(routine.nextRunAt).toBe(lateAt);
+    await h.manager.tick();
+    expect(h.started).toHaveLength(1);
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "running", scheduledFor: lateAt });
+  });
 });

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -539,7 +539,13 @@ export class RoutineManager {
   }
 
   private initialOccurrence(schedule: RoutineSchedule, now: number): number | null {
-    if (schedule.type === "once") return Math.max(schedule.at, now);
+    // Return the original time, not max(at, now): tick() already decides
+    // whether a stale "once" run fires or is recorded as "missed" based on
+    // how far past the scheduled time it is. Clamping to now here hides the
+    // original schedule from the run receipt (scheduledFor would read "now"
+    // instead of the time the user chose) and prevents the 12-hour missed
+    // threshold from ever triggering for a "once" routine created late.
+    if (schedule.type === "once") return schedule.at;
     return nextOccurrence(schedule, now);
   }
 


### PR DESCRIPTION
## Problem

A `once` routine created with a past scheduled time has its `nextRunAt` clamped to the current time via `Math.max(schedule.at, now)` in `initialOccurrence`. This causes two issues:

1. **Wrong `scheduledFor` in the run receipt**: the receipt shows the current time instead of the time the user chose.
2. **The 12-hour missed threshold never triggers**: `tick()` computes `late = now - scheduledFor`, but since `scheduledFor` was clamped to `now`, `late` is always 0. A routine created 13+ hours late runs immediately instead of being recorded as `missed`.

## Triage / Root cause

`server/routines.ts`, `initialOccurrence`:

```ts
private initialOccurrence(schedule: RoutineSchedule, now: number): number | null {
  if (schedule.type === "once") return Math.max(schedule.at, now);  // ← clamps past times to now
  return nextOccurrence(schedule, now);
}
```

`nextOccurrence` (used by `tick()` for recurring schedules) already returns `schedule.at` for future `once` times and `null` for past ones. `initialOccurrence` is inconsistent: it clamps past times to `now` instead of preserving the original time.

`tick()` already has the logic to decide whether a stale run should fire or be recorded as missed:

```ts
const late = now - scheduledFor;
if (late > CATCH_UP_MS) {
  // record as missed
} else {
  // run it
}
```

The `Math.max` clamp short-circuits this decision by always making `late = 0`.

## Fix

Return `schedule.at` directly for `once` schedules, letting `tick()` handle the late/missed logic with the correct `scheduledFor`:

```ts
private initialOccurrence(schedule: RoutineSchedule, now: number): number | null {
  if (schedule.type === "once") return schedule.at;
  return nextOccurrence(schedule, now);
}
```

For future times, `schedule.at > now` so the behavior is unchanged. For past times, `tick()` now sees the original `scheduledFor` and correctly records the run as `missed` if it is more than 12 hours stale, or runs it with the correct receipt time if it is within the catch-up window.

## Verification

```
pnpm typecheck          # passes
vitest run server/routines.test.ts   # 14/14 pass
```

Two new regression tests:
- `records a missed receipt for a once routine created with a long-past time`: creates a `once` routine 26 hours in the past and asserts it is recorded as `missed` (not run), with the original `scheduledFor` preserved.
- `runs a once routine created slightly late and records the original scheduled time`: creates a `once` routine 5 minutes in the past and asserts it runs with the original `scheduledFor` preserved.

All 12 existing tests pass unmodified.

## Notes / Risks

- The fix only changes behavior for `once` routines created with a past scheduled time. `daily` routines are unaffected (they use `nextOccurrence`).
- The `update` path also calls `initialOccurrence`, so editing a `once` routine's schedule to a past time now preserves the original time too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of one-time routines that are overdue.
  * Long-overdue routines are marked as missed without launching.
  * Slightly late routines can still run while retaining their original scheduled time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->