### PR TITLE
fix(stream): make live chat delivery resilient

### DIFF
--- a/server/drafts.test.ts
+++ b/server/drafts.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clearReplyDraft,
+  discardReplyDraft,
+  draftRevision,
+  failedComposerSends,
+  replyDraft,
+  forgetFailedComposerSend,
   getDraft,
   getDraftAttachments,
+  markDraftEdited,
+  recoverFailedComposerSend,
+  rememberReplyDraft,
+  restoredSendId,
+  selectReplyDraft,
   setDraft,
   setDraftAttachments,
 } from "../src/lib/drafts.ts";
@@ -15,6 +26,8 @@ function memoryStore() {
     setItem: (key: string, value: string) => void values.set(key, value),
   };
 }
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("composer drafts", () => {
   it("keeps text and attachments isolated per bot or room", () => {
@@ -42,5 +55,120 @@ describe("composer drafts", () => {
 
     expect(getDraft(store, "bot:one")).toBe("");
     expect(getDraftAttachments(store, "bot:one")).toEqual([]);
+  });
+
+  it("restores a rejected send into its task draft", () => {
+    const store = memoryStore();
+    vi.stubGlobal("localStorage", store);
+    const draftId = "bot:restore:thread-a";
+    const attachment = fileAttachment("notes.txt", "/tmp/notes.txt", 12);
+    const revision = draftRevision(draftId);
+
+    expect(
+      recoverFailedComposerSend({
+        draftId,
+        revision,
+        sendId: "send-restore",
+        text: "please retry",
+        requestText: "please retry\n\n<attached-file path=\"/tmp/notes.txt\" />",
+        attachments: [attachment],
+        threadId: "thread-a",
+      }),
+    ).toBe("restored");
+    expect(getDraft(store, draftId)).toBe("please retry");
+    expect(getDraftAttachments(store, draftId)).toEqual([attachment]);
+    expect(restoredSendId(draftId)).toBe("send-restore");
+    markDraftEdited(draftId);
+    expect(restoredSendId(draftId)).toBeUndefined();
+  });
+
+  it("keeps a failed send in the outbox when a newer draft exists", () => {
+    const store = memoryStore();
+    vi.stubGlobal("localStorage", store);
+    const draftId = "group:preserve:thread-b";
+    const revision = draftRevision(draftId);
+    markDraftEdited(draftId);
+    setDraft(store, draftId, "new draft");
+
+    expect(
+      recoverFailedComposerSend({
+        draftId,
+        revision,
+        sendId: "send-preserve",
+        text: "older failed send",
+        requestText: "older failed send",
+        attachments: [],
+        replyToId: "message-1",
+        threadId: "thread-b",
+      }),
+    ).toBe("outbox");
+    expect(getDraft(store, draftId)).toBe("new draft");
+    expect(failedComposerSends(draftId)).toMatchObject([
+      {
+        text: "older failed send",
+        requestText: "older failed send",
+        replyToId: "message-1",
+        threadId: "thread-b",
+      },
+    ]);
+
+    const [failed] = failedComposerSends(draftId);
+    forgetFailedComposerSend(draftId, failed.id);
+    expect(failedComposerSends(draftId)).toEqual([]);
+  });
+
+  it("keeps reply targets isolated by task", () => {
+    rememberReplyDraft("thread-reply-a", "message-a");
+    rememberReplyDraft("thread-reply-b", "message-b");
+    expect(replyDraft("thread-reply-a")).toBe("message-a");
+    expect(replyDraft("thread-reply-b")).toBe("message-b");
+    clearReplyDraft("thread-reply-a");
+    expect(replyDraft("thread-reply-a")).toBeUndefined();
+    expect(replyDraft("thread-reply-b")).toBe("message-b");
+    clearReplyDraft("thread-reply-b");
+  });
+
+  it("preserves the original send separately after a reply-only edit", () => {
+    const store = memoryStore();
+    vi.stubGlobal("localStorage", store);
+    const draftId = "bot:reply-edit:thread-c";
+    const threadId = "thread-c";
+    const revision = draftRevision(draftId);
+
+    selectReplyDraft(draftId, threadId, "new-reply");
+    expect(
+      recoverFailedComposerSend({
+        draftId,
+        revision,
+        sendId: "send-reply-select",
+        text: "reply to the original",
+        requestText: "reply to the original",
+        attachments: [],
+        replyToId: "original-reply",
+        threadId,
+      }),
+    ).toBe("outbox");
+    expect(replyDraft(threadId)).toBe("new-reply");
+    expect(failedComposerSends(draftId)[0]?.replyToId).toBe("original-reply");
+
+    const nextRevision = draftRevision(draftId);
+    discardReplyDraft(draftId, threadId);
+    expect(
+      recoverFailedComposerSend({
+        draftId,
+        revision: nextRevision,
+        sendId: "send-reply-clear",
+        text: "second original",
+        requestText: "second original",
+        attachments: [],
+        replyToId: "another-reply",
+        threadId,
+      }),
+    ).toBe("outbox");
+    expect(replyDraft(threadId)).toBeUndefined();
+
+    for (const failed of failedComposerSends(draftId)) {
+      forgetFailedComposerSend(draftId, failed.id);
+    }
   });
 });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -223,6 +223,9 @@ beforeAll(async () => {
       OMB_BOX_API: `http://127.0.0.1:${boxStubPort}`,
       OMB_COMPOSIO_API: `http://127.0.0.1:${boxStubPort}/api/v3.1`,
       OMB_STATIC_DIR: staticDir,
+      // Production uses 15s. Keep the real timer path while making the
+      // browser-visible heartbeat assertion fast and deterministic.
+      OMB_SSE_HEARTBEAT_MS: "50",
       FAKE_CLAUDE_MODE: "hang",
       FAKE_CLAUDE_DUMP: fakeClaudeDump,
     },
@@ -497,6 +500,70 @@ describe("harness HTTP API", () => {
     } finally {
       await api("POST", `/api/groups/${group.id}/interrupt`, {});
       await api("DELETE", `/api/groups/${group.id}`);
+    }
+  });
+
+  it("returns the canonical stored user message for direct and channel sends", async () => {
+    const created = await api("POST", "/api/bots", {
+      modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    });
+    expect(created.status).toBe(201);
+    const bot = created.body.bot;
+    let room: any;
+    try {
+      const direct = await api("POST", `/api/bots/${bot.id}/messages`, { text: "canonical direct" });
+      expect(direct.status).toBe(202);
+      expect(direct.body).toMatchObject({
+        ok: true,
+        threadId: bot.threadId,
+        message: {
+          id: expect.any(String),
+          at: expect.any(Number),
+          role: "user",
+          kind: "text",
+          text: "canonical direct",
+        },
+      });
+      const afterDirect = (await api("GET", "/api/bots?messages=20")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(afterDirect.messages.find((message: { id: string }) => message.id === direct.body.message.id))
+        .toEqual(direct.body.message);
+
+      expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((candidate: { id: string }) => candidate.id === bot.id)?.busy;
+      }, { timeout: 5_000 }).toBe(false);
+
+      room = (await api("POST", "/api/groups", {
+        name: "Canonical response room",
+        memberIds: [bot.id],
+        setup: { bulletin: "", defaultResponder: { kind: "mentions" } },
+      })).body.group;
+      const channel = await api("POST", `/api/groups/${room.id}/messages`, { text: "canonical channel" });
+      expect(channel.status).toBe(202);
+      expect(channel.body).toMatchObject({
+        ok: true,
+        threadId: room.threadId,
+        message: {
+          id: expect.any(String),
+          at: expect.any(Number),
+          role: "user",
+          kind: "text",
+          text: "canonical channel",
+        },
+      });
+      const afterChannel = (await api("GET", "/api/bots?messages=20")).body.groups.find(
+        (candidate: { id: string }) => candidate.id === room.id,
+      );
+      expect(afterChannel.messages.find((message: { id: string }) => message.id === channel.body.message.id))
+        .toEqual(channel.body.message);
+    } finally {
+      if (room) await api("DELETE", `/api/groups/${room.id}`);
+      await api("POST", `/api/bots/${bot.id}/interrupt`).catch(() => undefined);
+      await api("DELETE", `/api/bots/${bot.id}`);
     }
   });
 
@@ -3057,6 +3124,31 @@ describe("resumable event stream", () => {
     }
   });
 
