### PR TITLE
feat(pi): inject live local models into Custom

### DIFF
--- a/server/drivers/local-inject-matrix.test.ts
+++ b/server/drivers/local-inject-matrix.test.ts
@@ -14,6 +14,7 @@ import { HermesAgentDriver, ensureHermesInjectProvider, hermesAcpModelId } from 
 import { ensureKimiInjectAlias, KimiAgentDriver } from "./acp/kimi.ts";
 import { ensureOpenCodeInjectModel } from "./acp/opencode-go.ts";
 import { ensureQwenInjectModel, QwenAgentDriver } from "./acp/qwen.ts";
+import { ensurePiInjectModel, PiDriver } from "./pi.ts";
 import { recordEvents } from "../testing/events.ts";
 import {
   applyClaudeInject,
@@ -540,10 +541,40 @@ describe("room turns must pass the picker model", () => {
   });
 });
 
+describe("Pi writer × hosts", () => {
+  it.each(UNIQUE_HOSTS)("stores $id in ~/.pi/agent/models.json as openai-completions", (host) => {
+    const home = scratchHome("omb-pi-mx-");
+    const split = ensurePiInjectModel(encodeInjectId(host.id, "gemma-4-31b-it-bf16"), {
+      HOME: home,
+      UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-secret",
+    });
+    expect(split).toEqual({ provider: host.id, modelId: "gemma-4-31b-it-bf16" });
+    const written = JSON.parse(readFileSync(join(home, ".pi", "agent", "models.json"), "utf8")) as {
+      providers: Record<
+        string,
+        { baseUrl: string; api: string; apiKey: string; models: Array<{ id: string }> }
+      >;
+    };
+    const row = written.providers[host.id];
+    expect(row.baseUrl).toBe(host.baseUrl);
+    expect(row.api).toBe("openai-completions");
+    expect(row.apiKey).toBe(hostApiKey(host, { UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-secret" }));
+    expect(row.models.map((m) => m.id)).toEqual(["gemma-4-31b-it-bf16"]);
+  });
+
+  it("leaves official pi slugs untouched", () => {
+    expect(ensurePiInjectModel("ollama-cloud/glm-5.2", { HOME: scratchHome("omb-pi-cloud-") })).toEqual({
+      provider: "ollama-cloud",
+      modelId: "glm-5.2",
+    });
+  });
+});
+
 describe("Cloud vs Local catalog access", () => {
-  it("Qwen and Hermes advertise access=custom", () => {
+  it("Qwen, Hermes, and pi advertise access=custom", () => {
     expect(QwenAgentDriver.metadata.access).toBe("custom");
     expect(HermesAgentDriver.metadata.access).toBe("custom");
+    expect(PiDriver.metadata.access).toBe("custom");
   });
 
   it("Kimi and Droid stay Cloud (subscription catalog + Custom)", () => {

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -5,7 +5,7 @@
 //
 // The fake CLI is a shebang script Windows cannot exec directly; spawnCli
 // resolves it to `node <script>`, so these run everywhere.
-import { chmodSync, mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,7 +14,17 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { buildMcpServers, fetchPiModels, parsePiCatalog, PiDriver } from "./pi.ts";
+import { encodeInjectId, localHost } from "./local-inject.ts";
+import {
+  applyPiLocalCatalog,
+  buildMcpServers,
+  ensurePiInjectModel,
+  fetchPiModels,
+  parsePiCatalog,
+  PiDriver,
+  preferPiInjectRows,
+  splitPiModel,
+} from "./pi.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-pi-cli.ts");
 const MODELS_LINE =
@@ -477,6 +487,173 @@ describe("PiDriver turns (fake CLI)", () => {
     await instance.adapter.interruptTurn("t-interrupt");
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: true, stopReason: "cancelled" });
+  });
+
+  it("writes models.json and set_model for a host::model inject pick", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-turn-inject-"));
+    const dump = join(home, "dump.jsonl");
+    await create(undefined, { HOME: home, FAKE_PI_DUMP: dump });
+    const { turnId } = await instance.adapter.sendTurn({
+      threadId: "t-inject",
+      text: "hi",
+      model: encodeInjectId("omlx", "MiniMax-M3-4bit"),
+    });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+    const dumps = readFileSync(dump, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { setModel?: { provider: string; modelId: string } });
+    expect(dumps.some((row) => row.setModel?.provider === "omlx" && row.setModel?.modelId === "MiniMax-M3-4bit")).toBe(
+      true,
+    );
+    const written = JSON.parse(readFileSync(join(home, ".pi", "agent", "models.json"), "utf8")) as {
+      providers: { omlx: { baseUrl: string; models: Array<{ id: string }> } };
+    };
+    expect(written.providers.omlx.baseUrl).toBe("http://127.0.0.1:8080/v1");
+    expect(written.providers.omlx.models.some((m) => m.id === "MiniMax-M3-4bit")).toBe(true);
+  });
+});
+
+describe("splitPiModel", () => {
+  it("splits native provider/model composites, including slashes in the model id", () => {
+    expect(splitPiModel("ollama-cloud/glm-5.2")).toEqual({ provider: "ollama-cloud", modelId: "glm-5.2" });
+    expect(splitPiModel("openai/gpt-4o")).toEqual({ provider: "openai", modelId: "gpt-4o" });
+    expect(splitPiModel("openrouter/qwen/qwen3-coder-next")).toEqual({
+      provider: "openrouter",
+      modelId: "qwen/qwen3-coder-next",
+    });
+  });
+
+  it("splits live-host inject ids on ::, not /", () => {
+    expect(splitPiModel("omlx::MiniMax-M3-4bit")).toEqual({ provider: "omlx", modelId: "MiniMax-M3-4bit" });
+    expect(splitPiModel("ollama::llama3.1:70b")).toEqual({ provider: "ollama", modelId: "llama3.1:70b" });
+    expect(splitPiModel("unsloth::unsloth/gemma-4-26B-A4B-it-GGUF")).toEqual({
+      provider: "unsloth",
+      modelId: "unsloth/gemma-4-26B-A4B-it-GGUF",
+    });
+  });
+
+  it("returns null for empty or unstructured ids", () => {
+    expect(splitPiModel("")).toBeNull();
+    expect(splitPiModel("glm-5.2")).toBeNull();
+  });
+});
+
+describe("preferPiInjectRows", () => {
+  it("drops host/model rows when the same live host::model is present", () => {
+    const catalog = preferPiInjectRows({
+      default: "omlx/MiniMax-M3-4bit",
+      options: [
+        { id: "omlx/MiniMax-M3-4bit", label: "MiniMax-M3-4bit", custom: true },
+        { id: "openai/gpt-4o", label: "GPT-4o", custom: true },
+        { id: "omlx::MiniMax-M3-4bit", label: "MiniMax-M3-4bit (oMLX)", custom: true, loaded: true },
+      ],
+    });
+    expect(catalog.options.map((o) => o.id)).toEqual(["openai/gpt-4o", "omlx::MiniMax-M3-4bit"]);
+    expect(catalog.default).toBe("omlx::MiniMax-M3-4bit");
+  });
+
+  it("leaves the catalog alone when there are no inject rows", () => {
+    const catalog = {
+      default: "omlx/keep",
+      options: [{ id: "omlx/keep", label: "keep", custom: true as const }],
+    };
+    expect(preferPiInjectRows(catalog)).toEqual(catalog);
+  });
+});
+
+describe("ensurePiInjectModel", () => {
+  it("upserts a provider into ~/.pi/agent/models.json without dropping existing models", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-inject-"));
+    mkdirSync(join(home, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      join(home, ".pi", "agent", "models.json"),
+      JSON.stringify({
+        providers: {
+          omlx: {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            api: "openai-completions",
+            apiKey: "omlx",
+            compat: { supportsDeveloperRole: false, supportsReasoningEffort: true },
+            models: [{ id: "keep-me", name: "Keep me", contextWindow: 8192, maxTokens: 1024 }],
+          },
+        },
+      }),
+    );
+    const split = ensurePiInjectModel("omlx::MiniMax-M3-4bit", { HOME: home });
+    expect(split).toEqual({ provider: "omlx", modelId: "MiniMax-M3-4bit" });
+    const written = JSON.parse(readFileSync(join(home, ".pi", "agent", "models.json"), "utf8")) as {
+      providers: {
+        omlx: {
+          baseUrl: string;
+          api: string;
+          apiKey: string;
+          models: Array<{ id: string; contextWindow?: number }>;
+        };
+      };
+    };
+    expect(written.providers.omlx.baseUrl).toBe("http://127.0.0.1:8080/v1");
+    expect(written.providers.omlx.api).toBe("openai-completions");
+    expect(written.providers.omlx.apiKey).toBe("omlx");
+    expect(written.providers.omlx.models.map((m) => m.id)).toEqual(["keep-me", "MiniMax-M3-4bit"]);
+    expect(written.providers.omlx.models[0]).toMatchObject({ id: "keep-me", contextWindow: 8192 });
+  });
+
+  it("writes Unsloth's studio token, not the placeholder", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-unsloth-"));
+    const split = ensurePiInjectModel("unsloth::Qwen3.8-27B", {
+      HOME: home,
+      UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-secret",
+    });
+    expect(split).toEqual({ provider: "unsloth", modelId: "Qwen3.8-27B" });
+    const written = JSON.parse(readFileSync(join(home, ".pi", "agent", "models.json"), "utf8")) as {
+      providers: { unsloth: { apiKey: string; baseUrl: string } };
+    };
+    expect(written.providers.unsloth.apiKey).toBe("unsloth-secret");
+    expect(written.providers.unsloth.baseUrl).toBe(localHost("unsloth")!.baseUrl);
+  });
+
+  it("leaves official slugs and the models.json file untouched", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-cloud-"));
+    expect(ensurePiInjectModel("openai/gpt-4o", { HOME: home })).toEqual({ provider: "openai", modelId: "gpt-4o" });
+    expect(() => readFileSync(join(home, ".pi", "agent", "models.json"))).toThrow();
+  });
+
+  it("does not destroy a malformed models.json", () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-badjson-"));
+    mkdirSync(join(home, ".pi", "agent"), { recursive: true });
+    const path = join(home, ".pi", "agent", "models.json");
+    writeFileSync(path, "not json");
+    expect(ensurePiInjectModel("omlx::MiniMax-M3-4bit", { HOME: home })).toEqual({
+      provider: "omlx",
+      modelId: "MiniMax-M3-4bit",
+    });
+    expect(readFileSync(path, "utf8")).toBe("not json");
+  });
+});
+
+describe("applyPiLocalCatalog", () => {
+  it("merges live inject rows onto the probed catalog", async () => {
+    const catalog = await applyPiLocalCatalog(
+      {
+        default: "openai/gpt-4o",
+        options: [
+          { id: "openai/gpt-4o", label: "GPT-4o", custom: true },
+          { id: "omlx/MiniMax-M3-4bit", label: "MiniMax-M3-4bit", custom: true },
+        ],
+      },
+      { VITEST: "true", OPENMAUSBOT_PROBE_LOCAL_INJECT: "1" },
+      async (url) => {
+        if (String(url).includes(":8080")) {
+          return new Response(JSON.stringify({ data: [{ id: "MiniMax-M3-4bit" }] }), { status: 200 });
+        }
+        return new Response("nope", { status: 500 });
+      },
+    );
+    expect(catalog.options.some((o) => o.id === "omlx::MiniMax-M3-4bit")).toBe(true);
+    expect(catalog.options.some((o) => o.id === "omlx/MiniMax-M3-4bit")).toBe(false);
+    expect(catalog.options.some((o) => o.id === "openai/gpt-4o")).toBe(true);
   });
 });
 

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -461,6 +461,13 @@ export const PiDriver: ProviderDriver<PiConfig> = {
       const pending = new Map<string, (decision: { behavior: "allow" | "deny" | "answer"; message?: string }) => void>();
       let settled = false;
 
+      // Write ~/.pi/agent/models.json before creating any credential-bearing
+      // MCP temp files. If model setup fails, there is nothing sensitive to
+      // clean up yet.
+      if (typeof turn.model === "string" && turn.model) {
+        ensurePiInjectModel(turn.model, { ...process.env, ...input.environment });
+      }
+
       // integrations → stdio MCP servers for the pi-mcp-extension. The config
       // carries credentials (box token, composio key, comms token), so it goes
       // into a 0600 temp file removed when the turn settles — never on argv.
@@ -482,12 +489,6 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         }
       }
       const childArgs = mcpServers ? [...PI_ARGS, "-e", SPAWNED_PROXIES.piMcpExtension] : PI_ARGS;
