### PR TITLE
fix(onboarding): use the success and warning tokens for status badges

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -34,7 +34,7 @@ function StatusRow({
     <div className="flex items-start gap-3 rounded-xl bg-card p-3.5">
       <span
         className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full ${
-          ok ? "bg-[#00c97222] text-[#38d591]" : warn ? "bg-[#ff980022] text-[#ff9800]" : "bg-raised text-ink-secondary"
+          ok ? "bg-success/15 text-success" : warn ? "bg-warning/15 text-warning" : "bg-raised text-ink-secondary"
         }`}
       >
         {ok ? <Check size={14} /> : <AlertTriangle size={13} />}
@@ -298,7 +298,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                   </div>
                 </div>
                 {perms?.mic === "granted" ? (
-                  <Check size={16} className="shrink-0 text-[#38d591]" />
+                  <Check size={16} className="shrink-0 text-success" />
                 ) : perms?.mic === "denied" || perms?.mic === "restricted" ? (
                   <button
                     onClick={() => window.ogb?.permOpenSettings?.("mic")}


### PR DESCRIPTION
## What changed

The onboarding status badges in `src/components/Onboarding.tsx` move from
hardcoded hex to the `success` and `warning` tokens: `bg-success/15 text-success`
and `bg-warning/15 text-warning` for the round badge in `StatusRow`, and
`text-success` for the microphone-granted tick.

## Why

`#38d591` and `#ff9800` are not arbitrary colours — they are Midnight's own
`--color-success` and `--color-warning`, copied into the component. Every skin
redefines those tokens, and the two light skins deliberately darken them;
`styles.css` annotates the Atelier warning with `/* darkened → 4.98:1 */`.
Painting the literal bypasses exactly the re-tuning that annotation exists for,
so on Atelier and Lagoon the badges keep Midnight's bright green and orange on a
near-white card:

| skin | ok badge | warn badge | mic tick |
|---|---|---|---|
| midnight | 6.35:1 | 5.50:1 | 8.00:1 |
| atelier | **1.69:1** | **1.94:1** | **1.89:1** |
| foundry | 7.35:1 | 6.32:1 | 9.15:1 |
| lagoon | **1.69:1** | **1.94:1** | **1.89:1** |

1.69:1 is below the 3:1 floor for non-text graphics, not just below AA — the tick
is close to invisible against its own tint, which is visible in the screenshots.

`bg-success/15 text-success` is the pattern this same round status pill already
uses at `ConnectorCard.tsx:103` and `SecretRequestCard.tsx:114`
(`LocalComputerSection` uses the `/20` step for its step badge). `/15` is the
nearest Tailwind step to the literal's own `0x22` alpha, so the dark skins keep
the appearance they have today — midnight and foundry are unchanged in the
screenshots below.

After the change every skin clears AA:

| skin | ok badge | warn badge | mic tick |
|---|---|---|---|
| midnight | 5.88:1 | 5.31:1 | 8.00:1 |
| atelier | 4.99:1 | 4.86:1 | 6.17:1 |
| foundry | 5.12:1 | 5.94:1 | 6.50:1 |
| lagoon | 5.07:1 | 5.10:1 | 6.29:1 |

Scope: after this change `Onboarding.tsx` has no colour literals left, and these
three were the last occurrences of `#38d591` / `#ff9800` / `#00c972` anywhere in
`src/`.

Worth noting for context: `electron/skin-overlay.test.mjs` already guards the
native chrome table against exactly this class of drift, but it covers the
Electron colour table rather than the components, which is why these three
survived.

## How it was verified

macOS 26.6, Node 26, `pnpm dev` + `pnpm dev:server`. The numbers are read out of
the running app, not computed by hand: a harness mounts the badges inside a
`[data-skin]` wrapper (the skin blocks are written so any element can open a skin
context for its subtree), extracts the class strings from `Onboarding.tsx` so it
cannot drift from what ships, then composites `getComputedStyle` colours over the
first opaque ancestor and measures. Same harness before and after; only the
component changed between runs.

```
pnpm typecheck                          # clean
pnpm test                               # 200 files, 2114 tests passed, 1 file / 18 skipped
node scripts/check-skin-contrast.mjs    # green
pnpm check:contrast                     # green, no new failures
```

No test is added: every test under `src/` is a pure-logic test on exported
functions, with no DOM or layout harness in the repo, and CONTRIBUTING asks UI
changes for screenshots instead.

## Screenshots (UI changes)

The three badges in all four skins — the `ok` badge, the `warn` badge, and the
bare mic tick.

**Before** — atelier and lagoon wash out; the ticks barely separate from their
own tint:

![before](https://raw.githubusercontent.com/Maksim-Burtsev/OpenMausBot/pr-443-assets/ob-before.png)

**After** — the light skins pick up their darkened tokens and read clearly;
midnight and foundry are unchanged:

![after](https://raw.githubusercontent.com/Maksim-Burtsev/OpenMausBot/pr-443-assets/ob-after.png)

<sub>Screenshots live on a separate branch of my fork so they stay out of this PR's diff.</sub>

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — n/a, no server change; this is CSS only
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building — n/a
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated onboarding status indicators to use consistent semantic success and warning colors.
  * Improved visual consistency for the microphone permission confirmation icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->