### PR TITLE
fix(routines): flat schedule schema + coercion so chat proposals survive provider schema conversion

### DIFF
--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -178,20 +178,20 @@ describe("agents-proxy MCP surface", () => {
     ]);
   });
 
-  it("publishes explicit, bounded routine schedule schemas", async () => {
+  it("publishes a flat routine schedule schema that survives provider conversion", async () => {
     const list = await rpc("tools/list");
     const create = list.result.tools.find((t: { name: string }) => t.name === "propose_routine");
     expect(create.inputSchema.required).toEqual(["name", "instructions", "schedule"]);
-    expect(create.inputSchema.properties.schedule.oneOf).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ required: ["type", "at"] }),
-        expect.objectContaining({ required: ["type", "time", "weekdays"] }),
-      ]),
-    );
-    const weekly = create.inputSchema.properties.schedule.oneOf.find(
-      (option: any) => option.properties.type.const === "weekly",
-    );
-    expect(weekly.properties.weekdays.items.enum).toEqual([
+    const schedule = create.inputSchema.properties.schedule;
+    // No composition keywords anywhere in the tool surface: several agent
+    // CLIs flatten or drop oneOf/anyOf/const when converting MCP tools for
+    // their model API, and a model that never saw the branches guesses
+    // shapes forever (the 0.1.38 field failure).
+    expect(JSON.stringify(create.inputSchema)).not.toMatch(/"oneOf"|"anyOf"|"allOf"|"const"/);
+    expect(schedule.type).toBe("object");
+    expect(schedule.required).toEqual(["type"]);
+    expect(schedule.properties.type.enum).toEqual(["once", "weekly", "daily"]);
+    expect(schedule.properties.weekdays.items.enum).toEqual([
       "monday",
       "tuesday",
       "wednesday",
@@ -379,6 +379,67 @@ describe("agents-proxy MCP surface", () => {
       action: "delete",
       routineId: "routine-1",
     });
+  });
+
+  it("coerces the schedule shapes models actually send", async () => {
+    // "daily" is the natural word for every-day; it becomes weekly on all
+    // seven days on the wire, so the harness dialect stays unchanged.
+    await callTool("propose_routine", {
+      name: "Daily check",
+      instructions: "Check things.",
+      schedule: { type: "daily", time: "09:00" },
+    });
+    expect(lastRoutineRequestBody.routine.schedule).toEqual({
+      type: "weekly",
+      time: "09:00",
+      weekdays: ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
+    });
+
+    // Capitalized and short weekday names have one obvious meaning.
+    await callTool("propose_routine", {
+      name: "Caps",
+      instructions: "x.",
+      schedule: { type: "weekly", time: "09:00", weekdays: ["Monday", "FRI"] },
+    });
+    expect(lastRoutineRequestBody.routine.schedule.weekdays).toEqual(["monday", "friday"]);
+
+    // Models routinely deliver nested objects as JSON strings.
+    await callTool("propose_routine", {
+      name: "Str",
+      instructions: "x.",
+      schedule: JSON.stringify({ type: "weekly", time: "09:00", weekdays: ["monday"] }),
+    });
+    expect(lastRoutineRequestBody.routine.schedule).toEqual({ type: "weekly", time: "09:00", weekdays: ["monday"] });
+  });
+
+  it("answers unsupported schedules with instructions, before calling the harness", async () => {
+    lastRoutineRequestBody = null;
+    const interval = await callTool("propose_routine", {
+      name: "Interval",
+      instructions: "x.",
+      schedule: { type: "interval", minutes: 30 },
+    });
+    expect(interval.result.isError).toBe(true);
+    expect(interval.result.content[0].text).toContain("sub-day intervals");
+    expect(interval.result.content[0].text).toContain('"type":"daily"');
+
+    const noDays = await callTool("propose_routine", {
+      name: "NoDays",
+      instructions: "x.",
+      schedule: { type: "weekly", time: "09:00" },
+    });
+    expect(noDays.result.isError).toBe(true);
+    expect(noDays.result.content[0].text).toContain("weekdays");
+    expect(noDays.result.content[0].text).toContain("daily");
+
+    const unknown = await callTool("propose_routine_action", {
+      routine_id: "routine-1",
+      action: "update",
+      changes: { schedule: { type: "fortnightly", time: "09:00" } },
+    });
+    expect(unknown.result.isError).toBe(true);
+    expect(unknown.result.content[0].text).toContain("Unknown schedule type");
+    expect(lastRoutineRequestBody).toBeNull();
   });
 
   it("rejects malformed routine proposals before calling the harness", async () => {

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -46,44 +46,118 @@ const WEEKDAYS = [
   "sunday",
 ] as const;
 
+// One flat object, deliberately free of oneOf/const/format: several agent
+// CLIs flatten or drop JSON-Schema composition keywords when converting MCP
+// tools into their provider's function-call format, and a model that never
+// saw the branches guesses shapes forever (the 0.1.38 field failure). The
+// per-type rules live in descriptions and are enforced with guiding errors
+// in normalizeScheduleInput below.
 const ROUTINE_SCHEDULE_SCHEMA = {
-  oneOf: [
-    {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        type: { type: "string", const: "once" },
-        at: {
-          type: "string",
-          format: "date-time",
-          description:
-            "Future RFC3339 date-time with an explicit timezone offset, for example 2026-09-01T09:00:00+05:30 or 2026-09-01T03:30:00Z.",
-        },
-      },
-      required: ["type", "at"],
+  type: "object",
+  additionalProperties: false,
+  description:
+    'Either {"type":"once","at":RFC3339} for one future run, {"type":"weekly","time":"HH:MM","weekdays":[...]} for chosen days, or {"type":"daily","time":"HH:MM"} to run every day. Sub-day intervals (every N minutes/hours) are not supported.',
+  properties: {
+    type: {
+      type: "string",
+      enum: ["once", "weekly", "daily"],
+      description: "once = a single future run; weekly = chosen weekdays; daily = every day of the week.",
     },
-    {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        type: { type: "string", const: "weekly" },
-        time: {
-          type: "string",
-          pattern: "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
-          description: "Local computer time in 24-hour HH:MM format.",
-        },
-        weekdays: {
-          type: "array",
-          minItems: 1,
-          uniqueItems: true,
-          items: { type: "string", enum: WEEKDAYS },
-          description: "Days on which the routine should run in the computer's local timezone.",
-        },
-      },
-      required: ["type", "time", "weekdays"],
+    at: {
+      type: "string",
+      description:
+        "Only for type once: future RFC3339 date-time with an explicit timezone offset, for example 2026-09-01T09:00:00+05:30 or 2026-09-01T03:30:00Z.",
     },
-  ],
+    time: {
+      type: "string",
+      description: "For type weekly or daily: local computer time in 24-hour HH:MM format, for example 09:00.",
+    },
+    weekdays: {
+      type: "array",
+      items: { type: "string", enum: WEEKDAYS },
+      description: "Only for type weekly: which days the routine runs, in the computer's local timezone.",
+    },
+  },
+  required: ["type"],
 } as const;
+
+const SHORT_WEEKDAYS = {
+  mon: "monday",
+  tue: "tuesday",
+  tues: "tuesday",
+  wed: "wednesday",
+  thu: "thursday",
+  thur: "thursday",
+  thurs: "thursday",
+  fri: "friday",
+  sat: "saturday",
+  sun: "sunday",
+} as const satisfies Record<string, (typeof WEEKDAYS)[number]>;
+
+const SUPPORTED_SCHEDULES =
+  'Supported schedules: {"type":"once","at":"2026-09-01T09:00:00+05:30"} (future RFC3339 with explicit offset), ' +
+  '{"type":"weekly","time":"09:00","weekdays":["monday","friday"]}, or {"type":"daily","time":"09:00"} for every day.';
+
+/** The outcome of coercing a model-sent schedule: the harness-dialect
+ * schedule, or a message telling the model exactly what to send instead. */
+interface NormalizedSchedule {
+  schedule?: Json;
+  error?: string;
+}
+
+/** A schedule as the harness accepts it, or a message telling the model
+ * exactly what to send instead. Coercion first, error second: models
+ * routinely stringify nested objects, say "daily", or shorten weekday
+ * names, and each of those has one obvious meaning. */
+function normalizeScheduleInput(args: Json): NormalizedSchedule {
+  let raw = args.schedule;
+  if (typeof raw === "string") {
+    // Some models deliver nested objects as JSON strings.
+    try {
+      raw = JSON.parse(raw);
+    } catch {
+      return { error: `The schedule must be a JSON object, not text. ${SUPPORTED_SCHEDULES}` };
+    }
+  }
+  if (!jsonRecord(raw)) return { error: `The schedule must be a JSON object. ${SUPPORTED_SCHEDULES}` };
+  const type = typeof raw.type === "string" ? raw.type.trim().toLowerCase() : "";
+  if (type === "once") {
+    if (typeof raw.at !== "string" || !raw.at.trim()) {
+      return { error: `A once schedule needs "at": a future RFC3339 date-time with an explicit offset, for example 2026-09-01T09:00:00+05:30.` };
+    }
+    return { schedule: { type: "once", at: raw.at.trim() } };
+  }
+  if (type === "weekly" || type === "daily") {
+    const time = typeof raw.time === "string" ? raw.time.trim() : "";
+    if (!time) return { error: `A ${type} schedule needs "time" in 24-hour HH:MM, for example 09:00.` };
+    let weekdays: string[];
+    if (type === "daily") {
+      // daily = weekly on all seven days; an explicit weekdays list narrows it.
+      weekdays = Array.isArray(raw.weekdays) && raw.weekdays.length ? raw.weekdays : [...WEEKDAYS];
+    } else {
+      if (!Array.isArray(raw.weekdays) || raw.weekdays.length === 0) {
+        return { error: `A weekly schedule needs "weekdays", for example ["monday","friday"] — or use {"type":"daily"} to run every day.` };
+      }
+      weekdays = raw.weekdays;
+    }
+    const normalized: string[] = [];
+    for (const day of weekdays) {
+      const lower = String(day).trim().toLowerCase();
+      const full = (WEEKDAYS as readonly string[]).includes(lower)
+        ? lower
+        : Object.hasOwn(SHORT_WEEKDAYS, lower)
+          ? SHORT_WEEKDAYS[lower as keyof typeof SHORT_WEEKDAYS]
+          : undefined;
+      if (!full) return { error: `Unsupported weekday "${String(day)}". Use full names: ${WEEKDAYS.join(", ")}.` };
+      if (!normalized.includes(full)) normalized.push(full);
+    }
+    return { schedule: { type: "weekly", time, weekdays: normalized } };
+  }
+  if (type === "interval" || type === "cron" || type === "hourly" || type === "minutes") {
+    return { error: `Routines cannot run on sub-day intervals. ${SUPPORTED_SCHEDULES} Pick the closest daily or weekly time and tell the user about this limit.` };
+  }
+  return { error: `Unknown schedule type "${type || "(missing)"}". ${SUPPORTED_SCHEDULES}` };
+}
 
 const ROUTINE_FIELDS_SCHEMA = {
   name: { type: "string", minLength: 1, maxLength: 80, description: "Short name shown in Routines." },
@@ -247,16 +321,18 @@ function routineAction(value: unknown): RoutineAction | null {
     : null;
 }
 
-function routineFields(args: Json): Json {
+function routineFields(args: Json): { fields: Json; error?: string } {
   const fields: Json = {};
   if (typeof args.name === "string") fields.name = args.name.trim();
   if (typeof args.instructions === "string") fields.instructions = args.instructions.trim();
-  if (args.schedule && typeof args.schedule === "object" && !Array.isArray(args.schedule)) {
-    fields.schedule = args.schedule;
+  if (args.schedule !== undefined && args.schedule !== null) {
+    const normalized = normalizeScheduleInput(args);
+    if (normalized.error) return { fields, error: normalized.error };
+    fields.schedule = normalized.schedule;
   }
   if (typeof args.run_on === "string") fields.runOn = args.run_on;
   if (typeof args.duration_minutes === "number") fields.durationMinutes = args.duration_minutes;
-  return fields;
+  return { fields };
 }
 
 function confirmationResult(r: Json, fallback: string): { text: string } {
@@ -370,7 +446,8 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     };
   }
   if (name === "propose_routine") {
-    const routine = routineFields(args);
+    const { fields: routine, error: scheduleError } = routineFields(args);
+    if (scheduleError) return { text: scheduleError, isError: true };
     if (!routine.name || !routine.instructions || !routine.schedule) {
       return { text: "propose_routine needs name, instructions, and schedule.", isError: true };
     }
@@ -401,7 +478,8 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       if (!jsonRecord(args.changes)) {
         return { text: "The update action needs at least one field in changes.", isError: true };
       }
-      const changes = routineFields(args.changes);
+      const { fields: changes, error: scheduleError } = routineFields(args.changes);
+      if (scheduleError) return { text: scheduleError, isError: true };
       if (!Object.keys(changes).length) {
         return { text: "The update action needs at least one supported field in changes.", isError: true };
       }


### PR DESCRIPTION
## What changed

`propose_routine`'s schedule schema and input handling in the agents MCP proxy. Harness dialect and server are untouched.

- **Flat schema, no `oneOf`/`const`/`format`.** The schedule was a `oneOf` of two `const`-discriminated branches — exactly the JSON-Schema composition keywords several agent CLIs flatten or drop when converting MCP tools into their provider's function-call format (codex-rs only began preserving `oneOf` in June 2026, `codex-rs/tools/src/json_schema.rs` #24118; its large-schema compaction still prunes compositions; other drivers simplify harder). A model that never saw the branches guesses shapes forever. The schema is now one flat object (`type: once|weekly|daily` + `at`/`time`/`weekdays`) with the rules in descriptions.
- **Coercion for what models actually send** (`normalizeScheduleInput`): `"daily"` → weekly-on-all-7-days on the wire; JSON-string schedules parsed; weekday names case-folded, short names (`mon`…`sun`) expanded.
- **Guiding errors instead of walls**: sub-day intervals are named as unsupported with the closest alternatives spelled out; `weekly` without `weekdays` points at `"daily"`; unknown types list the three supported shapes with examples. Same for `propose_routine_action` update changes.

## Why

Field report hours after 0.1.38 shipped #540: a bot (gpt-5.6-sol) failed `agents_propose_routine` on **every** attempt — tried a 30-min interval, concluded "only weekly is supported, best I can do is daily", sent `type:"daily"`, failed six more times, then told the user "the routine proposal tool is returning errors every time — it's not accepting any input."

I reproduced the full pipeline against a live server (real proxy → real `/api/internal/routine-requests`): **valid payloads work** — the field failures are all model-shaped inputs, and the old replies never taught the model the correct shape:

| payload | before | after |
|---|---|---|
| valid weekly | ✅ card | ✅ card (byte-identical dialect) |
| `type:"daily"` | ❌ `Invalid discriminator value. Expected 'once' \| 'weekly'` | ✅ card (weekly × 7 days) |
| schedule as JSON string | ❌ needs name/instructions/schedule | ✅ card |
| `["Mon","FRI"]` | ❌ (short names) / ✅ caps only | ✅ card |
| 30-min interval | ❌ `Invalid discriminator value…` | ❌ with instructions naming the limit + closest shapes |
| weekly w/o weekdays | ❌ `expected array, received undefined` | ❌ with `use {"type":"daily"}` guidance |

## How it was verified

- `npx vitest run server/drivers/agents-proxy.test.ts` — 20 pass. New: flat-schema assertion (regexp-guards against any composition keyword reappearing in the tool surface), daily-alias wire shape, case/short weekday folding, string-schedule parsing, guided errors that never reach the harness. Existing weekly/once passthrough tests unchanged.
- Mutation check: disabling the daily alias fails the new tests; restoring passes.
- Live end-to-end (dev server on a scratch data dir + real proxy): the table above is from that run.
- `pnpm typecheck` clean. Lint: this file has 35 pre-existing anti-slop findings on main; the additions follow the file's existing no-deps `typeof`-boundary style (6 more of the same rules; lint is not a CI gate — flagging for transparency).

## Note for reviewers

The same conversion fragility applies to any future MCP tool schema: **avoid `oneOf`/`anyOf`/`const` in tool inputs** — flat objects + description-enforced rules + instructive errors survive every driver. Might be worth a line in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved routine scheduling support for one-time, weekly, and daily routines.
  - Daily schedules are automatically interpreted across all seven days.
  - Weekday names are normalized consistently, including abbreviated and capitalized forms.
  - Schedule details provided as JSON text are now recognized automatically.

- **Bug Fixes**
  - Unsupported or incomplete schedules now return clearer guidance before a routine is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->