### PR TITLE
chore(release): bump version to 0.1.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop app version from 0.1.38 to 0.1.39
- include the routine/MCP provider-schema compatibility fix already merged in #544
- leave the separately versioned iOS/TestFlight app unchanged

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- git diff --check
- verified package.json is the only changed file
- verified v0.1.39 does not already exist in the release repository

After this merges, the Release workflow can be dispatched manually from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.39.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->