### PR TITLE
fix(usage): show the cached share of a turn's tokens so "100k for 5 messages" reads as context, not a bug

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -104,7 +104,7 @@ export type RuntimeEvent = RuntimeEventBase &
          * The one figure the harness accumulates — thread.token-usage.updated
          * is a live indicator whose meaning differs per driver (a per-call
          * delta, a thread total, a per-step figure) and must never be summed. */
-        usage?: { input: number; output: number };
+        usage?: { input: number; output: number; cachedInput?: number };
       }
     | { type: "item.started"; itemType: "tool" | "reasoning"; title?: string }
     | { type: "item.updated"; itemType: "tool" | "reasoning"; tokens?: number | null }
@@ -128,7 +128,7 @@ export type RuntimeEvent = RuntimeEventBase &
         source: "user" | "auto" | "timeout" | "system" | "unavailable" | "peer";
         approvalScope?: "local-computer";
       }
-    | { type: "thread.token-usage.updated"; input: number; output: number }
+    | { type: "thread.token-usage.updated"; input: number; output: number; cachedInput?: number }
     // `setup: true` marks a failure the user fixes by installing or
     // configuring something, not by retrying — the UI offers setup instead.
     | { type: "runtime.error"; message: string; setup?: boolean }

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -222,11 +222,11 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(recorder.events.every((e) => e.turnId === turnId && e.provider === "claudeAgent")).toBe(true);
 
     const usage = recorder.events.find((e) => e.type === "thread.token-usage.updated")!;
-    expect(usage).toMatchObject({ input: 12, output: 5 }); // input + cache_read
+    expect(usage).toMatchObject({ input: 12, output: 5, cachedInput: 2 }); // input + cache_read, cache_read named
     const done = recorder.events.at(-1)!;
     // usage on the settle is the turn total from the result message, so
     // the harness has one figure to bank per turn
-    expect(done).toMatchObject({ type: "turn.completed", ok: true, cost: 0.01, usage: { input: 12, output: 5 } });
+    expect(done).toMatchObject({ type: "turn.completed", ok: true, cost: 0.01, usage: { input: 12, output: 5, cachedInput: 2 } });
     expect(instance.adapter.hasSession("t-happy")).toBe(false);
   });
 

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -845,6 +845,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                 type: "thread.token-usage.updated",
                 input: (msg.usage.input_tokens || 0) + (msg.usage.cache_read_input_tokens || 0),
                 output: msg.usage.output_tokens || 0,
+                cachedInput: msg.usage.cache_read_input_tokens || 0,
               });
             }
             break;
@@ -859,7 +860,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           case "result":
             // result.usage is this invocation's total — one process per turn,
             // so it is the turn's figure. cache reads count as input: they
-            // are billed (at the cache rate) and they fill the window.
+            // are billed (at the cache rate) and they fill the window — but
+            // they are reported separately too, so the UI can show how much
+            // of the figure was context re-read rather than new text.
             settle(
               o.is_error !== true,
               o.stop_reason ?? o.terminal_reason ?? null,
@@ -868,6 +871,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                 ? {
                     input: (o.usage.input_tokens || 0) + (o.usage.cache_read_input_tokens || 0) + (o.usage.cache_creation_input_tokens || 0),
                     output: o.usage.output_tokens || 0,
+                    cachedInput: o.usage.cache_read_input_tokens || 0,
                   }
                 : undefined,
             );

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -764,7 +764,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         ok: boolean,
         stopReason: string | null,
         cost: number | null = null,
-        usage?: { input: number; output: number },
+        usage?: { input: number; output: number; cachedInput?: number },
       ) => {
         const t = session.turn;
         if (!t || t.settled) return;
@@ -845,7 +845,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                 type: "thread.token-usage.updated",
                 input: (msg.usage.input_tokens || 0) + (msg.usage.cache_read_input_tokens || 0),
                 output: msg.usage.output_tokens || 0,
-                cachedInput: msg.usage.cache_read_input_tokens || 0,
+                ...(typeof msg.usage.cache_read_input_tokens === "number"
+                  ? { cachedInput: msg.usage.cache_read_input_tokens }
+                  : {}),
               });
             }
             break;
