### PR TITLE
fix(win): recolor the caption-button overlay per skin (no black block on light skins)

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -952,6 +952,7 @@ ipcMain.on("desktop:unread-count", (event, value) => {
 
 function createWindow() {
   const isMac = process.platform === "darwin";
+  const waitsForSkinSync = process.platform === "win32";
   const primary = screen.getPrimaryDisplay();
   const displays = [primary, ...screen.getAllDisplays().filter((display) => display.id !== primary.id)];
   const restored = resolveWindowState(readWindowState(), displays.map((display) => display.workArea));
@@ -959,6 +960,11 @@ function createWindow() {
     ...restored.bounds,
     minWidth: 900,
     minHeight: 600,
+    // The renderer restores its persisted skin before mounting React and
+    // mirrors it over desktop:skin. Keep Windows hidden until that handshake
+    // recolors the native caption-button overlay, otherwise a saved light
+    // skin still flashes the Midnight-black block on every cold start.
+    show: !waitsForSkinSync,
     icon: APP_ICON,
     backgroundColor: "#070707",
     autoHideMenuBar: process.platform !== "darwin",
@@ -986,6 +992,18 @@ function createWindow() {
     },
   });
   mainWindow = win;
+  if (waitsForSkinSync) {
+    // A broken renderer or preload must not strand the app as an invisible
+    // process. Normal startup shows from desktop:skin almost immediately;
+    // this is only the bounded recovery path.
+    const skinSyncFallback = setTimeout(() => {
+      if (!win.isDestroyed() && !win.isVisible()) win.show();
+    }, 5_000);
+    skinSyncFallback.unref?.();
+    const clearSkinSyncFallback = () => clearTimeout(skinSyncFallback);
+    win.once("show", clearSkinSyncFallback);
+    win.once("closed", clearSkinSyncFallback);
+  }
   installWindowStatePersistence(win);
   applyUnreadBadge(win);
   if (restored.maximized) win.maximize();
@@ -1265,6 +1283,9 @@ ipcMain.handle("desktop:skin", (event, skin) => {
     const sender = BrowserWindow.fromWebContents(event.sender);
     try {
       sender?.setTitleBarOverlay({ ...skinChrome(skin), height: 60 });
+      // The first Windows window starts hidden so a persisted light skin is
+      // already applied when native chrome becomes visible.
+      if (sender && !sender.isVisible()) sender.show();
     } catch {
       // a window created without an overlay throws; safe to ignore
     }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -38,6 +38,7 @@ import {
   withoutManagedCompanionTunnelAccess,
 } from "./managed-companion-tunnel.mjs";
 import { createSecureCredentialState } from "./secure-credential-state.mjs";
+import { skinChrome, isKnownSkin } from "./skin-overlay.cjs";
 import { readSecureCredentials } from "./secure-credentials.mjs";
 import { createControlPlaneClient } from "./control-plane-client.mjs";
 import {
@@ -69,6 +70,9 @@ let desktopViewerOwner = null;
 let desktopViewerContextId = null;
 let pendingPackageInstallUrl = packageUrlFromCommandLine(process.argv);
 let mainWindow = null;
+// The active skin id, mirrored from the renderer so a window's native
+// caption-button overlay (issue #454) starts and stays on the right colours.
+let currentSkin = "midnight";
 let unreadCount = 0;
 let unreadOverlayIcon = null;
 
@@ -969,7 +973,11 @@ function createWindow() {
             // around a 36px control row = 60). Windows draws the caption buttons
             // to fill the overlay, so anything shorter leaves a dead band under
             // them and anything taller overhangs the header.
-            titleBarOverlay: { color: "#070707", symbolColor: "#b5b5b5", height: 60 },
+            // color/symbolColor follow the active skin (issue #454): the
+            // caption buttons live in this native overlay, and a light skin
+            // with a Midnight-black overlay is the "black block in the
+            // top-right corner". height stays 60 — see the note above.
+            titleBarOverlay: { ...skinChrome(currentSkin), height: 60 },
           }
         : {}),
     webPreferences: {
@@ -1241,6 +1249,27 @@ ipcMain.handle("desktop:save-file", async (event, rawPath) => {
     shell.showItemInFolder(choice.filePath);
     return choice.filePath;
   });
+});
+
+// The renderer owns the skin (it lives in localStorage and stamps
+// [data-skin] before first paint); it tells the main process so the one
+// surface CSS cannot reach — the Windows caption-button overlay — matches.
+// Persisted in-process so a window opened later starts on the right colours.
+ipcMain.handle("desktop:skin", (event, skin) => {
+  if (!isKnownSkin(skin)) return false;
+  currentSkin = skin;
+  // The caption-button overlay is a Windows-only surface (createWindow only
+  // configures titleBarOverlay there); on macOS/Linux the renderer's CSS is
+  // the whole story and there is nothing native to recolour.
+  if (process.platform === "win32") {
+    const sender = BrowserWindow.fromWebContents(event.sender);
+    try {
+      sender?.setTitleBarOverlay({ ...skinChrome(skin), height: 60 });
+    } catch {
+      // a window created without an overlay throws; safe to ignore
+    }
+  }
+  return true;
 });
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -118,6 +118,9 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Open a web link in the default browser. Unlike renderer window.open,
    * this remains reliable after an asynchronous API request. */
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
+  /** Tell the window which skin the page wears, so the native chrome the
+   * renderer cannot paint (the Windows caption-button overlay) matches. */
+  applySkin: (skin) => ipcRenderer.invoke("desktop:skin", skin),
   /** A reviewed BotMRR package opened through openmausbot://install. */
   onPackageInstall: (cb) => {
     packageInstallListeners.add(cb);

--- a/electron/skin-overlay.cjs
+++ b/electron/skin-overlay.cjs
@@ -1,0 +1,34 @@
+// The native window chrome that CSS cannot reach, per skin. Everything the
+// renderer paints follows `[data-skin]` in src/styles.css; the Windows
+// caption-button overlay and the window's own background are drawn by the
+// main process and have to be told the same colours. The values mirror each
+// skin's `--color-app` (the header strip is `bg-app`) and, for the symbols,
+// its `--color-ink-secondary` — flattened to opaque hex because the overlay
+// accepts no alpha. Keep in step with src/styles.css and src/lib/skins.ts.
+"use strict";
+
+const SKIN_CHROME = Object.freeze({
+  midnight: Object.freeze({ color: "#070707", symbolColor: "#b5b5b5" }),
+  atelier: Object.freeze({ color: "#f5f1eb", symbolColor: "#6b6559" }),
+  foundry: Object.freeze({ color: "#100e0b", symbolColor: "#b0a696" }),
+  lagoon: Object.freeze({ color: "#dfeceb", symbolColor: "#4d5c5b" }),
+});
+
+const DEFAULT_SKIN = "midnight";
+
+/** The chrome colours for a skin id sent by the renderer. Anything that is
+ * not a known skin — a renamed skin, a stale value, a non-string — falls
+ * back to Midnight rather than throwing, because the renderer has already
+ * painted and a wrong overlay is recoverable while a broken IPC is not. */
+function skinChrome(skin) {
+  return Object.hasOwn(SKIN_CHROME, skin) ? SKIN_CHROME[skin] : SKIN_CHROME[DEFAULT_SKIN];
+}
+
+/** True when the id names a skin this module knows. A non-string coerces to a
+ * property key that cannot match a skin id, so it answers false without a
+ * separate type guard. */
+function isKnownSkin(skin) {
+  return Object.hasOwn(SKIN_CHROME, skin);
+}
+
+module.exports = { SKIN_CHROME, DEFAULT_SKIN, skinChrome, isKnownSkin };

--- a/electron/skin-overlay.test.mjs
+++ b/electron/skin-overlay.test.mjs
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { SKIN_CHROME, DEFAULT_SKIN, skinChrome, isKnownSkin } = require("./skin-overlay.cjs");
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(here, "../src/styles.css"), "utf8");
+const skinIds = readFileSync(join(here, "../src/lib/skins.ts"), "utf8");
+
+// The value CSS defines for one custom property inside one skin's block.
+function cssToken(skin, name) {
+  const block = css.match(new RegExp(`\\[data-skin="${skin}"\\]\\s*\\{([^}]*)\\}`))?.[1] ?? "";
+  return block.match(new RegExp(`${name}\\s*:\\s*(#[0-9a-fA-F]+)`))?.[1]?.toLowerCase() ?? null;
+}
+
+describe("skin overlay chrome", () => {
+  it("covers exactly the skins the renderer ships", () => {
+    // SKIN_IDS is the source of truth (src/lib/skins.ts); a skin added there
+    // without a chrome entry here would leave that skin's caption buttons on
+    // the previous colour — the issue #454 failure, but for a new skin.
+    const registered = [...skinIds.matchAll(/"([a-z-]+)"/g)]
+      .map(([, id]) => id)
+      .filter((id) => css.includes(`[data-skin="${id}"]`));
+    expect(new Set(registered)).toEqual(new Set(Object.keys(SKIN_CHROME)));
+  });
+
+  it("matches each skin's --color-app (the header strip is bg-app)", () => {
+    for (const [skin, chrome] of Object.entries(SKIN_CHROME)) {
+      expect(chrome.color.toLowerCase()).toBe(cssToken(skin, "--color-app"));
+    }
+  });
+
+  it("uses opaque symbol colours the overlay can accept", () => {
+    // The Windows overlay rejects alpha, so every symbolColor must be a plain
+    // 6-digit hex even though the CSS ink tokens may carry an alpha byte.
+    for (const chrome of Object.values(SKIN_CHROME)) {
+      expect(chrome.symbolColor).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it("falls back to the default skin for anything unknown, never throwing", () => {
+    expect(isKnownSkin("midnight")).toBe(true);
+    expect(isKnownSkin("does-not-exist")).toBe(false);
+    expect(isKnownSkin(undefined)).toBe(false);
+    expect(isKnownSkin(42)).toBe(false);
+    expect(skinChrome("does-not-exist")).toEqual(SKIN_CHROME[DEFAULT_SKIN]);
+    expect(skinChrome(null)).toEqual(SKIN_CHROME[DEFAULT_SKIN]);
+  });
+});

--- a/src/lib/skins.ts
+++ b/src/lib/skins.ts
@@ -67,4 +67,14 @@ export function applySkin(id: SkinId): void {
   } catch {
     /* quota / private mode — the skin still applies for this session */
   }
+  // The one surface CSS cannot reach: on Windows the caption buttons sit in a
+  // native overlay the main process paints. Left at the default it stays
+  // Midnight-black on a light skin — the "black block in the top-right
+  // corner" of issue #454. Best-effort: a browser tab or an older desktop
+  // build has no bridge, and the skin still applies without it.
+  try {
+    void window.ogb?.applySkin?.(id)?.catch(() => undefined);
+  } catch {
+    /* no bridge */
+  }
 }

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -159,6 +159,8 @@ type SkillRecordingPayload = {
       openInstallTerminal?(command: string): Promise<boolean>;
       /** Opens an http(s) link in the user's default browser. */
       openExternal?(url: string): Promise<boolean>;
+      /** Recolor the native window chrome for a skin; absent on older builds. */
+      applySkin?(skin: string): Promise<boolean>;
       /** Receives a GitHub package URL opened through openmausbot://install. */
       onPackageInstall?(cb: (url: string) => void): () => void;
       /** Updates the native Dock/taskbar unread indicator. */


### PR DESCRIPTION
## What changed

On Windows the caption buttons (min/max/close) sit in a native overlay the main process paints, not in the page. `createWindow` hardcoded it to Midnight black (`#070707`) for every skin, so on a light skin (Atelier, Lagoon) the top-right corner kept a black rectangle behind the buttons — the reported "black block in the top-right corner".

- `applySkin` (renderer) now also calls a new `desktop:skin` IPC; the main process runs `setTitleBarOverlay` with the skin's colours, and `createWindow` seeds the overlay from the same source so a later-opened window starts correct.
- Colours live in `electron/skin-overlay.cjs`, mirroring each skin's `--color-app` (the header strip is `bg-app`) and `--color-ink-secondary`, flattened to opaque hex (the overlay takes no alpha).
- Windows-only: macOS/Linux configure no overlay and are untouched; a browser tab or an older desktop build without the bridge still applies the skin's CSS.

## Why

#454. The overlay is the one piece of chrome CSS can't reach, so it stayed Midnight-black under every skin.

## How it was verified

- `pnpm typecheck` clean; `pnpm test` — electron + renderer suites pass (`electron/` 232 pass, `src/lib/skins.test.ts` green).
- New `electron/skin-overlay.test.mjs` asserts the chrome map covers exactly the shipped skins (from `src/lib/skins.ts` ∩ `styles.css`), each `color` equals that skin's `--color-app` in `styles.css`, every `symbolColor` is opaque 6-digit hex, and unknown/`null`/non-string ids fall back to Midnight without throwing. So a skin added to `skins.ts` + `styles.css` but not here fails the test instead of shipping another black block.
- I don't have a Windows box to screenshot; the fix is confined to the Windows overlay path and the colour values are asserted against `styles.css`. A Windows before/after screenshot would be a welcome addition on review.

## Screenshots (UI changes)

Windows-only native chrome; verified by the colour-parity test against `styles.css` (see above). Reporter's before image is in #454.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (helper is unit-tested)
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated (this is Windows-gated; no `shell:true`)
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native window controls now match the selected skin on Windows.
  * Skin changes update the window appearance immediately.
  * Supported skins include Midnight, Atelier, Foundry, and Lagoon.
  * Windows windows now start with correctly themed controls before appearing.

* **Bug Fixes**
  * Invalid or unavailable skin settings safely fall back to Midnight.
  * Skin styling continues to work when native desktop integration is unavailable.
  * Windows windows appear automatically if skin synchronization is delayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->