### PR TITLE
feat(openai-compat): pin OpenRouter upstream provider and default model

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -304,6 +304,8 @@ describe("credential env preference", () => {
     "XAI_API_KEY",
     "OPENAI_COMPAT_API_KEY",
     "OPENAI_COMPAT_URL",
+    "OPENAI_COMPAT_MODEL",
+    "OPENAI_COMPAT_PROVIDER",
     "BOX_TOKEN",
     "OPENCODE_API_KEY",
     "OMB_TTS_KEY",
@@ -388,6 +390,35 @@ describe("credential env preference", () => {
     expect(process.env.COMPOSIO_API_KEY).toBe("ak_just_saved");
     expect(process.env.BOX_TOKEN).toBeUndefined();
     expect(process.env.OMB_TTS_KEY).toBeUndefined();
+  });
+
+  it("syncCredentialEnv keeps model and provider env in step with a save", () => {
+    // loadConfig() prefers OPENAI_COMPAT_MODEL/PROVIDER over the file, so a
+    // mid-session save must update them like key/url or the boot-injected
+    // values shadow the save until relaunch
+    process.env.OPENAI_COMPAT_MODEL = "boot-model";
+    process.env.OPENAI_COMPAT_PROVIDER = "boot-provider";
+    syncCredentialEnv({
+      openaiCompat: { model: "vendor/just-saved", provider: "fireworks" },
+    });
+    expect(process.env.OPENAI_COMPAT_MODEL).toBe("vendor/just-saved");
+    expect(process.env.OPENAI_COMPAT_PROVIDER).toBe("fireworks");
+  });
+
+  it("syncCredentialEnv clears model and provider env on an empty-string save", () => {
+    process.env.OPENAI_COMPAT_MODEL = "boot-model";
+    process.env.OPENAI_COMPAT_PROVIDER = "boot-provider";
+    syncCredentialEnv({ openaiCompat: { model: "", provider: "" } });
+    expect(process.env.OPENAI_COMPAT_MODEL).toBeUndefined();
+    expect(process.env.OPENAI_COMPAT_PROVIDER).toBeUndefined();
+  });
+
+  it("syncCredentialEnv leaves model and provider env untouched when absent from the patch", () => {
+    process.env.OPENAI_COMPAT_MODEL = "boot-model";
+    process.env.OPENAI_COMPAT_PROVIDER = "boot-provider";
+    syncCredentialEnv({ openaiCompat: { key: "just-saved" } });
+    expect(process.env.OPENAI_COMPAT_MODEL).toBe("boot-model");
+    expect(process.env.OPENAI_COMPAT_PROVIDER).toBe("boot-provider");
   });
 });
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -77,7 +77,11 @@ const instanceConfigSchema = z.object({
 const instanceConfigMapSchema = z.record(z.string(), instanceConfigSchema);
 const appConfigSchema = z.object({
   xai: z.object({ key: optionalText, url: optionalText }).optional(),
-  openaiCompat: z.object({ key: optionalText, url: optionalText }).optional(),
+  /** `model` seeds the default selection; `provider` pins an OpenRouter
+   * upstream (e.g. "fireworks"). Both are non-secret and optional. */
+  openaiCompat: z
+    .object({ key: optionalText, url: optionalText, model: optionalText, provider: optionalText })
+    .optional(),
   /** Project key used for Sessions, catalog and agent tools. userId/sessionId
    * are non-secret local identifiers used to reuse one Composio Session. */
   composio: z.object({ apiKey: optionalText, userId: optionalText, sessionId: optionalText }).optional(),
@@ -103,7 +107,7 @@ const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   xai?: { key?: string; url?: string };
-  openaiCompat?: { key?: string; url?: string };
+  openaiCompat?: { key?: string; url?: string; model?: string; provider?: string };
   composio?: { apiKey?: string; userId?: string; sessionId?: string };
   box?: { token?: string };
   /** A named host from the user's SSH config. Authentication stays with SSH. */
@@ -198,6 +202,8 @@ export function loadConfig(): AppConfig {
   cfg.openaiCompat = { ...cfg.openaiCompat };
   if (process.env.OPENAI_COMPAT_API_KEY !== undefined) cfg.openaiCompat.key = process.env.OPENAI_COMPAT_API_KEY;
   if (process.env.OPENAI_COMPAT_URL !== undefined) cfg.openaiCompat.url = process.env.OPENAI_COMPAT_URL;
+  if (process.env.OPENAI_COMPAT_MODEL !== undefined) cfg.openaiCompat.model = process.env.OPENAI_COMPAT_MODEL;
+  if (process.env.OPENAI_COMPAT_PROVIDER !== undefined) cfg.openaiCompat.provider = process.env.OPENAI_COMPAT_PROVIDER;
   cfg.composio = { ...cfg.composio };
   if (process.env.COMPOSIO_API_KEY !== undefined) cfg.composio.apiKey = process.env.COMPOSIO_API_KEY;
   cfg.box = { ...cfg.box };
@@ -457,15 +463,21 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     // intentionally not consulted by ProviderRegistry when it decodes a
     // driver's config, so carry the workspace default into the transient
     // instance map while preserving a per-instance override.
-    if (entry.driver === "openai-compat" && cfg.openaiCompat?.url) {
-      const raw = entry.config;
-      if (raw === undefined) {
-        entry.config = { url: cfg.openaiCompat.url };
-      } else if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
-        const current = raw as Record<string, unknown>;
-        if (typeof current.url !== "string" || !current.url.trim()) {
-          entry.config = { ...current, url: cfg.openaiCompat.url };
+    if (entry.driver === "openai-compat" && cfg.openaiCompat) {
+      const defaults: Record<string, string> = {};
+      if (cfg.openaiCompat.url) defaults.url = cfg.openaiCompat.url;
+      if (cfg.openaiCompat.model) defaults.model = cfg.openaiCompat.model;
+      if (cfg.openaiCompat.provider) defaults.provider = cfg.openaiCompat.provider;
+      if (Object.keys(defaults).length) {
+        const raw = entry.config;
+        const current =
+          typeof raw === "object" && raw !== null && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+        const merged = { ...current };
+        // A per-instance value always wins over the workspace default.
+        for (const [k, v] of Object.entries(defaults)) {
+          if (typeof merged[k] !== "string" || !(merged[k] as string).trim()) merged[k] = v;
         }
+        entry.config = merged;
       }
     }
   }

--- a/server/config.ts
+++ b/server/config.ts
@@ -239,9 +239,17 @@ export function syncCredentialEnv(patch: Partial<AppConfig>): void {
     if (value) process.env[name] = value;
     else delete process.env[name];
   }
-  if (patch.openaiCompat?.url !== undefined) {
-    if (patch.openaiCompat.url) process.env["OPENAI_COMPAT_URL"] = patch.openaiCompat.url;
-    else delete process.env["OPENAI_COMPAT_URL"];
+  // loadConfig() also prefers env for url/model/provider, so a saved value
+  // must follow the same set-when-truthy / delete-when-cleared rule as keys.
+  const settings: Array<[value: string | undefined, name: string]> = [
+    [patch.openaiCompat?.url, "OPENAI_COMPAT_URL"],
+    [patch.openaiCompat?.model, "OPENAI_COMPAT_MODEL"],
+    [patch.openaiCompat?.provider, "OPENAI_COMPAT_PROVIDER"],
+  ];
+  for (const [value, name] of settings) {
+    if (value === undefined) continue;
+    if (value) process.env[name] = value;
+    else delete process.env[name];
   }
 }
 

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -224,4 +224,106 @@ describe("OpenAICompatDriver", () => {
     recorder.stop();
     await inst.dispose();
   });
+
+  it("decodes a default model and provider from config", () => {
+    const cfg = OpenAICompatDriver.decodeConfig({
+      model: "deepseek/deepseek-v4-flash-0731",
+      provider: "fireworks",
+    });
+    expect(cfg.model).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(cfg.provider).toBe("fireworks");
+  });
+
+  it("seeds the picker with the configured default model", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 })),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-default-model",
+      displayName: "Default model",
+      enabled: true,
+      config: {
+        url: "https://openrouter.ai/api/v1",
+        apiKeyEnv: "TEST_KEY",
+        model: "deepseek/deepseek-v4-flash-0731",
+      },
+      environment: { TEST_KEY: "secret" },
+    });
+    expect(inst.models.default).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(inst.models.options.some((o) => o.id === "deepseek/deepseek-v4-flash-0731")).toBe(true);
+    await inst.dispose();
+  });
+
+  it("pins the OpenRouter upstream provider in the request body", async () => {
+    let sentBody: any = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n' + "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-provider-route",
+      displayName: "Provider route",
+      enabled: true,
+      config: {
+        url: "https://openrouter.ai/api/v1",
+        apiKeyEnv: "TEST_KEY",
+        provider: "fireworks",
+      },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({
+      threadId: "thread-p",
+      text: "prompt",
+      model: "deepseek/deepseek-v4-flash-0731",
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(sentBody?.model).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(sentBody?.provider).toEqual({ order: ["fireworks"], allow_fallbacks: false });
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("omits provider routing when none is configured", async () => {
+    let sentBody: any = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n' + "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-no-provider",
+      displayName: "No provider",
+      enabled: true,
+      config: { url: "https://openrouter.ai/api/v1", apiKeyEnv: "TEST_KEY" },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread-np", text: "prompt", model: "vendor/model" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(sentBody).not.toBeNull();
+    expect("provider" in sentBody).toBe(false);
+    recorder.stop();
+    await inst.dispose();
+  });
 });

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -295,6 +295,117 @@ describe("OpenAICompatDriver", () => {
     await inst.dispose();
   });
 
+  it("omits provider routing on non-OpenRouter endpoints even when configured", async () => {
+    let sentBody: any = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n' + "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-groq-no-provider",
+      displayName: "Groq strict",
+      enabled: true,
+      config: {
+        url: "https://api.groq.com/openai/v1",
+        apiKeyEnv: "TEST_KEY",
+        provider: "fireworks",
+      },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread-g", text: "prompt", model: "vendor/model" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    // Strict OpenAI-compatible endpoints (Groq et al.) reject unknown
+    // top-level fields — `provider` is OpenRouter-only routing.
+    expect(sentBody).not.toBeNull();
+    expect("provider" in sentBody).toBe(false);
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("does not treat a lookalike host as OpenRouter", async () => {
+    let sentBody: any = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n' + "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-lookalike",
+      displayName: "Lookalike host",
+      enabled: true,
+      config: {
+        // hostname is NOT openrouter.ai — substring matching on the whole
+        // URL would be fooled by a lookalike domain or a path segment
+        url: "https://notopenrouter.ai/api/v1",
+        apiKeyEnv: "TEST_KEY",
+        provider: "fireworks",
+      },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread-l", text: "prompt", model: "vendor/model" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(sentBody).not.toBeNull();
+    expect("provider" in sentBody).toBe(false);
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("pins the provider on an OpenRouter subdomain", async () => {
+    let sentBody: any = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n' + "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OpenAICompatDriver.create({
+      instanceId: "test-subdomain",
+      displayName: "OpenRouter subdomain",
+      enabled: true,
+      config: {
+        url: "https://gateway.openrouter.ai/api/v1",
+        apiKeyEnv: "TEST_KEY",
+        provider: "fireworks",
+      },
+      environment: { TEST_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread-s", text: "prompt", model: "vendor/model" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(sentBody?.provider).toEqual({ order: ["fireworks"], allow_fallbacks: false });
+    recorder.stop();
+    await inst.dispose();
+  });
+
   it("omits provider routing when none is configured", async () => {
     let sentBody: any = null;
     vi.stubGlobal(

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -42,9 +42,22 @@ export interface OpenAICompatConfig {
   /** Default model when a turn doesn't specify one (seeds the picker). */
   model?: string;
   /** OpenRouter upstream provider slug to pin (e.g. "fireworks"). Sent as
-   * `provider: { order: [provider], allow_fallbacks: false }`; endpoints that
-   * don't speak OpenRouter routing ignore the extra field. */
+   * `provider: { order: [provider], allow_fallbacks: false }` — but only to
+   * OpenRouter endpoints: strict OpenAI-compatible servers (Groq et al.)
+   * reject unknown top-level fields. */
   provider?: string;
+}
+
+/** True when the configured base URL points at OpenRouter (openrouter.ai or
+ * a subdomain). Parses the hostname rather than substring-matching the whole
+ * URL, so lookalike domains and path segments don't count. */
+function isOpenRouterUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "openrouter.ai" || host.endsWith(".openrouter.ai");
+  } catch {
+    return false;
+  }
 }
 
 function decodeConfig(raw: unknown): OpenAICompatConfig {
@@ -147,8 +160,11 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           model,
           messages,
           stream: opts.stream,
-          // OpenRouter routing: pin the upstream provider when configured.
-          ...(config.provider ? { provider: { order: [config.provider], allow_fallbacks: false } } : {}),
+          // OpenRouter routing: pin the upstream provider when configured —
+          // only on OpenRouter itself; strict endpoints reject the field.
+          ...(config.provider && isOpenRouterUrl(config.url)
+            ? { provider: { order: [config.provider], allow_fallbacks: false } }
+            : {}),
         }),
         signal: opts.signal ?? AbortSignal.timeout(120_000),
       });

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -39,11 +39,19 @@ export interface OpenAICompatConfig {
   apiKeyEnv: string;
   /** Direct API key if configured */
   key?: string;
+  /** Default model when a turn doesn't specify one (seeds the picker). */
+  model?: string;
+  /** OpenRouter upstream provider slug to pin (e.g. "fireworks"). Sent as
+   * `provider: { order: [provider], allow_fallbacks: false }`; endpoints that
+   * don't speak OpenRouter routing ignore the extra field. */
+  provider?: string;
 }
 
 function decodeConfig(raw: unknown): OpenAICompatConfig {
   const o = (raw ?? {}) as Record<string, unknown>;
   const envUrl = process.env.OPENAI_COMPAT_URL;
+  const envModel = process.env.OPENAI_COMPAT_MODEL;
+  const envProvider = process.env.OPENAI_COMPAT_PROVIDER;
   return {
     url:
       typeof o.url === "string" && o.url
@@ -53,6 +61,8 @@ function decodeConfig(raw: unknown): OpenAICompatConfig {
           : "https://openrouter.ai/api/v1",
     apiKeyEnv: typeof o.apiKeyEnv === "string" && o.apiKeyEnv ? o.apiKeyEnv : "OPENAI_COMPAT_API_KEY",
     key: typeof o.key === "string" && o.key ? o.key : undefined,
+    model: typeof o.model === "string" && o.model ? o.model : envModel || undefined,
+    provider: typeof o.provider === "string" && o.provider ? o.provider : envProvider || undefined,
   };
 }
 
@@ -92,7 +102,16 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
       "";
     const listeners = new Set<RuntimeEventListener>();
     const active = new Map<string, { abort: AbortController; turnId: string }>();
-    let catalog = DEFAULT_MODELS;
+    // A configured default model seeds the picker so the intended model is
+    // pre-selected before /models refreshes the catalog from the endpoint.
+    let catalog: ModelCatalog = config.model
+      ? {
+          default: config.model,
+          options: DEFAULT_MODELS.options.some((o) => o.id === config.model)
+            ? DEFAULT_MODELS.options
+            : [{ id: config.model, label: config.model }, ...DEFAULT_MODELS.options],
+        }
+      : DEFAULT_MODELS;
 
     const emit = (event: RuntimeEvent) => {
       for (const l of [...listeners]) l(event);
@@ -124,7 +143,13 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           authorization: `Bearer ${apiKey}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ model, messages, stream: opts.stream }),
+        body: JSON.stringify({
+          model,
+          messages,
+          stream: opts.stream,
+          // OpenRouter routing: pin the upstream provider when configured.
+          ...(config.provider ? { provider: { order: [config.provider], allow_fallbacks: false } } : {}),
+        }),
         signal: opts.signal ?? AbortSignal.timeout(120_000),
       });
       if (!res.ok) {
@@ -221,7 +246,12 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           options.push({ id, label });
         }
         if (options.length) {
-          catalog = { default: options[0].id, options };
+          // Keep a configured default selected; surface it even if the
+          // endpoint's catalog omits it.
+          const preferred =
+            config.model && (options.some((o) => o.id === config.model) ? config.model : null);
+          if (config.model && !preferred) options.unshift({ id: config.model, label: config.model });
+          catalog = { default: config.model ?? options[0].id, options };
         }
       } catch {
         // keep DEFAULT_MODELS — never fail the instance on a catalog miss


### PR DESCRIPTION
## What changed

Two optional `openaiCompat` config fields: `model` seeds the picker's default
selection, and `provider` pins an OpenRouter upstream (e.g. `fireworks`). When
`provider` is set the driver sends `provider: { order: [provider],
allow_fallbacks: false }`; endpoints that don't speak OpenRouter routing ignore
the field. A configured `model` is pre-selected and survives the `/models`
refresh. Both thread through the existing `instanceConfigs` workspace-default
carry next to `url`, and fall back to `OPENAI_COMPAT_MODEL` /
`OPENAI_COMPAT_PROVIDER`.

## Why

The driver already defaults to OpenRouter, but there was no way to pin a
specific upstream. OpenRouter auto-routes, so a setup that needs one provider
for a given model (Fireworks for `deepseek/deepseek-v4-flash-0731`, in my case)
couldn't express it, and there's no UI for it. Seeding a default model needed
the same plumbing.

## How it was verified

- `pnpm typecheck` and `pnpm test` pass (Node 24).
- New unit tests in `openai-compat.test.ts`: config decode, catalog seeding,
  request body carries `provider` when configured and omits it when not.
- Live call to OpenRouter with `provider: fireworks` returned `provider:
  Fireworks` on the response.

## Screenshots (UI changes)

None; no UI change.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building (n/a)
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a default model for OpenAI-compatible connections.
  * Added optional provider routing for OpenRouter requests.
  * Preserved configured default models even when they are absent from the fetched model catalog.
  * Added environment variable configuration for model and provider settings.
  * Applied configured workspace defaults to temporary OpenAI-compatible connections.
  * Restricted provider routing to supported OpenRouter hostnames for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->