### PR TITLE
docs(contributing): keep MCP tool schemas flat — provider conversion eats composition keywords

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,24 @@ The SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately small. A
    failed spawn as a failed turn — never a hang, never a crash.
 5. Bring a contract test following the fake-CLI pattern (scripted fake process + `recordEvents`).
 
+## MCP tool schemas
+
+Tool `inputSchema`s travel through every engine's own MCP-to-provider conversion before a model
+sees them, and those converters are lossy: composition keywords get flattened, dropped, or pruned
+by size-compaction passes (codex only began preserving `oneOf` in mid-2026; others simplify
+harder). A model that never saw your schema's branches guesses shapes forever — that is exactly
+how chat routine proposals failed in the field hours after 0.1.38 shipped (#544).
+
+- **Never use `oneOf`, `anyOf`, `allOf`, `const`, or `format` in a tool `inputSchema`.** Advertise
+  one flat object; put per-variant rules in `description`s. `enum` on plain strings is fine.
+- **Coerce before you reject.** Models stringify nested objects, shorten enum values, and vary
+  case. If an input has one obvious meaning, accept it and normalize on the wire.
+- **Errors must teach.** When you refuse an input, the message states the supported shapes with a
+  literal example the model can copy. "Invalid discriminator value" burns a turn; an example
+  fixes the next call.
+- A schema test should assert the tool surface stays flat
+  (see `server/drivers/agents-proxy.test.ts` — it regexp-guards the serialized schema).
+
 ## Platform rules
 
 - The harness (`server/`) must stay portable Node. Anything macOS-only (TCC, Swift helpers,


### PR DESCRIPTION
## What changed

A new **MCP tool schemas** section in CONTRIBUTING.md, between the driver SPI guidance and Platform rules:

- never `oneOf`/`anyOf`/`allOf`/`const`/`format` in a tool `inputSchema` — flat object + description-enforced rules (string `enum` is fine)
- coerce inputs with one obvious meaning instead of rejecting them
- refusal messages must state the supported shapes with a copyable example
- keep a schema test that regexp-guards the serialized tool surface (pattern in `server/drivers/agents-proxy.test.ts`)

## Why

Follow-up to #544, as suggested in its review notes: the routine-proposal field failure happened because engines' MCP-to-provider schema converters flatten or drop composition keywords, and the model never saw the branches. The rule belongs in CONTRIBUTING so the next tool surface doesn't relearn it in production.

## How it was verified

Docs-only; rendered locally. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for designing MCP tool schemas.
  * Documented supported schema patterns, input handling expectations, refusal error examples, and requirements for maintaining a flat tool interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->