+  it("sends browser-visible heartbeats without moving the replay cursor", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+    const first = await openSse(`${BASE}/api/events`);
+    const hello = await first.until((frame) => frame.kind === "hello");
+    try {
+      expect(await first.until((frame) => frame.kind === "ping")).toEqual({ kind: "ping" });
+      await nudge(botId);
+      const next = await first.until((frame) => frame.kind === "bot" && frame.bot?.id === botId);
+      expect(next.seq).toBe(Number(hello.cursor.split(":")[1]) + 1);
+    } finally {
+      first.close();
+    }
+
+    // Heartbeats describe connection health, not application state. A
+    // reconnect from the numbered application frame remains fully resumable.
+    const cursor = `${hello.cursor.split(":")[0]}:${Number(hello.cursor.split(":")[1]) + 1}`;
+    const resumed = await openSse(`${BASE}/api/events?since=${encodeURIComponent(cursor)}`);
+    try {
+      expect((await resumed.until((frame) => frame.kind === "hello")).resumed).toBe(true);
+    } finally {
+      resumed.close();
+    }
+  });
+
   it("replays exactly what a disconnected client missed", async () => {
     const { body } = await api("GET", "/api/bots");
     const botId = body.bots[0].id;
@@ -3102,6 +3194,33 @@ describe("resumable event stream", () => {
     try {
       expect((await resumed.until((f) => f.kind === "hello")).resumed).toBe(true);
       await resumed.until((f) => f.kind === "bot");
+    } finally {
+      resumed.close();
+    }
+  });
+
+  it("prefers a newer Last-Event-ID over the EventSource URL's stale cursor", async () => {
+    const { body } = await api("GET", "/api/bots");
+    const botId = body.bots[0].id;
+
+    const first = await openSse(`${BASE}/api/events`);
+    const hello = await first.until((frame) => frame.kind === "hello");
+    await nudge(botId);
+    const seen = await first.until((frame) => frame.kind === "bot" && frame.bot?.id === botId);
+    first.close();
+    await nudge(botId);
+
+    // Native EventSource reconnects reuse their original URL, including its
+    // old query, but add Last-Event-ID for the newest numbered frame seen.
+    const resumed = await openSse(
+      `${BASE}/api/events?since=${encodeURIComponent(hello.cursor)}`,
+      { "last-event-id": `${hello.cursor.split(":")[0]}:${seen.seq}` },
+    );
+    try {
+      expect((await resumed.until((frame) => frame.kind === "hello")).resumed).toBe(true);
+      await resumed.until((frame) => frame.kind === "bot" && frame.bot?.id === botId);
+      const replayed = resumed.frames.filter((frame) => frame.kind === "bot" && frame.bot?.id === botId);
+      expect(replayed.map((frame) => frame.seq)).toEqual([seen.seq + 1]);
     } finally {
       resumed.close();
     }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -567,6 +567,111 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("deduplicates direct send retries by sendId, including after the accepted task becomes inactive", async () => {
+    const created = await api("POST", "/api/bots", {
+      modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    });
+    expect(created.status).toBe(201);
+    const bot = created.body.bot;
+    const originalThreadId = bot.threadId;
+    const sendId = "direct_retry_1234567890";
+    const request = { text: "retry this direct message once", threadId: originalThreadId, sendId };
+    try {
+      const first = await api("POST", `/api/bots/${bot.id}/messages`, request);
+      expect(first.status).toBe(202);
+      expect(first.body).toMatchObject({
+        ok: true,
+        threadId: originalThreadId,
+        message: { role: "user", kind: "text", text: request.text, sendId },
+      });
+
+      const duplicate = await api("POST", `/api/bots/${bot.id}/messages`, request);
+      expect(duplicate.status).toBe(202);
+      expect(duplicate.body).toEqual(first.body);
+
+      const conflict = await api("POST", `/api/bots/${bot.id}/messages`, {
+        ...request,
+        text: "a different message cannot reuse that identity",
+      });
+      expect(conflict.status).toBe(409);
+      expect(conflict.body.error).toMatch(/sendId already belongs/i);
+
+      const invalid = await api("POST", `/api/bots/${bot.id}/messages`, {
+        text: "invalid identity must not land",
+        threadId: originalThreadId,
+        sendId: "short",
+      });
+      expect(invalid.status).toBe(400);
+
+      const accepted = (await api("GET", "/api/bots?messages=50")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(accepted.messages.filter((message: { role: string; sendId?: string }) =>
+        message.role === "user" && message.sendId === sendId
+      )).toHaveLength(1);
+      expect(accepted.messages.some((message: { text?: string }) => message.text === "invalid identity must not land"))
+        .toBe(false);
+
+      await api("POST", `/api/bots/${bot.id}/interrupt`, { threadId: originalThreadId });
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+          (candidate: { id: string }) => candidate.id === bot.id,
+        );
+        return state?.busy;
+      }, { timeout: 5_000 }).toBe(false);
+
+      const nextTask = await api("POST", `/api/bots/${bot.id}/tasks`, { title: "Now active" });
+      expect(nextTask.status).toBe(201);
+      expect(nextTask.body.task.threadId).not.toBe(originalThreadId);
+
+      const inactiveRetry = await api("POST", `/api/bots/${bot.id}/messages`, request);
+      expect(inactiveRetry.status).toBe(202);
+      expect(inactiveRetry.body).toEqual(first.body);
+      const current = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(current.threadId).toBe(nextTask.body.task.threadId);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`, {}).catch(() => undefined);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("deduplicates channel send retries by sendId", async () => {
+    const member = (await api("GET", "/api/bots?messages=0")).body.bots[0];
+    const room = (await api("POST", "/api/groups", {
+      name: "Idempotent channel",
+      memberIds: [member.id],
+      setup: { bulletin: "", defaultResponder: { kind: "mentions" } },
+    })).body.group;
+    const sendId = "channel_retry_123456789";
+    const request = { text: "one canonical channel message", threadId: room.threadId, sendId };
+    try {
+      const first = await api("POST", `/api/groups/${room.id}/messages`, request);
+      expect(first.status).toBe(202);
+      expect(first.body).toMatchObject({
+        ok: true,
+        threadId: room.threadId,
+        message: { role: "user", kind: "text", text: request.text, sendId },
+      });
+
+      const duplicate = await api("POST", `/api/groups/${room.id}/messages`, request);
+      expect(duplicate.status).toBe(202);
+      expect(duplicate.body).toEqual(first.body);
+
+      const snapshot = (await api("GET", "/api/bots?messages=50")).body.groups.find(
+        (candidate: { id: string }) => candidate.id === room.id,
+      );
+      expect(snapshot.messages.filter((message: { role: string; sendId?: string }) =>
+        message.role === "user" && message.sendId === sendId
+      )).toHaveLength(1);
+    } finally {
+      await api("POST", `/api/groups/${room.id}/interrupt`, {}).catch(() => undefined);
+      await api("DELETE", `/api/groups/${room.id}`);
+    }
+  });
+
   it("rejects an entire channel roster when any requested member is unknown", async () => {
     const bot = (await api("GET", "/api/bots?messages=0")).body.bots[0];
     const before = (await api("GET", "/api/bots?messages=0")).body.groups.length;

--- a/server/index.ts
+++ b/server/index.ts
@@ -622,6 +622,11 @@ const sseClients = new Set<SseClient>();
  * correctly through its own Last-Event-ID with no client code at all. */
 const STREAM_ID = randomUUID().slice(0, 8);
 const REPLAY_MAX = 500;
+const configuredSseHeartbeatMs = Number(process.env.OMB_SSE_HEARTBEAT_MS);
+const SSE_HEARTBEAT_MS =
+  Number.isFinite(configuredSseHeartbeatMs) && configuredSseHeartbeatMs > 0
+    ? configuredSseHeartbeatMs
+    : 15_000;
 let lastSeq = 0;
 const replayBuffer: Array<{ seq: number; kind: string; frame: string | null }> = [];
 
@@ -1492,7 +1497,7 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
       // busy. Those asynchronous setup failures do not emit turn.completed,
       // so clear the watch and report them through this callback too.
       onDispatchError: reportStartFailure,
-    }).catch((err) => {
+    }).then(() => undefined).catch((err) => {
       reportStartFailure(err);
     });
 };
@@ -1529,7 +1534,7 @@ function drainQueuedSends() {
     // Drain just appended the held lines; userMessage keeps startTurn
     // from duplicating the last one, and excludeIds drops every drained
     // line from the transcript-replay so they are not also in `prompt`.
-    startTurn(botId, prompt, { threadId, userMessage, excludeMessageIds: excludeIds }).catch((err) => {
+    startTurn(botId, prompt, { threadId, userMessage, excludeMessageIds: excludeIds }).then(() => undefined).catch((err) => {
       store.appendMessage(threadId, {
         role: "bot",
         kind: "activity",
@@ -2125,6 +2130,7 @@ async function startTurn(
       drainSecretResumes();
     }
   })();
+  return userMessage;
 }
 
 // ── routines: persisted definitions → detached bot tasks ───────────────
@@ -2143,7 +2149,8 @@ routines = new RoutineManager({
     return task;
   },
   startTurn: (botId, threadId, prompt, runOn, triggerSource, onDispatchError) =>
-    startTurn(botId, prompt, { threadId, runOn, automationSource: triggerSource, onDispatchError }),
+    startTurn(botId, prompt, { threadId, runOn, automationSource: triggerSource, onDispatchError })
+      .then(() => undefined),
   interruptTurn: async (botId, threadId, runOn) => {
     const bot = store.bot(botId);
     const instance = runOn === "cloud"
@@ -2622,7 +2629,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
   // Capture the active thread once. Every queued responder below is bound to
   // this task even if another client asks to switch later.
   const threadId = group.threadId;
-  store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: replyTo?.id });
+  const message = store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: replyTo?.id });
   if (!group.dm) store.titleGroupTaskFromFirstMessage(group.id, text, threadId);
 
   const members = group.memberIds
@@ -2666,7 +2673,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
         tool: { name: unavailableMessage, ok: false },
       });
     }
-    return;
+    return message;
   }
 
   const operation = beginGroupTurnOperation(groupId, threadId);
@@ -2701,6 +2708,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
   });
   const tracked = next.finally(() => finishGroupTurnOperation(groupId, operation));
   groupQueues.set(groupId, tracked.catch(() => {}));
+  return message;
 }
 
 function roomSetupPending(group: GroupRecord): boolean {
@@ -3756,7 +3764,13 @@ const server = createServer(async (req, res) => {
       // Resume, if the client offered a cursor we can honour. `?since=` is
       // for clients that read the stream by hand; Last-Event-ID is what a
       // browser EventSource sends by itself.
-      const since = cursorSeq(url.searchParams.get("since") ?? req.headers["last-event-id"]);
+      // Once EventSource has received a numbered frame, its automatic
+      // reconnect carries a newer Last-Event-ID even though the original
+      // URL may still contain an older manual `since` cursor. Prefer the
+      // valid browser cursor or the stale query would replay forever.
+      const since =
+        cursorSeq(req.headers["last-event-id"]) ??
+        cursorSeq(url.searchParams.get("since") ?? undefined);
       // The buffer only reaches so far back. If the client's cursor fell off
       // the end, saying so is the only honest answer — a partial replay
       // would leave a permanent hole in its state.
@@ -3781,11 +3795,17 @@ const server = createServer(async (req, res) => {
       }
 
       sseClients.add(client);
+      // Keep this long-lived response out of socket idle-timeout handling
+      // without weakening timeouts for every other API request.
+      req.socket.setTimeout(0);
+      // A comment keeps intermediaries from idling the connection, while a
+      // data frame is visible to EventSource clients and resets their own
+      // liveness watchdog. Heartbeats carry no id and never advance replay.
       const keepalive = setInterval(() => {
         try {
-          res.write(": keepalive\n\n");
+          res.write(`: keepalive\n\ndata: ${JSON.stringify({ kind: "ping" })}\n\n`);
         } catch {}
-      }, 25_000);
+      }, SSE_HEARTBEAT_MS);
       req.on("close", () => {
         clearInterval(keepalive);
         sseClients.delete(client);
@@ -4581,8 +4601,8 @@ const server = createServer(async (req, res) => {
         return json(res, 409, { error: "the channel switched tasks before it could receive the message" });
       }
       const replyTo = resolveReplyTarget(group.threadId, body.replyToId);
-      startGroupTurn(group.id, text, replyTo);
-      return json(res, 202, { ok: true });
+      const message = startGroupTurn(group.id, text, replyTo);
+      return json(res, 202, { ok: true, threadId: group.threadId, message });
     }
     m = path.match(/^\/api\/groups\/([\w-]+)\/interrupt$/);
     if (m && method === "POST") {
@@ -5181,14 +5201,14 @@ const server = createServer(async (req, res) => {
             .catch(() => false);
           if (steered) {
             clearUnattended(bot.id);
-            store.appendMessage(bot.threadId, {
+            const message = store.appendMessage(bot.threadId, {
               role: "user",
               kind: "text",
               text,
               replyToId: replyTo?.id,
               steered: true,
             });
-            return json(res, 202, { ok: true, steered: true });
+            return json(res, 202, { ok: true, steered: true, threadId: bot.threadId, message });
           }
         }
         const queued = queueSteeredMessage(bot, text, {
@@ -5197,8 +5217,8 @@ const server = createServer(async (req, res) => {
         });
         return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId: bot.threadId });
       }
-      await startTurn(bot.id, text, { replyTo });
-      return json(res, 202, { ok: true });
+      const message = await startTurn(bot.id, text, { replyTo });
+      return json(res, 202, { ok: true, threadId: bot.threadId, message });
     }
 
     m = path.match(/^\/api\/bots\/([\w-]+)\/queue\/([\w-]+)$/);

--- a/server/index.ts
+++ b/server/index.ts
@@ -5199,27 +5199,18 @@ const server = createServer(async (req, res) => {
       // existing server-side queue records it atomically for the next turn.
       if (bot.busy) {
         const instance = registry.get(bot.modelSelection.instanceId);
+        let steered = false;
         if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
-          const steered = await instance.adapter
+          steered = await instance.adapter
             .steer(threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
             .catch(() => false);
-          if (steered) {
-            clearUnattended(bot.id);
-            const message = store.appendMessage(threadId, {
-              role: "user",
-              kind: "text",
-              text,
-              replyToId: replyTo?.id,
-              steered: true,
-            });
-            return json(res, 202, { ok: true, steered: true, threadId, message });
-          }
         }
-        // The turn can settle while steer() is awaited. Re-read every mutable
-        // invariant before choosing the fallback: direct turns are owned by
-        // bot.threadId, so starting or queueing the old task after a switch
-        // would create a hidden turn that the ordinary interrupt route cannot
-        // stop. A conflict leaves the text in the client's composer to resend.
+        // steer() is awaited adapter work. The turn can settle, the task can
+        // switch, or the whole bot can be deleted before its acknowledgement
+        // arrives. Re-read every ownership invariant before appending even a
+        // successful steer; otherwise that late acknowledgement writes a user
+        // message into a task the bot no longer owns. A conflict leaves the
+        // text in the client's composer/outbox to resend deliberately.
         const current = store.bot(bot.id);
         if (!current) return json(res, 404, { error: "no such bot" });
         if (!store.taskByThread(bot.id, threadId)) {
@@ -5227,6 +5218,20 @@ const server = createServer(async (req, res) => {
         }
         if (current.threadId !== threadId) {
           return json(res, 409, { error: "the bot switched tasks before it could receive the message" });
+        }
+        if (steered) {
+          if (!current.busy) {
+            return json(res, 409, { error: "the running turn ended before the steered message could be recorded" });
+          }
+          clearUnattended(current.id);
+          const message = store.appendMessage(threadId, {
+            role: "user",
+            kind: "text",
+            text,
+            replyToId: replyTo?.id,
+            steered: true,
+          });
+          return json(res, 202, { ok: true, steered: true, threadId, message });
         }
         if (!current.busy) {
           const message = await startTurn(bot.id, text, { threadId, replyTo });

--- a/server/index.ts
+++ b/server/index.ts
@@ -5183,13 +5183,17 @@ const server = createServer(async (req, res) => {
       if (!text) return json(res, 400, { error: "text required" });
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
+      // Pin the target once. startTurn returns immediately after persisting,
+      // but an awaited steering adapter can yield before the response; never
+      // report or append against a task selected by a later request.
+      const threadId = bot.threadId;
       if (body.threadId !== undefined && (typeof body.threadId !== "string" || !/^[\w-]+$/.test(body.threadId))) {
         return json(res, 400, { error: "threadId must be a task id" });
       }
-      if (body.threadId !== undefined && body.threadId !== bot.threadId) {
+      if (body.threadId !== undefined && body.threadId !== threadId) {
         return json(res, 409, { error: "the bot switched tasks before it could receive the message" });
       }
-      const replyTo = resolveReplyTarget(bot.threadId, body.replyToId);
+      const replyTo = resolveReplyTarget(threadId, body.replyToId);
       // Claude can accept the message inside its live turn. If the write
       // loses a race with turn settlement, or the engine cannot steer, the
       // existing server-side queue records it atomically for the next turn.
@@ -5197,28 +5201,28 @@ const server = createServer(async (req, res) => {
         const instance = registry.get(bot.modelSelection.instanceId);
         if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
           const steered = await instance.adapter
-            .steer(bot.threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
+            .steer(threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
             .catch(() => false);
           if (steered) {
             clearUnattended(bot.id);
-            const message = store.appendMessage(bot.threadId, {
+            const message = store.appendMessage(threadId, {
               role: "user",
               kind: "text",
               text,
               replyToId: replyTo?.id,
               steered: true,
             });
-            return json(res, 202, { ok: true, steered: true, threadId: bot.threadId, message });
+            return json(res, 202, { ok: true, steered: true, threadId, message });
           }
         }
         const queued = queueSteeredMessage(bot, text, {
           replyToId: replyTo?.id,
           prompt: promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
         });
-        return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId: bot.threadId });
+        return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId });
       }
-      const message = await startTurn(bot.id, text, { replyTo });
-      return json(res, 202, { ok: true, threadId: bot.threadId, message });
+      const message = await startTurn(bot.id, text, { threadId, replyTo });
+      return json(res, 202, { ok: true, threadId, message });
     }
 
     m = path.match(/^\/api\/bots\/([\w-]+)\/queue\/([\w-]+)$/);

--- a/server/index.ts
+++ b/server/index.ts
@@ -5215,22 +5215,24 @@ const server = createServer(async (req, res) => {
             return json(res, 202, { ok: true, steered: true, threadId, message });
           }
         }
-        // The turn can settle while steer() is awaited. If it did, its queue
-        // drain already ran; enqueueing now would strand this message until
-        // some unrelated future turn settles. Start the pinned task directly
-        // instead. If another turn claimed the bot meanwhile, queue behind it
-        // but keep the original task target.
+        // The turn can settle while steer() is awaited. Re-read every mutable
+        // invariant before choosing the fallback: direct turns are owned by
+        // bot.threadId, so starting or queueing the old task after a switch
+        // would create a hidden turn that the ordinary interrupt route cannot
+        // stop. A conflict leaves the text in the client's composer to resend.
         const current = store.bot(bot.id);
         if (!current) return json(res, 404, { error: "no such bot" });
         if (!store.taskByThread(bot.id, threadId)) {
           return json(res, 409, { error: "the target task no longer exists" });
         }
+        if (current.threadId !== threadId) {
+          return json(res, 409, { error: "the bot switched tasks before it could receive the message" });
+        }
         if (!current.busy) {
           const message = await startTurn(bot.id, text, { threadId, replyTo });
           return json(res, 202, { ok: true, threadId, message });
         }
-        const queued = queueSteeredMessage(current, text, {
-          threadId,
+        const queued = queueSteeredMessage(current.id, threadId, text, {
           replyToId: replyTo?.id,
           prompt: promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
         });
@@ -5245,7 +5247,7 @@ const server = createServer(async (req, res) => {
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
       const queueId = m[2];
-      if (!cancelSteeredMessage(bot.threadId, queueId)) {
+      if (!cancelSteeredMessage(bot.id, queueId)) {
         return json(res, 404, { error: "no such queued message" });
       }
       return json(res, 200, { ok: true });

--- a/server/index.ts
+++ b/server/index.ts
@@ -87,7 +87,18 @@ import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type C
 import { searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
 import { _loadPending, discardDelegations, drainDelegations, pendingDelegationSnapshot, pendingThreads, queueDelegation, type QueueResult } from "./delegations.ts";
-import { cancelSteeredMessage, drainSteeredMessages, queueSteeredMessage } from "./steer-queue.ts";
+import {
+  cancelSteeredMessage,
+  drainSteeredMessages,
+  queuedSteeredMessage,
+  queueSteeredMessage,
+} from "./steer-queue.ts";
+import {
+  acceptedSendMatch,
+  parseSendId,
+  sendFingerprint,
+  SendSequencer,
+} from "./send-idempotency.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
 import { cancelPeerApprovalsFor, cancelPeerApprovalsForThread, dismissStalePeerCards, requestPeerApproval, resolvePeerComms, type ApprovalBus } from "./peer-approval.ts";
@@ -427,6 +438,7 @@ function checkedMemberIds(value: unknown): { ok: true; memberIds: string[] } | {
 }
 let bootSelection = { instanceId: "", model: "" };
 const store = new Store(() => bootSelection);
+const sendSequencer = new SendSequencer();
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
 
@@ -1677,6 +1689,9 @@ async function startTurn(
     cardContinuation?: boolean;
     /** Earlier text message this user turn is replying to. */
     replyTo?: Message;
+    /** Stable identity supplied by the composer so a network retry cannot
+     * dispatch the same user action twice. */
+    sendId?: string;
     onDispatchError?: (message: string) => void;
   },
 ) {
@@ -1731,7 +1746,13 @@ async function startTurn(
   if (!userMessage) {
     userMessage = opts?.cardContinuation
       ? { id: `card-${randomUUID()}`, at: Date.now(), role: "user", kind: "text", text }
-      : store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: opts?.replyTo?.id });
+      : store.appendMessage(threadId, {
+          role: "user",
+          kind: "text",
+          text,
+          replyToId: opts?.replyTo?.id,
+          sendId: opts?.sendId,
+        });
   }
 
   // transcript for API-backed drivers: settled text turns on the ACTIVE
@@ -2620,7 +2641,7 @@ async function runGroupMemberTurn(
   return true;
 }
 
-function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
+function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId?: string) {
   const group = store.group(groupId);
   if (!group) throw Object.assign(new Error("no such group"), { status: 404 });
   if (roomSetupPending(group)) {
@@ -2629,7 +2650,13 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message) {
   // Capture the active thread once. Every queued responder below is bound to
   // this task even if another client asks to switch later.
   const threadId = group.threadId;
-  const message = store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId: replyTo?.id });
+  const message = store.appendMessage(threadId, {
+    role: "user",
+    kind: "text",
+    text,
+    replyToId: replyTo?.id,
+    sendId,
+  });
   if (!group.dm) store.titleGroupTaskFromFirstMessage(group.id, text, threadId);
 
   const members = group.memberIds
@@ -3759,6 +3786,9 @@ const server = createServer(async (req, res) => {
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
         connection: "keep-alive",
+        // Honoured by nginx-compatible reverse proxies; harmless elsewhere.
+        // Remote clients need each frame now, not when a proxy buffer fills.
+        "x-accel-buffering": "no",
       });
 
       // Resume, if the client offered a cursor we can honour. `?since=` is
@@ -4597,12 +4627,40 @@ const server = createServer(async (req, res) => {
       if (body.threadId !== undefined && (typeof body.threadId !== "string" || !/^[\w-]+$/.test(body.threadId))) {
         return json(res, 400, { error: "threadId must be a task id" });
       }
-      if (body.threadId !== undefined && body.threadId !== group.threadId) {
+      const threadId = body.threadId ?? group.threadId;
+      const ownsThread = group.dm
+        ? group.threadId === threadId
+        : Boolean(store.groupTaskByThread(group.id, threadId));
+      if (!ownsThread) {
         return json(res, 409, { error: "the channel switched tasks before it could receive the message" });
       }
-      const replyTo = resolveReplyTarget(group.threadId, body.replyToId);
-      const message = startGroupTurn(group.id, text, replyTo);
-      return json(res, 202, { ok: true, threadId: group.threadId, message });
+      const sendId = parseSendId(body.sendId);
+      const replyTo = resolveReplyTarget(threadId, body.replyToId);
+      const receipt = await sendSequencer.run(
+        sendId ? `group:${group.id}:${threadId}:${sendId}` : undefined,
+        sendFingerprint(text, replyTo?.id),
+        async () => {
+          if (sendId) {
+            const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id);
+            if (accepted.kind === "conflict") {
+              throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
+            }
+            if (accepted.kind === "match") {
+              return { ok: true as const, threadId, message: accepted.message };
+            }
+          }
+          const current = store.group(group.id);
+          if (!current) throw Object.assign(new Error("no such group"), { status: 404 });
+          if (current.threadId !== threadId) {
+            throw Object.assign(new Error("the channel switched tasks before it could receive the message"), {
+              status: 409,
+            });
+          }
+          const message = startGroupTurn(current.id, text, replyTo, sendId);
+          return { ok: true as const, threadId, message };
+        },
+      );
+      return json(res, 202, receipt);
     }
     m = path.match(/^\/api\/groups\/([\w-]+)\/interrupt$/);
     if (m && method === "POST") {
@@ -5183,68 +5241,118 @@ const server = createServer(async (req, res) => {
       if (!text) return json(res, 400, { error: "text required" });
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
-      // Pin the target once. startTurn returns immediately after persisting,
-      // but an awaited steering adapter can yield before the response; never
-      // report or append against a task selected by a later request.
-      const threadId = bot.threadId;
       if (body.threadId !== undefined && (typeof body.threadId !== "string" || !/^[\w-]+$/.test(body.threadId))) {
         return json(res, 400, { error: "threadId must be a task id" });
       }
-      if (body.threadId !== undefined && body.threadId !== threadId) {
+      // A retry carries its original task. That lets us return the canonical
+      // receipt after a task switch, while a genuinely new send still has to
+      // target the task that is active now.
+      const threadId = body.threadId ?? bot.threadId;
+      if (!store.taskByThread(bot.id, threadId)) {
         return json(res, 409, { error: "the bot switched tasks before it could receive the message" });
       }
+      const sendId = parseSendId(body.sendId);
       const replyTo = resolveReplyTarget(threadId, body.replyToId);
-      // Claude can accept the message inside its live turn. If the write
-      // loses a race with turn settlement, or the engine cannot steer, the
-      // existing server-side queue records it atomically for the next turn.
-      if (bot.busy) {
-        const instance = registry.get(bot.modelSelection.instanceId);
-        let steered = false;
-        if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
-          steered = await instance.adapter
-            .steer(threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
-            .catch(() => false);
-        }
-        // steer() is awaited adapter work. The turn can settle, the task can
-        // switch, or the whole bot can be deleted before its acknowledgement
-        // arrives. Re-read every ownership invariant before appending even a
-        // successful steer; otherwise that late acknowledgement writes a user
-        // message into a task the bot no longer owns. A conflict leaves the
-        // text in the client's composer/outbox to resend deliberately.
-        const current = store.bot(bot.id);
-        if (!current) return json(res, 404, { error: "no such bot" });
-        if (!store.taskByThread(bot.id, threadId)) {
-          return json(res, 409, { error: "the target task no longer exists" });
-        }
-        if (current.threadId !== threadId) {
-          return json(res, 409, { error: "the bot switched tasks before it could receive the message" });
-        }
-        if (steered) {
-          if (!current.busy) {
-            return json(res, 409, { error: "the running turn ended before the steered message could be recorded" });
+      const receipt = await sendSequencer.run(
+        sendId ? `bot:${bot.id}:${threadId}:${sendId}` : undefined,
+        sendFingerprint(text, replyTo?.id),
+        async () => {
+          if (sendId) {
+            const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id);
+            if (accepted.kind === "conflict") {
+              throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
+            }
+            if (accepted.kind === "match") {
+              const canonical = {
+                ok: true as const,
+                threadId,
+                message: accepted.message,
+              };
+              return accepted.message.steered
+                ? { ...canonical, steered: true as const }
+                : canonical;
+            }
+            const queued = queuedSteeredMessage(bot.id, threadId, sendId);
+            if (queued) {
+              if (queued.text !== text || queued.replyToId !== replyTo?.id) {
+                throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
+              }
+              return { ok: true as const, queued: true as const, queueId: queued.id, threadId };
+            }
           }
-          clearUnattended(current.id);
-          const message = store.appendMessage(threadId, {
-            role: "user",
-            kind: "text",
-            text,
-            replyToId: replyTo?.id,
-            steered: true,
-          });
-          return json(res, 202, { ok: true, steered: true, threadId, message });
-        }
-        if (!current.busy) {
-          const message = await startTurn(bot.id, text, { threadId, replyTo });
-          return json(res, 202, { ok: true, threadId, message });
-        }
-        const queued = queueSteeredMessage(current.id, threadId, text, {
-          replyToId: replyTo?.id,
-          prompt: promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
-        });
-        return json(res, 202, { ok: true, queued: true, queueId: queued.id, threadId });
-      }
-      const message = await startTurn(bot.id, text, { threadId, replyTo });
-      return json(res, 202, { ok: true, threadId, message });
+
+          const currentAtStart = store.bot(bot.id);
+          if (!currentAtStart) throw Object.assign(new Error("no such bot"), { status: 404 });
+          if (!store.taskByThread(currentAtStart.id, threadId)) {
+            throw Object.assign(new Error("the target task no longer exists"), { status: 409 });
+          }
+          if (currentAtStart.threadId !== threadId) {
+            throw Object.assign(new Error("the bot switched tasks before it could receive the message"), {
+              status: 409,
+            });
+          }
+
+          // Claude can accept the message inside its live turn. If the write
+          // loses a race with turn settlement, or the engine cannot steer, the
+          // existing server-side queue records it atomically for the next turn.
+          if (currentAtStart.busy) {
+            const instance = registry.get(currentAtStart.modelSelection.instanceId);
+            let steered = false;
+            if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
+              steered = await instance.adapter
+                .steer(threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
+                .catch(() => false);
+            }
+            // steer() is awaited adapter work. The turn can settle, the task can
+            // switch, or the whole bot can be deleted before its acknowledgement
+            // arrives. Re-read every ownership invariant before appending even a
+            // successful steer; otherwise that late acknowledgement writes a user
+            // message into a task the bot no longer owns. A conflict leaves the
+            // text in the client's composer/outbox to resend deliberately.
+            const current = store.bot(bot.id);
+            if (!current) throw Object.assign(new Error("no such bot"), { status: 404 });
+            if (!store.taskByThread(bot.id, threadId)) {
+              throw Object.assign(new Error("the target task no longer exists"), { status: 409 });
+            }
+            if (current.threadId !== threadId) {
+              throw Object.assign(new Error("the bot switched tasks before it could receive the message"), {
+                status: 409,
+              });
+            }
+            if (steered) {
+              if (!current.busy) {
+                throw Object.assign(
+                  new Error("the running turn ended before the steered message could be recorded"),
+                  { status: 409 },
+                );
+              }
+              clearUnattended(current.id);
+              const message = store.appendMessage(threadId, {
+                role: "user",
+                kind: "text",
+                text,
+                replyToId: replyTo?.id,
+                sendId,
+                steered: true,
+              });
+              return { ok: true as const, steered: true as const, threadId, message };
+            }
+            if (!current.busy) {
+              const message = await startTurn(bot.id, text, { threadId, replyTo, sendId });
+              return { ok: true as const, threadId, message };
+            }
+            const queued = queueSteeredMessage(current.id, threadId, text, {
+              replyToId: replyTo?.id,
+              sendId,
+              prompt: promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
+            });
+            return { ok: true as const, queued: true as const, queueId: queued.id, threadId };
+          }
+          const message = await startTurn(bot.id, text, { threadId, replyTo, sendId });
+          return { ok: true as const, threadId, message };
+        },
+      );
+      return json(res, 202, receipt);
     }
 
     m = path.match(/^\/api\/bots\/([\w-]+)\/queue\/([\w-]+)$/);

--- a/server/index.ts
+++ b/server/index.ts
@@ -5215,7 +5215,22 @@ const server = createServer(async (req, res) => {
             return json(res, 202, { ok: true, steered: true, threadId, message });
           }
         }
-        const queued = queueSteeredMessage(bot, text, {
+        // The turn can settle while steer() is awaited. If it did, its queue
+        // drain already ran; enqueueing now would strand this message until
+        // some unrelated future turn settles. Start the pinned task directly
+        // instead. If another turn claimed the bot meanwhile, queue behind it
+        // but keep the original task target.
+        const current = store.bot(bot.id);
+        if (!current) return json(res, 404, { error: "no such bot" });
+        if (!store.taskByThread(bot.id, threadId)) {
+          return json(res, 409, { error: "the target task no longer exists" });
+        }
+        if (!current.busy) {
+          const message = await startTurn(bot.id, text, { threadId, replyTo });
+          return json(res, 202, { ok: true, threadId, message });
+        }
+        const queued = queueSteeredMessage(current, text, {
+          threadId,
           replyToId: replyTo?.id,
           prompt: promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
         });

--- a/server/send-idempotency.test.ts
+++ b/server/send-idempotency.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { acceptedSendMatch, parseSendId, sendFingerprint, SendSequencer } from "./send-idempotency.ts";
+import type { Message } from "./store.ts";
+
+function userMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "message-1",
+    at: 1,
+    role: "user",
+    kind: "text",
+    text: "ship it",
+    sendId: "send_1234567890123456",
+    ...overrides,
+  };
+}
+
+describe("send idempotency", () => {
+  it("accepts bounded client ids and rejects malformed input", () => {
+    expect(parseSendId(undefined)).toBeUndefined();
+    expect(parseSendId("send_1234567890123456")).toBe("send_1234567890123456");
+    expect(() => parseSendId("short")).toThrow(/client-generated id/);
+    expect(() => parseSendId("spaces are not ids 1234")).toThrow(/client-generated id/);
+  });
+
+  it("returns only an exact canonical user-message receipt", () => {
+    const sendId = "send_1234567890123456";
+    const message = userMessage({ replyToId: "reply-1" });
+    expect(acceptedSendMatch([message], sendId, "ship it", "reply-1")).toEqual({
+      kind: "match",
+      message,
+    });
+    expect(acceptedSendMatch([message], sendId, "different", "reply-1")).toEqual({
+      kind: "conflict",
+    });
+    expect(acceptedSendMatch([message], "send_9999999999999999", "ship it", "reply-1")).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("coalesces simultaneous retries onto one operation", async () => {
+    const sequencer = new SendSequencer();
+    let releaseFirst = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const order: string[] = [];
+    const fingerprint = sendFingerprint("first", undefined);
+    const first = sequencer.run("same", fingerprint, async () => {
+      order.push("first:start");
+      await gate;
+      order.push("first:end");
+      return 1;
+    });
+    const secondWork = vi.fn(async () => {
+      order.push("second");
+      return 2;
+    });
+    const second = sequencer.run("same", fingerprint, secondWork);
+    await Promise.resolve();
+    expect(secondWork).not.toHaveBeenCalled();
+    releaseFirst();
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 1]);
+    expect(order).toEqual(["first:start", "first:end"]);
+    expect(secondWork).not.toHaveBeenCalled();
+
+    await expect(sequencer.run("same", fingerprint, secondWork)).resolves.toBe(2);
+    expect(secondWork).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a concurrent payload change and shares the first rejection", async () => {
+    const sequencer = new SendSequencer();
+    let rejectFirst = (_error: Error) => {};
+    const gate = new Promise<number>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    const firstWork = vi.fn(() => gate);
+    const secondWork = vi.fn(async () => 2);
+    const first = sequencer.run("same-error", "one", firstWork);
+    const same = sequencer.run("same-error", "one", secondWork);
+    await expect(sequencer.run("same-error", "different", secondWork)).rejects.toMatchObject({
+      status: 409,
+    });
+    rejectFirst(new Error("transport lost"));
+    await expect(first).rejects.toThrow("transport lost");
+    await expect(same).rejects.toThrow("transport lost");
+    expect(firstWork).toHaveBeenCalledOnce();
+    expect(secondWork).not.toHaveBeenCalled();
+
+    await expect(sequencer.run("same-error", "one", secondWork)).resolves.toBe(2);
+  });
+});

--- a/server/send-idempotency.ts
+++ b/server/send-idempotency.ts
@@ -1,0 +1,72 @@
+import type { Message } from "./store.ts";
+import { z } from "zod";
+
+const sendIdSchema = z.string().regex(/^[A-Za-z0-9_-]{16,80}$/).optional();
+
+/** Parse an optional client-generated identity at the HTTP boundary. */
+export function parseSendId(value: string | null | undefined): string | undefined {
+  const parsed = sendIdSchema.safeParse(value);
+  if (!parsed.success) {
+    throw Object.assign(new Error("sendId must be a client-generated id"), { status: 400 });
+  }
+  return parsed.data;
+}
+
+export type AcceptedSendMatch =
+  | { kind: "none" }
+  | { kind: "match"; message: Message }
+  | { kind: "conflict" };
+
+/** Match a retry to the canonical user message already persisted for it. */
+export function acceptedSendMatch(
+  messages: Message[],
+  sendId: string,
+  text: string,
+  replyToId?: string,
+): AcceptedSendMatch {
+  const message = messages.find((candidate) => candidate.sendId === sendId);
+  if (!message) return { kind: "none" };
+  if (
+    message.role !== "user" ||
+    message.kind !== "text" ||
+    message.text !== text ||
+    message.replyToId !== replyToId
+  ) {
+    return { kind: "conflict" };
+  }
+  return { kind: "match", message };
+}
+
+/** Coalesces simultaneous retries onto the first request's exact outcome. */
+export class SendSequencer {
+  private readonly inFlight = new Map<string, { fingerprint: string; result: Promise<unknown> }>();
+
+  async run<T>(
+    key: string | undefined,
+    fingerprint: string,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    if (!key) return work();
+    const existing = this.inFlight.get(key);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
+      }
+      // SAFETY: one key identifies one HTTP endpoint receipt, so every
+      // coalesced caller has the same result contract as the owner.
+      return existing.result as Promise<T>;
+    }
+    const current = work();
+    const entry = { fingerprint, result: current };
+    this.inFlight.set(key, entry);
+    const clear = () => {
+      if (this.inFlight.get(key) === entry) this.inFlight.delete(key);
+    };
+    void current.then(clear, clear);
+    return current;
+  }
+}
+
+export function sendFingerprint(text: string, replyToId?: string): string {
+  return JSON.stringify([text, replyToId ?? null]);
+}

--- a/server/steer-e2e.test.ts
+++ b/server/steer-e2e.test.ts
@@ -24,6 +24,7 @@ posixOnly("mid-turn steering e2e", () => {
   let child: ChildProcess;
   let home: string;
   let stderr = "";
+  let steerGate: string;
 
   const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
     const res = await fetch(`${BASE}${path}`, {
@@ -47,11 +48,17 @@ posixOnly("mid-turn steering e2e", () => {
     chmodSync(FAKE_ACP, 0o755);
     home = mkdtempSync(join(tmpdir(), "omb-steer-"));
     mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    steerGate = join(home, "delayed-steer.gate");
     writeFileSync(
       join(home, ".openmausbot", "config.json"),
       JSON.stringify({
         instances: {
           claude: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "slow" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+          claudeRace: {
+            driver: "claudeAgent",
+            environment: { FAKE_CLAUDE_MODE: "slow", FAKE_CLAUDE_STEER_GATE: steerGate },
+            config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
+          },
           // no live session: a message while busy uses the server-side queue
           acp: { driver: "grokAgent", environment: { FAKE_ACP_MODE: "hang" }, config: { cli: FAKE_ACP, fullAuto: true } },
         },
@@ -120,6 +127,41 @@ posixOnly("mid-turn steering e2e", () => {
     },
     40_000,
   );
+
+  it("rejects a delayed steer acknowledgement after the bot is deleted", async () => {
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, {
+      modelSelection: { instanceId: "claudeRace", model: "claude-fake" },
+    });
+
+    expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first race turn" })).status).toBe(202);
+    await waitFor(async () => (await getBot(created.id))?.busy === true, "the race turn to start");
+    await waitFor(
+      async () => (await getBot(created.id))?.messages.some((message: any) => message.kind === "activity"),
+      "the race turn tool chip",
+    );
+
+    // The fake has paused stdin after the first prompt. This exceeds a pipe's
+    // writable buffer, so the steer promise cannot acknowledge until the gate
+    // opens; meanwhile the first turn is free to settle normally.
+    const delayed = api("POST", `/api/bots/${created.id}/messages`, {
+      text: `delayed ownership check ${"x".repeat(900_000)}`,
+      threadId: created.threadId,
+    });
+    const prematurelySettled = await Promise.race([
+      delayed.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+    ]);
+    expect(prematurelySettled).toBe(false);
+
+    await waitFor(async () => (await getBot(created.id))?.busy === false, "the original race turn to settle");
+    expect((await api("DELETE", `/api/bots/${created.id}`)).status).toBe(200);
+    writeFileSync(steerGate, "open");
+
+    const rejected = await delayed;
+    expect(rejected.status).toBe(404);
+    expect(rejected.body.error).toMatch(/no such bot/i);
+  }, 40_000);
 
   it("an engine without a live session preserves the message in the server-side queue", async () => {
     const created = (await api("POST", "/api/bots")).body.bot;

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -151,6 +151,35 @@ describe("steer-queue module", () => {
     expect(run.mock.calls[0][2]).toBe("Reply context\nThat part");
   });
 
+  it("keeps the caller's pinned task when the mutable bot switches during steering", () => {
+    const bot = fakeBot("bot-switch", "thread-original", true);
+    const store = fakeStore([bot]);
+
+    // This mirrors an adapter steer() yielding until the old turn settles,
+    // after which another request changes the bot's active task.
+    bot.threadId = "thread-new";
+    queueSteeredMessage(bot, "keep this with the original task", {
+      threadId: "thread-original",
+    });
+
+    expect(_queuedCount("thread-original")).toBe(1);
+    expect(_queuedCount("thread-new")).toBe(0);
+    bot.busy = false;
+    const run = vi.fn();
+    drainSteeredMessages(store, run);
+    expect(store.messages[0]).toMatchObject({
+      id: expect.stringContaining("thread-original"),
+      text: "keep this with the original task",
+    });
+    expect(run).toHaveBeenCalledWith(
+      bot.id,
+      "thread-original",
+      "keep this with the original task",
+      expect.objectContaining({ text: "keep this with the original task" }),
+      expect.any(Array),
+    );
+  });
+
   it("fires nothing when nothing is queued", () => {
     const run = vi.fn();
     drainSteeredMessages(fakeStore([fakeBot("bot-c", "thread-c", false)]), run);

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -66,7 +66,7 @@ describe("steer-queue module", () => {
   it("does not append a queued user message until drain", () => {
     const bot = fakeBot("bot-a", "thread-a", true);
     const store = fakeStore([bot]);
-    const queued = queueSteeredMessage(bot, "hold that thought");
+    const queued = queueSteeredMessage(bot.id, bot.threadId, "hold that thought");
     expect(queued).toMatchObject({ id: expect.any(String) });
     expect(store.messages).toHaveLength(0);
     expect(_queuedCount("thread-a")).toBe(1);
@@ -89,8 +89,8 @@ describe("steer-queue module", () => {
   it("holds the queue while the bot is busy and drains it once when idle", () => {
     const bot = fakeBot("bot-b", "thread-b", true);
     const store = fakeStore([bot]);
-    const first = queueSteeredMessage(bot, "first note");
-    const second = queueSteeredMessage(bot, "second note");
+    const first = queueSteeredMessage(bot.id, bot.threadId, "first note");
+    const second = queueSteeredMessage(bot.id, bot.threadId, "second note");
     const run = vi.fn();
 
     drainSteeredMessages(store, run);
@@ -122,10 +122,10 @@ describe("steer-queue module", () => {
   it("drops a cancelled message so drain does not send it", () => {
     const bot = fakeBot("bot-cancel", "thread-cancel", true);
     const store = fakeStore([bot]);
-    const first = queueSteeredMessage(bot, "keep me");
-    const second = queueSteeredMessage(bot, "drop me");
-    expect(cancelSteeredMessage("thread-cancel", second.id)).toBe(true);
-    expect(cancelSteeredMessage("thread-cancel", "missing")).toBe(false);
+    const first = queueSteeredMessage(bot.id, bot.threadId, "keep me");
+    const second = queueSteeredMessage(bot.id, bot.threadId, "drop me");
+    expect(cancelSteeredMessage(bot.id, second.id)).toBe(true);
+    expect(cancelSteeredMessage(bot.id, "missing")).toBe(false);
     expect(_queuedCount("thread-cancel")).toBe(1);
 
     bot.busy = false;
@@ -140,7 +140,7 @@ describe("steer-queue module", () => {
   it("keeps reply metadata and the provider-facing reply prompt while queued", () => {
     const bot = fakeBot("bot-reply", "thread-reply", true);
     const store = fakeStore([bot]);
-    queueSteeredMessage(bot, "That part", {
+    queueSteeredMessage(bot.id, bot.threadId, "That part", {
       replyToId: "original-message",
       prompt: "Reply context\nThat part",
     });
@@ -151,33 +151,15 @@ describe("steer-queue module", () => {
     expect(run.mock.calls[0][2]).toBe("Reply context\nThat part");
   });
 
-  it("keeps the caller's pinned task when the mutable bot switches during steering", () => {
-    const bot = fakeBot("bot-switch", "thread-original", true);
-    const store = fakeStore([bot]);
+  it("cancels a pinned-task queue after the bot switches without crossing bot ownership", () => {
+    const bot = fakeBot("bot-switch-cancel", "thread-original-cancel", true);
+    const queued = queueSteeredMessage(bot.id, bot.threadId, "cancel on the old task");
 
-    // This mirrors an adapter steer() yielding until the old turn settles,
-    // after which another request changes the bot's active task.
-    bot.threadId = "thread-new";
-    queueSteeredMessage(bot, "keep this with the original task", {
-      threadId: "thread-original",
-    });
-
-    expect(_queuedCount("thread-original")).toBe(1);
-    expect(_queuedCount("thread-new")).toBe(0);
-    bot.busy = false;
-    const run = vi.fn();
-    drainSteeredMessages(store, run);
-    expect(store.messages[0]).toMatchObject({
-      id: expect.stringContaining("thread-original"),
-      text: "keep this with the original task",
-    });
-    expect(run).toHaveBeenCalledWith(
-      bot.id,
-      "thread-original",
-      "keep this with the original task",
-      expect.objectContaining({ text: "keep this with the original task" }),
-      expect.any(Array),
-    );
+    bot.threadId = "thread-new-cancel";
+    expect(cancelSteeredMessage("some-other-bot", queued.id)).toBe(false);
+    expect(_queuedCount("thread-original-cancel")).toBe(1);
+    expect(cancelSteeredMessage(bot.id, queued.id)).toBe(true);
+    expect(_queuedCount("thread-original-cancel")).toBe(0);
   });
 
   it("fires nothing when nothing is queued", () => {
@@ -188,7 +170,7 @@ describe("steer-queue module", () => {
 
   it("drops the queue of a deleted bot without running it", () => {
     const bot = fakeBot("bot-d", "thread-d", true);
-    queueSteeredMessage(bot, "orphaned");
+    queueSteeredMessage(bot.id, bot.threadId, "orphaned");
     const run = vi.fn();
     drainSteeredMessages(fakeStore([]), run);
     expect(run).not.toHaveBeenCalled();

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -16,7 +16,14 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { cancelSteeredMessage, drainSteeredMessages, queueSteeredMessage, _queuedCount, type SteerStore } from "./steer-queue.ts";
+import {
+  cancelSteeredMessage,
+  drainSteeredMessages,
+  queuedSteeredMessage,
+  queueSteeredMessage,
+  _queuedCount,
+  type SteerStore,
+} from "./steer-queue.ts";
 import type { BotRecord, Message } from "./store.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
@@ -84,6 +91,31 @@ describe("steer-queue module", () => {
     expect(store.messages[0]!.queued).toBeUndefined();
     expect(run).toHaveBeenCalledTimes(1);
     expect(_queuedCount("thread-a")).toBe(0);
+  });
+
+  it("keeps a stable client receipt while a send waits to drain", () => {
+    const bot = fakeBot("bot-receipt", "thread-receipt", true);
+    const store = fakeStore([bot]);
+    const queued = queueSteeredMessage(bot.id, bot.threadId, "retry safely", {
+      replyToId: "reply-1",
+      sendId: "send_1234567890123456",
+    });
+
+    expect(queuedSteeredMessage(bot.id, bot.threadId, "send_1234567890123456")).toEqual({
+      id: queued.id,
+      text: "retry safely",
+      replyToId: "reply-1",
+    });
+    expect(queuedSteeredMessage("other-bot", bot.threadId, "send_1234567890123456")).toBeNull();
+
+    bot.busy = false;
+    drainSteeredMessages(store, vi.fn());
+    expect(store.messages[0]).toMatchObject({
+      text: "retry safely",
+      sendId: "send_1234567890123456",
+      queueId: queued.id,
+    });
+    expect(queuedSteeredMessage(bot.id, bot.threadId, "send_1234567890123456")).toBeNull();
   });
 
   it("holds the queue while the bot is busy and drains it once when idle", () => {

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -37,18 +37,22 @@ interface QueueEntry {
 
 const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
 
+export interface QueuedSteer {
+  id: string;
+}
+
 /** Hold a mid-turn send off the transcript until drain. */
 export function queueSteeredMessage(
-  bot: BotRecord,
+  botId: string,
+  threadId: string,
   text: string,
-  options: { prompt?: string; replyToId?: string; threadId?: string } = {},
-): { id: string } {
-  // An adapter steer can yield while the running turn settles. Its caller
-  // pins the task before that await; do not let a later task switch silently
-  // retarget this queued message through the mutable bot record.
-  const threadId = options.threadId ?? bot.threadId;
+  options: { prompt?: string; replyToId?: string } = {},
+): QueuedSteer {
   const id = newId();
-  const entry = queues.get(threadId) ?? { botId: bot.id, items: [] };
+  const entry = queues.get(threadId) ?? { botId, items: [] };
+  // A thread cannot legitimately change owners. Refuse to merge unrelated
+  // queues even if a corrupt caller reuses a thread id.
+  if (entry.botId !== botId) throw new Error("queued task belongs to another bot");
   entry.items.push({ messageId: id, text, prompt: options.prompt ?? text, replyToId: options.replyToId });
   queues.set(threadId, entry);
   return { id };
@@ -110,17 +114,20 @@ export function drainSteeredMessages(
   }
 }
 
-/** Drop one waiting send so it never drains. Returns false when that
- * queue id was not in the in-memory queue (already drained, or a restart
- * lost the auto-run intent). */
-export function cancelSteeredMessage(threadId: string, messageId: string): boolean {
-  const entry = queues.get(threadId);
-  if (!entry) return false;
-  const items = entry.items.filter((item) => item.messageId !== messageId);
-  if (items.length === entry.items.length) return false;
-  if (items.length === 0) queues.delete(threadId);
-  else queues.set(threadId, { botId: entry.botId, items });
-  return true;
+/** Drop one waiting send owned by this bot so it never drains. The queue id
+ * is stable even if the bot switches away from the task while the request is
+ * in flight. Returns false when it was already drained, belongs to another
+ * bot, or a restart lost the in-memory auto-run intent. */
+export function cancelSteeredMessage(botId: string, messageId: string): boolean {
+  for (const [threadId, entry] of queues) {
+    if (entry.botId !== botId) continue;
+    const items = entry.items.filter((item) => item.messageId !== messageId);
+    if (items.length === entry.items.length) continue;
+    if (items.length === 0) queues.delete(threadId);
+    else queues.set(threadId, { botId: entry.botId, items });
+    return true;
+  }
+  return false;
 }
 
 /** Test helper: how many messages remain queued for a thread. */

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -41,9 +41,12 @@ const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
 export function queueSteeredMessage(
   bot: BotRecord,
   text: string,
-  options: { prompt?: string; replyToId?: string } = {},
+  options: { prompt?: string; replyToId?: string; threadId?: string } = {},
 ): { id: string } {
-  const threadId = bot.threadId;
+  // An adapter steer can yield while the running turn settles. Its caller
+  // pins the task before that await; do not let a later task switch silently
+  // retarget this queued message through the mutable bot record.
+  const threadId = options.threadId ?? bot.threadId;
   const id = newId();
   const entry = queues.get(threadId) ?? { botId: bot.id, items: [] };
   entry.items.push({ messageId: id, text, prompt: options.prompt ?? text, replyToId: options.replyToId });

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -32,7 +32,7 @@ interface QueueEntry {
    * happen on a DIFFERENT thread (a room turn) — drain matches on "this
    * queue's bot is idle now", which needs the bot, not the settling thread. */
   botId: string;
-  items: Array<{ messageId: string; text: string; prompt: string; replyToId?: string }>;
+  items: Array<{ messageId: string; text: string; prompt: string; replyToId?: string; sendId?: string }>;
 }
 
 const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
@@ -46,14 +46,20 @@ export function queueSteeredMessage(
   botId: string,
   threadId: string,
   text: string,
-  options: { prompt?: string; replyToId?: string } = {},
+  options: { prompt?: string; replyToId?: string; sendId?: string } = {},
 ): QueuedSteer {
   const id = newId();
   const entry = queues.get(threadId) ?? { botId, items: [] };
   // A thread cannot legitimately change owners. Refuse to merge unrelated
   // queues even if a corrupt caller reuses a thread id.
   if (entry.botId !== botId) throw new Error("queued task belongs to another bot");
-  entry.items.push({ messageId: id, text, prompt: options.prompt ?? text, replyToId: options.replyToId });
+  entry.items.push({
+    messageId: id,
+    text,
+    prompt: options.prompt ?? text,
+    replyToId: options.replyToId,
+    sendId: options.sendId,
+  });
   queues.set(threadId, entry);
   return { id };
 }
@@ -97,6 +103,7 @@ export function drainSteeredMessages(
           kind: "text",
           text: item.text,
           replyToId: item.replyToId,
+          sendId: item.sendId,
           queueId: item.messageId,
         }),
       );
@@ -112,6 +119,18 @@ export function drainSteeredMessages(
       appended.map((message) => message.id),
     );
   }
+}
+
+/** Find the receipt for a retry whose message is still waiting to drain. */
+export function queuedSteeredMessage(
+  botId: string,
+  threadId: string,
+  sendId: string,
+): { id: string; text: string; replyToId?: string } | null {
+  const entry = queues.get(threadId);
+  if (!entry || entry.botId !== botId) return null;
+  const item = entry.items.find((candidate) => candidate.sendId === sendId);
+  return item ? { id: item.messageId, text: item.text, replyToId: item.replyToId } : null;
 }
 
 /** Drop one waiting send owned by this bot so it never drains. The queue id

--- a/server/store.ts
+++ b/server/store.ts
@@ -113,6 +113,8 @@ export interface Message {
   /** Optional flat reply reference. Unlike parentId this never changes the
    * conversation branch; it only quotes one earlier text message inline. */
   replyToId?: string;
+  /** Stable client identity for at-most-once chat POST retries. */
+  sendId?: string;
   /** group threads: which member said this (sender attribution). */
   from?: { botId: string; name: string; color: string };
   /** emoji reactions; by = "user" or a member botId. */

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -17,7 +17,7 @@
 //                      inherited-api-key — what `auth status` reports
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CLAUDE_MODE ?? "happy";
 
@@ -85,6 +85,23 @@ let dumped = false;
 let turnRunning = false;
 let steered: string[] = [];
 let stdinEnded = false;
+let steerGateArmed = false;
+
+// Ownership-race fixture: after accepting the first prompt, stop consuming
+// stdin until the test creates this file. A large second write then leaves
+// adapter.steer() genuinely pending while the first turn settles and another
+// HTTP request deletes or switches the bot.
+const armSteerGate = () => {
+  const gate = process.env.FAKE_CLAUDE_STEER_GATE;
+  if (!gate || steerGateArmed) return;
+  steerGateArmed = true;
+  process.stdin.pause();
+  const poll = setInterval(() => {
+    if (!existsSync(gate)) return;
+    clearInterval(poll);
+    process.stdin.resume();
+  }, 10);
+};
 
 const promptText = (prompt: JsonValue): string => {
   const m = prompt && typeof prompt === "object" && !Array.isArray(prompt) ? (prompt as { message?: { content?: unknown } }).message : undefined;
@@ -213,7 +230,10 @@ process.stdin.on("data", (c) => {
       continue;
     }
     if (turnRunning) steered.push(promptText(prompt));
-    else playTurn(prompt);
+    else {
+      playTurn(prompt);
+      armSteerGate();
+    }
   }
 });
 process.stdin.on("end", () => {

--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -368,7 +368,7 @@ function Call({ bot }: { bot: Bot }) {
       }
 
       move("sending");
-      dispatch({ type: "send", botId: bot.id, text: said });
+      dispatch({ type: "send", botId: bot.id, text: said, threadId: bot.threadId });
     });
     const offEnd = bridge.onSpeechEnd(({ code, reason }) => {
       if (!alive.current || currentCall() !== bot.id) return;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -73,6 +73,7 @@ import {
   tailWindowStart,
 } from "@/lib/transcript-window";
 import { timelineEvents } from "@/lib/taskTimeline";
+import { useReplyDraft } from "@/lib/drafts";
 
 /** Long user messages collapse behind a fade so pasted walls of text don't
  * bury the conversation; bots get full markdown. */
@@ -806,9 +807,12 @@ export function ChatView({ bot }: { bot: Bot }) {
   const provisioning = state.provisioning[bot.id];
   const mascotMotion = state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
   const [findOpen, setFindOpen] = useState(false);
-  const [replyTo, setReplyTo] = useState<Message | null>(null);
+  const { replyTo, selectReply, clearReply, consumeReply, restoreReply } = useReplyDraft(
+    bot.threadId,
+    `bot:${bot.id}:${bot.threadId}`,
+    bot.messages,
+  );
   useEffect(() => setFindOpen(false), [bot.threadId]);
-  useEffect(() => setReplyTo(null), [bot.threadId]);
   useEffect(() => {
     const onFind = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
@@ -1190,7 +1194,7 @@ export function ChatView({ bot }: { bot: Bot }) {
             onCancelEdit={cancelEdit}
             onSubmitEdit={submitEdit}
             onRegenerate={regenerate}
-            onReply={setReplyTo}
+            onReply={selectReply}
           />
           {laterCount > 0 && (
             <div className="flex justify-center">
@@ -1247,17 +1251,18 @@ export function ChatView({ bot }: { bot: Bot }) {
         </button>
       )}
 
-      {/* keyed by bot: a draft belongs to the conversation it was typed in,
-          so switching bots starts from an empty composer instead of carrying
-          the previous bot's half-written message over. ArrowUp-to-edit is
-          gated on busy like the pencil button — editing rewinds the thread,
-          which a live turn forbids (the server 409s it). */}
+      {/* Keyed by task: each conversation keeps its own draft and a failed
+          request can restore the old task without spilling into the newly
+          selected one. ArrowUp-to-edit stays gated on busy because editing
+          rewinds the thread, which a live turn forbids (the server 409s it). */}
       <div className="absolute inset-x-0 bottom-0 z-[2]">
       <Composer
-        key={bot.id}
+        key={bot.threadId}
         bot={bot}
         replyTo={replyTo}
-        onClearReply={() => setReplyTo(null)}
+        onClearReply={clearReply}
+        onConsumeReply={consumeReply}
+        onRestoreReply={restoreReply}
         onEditLast={lastUserMessage && !bot.busy ? () => setEditingId(lastUserMessage.id) : undefined}
       />
       </div>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -336,7 +336,6 @@ export function Composer({
   // pending row so they cannot become the active leaf mid-turn.
   const [queued, setQueued] = useState<QueuedGroupSend | null>(null);
   const queuedRef = useRef(queued);
-  queuedRef.current = queued;
   const clearQueued = useCallback(() => {
     queuedRef.current = null;
     setQueued(null);

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,9 +1,20 @@
 import { track } from "@/lib/analytics";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
 import { ArrowUp, Check, Clock, Hand, Mic, Paperclip, ShieldCheck, Square, Users, X } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group, type Message } from "@/state/store";
 import { cn } from "@/lib/cn";
-import { useComposerDraft } from "@/lib/drafts";
+import {
+  draftRevision,
+  forgetFailedComposerSend,
+  markDraftEdited,
+  recoverFailedComposerSend,
+  rememberFailedComposerSend,
+  restoredSendId,
+  useComposerDraft,
+  useFailedComposerSends,
+  type ComposerSendSnapshot,
+  type FailedComposerSend,
+} from "@/lib/drafts";
 import { MausAvatar } from "./Avatar";
 import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
@@ -37,6 +48,16 @@ function mentionQueryAt(text: string, caret: number): { start: number; query: st
 }
 
 type MentionChoice = { id: string; name: string; bot?: Bot };
+
+interface ComposerDraftSnapshot extends ComposerSendSnapshot {
+  reply: Message | null;
+}
+
+interface QueuedGroupSend {
+  text: string;
+  replyToId?: string;
+  draft: ComposerDraftSnapshot;
+}
 
 function PermissionModeSelector({ bot, onSetAuto }: { bot: Bot; onSetAuto: (auto: boolean) => void }) {
   const [open, setOpen] = useState(false);
@@ -141,6 +162,8 @@ export function Composer({
   onEditLast,
   replyTo,
   onClearReply,
+  onConsumeReply,
+  onRestoreReply,
   locked = false,
 }: {
   bot?: Bot;
@@ -149,6 +172,8 @@ export function Composer({
   onEditLast?: () => void;
   replyTo?: Message | null;
   onClearReply?: () => void;
+  onConsumeReply?: () => void;
+  onRestoreReply?: (message: Message, threadId: string) => void;
   /** New rooms keep the composer inert until their setup is saved or skipped. */
   locked?: boolean;
 }) {
@@ -177,23 +202,52 @@ export function Composer({
     : (bot?.name ?? "The bot");
   // Per-thread draft: switching bots unmounts this component, so both the
   // text and its attachment chips have to outlive it (see lib/drafts).
+  const draftId = group
+    ? `group:${group.id}:${group.threadId}`
+    : `bot:${bot?.id ?? ""}:${bot?.threadId ?? ""}`;
   const [text, setText, attachments, setAttachments] = useComposerDraft(
-    group ? `group:${group.id}:${group.threadId}` : `bot:${bot?.id ?? ""}`,
+    draftId,
+    !group && bot ? `bot:${bot.id}` : undefined,
+  );
+  const failedSends = useFailedComposerSends(draftId);
+  const editText = useCallback(
+    (next: string) => {
+      markDraftEdited(draftId);
+      setText(next);
+    },
+    [draftId, setText],
+  );
+  const editAttachments = useCallback(
+    (next: SetStateAction<Attachment[]>) => {
+      markDraftEdited(draftId);
+      setAttachments(next);
+    },
+    [draftId, setAttachments],
+  );
+  const restoreDraft = useCallback(
+    (sent: ComposerDraftSnapshot) => {
+      // Shared recovery reaches a newly mounted view after navigation and
+      // falls back to a separate retry item when a newer draft already exists.
+      if (recoverFailedComposerSend(sent) === "restored" && sent.reply) {
+        onRestoreReply?.(sent.reply, sent.threadId);
+      }
+    },
+    [onRestoreReply],
   );
   const addAttachments = useCallback(
-    (next: Attachment[]) => setAttachments((prev) => [...prev, ...next]),
-    [setAttachments],
+    (next: Attachment[]) => editAttachments((prev) => [...prev, ...next]),
+    [editAttachments],
   );
   const removeAttachment = useCallback(
-    (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
-    [setAttachments],
+    (id: string) => editAttachments((prev) => prev.filter((a) => a.id !== id)),
+    [editAttachments],
   );
   const displayPasteInChatBox = useCallback(
     /** Moves one pasted attachment into the editable draft and restores focus. */
     function displayPasteInChatBox(attachment: PasteAttachment) {
       const nextText = appendPastedText(text, attachment.text);
-      setText(nextText);
-      setAttachments((prev) => prev.filter((a) => a.id !== attachment.id));
+      editText(nextText);
+      editAttachments((prev) => prev.filter((a) => a.id !== attachment.id));
       setCaret(nextText.length);
       setDismissedAt(null);
       requestAnimationFrame(() => {
@@ -203,7 +257,7 @@ export function Composer({
         input.setSelectionRange(nextText.length, nextText.length);
       });
     },
-    [text, setText, setAttachments],
+    [text, editText, editAttachments],
   );
   const [recording, setRecording] = useState(false);
   const [speechError, setSpeechError] = useState<string | null>(null);
@@ -265,7 +319,7 @@ export function Composer({
     if (!mention) return;
     const after = text.slice(caret);
     const next = `${text.slice(0, mention.start)}@${peer.name} ${after}`;
-    setText(next);
+    editText(next);
     const newCaret = mention.start + peer.name.length + 2;
     setCaret(newCaret);
     // picking completes this tag — close the popup so the next Enter sends
@@ -280,7 +334,20 @@ export function Composer({
   // the moment the room settles. 1:1 mid-turn sends still POST (the harness
   // queue), but stay off the transcript until drain — the chip here is the
   // pending row so they cannot become the active leaf mid-turn.
-  const [queued, setQueued] = useState<{ text: string; replyToId?: string } | null>(null);
+  const [queued, setQueued] = useState<QueuedGroupSend | null>(null);
+  const queuedRef = useRef(queued);
+  queuedRef.current = queued;
+  const clearQueued = useCallback(() => {
+    queuedRef.current = null;
+    setQueued(null);
+  }, []);
+  useEffect(
+    () => () => {
+      const unsent = queuedRef.current;
+      if (unsent) restoreDraft(unsent.draft);
+    },
+    [draftId, restoreDraft],
+  );
   const pendingChip = group
     ? queued?.text
     : bot
@@ -318,45 +385,113 @@ export function Composer({
   };
 
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
+  const retryFailedSend = (failed: FailedComposerSend) => {
+    if (failed.requestText.includes("<attached-image ") && !imageTargetsSupport(failed.requestText)) {
+      dispatch({ type: "error", message: "The selected responder does not support image attachments." });
+      return;
+    }
+    forgetFailedComposerSend(draftId, failed.id);
+    const retry = {
+      sendId: failed.sendId,
+      text: failed.requestText,
+      replyToId: failed.replyToId,
+      threadId: failed.threadId,
+      onError: () => {
+        rememberFailedComposerSend(draftId, {
+          sendId: failed.sendId,
+          text: failed.text,
+          requestText: failed.requestText,
+          replyToId: failed.replyToId,
+          threadId: failed.threadId,
+        });
+      },
+    };
+    if (group) {
+      dispatch({ type: "sendGroup", groupId: group.id, ...retry });
+    } else if (bot) {
+      dispatch({ type: "send", botId: bot.id, ...retry });
+    }
+  };
   const send = () => {
-    if (locked) return;
+    // A busy channel already has one locally held send. Keep any newer text
+    // as an editable draft until that send is dispatched; replacing the slot
+    // here would silently lose the first message.
+    if (locked || (group && queued)) return;
     if (attachments.some((attachment) => attachment.kind === "image") && !imageTargetsSupport(text)) {
       dispatch({ type: "error", message: "The selected responder does not support image attachments." });
       return;
     }
     const t = composeMessage(text, attachments);
     if (!t) return;
+    const sentDraft: ComposerDraftSnapshot = {
+      draftId,
+      revision: draftRevision(draftId),
+      sendId: restoredSendId(draftId) ?? crypto.randomUUID(),
+      text,
+      requestText: t,
+      attachments: [...attachments],
+      reply: replyTo ?? null,
+      replyToId: replyTo?.id,
+      threadId,
+    };
     if (busy && group) {
-      setQueued({ text: t, replyToId: replyTo?.id });
+      const pending = { text: t, replyToId: replyTo?.id, draft: sentDraft };
+      queuedRef.current = pending;
+      setQueued(pending);
       setText("");
       setAttachments([]);
-      onClearReply?.();
+      onConsumeReply?.();
       return;
     }
     if (group) {
-      dispatch({ type: "sendGroup", groupId: group.id, text: t, replyToId: replyTo?.id });
+      dispatch({
+        type: "sendGroup",
+        groupId: group.id,
+        text: t,
+        sendId: sentDraft.sendId,
+        replyToId: replyTo?.id,
+        threadId,
+        onError: () => restoreDraft(sentDraft),
+      });
       track("message_sent", { room: true });
     } else if (bot) {
-      dispatch({ type: "send", botId: bot.id, text: t, replyToId: replyTo?.id });
+      dispatch({
+        type: "send",
+        botId: bot.id,
+        text: t,
+        sendId: sentDraft.sendId,
+        replyToId: replyTo?.id,
+        threadId,
+        onError: () => restoreDraft(sentDraft),
+      });
       track("message_sent", { driver: bot.modelSelection?.instanceId, queued: busy && !canSteer });
     }
     setText("");
     setAttachments([]);
-    onClearReply?.();
+    onConsumeReply?.();
   };
   useEffect(() => {
     if (busy || !queued) return;
     if (group) {
       if (queued.text.includes("<attached-image ") && !imageTargetsSupport(queued.text)) {
         dispatch({ type: "error", message: "The selected responder does not support image attachments." });
-        setQueued(null);
+        clearQueued();
+        restoreDraft(queued.draft);
         return;
       }
-      dispatch({ type: "sendGroup", groupId: group.id, text: queued.text, replyToId: queued.replyToId });
+      clearQueued();
+      dispatch({
+        type: "sendGroup",
+        groupId: group.id,
+        text: queued.text,
+        sendId: queued.draft.sendId,
+        replyToId: queued.replyToId,
+        threadId: queued.draft.threadId,
+        onError: () => restoreDraft(queued.draft),
+      });
       track("message_sent", { room: true, queued: true });
     }
-    setQueued(null);
-  }, [busy, queued, group, members, state.instances, dispatch]);
+  }, [busy, queued, group, members, state.instances, dispatch, clearQueued, restoreDraft]);
 
   // native dictation: partials stream into the input while the Swift
   // helper runs; the final transcript stays in the box, ready to edit/send
@@ -371,7 +506,7 @@ export function Composer({
     const offTranscript = bridge.onSpeechTranscript((line) => {
       if (typeof line.text === "string") {
         const base = baseText.current;
-        setText(base ? `${base} ${line.text}` : line.text);
+        editText(base ? `${base} ${line.text}` : line.text);
       }
     });
     const offEnd = bridge.onSpeechEnd(({ code }) => {
@@ -390,7 +525,7 @@ export function Composer({
       offEnd();
       void bridge.speechStop();
     };
-  }, [recording]);
+  }, [recording, editText]);
 
   const toggleMic = () => {
     if (!capabilities.dictation.available || !window.ogb) {
@@ -411,6 +546,32 @@ export function Composer({
         </div>
       )}
       <div className="pointer-events-auto relative w-full">
+        {failedSends.map((failed) => (
+          <div
+            key={failed.id}
+            className="mb-2 flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12.5px] text-danger"
+          >
+            <span className="min-w-0 flex-1 truncate">
+              Not sent: “{failed.text.trim() || "attachment"}”
+            </span>
+            <button
+              type="button"
+              onClick={() => retryFailedSend(failed)}
+              className="shrink-0 rounded px-2 py-1 font-medium hover:bg-danger/10"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={() => forgetFailedComposerSend(draftId, failed.id)}
+              aria-label="Dismiss failed message"
+              title="Dismiss"
+              className="flex size-5 shrink-0 items-center justify-center rounded hover:bg-danger/10"
+            >
+              <X size={13} strokeWidth={2.5} />
+            </button>
+          </div>
+        ))}
         {pendingChip && (
           <div className="mb-2 flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel px-3 py-2 text-[12.5px] text-ink-secondary">
             <Clock size={13} className="shrink-0" />
@@ -421,7 +582,7 @@ export function Composer({
               type="button"
               onClick={() => {
                 if (group) {
-                  setQueued(null);
+                  clearQueued();
                   return;
                 }
                 if (!bot) return;
@@ -544,7 +705,7 @@ export function Composer({
           rows={1}
           value={text}
           onChange={(e) => {
-            setText(e.target.value);
+            editText(e.target.value);
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
           }}
@@ -559,7 +720,7 @@ export function Composer({
                 for (const file of imageFiles) {
                   try {
                     const attachment = await imageAttachmentFromFile(file);
-                    if (attachment) setAttachments((prev) => [...prev, attachment]);
+                    if (attachment) editAttachments((prev) => [...prev, attachment]);
                   } catch (err) {
                     dispatch({
                       type: "error",
@@ -579,10 +740,10 @@ export function Composer({
             const start = e.currentTarget.selectionStart;
             const end = e.currentTarget.selectionEnd;
             if (start !== end) {
-              setText(`${text.slice(0, start)}${text.slice(end)}`);
+              editText(`${text.slice(0, start)}${text.slice(end)}`);
               setCaret(start);
             }
-            setAttachments((prev) => [...prev, pasteAttachment(pasted)]);
+            editAttachments((prev) => [...prev, pasteAttachment(pasted)]);
           }}
           onKeyUp={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
@@ -671,11 +832,32 @@ export function Composer({
         {hasContent && !locked && (
           <button
             onClick={send}
-            aria-label={busy && canSteer ? "Send into the running turn" : busy ? "Queue message" : "Send message"}
-            title={busy && canSteer ? "Send into the running turn" : busy ? "Sends when the current turn finishes" : "Send"}
+            disabled={Boolean(group && queued)}
+            aria-label={
+              group && queued
+                ? "Waiting for queued message"
+                : busy && canSteer
+                  ? "Send into the running turn"
+                  : busy
+                    ? "Queue message"
+                    : "Send message"
+            }
+            title={
+              group && queued
+                ? "Your earlier message will send when the current turn finishes"
+                : busy && canSteer
+                  ? "Send into the running turn"
+                  : busy
+                    ? "Sends when the current turn finishes"
+                    : "Send"
+            }
             className={cn(
               "flex size-8 shrink-0 items-center justify-center rounded-full text-white",
-              busy && !canSteer ? "bg-raised text-ink-secondary hover:bg-raised-hover" : "bg-accent hover:brightness-110",
+              group && queued
+                ? "cursor-not-allowed bg-raised text-ink-secondary"
+                : busy && !canSteer
+                  ? "bg-raised text-ink-secondary hover:bg-raised-hover"
+                  : "bg-accent hover:brightness-110",
             )}
           >
             {busy && !canSteer ? <Clock size={15} /> : <ArrowUp size={17} />}

--- a/src/components/GroupCallView.tsx
+++ b/src/components/GroupCallView.tsx
@@ -286,7 +286,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
 
       allowBargeIn.current = false;
       move(busyRef.current ? "working" : "sending");
-      dispatch({ type: "sendGroup", groupId: group.id, text: routed.text });
+      dispatch({ type: "sendGroup", groupId: group.id, text: routed.text, threadId: group.threadId });
       scheduleListen(false, 600);
     });
     const offEnd = bridge.onSpeechEnd(({ code, reason }) => {

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -48,6 +48,7 @@ import {
   resolveTranscriptWindow,
   tailWindowStart,
 } from "@/lib/transcript-window";
+import { useReplyDraft } from "@/lib/drafts";
 
 function dayLabel(at: number): string {
   const d = new Date(at);
@@ -813,11 +814,14 @@ export function GroupView({ group }: { group: Group }) {
   const [folderOpen, setFolderOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
   const [findOpen, setFindOpen] = useState(false);
-  const [replyTo, setReplyTo] = useState<Message | null>(null);
+  const { replyTo, selectReply, clearReply, consumeReply, restoreReply } = useReplyDraft(
+    group.threadId,
+    `group:${group.id}:${group.threadId}`,
+    group.messages,
+  );
   const membersTriggerRef = useRef<HTMLButtonElement>(null);
   const closeMembers = useCallback(() => setMembersOpen(false), []);
   useEffect(() => setFindOpen(false), [group.threadId]);
-  useEffect(() => setReplyTo(null), [group.threadId]);
   useEffect(() => {
     const onFind = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
@@ -1199,7 +1203,7 @@ export function GroupView({ group }: { group: Group }) {
             messages={windowedMessages}
             transcript={group.messages}
             emergingId={popping?.id}
-            onReply={setReplyTo}
+            onReply={selectReply}
           />
           {laterCount > 0 && (
             <div className="flex justify-center">
@@ -1261,7 +1265,9 @@ export function GroupView({ group }: { group: Group }) {
         members={members}
         locked={setupPending}
         replyTo={replyTo}
-        onClearReply={() => setReplyTo(null)}
+        onClearReply={clearReply}
+        onConsumeReply={consumeReply}
+        onRestoreReply={restoreReply}
       />
       </div>
       </div>

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -31,7 +31,7 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
   const loadAbort = useRef<AbortController | null>(null);
   const managedRefresh = useRef<() => void>(() => {});
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (): Promise<boolean> => {
     loadAbort.current?.abort();
     const controller = new AbortController();
     loadAbort.current = controller;
@@ -41,12 +41,14 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
       // SAFETY: this same-version renderer calls the harness's typed
       // inspector endpoint; malformed transport data is handled by catch.
       const next = (await res.json()) as InspectorPage;
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) return false;
       setPage(next);
       setError(null);
+      return true;
     } catch (e) {
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) return false;
       setError(e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       if (loadAbort.current === controller) loadAbort.current = null;
     }
@@ -89,30 +91,44 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
       });
     };
 
-    const refresh = () => {
+    const flushPendingRuntime = () => {
+      for (const runtime of pendingRuntime.splice(0)) appendRuntime(runtime);
+    };
+
+    const refresh = async (flushLiveOnFailure: boolean): Promise<boolean> => {
       const generation = ++refreshGeneration;
       refreshing = true;
-      void load().finally(() => {
-        // A later refresh aborts the earlier fetch. Only its completion owns
-        // the buffered live tail, otherwise the earlier finally can flush
-        // frames immediately before the newer snapshot overwrites them.
-        if (!alive || generation !== refreshGeneration) return;
-        refreshing = false;
-        for (const runtime of pendingRuntime.splice(0)) appendRuntime(runtime);
-      });
+      const loaded = await load();
+      // A later refresh aborts the earlier fetch. Only its completion owns
+      // the buffered live tail, otherwise the earlier finally can flush
+      // frames immediately before the newer snapshot overwrites them.
+      if (!alive || generation !== refreshGeneration) return false;
+      refreshing = false;
+      // An ordinary Reload keeps the previous page when its fetch fails, so
+      // live frames buffered during that request still belong on that page.
+      // A replacement snapshot must not expose them: its caller will close
+      // and replay the stream from the last acknowledged cursor instead.
+      if (!loaded) {
+        if (flushLiveOnFailure) flushPendingRuntime();
+        return false;
+      }
+      flushPendingRuntime();
+      return true;
     };
-    managedRefresh.current = refresh;
+    const requestRefresh = () => void refresh(true);
+    const refreshFromSnapshot = (): Promise<boolean> => {
+      // A refused resume starts a new stream generation. Frames retained by
+      // an earlier failed refresh will be present in the new disk snapshot or
+      // replayed again, so do not carry them across the generation boundary.
+      pendingRuntime.splice(0);
+      return refresh(false);
+    };
+    managedRefresh.current = requestRefresh;
 
     const stopLive = openLiveEvents({
       screens: false,
+      onSnapshotRequired: refreshFromSnapshot,
       onFrame: (frame) => {
-        if (frame.kind === "hello") {
-          // A refused resume means runtime entries may have fallen outside
-          // the replay window. Buffer its new live tail while the persisted
-          // snapshot closes that gap, then dedupe by canonical event id.
-          if (frame.resumed === false) refresh();
-          return;
-        }
         if (frame.kind !== "runtime") return;
         const event = frame.event;
         if (!event || Array.isArray(event) || Object(event) !== event) return;
@@ -124,13 +140,13 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
         else appendRuntime(runtime);
         if (runtime.type === "turn.completed" || runtime.type === "runtime.error") {
           if (settle) clearTimeout(settle);
-          settle = setTimeout(refresh, 400);
+          settle = setTimeout(requestRefresh, 400);
         }
       },
     });
     return () => {
       alive = false;
-      if (managedRefresh.current === refresh) managedRefresh.current = () => {};
+      if (managedRefresh.current === requestRefresh) managedRefresh.current = () => {};
       stopLive();
       if (settle) clearTimeout(settle);
     };

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -65,14 +65,50 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
   // up. Own EventSource on purpose: the store folds runtime events into
   // chat state and does not re-emit them.
   useEffect(() => {
+    let alive = true;
     let settle: ReturnType<typeof setTimeout> | null = null;
+    let refreshGeneration = 0;
+    let refreshing = false;
+    const pendingRuntime: RuntimeEvent[] = [];
+
+    const appendRuntime = (runtime: RuntimeEvent) => {
+      setPage((prev) => {
+        // A disk refresh and replay can overlap. eventId is canonical, so a
+        // replayed entry already present in the snapshot is an exact no-op.
+        if (
+          prev?.entries.some(
+            (entry) => entry.kind === "runtime" && entry.data.eventId === runtime.eventId,
+          )
+        ) {
+          return prev;
+        }
+        const entry: InspectorEntry = { kind: "runtime", at: runtime.createdAt, data: runtime };
+        if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
+        return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
+      });
+    };
+
+    const refresh = () => {
+      const generation = ++refreshGeneration;
+      refreshing = true;
+      void load().finally(() => {
+        // A later refresh aborts the earlier fetch. Only its completion owns
+        // the buffered live tail, otherwise the earlier finally can flush
+        // frames immediately before the newer snapshot overwrites them.
+        if (!alive || generation !== refreshGeneration) return;
+        refreshing = false;
+        for (const runtime of pendingRuntime.splice(0)) appendRuntime(runtime);
+      });
+    };
+
     const stopLive = openLiveEvents({
       screens: false,
       onFrame: (frame) => {
         if (frame.kind === "hello") {
           // A refused resume means runtime entries may have fallen outside
-          // the replay window; re-read the persisted log to close that gap.
-          if (frame.resumed === false) void load();
+          // the replay window. Buffer its new live tail while the persisted
+          // snapshot closes that gap, then dedupe by canonical event id.
+          if (frame.resumed === false) refresh();
           return;
         }
         if (frame.kind !== "runtime") return;
@@ -82,18 +118,16 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
         // bus; this guard rejects non-object transport corruption.
         const runtime = event as RuntimeEvent;
         if (runtime.threadId !== threadId) return;
-        setPage((prev) => {
-          const entry: InspectorEntry = { kind: "runtime", at: runtime.createdAt, data: runtime };
-          if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
-          return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
-        });
+        if (refreshing) pendingRuntime.push(runtime);
+        else appendRuntime(runtime);
         if (runtime.type === "turn.completed" || runtime.type === "runtime.error") {
           if (settle) clearTimeout(settle);
-          settle = setTimeout(() => void load(), 400);
+          settle = setTimeout(refresh, 400);
         }
       },
     });
     return () => {
+      alive = false;
       stopLive();
       if (settle) clearTimeout(settle);
     };

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -14,6 +14,7 @@ import { Bug, ChevronDown, ChevronRight, RefreshCw, X } from "lucide-react";
 import { useStore, type Bot } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { formatTime, toRows, type InspectorEntry, type InspectorPage, type InspectorRow } from "@/lib/inspector";
+import { openLiveEvents } from "@/lib/live-events";
 import type { RuntimeEvent } from "../../server/contracts.ts";
 
 type Lens = "events" | "raw";
@@ -36,6 +37,8 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
     try {
       const res = await fetch(`/api/threads/${threadId}/events?limit=400`, { signal: controller.signal });
       if (!res.ok) throw new Error(`${res.status}`);
+      // SAFETY: this same-version renderer calls the harness's typed
+      // inspector endpoint; malformed transport data is handled by catch.
       const next = (await res.json()) as InspectorPage;
       if (controller.signal.aborted) return;
       setPage(next);
@@ -62,29 +65,36 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
   // up. Own EventSource on purpose: the store folds runtime events into
   // chat state and does not re-emit them.
   useEffect(() => {
-    const es = new EventSource("/api/events?screens=off");
     let settle: ReturnType<typeof setTimeout> | null = null;
-    es.onmessage = (raw) => {
-      let frame: { kind?: string; event?: RuntimeEvent };
-      try {
-        frame = JSON.parse(raw.data);
-      } catch {
-        return;
-      }
-      if (frame.kind !== "runtime" || !frame.event || frame.event.threadId !== threadId) return;
-      const event = frame.event;
-      setPage((prev) => {
-        const entry: InspectorEntry = { kind: "runtime", at: event.createdAt, data: event };
-        if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
-        return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
-      });
-      if (event.type === "turn.completed" || event.type === "runtime.error") {
-        if (settle) clearTimeout(settle);
-        settle = setTimeout(() => void load(), 400);
-      }
-    };
+    const stopLive = openLiveEvents({
+      screens: false,
+      onFrame: (frame) => {
+        if (frame.kind === "hello") {
+          // A refused resume means runtime entries may have fallen outside
+          // the replay window; re-read the persisted log to close that gap.
+          if (frame.resumed === false) void load();
+          return;
+        }
+        if (frame.kind !== "runtime") return;
+        const event = frame.event;
+        if (!event || Array.isArray(event) || Object(event) !== event) return;
+        // SAFETY: runtime stream frames are produced from the typed harness
+        // bus; this guard rejects non-object transport corruption.
+        const runtime = event as RuntimeEvent;
+        if (runtime.threadId !== threadId) return;
+        setPage((prev) => {
+          const entry: InspectorEntry = { kind: "runtime", at: runtime.createdAt, data: runtime };
+          if (!prev) return { entries: [entry], total: { runtime: 1, native: 0 } };
+          return { entries: [...prev.entries, entry], total: { ...prev.total, runtime: prev.total.runtime + 1 } };
+        });
+        if (runtime.type === "turn.completed" || runtime.type === "runtime.error") {
+          if (settle) clearTimeout(settle);
+          settle = setTimeout(() => void load(), 400);
+        }
+      },
+    });
     return () => {
-      es.close();
+      stopLive();
       if (settle) clearTimeout(settle);
     };
   }, [threadId, load]);

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -29,6 +29,7 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
   const listRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
   const loadAbort = useRef<AbortController | null>(null);
+  const managedRefresh = useRef<() => void>(() => {});
 
   const load = useCallback(async () => {
     loadAbort.current?.abort();
@@ -100,6 +101,7 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
         for (const runtime of pendingRuntime.splice(0)) appendRuntime(runtime);
       });
     };
+    managedRefresh.current = refresh;
 
     const stopLive = openLiveEvents({
       screens: false,
@@ -128,6 +130,7 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
     });
     return () => {
       alive = false;
+      if (managedRefresh.current === refresh) managedRefresh.current = () => {};
       stopLive();
       if (settle) clearTimeout(settle);
     };
@@ -195,7 +198,7 @@ export function InspectorPanel({ bot }: { bot: Bot }) {
         <span className="ml-auto text-[11px] text-ink-secondary">
           {page ? (shown < total ? `last ${shown} of ${total}` : `${shown} entries`) : "loading…"}
         </span>
-        <button onClick={() => void load()} className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink" title="Reload from disk">
+        <button onClick={() => managedRefresh.current()} className="rounded-md p-1 text-ink-secondary hover:bg-raised hover:text-ink" title="Reload from disk">
           <RefreshCw size={14} />
         </button>
       </div>

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -1,12 +1,41 @@
-// Unsent composer text, kept per thread. The Composer is keyed by bot/room
-// id, so switching threads unmounts it and its local text state dies with
-// it. Drafts live in localStorage, so coming back to a bot — in this
+// Unsent composer input, kept per task. Switching tasks unmounts the Composer
+// and its local state. Drafts live in localStorage, so coming back to a task — in this
 // session or after a restart — finds what you were typing still there.
-import { useCallback, useState, type SetStateAction } from "react";
+import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
 import { isAttachment, type Attachment } from "./composer-attachments.js";
 
 const KEY = "omb-drafts";
 const ATTACHMENTS_KEY = "omb-draft-attachments";
+const SEND_IDS_KEY = "omb-draft-send-ids";
+// A task can be unmounted and mounted again while its POST is still in
+// flight. Keep the edit generation outside React so a late failure from the
+// old component cannot overwrite a newer draft created by the new one.
+const draftRevisions = new Map<string, number>();
+// Reply targets already live in each transcript. Keep only their id in memory
+// so task navigation and a rejected send can resolve the original message
+// without duplicating message contents in storage.
+const replyDrafts = new Map<string, string>();
+type DraftRestore = { text: string; attachments: Attachment[] };
+type DraftRestoreListener = (draft: DraftRestore) => void;
+const restoreListeners = new Map<string, Set<DraftRestoreListener>>();
+export interface FailedComposerSend {
+  id: string;
+  sendId: string;
+  text: string;
+  requestText: string;
+  replyToId?: string;
+  threadId: string;
+}
+type FailedComposerSendInput = Omit<FailedComposerSend, "id">;
+export interface ComposerSendSnapshot extends FailedComposerSendInput {
+  draftId: string;
+  revision: number;
+  attachments: Attachment[];
+}
+const failedSends = new Map<string, FailedComposerSend[]>();
+const failedSendListeners = new Map<string, Set<(sends: FailedComposerSend[]) => void>>();
+const restoredSendIds = new Map<string, string>();
+let failedSendSequence = 0;
 
 type Values = Record<string, unknown>;
 type Store = Pick<Storage, "getItem" | "setItem"> | undefined;
@@ -56,6 +85,189 @@ export function setDraftAttachments(store: Store, id: string, attachments: Attac
   }
 }
 
+export function rememberReplyDraft(threadId: string, messageId: string): void {
+  replyDrafts.set(threadId, messageId);
+}
+
+export function replyDraft(threadId: string): string | undefined {
+  return replyDrafts.get(threadId);
+}
+
+export function clearReplyDraft(threadId: string): void {
+  replyDrafts.delete(threadId);
+}
+
+export function selectReplyDraft(draftId: string, threadId: string, messageId: string): void {
+  markDraftEdited(draftId);
+  rememberReplyDraft(threadId, messageId);
+}
+
+export function discardReplyDraft(draftId: string, threadId: string): void {
+  markDraftEdited(draftId);
+  clearReplyDraft(threadId);
+}
+
+/** Keeps a reply target with its task across navigation and failed sends. */
+export function useReplyDraft<T extends { id: string }>(
+  threadId: string,
+  draftId: string,
+  messages: T[],
+) {
+  const [replyTo, setReplyTo] = useState<T | null>(null);
+  const activeThreadId = useRef(threadId);
+  const previousThreadId = activeThreadId.current;
+  activeThreadId.current = threadId;
+
+  useEffect(() => {
+    const replyId = replyDraft(threadId);
+    setReplyTo((current) => {
+      if (previousThreadId === threadId && current) return current;
+      return replyId ? (messages.find((message) => message.id === replyId) ?? null) : null;
+    });
+  }, [messages, previousThreadId, threadId]);
+
+  const selectReply = useCallback((message: T) => {
+    selectReplyDraft(draftId, activeThreadId.current, message.id);
+    setReplyTo(message);
+  }, [draftId]);
+
+  const clearReply = useCallback(() => {
+    discardReplyDraft(draftId, activeThreadId.current);
+    setReplyTo(null);
+  }, [draftId]);
+
+  const consumeReply = useCallback(() => {
+    clearReplyDraft(activeThreadId.current);
+    setReplyTo(null);
+  }, []);
+
+  const restoreReply = useCallback((message: T, targetThreadId: string) => {
+    const currentId = replyDraft(targetThreadId);
+    if (currentId && currentId !== message.id) return;
+    // Persist before touching React state: this callback can belong to a task
+    // view that unmounted while its request was still in flight.
+    rememberReplyDraft(targetThreadId, message.id);
+    if (activeThreadId.current === targetThreadId) {
+      setReplyTo((current) => current ?? message);
+    }
+  }, []);
+
+  return { replyTo, selectReply, clearReply, consumeReply, restoreReply };
+}
+
+export function draftRevision(draftId: string): number {
+  return draftRevisions.get(draftId) ?? 0;
+}
+
+export function markDraftEdited(draftId: string): void {
+  restoredSendIds.delete(draftId);
+  setStoredSendId(getStore(), draftId, undefined);
+  draftRevisions.set(draftId, draftRevision(draftId) + 1);
+}
+
+export function restoredSendId(draftId: string): string | undefined {
+  const memory = restoredSendIds.get(draftId);
+  if (memory) return memory;
+  const stored = read(getStore(), SEND_IDS_KEY)[draftId];
+  if (typeof stored !== "string") return undefined;
+  restoredSendIds.set(draftId, stored);
+  return stored;
+}
+
+function setStoredSendId(store: Store, draftId: string, sendId: string | undefined): void {
+  const ids = read(store, SEND_IDS_KEY);
+  if (sendId) ids[draftId] = sendId;
+  else delete ids[draftId];
+  try {
+    store?.setItem(SEND_IDS_KEY, JSON.stringify(ids));
+  } catch {
+    /* best-effort persistence; the in-memory identity still protects this session */
+  }
+}
+
+/** Restores a rejected send into storage and whichever task view is mounted. */
+export function restoreComposerDraft(id: string, draft: DraftRestore): void {
+  const store = getStore();
+  setDraft(store, id, draft.text);
+  setDraftAttachments(store, id, draft.attachments);
+  for (const listener of restoreListeners.get(id) ?? []) listener(draft);
+}
+
+function subscribeToDraftRestores(id: string, listener: DraftRestoreListener): () => void {
+  const listeners = restoreListeners.get(id) ?? new Set<DraftRestoreListener>();
+  listeners.add(listener);
+  restoreListeners.set(id, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) restoreListeners.delete(id);
+  };
+}
+
+function publishFailedSends(id: string): void {
+  const sends = failedSends.get(id) ?? [];
+  for (const listener of failedSendListeners.get(id) ?? []) listener(sends);
+}
+
+export function failedComposerSends(id: string): FailedComposerSend[] {
+  return failedSends.get(id) ?? [];
+}
+
+export function rememberFailedComposerSend(
+  id: string,
+  input: FailedComposerSendInput,
+): FailedComposerSend {
+  const failed = { ...input, id: `${Date.now().toString(36)}-${++failedSendSequence}` };
+  failedSends.set(id, [...failedComposerSends(id), failed]);
+  publishFailedSends(id);
+  return failed;
+}
+
+/** Recovers a rejected POST without ever replacing a newer draft. */
+export function recoverFailedComposerSend(sent: ComposerSendSnapshot): "restored" | "outbox" {
+  if (draftRevision(sent.draftId) !== sent.revision) {
+    rememberFailedComposerSend(sent.draftId, {
+      sendId: sent.sendId,
+      text: sent.text,
+      requestText: sent.requestText,
+      replyToId: sent.replyToId,
+      threadId: sent.threadId,
+    });
+    return "outbox";
+  }
+  markDraftEdited(sent.draftId);
+  restoreComposerDraft(sent.draftId, {
+    text: sent.text,
+    attachments: sent.attachments,
+  });
+  // If the response vanished after server acceptance, the next Send must
+  // reuse this identity instead of starting a duplicate turn.
+  restoredSendIds.set(sent.draftId, sent.sendId);
+  setStoredSendId(getStore(), sent.draftId, sent.sendId);
+  return "restored";
+}
+
+export function forgetFailedComposerSend(id: string, failedId: string): void {
+  const remaining = failedComposerSends(id).filter((failed) => failed.id !== failedId);
+  if (remaining.length > 0) failedSends.set(id, remaining);
+  else failedSends.delete(id);
+  publishFailedSends(id);
+}
+
+export function useFailedComposerSends(id: string): FailedComposerSend[] {
+  const [sends, setSends] = useState(() => failedComposerSends(id));
+  useEffect(() => {
+    setSends(failedComposerSends(id));
+    const listeners = failedSendListeners.get(id) ?? new Set<(next: FailedComposerSend[]) => void>();
+    listeners.add(setSends);
+    failedSendListeners.set(id, listeners);
+    return () => {
+      listeners.delete(setSends);
+      if (listeners.size === 0) failedSendListeners.delete(id);
+    };
+  }, [id]);
+  return sends;
+}
+
 // Reaching for localStorage is itself a failure point: on an origin with
 // storage blocked the getter throws, and `typeof` doesn't shield it.
 function getStore(): Store {
@@ -67,9 +279,17 @@ function getStore(): Store {
 }
 
 /** useState for the composer text, persisted under `id` (a bot or room). */
-export function useDraft(id: string): [string, (next: string) => void] {
+export function useDraft(id: string, legacyId?: string): [string, (next: string) => void] {
   const store = getStore();
-  const [text, setText] = useState(() => getDraft(store, id));
+  const [text, setText] = useState(() => {
+    const current = getDraft(store, id);
+    if (current || !legacyId) return current;
+    const legacy = getDraft(store, legacyId);
+    if (!legacy) return "";
+    setDraft(store, id, legacy);
+    setDraft(store, legacyId, "");
+    return legacy;
+  });
   const set = useCallback(
     (next: string) => {
       setText(next);
@@ -77,6 +297,13 @@ export function useDraft(id: string): [string, (next: string) => void] {
     },
     [store, id],
   );
+  useEffect(() => {
+    const unsubscribe = subscribeToDraftRestores(id, (draft) => setText(draft.text));
+    // Close the render-to-effect race: a rejected request may have restored
+    // storage after this mount initialized but before its listener attached.
+    setText(getDraft(store, id));
+    return unsubscribe;
+  }, [id, store]);
   return [text, set];
 }
 
@@ -84,6 +311,7 @@ export function useDraft(id: string): [string, (next: string) => void] {
  * from text so typing does not stringify a large pasted payload per keypress. */
 export function useComposerDraft(
   id: string,
+  legacyId?: string,
 ): [
   string,
   (next: string) => void,
@@ -91,12 +319,33 @@ export function useComposerDraft(
   (next: SetStateAction<Attachment[]>) => void,
 ] {
   const store = getStore();
-  const [text, setText] = useDraft(id);
-  const [attachments, setAttachmentState] = useState(() => getDraftAttachments(store, id));
+  const [text, setText] = useDraft(id, legacyId);
+  const [attachments, setAttachmentState] = useState(() => {
+    const current = getDraftAttachments(store, id);
+    if (current.length > 0 || !legacyId) return current;
+    const legacy = getDraftAttachments(store, legacyId);
+    if (legacy.length === 0) return [];
+    setDraftAttachments(store, id, legacy);
+    setDraftAttachments(store, legacyId, []);
+    return legacy;
+  });
+  useEffect(() => {
+    const unsubscribe = subscribeToDraftRestores(id, (draft) => setAttachmentState(draft.attachments));
+    setAttachmentState(getDraftAttachments(store, id));
+    return unsubscribe;
+  }, [id, store]);
   const setAttachments = useCallback(
     (next: SetStateAction<Attachment[]>) => {
+      if (typeof next !== "function") {
+        // Persist literal restores before asking React to render. A failed
+        // request may complete after its task was switched away and this
+        // component unmounted; the draft must still be there on return.
+        setDraftAttachments(store, id, next);
+        setAttachmentState(next);
+        return;
+      }
       setAttachmentState((previous) => {
-        const value = typeof next === "function" ? next(previous) : next;
+        const value = next(previous);
         setDraftAttachments(store, id, value);
         return value;
       });

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -1,7 +1,7 @@
 // Unsent composer input, kept per task. Switching tasks unmounts the Composer
 // and its local state. Drafts live in localStorage, so coming back to a task — in this
 // session or after a restart — finds what you were typing still there.
-import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
+import { useCallback, useEffect, useState, type SetStateAction } from "react";
 import { isAttachment, type Attachment } from "./composer-attachments.js";
 
 const KEY = "omb-drafts";
@@ -107,39 +107,49 @@ export function discardReplyDraft(draftId: string, threadId: string): void {
   clearReplyDraft(threadId);
 }
 
+function resolveReplyMessage<T extends { id: string }>(threadId: string, messages: T[]): T | null {
+  const replyId = replyDraft(threadId);
+  return replyId ? (messages.find((message) => message.id === replyId) ?? null) : null;
+}
+
 /** Keeps a reply target with its task across navigation and failed sends. */
 export function useReplyDraft<T extends { id: string }>(
   threadId: string,
   draftId: string,
   messages: T[],
 ) {
-  const [replyTo, setReplyTo] = useState<T | null>(null);
-  const activeThreadId = useRef(threadId);
-  const previousThreadId = activeThreadId.current;
-  activeThreadId.current = threadId;
+  const [replyState, setReplyState] = useState<{ threadId: string; message: T | null }>(() => ({
+    threadId,
+    message: resolveReplyMessage(threadId, messages),
+  }));
+  // Resolve a switched task synchronously so the previous task's target never
+  // flashes while the effect below synchronizes the hook state.
+  const replyTo =
+    replyState.threadId === threadId
+      ? replyState.message
+      : resolveReplyMessage(threadId, messages);
 
   useEffect(() => {
-    const replyId = replyDraft(threadId);
-    setReplyTo((current) => {
-      if (previousThreadId === threadId && current) return current;
-      return replyId ? (messages.find((message) => message.id === replyId) ?? null) : null;
+    setReplyState((current) => {
+      if (current.threadId === threadId && current.message) return current;
+      return { threadId, message: resolveReplyMessage(threadId, messages) };
     });
-  }, [messages, previousThreadId, threadId]);
+  }, [messages, threadId]);
 
   const selectReply = useCallback((message: T) => {
-    selectReplyDraft(draftId, activeThreadId.current, message.id);
-    setReplyTo(message);
-  }, [draftId]);
+    selectReplyDraft(draftId, threadId, message.id);
+    setReplyState({ threadId, message });
+  }, [draftId, threadId]);
 
   const clearReply = useCallback(() => {
-    discardReplyDraft(draftId, activeThreadId.current);
-    setReplyTo(null);
-  }, [draftId]);
+    discardReplyDraft(draftId, threadId);
+    setReplyState({ threadId, message: null });
+  }, [draftId, threadId]);
 
   const consumeReply = useCallback(() => {
-    clearReplyDraft(activeThreadId.current);
-    setReplyTo(null);
-  }, []);
+    clearReplyDraft(threadId);
+    setReplyState({ threadId, message: null });
+  }, [threadId]);
 
   const restoreReply = useCallback((message: T, targetThreadId: string) => {
     const currentId = replyDraft(targetThreadId);
@@ -147,10 +157,14 @@ export function useReplyDraft<T extends { id: string }>(
     // Persist before touching React state: this callback can belong to a task
     // view that unmounted while its request was still in flight.
     rememberReplyDraft(targetThreadId, message.id);
-    if (activeThreadId.current === targetThreadId) {
-      setReplyTo((current) => current ?? message);
+    if (threadId === targetThreadId) {
+      setReplyState((current) =>
+        current.threadId === targetThreadId && current.message
+          ? current
+          : { threadId: targetThreadId, message },
+      );
     }
-  }, []);
+  }, [threadId]);
 
   return { replyTo, selectReply, clearReply, consumeReply, restoreReply };
 }

--- a/src/lib/live-events.test.ts
+++ b/src/lib/live-events.test.ts
@@ -108,7 +108,10 @@ describe("live events supervisor", () => {
   it("uses data pings as liveness without forwarding them", () => {
     const test = harness();
     const onFrame = vi.fn();
-    const stop = openLiveEvents({ onFrame, staleMs: 1_000 }, test.platform);
+    const stop = openLiveEvents(
+      { onFrame, onSnapshotRequired: async () => true, staleMs: 1_000 },
+      test.platform,
+    );
 
     expect(test.sources).toHaveLength(1);
     test.sources[0].open();
@@ -132,7 +135,7 @@ describe("live events supervisor", () => {
     const test = harness();
     const onFrame = vi.fn();
     const stop = openLiveEvents(
-      { onFrame, retryMinMs: 100, retryMaxMs: 100 },
+      { onFrame, onSnapshotRequired: async () => true, retryMinMs: 100, retryMaxMs: 100 },
       test.platform,
     );
     const staleHandler = test.sources[0].onmessage;
@@ -147,11 +150,18 @@ describe("live events supervisor", () => {
     stop();
   });
 
-  it("keeps the old cursor through a successful hello, then resets it after a refused resume", () => {
+  it("commits a refused-resume boundary only after its replacement snapshot succeeds", async () => {
     const test = harness();
     const frames: unknown[] = [];
+    const snapshotResolutions: Array<(loaded: boolean) => void> = [];
     const stop = openLiveEvents(
-      { onFrame: (frame) => frames.push(frame), retryMinMs: 100, retryMaxMs: 100 },
+      {
+        onFrame: (frame) => frames.push(frame),
+        onSnapshotRequired: () =>
+          new Promise<boolean>((resolve) => snapshotResolutions.push(resolve)),
+        retryMinMs: 100,
+        retryMaxMs: 100,
+      },
       test.platform,
     );
 
@@ -167,16 +177,27 @@ describe("live events supervisor", () => {
     vi.advanceTimersByTime(100);
     expect(test.sources[2].url).toBe("/api/events?since=oldrun00%3A10");
 
-    // A restart/expired replay window has no frames to replay. The consumer
-    // hydrates on this hello, and subsequent connections start at its boundary.
+    // A restart/expired replay window has no frames to replay. Application
+    // frames may arrive while the consumer rebuilds, but neither their id nor
+    // the hello boundary is safe until that replacement snapshot succeeds.
     test.sources[2].message({ kind: "hello", resumed: false, cursor: "newrun00:7" });
-    test.sources[2].error();
+    test.sources[2].message({ kind: "message", value: "behind failed snapshot" }, "newrun00:8");
+    snapshotResolutions.shift()?.(false);
+    await Promise.resolve();
     vi.advanceTimersByTime(100);
-    expect(test.sources[3].url).toBe("/api/events?since=newrun00%3A7");
+    expect(test.sources[3].url).toBe("/api/events?since=oldrun00%3A10");
+
+    test.sources[3].message({ kind: "hello", resumed: false, cursor: "newrun00:8" });
+    test.sources[3].message({ kind: "message", value: "after snapshot" }, "newrun00:9");
+    snapshotResolutions.shift()?.(true);
+    await Promise.resolve();
+    test.sources[3].error();
+    vi.advanceTimersByTime(100);
+    expect(test.sources[4].url).toBe("/api/events?since=newrun00%3A9");
     expect(frames).toEqual([
       { kind: "message" },
-      { kind: "hello", resumed: true, cursor: "oldrun00:13" },
-      { kind: "hello", resumed: false, cursor: "newrun00:7" },
+      { kind: "message", value: "behind failed snapshot" },
+      { kind: "message", value: "after snapshot" },
     ]);
     stop();
   });
@@ -196,7 +217,14 @@ describe("live events supervisor", () => {
 
     vi.setSystemTime(0);
     const stop = openLiveEvents(
-      { onFrame: vi.fn(), onError, retryMinMs: 100, retryMaxMs: 400, staleMs: 10_000 },
+      {
+        onFrame: vi.fn(),
+        onSnapshotRequired: async () => true,
+        onError,
+        retryMinMs: 100,
+        retryMaxMs: 400,
+        staleMs: 10_000,
+      },
       platform,
     );
     vi.advanceTimersByTime(1_100);
@@ -209,7 +237,13 @@ describe("live events supervisor", () => {
   it("backs off an open/error flap until the stream survives a heartbeat", () => {
     const test = harness();
     const stop = openLiveEvents(
-      { onFrame: vi.fn(), retryMinMs: 100, retryMaxMs: 400, staleMs: 10_000 },
+      {
+        onFrame: vi.fn(),
+        onSnapshotRequired: async () => true,
+        retryMinMs: 100,
+        retryMaxMs: 400,
+        staleMs: 10_000,
+      },
       test.platform,
     );
 
@@ -236,7 +270,13 @@ describe("live events supervisor", () => {
   it("does not churn a suspended hidden stream and recovers once visible", () => {
     const test = harness({ visible: false });
     const stop = openLiveEvents(
-      { onFrame: vi.fn(), staleMs: 1_000, retryMinMs: 100, retryMaxMs: 100 },
+      {
+        onFrame: vi.fn(),
+        onSnapshotRequired: async () => true,
+        staleMs: 1_000,
+        retryMinMs: 100,
+        retryMaxMs: 100,
+      },
       test.platform,
     );
 
@@ -259,7 +299,10 @@ describe("live events supervisor", () => {
 
   it("recovers immediately on online/focus/visible and removes every owner on cleanup", () => {
     const test = harness({ online: false });
-    const stop = openLiveEvents({ onFrame: vi.fn(), staleMs: 1_000 }, test.platform);
+    const stop = openLiveEvents(
+      { onFrame: vi.fn(), onSnapshotRequired: async () => true, staleMs: 1_000 },
+      test.platform,
+    );
     expect(test.sources).toHaveLength(0);
 
     test.setOnline(true);

--- a/src/lib/live-events.test.ts
+++ b/src/lib/live-events.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LIVE_EVENTS_STALE_MS,
+  isLivePing,
+  liveEventsUrl,
+  openLiveEvents,
+  shouldReconnectLiveEvents,
+  type LiveEventSourceLike,
+  type LiveEventsPlatform,
+} from "./live-events";
+
+class FakeTarget {
+  private readonly listeners = new Map<string, Set<() => void>>();
+
+  addEventListener(type: string, listener: () => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: () => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+
+  count(type: string) {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+class FakeEventSource implements LiveEventSourceLike {
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string; lastEventId?: string }) => void) | null = null;
+  close = vi.fn();
+
+  constructor(readonly url: string) {}
+
+  open() {
+    this.onopen?.();
+  }
+
+  error() {
+    this.onerror?.();
+  }
+
+  message<T extends { kind: string }>(frame: T, lastEventId = "") {
+    this.onmessage?.({ data: JSON.stringify(frame), lastEventId });
+  }
+}
+
+function harness(options?: { online?: boolean; visible?: boolean; now?: number }) {
+  const sources: FakeEventSource[] = [];
+  const windowTarget = new FakeTarget();
+  const documentTarget = new FakeTarget();
+  let online = options?.online ?? true;
+  let visible = options?.visible ?? true;
+  let now = options?.now ?? 0;
+  const platform: LiveEventsPlatform = {
+    createEventSource: (url) => {
+      const source = new FakeEventSource(url);
+      sources.push(source);
+      return source;
+    },
+    windowTarget,
+    documentTarget,
+    isOnline: () => online,
+    isVisible: () => visible,
+    now: () => now,
+  };
+  return {
+    sources,
+    platform,
+    windowTarget,
+    documentTarget,
+    setOnline(value: boolean) {
+      online = value;
+    },
+    setVisible(value: boolean) {
+      visible = value;
+    },
+    setNow(value: number) {
+      now = value;
+    },
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("live events URL", () => {
+  it("builds cold, resumable, and screen-free stream URLs", () => {
+    expect(liveEventsUrl()).toBe("/api/events");
+    expect(liveEventsUrl({ screens: true })).toBe("/api/events");
+    expect(liveEventsUrl({ since: "ab12cd34:9" })).toBe("/api/events?since=ab12cd34%3A9");
+    expect(liveEventsUrl({ since: "ab12cd34:9", screens: false })).toBe(
+      "/api/events?since=ab12cd34%3A9&screens=off",
+    );
+    expect(liveEventsUrl({ screens: false })).toBe("/api/events?screens=off");
+  });
+});
+
+describe("live events supervisor", () => {
+  it("uses data pings as liveness without forwarding them", () => {
+    const test = harness();
+    const onFrame = vi.fn();
+    const stop = openLiveEvents({ onFrame, staleMs: 1_000 }, test.platform);
+
+    expect(test.sources).toHaveLength(1);
+    test.sources[0].open();
+    test.sources[0].message({ kind: "message" }, "run00000:4");
+    test.setNow(900);
+    test.sources[0].message({ kind: "ping" }, "run00000:999");
+    vi.advanceTimersByTime(1_500);
+    test.setNow(1_899);
+    expect(test.sources).toHaveLength(1);
+    expect(onFrame).toHaveBeenCalledOnce();
+
+    test.setNow(1_900);
+    vi.advanceTimersByTime(500);
+    expect(test.sources).toHaveLength(2);
+    expect(test.sources[1].url).toBe("/api/events?since=run00000%3A4");
+    expect(test.sources[0].close).toHaveBeenCalledOnce();
+    stop();
+  });
+
+  it("ignores frames from a stream generation after replacing it", () => {
+    const test = harness();
+    const onFrame = vi.fn();
+    const stop = openLiveEvents(
+      { onFrame, retryMinMs: 100, retryMaxMs: 100 },
+      test.platform,
+    );
+    const staleHandler = test.sources[0].onmessage;
+
+    test.sources[0].error();
+    vi.advanceTimersByTime(100);
+    staleHandler?.({ data: JSON.stringify({ kind: "message", value: "stale" }), lastEventId: "old:9" });
+    test.sources[1].message({ kind: "message", value: "current" }, "new:1");
+
+    expect(onFrame).toHaveBeenCalledOnce();
+    expect(onFrame).toHaveBeenCalledWith({ kind: "message", value: "current" });
+    stop();
+  });
+
+  it("keeps the old cursor through a successful hello, then resets it after a refused resume", () => {
+    const test = harness();
+    const frames: unknown[] = [];
+    const stop = openLiveEvents(
+      { onFrame: (frame) => frames.push(frame), retryMinMs: 100, retryMaxMs: 100 },
+      test.platform,
+    );
+
+    test.sources[0].message({ kind: "message" }, "oldrun00:10");
+    test.sources[0].error();
+    vi.advanceTimersByTime(100);
+    expect(test.sources[1].url).toBe("/api/events?since=oldrun00%3A10");
+
+    // The server has three replay frames queued. If the socket dies before
+    // they arrive, the next attempt still asks from the last consumed frame.
+    test.sources[1].message({ kind: "hello", resumed: true, cursor: "oldrun00:13" });
+    test.sources[1].error();
+    vi.advanceTimersByTime(100);
+    expect(test.sources[2].url).toBe("/api/events?since=oldrun00%3A10");
+
+    // A restart/expired replay window has no frames to replay. The consumer
+    // hydrates on this hello, and subsequent connections start at its boundary.
+    test.sources[2].message({ kind: "hello", resumed: false, cursor: "newrun00:7" });
+    test.sources[2].error();
+    vi.advanceTimersByTime(100);
+    expect(test.sources[3].url).toBe("/api/events?since=newrun00%3A7");
+    expect(frames).toEqual([
+      { kind: "message" },
+      { kind: "hello", resumed: true, cursor: "oldrun00:13" },
+      { kind: "hello", resumed: false, cursor: "newrun00:7" },
+    ]);
+    stop();
+  });
+
+  it("caps retry backoff when opening the stream keeps failing", () => {
+    const attempts: number[] = [];
+    const onError = vi.fn();
+    const platform: LiveEventsPlatform = {
+      createEventSource: () => {
+        attempts.push(Date.now());
+        throw new Error("offline");
+      },
+      isOnline: () => true,
+      isVisible: () => true,
+      now: Date.now,
+    };
+
+    vi.setSystemTime(0);
+    const stop = openLiveEvents(
+      { onFrame: vi.fn(), onError, retryMinMs: 100, retryMaxMs: 400, staleMs: 10_000 },
+      platform,
+    );
+    vi.advanceTimersByTime(1_100);
+
+    expect(attempts).toEqual([0, 100, 300, 700, 1_100]);
+    expect(onError).toHaveBeenCalledTimes(5);
+    stop();
+  });
+
+  it("backs off an open/error flap until the stream survives a heartbeat", () => {
+    const test = harness();
+    const stop = openLiveEvents(
+      { onFrame: vi.fn(), retryMinMs: 100, retryMaxMs: 400, staleMs: 10_000 },
+      test.platform,
+    );
+
+    test.sources[0].open();
+    test.sources[0].error();
+    vi.advanceTimersByTime(99);
+    expect(test.sources).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    test.sources[1].open();
+    test.sources[1].error();
+    vi.advanceTimersByTime(199);
+    expect(test.sources).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    test.sources[2].open();
+    test.sources[2].message({ kind: "ping" });
+    test.sources[2].error();
+    vi.advanceTimersByTime(99);
+    expect(test.sources).toHaveLength(3);
+    vi.advanceTimersByTime(1);
+    expect(test.sources).toHaveLength(4);
+    stop();
+  });
+
+  it("does not churn a suspended hidden stream and recovers once visible", () => {
+    const test = harness({ visible: false });
+    const stop = openLiveEvents(
+      { onFrame: vi.fn(), staleMs: 1_000, retryMinMs: 100, retryMaxMs: 100 },
+      test.platform,
+    );
+
+    test.setNow(10_000);
+    vi.advanceTimersByTime(10_000);
+    expect(test.sources).toHaveLength(1);
+
+    // Even an explicit transport error stays quiet in the background; the
+    // visibility edge below is the single owner of recovery.
+    test.sources[0].error();
+    vi.advanceTimersByTime(1_000);
+    expect(test.sources).toHaveLength(1);
+
+    test.setVisible(true);
+    test.documentTarget.emit("visibilitychange");
+    expect(test.sources).toHaveLength(2);
+    expect(test.sources[0].close).toHaveBeenCalledOnce();
+    stop();
+  });
+
+  it("recovers immediately on online/focus/visible and removes every owner on cleanup", () => {
+    const test = harness({ online: false });
+    const stop = openLiveEvents({ onFrame: vi.fn(), staleMs: 1_000 }, test.platform);
+    expect(test.sources).toHaveLength(0);
+
+    test.setOnline(true);
+    test.windowTarget.emit("online");
+    expect(test.sources).toHaveLength(1);
+
+    test.setNow(1_001);
+    test.windowTarget.emit("focus");
+    expect(test.sources).toHaveLength(2);
+    expect(test.sources[0].close).toHaveBeenCalledOnce();
+
+    test.setVisible(false);
+    test.setNow(2_002);
+    test.documentTarget.emit("visibilitychange");
+    expect(test.sources).toHaveLength(2);
+    test.setVisible(true);
+    test.documentTarget.emit("visibilitychange");
+    expect(test.sources).toHaveLength(3);
+
+    stop();
+    stop();
+    expect(test.sources[2].close).toHaveBeenCalledOnce();
+    expect(test.windowTarget.count("online")).toBe(0);
+    expect(test.windowTarget.count("focus")).toBe(0);
+    expect(test.documentTarget.count("visibilitychange")).toBe(0);
+  });
+});
+
+describe("live event liveness predicates", () => {
+  it("recognizes only ping frames and reconnects at the stale boundary", () => {
+    expect(isLivePing({ kind: "ping" })).toBe(true);
+    expect(isLivePing({ kind: "message" })).toBe(false);
+    expect(shouldReconnectLiveEvents(0, LIVE_EVENTS_STALE_MS - 1)).toBe(false);
+    expect(shouldReconnectLiveEvents(0, LIVE_EVENTS_STALE_MS)).toBe(true);
+  });
+});

--- a/src/lib/live-events.ts
+++ b/src/lib/live-events.ts
@@ -1,0 +1,311 @@
+/**
+ * Supervise one browser EventSource for `/api/events`.
+ *
+ * EventSource hides SSE comment keepalives, so a half-open proxy can leave the
+ * UI looking connected forever. The server also sends a visible `ping` frame;
+ * this supervisor uses it as liveness, owns reconnects itself, and carries an
+ * explicit replay cursor whenever it replaces the native EventSource.
+ */
+export const LIVE_EVENTS_PATH = "/api/events";
+export const LIVE_EVENTS_STALE_MS = 40_000;
+export const LIVE_EVENTS_RETRY_MIN_MS = 500;
+export const LIVE_EVENTS_RETRY_MAX_MS = 10_000;
+
+export interface LiveFrame {
+  kind: string;
+  cursor?: string;
+  resumed?: boolean;
+  event?: unknown;
+}
+
+interface LiveMessageEvent {
+  data: string;
+  lastEventId?: string;
+}
+
+export interface LiveEventSourceLike {
+  onopen: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: LiveMessageEvent) => void) | null;
+  close: () => void;
+}
+
+interface ListenerTarget {
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+}
+
+export interface LiveEventsPlatform {
+  createEventSource: (url: string) => LiveEventSourceLike;
+  windowTarget?: ListenerTarget;
+  documentTarget?: ListenerTarget;
+  isVisible: () => boolean;
+  isOnline: () => boolean;
+  now: () => number;
+}
+
+export interface LiveEventsHandlers {
+  onFrame: (frame: LiveFrame) => void;
+  onOpen?: () => void;
+  onError?: () => void;
+  screens?: boolean;
+  staleMs?: number;
+  retryMinMs?: number;
+  retryMaxMs?: number;
+}
+
+export function liveEventsUrl(options?: { since?: string | null; screens?: boolean }): string {
+  const params = new URLSearchParams();
+  if (options?.since) params.set("since", options.since);
+  if (options?.screens === false) params.set("screens", "off");
+  const query = params.toString();
+  return query ? `${LIVE_EVENTS_PATH}?${query}` : LIVE_EVENTS_PATH;
+}
+
+export function isLivePing(frame: Pick<LiveFrame, "kind">): boolean {
+  return frame.kind === "ping";
+}
+
+export function shouldReconnectLiveEvents(
+  lastHeardAt: number,
+  now: number,
+  staleMs = LIVE_EVENTS_STALE_MS,
+): boolean {
+  return now - lastHeardAt >= staleMs;
+}
+
+/** Parse only the transport envelope here. Payloads remain owned by their
+ * consumers; cloning every token delta through a general schema would put
+ * avoidable work on the hottest renderer path. */
+function parseLiveFrame(data: string): LiveFrame | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!value || Array.isArray(value) || Object(value) !== value) return null;
+  // SAFETY: the object guard above establishes an indexable JSON object; each
+  // transport-owned field is validated below before exposing LiveFrame.
+  const candidate = value as {
+    kind?: unknown;
+    cursor?: unknown;
+    resumed?: unknown;
+    event?: unknown;
+  };
+  if (candidate.kind !== String(candidate.kind)) return null;
+  if (candidate.cursor !== undefined && candidate.cursor !== String(candidate.cursor)) return null;
+  if (candidate.resumed !== undefined && candidate.resumed !== Boolean(candidate.resumed)) return null;
+  // SAFETY: kind is a string and the two optional transport fields were
+  // checked against their exact primitive representations above.
+  return candidate as LiveFrame;
+}
+
+function browserPlatform(overrides: Partial<LiveEventsPlatform>): LiveEventsPlatform | null {
+  const NativeEventSource = globalThis.EventSource;
+  const createEventSource =
+    overrides.createEventSource ??
+    (!NativeEventSource
+      ? undefined
+      : (url: string) => {
+          const native = new NativeEventSource(url);
+          const adapter: LiveEventSourceLike = {
+            onopen: null,
+            onerror: null,
+            onmessage: null,
+            close: () => native.close(),
+          };
+          native.onopen = () => adapter.onopen?.();
+          native.onerror = () => adapter.onerror?.();
+          native.onmessage = (event) => adapter.onmessage?.(event);
+          return adapter;
+        });
+  if (!createEventSource) return null;
+
+  const browserWindow = globalThis.window;
+  const browserDocument = globalThis.document;
+  return {
+    createEventSource,
+    windowTarget:
+      overrides.windowTarget ??
+      (browserWindow
+        ? {
+            addEventListener: (type, listener) => browserWindow.addEventListener(type, listener),
+            removeEventListener: (type, listener) => browserWindow.removeEventListener(type, listener),
+          }
+        : undefined),
+    documentTarget:
+      overrides.documentTarget ??
+      (browserDocument
+        ? {
+            addEventListener: (type, listener) => browserDocument.addEventListener(type, listener),
+            removeEventListener: (type, listener) => browserDocument.removeEventListener(type, listener),
+          }
+        : undefined),
+    isVisible:
+      overrides.isVisible ?? (() => !browserDocument || browserDocument.visibilityState === "visible"),
+    isOnline: overrides.isOnline ?? (() => globalThis.navigator?.onLine !== false),
+    now: overrides.now ?? Date.now,
+  };
+}
+
+/**
+ * Open and supervise one live stream. The returned function owns all cleanup:
+ * after it runs, no EventSource, reconnect timer, or browser listener remains.
+ * The optional platform is intentionally narrow so connection behavior can be
+ * tested without a browser or network.
+ */
+export function openLiveEvents(
+  handlers: LiveEventsHandlers,
+  platformOverrides: Partial<LiveEventsPlatform> = {},
+): () => void {
+  const platform = browserPlatform(platformOverrides);
+  if (!platform) {
+    handlers.onError?.();
+    return () => {};
+  }
+
+  const staleMs = handlers.staleMs ?? LIVE_EVENTS_STALE_MS;
+  const retryMinMs = Math.max(1, handlers.retryMinMs ?? LIVE_EVENTS_RETRY_MIN_MS);
+  const retryMaxMs = Math.max(retryMinMs, handlers.retryMaxMs ?? LIVE_EVENTS_RETRY_MAX_MS);
+  const staleCheckMs = Math.min(10_000, Math.max(250, staleMs / 2));
+
+  let stopped = false;
+  let source: LiveEventSourceLike | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryAttempt = 0;
+  let cursor: string | null = null;
+  let lastHeardAt = platform.now();
+
+  const clearRetry = () => {
+    if (retryTimer === null) return;
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  };
+
+  const closeSource = () => {
+    const current = source;
+    source = null;
+    if (!current) return;
+    current.onopen = null;
+    current.onerror = null;
+    current.onmessage = null;
+    current.close();
+  };
+
+  let connect: () => void;
+  const scheduleReconnect = () => {
+    if (stopped || retryTimer !== null || !platform.isOnline() || !platform.isVisible()) return;
+    const exponent = Math.min(retryAttempt, 20);
+    const delay = Math.min(retryMaxMs, retryMinMs * 2 ** exponent);
+    retryAttempt += 1;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (!platform.isVisible()) return;
+      connect();
+    }, delay);
+  };
+
+  const connectionLost = (current: LiveEventSourceLike) => {
+    if (stopped || source !== current) return;
+    closeSource();
+    handlers.onError?.();
+    scheduleReconnect();
+  };
+
+  connect = () => {
+    if (stopped || source || !platform.isOnline()) return;
+    let current: LiveEventSourceLike;
+    try {
+      current = platform.createEventSource(
+        liveEventsUrl({ since: cursor, screens: handlers.screens }),
+      );
+    } catch {
+      handlers.onError?.();
+      scheduleReconnect();
+      return;
+    }
+
+    source = current;
+    lastHeardAt = platform.now();
+    current.onopen = () => {
+      if (stopped || source !== current) return;
+      lastHeardAt = platform.now();
+      handlers.onOpen?.();
+    };
+    current.onerror = () => connectionLost(current);
+    current.onmessage = (event) => {
+      if (stopped || source !== current) return;
+      lastHeardAt = platform.now();
+
+      const frame = parseLiveFrame(event.data);
+      if (!frame) return;
+
+      // Heartbeats prove this socket is alive, but they are not application
+      // state and never establish a replay boundary of their own.
+      if (isLivePing(frame)) {
+        // An open event only proves that a TCP handshake happened. A ping
+        // proves the stream stayed usable, so only now forgive prior flaps.
+        retryAttempt = 0;
+        return;
+      }
+
+      if (frame.kind === "hello") {
+        // `resumed:true` is followed by replay frames. Advancing to hello's
+        // newest cursor here would skip any replay frame not yet delivered if
+        // this socket died mid-replay. A failed resume has no replay, so its
+        // cursor is the new snapshot boundary and must replace the stale one.
+        if (frame.resumed === false) {
+          cursor = frame.cursor || null;
+        }
+      } else if (event.lastEventId) {
+        cursor = event.lastEventId;
+      }
+
+      handlers.onFrame(frame);
+    };
+  };
+
+  const reconnectNow = (reportDisconnect: boolean) => {
+    if (stopped || !platform.isOnline()) return;
+    clearRetry();
+    if (source) {
+      closeSource();
+      if (reportDisconnect) handlers.onError?.();
+    }
+    connect();
+  };
+
+  const recover = () => {
+    // Background tabs suspend timers and network delivery. Let visibility or
+    // focus perform one recovery on wake instead of churning hidden sockets.
+    if (stopped || !platform.isOnline() || !platform.isVisible()) return;
+    if (!source || shouldReconnectLiveEvents(lastHeardAt, platform.now(), staleMs)) {
+      reconnectNow(source !== null);
+    }
+  };
+  const onOnline = () => recover();
+  const onFocus = () => {
+    if (platform.isVisible()) recover();
+  };
+  const onVisibilityChange = () => {
+    if (platform.isVisible()) recover();
+  };
+
+  connect();
+  const staleTimer = setInterval(recover, staleCheckMs);
+  platform.windowTarget?.addEventListener("online", onOnline);
+  platform.windowTarget?.addEventListener("focus", onFocus);
+  platform.documentTarget?.addEventListener("visibilitychange", onVisibilityChange);
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(staleTimer);
+    clearRetry();
+    closeSource();
+    platform.windowTarget?.removeEventListener("online", onOnline);
+    platform.windowTarget?.removeEventListener("focus", onFocus);
+    platform.documentTarget?.removeEventListener("visibilitychange", onVisibilityChange);
+  };
+}

--- a/src/lib/live-events.ts
+++ b/src/lib/live-events.ts
@@ -46,6 +46,11 @@ export interface LiveEventsPlatform {
 
 export interface LiveEventsHandlers {
   onFrame: (frame: LiveFrame) => void;
+  /** Rebuild the consumer's complete snapshot after the server says its
+   * replay gap cannot be filled. The transport commits the new cursor only
+   * after this succeeds; false/rejection closes the stream and retries from
+   * the last known-good boundary. */
+  onSnapshotRequired: () => Promise<boolean>;
   onOpen?: () => void;
   onError?: () => void;
   screens?: boolean;
@@ -176,6 +181,13 @@ export function openLiveEvents(
   let retryAttempt = 0;
   let cursor: string | null = null;
   let lastHeardAt = platform.now();
+  let snapshotGeneration = 0;
+  let pendingSnapshot: {
+    generation: number;
+    source: LiveEventSourceLike;
+    boundaryCursor: string | null;
+    newestFrameCursor: string | null;
+  } | null = null;
 
   const clearRetry = () => {
     if (retryTimer === null) return;
@@ -187,6 +199,10 @@ export function openLiveEvents(
     const current = source;
     source = null;
     if (!current) return;
+    if (pendingSnapshot?.source === current) {
+      snapshotGeneration += 1;
+      pendingSnapshot = null;
+    }
     current.onopen = null;
     current.onerror = null;
     current.onmessage = null;
@@ -253,16 +269,55 @@ export function openLiveEvents(
       if (frame.kind === "hello") {
         // `resumed:true` is followed by replay frames. Advancing to hello's
         // newest cursor here would skip any replay frame not yet delivered if
-        // this socket died mid-replay. A failed resume has no replay, so its
-        // cursor is the new snapshot boundary and must replace the stale one.
+        // this socket died mid-replay. A failed resume has no replay, but its
+        // cursor is safe only after the consumer's replacement snapshot loads.
         if (frame.resumed === false) {
-          cursor = frame.cursor || null;
+          const generation = ++snapshotGeneration;
+          pendingSnapshot = {
+            generation,
+            source: current,
+            boundaryCursor: frame.cursor || null,
+            newestFrameCursor: null,
+          };
+          void (async () => {
+            let loaded = false;
+            try {
+              loaded = await handlers.onSnapshotRequired();
+            } catch {
+              loaded = false;
+            }
+            const pending = pendingSnapshot;
+            if (
+              stopped ||
+              source !== current ||
+              !pending ||
+              pending.generation !== generation
+            ) {
+              return;
+            }
+            if (!loaded) {
+              pendingSnapshot = null;
+              connectionLost(current);
+              return;
+            }
+            // The consumer resolved only after applying every frame it held
+            // behind the snapshot. Commit the newest delivered cursor, or the
+            // hello boundary when no application frame arrived meanwhile.
+            cursor = pending.newestFrameCursor ?? pending.boundaryCursor;
+            pendingSnapshot = null;
+          })();
         }
       } else if (event.lastEventId) {
-        cursor = event.lastEventId;
+        if (pendingSnapshot?.source === current) {
+          pendingSnapshot.newestFrameCursor = event.lastEventId;
+        } else {
+          cursor = event.lastEventId;
+        }
       }
 
-      handlers.onFrame(frame);
+      // Hello is transport control, not application state. Consumers rebuild
+      // through onSnapshotRequired and receive only numbered application data.
+      if (frame.kind !== "hello") handlers.onFrame(frame);
     };
   };
 

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -485,6 +485,41 @@ describe("pending queued chip", () => {
     expect(late.consumedQueueIds).toEqual({});
   });
 
+  it("reconciles a missed drain from hydration and rejects its late POST continuation", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const queued = reducer(withBot, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "q-snapshot",
+      text: "already ran",
+    });
+    const canonical = {
+      id: "m-snapshot",
+      at: 100,
+      role: "user",
+      kind: "text",
+      text: "already ran",
+      queueId: "q-snapshot",
+    } satisfies Message;
+    const hydrated = reducer(queued, {
+      type: "hydrate",
+      bots: [{ ...bot, messages: [canonical] }],
+      groups: [],
+      computerControl: {},
+    });
+
+    expect(hydrated.pendingQueued).toEqual({});
+    expect(hydrated.consumedQueueIds["q-snapshot"]).toBe(true);
+    const late = reducer(hydrated, {
+      type: "pendingQueued",
+      threadId: "t1",
+      queueId: "q-snapshot",
+      text: "already ran",
+    });
+    expect(late.pendingQueued).toEqual({});
+    expect(late.consumedQueueIds["q-snapshot"]).toBeUndefined();
+  });
+
   it("bounds unmatched queue tombstones from other clients", () => {
     const withBot = reducer(initialState, { type: "botPatched", bot });
     let state = withBot;

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -3,12 +3,89 @@ import { describe, expect, it, vi } from "vitest";
 import {
   configStatusFromFrame,
   initialState,
+  loadSnapshotBoundary,
   openNotificationTarget,
   reducer,
   type Bot,
   type Group,
   type Message,
 } from "./store";
+import { openLiveEvents, type LiveEventSourceLike, type LiveEventsPlatform } from "../lib/live-events";
+
+type SnapshotFrame =
+  | { kind: "hello"; resumed: boolean; cursor: string }
+  | { kind: "message"; threadId: string; message: { id: string } };
+
+class SnapshotEventSource implements LiveEventSourceLike {
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string; lastEventId?: string }) => void) | null = null;
+  close = vi.fn();
+
+  constructor(readonly url: string) {}
+
+  message(frame: SnapshotFrame, lastEventId = "") {
+    this.onmessage?.({ data: JSON.stringify(frame), lastEventId });
+  }
+}
+
+describe("replacement snapshot boundary", () => {
+  it("flushes bot frames without reconnecting when a peripheral snapshot fails", async () => {
+    const sources: SnapshotEventSource[] = [];
+    const applied: unknown[] = [];
+    const pending: unknown[] = [];
+    const scheduleRetry = vi.fn();
+    let hydrated = false;
+    const platform: LiveEventsPlatform = {
+      createEventSource: (url) => {
+        const source = new SnapshotEventSource(url);
+        sources.push(source);
+        return source;
+      },
+      isOnline: () => true,
+      isVisible: () => true,
+      now: Date.now,
+    };
+    const stop = openLiveEvents(
+      {
+        onSnapshotRequired: async () => {
+          const chatReady = await loadSnapshotBoundary(
+            async () => {},
+            [{ key: "webhooks", load: async () => Promise.reject(new Error("webhooks unavailable")) }],
+            (part, error) => scheduleRetry(part.key, error),
+          );
+          if (chatReady) {
+            hydrated = true;
+            applied.push(...pending.splice(0));
+          }
+          return chatReady;
+        },
+        onFrame: (frame) => {
+          if (hydrated) applied.push(frame);
+          else pending.push(frame);
+        },
+        retryMinMs: 1,
+        retryMaxMs: 1,
+      },
+      platform,
+    );
+
+    sources[0]!.message({ kind: "hello", resumed: false, cursor: "stream00:4" });
+    sources[0]!.message(
+      { kind: "message", threadId: "bot-thread", message: { id: "user-1" } },
+      "stream00:5",
+    );
+    await vi.waitFor(() => expect(applied).toHaveLength(1));
+
+    expect(applied).toEqual([
+      { kind: "message", threadId: "bot-thread", message: { id: "user-1" } },
+    ]);
+    expect(scheduleRetry).toHaveBeenCalledWith("webhooks", expect.any(Error));
+    expect(sources).toHaveLength(1);
+    expect(sources[0]!.close).not.toHaveBeenCalled();
+    stop();
+  });
+});
 
 describe("notification routing", () => {
   const bots = [{ id: "bot-1", threadId: "main-thread", tasks: [{ threadId: "detached-thread" }] }] as never;

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -270,6 +270,51 @@ describe("cross-client bot creation", () => {
   });
 });
 
+describe("canonical message races", () => {
+  it("does not rewind the active branch when POST repeats a user message after the reply", () => {
+    const sent = {
+      id: "sent",
+      role: "user",
+      kind: "text",
+      text: "Ship it",
+      at: 1,
+      parentId: null,
+    } satisfies Message;
+    const reply = {
+      id: "reply",
+      role: "bot",
+      kind: "text",
+      text: "Done",
+      at: 2,
+      parentId: sent.id,
+    } satisfies Message;
+    const bot = {
+      id: "race-bot",
+      threadId: "race-thread",
+      name: "Race",
+      title: "",
+      description: "",
+      notifications: true,
+      color: "green",
+      unread: false,
+      modelSelection: { instanceId: "codex", model: "default" },
+      messages: [sent, reply],
+      activeLeafId: reply.id,
+    } satisfies Bot;
+    const state = { ...initialState, bots: [bot] };
+
+    const next = reducer(state, {
+      type: "messageAdded",
+      threadId: bot.threadId,
+      message: sent,
+    });
+
+    expect(next).toBe(state);
+    expect(next.bots[0]?.activeLeafId).toBe(reply.id);
+    expect(next.bots[0]?.messages).toEqual([sent, reply]);
+  });
+});
+
 describe("section Chiefs", () => {
   const bot = (id: string, section: string, chiefOfStaff = false) => ({
     id,

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -24,6 +24,7 @@ import { showNotification, type NotificationTarget } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
 import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { openLiveEvents } from "@/lib/live-events";
 
 export type { MausColor } from "@/lib/mascot";
 
@@ -818,11 +819,12 @@ export function reducer(state: AppState, action: Action): AppState {
           ),
         };
       }
+      // The POST response and the canonical SSE frame may arrive in either
+      // order. A repeated message is already folded; moving the active leaf
+      // back to it can hide a newer assistant reply that won the race.
+      if (bot.messages.some((message) => message.id === action.message.id)) return state;
       // every server-side append chains onto (and becomes) the active leaf
       const next = updateBot(state, bot.id, (b) => {
-        if (b.messages.some((m) => m.id === action.message.id)) {
-          return { ...b, activeLeafId: action.message.id };
-        }
         let messages = [...b.messages, action.message];
         // base64 screen frames are big; a long computer-use session would
         // grow memory without bound. Keep the newest few frames' pixels and
@@ -1335,11 +1337,15 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // persist through the existing card route so an older server that
           // does not auto-dismiss still hides the quiz on this client
           if (quizBeforeSend) persistCard(action.botId, quizBeforeSend.id, { dismissed: true });
+          const threadId = stateRef.current.bots.find((bot) => bot.id === action.botId)?.threadId;
           void api(`/api/bots/${action.botId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text, replyToId: action.replyToId }),
+            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId }),
           })
             .then((body) => {
+              if (body?.message && typeof body.threadId === "string") {
+                rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
+              }
               if (
                 body?.queued &&
                 typeof body.threadId === "string" &&
@@ -1499,12 +1505,20 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             })
             .catch(showError);
           break;
-        case "sendGroup":
+        case "sendGroup": {
+          const threadId = stateRef.current.groups.find((group) => group.id === action.groupId)?.threadId;
           api(`/api/groups/${action.groupId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text, replyToId: action.replyToId }),
-          }).catch(showError);
+            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId }),
+          })
+            .then((body) => {
+              if (body?.message && typeof body.threadId === "string") {
+                rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
+              }
+            })
+            .catch(showError);
           break;
+        }
         case "patchGroup":
           api(`/api/groups/${action.groupId}`, {
             method: "PATCH",
@@ -1655,12 +1669,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // gap before that connection opened.
     const hydrationFallback = setTimeout(hydrate, 1_000);
 
-    const es = new EventSource("/api/events");
     // The hydrate decision belongs to the hello frame, not to onopen: the
     // server replays what we missed when it can, and re-downloading every
     // transcript on a reconnect it already covered is pure waste.
-    es.onopen = () => rawDispatch({ type: "connected", value: true });
-    es.onerror = () => rawDispatch({ type: "connected", value: false });
     handleFrame = (frame) => {
       switch (frame.kind) {
         case "message": {
@@ -1820,27 +1831,31 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
       }
     };
-    es.onmessage = (raw) => {
-      let frame: any;
-      try {
-        frame = JSON.parse(raw.data);
-      } catch {
-        return;
-      }
-      // `hello` is the snapshot boundary. A false `resumed` means the server
-      // could not fill the gap, so queue subsequent frames behind a hydrate.
-      if (frame.kind === "hello") {
-        clearTimeout(hydrationFallback);
-        if (!frame.resumed) hydrate();
-        return;
-      }
-      if (hydrated) handleFrame(frame);
-      else pendingFrames.push(frame);
-    };
+    const stopLive = openLiveEvents({
+      onOpen: () => rawDispatch({ type: "connected", value: true }),
+      onError: () => rawDispatch({ type: "connected", value: false }),
+      onFrame: (frame) => {
+        // `hello` is the snapshot boundary. A false `resumed` means the server
+        // could not fill the gap, so queue subsequent frames behind a hydrate.
+        if (frame.kind === "hello") {
+          clearTimeout(hydrationFallback);
+          if (!frame.resumed) {
+            // This server could not replay the gap. Anything queued behind an
+            // older snapshot belongs to the abandoned stream generation and
+            // must not be folded over the fresh snapshot we are about to load.
+            pendingFrames.splice(0);
+            hydrate();
+          }
+          return;
+        }
+        if (hydrated) handleFrame(frame);
+        else pendingFrames.push(frame);
+      },
+    });
     return () => {
       alive = false;
       clearTimeout(hydrationFallback);
-      es.close();
+      stopLive();
     };
   }, []);
 

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1225,6 +1225,35 @@ export async function api(path: string, init?: RequestInit): Promise<any> {
   return body;
 }
 
+export interface PeripheralSnapshotLoad<Key extends string = string> {
+  key: Key;
+  load: () => Promise<void>;
+}
+
+function normalizeSnapshotFailure(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+/** A refused SSE resume needs the chat transcript snapshot before its cursor
+ * can be acknowledged. The other panels should refresh at the same boundary,
+ * but a broken optional endpoint must not hold every chat frame hostage. */
+export async function loadSnapshotBoundary<Key extends string>(
+  loadChat: () => Promise<void>,
+  peripherals: readonly PeripheralSnapshotLoad<Key>[],
+  onPeripheralFailure: (part: PeripheralSnapshotLoad<Key>, error: Error) => void,
+): Promise<boolean> {
+  const [chat, ...settledPeripherals] = await Promise.allSettled([
+    loadChat(),
+    ...peripherals.map((part) => part.load()),
+  ]);
+  settledPeripherals.forEach((result, index) => {
+    if (result.status === "rejected") {
+      onPeripheralFailure(peripherals[index]!, normalizeSnapshotFailure(result.reason));
+    }
+  });
+  return chat.status === "fulfilled";
+}
+
 /** Per-frame stream state lives in its OWN context: token frames update only
  * the components that read this hook (the chat's streaming tail), while every
  * useStore consumer — sidebar, mascots, pickers, the settled transcript —
@@ -1660,26 +1689,122 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // ── initial load + SSE fold ──────────────────────────────────────────
   useEffect(() => {
     let alive = true;
+    type PeripheralKey = "instances" | "config" | "routines" | "webhooks";
+    type PeripheralPart = {
+      key: PeripheralKey;
+      request: () => Promise<() => void>;
+    };
+    type PeripheralRefresh = {
+      attempt: number;
+      generation: number;
+      timer: ReturnType<typeof setTimeout> | null;
+      version: number;
+    };
+    const peripheralRefresh = new Map<PeripheralKey, PeripheralRefresh>();
+    const refreshState = (key: PeripheralKey) => {
+      let current = peripheralRefresh.get(key);
+      if (!current) {
+        current = { attempt: 0, generation: 0, timer: null, version: 0 };
+        peripheralRefresh.set(key, current);
+      }
+      return current;
+    };
+    const peripheralParts: PeripheralPart[] = [
+      {
+        key: "instances",
+        request: async () => {
+          const { instances } = await api("/api/instances");
+          return () => rawDispatch({ type: "instances", instances });
+        },
+      },
+      {
+        key: "config",
+        request: async () => {
+          const config = await api("/api/config");
+          return () => rawDispatch({ type: "configStatus", config });
+        },
+      },
+      {
+        key: "routines",
+        request: async () => {
+          const { routines, runs } = await api("/api/routines");
+          return () => rawDispatch({ type: "routinesHydrated", routines, runs });
+        },
+      },
+      {
+        key: "webhooks",
+        request: async () => {
+          const { webhooks, attempts, ingress } = await api("/api/webhooks");
+          return () =>
+            rawDispatch({ type: "webhooksHydrated", webhooks, attempts: attempts ?? [], ingress });
+        },
+      },
+    ];
+    const partByKey = new Map(peripheralParts.map((part) => [part.key, part]));
+    const schedulePeripheralRetry = (part: PeripheralPart, error?: Error) => {
+      if (!alive) return;
+      const refresh = refreshState(part.key);
+      if (refresh.timer) return;
+      if (error !== undefined) {
+        console.warn(`snapshot: ${part.key} refresh failed; retrying`, error);
+      }
+      const delay = Math.min(30_000, 1_000 * 2 ** Math.min(refresh.attempt, 5));
+      refresh.attempt += 1;
+      refresh.timer = setTimeout(() => {
+        refresh.timer = null;
+        void loadPeripheral(part, true).catch((nextError) => schedulePeripheralRetry(part, nextError));
+      }, delay);
+    };
+    const loadPeripheral = async (part: PeripheralPart, protectLiveFrames: boolean): Promise<void> => {
+      const refresh = refreshState(part.key);
+      if (refresh.timer) {
+        clearTimeout(refresh.timer);
+        refresh.timer = null;
+      }
+      const generation = ++refresh.generation;
+      const version = refresh.version;
+      try {
+        const apply = await part.request();
+        if (!alive || refresh.generation !== generation) return;
+        // A background retry must never replace a live patch that arrived
+        // after its request began. Discard that stale response and try again
+        // from the newer event boundary instead.
+        if (protectLiveFrames && refresh.version !== version) {
+          schedulePeripheralRetry(part);
+          return;
+        }
+        apply();
+        refresh.attempt = 0;
+      } catch (error) {
+        // A newer refresh owns this lane now; its result will decide whether
+        // another retry is needed.
+        if (!alive || refresh.generation !== generation) return;
+        throw normalizeSnapshotFailure(error);
+      }
+    };
+    const bumpPeripheralVersion = (...keys: PeripheralKey[]) => {
+      for (const key of keys) refreshState(key).version += 1;
+    };
     const loadAll = async (): Promise<boolean> => {
-      const results = await Promise.allSettled([
-        api("/api/bots")
-          .then(({ bots, groups, computerControl }) =>
-            alive && rawDispatch({
-              type: "hydrate",
-              bots,
-              groups: groups ?? [],
-              computerControl: computerControl ?? {},
-            })),
-        api("/api/instances")
-          .then(({ instances }) => alive && rawDispatch({ type: "instances", instances })),
-        api("/api/config")
-          .then((config) => alive && rawDispatch({ type: "configStatus", config })),
-        api("/api/routines")
-          .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs })),
-        api("/api/webhooks")
-          .then(({ webhooks, attempts, ingress }) => alive && rawDispatch({ type: "webhooksHydrated", webhooks, attempts: attempts ?? [], ingress })),
-      ]);
-      return alive && results.every((result) => result.status === "fulfilled");
+      const chat = () =>
+        api("/api/bots").then(({ bots, groups, computerControl }) => {
+          if (!alive) return;
+          rawDispatch({
+            type: "hydrate",
+            bots,
+            groups: groups ?? [],
+            computerControl: computerControl ?? {},
+          });
+        });
+      const peripherals = peripheralParts.map((part) => ({
+        key: part.key,
+        load: () => loadPeripheral(part, false),
+      }));
+      const chatReady = await loadSnapshotBoundary(chat, peripherals, (failed, error) => {
+        const part = partByKey.get(failed.key);
+        if (part) schedulePeripheralRetry(part, error);
+      });
+      return alive && chatReady;
     };
 
     // A snapshot and the live fold have to meet at a defined boundary. Start
@@ -1724,6 +1849,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // server replays what we missed when it can, and re-downloading every
     // transcript on a reconnect it already covered is pure waste.
     handleFrame = (frame) => {
+      if (frame.kind === "config") bumpPeripheralVersion("config", "instances");
+      else if (frame.kind === "routine" || frame.kind === "routine.deleted" || frame.kind === "routine.run") {
+        bumpPeripheralVersion("routines");
+      } else if (
+        frame.kind === "webhook" ||
+        frame.kind === "webhook.attempt" ||
+        frame.kind === "webhook.deleted"
+      ) {
+        bumpPeripheralVersion("webhooks");
+      }
       switch (frame.kind) {
         case "message": {
           rawDispatch({ type: "messageAdded", threadId: frame.threadId, message: frame.message });
@@ -1900,6 +2035,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     return () => {
       alive = false;
       clearTimeout(hydrationFallback);
+      for (const refresh of peripheralRefresh.values()) {
+        if (refresh.timer) clearTimeout(refresh.timer);
+      }
       stopLive();
     };
   }, []);

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -94,6 +94,8 @@ export interface Message {
   parentId?: string | null;
   /** Flat reply reference for an inline quote; unrelated to branch ancestry. */
   replyToId?: string;
+  /** Stable client identity for at-most-once chat POST retries. */
+  sendId?: string;
   /** rooms: which member said this (sender attribution). */
   from?: { botId: string; name: string; color: MausColor };
   /** emoji reactions; by = "user" or a member botId. */
@@ -495,7 +497,15 @@ export type Action =
   | { type: "groupPatched"; group: Partial<Group> & { id: string } }
   | { type: "groupDeleted"; groupId: string }
   | { type: "createGroup"; memberIds: string[]; name?: string; section?: string }
-  | { type: "sendGroup"; groupId: string; text: string; replyToId?: string }
+  | {
+      type: "sendGroup";
+      groupId: string;
+      text: string;
+      sendId?: string;
+      replyToId?: string;
+      threadId?: string;
+      onError?: () => void;
+    }
   | {
       type: "patchGroup";
       groupId: string;
@@ -511,7 +521,15 @@ export type Action =
   | { type: "instances"; instances: InstanceInfo[] }
   | { type: "configStatus"; config: ConfigStatus }
   | { type: "select"; id: string }
-  | { type: "send"; botId: string; text: string; replyToId?: string }
+  | {
+      type: "send";
+      botId: string;
+      text: string;
+      sendId?: string;
+      replyToId?: string;
+      threadId?: string;
+      onError?: () => void;
+    }
   | { type: "pendingQueued"; threadId: string; queueId: string; text: string }
   | { type: "consumePendingQueued"; threadId: string; queueId: string }
   | { type: "cancelQueued"; botId: string; queueId: string }
@@ -1418,10 +1436,12 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           // persist through the existing card route so an older server that
           // does not auto-dismiss still hides the quiz on this client
           if (quizBeforeSend) persistCard(action.botId, quizBeforeSend.id, { dismissed: true });
-          const threadId = stateRef.current.bots.find((bot) => bot.id === action.botId)?.threadId;
+          const threadId =
+            action.threadId ?? stateRef.current.bots.find((bot) => bot.id === action.botId)?.threadId;
+          const sendId = action.sendId ?? crypto.randomUUID();
           void api(`/api/bots/${action.botId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId }),
+            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId, sendId }),
           })
             .then((body) => {
               if (body?.message && typeof body.threadId === "string") {
@@ -1440,7 +1460,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
                 });
               }
             })
