### PR TITLE
chore(release): bump version to 0.1.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop app version from 0.1.37 to 0.1.38
- keep the release source of truth limited to the root package version
- leave the separately versioned iOS/TestFlight app unchanged

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- git diff --check
- verified package.json is the only changed file

After this merges, the Release workflow can be dispatched manually from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Released version 0.1.38 with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->