### PR TITLE
fix(composio): use a project's own auth configs so no-managed-auth toolkits (Twitter/X) connect

### DIFF
--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -292,7 +292,9 @@ describe.sequential("Composio Sessions", () => {
     customAuthConfigs = [{ id: "ac_twitter", toolkit: { slug: "twitter" }, is_composio_managed: false, status: "ENABLED" }];
     sessionAuthConfigs = {};
     const cfg: AppConfig = {
-      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+      // The live Session is authoritative. A stale local user ID must never
+      // move the rebuilt Session away from the existing connected accounts.
+      composio: { apiKey: "ak_test", userId: "stale-local-user", sessionId: "trs_test" },
     };
     try {
       const before = calls.length;
@@ -316,7 +318,10 @@ describe.sequential("Composio Sessions", () => {
     const cfg: AppConfig = {
       composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
     };
+    const before = calls.length;
     await expect(authorizeService(cfg, "twitter")).rejects.toThrow(/create an auth config for "twitter"/i);
+    expect(calls.slice(before).some((call) => call.method === "POST" && call.path.endsWith("/session"))).toBe(false);
+    expect(cfg.composio).toMatchObject({ userId: "openmausbot_existing", sessionId: "trs_test" });
     // and a failure that is not about auth configs is passed through untouched
     await expect(authorizeService(cfg, "github", "personal-three")).resolves.toEqual({
       url: "https://connect.composio.dev/link/github",

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -21,6 +21,11 @@ let base = "";
 const calls: Array<{ method: string; path: string; query: string; body: any }> = [];
 let malformedConnectedAccounts = false;
 let connectedAccountsUnavailable = false;
+// The project's own auth configs, and the ones the stub Session was created
+// with — a Session only knows the configs named at its creation, which is
+// the whole reason #509 happened.
+let customAuthConfigs: Array<Record<string, unknown>> = [];
+let sessionAuthConfigs: Record<string, string> = {};
 
 beforeAll(async () => {
   api = createServer(async (req, res) => {
@@ -36,11 +41,12 @@ beforeAll(async () => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/v3.1/tool_router/session") {
+      sessionAuthConfigs = body.auth_configs ?? {};
       res.writeHead(201, { "content-type": "application/json" });
       return res.end(JSON.stringify({
         session_id: "trs_test",
         mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_test/mcp" },
-        config: { user_id: body.user_id, multi_account: body.multi_account },
+        config: { user_id: body.user_id, multi_account: body.multi_account, auth_configs: sessionAuthConfigs },
       }));
     }
     if (req.method === "GET" && url.pathname === "/api/v3.1/tool_router/session/trs_test") {
@@ -55,8 +61,13 @@ beforeAll(async () => {
             max_accounts_per_toolkit: 5,
             require_explicit_selection: true,
           },
+          auth_configs: sessionAuthConfigs,
         },
       }));
+    }
+    if (req.method === "GET" && url.pathname === "/api/v3.1/auth_configs") {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ items: customAuthConfigs }));
     }
     if (req.method === "GET" && url.pathname === "/api/v3.1/tool_router/session/trs_legacy") {
       res.writeHead(200, { "content-type": "application/json" });
@@ -112,6 +123,18 @@ beforeAll(async () => {
       }));
     }
     if (req.method === "POST" && url.pathname.endsWith("/link")) {
+      // twitter has no Composio-managed auth: the link only works when the
+      // Session was created with the project's own config for it
+      if (body.toolkit === "twitter" && !sessionAuthConfigs.twitter) {
+        res.writeHead(400, { "content-type": "application/json" });
+        return res.end(JSON.stringify({
+          error: {
+            message:
+              "Composio does not manage auth for toolkit twitter and no auth config without required fields is available. "
+              + "Please create an auth config manually or specify one in auth_config_override.",
+          },
+        }));
+      }
       res.writeHead(201, { "content-type": "application/json" });
       return res.end(JSON.stringify({ redirect_url: `https://connect.composio.dev/link/${body.toolkit}` }));
     }
@@ -234,6 +257,69 @@ describe.sequential("Composio Sessions", () => {
         max_accounts_per_toolkit: 5,
         require_explicit_selection: true,
       },
+    });
+  });
+
+  it("names the project's own auth configs at creation and rebuilds a Session that predates them", async () => {
+    customAuthConfigs = [
+      { id: "ac_twitter_old", toolkit: { slug: "twitter" }, is_composio_managed: false, status: "ENABLED", last_updated_at: "2026-08-20T00:00:00Z" },
+      // newest wins, and the slug is matched case-insensitively
+      { id: "ac_twitter", toolkit: { slug: "TWITTER" }, is_composio_managed: false, status: "ENABLED", last_updated_at: "2026-08-25T00:00:00Z" },
+      // Composio-managed, disabled, and switched-off-for-Sessions configs are not the user's choice
+      { id: "ac_github_managed", toolkit: { slug: "github" }, is_composio_managed: true, status: "ENABLED" },
+      { id: "ac_slack_disabled", toolkit: { slug: "slack" }, is_composio_managed: false, status: "DISABLED" },
+      { id: "ac_notion_off", toolkit: { slug: "notion" }, is_composio_managed: false, is_enabled_for_tool_router: false },
+    ];
+    sessionAuthConfigs = {};
+    try {
+      const current = { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" };
+      const before = calls.length;
+      await expect(prepareProjectSession("ak_test", current)).resolves.toEqual({ ...current });
+      const creates = calls.slice(before).filter((call) => call.method === "POST" && call.path.endsWith("/session"));
+      expect(creates).toHaveLength(1);
+      expect(creates[0].body).toMatchObject({ user_id: "openmausbot_existing", auth_configs: { twitter: "ac_twitter" } });
+      // the rebuilt Session now covers the configs, so the next check reuses it
+      const after = calls.length;
+      await prepareProjectSession("ak_test", current);
+      expect(calls.slice(after).some((call) => call.method === "POST" && call.path.endsWith("/session"))).toBe(false);
+    } finally {
+      customAuthConfigs = [];
+      sessionAuthConfigs = {};
+    }
+  });
+
+  it("rebuilds the Session and retries when a toolkit needs the project's own auth config", async () => {
+    customAuthConfigs = [{ id: "ac_twitter", toolkit: { slug: "twitter" }, is_composio_managed: false, status: "ENABLED" }];
+    sessionAuthConfigs = {};
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    try {
+      const before = calls.length;
+      await expect(authorizeService(cfg, "twitter")).resolves.toEqual({ url: "https://connect.composio.dev/link/twitter" });
+      const since = calls.slice(before);
+      // once against the stale Session, once against the rebuilt one
+      expect(since.filter((call) => call.method === "POST" && call.path.endsWith("/link"))).toHaveLength(2);
+      expect(since.filter((call) => call.method === "POST" && call.path.endsWith("/session")).at(-1)?.body).toMatchObject({
+        user_id: "openmausbot_existing",
+        auth_configs: { twitter: "ac_twitter" },
+      });
+      // the same Composio user keeps every existing connection
+      expect(cfg.composio).toMatchObject({ userId: "openmausbot_existing", sessionId: "trs_test" });
+    } finally {
+      customAuthConfigs = [];
+      sessionAuthConfigs = {};
+    }
+  });
+
+  it("says what to create when the project has no auth config for the toolkit", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    await expect(authorizeService(cfg, "twitter")).rejects.toThrow(/create an auth config for "twitter"/i);
+    // and a failure that is not about auth configs is passed through untouched
+    await expect(authorizeService(cfg, "github", "personal-three")).resolves.toEqual({
+      url: "https://connect.composio.dev/link/github",
     });
   });
 

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -316,8 +316,9 @@ async function getProjectSession(apiKey: string, sessionId: string): Promise<Ses
 
 /** The project's own (non-Composio-managed) auth configs, one per toolkit.
  *  Disabled configs and ones switched off for Sessions are skipped; when a
- *  toolkit has several, the most recently updated wins. A scoped key can be
- *  denied this list — callers treat a failure as "none", never as fatal. */
+ *  toolkit has several, the most recently updated wins. Ordinary Session
+ *  preparation treats a denied list as "none"; an explicit auth retry surfaces
+ *  the denial so it cannot replace a usable Session with an incomplete one. */
 export async function listCustomAuthConfigs(apiKey: string): Promise<AuthConfigMap> {
   const chosen = new Map<string, { id: string; updated: string }>();
   let cursor: string | undefined;
@@ -363,6 +364,7 @@ function authConfigsKey(sessionId: string, wanted: AuthConfigMap): string {
 export async function prepareProjectSession(
   apiKey: string,
   current?: { apiKey?: string; userId?: string; sessionId?: string },
+  knownAuthConfigs?: AuthConfigMap,
 ): Promise<{ apiKey: string; userId: string; sessionId: string }> {
   const trimmed = apiKey.trim();
   if (!trimmed) throw new Error("Enter a Composio project API key");
@@ -372,7 +374,8 @@ export async function prepareProjectSession(
   // cannot be edited later — so they are read before deciding whether the
   // current Session is still the right one (issue #509: a twitter auth
   // config created after the Session existed was never used).
-  const authConfigs = await listCustomAuthConfigs(trimmed).catch((): AuthConfigMap => ({}));
+  const authConfigs = knownAuthConfigs
+    ?? await listCustomAuthConfigs(trimmed).catch((): AuthConfigMap => ({}));
   let priorUserId = current?.userId;
   if (trimmed === current?.apiKey && current.sessionId) {
     const existing = await getProjectSession(trimmed, current.sessionId);
@@ -443,10 +446,18 @@ async function ensureProjectSession(cfg: AppConfig): Promise<SessionResponse> {
 /** Replace the current Session with a freshly created one — the only way to
  *  pick up an auth config the user added after the Session was made. The
  *  Composio user id is kept, so every existing connection survives. */
-async function recreateProjectSession(cfg: AppConfig): Promise<SessionResponse> {
+async function recreateProjectSession(
+  cfg: AppConfig,
+  userId: string,
+  authConfigs: AuthConfigMap,
+): Promise<SessionResponse> {
   const composio = cfg.composio;
   if (!composio?.apiKey) throw new Error("No Composio project key configured");
-  const prepared = await prepareProjectSession(composio.apiKey, { apiKey: composio.apiKey, userId: composio.userId });
+  const prepared = await prepareProjectSession(
+    composio.apiKey,
+    { apiKey: composio.apiKey, userId },
+    authConfigs,
+  );
   multiAccountUpgradeAttempted.add(prepared.sessionId);
   composio.userId = prepared.userId;
   composio.sessionId = prepared.sessionId;
@@ -842,15 +853,16 @@ export async function authorizeService(cfg: AppConfig, slug: string, requestedAl
     // the Session existed is invisible to it: rebuild the Session once and
     // retry. If the project has no config for this toolkit, say what to do
     // instead of echoing Composio's "auth_config_override" hint.
-    const fresh = await recreateProjectSession(cfg);
     const slugLower = slug.toLowerCase();
-    const covered = Object.keys(fresh.config?.auth_configs ?? {}).some((key) => key.toLowerCase() === slugLower);
+    const authConfigs = await listCustomAuthConfigs(apiKey);
+    const covered = Object.keys(authConfigs).some((key) => key.toLowerCase() === slugLower);
     if (!covered) {
       throw inputError(
         `${slug} has no Composio-managed sign-in. In your Composio project, create an auth config for "${slug}" `
           + "(Auth Configs → Create) with your own app credentials, then click Connect again.",
       );
     }
+    const fresh = await recreateProjectSession(cfg, userId, authConfigs);
     res = await link(fresh.session_id);
     if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
   }

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -25,9 +25,30 @@ const sessionResponseSchema = z.object({
       max_accounts_per_toolkit: z.number().optional(),
       require_explicit_selection: z.boolean().optional(),
     }).optional(),
+    /** toolkit slug → the project's own auth config the Session uses for it */
+    auth_configs: z.record(z.string(), z.string()).optional(),
   }).optional(),
 });
 type SessionResponse = z.infer<typeof sessionResponseSchema>;
+
+// A project's own auth configs (bring-your-own OAuth app, API-key toolkits
+// such as twitter that Composio does not manage). A Session only uses one
+// when it was created with the config's id under `auth_configs`.
+const authConfigItemSchema = z.object({
+  id: z.string().optional(),
+  status: z.string().nullable().optional(),
+  is_composio_managed: z.boolean().optional(),
+  is_enabled_for_tool_router: z.boolean().nullable().optional(),
+  last_updated_at: z.string().nullable().optional(),
+  toolkit: z.object({ slug: z.string().optional() }).optional(),
+});
+const authConfigsPageSchema = z.object({
+  items: z.array(authConfigItemSchema).optional(),
+  next_cursor: z.string().nullable().optional(),
+});
+/** toolkit slug (lowercase) → auth config id */
+type AuthConfigMap = Record<string, string>;
+const MAX_AUTH_CONFIG_PAGES = 20;
 
 export interface ConnectedAccountSummary {
   id: string;
@@ -88,6 +109,16 @@ const MULTI_ACCOUNT_CONFIG = {
   max_accounts_per_toolkit: 5,
   require_explicit_selection: true,
 } as const;
+
+interface SessionCreateRequest {
+  user_id: string;
+  manage_connections: { enable: boolean; enable_wait_for_connections: boolean; enable_connection_removal: boolean };
+  multi_account: typeof MULTI_ACCOUNT_CONFIG;
+  /** toolkit slug → the project's own auth config id; named only when the
+   * project has its own configs, since a Session cannot be edited afterwards
+   * and an empty map would pin "no custom auth" for the Session's lifetime */
+  auth_configs?: AuthConfigMap;
+}
 const MAX_CONNECTED_ACCOUNT_PAGES = 100;
 const ACCOUNT_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const printableAliasSchema = z.string().min(1).max(64).refine((value) => {
@@ -249,6 +280,10 @@ function supportsMultiAccount(session: SessionResponse): boolean {
  *  what we have (single-account behavior) instead of recreating a Session and
  *  rewriting config.json on every request. */
 const multiAccountUpgradeAttempted = new Set<string>();
+/** Session id + auth-config map pairs this boot already created a Session
+ *  for. Same idea: if Composio does not echo `auth_configs`, recreating the
+ *  Session on every check would loop without changing anything. */
+const authConfigUpgradeAttempted = new Set<string>();
 
 function inputError(message: string, status = 400) {
   return Object.assign(new Error(message), { status });
@@ -279,6 +314,51 @@ async function getProjectSession(apiKey: string, sessionId: string): Promise<Ses
   return parseSessionResponse(sessionResponseSchema.parse(await res.json()));
 }
 
+/** The project's own (non-Composio-managed) auth configs, one per toolkit.
+ *  Disabled configs and ones switched off for Sessions are skipped; when a
+ *  toolkit has several, the most recently updated wins. A scoped key can be
+ *  denied this list — callers treat a failure as "none", never as fatal. */
+export async function listCustomAuthConfigs(apiKey: string): Promise<AuthConfigMap> {
+  const chosen = new Map<string, { id: string; updated: string }>();
+  let cursor: string | undefined;
+  for (let page = 0; page < MAX_AUTH_CONFIG_PAGES; page++) {
+    const params = new URLSearchParams({ is_composio_managed: "false", limit: "100" });
+    if (cursor) params.set("cursor", cursor);
+    const res = await fetch(`${apiBase()}/auth_configs?${params}`, {
+      headers: projectHeaders(apiKey),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) throw new Error(await responseError(res, `Composio auth configs: HTTP ${res.status}`));
+    const body = authConfigsPageSchema.parse(await res.json());
+    for (const item of body.items ?? []) {
+      const slug = item.toolkit?.slug?.toLowerCase();
+      if (!slug || !item.id || item.is_composio_managed === true) continue;
+      if (item.is_enabled_for_tool_router === false) continue;
+      if (item.status && /^(disabled|inactive|expired|deleted)$/i.test(item.status)) continue;
+      const updated = item.last_updated_at ?? "";
+      const current = chosen.get(slug);
+      if (!current || updated > current.updated) chosen.set(slug, { id: item.id, updated });
+    }
+    const next = body.next_cursor ?? undefined;
+    if (!next || next === cursor) break;
+    cursor = next;
+  }
+  return Object.fromEntries([...chosen].sort(([a], [b]) => a.localeCompare(b)).map(([slug, { id }]) => [slug, id]));
+}
+
+/** True when the Session already routes every wanted toolkit through the
+ *  project's own auth config. Extra configs on the Session are fine; a
+ *  missing or different one means the Session predates the config. */
+function sessionCoversAuthConfigs(session: SessionResponse, wanted: AuthConfigMap): boolean {
+  const have = session.config?.auth_configs ?? {};
+  const haveLower = Object.fromEntries(Object.entries(have).map(([slug, id]) => [slug.toLowerCase(), id]));
+  return Object.entries(wanted).every(([slug, id]) => haveLower[slug] === id);
+}
+
+function authConfigsKey(sessionId: string, wanted: AuthConfigMap): string {
+  return `${sessionId}:${JSON.stringify(wanted)}`;
+}
+
 /** Validate a project key and return one reusable Session for this install. */
 export async function prepareProjectSession(
   apiKey: string,
@@ -288,10 +368,20 @@ export async function prepareProjectSession(
   if (!trimmed) throw new Error("Enter a Composio project API key");
   if (!trimmed.startsWith("ak_")) throw new Error("Composio project API keys start with ak_");
 
+  // The project's own auth configs must be named at creation — a Session
+  // cannot be edited later — so they are read before deciding whether the
+  // current Session is still the right one (issue #509: a twitter auth
+  // config created after the Session existed was never used).
+  const authConfigs = await listCustomAuthConfigs(trimmed).catch((): AuthConfigMap => ({}));
   let priorUserId = current?.userId;
   if (trimmed === current?.apiKey && current.sessionId) {
     const existing = await getProjectSession(trimmed, current.sessionId);
-    if (existing && supportsMultiAccount(existing)) {
+    if (
+      existing
+      && supportsMultiAccount(existing)
+      && (sessionCoversAuthConfigs(existing, authConfigs)
+        || authConfigUpgradeAttempted.has(authConfigsKey(existing.session_id, authConfigs)))
+    ) {
       return {
         apiKey: trimmed,
         userId: existing.config?.user_id ?? current.userId ?? `openmausbot_${randomUUID()}`,
@@ -305,22 +395,27 @@ export async function prepareProjectSession(
   }
 
   const userId = priorUserId ?? `openmausbot_${randomUUID()}`;
+  const sessionRequest: SessionCreateRequest = {
+    user_id: userId,
+    manage_connections: {
+      enable: true,
+      enable_wait_for_connections: true,
+      enable_connection_removal: true,
+    },
+    multi_account: MULTI_ACCOUNT_CONFIG,
+  };
+  if (Object.keys(authConfigs).length) sessionRequest.auth_configs = authConfigs;
   const res = await fetch(`${apiBase()}/tool_router/session`, {
     method: "POST",
     headers: projectHeaders(trimmed, true),
-    body: JSON.stringify({
-      user_id: userId,
-      manage_connections: {
-        enable: true,
-        enable_wait_for_connections: true,
-        enable_connection_removal: true,
-      },
-      multi_account: MULTI_ACCOUNT_CONFIG,
-    }),
+    body: JSON.stringify(sessionRequest),
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) throw new Error(await responseError(res, `Composio rejected this key (HTTP ${res.status})`));
   const session = parseSessionResponse(sessionResponseSchema.parse(await res.json()));
+  // If Composio does not echo the configs back, a later check would ask for
+  // the same creation again — remember this attempt so it happens once.
+  authConfigUpgradeAttempted.add(authConfigsKey(session.session_id, authConfigs));
   return { apiKey: trimmed, userId, sessionId: session.session_id };
 }
 
@@ -344,6 +439,26 @@ async function ensureProjectSession(cfg: AppConfig): Promise<SessionResponse> {
   if (!created) throw new Error("Composio Session disappeared after creation");
   return created;
 }
+
+/** Replace the current Session with a freshly created one — the only way to
+ *  pick up an auth config the user added after the Session was made. The
+ *  Composio user id is kept, so every existing connection survives. */
+async function recreateProjectSession(cfg: AppConfig): Promise<SessionResponse> {
+  const composio = cfg.composio;
+  if (!composio?.apiKey) throw new Error("No Composio project key configured");
+  const prepared = await prepareProjectSession(composio.apiKey, { apiKey: composio.apiKey, userId: composio.userId });
+  multiAccountUpgradeAttempted.add(prepared.sessionId);
+  composio.userId = prepared.userId;
+  composio.sessionId = prepared.sessionId;
+  saveConfig({ composio: { userId: prepared.userId, sessionId: prepared.sessionId } });
+  const created = await getProjectSession(composio.apiKey, prepared.sessionId);
+  if (!created) throw new Error("Composio Session disappeared after creation");
+  return created;
+}
+
+/** Composio's wording when a toolkit has no managed auth and the Session was
+ *  not told which of the project's own auth configs to use. */
+const NEEDS_AUTH_CONFIG = /does not manage auth|auth[_ ]?config/i;
 
 export async function mcpIntegration(
   cfg: AppConfig,
@@ -710,13 +825,35 @@ export async function authorizeService(cfg: AppConfig, slug: string, requestedAl
   }
   const linkRequest: AccountLinkRequest = { toolkit: slug };
   if (alias) linkRequest.alias = alias;
-  const res = await fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/link`, {
-    method: "POST",
-    headers: projectHeaders(cfg.composio.apiKey, true),
-    body: JSON.stringify(linkRequest),
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
+  const apiKey = cfg.composio.apiKey;
+  const link = (sessionId: string) =>
+    fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
+      method: "POST",
+      headers: projectHeaders(apiKey, true),
+      body: JSON.stringify(linkRequest),
+      signal: AbortSignal.timeout(30_000),
+    });
+  let res = await link(session.session_id);
+  if (!res.ok) {
+    const message = await responseError(res, `Composio authorization: HTTP ${res.status}`);
+    if (!NEEDS_AUTH_CONFIG.test(message)) throw new Error(message);
+    // The toolkit needs one of the project's own auth configs. The Session
+    // names those only at creation, so an auth config the user created after
+    // the Session existed is invisible to it: rebuild the Session once and
+    // retry. If the project has no config for this toolkit, say what to do
+    // instead of echoing Composio's "auth_config_override" hint.
+    const fresh = await recreateProjectSession(cfg);
+    const slugLower = slug.toLowerCase();
+    const covered = Object.keys(fresh.config?.auth_configs ?? {}).some((key) => key.toLowerCase() === slugLower);
+    if (!covered) {
+      throw inputError(
+        `${slug} has no Composio-managed sign-in. In your Composio project, create an auth config for "${slug}" `
+          + "(Auth Configs → Create) with your own app credentials, then click Connect again.",
+      );
+    }
+    res = await link(fresh.session_id);
+    if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
+  }
   const body = linkResponseSchema.parse(await res.json());
   return { url: trustedAuthUrl(body.redirect_url, slug) };
 }


### PR DESCRIPTION
## What changed

A self-hosted Composio project (project key `ak_…`) runs one long-lived Tool Router Session. A Session names the project's own auth configs **only at creation** — the Session API has no update endpoint. So a toolkit Composio doesn't manage auth for (Twitter/X, and any bring-your-own-OAuth toolkit) always failed with *"Composio does not manage auth for toolkit twitter … specify one in auth_config_override"*, even after the user created the auth config in their Composio project — the Session predated it and never carried it.

- `prepareProjectSession` now lists the project's non-managed auth configs (`GET /auth_configs?is_composio_managed=false`, paginated; newest per toolkit wins; disabled / not-enabled-for-tool-router configs skipped) and passes them as `auth_configs` when creating a Session.
- A Session that lacks a wanted config no longer counts as reusable, so adding a config rebuilds the Session **once** — same Composio `user_id`, so every existing connection survives. A `Set` guards against a rebuild loop if Composio doesn't echo the map back.
- `authorizeService` recognises the "needs an auth config" error, rebuilds the Session once and retries the link; if the project genuinely has no config for that toolkit it now returns actionable text (*create an auth config for "twitter" in your Composio project, then Connect again*) instead of echoing Composio's raw `auth_config_override` hint.

## Why

#509 — a user created a working Twitter auth config in their Composio project, entered their project key, restarted, and still got the managed-auth error. The Session created before the config existed never used it. Naming the configs at creation (and rebuilding when they change) is the fix; the managed/broker path is untouched.

## How it was verified

- `pnpm typecheck` clean; `pnpm test` — full server suite passes.
- `server/composio.test.ts` (15 pass) gains a stateful stub where the Session only "knows" the configs it was created with and `/link` for `twitter` 400s exactly as Composio does until it does. New cases: configs named at creation (newest-per-slug, case-insensitive, managed/disabled/off-for-tool-router excluded) with the Session rebuilt once then reused; the authorize retry rebuilds + succeeds keeping the same user id; the "no config exists" path returns the actionable error while a non-auth-config failure passes through untouched.
- Mutation check: dropping `auth_configs` from the create body fails the two new tests; restoring passes them.
- `pnpm lint` reports nothing new on the touched lines (its two findings there — `applyManagedBrokerMessage`/`setManagedBrokerAccess` — pre-date this change; lint is not a CI gate).

Closes #509

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] No macOS-only code
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for project-owned authentication configurations in sessions.
  * Sessions now include applicable authentication configuration details.
  * Added automatic session rebuilding when a toolkit requires a project-owned configuration.
  * Added support for listing available project authentication configurations.

* **Bug Fixes**
  * Improved authorization errors with guidance when a required configuration is unavailable.
  * Preserved session user identity when rebuilding sessions.
  * Prevented unnecessary session creation when authorization configuration retrieval fails.
  * Prevented repeated session-rebuild attempts during authorization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->