-            .catch(showError);
+            .catch((error) => {
+              showError(error);
+              action.onError?.();
+            });
           break;
         }
         case "editMessage":
@@ -1587,17 +1610,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             .catch(showError);
           break;
         case "sendGroup": {
-          const threadId = stateRef.current.groups.find((group) => group.id === action.groupId)?.threadId;
+          const threadId =
+            action.threadId ?? stateRef.current.groups.find((group) => group.id === action.groupId)?.threadId;
+          const sendId = action.sendId ?? crypto.randomUUID();
           api(`/api/groups/${action.groupId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId }),
+            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId, sendId }),
           })
             .then((body) => {
               if (body?.message && typeof body.threadId === "string") {
                 rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
               }
             })
-            .catch(showError);
+            .catch((error) => {
+              showError(error);
+              action.onError?.();
+            });
           break;
         }
         case "patchGroup":

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -418,13 +418,52 @@ export interface AppState {
 
 const MAX_CONSUMED_QUEUE_IDS = 64;
 
-function rememberConsumedQueueId(consumed: Record<string, true>, queueId: string): Record<string, true> {
+function rememberConsumedQueueId(
+  consumed: AppState["consumedQueueIds"],
+  queueId: string,
+): AppState["consumedQueueIds"] {
   const next = { ...consumed, [queueId]: true as const };
   const overflow = Object.keys(next).length - MAX_CONSUMED_QUEUE_IDS;
   if (overflow > 0) {
     for (const id of Object.keys(next).slice(0, overflow)) delete next[id];
   }
   return next;
+}
+
+interface QueueReceiptSnapshot {
+  messages?: Message[];
+}
+
+/** A replacement snapshot can contain the canonical user line after this
+ * window missed its queue-drain frame. Remove any matching chip and retain a
+ * short tombstone so a slower POST continuation cannot add the chip back. */
+function reconcileSnapshotQueues(
+  state: AppState,
+  conversations: QueueReceiptSnapshot[],
+): AppState {
+  const landed: Array<{ queueId: string; at: number }> = [];
+  for (const conversation of conversations) {
+    for (const message of conversation.messages ?? []) {
+      if (message.queueId) landed.push({ queueId: message.queueId, at: message.at });
+    }
+  }
+  if (landed.length === 0) return state;
+
+  const landedIds = new Set(landed.map((entry) => entry.queueId));
+  const pendingQueued: AppState["pendingQueued"] = {};
+  for (const [threadId, entries] of Object.entries(state.pendingQueued)) {
+    const waiting = entries.filter((entry) => !landedIds.has(entry.queueId));
+    if (waiting.length > 0) pendingQueued[threadId] = waiting;
+  }
+
+  let consumedQueueIds = state.consumedQueueIds;
+  // Preserve the newest receipts when a large historical snapshot contains
+  // more than the bounded tombstone window.
+  landed.sort((left, right) => left.at - right.at);
+  for (const entry of landed) {
+    consumedQueueIds = rememberConsumedQueueId(consumedQueueIds, entry.queueId);
+  }
+  return { ...state, pendingQueued, consumedQueueIds };
 }
 
 export type BotAnnouncement = Omit<Bot, "messages"> & { messages?: Message[] };
@@ -604,13 +643,16 @@ export function reducer(state: AppState, action: Action): AppState {
       const known = (id: string) => action.bots.some((b) => b.id === id) || action.groups.some((g) => g.id === id);
       const selectedId =
         state.selectedId && known(state.selectedId) ? state.selectedId : (action.bots[0]?.id ?? "");
-      return {
-        ...state,
-        bots: action.bots,
-        groups: action.groups,
-        computerControl: action.computerControl,
-        selectedId,
-      };
+      return reconcileSnapshotQueues(
+        {
+          ...state,
+          bots: action.bots,
+          groups: action.groups,
+          computerControl: action.computerControl,
+          selectedId,
+        },
+        [...action.bots, ...action.groups],
+      );
     }
     case "showRoutines":
       return {
@@ -766,10 +808,11 @@ export function reducer(state: AppState, action: Action): AppState {
       // team import), so add it now; the following message frames will fill
       // its greeting without waiting for a full-page hydration.
       if (!before) {
-        return {
+        const added = {
           ...state,
           bots: [{ ...action.bot, messages: action.bot.messages ?? [] }, ...state.bots],
         };
+        return reconcileSnapshotQueues(added, [action.bot]);
       }
       const kind =
         action.bot.unread && !before?.unread
@@ -792,7 +835,7 @@ export function reducer(state: AppState, action: Action): AppState {
         : animated;
       const switchedThread =
         typeof action.bot.threadId === "string" && action.bot.threadId !== before.threadId;
-      return updateBot(next, action.bot.id, (b) => ({
+      const patched = updateBot(next, action.bot.id, (b) => ({
         ...b,
         ...action.bot,
         // Ordinary bot patches omit messages and must preserve the current
@@ -804,6 +847,9 @@ export function reducer(state: AppState, action: Action): AppState {
             ? action.bot.messages
             : b.messages,
       }));
+      return switchedThread && Array.isArray(action.bot.messages)
+        ? reconcileSnapshotQueues(patched, [action.bot])
+        : patched;
     }
     case "messageAdded": {
       const bot = state.bots.find((b) => b.threadId === action.threadId);
@@ -1111,8 +1157,14 @@ export function reducer(state: AppState, action: Action): AppState {
             : group,
         ),
       };
-    case "taskSwitched":
-      return updateBot(state, action.bot.id, (bot) => ({ ...bot, ...action.bot, messages: action.bot.messages ?? [] }));
+    case "taskSwitched": {
+      const switched = updateBot(state, action.bot.id, (bot) => ({
+        ...bot,
+        ...action.bot,
+        messages: action.bot.messages ?? [],
+      }));
+      return reconcileSnapshotQueues(switched, [action.bot]);
+    }
     case "newBot":
     case "duplicateBot":
     case "interrupt":
@@ -1608,8 +1660,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // ── initial load + SSE fold ──────────────────────────────────────────
   useEffect(() => {
     let alive = true;
-    const loadAll = () =>
-      Promise.all([
+    const loadAll = async (): Promise<boolean> => {
+      const results = await Promise.allSettled([
         api("/api/bots")
           .then(({ bots, groups, computerControl }) =>
             alive && rawDispatch({
@@ -1617,21 +1669,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
               bots,
               groups: groups ?? [],
               computerControl: computerControl ?? {},
-            }))
-          .catch(() => {}),
+            })),
         api("/api/instances")
-          .then(({ instances }) => alive && rawDispatch({ type: "instances", instances }))
-          .catch(() => {}),
+          .then(({ instances }) => alive && rawDispatch({ type: "instances", instances })),
         api("/api/config")
-          .then((config) => alive && rawDispatch({ type: "configStatus", config }))
-          .catch(() => {}),
+          .then((config) => alive && rawDispatch({ type: "configStatus", config })),
         api("/api/routines")
-          .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs }))
-          .catch(() => {}),
+          .then(({ routines, runs }) => alive && rawDispatch({ type: "routinesHydrated", routines, runs })),
         api("/api/webhooks")
-          .then(({ webhooks, attempts, ingress }) => alive && rawDispatch({ type: "webhooksHydrated", webhooks, attempts: attempts ?? [], ingress }))
-          .catch(() => {}),
+          .then(({ webhooks, attempts, ingress }) => alive && rawDispatch({ type: "webhooksHydrated", webhooks, attempts: attempts ?? [], ingress })),
       ]);
+      return alive && results.every((result) => result.status === "fulfilled");
+    };
 
     // A snapshot and the live fold have to meet at a defined boundary. Start
     // hydration only after the stream says hello, queue frames that arrive
@@ -1639,30 +1688,32 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // a late hydrate can overwrite a newer event, or an event can land between
     // an eager request and the stream opening and disappear entirely.
     let hydrated = false;
-    let hydrating = false;
+    let hydrationPromise: Promise<boolean> | null = null;
     let rehydrateRequested = false;
     const pendingFrames: any[] = [];
     let handleFrame: (frame: any) => void;
-    const hydrate = () => {
-      if (hydrating) {
+    const hydrate = (): Promise<boolean> => {
+      if (hydrationPromise) {
         // A second non-resumable hello means this snapshot may have started
         // before another connection gap. Run one more after it settles.
         rehydrateRequested = true;
-        return;
+        return hydrationPromise;
       }
-      hydrating = true;
       hydrated = false;
-      void loadAll().finally(() => {
-        if (!alive) return;
-        hydrating = false;
-        if (rehydrateRequested) {
+      hydrationPromise = (async () => {
+        let loaded = false;
+        do {
           rehydrateRequested = false;
-          hydrate();
-          return;
-        }
+          loaded = await loadAll();
+        } while (alive && rehydrateRequested);
+        if (!alive || !loaded) return false;
         hydrated = true;
         for (const frame of pendingFrames.splice(0)) handleFrame(frame);
+        return true;
+      })().finally(() => {
+        hydrationPromise = null;
       });
+      return hydrationPromise;
     };
     // If SSE is unavailable, the app should still show its saved state. A
     // later first hello hydrates again because it cannot prove there was no
@@ -1834,20 +1885,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     const stopLive = openLiveEvents({
       onOpen: () => rawDispatch({ type: "connected", value: true }),
       onError: () => rawDispatch({ type: "connected", value: false }),
+      onSnapshotRequired: () => {
+        clearTimeout(hydrationFallback);
+        // Frames buffered before this non-resumable stream belong to an
+        // abandoned generation. Keep the new generation behind hydrate().
+        pendingFrames.splice(0);
+        return hydrate();
+      },
       onFrame: (frame) => {
-        // `hello` is the snapshot boundary. A false `resumed` means the server
-        // could not fill the gap, so queue subsequent frames behind a hydrate.
-        if (frame.kind === "hello") {
-          clearTimeout(hydrationFallback);
-          if (!frame.resumed) {
-            // This server could not replay the gap. Anything queued behind an
-            // older snapshot belongs to the abandoned stream generation and
-            // must not be folded over the fresh snapshot we are about to load.
-            pendingFrames.splice(0);
-            hydrate();
-          }
-          return;
-        }
         if (hydrated) handleFrame(frame);
         else pendingFrames.push(frame);
       },

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -2039,9 +2039,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             type: "configStatus",
             config: configStatusFromFrame(frame),
           });
-          api("/api/instances")
-            .then(({ instances }) => rawDispatch({ type: "instances", instances }))
-            .catch(() => {});
+          {
+            const instances = partByKey.get("instances");
+            if (instances) {
+              void loadPeripheral(instances, true).catch((error) =>
+                schedulePeripheralRetry(instances, error),
+              );
+            }
+          }
           break;
       }
     };


### PR DESCRIPTION
## Why

Remote and suspended clients could keep a half-dead EventSource connection that looked open while chat frames stopped arriving. A lost POST response could also leave the composer empty and make a manual retry dispatch the same action twice.

This is a focused, from-scratch replacement for #549. It keeps and expands the contributor's live-delivery idea without bringing in the unrelated sidebar changes or exposing the local control server on the network. Thank you @matt5115 for finding the failure mode and proposing the visible heartbeat/canonical POST receipt approach.

## What changed

- supervise the live EventSource with visible heartbeats, replay cursors, bounded reconnects, and focus/online recovery
- acknowledge replacement snapshots before advancing the replay cursor
- let chat hydration succeed even when a peripheral settings, routines, or webhooks snapshot temporarily fails
- return canonical user messages from direct and channel POSTs so the UI does not wait for SSE
- pin sends, calls, queued work, and late steer acknowledgements to their original task
- attach stable send IDs so direct, channel, steered, and drained-queue retries are idempotent
- restore failed drafts, attachments, and replies without overwriting anything typed later
- reconcile pending queue chips from replacement snapshots and buffer inspector refreshes safely
- keep the server loopback-only and disable compatible reverse-proxy buffering only for SSE

## Safety

- no 0.0.0.0 bind
- no global HTTP timeout weakening
- no unrelated sidebar or model-picker changes
- stale async acknowledgements cannot append into deleted or switched tasks

## Verification

- full suite: 2,307 tests counted; 2,288 passed and 19 expected skips
- Composio broker, updater, desktop viewer, package link, save-file, boot-probe, and packaged-server smoke checks passed
- renderer/server typechecks passed
- production Vite build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable message sending with retry deduplication and stable receipts.
  - Added automatic recovery for failed or interrupted drafts, including attachments and replies.
  - Added live event updates with heartbeats, reconnection, and snapshot recovery.
  - Improved queued and mid-turn messages with safer task and thread handling.

- **Bug Fixes**
  - Prevented duplicate messages and queued-message indicators.
  - Preserved reply context when switching tasks or threads.
  - Improved live updates after reconnects and delayed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->