@@ -871,7 +873,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                 ? {
                     input: (o.usage.input_tokens || 0) + (o.usage.cache_read_input_tokens || 0) + (o.usage.cache_creation_input_tokens || 0),
                     output: o.usage.output_tokens || 0,
-                    cachedInput: o.usage.cache_read_input_tokens || 0,
+                    ...(typeof o.usage.cache_read_input_tokens === "number"
+                      ? { cachedInput: o.usage.cache_read_input_tokens }
+                      : {}),
                   }
                 : undefined,
             );

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -106,6 +106,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(recorder.events.find((e) => e.type === "thread.token-usage.updated")).toMatchObject({
       input: 7,
       output: 3,
+      cachedInput: 4,
     });
     expect(recorder.events.filter((event) => event.itemId === "w1")).toMatchObject([
       { type: "item.started", itemType: "tool", title: "web_search" },
@@ -113,7 +114,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     ]);
     // codex reports the THREAD total; the driver turns it into this turn's
     // figure so the harness never sums a running total
-    expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true, usage: { input: 7, output: 3 } });
+    expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true, usage: { input: 7, output: 3, cachedInput: 4 } });
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.env.OPENAI_API_KEY).toBeUndefined();

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -202,7 +202,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         sawStreamDelta: false,
         // codex reports token usage as a running THREAD total; the harness
         // wants this turn's figure, so the last report is banked on settle
-        usage: undefined as { input: number; output: number } | undefined,
+        usage: undefined as { input: number; output: number; cachedInput?: number } | undefined,
       };
 
       const asks = new Map<string, (behavior: "allow" | "deny" | "answer", message?: string, source?: "user" | "timeout" | "system") => void>();
@@ -403,7 +403,16 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             // `total` is the thread so far — a fresh app-server per turn
             // makes that this turn's figure too
             const turnUsage = p.tokenUsage?.last ?? p.tokenUsage?.total;
-            if (turnUsage) state.usage = { input: turnUsage.inputTokens ?? 0, output: turnUsage.outputTokens ?? 0 };
+            // codex's inputTokens already includes cachedInputTokens; the
+            // cached share is carried alongside so the UI can say how much
+            // of a turn was context re-read rather than new text
+            if (turnUsage) {
+              state.usage = {
+                input: turnUsage.inputTokens ?? 0,
+                output: turnUsage.outputTokens ?? 0,
+                cachedInput: turnUsage.cachedInputTokens ?? 0,
+              };
+            }
             const t = p.tokenUsage?.total;
             if (t) {
               emit({
@@ -411,6 +420,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
                 type: "thread.token-usage.updated",
                 input: t.inputTokens ?? 0,
                 output: t.outputTokens ?? 0,
+                cachedInput: t.cachedInputTokens ?? 0,
               });
             }
             break;

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -410,7 +410,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
               state.usage = {
                 input: turnUsage.inputTokens ?? 0,
                 output: turnUsage.outputTokens ?? 0,
-                cachedInput: turnUsage.cachedInputTokens ?? 0,
+                ...(typeof turnUsage.cachedInputTokens === "number"
+                  ? { cachedInput: turnUsage.cachedInputTokens }
+                  : {}),
               };
             }
             const t = p.tokenUsage?.total;
@@ -420,7 +422,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
                 type: "thread.token-usage.updated",
                 input: t.inputTokens ?? 0,
                 output: t.outputTokens ?? 0,
-                cachedInput: t.cachedInputTokens ?? 0,
+                ...(typeof t.cachedInputTokens === "number"
+                  ? { cachedInput: t.cachedInputTokens }
+                  : {}),
               });
             }
             break;

