### PR TITLE
fix: remote live stream bubbles + sidebar grouping

### DIFF
--- a/server/comms-visibility.test.ts
+++ b/server/comms-visibility.test.ts
@@ -1,0 +1,41 @@
+import { rmSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { BOT_CHATS_SECTION } from "../shared/sidebar-layout.ts";
+import { DATA_DIR } from "./config.ts";
+import type { ModelSelection } from "./contracts.ts";
+import { getOrCreateChannel } from "./comms-visibility.ts";
+import { closeMessageDb } from "./message-db.ts";
+import { Store } from "./store.ts";
+
+const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
+
+describe("getOrCreateChannel", () => {
+  beforeEach(() => {
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+  afterEach(() => {
+    closeMessageDb();
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+
+  it("files a new bot chat under Bot Chats, not the sender's team section", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const channel = getOrCreateChannel(store, from, target);
+    expect(channel.dm).toBe(true);
+    expect(channel.section).toBe(BOT_CHATS_SECTION);
+    expect(channel.name).toContain("⇄");
+  });
+
+  it("moves an existing Agents DM into Bot Chats the next time the pair talks", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const stale = store.createGroup("Forge ⇄ Quarry", [from.id, target.id], true, "Agents");
+    const channel = getOrCreateChannel(store, from, target);
+    expect(channel.id).toBe(stale.id);
+    expect(channel.section).toBe(BOT_CHATS_SECTION);
+  });
+});

--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -2,6 +2,7 @@
 // per-thread chips. Extracted from /api/internal/ask-bot so delegations
 // (delegate_bot) and any future peer flow reuse the same UX without a copy.
 
+import { BOT_CHATS_SECTION } from "../shared/sidebar-layout.ts";
 import { sectionKey, type BotRecord, type GroupRecord, type Message, type Store } from "./store.ts";
 
 /** What a peer-exchange helper needs from the outside world:
@@ -20,12 +21,12 @@ export interface CommsBus {
 export function getOrCreateChannel(store: Store, from: BotRecord, target: BotRecord): GroupRecord {
   const existing = store.dmGroup(from.id, target.id);
   if (existing) {
-    if (sectionKey(existing.section) !== sectionKey(from.section)) {
-      return store.patchGroup(existing.id, { section: from.section }) ?? existing;
+    if (sectionKey(existing.section) !== sectionKey(BOT_CHATS_SECTION)) {
+      return store.patchGroup(existing.id, { section: BOT_CHATS_SECTION }) ?? existing;
     }
     return existing;
   }
-  return store.createGroup(`${from.name} ⇄ ${target.name}`, [from.id, target.id], true, from.section);
+  return store.createGroup(`${from.name} ⇄ ${target.name}`, [from.id, target.id], true, BOT_CHATS_SECTION);
 }
 
 /** Mirror `from`'s outgoing message into the channel, drop chips into

--- a/server/index.ts
+++ b/server/index.ts
@@ -2125,6 +2125,7 @@ async function startTurn(
       drainSecretResumes();
     }
   })();
+  return userMessage;
 }
 
 // ── routines: persisted definitions → detached bot tasks ───────────────
@@ -2622,7 +2623,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
   // Capture the active thread once. Every queued responder below is bound to
   // this task even if another client asks to switch later.
   const threadId = group.threadId;
-  store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: replyTo?.id });
+  const message = store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: replyTo?.id });
   if (!group.dm) store.titleGroupTaskFromFirstMessage(group.id, text, threadId);
 
   const members = group.memberIds
@@ -2666,7 +2667,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
         tool: { name: unavailableMessage, ok: false },
       });
     }
-    return;
+    return message;
   }
 
   const operation = beginGroupTurnOperation(groupId, threadId);
@@ -2701,6 +2702,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
   });
   const tracked = next.finally(() => finishGroupTurnOperation(groupId, operation));
   groupQueues.set(groupId, tracked.catch(() => {}));
+  return message;
 }
 
 function roomSetupPending(group: GroupRecord): boolean {
@@ -3781,11 +3783,14 @@ const server = createServer(async (req, res) => {
       }
 
       sseClients.add(client);
+      req.socket.setTimeout(0);
+      // Comment keepalives hold the TCP socket; a `data:` ping is what
+      // EventSource can actually see, so a remote client notices a dead hop.
       const keepalive = setInterval(() => {
         try {
-          res.write(": keepalive\n\n");
+          res.write(`: keepalive\n\ndata: ${JSON.stringify({ kind: "ping" })}\n\n`);
         } catch {}
-      }, 25_000);
+      }, 15_000);
       req.on("close", () => {
         clearInterval(keepalive);
         sseClients.delete(client);
@@ -4581,8 +4586,8 @@ const server = createServer(async (req, res) => {
         return json(res, 409, { error: "the channel switched tasks before it could receive the message" });
       }
       const replyTo = resolveReplyTarget(group.threadId, body.replyToId);
-      startGroupTurn(group.id, text, replyTo);
-      return json(res, 202, { ok: true });
+      const message = startGroupTurn(group.id, text, replyTo);
+      return json(res, 202, { ok: true, threadId: group.threadId, message });
     }
     m = path.match(/^\/api\/groups\/([\w-]+)\/interrupt$/);
     if (m && method === "POST") {
@@ -5181,14 +5186,14 @@ const server = createServer(async (req, res) => {
             .catch(() => false);
           if (steered) {
             clearUnattended(bot.id);
-            store.appendMessage(bot.threadId, {
+            const message = store.appendMessage(bot.threadId, {
               role: "user",
               kind: "text",
               text,
               replyToId: replyTo?.id,
               steered: true,
             });
-            return json(res, 202, { ok: true, steered: true });
+            return json(res, 202, { ok: true, steered: true, threadId: bot.threadId, message });
           }
         }
         const queued = queueSteeredMessage(bot, text, {
@@ -5197,8 +5202,8 @@ const server = createServer(async (req, res) => {
         });
         return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId: bot.threadId });
       }
-      await startTurn(bot.id, text, { replyTo });
-      return json(res, 202, { ok: true });
+      const message = await startTurn(bot.id, text, { replyTo });
+      return json(res, 202, { ok: true, threadId: bot.threadId, message });
     }
 
     m = path.match(/^\/api\/bots\/([\w-]+)\/queue\/([\w-]+)$/);
@@ -6091,6 +6096,9 @@ const server = createServer(async (req, res) => {
     return json(res, status, { error: e instanceof Error ? e.message : String(e) });
   }
 });
+
+server.requestTimeout = 0;
+server.headersTimeout = 0;
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);

--- a/server/store.ts
+++ b/server/store.ts
@@ -14,6 +14,7 @@ import { newId, type CloudBackend, type ModelSelection, type ThreadId } from "./
 import { pickBotName } from "./names.ts";
 import { redactSecretsInText } from "./redact.ts";
 import { botAvatarProfile, type BotAvatarCrop } from "../shared/bot-avatar.ts";
+import { BOT_CHATS_SECTION } from "../shared/sidebar-layout.ts";
 import type { RoutineRequestCardData } from "../shared/routine-request.ts";
 
 export type MausColor =
@@ -626,6 +627,10 @@ export class Store {
       g.defaultResponder = normalized;
       // Bot-to-bot channels intentionally remain one canonical thread.
       if (g.dm) {
+        if (sectionKey(g.section) !== sectionKey(BOT_CHATS_SECTION)) {
+          g.section = BOT_CHATS_SECTION;
+          groupsMigrated = true;
+        }
         if (g.tasks !== undefined) {
           delete g.tasks;
           groupsMigrated = true;

--- a/shared/codex-micro-slots.ts
+++ b/shared/codex-micro-slots.ts
@@ -1,0 +1,65 @@
+import { partitionSidebarBots, type SidebarMember } from "./sidebar-layout.ts";
+
+export const CODEX_MICRO_SLOT_COUNT = 6;
+
+export type CodexMicroStatus = "ready" | "working" | "waiting" | "needsYou" | "error" | "offline";
+
+export interface CodexMicroAgent {
+  id: string;
+  name: string;
+  status: CodexMicroStatus;
+}
+
+/** First six sidebar bots: unsectioned Chief of Staff, then pinned, then the rest. */
+export function codexMicroSlotBots<T extends SidebarMember>(bots: T[], limit = CODEX_MICRO_SLOT_COUNT): T[] {
+  const parts = partitionSidebarBots(bots);
+  const ordered = [
+    ...(parts.unsectionedChief ? [parts.unsectionedChief] : []),
+    ...parts.pinnedUnderChief,
+    ...parts.unsectionedBots,
+    ...parts.sectionChiefs,
+    ...parts.sectionedBots,
+  ];
+  const seen = new Set<string>();
+  const slots: T[] = [];
+  for (const bot of ordered) {
+    if (seen.has(bot.id)) continue;
+    seen.add(bot.id);
+    slots.push(bot);
+    if (slots.length >= limit) break;
+  }
+  return slots;
+}
+
+export function botCodexStatus(bot: {
+  activity?: "working" | "waiting-on-you" | "idle" | "no-signal" | "dead";
+  busy?: boolean;
+}): CodexMicroStatus {
+  if (bot.activity === "working" || bot.busy) return "working";
+  if (bot.activity === "waiting-on-you") return "needsYou";
+  if (bot.activity === "no-signal") return "waiting";
+  if (bot.activity === "dead") return "error";
+  return "ready";
+}
+
+export interface CodexMicroRoster {
+  agents: CodexMicroAgent[];
+}
+
+export function codexMicroRoster(
+  bots: Array<
+    SidebarMember & {
+      name?: string;
+      activity?: "working" | "waiting-on-you" | "idle" | "no-signal" | "dead";
+      busy?: boolean;
+    }
+  >,
+): CodexMicroRoster {
+  return {
+    agents: codexMicroSlotBots(bots).map((bot) => ({
+      id: bot.id,
+      name: bot.name?.trim() || bot.id,
+      status: botCodexStatus(bot),
+    })),
+  };
+}

--- a/shared/sidebar-layout.ts
+++ b/shared/sidebar-layout.ts
@@ -1,0 +1,170 @@
+/** Built-in Projects row (unsectioned rooms). Id stays `channels` so saved
+ * collapse/order keys keep working. */
+export const CHANNELS_SECTION_ID = "channels";
+export const PROJECTS_SECTION = "Projects";
+
+/** Built-in bucket for bot⇄bot DMs. Displayed from `group.dm`, not from a user-created section name. */
+export const BOT_CHATS_SECTION_ID = "bot-chats";
+export const BOT_CHATS_SECTION = "Bot Chats";
+
+/** Built-in bucket for pinned bots. Displayed from `bot.pinned`, not a user section name. */
+export const PINNED_SECTION_ID = "pinned";
+
+/** Unsectioned, unpinned bots. */
+export const BOTS_SECTION_ID = "bots";
+
+/** Footer tools (Team map, routines, connected apps). Profile + settings stay visible. */
+export const MORE_NAV_ID = "more";
+
+/** Default list order for built-in buckets. User sections follow unless the user moved them. */
+export const DEFAULT_BUILTIN_SECTION_ORDER = [
+  PINNED_SECTION_ID,
+  CHANNELS_SECTION_ID,
+  BOT_CHATS_SECTION_ID,
+  BOTS_SECTION_ID,
+] as const;
+
+export function sidebarSectionLabel(id: string): string {
+  if (id === PINNED_SECTION_ID) return "Pinned";
+  if (id === CHANNELS_SECTION_ID) return PROJECTS_SECTION;
+  if (id === BOT_CHATS_SECTION_ID) return BOT_CHATS_SECTION;
+  if (id === BOTS_SECTION_ID) return "Bots";
+  return id;
+}
+
+export function isReservedSectionId(id: string): boolean {
+  return (
+    id === PINNED_SECTION_ID ||
+    id === CHANNELS_SECTION_ID ||
+    id === BOT_CHATS_SECTION_ID ||
+    id === BOTS_SECTION_ID
+  );
+}
+
+export type SidebarMember = {
+  id: string;
+  chiefOfStaff?: boolean;
+  section?: string;
+  pinned?: boolean;
+  hidden?: boolean;
+};
+
+export type SidebarGroup = {
+  id: string;
+  section?: string;
+  dm?: boolean;
+};
+
+/** Bot⇄bot DMs always sit in the built-in Bot Chats bucket, even if they
+ * were previously filed under the sender's team section (Agents). */
+export function partitionSidebarGroups<T extends SidebarGroup>(groups: T[]) {
+  const botChats = groups.filter((group) => Boolean(group.dm) || group.section === BOT_CHATS_SECTION);
+  const botChatIds = new Set(botChats.map((group) => group.id));
+  const rooms = groups.filter((group) => !botChatIds.has(group.id));
+  const sectionedRooms = rooms.filter((group) => Boolean(group.section));
+  const unsectionedRooms = rooms.filter((group) => !group.section);
+  return { botChats, sectionedRooms, unsectionedRooms };
+}
+
+export function orderedSectionNames(discovered: string[], savedOrder: string[]): string[] {
+  const unique = [...new Set(discovered.filter(Boolean))];
+  const known = savedOrder.filter((name) => unique.includes(name));
+  const rest = unique.filter((name) => !known.includes(name));
+  return [...known, ...rest];
+}
+
+/** Mix built-in buckets and user sections. Saved order wins; anything new
+ * (Pinned, Projects, a newly created team) inserts at its default index
+ * relative to the current list instead of dumping at the end. */
+export function orderedSidebarSections(present: string[], savedOrder: string[]): string[] {
+  const unique = [...new Set(present.filter(Boolean))];
+  const known = savedOrder.filter((id) => unique.includes(id));
+  if (known.length === 0) return unique;
+  const result = [...known];
+  for (const id of unique) {
+    if (result.includes(id)) continue;
+    const defaultIndex = unique.indexOf(id);
+    let insertAt = result.length;
+    for (let i = 0; i < result.length; i++) {
+      if (unique.indexOf(result[i]!) > defaultIndex) {
+        insertAt = i;
+        break;
+      }
+    }
+    result.splice(insertAt, 0, id);
+  }
+  return result;
+}
+
+export function moveSection(names: string[], name: string, direction: -1 | 1): string[] {
+  const index = names.indexOf(name);
+  const nextIndex = index + direction;
+  if (index < 0 || nextIndex < 0 || nextIndex >= names.length) return names;
+  const next = names.slice();
+  const [moved] = next.splice(index, 1);
+  next.splice(nextIndex, 0, moved);
+  return next;
+}
+
+export type SectionDropPlace = "before" | "after";
+
+/** Drop `fromId` before or after `targetId`. Same-item drops are a no-op. */
+export function placeSection(
+  ids: string[],
+  fromId: string,
+  targetId: string,
+  place: SectionDropPlace,
+): string[] {
+  if (fromId === targetId) return ids;
+  const from = ids.indexOf(fromId);
+  const target = ids.indexOf(targetId);
+  if (from < 0 || target < 0) return ids;
+  const next = ids.filter((id) => id !== fromId);
+  let insertAt = next.indexOf(targetId);
+  if (insertAt < 0) return ids;
+  if (place === "after") insertAt += 1;
+  next.splice(insertAt, 0, fromId);
+  return next;
+}
+
+export function sameSectionOrder(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}
+
+/** Apply a new visible order and put empty sections back after the neighbor
+ * they used to follow, instead of dropping them from the saved list. */
+export function mergeSectionOrder(saved: string[], visibleOrder: string[]): string[] {
+  const result = visibleOrder.filter(Boolean);
+  const inResult = new Set(result);
+  for (let savedIndex = 0; savedIndex < saved.length; savedIndex++) {
+    const id = saved[savedIndex];
+    if (!id || inResult.has(id)) continue;
+    let insertAt = result.length;
+    for (let i = savedIndex - 1; i >= 0; i--) {
+      const pos = result.indexOf(saved[i]!);
+      if (pos >= 0) {
+        insertAt = pos + 1;
+        break;
+      }
+    }
+    result.splice(insertAt, 0, id);
+    inResult.add(id);
+  }
+  return result;
+}
+
+/** Pinned non-chief bots sit directly under the unsectioned Chief of Staff. */
+export function partitionSidebarBots<T extends SidebarMember>(bots: T[]) {
+  const visible = bots.filter((bot) => !bot.hidden);
+  const unsectionedChief = visible.find((bot) => bot.chiefOfStaff && !bot.section) ?? null;
+  const pinnedUnderChief = visible.filter((bot) => !bot.chiefOfStaff && Boolean(bot.pinned));
+  const pinnedIds = new Set(pinnedUnderChief.map((bot) => bot.id));
+  const sectionChiefs = visible.filter((bot) => bot.chiefOfStaff && bot.section);
+  const sectionedBots = visible.filter(
+    (bot) => !bot.chiefOfStaff && bot.section && !pinnedIds.has(bot.id),
+  );
+  const unsectionedBots = visible.filter(
+    (bot) => !bot.chiefOfStaff && !bot.section && !pinnedIds.has(bot.id),
+  );
+  return { unsectionedChief, pinnedUnderChief, sectionChiefs, sectionedBots, unsectionedBots };
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { CommandPalette } from "@/components/CommandPalette";
 import { LocalVmWorkspace } from "@/components/LocalVmWorkspace";
 import { SkillRecorderPage } from "@/components/SkillRecorderPage";
 import { TeamMapPage } from "@/components/TeamMapPage";
+import { CODEX_MICRO_SLOT_COUNT, codexMicroSlotBots } from "@/lib/codex-micro-slots";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -46,17 +47,21 @@ function Shell() {
     !state.instances.some((i) => i.snapshot.state === "available");
 
   // App-wide shortcuts: ⌘N new bot · ⌘1–9 jump to bot · ⌘⇧[ / ⌘⇧] prev/next.
-  // Kept deliberately small; every panel already closes on Esc.
+  // ⌘1–6 match Codex Micro AG00–AG05 (Chief, then pinned, then the rest).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
       const bots = state.bots.filter((b) => !b.hidden);
+      const slots = codexMicroSlotBots(bots, CODEX_MICRO_SLOT_COUNT);
       if (e.key === "n" && !e.shiftKey) {
         e.preventDefault();
         dispatch({ type: "newBot" });
       } else if (/^[1-9]$/.test(e.key)) {
-        const target = bots[Number(e.key) - 1];
+        const digit = Number(e.key);
+        const target = digit <= CODEX_MICRO_SLOT_COUNT
+          ? slots[digit - 1]
+          : bots.filter((bot) => !slots.some((slot) => slot.id === bot.id))[digit - CODEX_MICRO_SLOT_COUNT - 1];
         if (target) {
           e.preventDefault();
           dispatch({ type: "select", id: target.id });

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -11,6 +11,7 @@ import { memo, useEffect, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Check, Copy } from "lucide-react";
+import { copyText } from "@/lib/copy-text";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed and capped. Streamed partials may land here
@@ -105,9 +106,11 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
   }, [code, lang, streaming]);
 
   const copy = () => {
-    void navigator.clipboard?.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+    void copyText(code).then((ok) => {
+      if (!ok) return;
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
   };
 
   return (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -24,6 +24,7 @@ import {
   Webhook,
   X,
 } from "lucide-react";
+import { copyText } from "@/lib/copy-text";
 import { cachedInput, costCaption, formatTokens, formatUsd, hasFiniteCost, usageChip, usageDetail } from "@/lib/usage";
 import {
   useStore,
@@ -147,10 +148,15 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
   const [copied, setCopied] = useState(false);
   return (
     <button
-      onClick={() => {
-        void navigator.clipboard?.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1200);
+      type="button"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void copyText(text).then((ok) => {
+          if (!ok) return;
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        });
       }}
       aria-label="Copy message"
       title="Copy message"

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -199,7 +199,7 @@ export function CommandPalette({ onOpenChange }: { onOpenChange?: (open: boolean
           )}
           {rooms.length > 0 && (
             <div className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-              Channels
+              Projects
             </div>
           )}
           {rooms.map((group, i) =>

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -14,6 +14,7 @@ import { Bug, ChevronDown, ChevronRight, RefreshCw, X } from "lucide-react";
 import { useStore, type Bot } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { formatTime, toRows, type InspectorEntry, type InspectorPage, type InspectorRow } from "@/lib/inspector";
+import { openLiveEvents } from "@/lib/live-events";
 import type { RuntimeEvent } from "../../server/contracts.ts";
 
 type Lens = "events" | "raw";
@@ -62,29 +63,29 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
   // up. Own EventSource on purpose: the store folds runtime events into
   // chat state and does not re-emit them.
   useEffect(() => {
-    const es = new EventSource("/api/events?screens=off");
     let settle: ReturnType<typeof setTimeout> | null = null;
-    es.onmessage = (raw) => {
-      let frame: { kind?: string; event?: RuntimeEvent };
-      try {
-        frame = JSON.parse(raw.data);
-      } catch {
-        return;
-      }
-      if (frame.kind !== "runtime" || !frame.event || frame.event.threadId !== threadId) return;
-      const event = frame.event;
-      setPage((prev) => {
-        const entry: InspectorEntry = { kind: "runtime", at: event.createdAt, data: event };
-        if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
-        return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
-      });
-      if (event.type === "turn.completed" || event.type === "runtime.error") {
-        if (settle) clearTimeout(settle);
-        settle = setTimeout(() => void load(), 400);
-      }
-    };
+    const stopLive = openLiveEvents({
+      screens: false,
+      onFrame: (raw) => {
+        if (raw.kind !== "runtime") return;
+        const event = raw.event;
+        if (!event || Array.isArray(event) || Object(event) !== event) return;
+        // SAFETY: runtime frames carry the harness RuntimeEvent payload.
+        const runtime = event as RuntimeEvent;
+        if (runtime.threadId !== threadId) return;
+        setPage((prev) => {
+          const entry: InspectorEntry = { kind: "runtime", at: runtime.createdAt, data: runtime };
+          if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
+          return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
+        });
+        if (runtime.type === "turn.completed" || runtime.type === "runtime.error") {
+          if (settle) clearTimeout(settle);
+          settle = setTimeout(() => void load(), 400);
+        }
+      },
+    });
     return () => {
-      es.close();
+      stopLive();
       if (settle) clearTimeout(settle);
     };
   }, [threadId, load]);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { track } from "@/lib/analytics";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   Archive,
@@ -8,6 +8,8 @@ import {
   Bot as BotIcon,
   CalendarDays,
   Check,
+  ChevronDown,
+  ChevronRight,
   ClipboardCopy,
   Copy,
   Crown,
@@ -45,12 +47,34 @@ import { MIN_QUERY, SearchResults } from "./SearchResults";
 import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
 import { BotPickerList } from "./BotPickerList";
+import { phoneSettingsAction, SidebarPhoneButton } from "./SidebarPhoneButton";
 import {
+  loadCollapsedSections,
+  loadSectionOrder,
   loadSidebarDensity,
+  saveCollapsedSections,
+  saveSectionOrder,
   saveSidebarDensity,
+  toggleCollapsedSection,
   type SidebarDensity,
 } from "@/lib/sidebar-preferences";
-import { phoneSettingsAction, SidebarPhoneButton } from "./SidebarPhoneButton";
+import {
+  BOT_CHATS_SECTION_ID,
+  BOTS_SECTION_ID,
+  CHANNELS_SECTION_ID,
+  MORE_NAV_ID,
+  PINNED_SECTION_ID,
+  isReservedSectionId,
+  mergeSectionOrder,
+  moveSection,
+  orderedSidebarSections,
+  partitionSidebarBots,
+  partitionSidebarGroups,
+  placeSection,
+  sameSectionOrder,
+  sidebarSectionLabel,
+  type SectionDropPlace,
+} from "@/lib/sidebar-layout";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
 function profileInitials(profile?: { name?: string; email?: string }): string {
@@ -290,6 +314,7 @@ function RoomContextMenu({
   }, [onClose]);
 
   if (!group) return null;
+  const isBotChat = Boolean(group.dm);
   const saveRename = () => {
     const name = nextRename(group.name, draft);
     if (name) dispatch({ type: "patchGroup", groupId: group.id, patch: { name } });
@@ -327,7 +352,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={saveRename}
-            aria-label="Save channel name"
+            aria-label={isBotChat ? "Save chat name" : "Save channel name"}
             title="Save"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -336,7 +361,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Cancel channel rename"
+            aria-label={isBotChat ? "Cancel chat rename" : "Cancel channel rename"}
             title="Cancel"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -352,19 +377,21 @@ function RoomContextMenu({
           className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
         >
           <Pencil size={16} className="text-ink-secondary" />
-          Rename Channel
+          {isBotChat ? "Rename chat" : "Rename Channel"}
         </button>
       )}
-      <button
-        onClick={() => {
-          onClose();
-          onMoveToSection(group.id);
-        }}
-        className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
-      >
-        <FolderPlus size={16} className="text-ink-secondary" />
-        Move to context
-      </button>
+      {!isBotChat && (
+        <button
+          onClick={() => {
+            onClose();
+            onMoveToSection(group.id);
+          }}
+          className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+        >
+          <FolderPlus size={16} className="text-ink-secondary" />
+          Move to context
+        </button>
+      )}
       <button
         onClick={() => {
           void navigator.clipboard?.writeText(group.threadId);
@@ -383,7 +410,7 @@ function RoomContextMenu({
         className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-danger hover:bg-raised/70"
       >
         <Trash2 size={16} />
-        Delete Channel
+        {isBotChat ? "Delete chat" : "Delete Channel"}
       </button>
     </div>,
     document.body,
@@ -464,15 +491,91 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
   );
 }
 
+const SECTION_DRAG_TYPE = "application/x-openmausbot-section";
+
 /** Labeled divider between sidebar sections. Same typographic register as
- * EngineGroupLabel so the sidebar reads as one system. */
-function SectionDivider({ name }: { name: string }) {
-  return (
-    <div className="flex items-center gap-2 px-3 pb-1 pt-3 first:pt-0" data-section={name}>
-      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+ * EngineGroupLabel so the sidebar reads as one system. Reorderable headers
+ * are the drag handle; a click (not a drag) still toggles collapse. */
+function SectionDivider({
+  name,
+  collapsed,
+  onToggle,
+  reorderable,
+  dragging,
+  onDragStart,
+  onDragEnd,
+  onMove,
+}: {
+  name: string;
+  collapsed?: boolean;
+  onToggle?: () => void;
+  reorderable?: boolean;
+  dragging?: boolean;
+  onDragStart?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: () => void;
+  onMove?: (direction: -1 | 1) => void;
+}) {
+  const skippedClick = useRef(false);
+  const Chevron = collapsed ? ChevronRight : ChevronDown;
+  const label = (
+    <>
+      {onToggle && <Chevron size={12} className="shrink-0 text-ink-secondary" />}
+      <span className="truncate px-1 text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
         {name}
       </span>
       <span className="h-px flex-1 bg-hairline/40" />
+    </>
+  );
+  return (
+    <div className="flex items-center gap-1 px-2 pb-1 pt-3 first:pt-0" data-section={name}>
+      {onToggle ? (
+        <div
+          role="button"
+          tabIndex={0}
+          draggable={Boolean(reorderable)}
+          aria-expanded={!collapsed}
+          aria-label={reorderable ? `${name}, drag to reorder` : name}
+          title={reorderable ? "Drag to reorder" : undefined}
+          onDragStart={(event) => {
+            skippedClick.current = true;
+            onDragStart?.(event);
+          }}
+          onDragEnd={() => {
+            onDragEnd?.();
+            window.setTimeout(() => {
+              skippedClick.current = false;
+            }, 0);
+          }}
+          onClick={() => {
+            if (skippedClick.current) {
+              skippedClick.current = false;
+              return;
+            }
+            onToggle();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onToggle();
+            } else if (event.key === "ArrowUp") {
+              event.preventDefault();
+              onMove?.(-1);
+            } else if (event.key === "ArrowDown") {
+              event.preventDefault();
+              onMove?.(1);
+            }
+          }}
+          className={cn(
+            "flex min-w-0 flex-1 select-none items-center gap-1.5 rounded-md px-1 py-0.5 text-left hover:bg-raised/50",
+            reorderable && "cursor-grab active:cursor-grabbing",
+            dragging && "opacity-40",
+          )}
+        >
+          {label}
+        </div>
+      ) : (
+        label
+      )}
     </div>
   );
 }
@@ -1035,6 +1138,18 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     return saved === "icons" ? "comfortable" : saved;
   });
   const [densityOpen, setDensityOpen] = useState(false);
+  const [collapsedSections, setCollapsedSections] = useState<string[]>(() => loadCollapsedSections());
+  const [sectionOrder, setSectionOrder] = useState<string[]>(() => loadSectionOrder());
+  const [draggingSectionId, setDraggingSectionId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: string; place: SectionDropPlace } | null>(null);
+  const dragRef = useRef<{
+    from: string | null;
+    over: { id: string; place: SectionDropPlace } | null;
+  }>({ from: null, over: null });
+  const orderRef = useRef<{ sectionIds: string[]; sectionOrder: string[] }>({
+    sectionIds: [],
+    sectionOrder: [],
+  });
 
   const setDensity = (next: SidebarDensity) => {
     setDensityState(next);
@@ -1227,29 +1342,79 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         (b.title ?? "").toLowerCase().includes(q) ||
         preview(b).toLowerCase().includes(q),
     );
-  const unsectionedChief = matchingBots.find((bot) => bot.chiefOfStaff && !bot.section);
-  const sectionChiefs = matchingBots.filter((bot) => bot.chiefOfStaff && bot.section);
-  const sectionedBots = matchingBots
-    .filter((bot) => !bot.chiefOfStaff && bot.section)
-    .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
-  const visibleBots = matchingBots
-    .filter((bot) => !bot.chiefOfStaff && !bot.section)
-    .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
+  const {
+    unsectionedChief,
+    pinnedUnderChief,
+    sectionChiefs,
+    sectionedBots,
+    unsectionedBots: visibleBots,
+  } = partitionSidebarBots(matchingBots);
   const visibleGroups = state.groups.filter((g) => !q || g.name.toLowerCase().includes(q));
-  const sectionedGroups = visibleGroups.filter((g) => g.section);
-  const unsectionedGroups = visibleGroups.filter((g) => !g.section);
-  // sections keep first-appearance order within the current list; a section
-  // whose members all moved away (or fell out of the filter) simply vanishes
-  const sectionNames: string[] = [];
+  const { botChats, sectionedRooms: sectionedGroups, unsectionedRooms: unsectionedGroups } =
+    partitionSidebarGroups(visibleGroups);
+  // Built-in buckets (Pinned, Projects, Bot Chats, Bots) share one order
+  // list with user sections so every header can be dragged.
+  const discoveredSectionNames: string[] = [];
   for (const bot of sectionedBots) {
-    if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
+    if (bot.section && !isReservedSectionId(bot.section) && !discoveredSectionNames.includes(bot.section)) {
+      discoveredSectionNames.push(bot.section);
+    }
   }
   for (const bot of sectionChiefs) {
-    if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
+    if (bot.section && !isReservedSectionId(bot.section) && !discoveredSectionNames.includes(bot.section)) {
+      discoveredSectionNames.push(bot.section);
+    }
   }
   for (const group of sectionedGroups) {
-    if (!sectionNames.includes(group.section!)) sectionNames.push(group.section!);
+    if (group.section && !isReservedSectionId(group.section) && !discoveredSectionNames.includes(group.section)) {
+      discoveredSectionNames.push(group.section);
+    }
   }
+  const presentSectionIds: string[] = [];
+  if (pinnedUnderChief.length > 0) presentSectionIds.push(PINNED_SECTION_ID);
+  if (unsectionedGroups.length > 0) presentSectionIds.push(CHANNELS_SECTION_ID);
+  if (botChats.length > 0) presentSectionIds.push(BOT_CHATS_SECTION_ID);
+  if (visibleBots.length > 0) presentSectionIds.push(BOTS_SECTION_ID);
+  presentSectionIds.push(...discoveredSectionNames);
+  const sectionIds = orderedSidebarSections(presentSectionIds, sectionOrder);
+  orderRef.current = { sectionIds, sectionOrder };
+  const collapseEnabled = density !== "icons" && !q;
+  const sectionCollapsed = (id: string) => collapseEnabled && collapsedSections.includes(id);
+  const toggleSection = (id: string) => {
+    const next = toggleCollapsedSection(collapsedSections, id);
+    setCollapsedSections(next);
+    saveCollapsedSections(next);
+  };
+  const commitSectionOrder = (visibleOrder: string[]) => {
+    const persist = mergeSectionOrder(orderRef.current.sectionOrder, visibleOrder);
+    if (sameSectionOrder(persist, orderRef.current.sectionOrder)) return;
+    orderRef.current = { ...orderRef.current, sectionOrder: persist };
+    setSectionOrder(persist);
+    saveSectionOrder(persist);
+  };
+  const shiftSection = (id: string, direction: -1 | 1) => {
+    commitSectionOrder(moveSection(orderRef.current.sectionIds, id, direction));
+  };
+  const finishSectionDrag = () => {
+    const { from, over } = dragRef.current;
+    dragRef.current = { from: null, over: null };
+    setDraggingSectionId(null);
+    setDropTarget(null);
+    if (!from || !over) return;
+    commitSectionOrder(placeSection(orderRef.current.sectionIds, from, over.id, over.place));
+  };
+  const updateDropTarget = (event: React.DragEvent<HTMLElement>, id: string) => {
+    if (!dragRef.current.from) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const place: SectionDropPlace = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    const current = dragRef.current.over;
+    if (current?.id === id && current.place === place) return;
+    const next = { id, place };
+    dragRef.current.over = next;
+    setDropTarget(next);
+  };
   const activeBotCount = state.bots.filter((bot) => !bot.hidden).length;
   const archivedBots = state.bots.filter((bot) => bot.hidden);
   const pendingTeamUndo = teamFeedback?.undo;
@@ -1433,9 +1598,16 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       </div>
 
       {/* Bot list */}
-      <div className="flex-1 overflow-y-auto px-2">
+      <div
+        className="flex-1 overflow-y-auto px-2"
+        onDragOver={(event) => {
+          if (!dragRef.current.from) return;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+        }}
+      >
         <div className="flex flex-col gap-0.5">
-          {!unsectionedChief && sectionChiefs.length === 0 && visibleBots.length === 0 && sectionedBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
+          {!unsectionedChief && pinnedUnderChief.length === 0 && sectionChiefs.length === 0 && visibleBots.length === 0 && sectionedBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
           )}
           {unsectionedChief && (
@@ -1449,114 +1621,190 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
               />
             </div>
           )}
-          {unsectionedGroups.length > 0 && density !== "icons" && <SectionDivider name="Channels" />}
-          {unsectionedGroups.map((g) => (
-            <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
-          ))}
-          {visibleBots.length > 0 && density !== "icons" && <SectionDivider name="Bots" />}
-          {visibleBots.map((b) => (
-            <BotListItem
-              key={b.id}
-              bot={b}
-              density={density}
-              onMenu={setMenu}
-              onArchive={(bot) => void archiveBot(bot)}
-              archiveDisabled={activeBotCount <= 1}
-            />
-          ))}
-          {sectionNames.map((name) => (
-            <Fragment key={name}>
-              {density !== "icons" && <SectionDivider name={name} />}
-              {sectionChiefs
-                .filter((bot) => bot.section === name)
-                .map((bot) => (
-                  <BotListItem
-                    key={bot.id}
-                    bot={bot}
-                    density={density}
-                    onMenu={setMenu}
-                    onArchive={(candidate) => void archiveBot(candidate)}
-                    archiveDisabled
-                  />
-                ))}
-              {sectionedGroups
-                .filter((g) => g.section === name)
-                .map((g) => (
-                  <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
-                ))}
-              {sectionedBots
-                .filter((b) => b.section === name)
-                .map((b) => (
-                  <BotListItem
-                    key={b.id}
-                    bot={b}
-                    density={density}
-                    onMenu={setMenu}
-                    onArchive={(bot) => void archiveBot(bot)}
-                    archiveDisabled={activeBotCount <= 1}
-                  />
-                ))}
-            </Fragment>
+          {sectionIds.map((id) => (
+            <div
+              key={id}
+              onDragOver={(event) => updateDropTarget(event, id)}
+              onDrop={(event) => {
+                event.preventDefault();
+                const fromId =
+                  event.dataTransfer.getData(SECTION_DRAG_TYPE) ||
+                  event.dataTransfer.getData("text/plain") ||
+                  dragRef.current.from;
+                if (fromId && !dragRef.current.over) {
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  dragRef.current.over = {
+                    id,
+                    place: event.clientY < rect.top + rect.height / 2 ? "before" : "after",
+                  };
+                }
+                if (fromId) dragRef.current.from = fromId;
+                finishSectionDrag();
+              }}
+            >
+              {dropTarget?.id === id && dropTarget.place === "before" && draggingSectionId !== id && (
+                <div className="mx-2 h-0.5 rounded-full bg-accent" />
+              )}
+              {density !== "icons" && (
+                <SectionDivider
+                  name={sidebarSectionLabel(id)}
+                  collapsed={sectionCollapsed(id)}
+                  onToggle={() => toggleSection(id)}
+                  reorderable={collapseEnabled}
+                  dragging={draggingSectionId === id}
+                  onDragStart={(event) => {
+                    event.dataTransfer.effectAllowed = "move";
+                    event.dataTransfer.setData(SECTION_DRAG_TYPE, id);
+                    event.dataTransfer.setData("text/plain", id);
+                    dragRef.current = { from: id, over: null };
+                    setDraggingSectionId(id);
+                  }}
+                  onDragEnd={() => finishSectionDrag()}
+                  onMove={(direction) => shiftSection(id, direction)}
+                />
+              )}
+              {!sectionCollapsed(id) && (
+                <>
+                  {id === PINNED_SECTION_ID &&
+                    pinnedUnderChief.map((b) => (
+                      <BotListItem
+                        key={b.id}
+                        bot={b}
+                        density={density}
+                        onMenu={setMenu}
+                        onArchive={(bot) => void archiveBot(bot)}
+                        archiveDisabled={activeBotCount <= 1}
+                      />
+                    ))}
+                  {id === CHANNELS_SECTION_ID &&
+                    unsectionedGroups.map((g) => (
+                      <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
+                    ))}
+                  {id === BOT_CHATS_SECTION_ID &&
+                    botChats.map((g) => (
+                      <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
+                    ))}
+                  {id === BOTS_SECTION_ID &&
+                    visibleBots.map((b) => (
+                      <BotListItem
+                        key={b.id}
+                        bot={b}
+                        density={density}
+                        onMenu={setMenu}
+                        onArchive={(bot) => void archiveBot(bot)}
+                        archiveDisabled={activeBotCount <= 1}
+                      />
+                    ))}
+                  {!isReservedSectionId(id) && (
+                    <>
+                      {sectionChiefs
+                        .filter((bot) => bot.section === id)
+                        .map((bot) => (
+                          <BotListItem
+                            key={bot.id}
+                            bot={bot}
+                            density={density}
+                            onMenu={setMenu}
+                            onArchive={(candidate) => void archiveBot(candidate)}
+                            archiveDisabled
+                          />
+                        ))}
+                      {sectionedGroups
+                        .filter((g) => g.section === id)
+                        .map((g) => (
+                          <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
+                        ))}
+                      {sectionedBots
+                        .filter((b) => b.section === id)
+                        .map((b) => (
+                          <BotListItem
+                            key={b.id}
+                            bot={b}
+                            density={density}
+                            onMenu={setMenu}
+                            onArchive={(bot) => void archiveBot(bot)}
+                            archiveDisabled={activeBotCount <= 1}
+                          />
+                        ))}
+                    </>
+                  )}
+                </>
+              )}
+              {dropTarget?.id === id && dropTarget.place === "after" && draggingSectionId !== id && (
+                <div className="mx-2 h-0.5 rounded-full bg-accent" />
+              )}
+            </div>
           ))}
           <SearchResults query={query} onLanded={() => setQuery("")} />
         </div>
       </div>
 
-      {/* Footer */}
+      {/* Footer — tools collapse; profile name + settings gear stay. */}
       <div className={cn("pb-3 pt-2", density === "icons" ? "px-2" : "px-3")}>
-        <button
-          onClick={() => dispatch({ type: "showTeamMap" })}
-          aria-label={density === "icons" ? "Team map" : undefined}
-          title={density === "icons" ? "Team map" : undefined}
-          className={cn(
-            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-            state.activeView === "team-map" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-          )}
-        >
-          <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
-        </button>
-        {skillRecorderEnabled(state.config) && (
-          <button
-            onClick={() => dispatch({ type: "showSkillRecorder" })}
-            aria-label={density === "icons" ? "Teach a skill" : undefined}
-            title={density === "icons" ? "Teach a skill" : undefined}
-            className={cn(
-              "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-              density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-              state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-            )}
-          >
-            <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
-            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
-          </button>
+        {density !== "icons" && (
+          <SectionDivider
+            name="More"
+            collapsed={sectionCollapsed(MORE_NAV_ID)}
+            onToggle={() => toggleSection(MORE_NAV_ID)}
+          />
         )}
-        <button
-          onClick={() => dispatch({ type: "showRoutines" })}
-          aria-label={density === "icons" ? "Tasks and routines" : undefined}
-          title={density === "icons" ? "Tasks and routines" : undefined}
-          className={cn(
-            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-            state.activeView === "routines" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-          )}
-        >
-          <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Tasks &amp; routines</span>
-          {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
-            <span className="size-2 rounded-full bg-danger" />
-          )}
-        </button>
-        <button
-          onClick={() => dispatch({ type: "togglePlugins", open: true })}
-          className={cn("flex min-h-10 w-full items-center rounded-xl py-2 text-left hover:bg-raised/50", density === "icons" ? "justify-center px-2" : "gap-3 px-3")}
-          aria-label={density === "icons" ? "Connected apps" : undefined}
-          title={density === "icons" ? "Connected apps" : undefined}
-        >
-          <Puzzle size={20} className="text-ink-secondary" />
-          <span className={cn("text-[14px] text-ink", density === "icons" && "hidden")}>Connected apps</span>
-        </button>
+        {!sectionCollapsed(MORE_NAV_ID) && (
+          <>
+            <button
+              onClick={() => dispatch({ type: "showTeamMap" })}
+              aria-label={density === "icons" ? "Team map" : undefined}
+              title={density === "icons" ? "Team map" : undefined}
+              className={cn(
+                "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+                density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+                state.activeView === "team-map" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+              )}
+            >
+              <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
+              <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
+            </button>
+            {skillRecorderEnabled(state.config) && (
+              <button
+                onClick={() => dispatch({ type: "showSkillRecorder" })}
+                aria-label={density === "icons" ? "Teach a skill" : undefined}
+                title={density === "icons" ? "Teach a skill" : undefined}
+                className={cn(
+                  "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+                  density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+                  state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+                )}
+              >
+                <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
+                <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
+              </button>
+            )}
+            <button
+              onClick={() => dispatch({ type: "showRoutines" })}
+              aria-label={density === "icons" ? "Tasks and routines" : undefined}
+              title={density === "icons" ? "Tasks and routines" : undefined}
+              className={cn(
+                "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+                density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+                state.activeView === "routines" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+              )}
+            >
+              <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
+              <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Tasks &amp; routines</span>
+              {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
+                <span className="size-2 rounded-full bg-danger" />
+              )}
+            </button>
+            <button
+              onClick={() => dispatch({ type: "togglePlugins", open: true })}
+              className={cn("flex min-h-10 w-full items-center rounded-xl py-2 text-left hover:bg-raised/50", density === "icons" ? "justify-center px-2" : "gap-3 px-3")}
+              aria-label={density === "icons" ? "Connected apps" : undefined}
+              title={density === "icons" ? "Connected apps" : undefined}
+            >
+              <Puzzle size={20} className="text-ink-secondary" />
+              <span className={cn("text-[14px] text-ink", density === "icons" && "hidden")}>Connected apps</span>
+            </button>
+          </>
+        )}
         {density === "icons" && (
           <SidebarPhoneButton
             density={density}

--- a/src/lib/codex-micro-slots.test.ts
+++ b/src/lib/codex-micro-slots.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { botCodexStatus, codexMicroRoster, codexMicroSlotBots } from "./codex-micro-slots";
+
+describe("codexMicroSlotBots", () => {
+  it("puts the unsectioned chief first, then pinned bots, then the rest", () => {
+    const slots = codexMicroSlotBots([
+      { id: "anchor", name: "Anchor", section: "Agents" },
+      { id: "forge", name: "Forge", pinned: true, section: "Agents" },
+      { id: "trace", name: "Trace", chiefOfStaff: true },
+      { id: "vera", name: "Vera" },
+    ]);
+    expect(slots.map((bot) => bot.id)).toEqual(["trace", "forge", "vera", "anchor"]);
+  });
+});
+
+describe("codexMicroRoster", () => {
+  it("maps activity onto the deck status vocabulary", () => {
+    expect(botCodexStatus({ activity: "working" })).toBe("working");
+    expect(botCodexStatus({ activity: "waiting-on-you" })).toBe("needsYou");
+    expect(botCodexStatus({ busy: true })).toBe("working");
+    expect(
+      codexMicroRoster([{ id: "trace", name: "Trace", chiefOfStaff: true, activity: "idle" }]).agents,
+    ).toEqual([{ id: "trace", name: "Trace", status: "ready" }]);
+  });
+});

--- a/src/lib/codex-micro-slots.ts
+++ b/src/lib/codex-micro-slots.ts
@@ -1,0 +1,1 @@
+export * from "../../shared/codex-micro-slots";

--- a/src/lib/copy-text.test.ts
+++ b/src/lib/copy-text.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyText } from "./copy-text";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("copyText", () => {
+  it("uses the clipboard API when it succeeds", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(copyText("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when the clipboard API rejects", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const field = {
+      value: "",
+      setAttribute: vi.fn(),
+      style: { position: "", left: "" },
+      select: vi.fn(),
+      remove: vi.fn(),
+    };
+    const execCommand = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("document", {
+      createElement: () => field,
+      body: { appendChild: vi.fn() },
+      execCommand,
+    });
+    await expect(copyText("fallback")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(field.value).toBe("fallback");
+  });
+});

--- a/src/lib/copy-text.ts
+++ b/src/lib/copy-text.ts
@@ -1,0 +1,31 @@
+/** Copy plain text. Prefers the Clipboard API; falls back to a hidden textarea
+ * so Electron/http://127.0.0.1 still works when `navigator.clipboard` is missing
+ * or permission is denied. */
+export async function copyText(text: string): Promise<boolean> {
+  const value = text ?? "";
+  const clip = globalThis.navigator?.clipboard;
+  try {
+    if (clip?.writeText) {
+      await clip.writeText(value);
+      return true;
+    }
+  } catch {
+    /* fall through to execCommand */
+  }
+  const doc = globalThis.document;
+  if (!doc?.body) return false;
+  try {
+    const field = doc.createElement("textarea");
+    field.value = value;
+    field.setAttribute("readonly", "");
+    field.style.position = "fixed";
+    field.style.left = "-9999px";
+    doc.body.appendChild(field);
+    field.select();
+    const ok = doc.execCommand("copy");
+    field.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/live-events.test.ts
+++ b/src/lib/live-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SSE_STALE_MS,
+  isLivePing,
+  liveEventsUrl,
+  shouldReconnectLiveEvents,
+} from "./live-events";
+
+describe("live events URL", () => {
+  it("omits the query on a cold connect", () => {
+    expect(liveEventsUrl()).toBe("/api/events");
+    expect(liveEventsUrl({ screens: true })).toBe("/api/events");
+  });
+
+  it("resumes from a cursor and can decline screens", () => {
+    expect(liveEventsUrl({ since: "ab12cd34:9" })).toBe("/api/events?since=ab12cd34%3A9");
+    expect(liveEventsUrl({ since: "ab12cd34:9", screens: false })).toBe(
+      "/api/events?since=ab12cd34%3A9&screens=off",
+    );
+    expect(liveEventsUrl({ screens: false })).toBe("/api/events?screens=off");
+  });
+});
+
+describe("live events liveness", () => {
+  it("reconnects after two missed pings", () => {
+    expect(shouldReconnectLiveEvents(0, SSE_STALE_MS - 1)).toBe(false);
+    expect(shouldReconnectLiveEvents(0, SSE_STALE_MS)).toBe(true);
+  });
+
+  it("treats ping frames as liveness, not chat", () => {
+    expect(isLivePing({ kind: "ping" })).toBe(true);
+    expect(isLivePing({ kind: "message" })).toBe(false);
+  });
+});

--- a/src/lib/live-events.ts
+++ b/src/lib/live-events.ts
@@ -1,0 +1,123 @@
+/** Live `/api/events` connection for the UI.
+ *
+ * Browser EventSource never surfaces SSE comment keepalives (`: ping`), so a
+ * Tailscale/Vite proxy that holds a half-dead socket looks "open" forever and
+ * chat bubbles stop arriving. The harness therefore emits a `kind:"ping"`
+ * data frame; this helper reconnects with `?since=` when those go silent. */
+
+export const LIVE_EVENTS_PATH = "/api/events";
+/** Two missed 15s pings, with slack for a slow hop. */
+export const SSE_STALE_MS = 40_000;
+
+export function liveEventsUrl(opts?: { since?: string | null; screens?: boolean }): string {
+  const params = new URLSearchParams();
+  if (opts?.since) params.set("since", opts.since);
+  if (opts?.screens === false) params.set("screens", "off");
+  const query = params.toString();
+  return query ? `${LIVE_EVENTS_PATH}?${query}` : LIVE_EVENTS_PATH;
+}
+
+export function shouldReconnectLiveEvents(lastHeardAt: number, now: number, staleMs = SSE_STALE_MS): boolean {
+  return now - lastHeardAt >= staleMs;
+}
+
+export function isLivePing(frame: { kind?: unknown }): boolean {
+  return frame.kind === "ping";
+}
+
+export interface LiveFrame {
+  kind?: string;
+  cursor?: string;
+  resumed?: boolean;
+  threadId?: string;
+  message?: unknown;
+  event?: unknown;
+  seq?: number;
+}
+
+export interface LiveEventsHandlers {
+  onFrame: (frame: LiveFrame) => void;
+  onOpen?: () => void;
+  onError?: () => void;
+  screens?: boolean;
+  staleMs?: number;
+  now?: () => number;
+  eventSource?: typeof EventSource;
+}
+
+export function openLiveEvents(handlers: LiveEventsHandlers): () => void {
+  const EventSrc = handlers.eventSource ?? globalThis.EventSource;
+  const staleMs = handlers.staleMs ?? SSE_STALE_MS;
+  const now = handlers.now ?? Date.now;
+  let closed = false;
+  if (!EventSrc) {
+    handlers.onError?.();
+    return () => {
+      closed = true;
+    };
+  }
+  let source: EventSource | null = null;
+  let lastEventId = "";
+  let lastHeard = now();
+  let connecting = false;
+
+  const connect = () => {
+    if (closed || connecting) return;
+    connecting = true;
+    source?.close();
+    source = new EventSrc(liveEventsUrl({ since: lastEventId || null, screens: handlers.screens }));
+    source.onopen = () => {
+      connecting = false;
+      lastHeard = now();
+      handlers.onOpen?.();
+    };
+    source.onerror = () => {
+      connecting = false;
+      handlers.onError?.();
+    };
+    source.onmessage = (raw) => {
+      lastHeard = now();
+      if (raw.lastEventId) lastEventId = raw.lastEventId;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw.data);
+      } catch {
+        return;
+      }
+      if (!parsed || Array.isArray(parsed) || Object(parsed) !== parsed) return;
+      // SAFETY: SSE data lines are JSON objects with kind/cursor.
+      const frame = parsed as LiveFrame;
+      if (frame.cursor && frame.kind === "hello" && !raw.lastEventId) {
+        lastEventId = frame.cursor;
+      }
+      if (isLivePing(frame)) return;
+      handlers.onFrame(frame);
+    };
+  };
+
+  const poke = () => {
+    if (closed) return;
+    if (!shouldReconnectLiveEvents(lastHeard, now(), staleMs)) return;
+    handlers.onError?.();
+    connecting = false;
+    connect();
+  };
+
+  connect();
+  const timer = setInterval(poke, Math.min(10_000, Math.max(1_000, staleMs / 2)));
+  const onVisible = () => {
+    if (document.visibilityState === "visible") poke();
+  };
+  document.addEventListener("visibilitychange", onVisible);
+  window.addEventListener("online", poke);
+  window.addEventListener("focus", poke);
+
+  return () => {
+    closed = true;
+    clearInterval(timer);
+    source?.close();
+    document.removeEventListener("visibilitychange", onVisible);
+    window.removeEventListener("online", poke);
+    window.removeEventListener("focus", poke);
+  };
+}

--- a/src/lib/sidebar-layout.test.ts
+++ b/src/lib/sidebar-layout.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BOT_CHATS_SECTION,
+  BOT_CHATS_SECTION_ID,
+  BOTS_SECTION_ID,
+  CHANNELS_SECTION_ID,
+  PINNED_SECTION_ID,
+  mergeSectionOrder,
+  moveSection,
+  placeSection,
+  orderedSectionNames,
+  orderedSidebarSections,
+  partitionSidebarBots,
+  partitionSidebarGroups,
+  sidebarSectionLabel,
+} from "./sidebar-layout";
+
+describe("sidebar section order", () => {
+  it("keeps a saved order and appends newly discovered names", () => {
+    expect(orderedSectionNames(["Agents", "Strategy"], ["Strategy"])).toEqual(["Strategy", "Agents"]);
+  });
+
+  it("moves a section up and down without wrapping", () => {
+    expect(moveSection(["A", "B", "C"], "B", -1)).toEqual(["B", "A", "C"]);
+    expect(moveSection(["A", "B", "C"], "B", 1)).toEqual(["A", "C", "B"]);
+    expect(moveSection(["A", "B", "C"], "A", -1)).toEqual(["A", "B", "C"]);
+  });
+
+  it("places a dragged section before or after a target", () => {
+    expect(placeSection(["A", "B", "C"], "C", "A", "before")).toEqual(["C", "A", "B"]);
+    expect(placeSection(["A", "B", "C"], "A", "C", "after")).toEqual(["B", "C", "A"]);
+    expect(placeSection(["A", "B", "C"], "A", "A", "after")).toEqual(["A", "B", "C"]);
+  });
+
+  it("keeps empty sections in their saved slots when merging a visible drag", () => {
+    const saved = [PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID, "Agents"];
+    const visible = ["Agents", PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID];
+    expect(mergeSectionOrder(saved, visible)).toEqual([
+      "Agents",
+      PINNED_SECTION_ID,
+      CHANNELS_SECTION_ID,
+      BOT_CHATS_SECTION_ID,
+      BOTS_SECTION_ID,
+    ]);
+  });
+
+  it("promotes a user-only saved order to the full visible list", () => {
+    const visible = [BOT_CHATS_SECTION_ID, PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOTS_SECTION_ID, "Agents"];
+    expect(mergeSectionOrder(["Agents"], visible)).toEqual(visible);
+  });
+
+  it("uses present order when nothing is saved", () => {
+    const present = [PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID, "Agents"];
+    expect(orderedSidebarSections(present, [])).toEqual(present);
+  });
+
+  it("inserts new built-in buckets at their default slots when the saved order is only user sections", () => {
+    const present = [PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID, "Agents"];
+    expect(orderedSidebarSections(present, ["Agents"])).toEqual(present);
+  });
+
+  it("keeps a user move of Projects below Agents", () => {
+    const present = [PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID, "Agents"];
+    const saved = [PINNED_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID, "Agents", CHANNELS_SECTION_ID];
+    expect(orderedSidebarSections(present, saved)).toEqual(saved);
+  });
+
+  it("restores an empty section to its saved place when it comes back", () => {
+    const saved = ["Agents", PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID];
+    const withoutBots = ["Agents", PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID];
+    expect(orderedSidebarSections(withoutBots, saved)).toEqual(withoutBots);
+    expect(orderedSidebarSections(saved, saved)).toEqual(saved);
+  });
+
+  it("labels built-in buckets for the divider", () => {
+    expect(sidebarSectionLabel(PINNED_SECTION_ID)).toBe("Pinned");
+    expect(sidebarSectionLabel(CHANNELS_SECTION_ID)).toBe("Projects");
+    expect(sidebarSectionLabel("Agents")).toBe("Agents");
+  });
+});
+
+describe("partitionSidebarBots", () => {
+  it("lifts pinned bots to sit under the unsectioned chief", () => {
+    const parts = partitionSidebarBots([
+      { id: "trace", chiefOfStaff: true },
+      { id: "forge", pinned: true, section: "Agents" },
+      { id: "anchor", section: "Agents" },
+      { id: "vera" },
+    ]);
+    expect(parts.unsectionedChief?.id).toBe("trace");
+    expect(parts.pinnedUnderChief.map((bot) => bot.id)).toEqual(["forge"]);
+    expect(parts.sectionedBots.map((bot) => bot.id)).toEqual(["anchor"]);
+    expect(parts.unsectionedBots.map((bot) => bot.id)).toEqual(["vera"]);
+  });
+});
+
+describe("partitionSidebarGroups", () => {
+  it("lifts bot DMs into Bot Chats even when they still carry an Agents section", () => {
+    const parts = partitionSidebarGroups([
+      { id: "launch", section: "Agents" },
+      { id: "dm-stale", dm: true, section: "Agents" },
+      { id: "dm-new", dm: true, section: BOT_CHATS_SECTION },
+      { id: "general" },
+    ]);
+    expect(parts.botChats.map((group) => group.id)).toEqual(["dm-stale", "dm-new"]);
+    expect(parts.sectionedRooms.map((group) => group.id)).toEqual(["launch"]);
+    expect(parts.unsectionedRooms.map((group) => group.id)).toEqual(["general"]);
+  });
+});

--- a/src/lib/sidebar-layout.ts
+++ b/src/lib/sidebar-layout.ts
@@ -1,0 +1,1 @@
+export * from "../../shared/sidebar-layout";

--- a/src/lib/sidebar-preferences.test.ts
+++ b/src/lib/sidebar-preferences.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  SIDEBAR_COLLAPSED_KEY,
   SIDEBAR_DENSITY_KEY,
+  loadCollapsedSections,
   loadSidebarDensity,
   parseSidebarDensity,
+  saveCollapsedSections,
   saveSidebarDensity,
+  toggleCollapsedSection,
 } from "./sidebar-preferences";
 
 describe("sidebar density preferences", () => {
@@ -22,5 +26,14 @@ describe("sidebar density preferences", () => {
     expect(setItem).toHaveBeenCalledWith(SIDEBAR_DENSITY_KEY, "icons");
     expect(loadSidebarDensity({ getItem: () => "compact" })).toBe("compact");
     expect(loadSidebarDensity({ getItem: () => { throw new Error("blocked"); } })).toBe("comfortable");
+  });
+
+  it("persists collapsed section ids", () => {
+    const setItem = vi.fn();
+    saveCollapsedSections(["channels", "Agents"], { setItem });
+    expect(setItem).toHaveBeenCalledWith(SIDEBAR_COLLAPSED_KEY, "channels\nAgents");
+    expect(loadCollapsedSections({ getItem: () => "Strategy" })).toEqual(["Strategy"]);
+    expect(toggleCollapsedSection(["Agents"], "channels")).toEqual(["Agents", "channels"]);
+    expect(toggleCollapsedSection(["channels"], "channels")).toEqual([]);
   });
 });

--- a/src/lib/sidebar-preferences.ts
+++ b/src/lib/sidebar-preferences.ts
@@ -34,3 +34,53 @@ export function saveSidebarDensity(
     // The in-memory React state still makes the control useful this session.
   }
 }
+
+export const SIDEBAR_COLLAPSED_KEY = "openmausbot.sidebarCollapsedSections";
+export const SIDEBAR_SECTION_ORDER_KEY = "openmausbot.sidebarSectionOrder";
+
+function readStringList(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw.split("\n").filter((value) => value.length > 0);
+}
+
+function writeStringList(key: string, values: string[], storage?: Pick<Storage, "setItem"> | null): void {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    target?.setItem(key, values.join("\n"));
+  } catch {
+    /* same localStorage failure mode as density */
+  }
+}
+
+export function loadCollapsedSections(storage?: Pick<Storage, "getItem"> | null): string[] {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    return readStringList(target?.getItem(SIDEBAR_COLLAPSED_KEY) ?? null);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCollapsedSections(
+  names: string[],
+  storage?: Pick<Storage, "setItem"> | null,
+): void {
+  writeStringList(SIDEBAR_COLLAPSED_KEY, [...new Set(names)], storage);
+}
+
+export function toggleCollapsedSection(names: string[], id: string): string[] {
+  return names.includes(id) ? names.filter((name) => name !== id) : [...names, id];
+}
+
+export function loadSectionOrder(storage?: Pick<Storage, "getItem"> | null): string[] {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    return readStringList(target?.getItem(SIDEBAR_SECTION_ORDER_KEY) ?? null);
+  } catch {
+    return [];
+  }
+}
+
+export function saveSectionOrder(names: string[], storage?: Pick<Storage, "setItem"> | null): void {
+  writeStringList(SIDEBAR_SECTION_ORDER_KEY, names, storage);
+}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -24,6 +24,7 @@ import { showNotification, type NotificationTarget } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
 import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { isLivePing, openLiveEvents } from "@/lib/live-events";
 
 export type { MausColor } from "@/lib/mascot";
 
@@ -1340,6 +1341,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             body: JSON.stringify({ text: action.text, replyToId: action.replyToId }),
           })
             .then((body) => {
+              if (body?.message && typeof body.threadId === "string") {
+                rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
+              }
               if (
                 body?.queued &&
                 typeof body.threadId === "string" &&
@@ -1503,7 +1507,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           api(`/api/groups/${action.groupId}/messages`, {
             method: "POST",
             body: JSON.stringify({ text: action.text, replyToId: action.replyToId }),
-          }).catch(showError);
+          })
+            .then((body) => {
+              if (body?.message && typeof body.threadId === "string") {
+                rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
+              }
+            })
+            .catch(showError);
           break;
         case "patchGroup":
           api(`/api/groups/${action.groupId}`, {
@@ -1655,12 +1665,6 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // gap before that connection opened.
     const hydrationFallback = setTimeout(hydrate, 1_000);
 
-    const es = new EventSource("/api/events");
-    // The hydrate decision belongs to the hello frame, not to onopen: the
-    // server replays what we missed when it can, and re-downloading every
-    // transcript on a reconnect it already covered is pure waste.
-    es.onopen = () => rawDispatch({ type: "connected", value: true });
-    es.onerror = () => rawDispatch({ type: "connected", value: false });
     handleFrame = (frame) => {
       switch (frame.kind) {
         case "message": {
@@ -1820,27 +1824,24 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
       }
     };
-    es.onmessage = (raw) => {
-      let frame: any;
-      try {
-        frame = JSON.parse(raw.data);
-      } catch {
-        return;
-      }
-      // `hello` is the snapshot boundary. A false `resumed` means the server
-      // could not fill the gap, so queue subsequent frames behind a hydrate.
-      if (frame.kind === "hello") {
-        clearTimeout(hydrationFallback);
-        if (!frame.resumed) hydrate();
-        return;
-      }
-      if (hydrated) handleFrame(frame);
-      else pendingFrames.push(frame);
-    };
+    const stopLive = openLiveEvents({
+      onOpen: () => rawDispatch({ type: "connected", value: true }),
+      onError: () => rawDispatch({ type: "connected", value: false }),
+      onFrame: (frame) => {
+        if (isLivePing(frame)) return;
+        if (frame.kind === "hello") {
+          clearTimeout(hydrationFallback);
+          if (!frame.resumed) hydrate();
+          return;
+        }
+        if (hydrated) handleFrame(frame);
+        else pendingFrames.push(frame);
+      },
+    });
     return () => {
       alive = false;
       clearTimeout(hydrationFallback);
-      es.close();
+      stopLive();
     };
   }, []);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,10 +27,11 @@ export default defineConfig({
     },
   },
   server: {
-    // IPv4 explicitly — a bare ::1 bind makes localhost a coin-flip for
-    // clients that resolve IPv4 first
-    host: "127.0.0.1",
+    // 0.0.0.0 so Tailscale (and LAN) can reach the UI; loopback still works.
+    // allowedHosts: true is required in Vite 7 or Host 100.x is blocked.
+    host: process.env.OMB_UI_HOST || "0.0.0.0",
     port: Number(process.env.OMB_UI_PORT) || 5199,
+    allowedHosts: true,
     // packager output lands inside the repo — its HTML files must never
     // trigger dev full-page reloads
     watch: {
@@ -41,6 +42,24 @@ export default defineConfig({
     proxy: {
       "/api": {
         target: `http://127.0.0.1:${process.env.OMB_PORT || process.env.OGB_PORT || 8799}`,
+        // Remote UI (Tailscale / LAN) presents as localhost so the harness
+        // loopback Host/Origin gate still accepts the proxied /api stream.
+        changeOrigin: true,
+        timeout: 0,
+        proxyTimeout: 0,
+        configure(proxy) {
+          proxy.on("proxyReq", (proxyReq) => {
+            proxyReq.setHeader("host", `127.0.0.1:${process.env.OMB_PORT || process.env.OGB_PORT || 8799}`);
+            proxyReq.removeHeader("origin");
+          });
+          proxy.on("proxyRes", (proxyRes) => {
+            const contentType = String(proxyRes.headers["content-type"] ?? "");
+            if (!contentType.includes("text/event-stream")) return;
+            proxyRes.headers["cache-control"] = "no-cache, no-transform";
+            proxyRes.headers["x-accel-buffering"] = "no";
+            proxyRes.headers["connection"] = "keep-alive";
+          });
+        },
       },
     },
   },


### PR DESCRIPTION
## Why

I host OpenMausBot on one Mac and use it from another over Tailscale. Sends hit the host, but the remote window stayed empty until I quit or opened a browser on the host. The SSE socket still *looked* connected.

The server was pinging with SSE comments (`: keepalive`). Browser `EventSource` ignores comments, so a half-dead hop never fired `onerror` and never reconnected. Chat bubbles only arrive on that stream (or after a full hydrate).

## The fix

- Emit a `kind: ping` **data** frame the client can see (keep the comment too for TCP).
- Reconnect with `?since=` when pings go quiet, and on focus / online / visible.
- Return the user message from `POST /api/bots/:id/messages` (and group sends) so the bubble does not wait on SSE.
- Bind Vite on `0.0.0.0`, `changeOrigin` the `/api` proxy, disable proxy timeouts, and disable buffering on `text/event-stream`.
- Disable Node `requestTimeout` / `headersTimeout` on the harness so long-lived SSE is not killed.

## Also in this PR (sidebar / copy)

- **Bot Chats** auto-files bot-to-bot DMs (they were inheriting the sender’s team, e.g. Agents). Delete from the chat menu.
- **Pinned** is its own collapsible section.
- **Channels** renamed **Projects**.
- Drag a section header to reorder (no up/down arrows). Empty sections keep their saved place.
- Copy on bubbles uses a clipboard fallback that works on this local/Electron path.
- ⌘1–6: Chief of Staff, then pinned, then the rest.

Not merged from this seat. No `.env` or credentials in the diff.

## Test plan

- [ ] Idle bot: send from a remote UI; user bubble appears without waiting for the assistant.
- [ ] Kill/stall the SSE hop; client reconnects; missed frames resume or hydrate.
- [ ] Sidebar: drag Projects below Agents, reload, order sticks; start a bot-to-bot DM, it lands under Bot Chats.
- [ ] Copy a bubble on desktop Electron / `http://127.0.0.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible, reorderable sidebar sections with saved layout preferences.
  * Introduced dedicated Bot Chats organization for bot-to-bot conversations.
  * Added Codex Micro slots, with keyboard shortcuts for quick access.
  * Improved live updates with automatic reconnection and keepalive handling.
  * Added reliable copy actions with clipboard fallback support.
* **Bug Fixes**
  * Bot conversations are now consistently placed in Bot Chats.
  * New messages appear immediately after sending.
  * Inspector updates are more reliable during completed or failed turns.
* **UI Improvements**
  * Renamed the Channels section to Projects.
  * Added clearer chat-specific room actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->