### PR TITLE
feat(tasks): search the header task switcher

### DIFF
--- a/src/components/TaskPicker.test.ts
+++ b/src/components/TaskPicker.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   TASK_PICKER_DISMISS_MS,
   TASK_RENAME_HINT,
+  filterTasks,
   taskPickerPointerIntent,
 } from "./TaskPicker";
 
@@ -33,5 +34,34 @@ describe("task picker copy", () => {
     expect(TASK_RENAME_HINT).toContain("double-click");
     expect(TASK_RENAME_HINT).toContain("right-click");
     expect(TASK_PICKER_DISMISS_MS).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("filterTasks", () => {
+  const tasks = [
+    { title: "Clean up" },
+    { title: "OpenMausBot Update" },
+    { title: "Investment report" },
+    { title: "Report drafts" },
+  ];
+
+  it("returns the original order when the query is empty", () => {
+    expect(filterTasks(tasks, "").map((task) => task.title)).toEqual(tasks.map((task) => task.title));
+    expect(filterTasks(tasks, "   ").map((task) => task.title)).toEqual(tasks.map((task) => task.title));
+  });
+
+  it("matches titles case-insensitively", () => {
+    expect(filterTasks(tasks, "openmaus").map((task) => task.title)).toEqual(["OpenMausBot Update"]);
+  });
+
+  it("ranks prefix hits ahead of substring hits, keeping input order in each tier", () => {
+    expect(filterTasks(tasks, "report").map((task) => task.title)).toEqual([
+      "Report drafts",
+      "Investment report",
+    ]);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(filterTasks(tasks, "zzzz")).toEqual([]);
   });
 });

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -259,7 +259,7 @@ function ConversationTaskPicker({
               />
             </div>
           </div>
-          <div className="max-h-[320px] overflow-y-auto" role="listbox" aria-label={looking ? `${visible.length} matching tasks` : "Tasks"}>
+          <div className="max-h-[320px] overflow-y-auto" role="group" aria-label={looking ? `${visible.length} matching tasks` : "Tasks"}>
             {visible.length === 0 ? (
               <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">
                 Nothing matches “{looking}”

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -5,7 +5,7 @@
 // own transcript and its own provider session — so sensitive work, a
 // long job and a quick question can sit side by side under one agent.
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, Pencil, Plus, Trash2 } from "lucide-react";
+import { Check, ChevronDown, Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { useStore, formatTime, type Bot, type Group, type Task } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { COMPACT_BUBBLE } from "@/lib/compact-chip";
@@ -30,6 +30,22 @@ export function taskPickerPointerIntent(
   if (type === "click" && detail >= 2) return "ignore";
   if (type === "click") return "select";
   return "ignore";
+}
+
+/** Filter the task switcher. Prefix matches float first so a few letters
+ * still find the right row in a long list; within a tier the caller's
+ * order (newest first) is preserved. */
+export function filterTasks<T extends { title: string }>(tasks: readonly T[], query: string): T[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...tasks];
+  const prefix: T[] = [];
+  const substring: T[] = [];
+  for (const task of tasks) {
+    const title = task.title.toLowerCase();
+    if (title.startsWith(needle)) prefix.push(task);
+    else if (title.includes(needle)) substring.push(task);
+  }
+  return [...prefix, ...substring];
 }
 
 /** Quiet per-task token tally — input+output combined, because one honest
@@ -68,6 +84,7 @@ function ConversationTaskPicker({
   const [open, setOpen] = useState(false);
   const [renaming, setRenaming] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
+  const [query, setQuery] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const finishingRename = useRef(false);
@@ -84,6 +101,7 @@ function ConversationTaskPicker({
   const closeMenu = () => {
     clearDismiss();
     setRenaming(null);
+    setQuery("");
     setOpen(false);
   };
 
@@ -96,7 +114,7 @@ function ConversationTaskPicker({
     }, TASK_PICKER_DISMISS_MS);
   };
 
-  const startRename = (task: Task) => {
+  const startRename = (task: PickerTask) => {
     clearDismiss();
     finishingRename.current = false;
     setDraft(task.title);
@@ -114,6 +132,7 @@ function ConversationTaskPicker({
         dismissTimer.current = null;
       }
       setRenaming(null);
+      setQuery("");
       return;
     }
     const onDown = (e: MouseEvent) => {
@@ -184,6 +203,8 @@ function ConversationTaskPicker({
     u && currentLabel
       ? `Switch task · ${currentLabel} (${u.input.toLocaleString()} in · ${u.output.toLocaleString()} out)`
       : "Switch task";
+  const visible = filterTasks(tasks, query);
+  const looking = query.trim();
 
   return (
     <div className="relative" ref={ref}>
@@ -207,8 +228,43 @@ function ConversationTaskPicker({
 
       {open && (
         <div className="absolute right-0 top-full z-40 mt-1 w-[300px] overflow-hidden rounded-xl border border-hairline/50 bg-card py-1 shadow-2xl shadow-black/50">
-          <div className="max-h-[320px] overflow-y-auto">
-            {tasks.map((task) => {
+          <div className="px-2 pb-1 pt-1.5">
+            <div className="flex items-center gap-2 rounded-lg border border-hairline/40 bg-inset px-2.5 py-1.5 focus-within:border-accent/60">
+              <Search size={13} className="shrink-0 text-ink-secondary" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (looking) setQuery("");
+                    else closeMenu();
+                    return;
+                  }
+                  if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                    const first = visible[0];
+                    if (!first) return;
+                    if (first.threadId !== threadId) onSwitch(first.threadId);
+                    closeMenu();
+                  }
+                }}
+                placeholder="Search tasks"
+                aria-label="Search tasks"
+                className="w-full bg-transparent text-[12.5px] text-ink placeholder:text-ink-secondary focus:outline-none"
+              />
+            </div>
+          </div>
+          <div className="max-h-[320px] overflow-y-auto" role="listbox" aria-label={looking ? `${visible.length} matching tasks` : "Tasks"}>
+            {visible.length === 0 ? (
+              <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">
+                Nothing matches “{looking}”
+              </div>
+            ) : visible.map((task) => {
               const active = task.threadId === threadId;
               return (
                 <div


### PR DESCRIPTION
## Why

The header magnifying glass searches the **current transcript**, not task titles. Once a bot has more than a handful of tasks, the switcher is a 320px scroll with no way to jump to a name.

## What

A search field at the top of the task menu (bots and channels):

- Focuses when the menu opens
- Filters titles as you type (case-insensitive)
- Prefix matches rank above substring matches; original order is kept inside each tier
- Enter switches to the top hit
- Escape clears the query, then closes
- Empty state: `Nothing matches “…”`

## Test plan

- [x] `pnpm exec vitest run src/components/TaskPicker.test.ts`
- [x] Typed `hey` in a 3-task menu → only **Hey bro** remained
- [x] Typed a miss → empty state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search to the task picker dropdown.
  * Search is case-insensitive, prioritizes title matches that start with the query, and preserves ordering within match groups.
  * Added keyboard support: Escape clears or closes the picker, and Enter selects the first match.
  * Added an empty-state message when no tasks match.

* **Accessibility**
  * Improved listbox labels and keyboard interaction support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->