--- a/server/index.ts
+++ b/server/index.ts
@@ -606,7 +606,7 @@ const groupSpeakers = new Map<string, { botId: string; name: string; color: stri
 // The latest running token totals for the turn in flight on each thread.
 // Providers report cumulative-within-turn numbers; the final value is folded
 // into the task's tally when the turn settles.
-const turnUsage = new Map<string, { input: number; output: number }>();
+const turnUsage = new Map<string, { input: number; output: number; cachedInput?: number }>();
 
 // Bounded per active turn. OpenHands uses a bounded recent-event scan for
 // the same class of stuck-loop detection; retaining an unlimited set of
@@ -1029,7 +1029,7 @@ bus.subscribe((event: RuntimeEvent) => {
     case "thread.token-usage.updated":
       // running totals for the turn in flight; folded into the task's
       // tally at turn.completed (below) so retries never double-count
-      turnUsage.set(event.threadId, { input: event.input, output: event.output });
+      turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
       const reply = lastReply.get(event.threadId) ?? "";
@@ -1052,6 +1052,7 @@ bus.subscribe((event: RuntimeEvent) => {
         store.addTaskUsage(bot.id, event.threadId, {
           input: tokens?.input,
           output: tokens?.output,
+          cachedInput: tokens?.cachedInput,
           costUsd: event.cost ?? null,
         });
         // settled → idle; a setup failure already marked it dead, keep that

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -72,19 +72,27 @@ describe("Store", () => {
   it("addTaskUsage accumulates settled-turn totals per task and survives a restart", () => {
     const store = new Store(selection);
     const bot = store.createBot();
-    expect(store.addTaskUsage(bot.id, bot.threadId, { input: 1200, output: 300, costUsd: null })).toEqual({
+    expect(store.addTaskUsage(bot.id, bot.threadId, { input: 1200, output: 300, cachedInput: 1000, costUsd: null })).toEqual({
       input: 1200,
       output: 300,
+      cachedInput: 1000,
       costUsd: null,
       turns: 1,
     });
+    // a driver that never reports the cached share leaves it unchanged
     store.addTaskUsage(bot.id, bot.threadId, { input: 800, output: 100, costUsd: null });
-    store.addTaskUsage(bot.id, bot.threadId, { input: Number.NaN, output: -20, costUsd: null });
+    store.addTaskUsage(bot.id, bot.threadId, { input: Number.NaN, output: -20, cachedInput: -5, costUsd: null });
     // a different thread never inherits another task's tally
     expect(store.addTaskUsage(bot.id, "no-such-thread", { input: 5, output: 5, costUsd: null })).toBeNull();
 
     const reloaded = new Store(selection);
-    expect(reloaded.taskByThread(bot.id, bot.threadId)?.usage).toEqual({ input: 2000, output: 400, costUsd: null, turns: 3 });
+    expect(reloaded.taskByThread(bot.id, bot.threadId)?.usage).toEqual({
+      input: 2000,
+      output: 400,
+      cachedInput: 1000,
+      costUsd: null,
+      turns: 3,
+    });
   });
 
   it("persists the per-bot composio gate", () => {

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -82,16 +82,19 @@ describe("Store", () => {
     // a driver that never reports the cached share leaves it unchanged
     store.addTaskUsage(bot.id, bot.threadId, { input: 800, output: 100, costUsd: null });
     store.addTaskUsage(bot.id, bot.threadId, { input: Number.NaN, output: -20, cachedInput: -5, costUsd: null });
+    // Providers occasionally report a cache count larger than input; keep the
+    // persisted share physically possible so percentages cannot exceed 100%.
+    store.addTaskUsage(bot.id, bot.threadId, { input: 10, output: 0, cachedInput: 20, costUsd: null });
     // a different thread never inherits another task's tally
     expect(store.addTaskUsage(bot.id, "no-such-thread", { input: 5, output: 5, costUsd: null })).toBeNull();
 
     const reloaded = new Store(selection);
     expect(reloaded.taskByThread(bot.id, bot.threadId)?.usage).toEqual({
-      input: 2000,
+      input: 2010,
       output: 400,
-      cachedInput: 1000,
+      cachedInput: 1010,
       costUsd: null,
-      turns: 3,
+      turns: 4,
     });
   });
 

--- a/server/store.ts
+++ b/server/store.ts
@@ -1008,10 +1008,14 @@ export class Store {
     // the cached share exists on a record only once a driver has reported
     // it — a driver that never does leaves the record shaped as before
     const cachedKnown = typeof prev.cachedInput === "number" || typeof turn.cachedInput === "number";
+    const prevInput = clean(prev.input);
+    const turnInput = clean(turn.input);
+    const nextCachedInput = Math.min(clean(prev.cachedInput), prevInput)
+      + Math.min(clean(turn.cachedInput), turnInput);
     task.usage = {
-      input: prev.input + clean(turn.input),
+      input: prevInput + turnInput,
       output: prev.output + clean(turn.output),
-      ...(cachedKnown ? { cachedInput: clean(prev.cachedInput) + clean(turn.cachedInput) } : {}),
+      ...(cachedKnown ? { cachedInput: nextCachedInput } : {}),
       costUsd: cost === null ? prevCost : (prevCost ?? 0) + cost,
       turns: prev.turns + 1,
     };

--- a/server/store.ts
+++ b/server/store.ts
@@ -202,6 +202,11 @@ export interface TaskRecord {
 export interface TaskUsage {
   input: number;
   output: number;
+  /** The part of `input` the provider served from its prompt cache — context
+   * the model re-read rather than fresh text. Every turn resends the whole
+   * conversation plus the system prompt and tool schemas, so on a chatty
+   * thread this is most of `input`. Absent on records from older builds. */
+  cachedInput?: number;
   /** null until any turn reports a cost — most engines never do. Records
    * written by builds before cost existed lack the field; read as null. */
   costUsd: number | null;
@@ -990,7 +995,7 @@ export class Store {
   addTaskUsage(
     botId: string,
     threadId: string,
-    turn: { input?: number; output?: number; costUsd: number | null },
+    turn: { input?: number; output?: number; cachedInput?: number; costUsd: number | null },
   ): TaskUsage | null {
     const task = this.taskByThread(botId, threadId);
     if (!task) return null;
@@ -1000,9 +1005,13 @@ export class Store {
     // providers occasionally report NaN or a negative on a partial turn —
     // never let that poison a running tally
     const clean = (n: number | undefined) => (typeof n === "number" && Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0);
+    // the cached share exists on a record only once a driver has reported
+    // it — a driver that never does leaves the record shaped as before
+    const cachedKnown = typeof prev.cachedInput === "number" || typeof turn.cachedInput === "number";
     task.usage = {
       input: prev.input + clean(turn.input),
       output: prev.output + clean(turn.output),
+      ...(cachedKnown ? { cachedInput: clean(prev.cachedInput) + clean(turn.cachedInput) } : {}),
       costUsd: cost === null ? prevCost : (prevCost ?? 0) + cost,
       turns: prev.turns + 1,
     };

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -52,7 +52,7 @@ const finishTurn = () => {
     notify("item/agentMessage/delta", { itemId: "m1", delta: "fake codex" });
   }
   notify("item/completed", { item: { id: "m1", type: "agentMessage", text: "done from fake codex" } });
-  notify("thread/tokenUsage/updated", { tokenUsage: { total: { inputTokens: 7, outputTokens: 3 } } });
+  notify("thread/tokenUsage/updated", { tokenUsage: { total: { inputTokens: 7, cachedInputTokens: 4, outputTokens: 3 } } });
   dump();
   notify("turn/completed", { turn: { status: "completed" } });
 };

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -25,7 +25,7 @@ import {
   Webhook,
   X,
 } from "lucide-react";
-import { costCaption, formatTokens, formatUsd, hasFiniteCost, usageChip } from "@/lib/usage";
+import { cachedInput, costCaption, formatTokens, formatUsd, hasFiniteCost, usageChip, usageDetail } from "@/lib/usage";
 import {
   useStore,
   useStreaming,
@@ -1264,7 +1264,11 @@ function UsageChip({ bot }: { bot: Bot }) {
   const billing = state.instances.find((i) => i.instanceId === bot.modelSelection.instanceId)?.snapshot.billing;
   const detail = [
     `${usage.turns} turn${usage.turns === 1 ? "" : "s"}`,
-    `${formatTokens(usage.input)} in · ${formatTokens(usage.output)} out`,
+    usageDetail(usage),
+    // the whole thread rides along on every turn, so most of "in" is the
+    // model re-reading what it already saw — say so, or the figure reads as
+    // a bug (issue #527)
+    cachedInput(usage) > 0 ? "cached = context re-read each turn, not new text" : null,
     hasFiniteCost(usage.costUsd) ? `${formatUsd(usage.costUsd)} ${costCaption(billing)}` : null,
   ]
     .filter(Boolean)

--- a/src/components/UsageSection.tsx
+++ b/src/components/UsageSection.tsx
@@ -5,7 +5,7 @@
 import { useStore } from "@/state/store";
 import { MausAvatar } from "./Avatar";
 import { Card } from "./SettingsPrimitives";
-import { botUsage, costCaption, formatTokens, formatUsd, hasFiniteCost, sumUsage } from "@/lib/usage";
+import { botUsage, cachedInput, costCaption, formatTokens, formatUsd, hasFiniteCost, sumUsage, usageDetail } from "@/lib/usage";
 
 export function UsageSection() {
   const { state } = useStore();
@@ -45,7 +45,7 @@ export function UsageSection() {
                 <span className="truncate">{bot.name}</span>
               </span>
               <span className="text-right tabular-nums text-ink-secondary">{usage.turns}</span>
-              <span className="text-right tabular-nums text-ink" title={`${formatTokens(usage.input)} in · ${formatTokens(usage.output)} out`}>
+              <span className="text-right tabular-nums text-ink" title={usageDetail(usage)}>
                 {formatTokens(usage.input + usage.output)}
               </span>
               <span className="text-right tabular-nums text-ink">{hasFiniteCost(usage.costUsd) ? formatUsd(usage.costUsd) : <span className="text-ink-secondary">—</span>}</span>
@@ -54,9 +54,16 @@ export function UsageSection() {
           <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-5 pt-2.5 text-[13px] font-medium text-ink">
             <span>All bots</span>
             <span className="text-right tabular-nums">{total.turns}</span>
-            <span className="text-right tabular-nums">{formatTokens(total.input + total.output)}</span>
+            <span className="text-right tabular-nums" title={usageDetail(total)}>{formatTokens(total.input + total.output)}</span>
             <span className="text-right tabular-nums">{hasFiniteCost(total.costUsd) ? formatUsd(total.costUsd) : "—"}</span>
           </div>
+          {cachedInput(total) > 0 && (
+            <div className="mt-3 text-[12px] leading-relaxed text-ink-secondary">
+              Tokens count everything the model read and wrote. Each turn resends the whole conversation with the system prompt and tool
+              schemas, so {formatTokens(cachedInput(total))} of the input was context re-read from the provider's cache rather than new text —
+              hover a figure for the split.
+            </div>
+          )}
           {hasFiniteCost(total.costUsd) && (
             <div className="mt-3 text-[12px] leading-relaxed text-ink-secondary">
               Cost is {billings.size === 1 ? costCaption([...billings][0]) : "as each engine reports it — on a subscription it's an equivalent, not a charge"}.

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { botUsage, costCaption, formatTokens, formatUsd, sumUsage, usageChip } from "./usage";
+import { botUsage, cachedInput, costCaption, formatTokens, formatUsd, sumUsage, usageChip, usageDetail } from "./usage";
 
 describe("usage formatting", () => {
   it("formats token counts compactly", () => {
@@ -37,6 +37,21 @@ describe("usage formatting", () => {
         { input: 2, output: 2, costUsd: 0.01, turns: 1 },
       ]),
     ).toEqual({ input: 3, output: 3, costUsd: 0.01, turns: 2 });
+  });
+
+  it("carries the cached share through sums and names it in the breakdown", () => {
+    // records from before the field existed simply don't contribute to it
+    expect(sumUsage([{ input: 100, output: 10, costUsd: null, turns: 1 }, { input: 200, output: 20, cachedInput: 150, costUsd: null, turns: 1 }]))
+      .toEqual({ input: 300, output: 30, cachedInput: 150, costUsd: null, turns: 2 });
+    expect(sumUsage([{ input: 100, output: 10, costUsd: null, turns: 1 }])).toEqual({ input: 100, output: 10, costUsd: null, turns: 1 });
+    // the headline stays the whole figure; the split is what explains it
+    expect(usageDetail({ input: 88_200, output: 1_200, cachedInput: 79_000, costUsd: null, turns: 5 })).toBe("88.2k in (79k cached) · 1.2k out");
+    expect(usageDetail({ input: 900, output: 50, costUsd: null, turns: 1 })).toBe("900 in · 50 out");
+    expect(usageDetail({ input: 900, output: 50, cachedInput: 0, costUsd: null, turns: 1 })).toBe("900 in · 50 out");
+    // a cached figure can never exceed the input it is part of, or go negative
+    expect(cachedInput({ input: 100, output: 0, cachedInput: 250, costUsd: null, turns: 1 })).toBe(100);
+    expect(cachedInput({ input: 100, output: 0, cachedInput: -3, costUsd: null, turns: 1 })).toBe(0);
+    expect(cachedInput({ input: 100, output: 0, cachedInput: Number.NaN, costUsd: null, turns: 1 })).toBe(0);
   });
 
   it("builds the chip: tokens always, cost only when known, nothing when unused", () => {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -17,6 +17,7 @@ export function sumUsage(items: Array<TaskUsage | undefined>): TaskUsage {
     out.input += u.input;
     out.output += u.output;
     out.turns += u.turns;
+    if (hasFiniteCost(u.cachedInput)) out.cachedInput = (out.cachedInput ?? 0) + u.cachedInput;
     if (hasFiniteCost(u.costUsd)) out.costUsd = (out.costUsd ?? 0) + u.costUsd;
   }
   return out;
@@ -41,6 +42,25 @@ export function formatUsd(usd: number): string {
   if (usd === 0) return "$0";
   if (usd < 0.01) return `$${usd.toFixed(3)}`;
   return `$${usd.toFixed(2)}`;
+}
+
+/** How much of `input` the provider served from its prompt cache. Clamped to
+ * `input` so a provider that reports cache reads outside its input figure
+ * can never produce a negative "fresh" number. */
+export function cachedInput(u: TaskUsage): number {
+  return hasFiniteCost(u.cachedInput) ? Math.min(Math.max(0, u.cachedInput), u.input) : 0;
+}
+
+/** The in/out breakdown behind the headline figure, with the cached share
+ * called out when there is one: "88.2k in (79k cached) · 1.2k out". The
+ * headline counts every token the model processed — five short messages
+ * on a thread with a system prompt and tool schemas really do cost the
+ * model ~17k tokens of reading each turn — so the breakdown is where the
+ * "was that really 100k?" question gets answered. */
+export function usageDetail(u: TaskUsage): string {
+  const cached = cachedInput(u);
+  const input = cached > 0 ? `${formatTokens(u.input)} in (${formatTokens(cached)} cached)` : `${formatTokens(u.input)} in`;
+  return `${input} · ${formatTokens(u.output)} out`;
 }
 
 /** The chip text: tokens, and cost when known. Empty string when nothing

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -161,6 +161,9 @@ export interface Task {
 export interface TaskUsage {
   input: number;
   output: number;
+  /** cached share of `input` (context the model re-read); absent on records
+   * from builds before it was tracked */
+  cachedInput?: number;
   /** null until any turn reported a cost — most engines never do; records
    * from builds before cost existed lack the field entirely */
   costUsd: number | null;


### PR DESCRIPTION
## What changed

Drivers now report how much of a turn's input the provider served from its prompt cache, and the UI shows that split.

- `thread.token-usage.updated` and `turn.completed.usage` carry an optional `cachedInput` (Claude Code: `cache_read_input_tokens`; Codex: `cachedInputTokens`).
- `store.addTaskUsage` banks it per task next to `input`/`output`. Records from drivers that never report it keep their old shape — the field only appears once a turn has carried it.
- The header chip tooltip and the Usage card now read `88.2k in (79k cached) · 1.2k out`, and the Usage card gets one caption explaining that each turn resends the whole conversation + system prompt + tool schemas, so most of "in" is context re-read rather than new text.
- The headline figure is unchanged: it is still every token the model read and wrote.

## Why

#527 — "100k tokens spent on 5 test messages, is that accurate?" It is: a Codex bot with MCP tool schemas puts ~17k tokens in front of the model on every turn, and five turns of that is ~88k. But a number with no breakdown reads as a bug, and the tooltip only said `in · out`. Naming the cached share is the honest fix; hiding it would understate what the model processed (and what a metered key is billed for at the cache rate).

## How it was verified

- `pnpm typecheck` clean.
- `npx vitest run src/lib/usage.test.ts server/store.test.ts server/drivers/claude.test.ts server/drivers/codex.test.ts` — 145 pass. New cases: `sumUsage` carries the cached share (and leaves it absent when no record has it), `usageDetail` formatting, `cachedInput` clamps to `[0, input]`, store banks/persists the share and leaves records untouched for drivers that never report it, the fake Claude CLI's `cache_read_input_tokens: 2` and fake Codex's `cachedInputTokens: 4` reach `turn.completed.usage`.
- `pnpm lint` reports no findings in the touched lines (the errors it prints are pre-existing on `main`).

Closes #527

## Checklist

- [x] `pnpm typecheck` and the touched test files pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] No macOS-only code
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached-input token tracking across supported runtimes.
  * Usage details now distinguish cached input from regular input and output tokens.
  * Added contextual explanations in usage tooltips and summaries when cached context is present.

* **Bug Fixes**
  * Improved usage aggregation and persistence while maintaining compatibility with older records.
  * Invalid or unavailable cached-input values are handled safely.

* **Tests**
  * Expanded coverage for cached token reporting, aggregation, persistence, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->