-
-      // Write ~/.pi/agent/models.json before spawn — pi loads custom
-      // providers at process start, so a post-spawn upsert would miss set_model.
-      if (typeof turn.model === "string" && turn.model) {
-        ensurePiInjectModel(turn.model, { ...process.env, ...input.environment });
-      }
 
       // spawnCli can throw synchronously (unresolvable CLI); if it does, the
       // 0600 temp file with the box token / composio key / comms token must

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -13,11 +13,14 @@
 //
 // Model ids in the picker are `provider/modelId` composites (e.g.
 // `ollama-cloud/glm-5.2`); `set_model` splits that into pi's separate
-// `{provider, modelId}` fields. The live catalog is probed from
-// `get_available_models` and every entry is flagged `custom` because pi is a
-// custom-only (BYOK) engine — the model picker's Local pane only lists
-// `custom` options for custom-only engines.
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+// `{provider, modelId}` fields. Live local hosts (oMLX / Ollama / EXO /
+// LM Studio / Unsloth) land as `host::model` inject ids the same way the
+// other engines do: mergeLocalInject lists them in Custom, and a pick
+// upserts ~/.pi/agent/models.json so pi can reach the host. The live
+// catalog is probed from `get_available_models` and every entry is flagged
+// `custom` because pi is a custom-only (BYOK) engine — the model picker's
+// Local pane only lists `custom` options for custom-only engines.
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -39,6 +42,13 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { EFFORT_LEVELS, newEventId, newId } from "../contracts.ts";
+import {
+  decodeInjectId,
+  encodeInjectId,
+  hostApiKey,
+  localHost,
+  mergeLocalInject,
+} from "./local-inject.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "piAgent";
@@ -125,6 +135,135 @@ export function parsePiCatalog(stdout: string, fallbackDefault = ""): ModelCatal
   }
   if (!def && options.length) def = options[0]!.id;
   return { default: def, options };
+}
+
+/** Split a picker id into pi's `{provider, modelId}`. Accepts both the
+ *  native `provider/modelId` composite and a live-host `host::model`
+ *  inject id. */
+export function splitPiModel(id: string): { provider: string; modelId: string } | null {
+  const inject = decodeInjectId(id);
+  if (inject) return { provider: inject.host, modelId: inject.model };
+  if (!id.includes("/")) return null;
+  const [provider, ...rest] = id.split("/");
+  if (!provider || !rest.length) return null;
+  return { provider, modelId: rest.join("/") };
+}
+
+/** Prefer live `host::model` inject rows over the same model already
+ *  listed as `host/model` from ~/.pi/agent/models.json, so Custom does
+ *  not show duplicates. */
+export function preferPiInjectRows(catalog: ModelCatalog): ModelCatalog {
+  const injectIds = new Set(
+    catalog.options.filter((option) => decodeInjectId(option.id)).map((option) => option.id),
+  );
+  if (!injectIds.size) return catalog;
+  const options = catalog.options.filter((option) => {
+    if (decodeInjectId(option.id)) return true;
+    const slash = option.id.indexOf("/");
+    if (slash <= 0) return true;
+    return !injectIds.has(encodeInjectId(option.id.slice(0, slash), option.id.slice(slash + 1)));
+  });
+  let def = catalog.default;
+  if (def && !options.some((option) => option.id === def)) {
+    const slash = def.indexOf("/");
+    const mapped = slash > 0 ? encodeInjectId(def.slice(0, slash), def.slice(slash + 1)) : "";
+    def = injectIds.has(mapped) ? mapped : (options[0]?.id ?? "");
+  }
+  return { default: def, options };
+}
+
+export async function applyPiLocalCatalog(
+  catalog: ModelCatalog,
+  env: Record<string, string | undefined> = process.env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ModelCatalog> {
+  return preferPiInjectRows(await mergeLocalInject(catalog, env, fetchImpl));
+}
+
+function piAgentDir(env: Record<string, string | undefined>): string {
+  return join(env.HOME || env.USERPROFILE || homedir(), ".pi", "agent");
+}
+
+/** Upsert a live local host into ~/.pi/agent/models.json so `set_model`
+ *  can reach it. Existing providers and models are kept. Returns the
+ *  `{provider, modelId}` pair pi's RPC expects, or null when the picker
+ *  id is not a model at all. */
+export function ensurePiInjectModel(
+  modelId: string,
+  env: Record<string, string | undefined> = process.env,
+): { provider: string; modelId: string } | null {
+  const split = splitPiModel(modelId);
+  if (!split) return null;
+  const inject = decodeInjectId(modelId);
+  if (!inject) return split;
+  const host = localHost(inject.host);
+  if (!host) return split;
+
+  const dir = piAgentDir(env);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "models.json");
+  let root: Record<string, unknown> = { providers: {} };
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        root = parsed as Record<string, unknown>;
+      } else {
+        // Malformed — do not destroy the file; still return the split so
+        // set_model can try.
+        return split;
+      }
+    } catch {
+      return split;
+    }
+  }
+
+  const providers =
+    root.providers && typeof root.providers === "object" && !Array.isArray(root.providers)
+      ? { ...(root.providers as Record<string, unknown>) }
+      : {};
+  const previous = providers[inject.host];
+  const existing: Record<string, unknown> =
+    previous && typeof previous === "object" && !Array.isArray(previous)
+      ? { ...(previous as Record<string, unknown>) }
+      : {
+          baseUrl: host.baseUrl,
+          api: "openai-completions",
+          apiKey: hostApiKey(host, env),
+          compat: { supportsDeveloperRole: false, supportsReasoningEffort: true },
+          models: [] as Array<Record<string, unknown>>,
+        };
+  existing.baseUrl = host.baseUrl;
+  existing.api = typeof existing.api === "string" && existing.api ? existing.api : "openai-completions";
+  existing.apiKey = hostApiKey(host, env);
+  if (!existing.compat) {
+    existing.compat = { supportsDeveloperRole: false, supportsReasoningEffort: true };
+  }
+  const models: Array<Record<string, unknown>> = Array.isArray(existing.models)
+    ? existing.models.filter(
+        (row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row),
+      )
+    : [];
+  if (!models.some((row) => row.id === inject.model)) {
+    models.push({
+      id: inject.model,
+      name: inject.model,
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 131072,
+      maxTokens: 16384,
+    });
+  }
+  existing.models = models;
+  providers[inject.host] = existing;
+  root.providers = providers;
+  writeFileSync(path, `${JSON.stringify(root, null, 2)}\n`, { mode: 0o600 });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Windows ignores POSIX modes; keep the inject even if chmod is unsupported.
+  }
+  return split;
 }
 
 /** The pi-side default model, read from ~/.pi/agent/settings.json so the
@@ -271,11 +410,18 @@ export const PiDriver: ProviderDriver<PiConfig> = {
     const catalogEnv = piEnvironment({ ...process.env, ...input.environment });
     let models = EMPTY;
     const refreshModels = async () => {
+      let base = models;
       try {
         const resolved = await fetchPiModels(config.cli, catalogEnv);
-        if (resolved.options.length) models = resolved;
+        if (resolved.options.length) base = resolved;
       } catch {
         // Keep the last usable catalog when the probe fails.
+      }
+      try {
+        const next = await applyPiLocalCatalog(base, catalogEnv);
+        if (next.options.length) models = next;
+      } catch {
+        if (base.options.length) models = base;
       }
     };
     await refreshModels();
@@ -336,6 +482,12 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         }
       }
       const childArgs = mcpServers ? [...PI_ARGS, "-e", SPAWNED_PROXIES.piMcpExtension] : PI_ARGS;
+
+      // Write ~/.pi/agent/models.json before spawn — pi loads custom
+      // providers at process start, so a post-spawn upsert would miss set_model.
+      if (typeof turn.model === "string" && turn.model) {
+        ensurePiInjectModel(turn.model, { ...process.env, ...input.environment });
+      }
 
       // spawnCli can throw synchronously (unresolvable CLI); if it does, the
       // 0600 temp file with the box token / composio key / comms token must
@@ -590,12 +742,12 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         // accepts a prompt without an explicit session.
       }
 
-      // pin the chosen model (composite id → provider + modelId)
-      if (typeof turn.model === "string" && turn.model.includes("/")) {
-        const [provider, ...rest] = turn.model.split("/");
+      // pin the chosen model (composite id or host::model inject → provider + modelId)
+      const chosen = typeof turn.model === "string" ? splitPiModel(turn.model) : null;
+      if (chosen) {
         try {
           const modelPromise = awaitResponse("set_model");
-          send({ type: "set_model", provider, modelId: rest.join("/") });
+          send({ type: "set_model", provider: chosen.provider, modelId: chosen.modelId });
           await modelPromise;
         } catch {
           /* keep going on the default model */

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -182,6 +182,13 @@ function handle(cmd: any) {
       send({ type: "response", command: "switch_session", success: true, data: { sessionId: "s-resumed", sessionFile: currentSessionFile } });
       return;
     case "set_model": {
+      if (process.env.FAKE_PI_DUMP) {
+        try {
+          appendFileSync(process.env.FAKE_PI_DUMP, JSON.stringify({ setModel: { provider: cmd.provider, modelId: cmd.modelId } }) + "\n");
+        } catch {
+          /* never let dumping break a run */
+        }
+      }
       send({ type: "response", command: "set_model", success: true, data: { id: cmd.modelId, provider: cmd.provider } });
       return;
     }


### PR DESCRIPTION
## What

Pi now gets the same live-local inject as Grok, Claude, Codex, and the other engines.

oMLX / Ollama / EXO / LM Studio / Unsloth models show up in **Custom** as `host::model`. Picking one upserts `~/.pi/agent/models.json` **before spawn** (pi loads custom providers at process start) and sends `set_model` with `{ provider: host, modelId }`. Official `provider/model` slugs are left alone.

If the same model is already listed as `host/model` from pi's own catalog, the live `host::model` row wins so Custom does not show duplicates.

## Testing

- `pnpm typecheck`
- `pnpm exec vitest run server/drivers/pi.test.ts server/drivers/local-inject-matrix.test.ts` (151 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using locally hosted models with Pi.
  * Automatically discovers and merges local models with existing catalogs.
  * Added per-turn model selection for local providers while preserving official model identifiers.
  * Updates provider credentials and model configuration automatically.

* **Bug Fixes**
  * Preserves existing catalogs when local configuration is incomplete or malformed.
  * Prevents duplicate model entries during catalog updates.
  * Ensures local model settings are available before starting a Pi session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->