### PR TITLE
preserve(v3): add isolated outcome-mode runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ electron/resources/speech-helper
 electron/resources/OpenMausBot Speech.app
 electron/resources/OpenMausBot Recorder.app
 release
+release-v3/
 .omb-scratch
 .smoke-data/
 .wrangler/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ electron/resources/OpenMausBot Speech.app
 electron/resources/OpenMausBot Recorder.app
 release
 .omb-scratch
+.smoke-data/
 .wrangler/
 .dev.vars
 .dev.vars.*

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# Agent Centipede V3 Outcome Mode
+
+This context names the durable concepts used when Centipede turns a requested outcome into bounded, verifiable work.
+
+## Outcome language
+
+**Outcome**:
+The user-visible result Shane wants, expressed with a quality bar and a definition of success.
+_Avoid_: Task, prompt, wish
+
+**Outcome Contract**:
+The versioned agreement that makes an Outcome executable: its success criteria, deadline, budget, quality bar, authority, escalation rules, evidence requirements, and rollback or termination behavior.
+_Avoid_: Plan, settings, goal
+
+**Constraint**:
+A limit the Outcome must respect, such as time, money, scope, quality, privacy, or allowed systems.
+_Avoid_: Preference, hint
+
+**Authority Grant**:
+An exact, bounded permission to perform a named action for a named purpose; absent a matching grant, authority is denied.
+_Avoid_: Permission, approval
+
+## Work and proof
+
+**Work**:
+The canonical executable unit owned by the existing Work system and linked to one Outcome Contract version.
+_Avoid_: Subtask, job
+
+**Evidence**:
+An attributed, time-bound observation or artifact reference that can be checked against a Contract’s success criteria.
+_Avoid_: Log, output
+
+**Capture Evidence**:
+Evidence observed through a Capture source and offered as a first-class intake path for inferring or linking an Outcome; it does not authorize execution by itself.
+_Avoid_: Trigger, instruction
+
+**Contractual Judgment**:
+The existing contract and authority verdict applied before consequential Work proceeds. Its product labels preserve the repository's canonical policy semantics: green permits only when the contract allows the exact work, yellow means durable Needs-you input, and red means refused, blocked, or parked.
+_Avoid_: Confidence score, execution shortcut
+
+**Verification**:
+An independent judgment that the exact Contract version’s success criteria are satisfied by the supplied Evidence and artifacts.
+_Avoid_: Completion, self-report
+
+**Receipt**:
+The durable record of a material decision or result, including the identities, version, evidence, and outcome needed to replay what happened.
+_Avoid_: Notification, status update
+
+**Needs-you Input**:
+A durable request for a specific human answer when execution cannot proceed safely without it; the answer becomes a Receipt.
+_Avoid_: Chat prompt, approval card
+
+**Terminal State**:
+An Outcome state after which no further execution is permitted: completed, failed, cancelled, or rolled back.
+_Avoid_: Done, inactive

--- a/docs/adr/0001-outcome-orchestrator-command-seam.md
+++ b/docs/adr/0001-outcome-orchestrator-command-seam.md
@@ -1,0 +1,3 @@
+# Outcome Orchestrator command seam
+
+Outcome Mode needs to own validation, event replay, legal transitions, exact Contract-version binding, and independent verification without making each caller understand those rules. We considered (1) an explicit interface with separate `declare`, `accept`, `start`, `answer`, `verify`, and `cancel` methods, which is discoverable but spreads transition and retry rules across a wide seam, and (2) a deep command seam with one validated `dispatch` entrypoint plus one `inspect` projection. We chose the second: the interface stays small while the implementation centralizes fail-closed replay and lifecycle behavior; the cost is that callers must construct a discriminated command, which boundary validation makes explicit.

--- a/docs/receipts/2026-08-28-agent-centipede-v3-outcome-mode.md
+++ b/docs/receipts/2026-08-28-agent-centipede-v3-outcome-mode.md
@@ -1,0 +1,61 @@
+# Agent Centipede V3 completion receipt — 2026-08-28
+
+## Result
+
+V3’s production server path is implemented and independently verified through the public Outcome dispatch seam, the real V2 WorkOrchestrator ingest/prepare/decide/execute/reconcile seam, durable WorkLock, WorkerJobs, independent reconciliation, trace/receipt learning feedback, and the packaged server entry point. The desktop shell and repository-wide lint still have explicit blockers below, so this receipt does not call the prototype fully ready or promoted.
+
+## Scope and isolation
+
+- Worktree: `C:\Users\shane\Documents\Codex\2026-08-26\give\worktrees\OpenMausBot-v3`
+- Branch: `codex/v3-outcome-mode`
+- Base/source commit: `667af71ae7e93640ba4b1a5f3b38a1ad342025da`
+- Live V2 checkout was read-only inspected at `C:\Users\shane\Documents\Codex\2026-08-26\give\work\OpenMausBot`; it was not edited.
+- V3 keeps its own product/app identity, ports, data root, WorkLock DB, worker journal, protocol, and package output. No install, deploy, publish, upload, promotion, merge, or V2 replacement occurred.
+
+## Implemented
+
+- `server/outcome-orchestrator.ts`: strict Zod command/event/contract boundaries; provenance-bearing Capture context deltas; graph-relative inference and conflict handling; canonical Work linking/dedupe; exact green/yellow/red judgment; fail-closed replay; complete trace identity; independent verification and receipts.
+- `server/centipede-v3-runtime.ts`: production V3 wiring to the real V2 WorkLock, WorkOrchestrator, WorkerJobs, worker receipt, action-policy, account, telemetry, verifier, context graph, and bounded learning stores.
+- `server/work-lock-store.ts`, `server/work-orchestrator.ts`, `server/worker-jobs.ts`, `server/worker-job-file-store.ts`, `server/worker-batch-receipt.ts`, and related V2 adapters: retained the locked external ingest/prepare/decide/execute/reconcile interface.
+- `server/centipede-v3-runtime.test.ts` and `server/outcome-orchestrator.test.ts`: red-first public-seam coverage for success, duplicate Capture, graph conflict/ambiguity, yellow/red gates, authority/deadline/budget refusal, worker delay/failure paths, forged verification refusal, corrupt journal, replay, context feedback, trace completeness, and exact-once execution.
+- `scripts/smoke-v3-coexistence.mjs`: starts real V2 and V3 server entries concurrently and checks distinct PIDs, identities, endpoints, data roots, and V3 WorkLock placement.
+- `electron/centipede-v3-identity.*`, `electron-builder.v3.yml`, and existing V3 main/runtime changes: distinct desktop/app/protocol/package identity and V3 server routing.
+
+## Verification evidence
+
+| Check | Result | Evidence |
+|---|---|---|
+| Focused V3 seams | passed | `vitest run server/centipede-v3-runtime.test.ts server/outcome-orchestrator.test.ts server/execution-learning.test.ts` — 3 files, 17 tests passed |
+| Full test floor | passed | `pnpm test` — 2,088 counted; 2,002 passed; 86 skipped; floor 1,070; broker/updater/viewer/package-link/save-file/packaged-server checks passed |
+| Client + server typecheck | passed | `pnpm typecheck` |
+| Production client build | passed | `pnpm build` — 2,578 modules transformed |
+| Server bundle | passed | `pnpm build:server` — `dist-server/v3-index.js` 1.9 MB |
+| Packaged server journey | passed | `pnpm test:packaged-v3-server` — V3 health 200, context 200, Capture 200, verify 200, completed outcome |
+| Fresh unpacked package journey | passed | `OMB_SMOKE_DIST=release-v3/win-unpacked/resources/server node scripts/smoke-packaged-v3-server.mjs` — health/Capture/verify all passed |
+| V2/V3 coexistence | passed | `pnpm test:v3-coexistence` — simultaneous `openmausbot` and `Centipede V3`, distinct PIDs 36444/8292 in the first green run, distinct ports/data roots, V3 WorkLock isolated |
+| V3 identity/deep links | passed | `node --test electron/centipede-v3-identity.node-test.mjs electron/package-link.node-test.mjs` — 3 passed |
+| Electron static check | passed | `pnpm check:electron` — 64 modules syntax-checked |
+| Strict touched/new-file lint | passed | `oxlint` over all V3 implementation, tests, smoke, identity, and copied V2 seam files — exit 0 |
+| Diff integrity | passed | `git diff --check` — exit 0; only normal LF→CRLF warnings |
+| Secret/private artifact scan | passed | scoped scan found no high-confidence credential markers in touched/new V3 artifacts |
+
+## Package artifacts
+
+- Setup: `C:\Users\shane\Documents\Codex\2026-08-26\give\worktrees\OpenMausBot-v3\release-v3\Centipede-V3-0.1.37-setup.exe`
+- Zip: `C:\Users\shane\Documents\Codex\2026-08-26\give\worktrees\OpenMausBot-v3\release-v3\Centipede-V3-0.1.37-x64.zip`
+- Requested copied setup: `C:\Users\shane\.openmausbot\workspaces\3df4d235-3dfc-4b20-a140-75ee2abb8875\outputs\Agent Centipede V3\Centipede-V3-0.1.37-setup.exe`
+- Setup SHA-256: `538F0C8E12E8F0D86F622CEB8CC9EE578C6ECA125DF14F981FB9B01AFF90FD27`
+- Copied setup SHA-256: same; source/destination bytes `122,983,015`
+- Zip SHA-256: `0FC40B38AEC32A5200B6D50B5D209D761C4B2A734437364053FE99CBDC2567E1`
+- Unpacked executable SHA-256: `B053621764B47F189D9799517B3FDEB9893E19D879D85B3D551061AEE60219EC`
+- Packaged `v3-index.js` SHA-256: `98630BFB3CBE6C751D8EC5F7720E56624D9F3526EC50A5EC93890002BE3909F1`
+
+## Remaining blockers
+
+1. The unpacked Electron shell was launched twice through direct process startup. Its V3 server child began on port 18899 and wrote the V3-only `logs/server.log`, but the desktop process exited before the health probe returned. A CUA foreground/window journey was not run because the Computer Use policy requires an action-time confirmation to run newly built software. Smallest next human action: approve that visible desktop launch, then verify the one V3 window and Capture → verify journey.
+2. `pnpm lint` remains red on the repository’s inherited anti-slop backlog in untouched legacy files and generated `release-v3` JavaScript. The complete touched/new V3 file lint set passes; no V3 lint failure remains.
+3. The V3 packaged runtime uses the real durable V2 WorkerJobs/WorkOrchestrator path, with the standalone bounded worker runner as its default provider adapter. A live provider/model turn runner remains an external integration choice; no provider credential or external action was assumed.
+
+## Approval boundary
+
+The package is rebuilt and copied, but not installed, launched for normal use, deployed, published, uploaded, promoted, or used to replace V2. V3 remains an isolated candidate pending the desktop action-time check, the inherited lint cleanup decision, and explicit promotion approval.

--- a/electron-builder.v3.yml
+++ b/electron-builder.v3.yml
@@ -1,0 +1,49 @@
+extends: electron-builder.yml
+
+appId: com.openmausbot.centipede.v3
+productName: Centipede V3
+artifactName: Centipede-V3-${version}-${arch}.${ext}
+
+protocols:
+  - name: Centipede V3 outcome package
+    schemes: [centipede-v3]
+
+publish:
+  - provider: github
+    owner: milind-soni
+    repo: openmausbot-releases
+    channel: centipede-v3
+
+win:
+  executableName: centipede-v3
+  target:
+    - target: nsis
+      arch: x64
+    - target: zip
+      arch: x64
+
+nsis:
+  shortcutName: Centipede V3
+  artifactName: Centipede-V3-${version}-setup.${ext}
+
+linux:
+  executableName: centipede-v3
+
+directories:
+  output: release-v3
+
+afterPack: ./scripts/after-pack-v3.mjs
+
+extraResources:
+  - from: LICENSE
+    to: licenses/Centipede-V3-LICENSE.txt
+  - from: NOTICE
+    to: licenses/Centipede-V3-NOTICE.txt
+  - from: dist
+    to: ui
+  - from: dist-server
+    to: server
+  - from: dist-companion
+    to: companion
+  - from: skills
+    to: skills

--- a/electron/centipede-v3-identity.mjs
+++ b/electron/centipede-v3-identity.mjs
@@ -1,0 +1,9 @@
+export const CENTIPEDE_V3_IDENTITY = Object.freeze({
+  appId: "com.openmausbot.centipede.v3",
+  productName: "Centipede V3",
+  executableName: "centipede-v3",
+  protocol: "centipede-v3",
+  serverPort: 18899,
+  dataDirectory: "Centipede V3",
+  updaterChannel: "centipede-v3",
+});

--- a/electron/centipede-v3-identity.node-test.mjs
+++ b/electron/centipede-v3-identity.node-test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CENTIPEDE_V3_IDENTITY } from "./centipede-v3-identity.mjs";
+
+test("Centipede V3 has a distinct desktop, runtime, protocol, and updater identity", () => {
+  assert.deepEqual(CENTIPEDE_V3_IDENTITY, {
+    appId: "com.openmausbot.centipede.v3",
+    productName: "Centipede V3",
+    executableName: "centipede-v3",
+    protocol: "centipede-v3",
+    serverPort: 18899,
+    dataDirectory: "Centipede V3",
+    updaterChannel: "centipede-v3",
+  });
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -45,6 +45,7 @@ import {
   resolveCompanionControlPlaneURL,
 } from "./companion-account-service.mjs";
 import capabilitiesModule from "./capabilities.cjs";
+import { CENTIPEDE_V3_IDENTITY } from "./centipede-v3-identity.mjs";
 
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
 const nativeActions = nativeDesktopActions(process.platform);
@@ -57,11 +58,17 @@ const { desktopViewerUrl, sameDesktopViewerOrigin } = require("./desktop-viewer.
 const { normalizeUnreadCount, parseWindowState, resolveWindowState } = require("./window-state.cjs");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+app.setName(CENTIPEDE_V3_IDENTITY.productName);
+if (process.platform === "win32") app.setAppUserModelId(CENTIPEDE_V3_IDENTITY.appId);
+app.setPath("userData", path.join(app.getPath("appData"), CENTIPEDE_V3_IDENTITY.dataDirectory));
+app.setPath("cache", path.join(app.getPath("userData"), "cache"));
+app.setPath("logs", path.join(app.getPath("userData"), "logs"));
+const V3_DATA_DIR = path.join(app.getPath("userData"), "data");
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
 // resolve to ::1 and paint a black window
 const DEV_URL = process.env.ELECTRON_START_URL ?? "http://127.0.0.1:5199";
 const DEFAULT_COMPOSIO_BROKER_URL = "https://openmausbot-composio.milindsoni201.workers.dev";
-let SERVER_PORT = 8799;
+let SERVER_PORT = CENTIPEDE_V3_IDENTITY.serverPort;
 const APP_ICON = path.join(__dirname, "resources/app-icon.png");
 let desktopViewerWindow = null;
 let desktopViewerOwner = null;
@@ -143,7 +150,7 @@ function applyUnreadBadge(win = mainWindow) {
 // intercepting input. This app is not graphics-heavy, so reliability wins.
 if (process.platform === "linux") {
   app.disableHardwareAcceleration();
-  app.setDesktopName("com.openmausbot.app.desktop");
+  app.setDesktopName("com.openmausbot.centipede.v3.desktop");
 }
 
 // One instance per user: without this lock a second launch forks a second
@@ -237,7 +244,7 @@ async function saveSecureCredentials(credentials) {
 }
 
 async function secureComposioConfig() {
-  const dataDir = process.env.OMB_DATA_DIR || path.join(app.getPath("home"), ".openmausbot");
+  const dataDir = process.env.OMB_DATA_DIR || V3_DATA_DIR;
   const configPath = path.join(dataDir, "config.json");
   try {
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
@@ -279,7 +286,7 @@ async function secureComposioConfig() {
 // migrates plaintext left by older versions or direct development clients.
 // See workspace-credentials.mjs for the exact rules.
 async function secureWorkspaceConfig() {
-  const dataDir = process.env.OMB_DATA_DIR || path.join(app.getPath("home"), ".openmausbot");
+  const dataDir = process.env.OMB_DATA_DIR || V3_DATA_DIR;
   const configPath = path.join(dataDir, "config.json");
   try {
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
@@ -651,9 +658,11 @@ async function gatherDiagnostics() {
 }
 
 async function startServerOn(port) {
-  const entry = path.join(process.resourcesPath, "server", "index.js");
+  const entry = path.join(process.resourcesPath, "server", "v3-index.js");
   const childEnv = managedComposioChildEnvironment(composioBrokerUrl(), secureCredentials, {
     ...process.env,
+    OMB_PRODUCT_ID: "centipede-v3",
+    OMB_DATA_DIR: process.env.OMB_DATA_DIR || V3_DATA_DIR,
     OMB_STATIC_DIR: path.join(process.resourcesPath, "ui"),
     OMB_RESOURCES_PATH: process.resourcesPath,
     OMB_SKILLS_DIR: path.join(process.resourcesPath, "skills"),
@@ -692,7 +701,7 @@ async function startServerOn(port) {
       const res = await fetch(`http://127.0.0.1:${port}/api/health`);
       if (res.ok) {
         const body = await res.json().catch(() => null);
-        if (body?.app === "openmausbot" && body.pid === proc.pid && body.static) return proc;
+        if (body?.app === CENTIPEDE_V3_IDENTITY.productName && body.pid === proc.pid && body.static) return proc;
         break; // someone else owns this port — try the next one
       }
     } catch {
@@ -710,7 +719,7 @@ async function startServerPackaged() {
   // two passes: a quit-and-reopen relaunch can race the dying instance's
   // server during teardown — one settle-and-retry covers it
   for (let attempt = 0; attempt < 2; attempt++) {
-    for (const port of [8799, 18799, 28799]) {
+    for (const port of [CENTIPEDE_V3_IDENTITY.serverPort, 28899, 38899]) {
       const proc = await startServerOn(port);
       if (proc) {
         serverProc = proc;
@@ -1422,7 +1431,7 @@ setCuaStateListener((connection) => {
 });
 
 app.whenReady().then(async () => {
-  if (app.isPackaged) app.setAsDefaultProtocolClient("openmausbot");
+  if (app.isPackaged) app.setAsDefaultProtocolClient(CENTIPEDE_V3_IDENTITY.protocol);
   if (process.platform === "darwin") app.dock.setIcon(APP_ICON);
   secureCredentials = await loadSecureCredentials();
   if (app.isPackaged) {

--- a/electron/package-link.mjs
+++ b/electron/package-link.mjs
@@ -7,7 +7,7 @@ export function packageUrlFromDeepLink(rawValue) {
   } catch {
     return null;
   }
-  if (link.protocol !== "openmausbot:" || link.hostname !== "install") return null;
+  if (link.protocol !== "centipede-v3:" || link.hostname !== "install") return null;
   const rawPackage = link.searchParams.get("url");
   if (!rawPackage) return null;
   let packageUrl;

--- a/electron/package-link.node-test.mjs
+++ b/electron/package-link.node-test.mjs
@@ -6,15 +6,15 @@ import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-lin
 describe("BotMRR package deep links", () => {
   it("accepts a public GitHub package URL", () => {
     const target = "https://raw.githubusercontent.com/acme/bots/main/reddit-lead-miner.md";
-    assert.equal(packageUrlFromDeepLink(`openmausbot://install?url=${encodeURIComponent(target)}`), target);
-    assert.equal(packageUrlFromCommandLine(["OpenMausBot", "--flag", `openmausbot://install?url=${encodeURIComponent(target)}`]), target);
+    assert.equal(packageUrlFromDeepLink(`centipede-v3://install?url=${encodeURIComponent(target)}`), target);
+    assert.equal(packageUrlFromCommandLine(["Centipede V3", "--flag", `centipede-v3://install?url=${encodeURIComponent(target)}`]), target);
   });
 
   it("rejects other commands, hosts, protocols, credentials, and unsupported file types", () => {
-    assert.equal(packageUrlFromDeepLink("openmausbot://settings"), null);
-    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://evil.example/bot.json"), null);
-    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=http://raw.githubusercontent.com/a/b/main/bot.json"), null);
-    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://user@example.com/bot.json"), null);
-    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://github.com/acme/bot/run.sh"), null);
+    assert.equal(packageUrlFromDeepLink("centipede-v3://settings"), null);
+    assert.equal(packageUrlFromDeepLink("centipede-v3://install?url=https://evil.example/bot.json"), null);
+    assert.equal(packageUrlFromDeepLink("centipede-v3://install?url=http://raw.githubusercontent.com/a/b/main/bot.json"), null);
+    assert.equal(packageUrlFromDeepLink("centipede-v3://install?url=https://user@example.com/bot.json"), null);
+    assert.equal(packageUrlFromDeepLink("centipede-v3://install?url=https://github.com/acme/bot/run.sh"), null);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "openmausbot",
+  "name": "centipede-v3",
   "private": true,
   "version": "0.1.37",
-  "description": "A local-first chat app for running a team of AI agents.",
+  "description": "Centipede V3 — a local-first outcome execution desktop.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "email": "46266943+milind-soni@users.noreply.github.com"
   },
   "license": "Apache-2.0",
-  "desktopName": "com.openmausbot.app.desktop",
+  "desktopName": "com.openmausbot.centipede.v3.desktop",
   "type": "module",
   "main": "electron/main.mjs",
   "engines": {
@@ -29,7 +29,7 @@
     "docs:build": "pnpm --filter @openmausbot/docs build",
     "docs:preview": "pnpm --filter @openmausbot/docs preview",
     "companion": "node --experimental-strip-types companion/src/index.ts",
-    "dev:server": "node --experimental-strip-types server/index.ts",
+    "dev:server": "node --experimental-strip-types server/v3-index.ts",
     "dev:desktop": "node scripts/prepare-cloudflared.mjs --current && electron .",
     "build": "tsc -b && tsc -p tsconfig.server.json && vite build",
     "typecheck": "tsc -b && tsc -p tsconfig.server.json",
@@ -57,6 +57,7 @@
     "package:prepare": "pnpm build && pnpm build:server && pnpm build:companion && pnpm build:updater && pnpm build:android-tools && pnpm build:cloudflared",
     "package:mac": "pnpm package:prepare && pnpm build:speech && pnpm build:recorder && pnpm build:cua && electron-builder --mac --publish never",
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
+    "package:v3:win": "pnpm package:prepare && electron-builder --config electron-builder.v3.yml --win --publish never",
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",
@@ -64,6 +65,8 @@
     "package:linux:dir": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux dir --x64 --publish never",
     "package": "pnpm package:mac",
     "test:packaged-server": "pnpm build:server && node scripts/smoke-packaged-server.mjs",
+    "test:packaged-v3-server": "pnpm build:server && node scripts/smoke-packaged-v3-server.mjs",
+    "test:v3-coexistence": "pnpm build:server && node scripts/smoke-v3-coexistence.mjs",
     "broker:types": "wrangler types --config cloudflare/composio-broker/wrangler.jsonc cloudflare/composio-broker/worker-configuration.d.ts",
     "broker:check": "pnpm broker:types && tsc -p cloudflare/composio-broker/tsconfig.json",
     "broker:test": "vitest run --config cloudflare/composio-broker/vitest.config.ts",

--- a/scripts/after-pack-v3.mjs
+++ b/scripts/after-pack-v3.mjs
@@ -1,0 +1,14 @@
+import { lstat } from "node:fs/promises";
+import path from "node:path";
+
+async function requireDirectory(directory) {
+  const details = await lstat(directory);
+  if (!details.isDirectory() || details.isSymbolicLink()) throw new Error(`V3 package resource is not a directory: ${directory}`);
+}
+
+export default async function afterPack(context) {
+  const resources = context.packager?.getResourcesDir?.(context.appOutDir) ?? path.join(context.appOutDir, "resources");
+  await requireDirectory(path.join(resources, "ui"));
+  await requireDirectory(path.join(resources, "server"));
+  await requireDirectory(path.join(resources, "companion"));
+}

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -41,6 +41,7 @@ const yamlEsmPlugin = {
 // Every file run as its own process. Keep in sync with the spawn sites above.
 const ENTRY_POINTS = [
   "index.ts",
+  "v3-index.ts",
   // The packaged smoke probe imports this manifest directly. Importing the
   // shared avatar contract widens TypeScript's inferred emit root to the repo,
   // so tsc may place its copy under dist-server/server/. Bundle an explicit

--- a/scripts/smoke-packaged-v3-server.mjs
+++ b/scripts/smoke-packaged-v3-server.mjs
@@ -1,0 +1,83 @@
+/* oxlint-disable anti-slop/no-runtime-typeof -- this smoke test validates untrusted HTTP JSON at its boundary. */
+import { spawn } from "node:child_process";
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const staging = mkdtempSync(join(tmpdir(), "centipede-v3-packaged-"));
+const data = join(staging, "data");
+const port = 22000 + Math.floor(Math.random() * 7000);
+cpSync(process.env.OMB_SMOKE_DIST ?? join(root, "dist-server"), join(staging, "server"), { recursive: true });
+
+const child = spawn(process.execPath, [join(staging, "server", "v3-index.js")], {
+  cwd: staging,
+  env: {
+    PATH: process.env.PATH ?? "",
+    SystemRoot: process.env.SystemRoot ?? "",
+    HOME: staging,
+    USERPROFILE: staging,
+    OMB_PRODUCT_ID: "centipede-v3",
+    OMB_PORT: String(port),
+    OMB_WEBHOOK_PORT: String(port + 1),
+    OMB_DATA_DIR: data,
+    OMB_STATIC_DIR: staging,
+  },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let output = "";
+child.stdout.on("data", (chunk) => { output += chunk; });
+child.stderr.on("data", (chunk) => { output += chunk; });
+
+const cleanup = () => {
+  child.kill("SIGKILL");
+  try { rmSync(staging, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); } catch { /* smoke verdict is already determined */ }
+};
+try {
+  const deadline = Date.now() + 45_000;
+  let health = null;
+  while (Date.now() < deadline && child.exitCode === null) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+      if (response.ok) { health = await response.json(); break; }
+    } catch { /* server is still booting */ }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  if (!health || health.app !== "Centipede V3" || health.pid !== child.pid || health.static !== true) {
+    throw new Error(`V3 packaged server health mismatch: ${JSON.stringify(health)}\n${output}`);
+  }
+  const context = await fetch(`http://127.0.0.1:${port}/api/v3/context`);
+  if (!context.ok) throw new Error(`V3 context route failed: ${context.status}`);
+  const capture = await fetch(`http://127.0.0.1:${port}/api/v3/commands`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      kind: "capture",
+      evidence: {
+        captureId: "packaged-smoke",
+        source: "packaged-smoke",
+        reference: "fixture:packaged-smoke",
+        summary: "Packaged V3 routed a provenance-bearing Capture into canonical Work.",
+        contentHash: "a".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "fixture:packaged-smoke", kind: "receipt", contentHash: "b".repeat(64) }],
+        observedAt: Date.now(),
+      },
+    }),
+  });
+  const captured = await capture.json();
+  if (!capture.ok || typeof captured?.view?.contract?.outcomeId !== "string") throw new Error(`V3 Capture route failed: ${capture.status} ${JSON.stringify(captured)}`);
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  const verify = await fetch(`http://127.0.0.1:${port}/api/v3/commands`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ kind: "verify", outcomeId: captured.view.contract.outcomeId, contractVersion: captured.view.contract.version }),
+  });
+  const verified = await verify.json();
+  if (!verify.ok || verified?.status !== "ok" || verified?.view?.state !== "completed") throw new Error(`V3 verification route failed: ${verify.status} ${JSON.stringify(verified)}`);
+  console.log(JSON.stringify({ app: health.app, pid: health.pid, port, contextStatus: context.status, captureStatus: capture.status, verifyStatus: verify.status, outcomeId: captured.view.contract.outcomeId }));
+} finally {
+  cleanup();
+}

--- a/scripts/smoke-v3-coexistence.mjs
+++ b/scripts/smoke-v3-coexistence.mjs
@@ -1,0 +1,79 @@
+/* oxlint-disable anti-slop/no-runtime-typeof -- this smoke test validates untrusted HTTP JSON at its boundary. */
+import { spawn } from "node:child_process";
+import { cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const staging = mkdtempSync(join(tmpdir(), "centipede-v3-coexistence-"));
+const v2Data = join(staging, "v2-data");
+const v3Data = join(staging, "v3-data");
+const dist = join(staging, "server");
+cpSync(process.env.OMB_SMOKE_DIST ?? join(root, "dist-server"), dist, { recursive: true });
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("OS did not provide a free TCP port");
+  await new Promise((resolve) => server.close(resolve));
+  return address.port;
+}
+
+const [v2Port, v2WebhookPort, v3Port, v3WebhookPort] = await Promise.all([freePort(), freePort(), freePort(), freePort()]);
+
+const baseEnv = {
+  PATH: process.env.PATH ?? "",
+  SystemRoot: process.env.SystemRoot ?? "",
+  HOME: staging,
+  USERPROFILE: staging,
+  OMB_STATIC_DIR: staging,
+};
+const v2 = spawn(process.execPath, [join(dist, "index.js")], {
+  cwd: staging,
+  env: { ...baseEnv, OMB_PRODUCT_ID: "openmausbot", OMB_PORT: String(v2Port), OMB_WEBHOOK_PORT: String(v2WebhookPort), OMB_DATA_DIR: v2Data },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+const v3 = spawn(process.execPath, [join(dist, "v3-index.js")], {
+  cwd: staging,
+  env: { ...baseEnv, OMB_PRODUCT_ID: "centipede-v3", OMB_PORT: String(v3Port), OMB_WEBHOOK_PORT: String(v3WebhookPort), OMB_DATA_DIR: v3Data },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let output = "";
+for (const child of [v2, v3]) {
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+}
+
+async function health(port, expectedApp, child) {
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline && child.exitCode === null) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+      const body = await response.json();
+      if (response.ok && body.app === expectedApp && body.pid === child.pid && body.static === true) return body;
+    } catch { /* server is still booting */ }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`health failed for ${expectedApp}; output:\n${output}`);
+}
+
+try {
+  const v2Health = await health(v2Port, "openmausbot", v2);
+  const v3Health = await health(v3Port, "Centipede V3", v3);
+  const v3Context = await fetch(`http://127.0.0.1:${v3Port}/api/v3/context`);
+  if (!v3Context.ok) throw new Error(`V3 context endpoint failed: ${v3Context.status}`);
+  if (v2.pid === v3.pid || v2Data === v3Data || v2Health.pid === v3Health.pid) throw new Error("V2 and V3 identity collision");
+  if (!existsSync(join(v3Data, "work-lock-store.db"))) throw new Error("V3 WorkLock store was not created in the V3 data root");
+  if (existsSync(join(v2Data, "work-lock-store.db"))) throw new Error("V2 unexpectedly shared the V3 WorkLock store");
+  console.log(JSON.stringify({ v2: { app: v2Health.app, pid: v2Health.pid, port: v2Port, dataRoot: v2Data }, v3: { app: v3Health.app, pid: v3Health.pid, port: v3Port, dataRoot: v3Data, workLock: join(v3Data, "work-lock-store.db") } }));
+} finally {
+  v2.kill("SIGKILL");
+  v3.kill("SIGKILL");
+  try { rmSync(staging, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); } catch { /* smoke verdict is already determined */ }
+}

--- a/server/account-directory.ts
+++ b/server/account-directory.ts
@@ -1,0 +1,534 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { z } from "zod";
+
+import { writeFileAtomic } from "./atomic.ts";
+import { parseJson } from "./schema.ts";
+
+/**
+ * The account directory is the owner-scoped seam between human names such as
+ * "Personal" and provider operations. It stores only account references and
+ * provenance; credentials belong to the provider connection, never here.
+ */
+
+/** A user-defined identity label; built-ins are conventions, not a closed set. */
+export type LogicalIdentity = string;
+export type LogicalIdentityInput = string;
+export type AccountSource = "connected-app" | "browser" | "phone" | "local";
+
+export interface AccountObservation {
+  readonly ownerId: string;
+  readonly identity: LogicalIdentityInput;
+  readonly provider: string;
+  readonly accountId: string;
+  readonly source: AccountSource;
+  readonly sourceId: string;
+  readonly observedAt?: string;
+  readonly evidenceRef?: string;
+}
+export interface AccountDirectoryOptions {
+  readonly ownerId: string;
+  readonly store?: AccountDirectoryStore;
+}
+
+/** Durable adapter seam. Implementations must persist only these safe references. */
+export interface AccountDirectoryStore {
+  load(ownerId: string): ReadonlyArray<AccountObservation>;
+  save(ownerId: string, observations: ReadonlyArray<AccountObservation>): void;
+}
+
+/** Useful for tests and embedded callers; replace with a file/database adapter for restart durability. */
+export class InMemoryAccountDirectoryStore implements AccountDirectoryStore {
+  private readonly records = new Map<string, AccountObservation[]>();
+
+  load(ownerId: string): ReadonlyArray<AccountObservation> {
+    return (this.records.get(ownerId) ?? []).map((record) => ({ ...record }));
+  }
+
+  save(ownerId: string, observations: ReadonlyArray<AccountObservation>): void {
+    this.records.set(ownerId, observations.map((observation) => ({ ...observation })));
+  }
+}
+
+const persistedObservationSchema = z.object({
+  ownerId: z.string(),
+  identity: z.string(),
+  provider: z.string(),
+  accountId: z.string(),
+  source: z.enum(["connected-app", "browser", "phone", "local"]),
+  sourceId: z.string(),
+  observedAt: z.string().optional(),
+  evidenceRef: z.string().optional(),
+}).strict();
+const persistedFileSchema = z.object({
+  version: z.literal(1),
+  owners: z.record(z.string(), z.array(persistedObservationSchema)),
+}).strict();
+type PersistedFile = z.infer<typeof persistedFileSchema>;
+
+/** Atomic, mode-restricted JSON persistence for one or more owner scopes. */
+export class JsonFileAccountDirectoryStore implements AccountDirectoryStore {
+  private readonly file: string;
+
+  constructor(file: string) {
+    if (!file.trim()) throw new AccountDirectoryError("invalid_storage", "An account directory file path is required");
+    this.file = file;
+  }
+
+  load(ownerId: string): ReadonlyArray<AccountObservation> {
+    const safeOwnerId = normalizeOpaqueId(ownerId);
+    if (!safeOwnerId) throw new AccountDirectoryError("invalid_storage", "The account directory owner is invalid");
+    const disk = this.readDisk();
+    const records = Object.hasOwn(disk.owners, safeOwnerId) ? disk.owners[safeOwnerId] : undefined;
+    return (records ?? []).map((record) => ({ ...record }));
+  }
+
+  save(ownerId: string, observations: ReadonlyArray<AccountObservation>): void {
+    const safeOwnerId = normalizeOpaqueId(ownerId);
+    if (!safeOwnerId) throw new AccountDirectoryError("invalid_storage", "The account directory owner is invalid");
+    const safeObservations: Array<z.infer<typeof persistedObservationSchema>> = [];
+    for (const observation of observations) {
+      const checked = persistedObservationSchema.safeParse(observation);
+      if (!checked.success) throw new AccountDirectoryError("storage_invalid", "The account directory contains an invalid record");
+      safeObservations.push(checked.data);
+    }
+    const disk = this.readDisk();
+    const owners = { ...disk.owners, [safeOwnerId]: safeObservations };
+    const next = { version: 1, owners } satisfies PersistedFile;
+    try {
+      mkdirSync(dirname(this.file), { recursive: true });
+      writeFileAtomic(this.file, JSON.stringify(next, null, 2), { mode: 0o600 });
+    } catch {
+      throw new AccountDirectoryError("storage_unwritable", "The account directory could not be written");
+    }
+  }
+
+  private readDisk(): PersistedFile {
+    let text: string;
+    try {
+      text = readFileSync(this.file, "utf8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return { version: 1, owners: {} };
+      }
+      throw new AccountDirectoryError("storage_invalid", "The account directory could not be read");
+    }
+    try {
+      const checked = persistedFileSchema.safeParse(parseJson(text));
+      if (!checked.success) throw new Error("invalid account directory storage");
+      return checked.data;
+    } catch {
+      throw new AccountDirectoryError("storage_invalid", "The account directory storage is invalid");
+    }
+  }
+}
+
+export interface AccountSourceRef {
+  readonly kind: AccountSource;
+  readonly sourceId: string;
+}
+
+export interface AccountBinding {
+  readonly ownerId: string;
+  readonly identity: LogicalIdentity;
+  readonly provider: string;
+  readonly accountId: string;
+  readonly sources: ReadonlyArray<AccountSourceRef>;
+  readonly evidenceRefs: ReadonlyArray<string>;
+}
+
+export type AccountRegistrationResult =
+  | { readonly status: "accepted"; readonly binding: AccountBinding }
+  | { readonly status: "duplicate"; readonly binding: AccountBinding };
+
+export interface AccountResolutionRequest {
+  readonly ownerId: string;
+  readonly identity: LogicalIdentity;
+  readonly provider: string;
+}
+
+export interface ExactAccountResolutionRequest extends AccountResolutionRequest {
+  readonly accountId: string;
+}
+
+/** An explicit inventory record paired with a human-selected logical slot.
+ * There is intentionally no display-name matching here: callers must provide
+ * the identity binding themselves when bootstrapping Personal/SEF/Anvil. */
+export interface ExplicitAccountBinding {
+  readonly identity: LogicalIdentity;
+  readonly provider: string;
+  readonly accountId: string;
+  readonly source: AccountSource;
+  readonly sourceId: string;
+  readonly observedAt?: string;
+  readonly evidenceRef?: string;
+}
+
+export interface AccountReconciliationResult {
+  readonly accepted: number;
+  readonly duplicates: number;
+  readonly rejected: ReadonlyArray<{ readonly binding: ExplicitAccountBinding; readonly reason: string }>;
+}
+
+/** Functional bootstrap seam for startup code that already has explicit
+ * Personal/SEF/Anvil mappings. It is intentionally a thin named helper so a
+ * future inventory adapter cannot silently infer identity from aliases. */
+export function reconcileAccountDirectory(
+  directory: AccountDirectory,
+  bindings: ReadonlyArray<ExplicitAccountBinding>,
+): AccountReconciliationResult {
+  return directory.reconcile(bindings);
+}
+
+export type AccountResolution =
+  | AccountBinding & { readonly status: "resolved" }
+  | {
+      readonly status: "ambiguous";
+      readonly ownerId: string;
+      readonly identity: LogicalIdentity;
+      readonly provider: string;
+      readonly candidates: ReadonlyArray<Pick<AccountBinding, "accountId" | "sources" | "evidenceRefs">>;
+    }
+  | {
+      readonly status: "not_found";
+      readonly ownerId: string;
+      readonly identity: LogicalIdentity;
+      readonly provider: string;
+    }
+  | { readonly status: "forbidden"; readonly reason: "owner_mismatch" }
+  | { readonly status: "invalid"; readonly reason: string };
+
+export type AccountDirectoryErrorCode =
+  | "invalid_owner"
+  | "invalid_storage"
+  | "storage_invalid"
+  | "storage_unwritable"
+  | "invalid_observation"
+  | "ownership_mismatch"
+  | "identity_conflict"
+  | "credentials_not_allowed";
+
+export class AccountDirectoryError extends Error {
+  readonly code: AccountDirectoryErrorCode;
+
+  constructor(code: AccountDirectoryErrorCode, message: string) {
+    super(message);
+    this.name = "AccountDirectoryError";
+    this.code = code;
+  }
+}
+
+interface StoredObservation {
+  readonly ownerId: string;
+  readonly identity: LogicalIdentity;
+  readonly provider: string;
+  readonly accountId: string;
+  readonly source: AccountSource;
+  readonly sourceId: string;
+  readonly evidenceRef?: string;
+}
+
+interface MutableCandidate {
+  readonly accountId: string;
+  readonly observations: Map<string, StoredObservation>;
+}
+
+const FORBIDDEN_FIELDS = new Set([
+  "access_token",
+  "accesstoken",
+  "api_key",
+  "apikey",
+  "authorization",
+  "client_secret",
+  "clientsecret",
+  "credential",
+  "credentials",
+  "password",
+  "private_key",
+  "privatekey",
+  "refresh_token",
+  "refreshtoken",
+  "secret",
+  "token",
+]);
+
+const SOURCE_ORDER = {
+  browser: 0,
+  "connected-app": 1,
+  local: 2,
+  phone: 3,
+} satisfies Readonly<Record<AccountSource, number>>;
+
+export class AccountDirectory {
+  private readonly ownerId: string;
+  private readonly store: AccountDirectoryStore;
+  private readonly candidates = new Map<string, Map<string, MutableCandidate>>();
+  private readonly accountClaims = new Map<string, LogicalIdentity>();
+  private readonly observations = new Map<string, StoredObservation>();
+
+  constructor(options: AccountDirectoryOptions) {
+    const ownerId = normalizeOpaqueId(options.ownerId);
+    if (!ownerId) throw new AccountDirectoryError("invalid_owner", "An owner ID is required");
+    this.ownerId = ownerId;
+    this.store = options.store ?? new InMemoryAccountDirectoryStore();
+    for (const observation of this.store.load(ownerId)) {
+      const safe = normalizeObservation(observation);
+      if (safe.ownerId !== ownerId) {
+        throw new AccountDirectoryError("ownership_mismatch", "The durable account record belongs to another owner");
+      }
+      this.insert(safe);
+    }
+  }
+
+  /** The owner scope used by this directory; exposed to trusted adapters so
+   * they cannot accidentally register a record under another owner. */
+  getOwnerId(): string {
+    return this.ownerId;
+  }
+
+  register(observation: AccountObservation): AccountRegistrationResult {
+    const safe = normalizeObservation(observation);
+    if (safe.ownerId !== this.ownerId) {
+      throw new AccountDirectoryError("ownership_mismatch", "The observation belongs to another owner");
+    }
+
+    const observationKey = keyOfObservation(safe);
+    const existing = this.observations.get(observationKey);
+    if (existing) {
+      const binding = this.bindingFor(safe.identity, safe.provider, safe.accountId);
+      return { status: "duplicate", binding };
+    }
+
+    this.insert(safe);
+    this.persist();
+    return { status: "accepted", binding: this.bindingFor(safe.identity, safe.provider, safe.accountId) };
+  }
+
+  /** Reconcile only explicitly bound inventory records. Unknown or malformed
+   * records are reported, never guessed into a logical identity. */
+  reconcile(bindings: ReadonlyArray<ExplicitAccountBinding>): AccountReconciliationResult {
+    let accepted = 0;
+    let duplicates = 0;
+    const rejected: Array<{ binding: ExplicitAccountBinding; reason: string }> = [];
+    for (const binding of bindings) {
+      try {
+        const result = this.register({ ownerId: this.ownerId, ...binding });
+        if (result.status === "accepted") accepted += 1;
+        else duplicates += 1;
+      } catch (error) {
+        rejected.push({
+          binding,
+          reason: error instanceof Error ? error.message : "The account binding was rejected",
+        });
+      }
+    }
+    return { accepted, duplicates, rejected };
+  }
+
+  resolve(request: AccountResolutionRequest): AccountResolution {
+    if (request.ownerId !== this.ownerId) return { status: "forbidden", reason: "owner_mismatch" };
+    const identity = normalizeIdentity(request.identity);
+    const provider = normalizeProvider(request.provider);
+    if (!identity || !provider) return { status: "invalid", reason: "A valid identity and provider are required" };
+
+    const byAccount = this.candidates.get(keyOfIdentity(identity, provider));
+    if (!byAccount || byAccount.size === 0) {
+      return { status: "not_found", ownerId: this.ownerId, identity, provider };
+    }
+    const bindings = [...byAccount.values()]
+      .sort((left, right) => left.accountId.localeCompare(right.accountId))
+      .map((candidate) => this.bindingFromCandidate(identity, provider, candidate));
+    if (bindings.length !== 1) {
+      return {
+        status: "ambiguous",
+        ownerId: this.ownerId,
+        identity,
+        provider,
+        candidates: bindings.map(({ accountId, sources, evidenceRefs }) => ({ accountId, sources, evidenceRefs })),
+      };
+    }
+    const binding = bindings[0];
+    if (!binding) return { status: "not_found", ownerId: this.ownerId, identity, provider };
+    return { status: "resolved", ...binding };
+  }
+
+  resolveExact(request: ExactAccountResolutionRequest): AccountResolution {
+    const base = this.resolve(request);
+    if (base.status !== "resolved") return base;
+    const accountId = normalizeAccountId(request.accountId);
+    if (!accountId || accountId !== base.accountId) {
+      return { status: "not_found", ownerId: base.ownerId, identity: base.identity, provider: base.provider };
+    }
+    return base;
+  }
+
+  /** Resolve an exact provider account without accepting a logical alias. */
+  findExactAccount(request: { readonly ownerId: string; readonly provider: string; readonly accountId: string }): AccountBinding | null {
+    if (request.ownerId !== this.ownerId) return null;
+    const provider = normalizeProvider(request.provider);
+    const accountId = normalizeAccountId(request.accountId);
+    if (!provider || !accountId) return null;
+    const identity = this.accountClaims.get(keyOfAccount(provider, accountId));
+    return identity ? this.bindingFor(identity, provider, accountId) : null;
+  }
+
+  snapshot(): ReadonlyArray<AccountBinding> {
+    const bindings: AccountBinding[] = [];
+    for (const [identityProvider, byAccount] of this.candidates) {
+      const separator = identityProvider.indexOf("\u0000");
+      const identityText = identityProvider.slice(0, separator);
+      const provider = identityProvider.slice(separator + 1);
+      const identity = normalizeIdentity(identityText);
+      if (!identity) continue;
+      for (const candidate of byAccount.values()) {
+        bindings.push(this.bindingFromCandidate(identity, provider, candidate));
+      }
+    }
+    return bindings.sort((left, right) =>
+      left.identity.localeCompare(right.identity) ||
+      left.provider.localeCompare(right.provider) ||
+      left.accountId.localeCompare(right.accountId),
+    );
+  }
+
+  private persist(): void {
+    this.store.save(this.ownerId, [...this.observations.values()].map((observation) => ({ ...observation })));
+  }
+
+  private insert(safe: StoredObservation): void {
+    const observationKey = keyOfObservation(safe);
+    if (this.observations.has(observationKey)) return;
+    const accountKey = keyOfAccount(safe.provider, safe.accountId);
+    const claimedIdentity = this.accountClaims.get(accountKey);
+    if (claimedIdentity && claimedIdentity !== safe.identity) {
+      throw new AccountDirectoryError(
+        "identity_conflict",
+        "An exact provider account cannot belong to two logical identities",
+      );
+    }
+    let byAccount = this.candidates.get(keyOfIdentity(safe.identity, safe.provider));
+    if (!byAccount) {
+      byAccount = new Map<string, MutableCandidate>();
+      this.candidates.set(keyOfIdentity(safe.identity, safe.provider), byAccount);
+    }
+    let candidate = byAccount.get(safe.accountId);
+    if (!candidate) {
+      candidate = { accountId: safe.accountId, observations: new Map<string, StoredObservation>() };
+      byAccount.set(safe.accountId, candidate);
+    }
+    candidate.observations.set(keyOfSource(safe.source, safe.sourceId), safe);
+    this.observations.set(observationKey, safe);
+    this.accountClaims.set(accountKey, safe.identity);
+  }
+
+  private bindingFor(identity: LogicalIdentity, provider: string, accountId: string): AccountBinding {
+    const byAccount = this.candidates.get(keyOfIdentity(identity, provider));
+    const candidate = byAccount?.get(accountId);
+    if (!candidate) throw new AccountDirectoryError("invalid_observation", "Account binding was not created");
+    return this.bindingFromCandidate(identity, provider, candidate);
+  }
+
+  private bindingFromCandidate(identity: LogicalIdentity, provider: string, candidate: MutableCandidate): AccountBinding {
+    const stored = [...candidate.observations.values()];
+    const sources = stored
+      .map(({ source, sourceId }) => ({ kind: source, sourceId }))
+      .sort((left, right) => SOURCE_ORDER[left.kind] - SOURCE_ORDER[right.kind] || left.sourceId.localeCompare(right.sourceId));
+    const evidenceRefs = [...new Set(stored.flatMap((item) => item.evidenceRef ? [item.evidenceRef] : []))].sort();
+    return { ownerId: this.ownerId, identity, provider, accountId: candidate.accountId, sources, evidenceRefs };
+  }
+}
+
+function normalizeObservation(input: AccountObservation): StoredObservation {
+  rejectCredentialFields(input);
+  const ownerId = normalizeOpaqueId(input.ownerId);
+  const identity = normalizeIdentity(input.identity);
+  const provider = normalizeProvider(input.provider);
+  const accountId = normalizeAccountId(input.accountId);
+  const source = normalizeSource(input.source);
+  const sourceId = normalizeOpaqueId(input.sourceId);
+  if (!ownerId || !identity || !provider || !accountId || !source || !sourceId) {
+    throw new AccountDirectoryError("invalid_observation", "The account observation contains an invalid reference");
+  }
+  if (input.observedAt !== undefined && Number.isNaN(Date.parse(input.observedAt))) {
+    throw new AccountDirectoryError("invalid_observation", "Observation time must be a valid date");
+  }
+  const evidenceRef = input.evidenceRef === undefined ? undefined : normalizeEvidenceRef(input.evidenceRef);
+  const safe = { ownerId, identity, provider, accountId, source, sourceId };
+  if (evidenceRef) return { ...safe, evidenceRef };
+  return safe;
+}
+
+function rejectCredentialFields(input: AccountObservation): void {
+  for (const field of Object.keys(input)) {
+    const normalized = field.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`).toLowerCase();
+    if (FORBIDDEN_FIELDS.has(normalized)) {
+      throw new AccountDirectoryError("credentials_not_allowed", "Credentials are never accepted by the account directory");
+    }
+  }
+}
+
+function normalizeIdentity(value: string): LogicalIdentity | null {
+  const normalized = value.trim();
+  if (normalized !== value || normalized.length === 0 || normalized.length > 100) return null;
+  for (const character of normalized) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint < 32 || codePoint === 127)) return null;
+  }
+  return normalized;
+}
+
+function normalizeSource(value: string): AccountSource | null {
+  switch (value.trim().toLowerCase().replaceAll("_", "-")) {
+    case "connected-app": return "connected-app";
+    case "browser": return "browser";
+    case "phone": return "phone";
+    case "local": return "local";
+    default: return null;
+  }
+}
+
+function normalizeProvider(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return /^[a-z][a-z0-9._-]{1,63}$/.test(normalized) ? normalized : null;
+}
+
+function normalizeAccountId(value: string): string | null {
+  const normalized = value.trim();
+  return normalized === value && /^ca_[A-Za-z0-9_-]{2,200}$/.test(normalized) ? normalized : null;
+}
+
+function normalizeOpaqueId(value: string): string | null {
+  const normalized = value.trim();
+  if (normalized !== value || normalized.length === 0 || normalized.length > 200 || /\s/u.test(normalized)) return null;
+  for (const character of normalized) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint < 32 || codePoint === 127)) return null;
+  }
+  return normalized;
+}
+
+function normalizeEvidenceRef(value: string): string | undefined {
+  const normalized = value.trim();
+  if (!normalized || normalized !== value || normalized.length > 500 || /(?:access[_-]?token|refresh[_-]?token|api[_-]?key|password|secret)=/i.test(normalized)) {
+    throw new AccountDirectoryError("credentials_not_allowed", "Credential-bearing evidence is never stored");
+  }
+  return normalized;
+}
+
+function keyOfIdentity(identity: LogicalIdentity, provider: string): string {
+  return `${identity}\u0000${provider}`;
+}
+
+function keyOfAccount(provider: string, accountId: string): string {
+  return `${provider}\u0000${accountId}`;
+}
+
+function keyOfSource(source: AccountSource, sourceId: string): string {
+  return `${source}\u0000${sourceId}`;
+}
+
+function keyOfObservation(observation: StoredObservation): string {
+  return `${observation.identity}\u0000${observation.provider}\u0000${observation.accountId}\u0000${observation.source}\u0000${observation.sourceId}`;
+}
+

--- a/server/action-policy.ts
+++ b/server/action-policy.ts
@@ -1,0 +1,861 @@
+/* oxlint-disable anti-slop/no-runtime-typeof, anti-slop/no-unknown-parameters, anti-slop/no-unsafe-dictionary-type -- SQLite returns unknown rows; the local row readers validate every column before constructing a domain object. */
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { DATA_DIR } from "./config.ts";
+import type { JsonValue } from "./schema.ts";
+
+export const ACTION_POLICY_EFFECTS = ["allow", "ask", "deny", "draft-only"] as const;
+export type ActionPolicyEffect = (typeof ACTION_POLICY_EFFECTS)[number];
+
+export const ACTION_POLICY_RULE_STATES = ["active", "revoked"] as const;
+export type ActionPolicyRuleState = (typeof ACTION_POLICY_RULE_STATES)[number];
+export const ACTION_RULE_CANDIDATE_STATUSES = ["pending", "promoted", "rejected"] as const;
+export type ActionRuleCandidateStatus = (typeof ACTION_RULE_CANDIDATE_STATUSES)[number];
+export const ACTION_AUTHORIZATION_STATES = ["active", "consumed", "revoked"] as const;
+export type ActionAuthorizationState = (typeof ACTION_AUTHORIZATION_STATES)[number];
+
+function isActionAuthorizationState(value: string): value is ActionAuthorizationState {
+  return ACTION_AUTHORIZATION_STATES.some((candidate) => candidate === value);
+}
+export interface ActionProposalInput {
+  operation: string;
+  accountId: string;
+  payload: JsonValue;
+  ownerId?: string;
+  evidence?: readonly string[];
+}
+
+/** The immutable, hash-addressed description of one proposed tool action. */
+export interface ActionProposal {
+  id: string;
+  operation: string;
+  accountId: string;
+  accountHash: string;
+  payload: JsonValue;
+  payloadHash: string;
+  proposalHash: string;
+  ownerId: string;
+  evidence: string[];
+  createdAt: number;
+}
+
+export interface ActionRuleCandidateInput {
+  proposal: ActionProposal;
+  effect: ActionPolicyEffect;
+  ownerId?: string;
+  expiresAt?: number | null;
+  reason?: string;
+}
+
+/** Durable proof that a human (or an explicitly named policy actor) decided
+ * to activate a candidate. The evidence should point at the Work approval
+ * or other durable decision record; it is never inferred from the candidate
+ * itself. */
+export interface ActionApprovalEvidence {
+  approvedBy: string;
+  approvalEvidence: string;
+  approvedAt: number;
+}
+
+export interface ActionRuleCandidate {
+  id: string;
+  proposalId: string;
+  operation: string;
+  accountHash: string;
+  payloadHash: string;
+  proposalHash: string;
+  effect: ActionPolicyEffect;
+  ownerId: string;
+  expiresAt: number | null;
+  reason: string;
+  status: ActionRuleCandidateStatus;
+  createdAt: number;
+  approvedBy: string | null;
+  approvalEvidence: string | null;
+  approvedAt: number | null;
+}
+
+export interface ActionRule {
+  id: string;
+  version: number;
+  operation: string;
+  accountHash: string;
+  payloadHash: string;
+  effect: ActionPolicyEffect;
+  ownerId: string;
+  expiresAt: number | null;
+  state: ActionPolicyRuleState;
+  createdAt: number;
+  revokedAt: number | null;
+  approvedBy: string | null;
+  approvalEvidence: string | null;
+  approvedAt: number | null;
+}
+
+/** A single-use authorization for one immutable proposal. Unlike a rule, this
+ * can never authorize a later action, even when every byte is identical. */
+export interface ActionAuthorization {
+  id: string;
+  proposalId: string;
+  proposalHash: string;
+  ownerId: string;
+  state: ActionAuthorizationState;
+  approvedBy: string;
+  approvalEvidence: string;
+  approvedAt: number;
+  createdAt: number;
+  consumedAt: number | null;
+  revokedAt: number | null;
+}
+
+export interface ActionPolicyDecision {
+  effect: ActionPolicyEffect;
+  /** Alias for callers that use decision terminology. */
+  decision: ActionPolicyEffect;
+  allowed: boolean;
+  requiresApproval: boolean;
+  proposalHash: string;
+  ruleId: string | null;
+  ruleVersion: number | null;
+  reason: string;
+}
+
+export type ActionExecutionInput = ActionProposalInput | ActionProposal;
+
+export interface ActionPolicyOptions {
+  file?: string;
+  now?: () => number;
+  defaultOwnerId?: string;
+}
+
+export interface ActionPolicyInterface {
+  prepareProposal(input: ActionProposalInput): ActionProposal;
+  prepare(input: ActionProposalInput): ActionProposal;
+  getProposal(id: string): ActionProposal | null;
+  prepareCandidate(input: ActionRuleCandidateInput): ActionRuleCandidate;
+  prepareCandidate(proposal: ActionProposal, effect: ActionPolicyEffect, options?: Omit<ActionRuleCandidateInput, "proposal" | "effect">): ActionRuleCandidate;
+  getCandidate(id: string): ActionRuleCandidate | null;
+  listCandidates(options?: { status?: ActionRuleCandidateStatus }): ActionRuleCandidate[];
+  rejectCandidate(candidateId: string): ActionRuleCandidate;
+  promoteCandidate(candidateId: string, approval: ActionApprovalEvidence): ActionRule;
+  promote(candidate: ActionRuleCandidate | string, approval: ActionApprovalEvidence): ActionRule;
+  authorizeOnce(proposal: ActionProposal, approval: ActionApprovalEvidence): ActionAuthorization;
+  getAuthorization(id: string): ActionAuthorization | null;
+  consumeAuthorization(id: string, actual: ActionExecutionInput, options?: { now?: number }): ActionPolicyDecision;
+  revokeAuthorization(id: string): boolean;
+  evaluate(proposal: ActionProposal, options?: { now?: number }): ActionPolicyDecision;
+  revalidate(approved: ActionProposal, actual: ActionExecutionInput, options?: { now?: number }): ActionPolicyDecision;
+  revokeRule(ruleId: string): boolean;
+  revoke(ruleId: string): boolean;
+  listRules(options?: { includeRevoked?: boolean }): ActionRule[];
+  close(): void;
+}
+
+/**
+ * Durable authorization for exact actions.
+ *
+ * The module's seam is intentionally narrow: callers prepare an immutable
+ * proposal, turn that proposal into a candidate, promote it after a human
+ * decision, and ask the module to evaluate/revalidate immediately before the
+ * connector executes. Rules cannot be authored independently of a proposal;
+ * every rule therefore carries an operation, account hash, and payload hash.
+ */
+export class ActionPolicy implements ActionPolicyInterface {
+  private readonly db: DatabaseSync;
+  private readonly now: () => number;
+  private readonly defaultOwnerId: string;
+
+  constructor(options: ActionPolicyOptions = {}) {
+    const file = options.file ?? join(DATA_DIR, "action-policy.db");
+    mkdirSync(dirname(file), { recursive: true });
+    this.db = new DatabaseSync(file);
+    this.now = options.now ?? Date.now;
+    this.defaultOwnerId = normalizeRequired(options.defaultOwnerId ?? "user", "ownerId", 120);
+    this.db.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS action_proposals (
+        id TEXT PRIMARY KEY,
+        operation TEXT NOT NULL,
+        account_id TEXT NOT NULL,
+        account_hash TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        payload_hash TEXT NOT NULL,
+        proposal_hash TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        evidence_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS action_rule_candidates (
+        id TEXT PRIMARY KEY,
+        proposal_id TEXT NOT NULL REFERENCES action_proposals(id),
+        operation TEXT NOT NULL,
+        account_hash TEXT NOT NULL,
+        payload_hash TEXT NOT NULL,
+        proposal_hash TEXT NOT NULL,
+        effect TEXT NOT NULL CHECK (effect IN ('allow', 'ask', 'deny', 'draft-only')),
+        owner_id TEXT NOT NULL,
+        expires_at INTEGER,
+        reason TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('pending', 'promoted', 'rejected')),
+        created_at INTEGER NOT NULL,
+        approved_by TEXT,
+        approval_evidence TEXT,
+        approved_at INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS action_rules (
+        id TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        operation TEXT NOT NULL,
+        account_hash TEXT NOT NULL,
+        payload_hash TEXT NOT NULL,
+        effect TEXT NOT NULL CHECK (effect IN ('allow', 'ask', 'deny', 'draft-only')),
+        owner_id TEXT NOT NULL,
+        expires_at INTEGER,
+        state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+        created_at INTEGER NOT NULL,
+        revoked_at INTEGER,
+        approved_by TEXT,
+        approval_evidence TEXT,
+        approved_at INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS action_rules_match
+        ON action_rules (operation, account_hash, payload_hash, state);
+      CREATE INDEX IF NOT EXISTS action_rules_scope_version
+        ON action_rules (operation, account_hash, payload_hash, version DESC);
+      CREATE TABLE IF NOT EXISTS action_authorizations (
+        id TEXT PRIMARY KEY,
+        proposal_id TEXT NOT NULL REFERENCES action_proposals(id),
+        proposal_hash TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('active', 'consumed', 'revoked')),
+        approved_by TEXT NOT NULL,
+        approval_evidence TEXT NOT NULL,
+        approved_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        consumed_at INTEGER,
+        revoked_at INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS action_authorizations_proposal_state
+        ON action_authorizations (proposal_id, state);
+    `);
+    // Existing installs may have created these tables before approval
+    // binding existed. Nullable columns are migration-safe for old rows;
+    // promotion still requires non-null evidence and writes all three values
+    // atomically for new rules.
+    ensureColumn(this.db, "action_rule_candidates", "approved_by", "TEXT");
+    ensureColumn(this.db, "action_rule_candidates", "approval_evidence", "TEXT");
+    ensureColumn(this.db, "action_rule_candidates", "approved_at", "INTEGER");
+    ensureColumn(this.db, "action_rules", "approved_by", "TEXT");
+    ensureColumn(this.db, "action_rules", "approval_evidence", "TEXT");
+    ensureColumn(this.db, "action_rules", "approved_at", "INTEGER");
+  }
+
+  prepareProposal(input: ActionProposalInput): ActionProposal {
+    const operation = normalizeRequired(input.operation, "operation", 240);
+    const accountId = normalizeRequired(input.accountId, "accountId", 240);
+    if (isBroadToken(operation) || isBroadToken(accountId)) {
+      throw new Error("Action proposals require an exact operation and account");
+    }
+    if (!isJsonValue(input.payload)) throw new Error("Action payload must be JSON-compatible");
+    const payload = input.payload;
+    const accountHash = hashActionAccount(accountId);
+    const payloadHash = hashActionPayload(payload);
+    const proposalHash = hashActionProposal(operation, accountId, payload);
+    const ownerId = normalizeRequired(input.ownerId ?? this.defaultOwnerId, "ownerId", 120);
+    const evidence = (input.evidence ?? []).map((item) => normalizeRequired(item, "evidence", 2_000));
+    const proposal: ActionProposal = {
+      id: randomUUID(), operation, accountId, accountHash, payload,
+      payloadHash, proposalHash, ownerId, evidence, createdAt: this.now(),
+    };
+    this.db.prepare(`
+      INSERT INTO action_proposals
+        (id, operation, account_id, account_hash, payload_json, payload_hash, proposal_hash, owner_id, evidence_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      proposal.id, proposal.operation, proposal.accountId, proposal.accountHash,
+      canonicalJson(proposal.payload), proposal.payloadHash, proposal.proposalHash,
+      proposal.ownerId, JSON.stringify(proposal.evidence), proposal.createdAt,
+    );
+    return proposal;
+  }
+
+  /** Short alias for the proposal seam. */
+  prepare(input: ActionProposalInput): ActionProposal {
+    return this.prepareProposal(input);
+  }
+
+  getProposal(id: string): ActionProposal | null {
+    const row = this.db.prepare(`SELECT * FROM action_proposals WHERE id = ?`).get(id);
+    return row === undefined ? null : proposalFromRow(row);
+  }
+
+  prepareCandidate(input: ActionRuleCandidateInput): ActionRuleCandidate;
+  prepareCandidate(proposal: ActionProposal, effect: ActionPolicyEffect, options?: Omit<ActionRuleCandidateInput, "proposal" | "effect">): ActionRuleCandidate;
+  prepareCandidate(
+    inputOrProposal: ActionRuleCandidateInput | ActionProposal,
+    requestedEffect?: ActionPolicyEffect,
+    requestedOptions: Omit<ActionRuleCandidateInput, "proposal" | "effect"> = {},
+  ): ActionRuleCandidate {
+    const input: ActionRuleCandidateInput = isActionProposal(inputOrProposal)
+      ? { ...requestedOptions, proposal: inputOrProposal, effect: requestedEffect ?? "ask" }
+      : inputOrProposal;
+    if (!ACTION_POLICY_EFFECTS.includes(input.effect)) throw new Error("Unknown action policy effect");
+    const proposal = this.assertStoredProposal(input.proposal);
+    const candidate: ActionRuleCandidate = {
+      id: randomUUID(), proposalId: proposal.id, operation: proposal.operation,
+      accountHash: proposal.accountHash, payloadHash: proposal.payloadHash,
+      proposalHash: proposal.proposalHash, effect: input.effect,
+      ownerId: normalizeRequired(input.ownerId ?? proposal.ownerId, "ownerId", 120),
+      expiresAt: normalizeExpiry(input.expiresAt),
+      reason: normalizeRequired(input.reason ?? "Explicit action policy candidate", "reason", 2_000),
+      status: "pending", createdAt: this.now(), approvedBy: null, approvalEvidence: null, approvedAt: null,
+    };
+    this.db.prepare(`
+      INSERT INTO action_rule_candidates
+        (id, proposal_id, operation, account_hash, payload_hash, proposal_hash, effect, owner_id, expires_at, reason, status, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+    `).run(
+      candidate.id, candidate.proposalId, candidate.operation, candidate.accountHash,
+      candidate.payloadHash, candidate.proposalHash, candidate.effect, candidate.ownerId,
+      candidate.expiresAt, candidate.reason, candidate.createdAt,
+    );
+    return candidate;
+  }
+
+  getCandidate(id: string): ActionRuleCandidate | null {
+    const row = this.db.prepare(`SELECT * FROM action_rule_candidates WHERE id = ?`).get(id);
+    return row === undefined ? null : candidateFromRow(row);
+  }
+
+  listCandidates(options: { status?: ActionRuleCandidateStatus } = {}): ActionRuleCandidate[] {
+    const status = options.status;
+    if (status !== undefined && !ACTION_RULE_CANDIDATE_STATUSES.includes(status)) {
+      throw new Error("Unknown action policy candidate status");
+    }
+    const rows = status === undefined
+      ? this.db.prepare(`SELECT * FROM action_rule_candidates ORDER BY created_at ASC, id ASC`).all()
+      : this.db.prepare(`SELECT * FROM action_rule_candidates WHERE status = ? ORDER BY created_at ASC, id ASC`).all(status);
+    return rows.map(candidateFromRow);
+  }
+
+  rejectCandidate(candidateId: string): ActionRuleCandidate {
+    return this.transaction(() => {
+      const candidate = this.getCandidate(candidateId);
+      if (candidate === null) throw new Error("Action policy candidate was not found");
+      if (candidate.status !== "pending") throw new Error("Action policy candidate is no longer pending");
+      this.db.prepare(`UPDATE action_rule_candidates SET status = 'rejected' WHERE id = ? AND status = 'pending'`).run(candidate.id);
+      return this.getCandidate(candidate.id) ?? (() => { throw new Error("Action policy candidate disappeared"); })();
+    });
+  }
+
+  promoteCandidate(candidateId: string, approval: ActionApprovalEvidence): ActionRule {
+    const binding = normalizeApprovalEvidence(approval);
+    return this.transaction(() => {
+      const row = this.db.prepare(`SELECT * FROM action_rule_candidates WHERE id = ?`).get(candidateId);
+      if (row === undefined) throw new Error("Action policy candidate was not found");
+      const candidate = candidateFromRow(row);
+      if (candidate.status !== "pending") throw new Error("Action policy candidate is no longer pending");
+      const proposal = this.assertStoredProposal(candidate.proposalId);
+      if (proposal.proposalHash !== candidate.proposalHash || proposal.payloadHash !== candidate.payloadHash) {
+        throw new Error("Action policy candidate no longer matches its proposal");
+      }
+      const latest = this.db.prepare(`
+        SELECT MAX(version) AS version FROM action_rules
+        WHERE operation = ? AND account_hash = ? AND payload_hash = ? AND owner_id = ?
+      `).get(candidate.operation, candidate.accountHash, candidate.payloadHash, candidate.ownerId);
+      const version = numberFromRow(latest, "version", 0) + 1;
+      const rule: ActionRule = {
+        id: randomUUID(), version, operation: candidate.operation,
+        accountHash: candidate.accountHash, payloadHash: candidate.payloadHash,
+        effect: candidate.effect, ownerId: candidate.ownerId, expiresAt: candidate.expiresAt,
+        state: "active", createdAt: this.now(), revokedAt: null,
+        approvedBy: binding.approvedBy, approvalEvidence: binding.approvalEvidence, approvedAt: binding.approvedAt,
+      };
+      this.db.prepare(`
+        INSERT INTO action_rules
+          (id, version, operation, account_hash, payload_hash, effect, owner_id, expires_at, state, created_at, revoked_at, approved_by, approval_evidence, approved_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, NULL, ?, ?, ?)
+      `).run(
+        rule.id, rule.version, rule.operation, rule.accountHash, rule.payloadHash,
+        rule.effect, rule.ownerId, rule.expiresAt, rule.createdAt,
+        rule.approvedBy, rule.approvalEvidence, rule.approvedAt,
+      );
+      this.db.prepare(`
+        UPDATE action_rule_candidates
+        SET status = 'promoted', approved_by = ?, approval_evidence = ?, approved_at = ?
+        WHERE id = ? AND status = 'pending'
+      `).run(binding.approvedBy, binding.approvalEvidence, binding.approvedAt, candidate.id);
+      return rule;
+    });
+  }
+
+  /** Promote a candidate returned by prepareCandidate. */
+  promote(candidate: ActionRuleCandidate | string, approval: ActionApprovalEvidence): ActionRule {
+    return this.promoteCandidate(typeof candidate === "string" ? candidate : candidate.id, approval);
+  }
+
+  authorizeOnce(proposal: ActionProposal, approval: ActionApprovalEvidence): ActionAuthorization {
+    const stored = this.assertStoredProposal(proposal);
+    const binding = normalizeApprovalEvidence(approval);
+    const authorization: ActionAuthorization = {
+      id: randomUUID(),
+      proposalId: stored.id,
+      proposalHash: stored.proposalHash,
+      ownerId: stored.ownerId,
+      state: "active",
+      approvedBy: binding.approvedBy,
+      approvalEvidence: binding.approvalEvidence,
+      approvedAt: binding.approvedAt,
+      createdAt: this.now(),
+      consumedAt: null,
+      revokedAt: null,
+    };
+    this.db.prepare(`
+      INSERT INTO action_authorizations
+        (id, proposal_id, proposal_hash, owner_id, state, approved_by, approval_evidence, approved_at, created_at, consumed_at, revoked_at)
+      VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, NULL, NULL)
+    `).run(
+      authorization.id, authorization.proposalId, authorization.proposalHash,
+      authorization.ownerId, authorization.approvedBy, authorization.approvalEvidence,
+      authorization.approvedAt, authorization.createdAt,
+    );
+    return authorization;
+  }
+
+  getAuthorization(id: string): ActionAuthorization | null {
+    const row = this.db.prepare(`SELECT * FROM action_authorizations WHERE id = ?`).get(id);
+    return row === undefined ? null : authorizationFromRow(row);
+  }
+
+  consumeAuthorization(
+    id: string,
+    actual: ActionExecutionInput,
+    options: { now?: number } = {},
+  ): ActionPolicyDecision {
+    return this.transaction(() => {
+      const authorization = this.getAuthorization(id);
+      if (authorization === null) return decision("", "deny", null, null, "One-time authorization was not found");
+      if (authorization.state !== "active") {
+        return decision(authorization.proposalHash, "deny", null, null, "One-time authorization is no longer active");
+      }
+      const stored = this.assertStoredProposal(authorization.proposalId);
+      let candidate: ActionProposal;
+      try {
+        candidate = isActionProposal(actual) ? actual : this.materializeWithoutPersist(actual, stored.id);
+      } catch {
+        return decision(stored.proposalHash, "deny", null, null, "Execution payload is not valid JSON");
+      }
+      const actualIsProposal = isActionProposal(actual);
+      if (
+        !isSelfConsistentProposal(candidate) ||
+        (actualIsProposal && candidate.id !== stored.id) ||
+        candidate.operation !== stored.operation ||
+        candidate.accountHash !== stored.accountHash ||
+        candidate.payloadHash !== stored.payloadHash ||
+        candidate.proposalHash !== stored.proposalHash ||
+        (actualIsProposal && candidate.ownerId !== stored.ownerId)
+      ) {
+        return decision(stored.proposalHash, "deny", null, null, "Execution does not match the one-time authorization");
+      }
+      const result = this.db.prepare(`
+        UPDATE action_authorizations SET state = 'consumed', consumed_at = ?
+        WHERE id = ? AND state = 'active'
+      `).run(options.now ?? this.now(), authorization.id);
+      if (result.changes !== 1) {
+        return decision(stored.proposalHash, "deny", null, null, "One-time authorization was already consumed");
+      }
+      return decision(stored.proposalHash, "allow", null, null, "Exact one-time authorization consumed");
+    });
+  }
+
+  revokeAuthorization(id: string): boolean {
+    const result = this.db.prepare(`
+      UPDATE action_authorizations SET state = 'revoked', revoked_at = ?
+      WHERE id = ? AND state = 'active'
+    `).run(this.now(), id);
+    return result.changes === 1;
+  }
+
+  evaluate(proposal: ActionProposal, options: { now?: number } = {}): ActionPolicyDecision {
+    const current = this.assertStoredProposal(proposal);
+    const now = options.now ?? this.now();
+    const rules = this.db.prepare(`
+      SELECT * FROM action_rules
+      WHERE operation = ? AND account_hash = ? AND payload_hash = ?
+        AND owner_id = ?
+        AND state = 'active' AND (expires_at IS NULL OR expires_at > ?)
+      ORDER BY version DESC
+    `).all(current.operation, current.accountHash, current.payloadHash, current.ownerId, now).map(ruleFromRow);
+    const selected = rules.sort((left, right) => {
+      const precedence = effectPrecedence(right.effect) - effectPrecedence(left.effect);
+      return precedence || right.version - left.version;
+    })[0];
+    if (selected === undefined) {
+      return decision(current.proposalHash, "ask", null, null, "No exact active rule matched this action");
+    }
+    return decision(
+      current.proposalHash, selected.effect, selected.id, selected.version,
+      selected.effect === "deny" ? "An exact deny rule dominates this action" : `Matched exact rule v${selected.version}`,
+    );
+  }
+
+  /**
+   * Re-check an approved proposal against the bytes/account/operation that
+   * are about to execute. This is the execution seam: a changed payload,
+   * account, operation, revoked rule, or expired rule fails closed.
+   */
+  revalidate(approved: ActionProposal, actual: ActionExecutionInput, options: { now?: number } = {}): ActionPolicyDecision {
+    const stored = this.assertStoredProposal(approved);
+    const actualIsProposal = isActionProposal(actual);
+    let actualProposal: ActionProposal;
+    try {
+      actualProposal = actualIsProposal
+        ? actual
+        : this.materializeWithoutPersist(actual, stored.id);
+    } catch {
+      return decision(stored.proposalHash, "deny", null, null, "Execution payload is not valid JSON");
+    }
+    if (
+      !isSelfConsistentProposal(actualProposal) ||
+      (actualIsProposal && actualProposal.id !== stored.id) ||
+      actualProposal.operation !== stored.operation ||
+      actualProposal.accountHash !== stored.accountHash ||
+      actualProposal.payloadHash !== stored.payloadHash ||
+      actualProposal.proposalHash !== stored.proposalHash ||
+      (actualIsProposal && actualProposal.ownerId !== stored.ownerId)
+    ) {
+      return decision(stored.proposalHash, "deny", null, null, "Execution does not match the approved proposal");
+    }
+    const result = this.evaluate(stored, options);
+    if (result.effect !== "allow") return result;
+    return { ...result, reason: "Approved proposal matches execution exactly" };
+  }
+
+  revokeRule(ruleId: string): boolean {
+    const result = this.db.prepare(`
+      UPDATE action_rules SET state = 'revoked', revoked_at = ?
+      WHERE id = ? AND state = 'active'
+    `).run(this.now(), ruleId);
+    return result.changes === 1;
+  }
+
+  revoke(ruleId: string): boolean {
+    return this.revokeRule(ruleId);
+  }
+
+  listRules(options: { includeRevoked?: boolean } = {}): ActionRule[] {
+    const rows = options.includeRevoked
+      ? this.db.prepare(`SELECT * FROM action_rules ORDER BY operation, account_hash, payload_hash, version DESC`).all()
+      : this.db.prepare(`SELECT * FROM action_rules WHERE state = 'active' ORDER BY operation, account_hash, payload_hash, version DESC`).all();
+    return rows.map(ruleFromRow);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private assertStoredProposal(proposal: ActionProposal | string): ActionProposal {
+    const found = typeof proposal === "string" ? this.getProposal(proposal) : this.getProposal(proposal.id);
+    if (found === null) throw new Error("Action proposal was not found");
+    if (
+      typeof proposal !== "string" &&
+      (found.operation !== proposal.operation || found.accountHash !== proposal.accountHash ||
+        found.proposalHash !== proposal.proposalHash || found.payloadHash !== proposal.payloadHash ||
+        !isSelfConsistentProposal(proposal))
+    ) throw new Error("Action proposal hash does not match durable proposal");
+    if (!isSelfConsistentProposal(found)) throw new Error("Stored action proposal failed integrity verification");
+    return found;
+  }
+
+  private materializeWithoutPersist(input: ActionProposalInput, id: string): ActionProposal {
+    const operation = normalizeRequired(input.operation, "operation", 240);
+    const accountId = normalizeRequired(input.accountId, "accountId", 240);
+    if (!isJsonValue(input.payload)) throw new Error("Action payload must be JSON-compatible");
+    return {
+      id, operation, accountId, accountHash: hashActionAccount(accountId), payload: input.payload,
+      payloadHash: hashActionPayload(input.payload), proposalHash: hashActionProposal(operation, accountId, input.payload),
+      ownerId: "execution", evidence: [], createdAt: 0,
+    };
+  }
+
+  private transaction<T>(work: () => T): T {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = work();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+export function createActionPolicy(options: ActionPolicyOptions = {}): ActionPolicy {
+  return new ActionPolicy(options);
+}
+
+export function canonicalizeActionPayload(value: JsonValue): string {
+  if (!isJsonValue(value)) throw new Error("Action payload must be JSON-compatible");
+  return canonicalJson(value);
+}
+
+export function hashActionPayload(value: JsonValue): string {
+  return sha256(canonicalizeActionPayload(value));
+}
+
+export function hashActionAccount(accountId: string): string {
+  return sha256(canonicalString(normalizeRequired(accountId, "accountId", 240)));
+}
+
+export function hashActionOperation(operation: string): string {
+  return sha256(canonicalString(normalizeRequired(operation, "operation", 240)));
+}
+
+export function hashActionProposal(operation: string, accountId: string, payload: JsonValue): string {
+  const normalizedOperation = normalizeRequired(operation, "operation", 240);
+  const normalizedAccount = normalizeRequired(accountId, "accountId", 240);
+  if (!isJsonValue(payload)) throw new Error("Action payload must be JSON-compatible");
+  return sha256(canonicalJson({ operation: normalizedOperation, accountId: normalizedAccount, payload }));
+}
+
+function decision(
+  proposalHash: string,
+  effect: ActionPolicyEffect,
+  ruleId: string | null,
+  ruleVersion: number | null,
+  reason: string,
+): ActionPolicyDecision {
+  return {
+    effect, decision: effect, allowed: effect === "allow", requiresApproval: effect === "ask",
+    proposalHash, ruleId, ruleVersion, reason,
+  };
+}
+
+function effectPrecedence(effect: ActionPolicyEffect): number {
+  switch (effect) {
+    case "deny": return 4;
+    case "draft-only": return 3;
+    case "ask": return 2;
+    case "allow": return 1;
+    default: return assertNever(effect);
+  }
+}
+
+function isActionProposal(value: unknown): value is ActionProposal {
+  return typeof value === "object" && value !== null && "proposalHash" in value && "payloadHash" in value && "accountHash" in value;
+}
+
+function proposalFromRow(value: unknown): ActionProposal {
+  const row = rowObject(value);
+  const payload = parseStoredPayload(row.payload_json);
+  return {
+    id: textColumn(row, "id"), operation: textColumn(row, "operation"), accountId: textColumn(row, "account_id"),
+    accountHash: textColumn(row, "account_hash"), payload, payloadHash: textColumn(row, "payload_hash"),
+    proposalHash: textColumn(row, "proposal_hash"), ownerId: textColumn(row, "owner_id"),
+    evidence: parseEvidence(row.evidence_json), createdAt: numberColumn(row, "created_at"),
+  };
+}
+
+function candidateFromRow(value: unknown): ActionRuleCandidate {
+  const row = rowObject(value);
+  const effect = effectColumn(row.effect);
+  const status = statusColumn(row.status);
+  return {
+    id: textColumn(row, "id"), proposalId: textColumn(row, "proposal_id"), operation: textColumn(row, "operation"),
+    accountHash: textColumn(row, "account_hash"), payloadHash: textColumn(row, "payload_hash"), proposalHash: textColumn(row, "proposal_hash"),
+    effect, ownerId: textColumn(row, "owner_id"), expiresAt: nullableNumber(row.expires_at), reason: textColumn(row, "reason"),
+    status, createdAt: numberColumn(row, "created_at"), approvedBy: nullableText(row.approved_by, "approved_by"),
+    approvalEvidence: nullableText(row.approval_evidence, "approval_evidence"), approvedAt: nullableNumber(row.approved_at),
+  };
+}
+
+function authorizationFromRow(value: unknown): ActionAuthorization {
+  const row = rowObject(value);
+  const state = textColumn(row, "state");
+  if (!isActionAuthorizationState(state)) {
+    throw new Error("Invalid action authorization state");
+  }
+  return {
+    id: textColumn(row, "id"),
+    proposalId: textColumn(row, "proposal_id"),
+    proposalHash: textColumn(row, "proposal_hash"),
+    ownerId: textColumn(row, "owner_id"),
+    state,
+    approvedBy: textColumn(row, "approved_by"),
+    approvalEvidence: textColumn(row, "approval_evidence"),
+    approvedAt: numberColumn(row, "approved_at"),
+    createdAt: numberColumn(row, "created_at"),
+    consumedAt: nullableNumber(row.consumed_at),
+    revokedAt: nullableNumber(row.revoked_at),
+  };
+}
+
+function ruleFromRow(value: unknown): ActionRule {
+  const row = rowObject(value);
+  return {
+    id: textColumn(row, "id"), version: numberColumn(row, "version"), operation: textColumn(row, "operation"),
+    accountHash: textColumn(row, "account_hash"), payloadHash: textColumn(row, "payload_hash"), effect: effectColumn(row.effect),
+    ownerId: textColumn(row, "owner_id"), expiresAt: nullableNumber(row.expires_at), state: ruleStateColumn(row.state),
+    createdAt: numberColumn(row, "created_at"), revokedAt: nullableNumber(row.revoked_at),
+    approvedBy: nullableText(row.approved_by, "approved_by"), approvalEvidence: nullableText(row.approval_evidence, "approval_evidence"),
+    approvedAt: nullableNumber(row.approved_at),
+  };
+}
+
+function rowObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Invalid action policy row");
+  return Object.fromEntries(Object.entries(value));
+}
+
+function textColumn(row: Record<string, unknown>, name: string): string {
+  const value = row[name];
+  if (typeof value !== "string") throw new Error(`Invalid action policy ${name}`);
+  return value;
+}
+
+function nullableText(value: unknown, name: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") throw new Error(`Invalid action policy ${name}`);
+  return value;
+}
+
+function numberColumn(row: Record<string, unknown>, name: string): number {
+  const value = row[name];
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`Invalid action policy ${name}`);
+  return value;
+}
+
+function numberFromRow(value: unknown, name: string, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  const row = rowObject(value);
+  const candidate = row[name];
+  return candidate === null || candidate === undefined ? fallback : numberColumn(row, name);
+}
+
+function nullableNumber(value: unknown): number | null {
+  return value === null || value === undefined ? null : typeof value === "number" && Number.isFinite(value) ? value : (() => { throw new Error("Invalid action policy timestamp"); })();
+}
+
+function parseStoredPayload(value: unknown): JsonValue {
+  if (typeof value !== "string") throw new Error("Invalid stored action payload");
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new Error("Invalid stored action payload"); }
+  if (!isJsonValue(parsed)) throw new Error("Invalid stored action payload");
+  return parsed;
+}
+
+function parseEvidence(value: unknown): string[] {
+  if (typeof value !== "string") throw new Error("Invalid stored action evidence");
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new Error("Invalid stored action evidence"); }
+  if (!Array.isArray(parsed) || !parsed.every((item): item is string => typeof item === "string")) throw new Error("Invalid stored action evidence");
+  return [...parsed];
+}
+
+function effectColumn(value: unknown): ActionPolicyEffect {
+  if (!isActionPolicyEffect(value)) throw new Error("Invalid action policy effect");
+  return value;
+}
+
+function isActionPolicyEffect(value: unknown): value is ActionPolicyEffect {
+  return value === "allow" || value === "ask" || value === "deny" || value === "draft-only";
+}
+
+function statusColumn(value: unknown): ActionRuleCandidate["status"] {
+  if (value === "pending" || value === "promoted" || value === "rejected") return value;
+  throw new Error("Invalid action policy candidate status");
+}
+
+function ruleStateColumn(value: unknown): ActionPolicyRuleState {
+  if (value === "active" || value === "revoked") return value;
+  throw new Error("Invalid action policy rule state");
+}
+
+function normalizeRequired(value: string, name: string, max: number): string {
+  if (typeof value !== "string") throw new Error(`${name} must be a string`);
+  const normalized = value.normalize("NFKC").trim();
+  if (!normalized || normalized.length > max) throw new Error(`${name} must be non-empty and at most ${max} characters`);
+  return normalized;
+}
+
+function normalizeExpiry(value: number | null | undefined): number | null {
+  if (value === undefined || value === null) return null;
+  if (!Number.isFinite(value) || value <= 0) throw new Error("expiresAt must be a positive timestamp");
+  return Math.round(value);
+}
+
+function normalizeApprovalEvidence(value: ActionApprovalEvidence): ActionApprovalEvidence {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Action policy promotion requires explicit approval evidence");
+  }
+  return {
+    approvedBy: normalizeRequired(value.approvedBy, "approvedBy", 300),
+    approvalEvidence: normalizeRequired(value.approvalEvidence, "approvalEvidence", 2_000),
+    approvedAt: normalizeTimestamp(value.approvedAt, "approvedAt"),
+  };
+}
+
+function normalizeTimestamp(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive timestamp`);
+  return Math.round(value);
+}
+
+function ensureColumn(db: DatabaseSync, table: string, column: string, definition: string): void {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all();
+  const exists = columns.some((value) => rowObject(value).name === column);
+  if (!exists) db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+function isBroadToken(value: string): boolean {
+  return value.includes("*") || value.includes("?") || value.toLowerCase() === "any";
+}
+
+function canonicalString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function canonicalJson(value: JsonValue): string {
+  if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    if (typeof value === "number" && !Number.isFinite(value)) throw new Error("Action payload numbers must be finite");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function isJsonValue(value: unknown, seen = new Set<object>()): value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  const valid = Array.isArray(value)
+    ? value.every((item) => isJsonValue(item, seen))
+    : Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null
+      ? Object.values(value).every((item) => isJsonValue(item, seen))
+      : false;
+  seen.delete(value);
+  return valid;
+}
+
+function isSelfConsistentProposal(value: ActionProposal): boolean {
+  try {
+    return hashActionPayload(value.payload) === value.payloadHash &&
+      hashActionProposal(value.operation, value.accountId, value.payload) === value.proposalHash &&
+      hashActionAccount(value.accountId) === value.accountHash;
+  } catch {
+    return false;
+  }
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected action policy effect: ${String(value)}`);
+}

--- a/server/autonomy-telemetry.ts
+++ b/server/autonomy-telemetry.ts
@@ -1,0 +1,319 @@
+import { createHash } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { z } from "zod";
+
+import { DATA_DIR } from "./config.ts";
+import type { JsonValue } from "./schema.ts";
+
+const SAFE_METADATA_FIELDS = {
+  provider: z.string().trim().min(1).max(80).optional(),
+  model: z.string().trim().min(1).max(120).optional(),
+  operation: z.string().trim().min(1).max(100).optional(),
+  reasonCode: z.string().trim().min(1).max(100).optional(),
+  region: z.string().trim().regex(/^[a-z]{2}(?:-[a-z0-9]+){1,3}$/).max(40).optional(),
+  resourceType: z.string().trim().regex(/^[a-z][a-z0-9_.:-]{0,79}$/).optional(),
+  resultCode: z.string().trim().regex(/^[a-z][a-z0-9_.:-]{0,79}$/).optional(),
+  source: z.string().trim().min(1).max(100).optional(),
+  environment: z.enum(["development", "test", "staging", "production"]).optional(),
+  attempt: z.number().int().min(0).max(10_000).optional(),
+  status: z.enum(["started", "succeeded", "failed", "cancelled", "unknown"]).optional(),
+  service: z.string().trim().regex(/^[a-z][a-z0-9_.:-]{0,79}$/).optional(),
+} as const;
+
+const metadataSchema = z.object(SAFE_METADATA_FIELDS).strict();
+export type TelemetryMetadata = z.infer<typeof metadataSchema>;
+
+const opaqueIdSchema = z.string().trim().min(1).max(300).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const idempotencyKeySchema = z.string().trim().min(1).max(300).regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/);
+const observedAtSchema = z.number().finite();
+const metadataInput = metadataSchema.optional();
+const commonInput = {
+  workId: opaqueIdSchema,
+  idempotencyKey: idempotencyKeySchema,
+  observedAt: observedAtSchema.optional(),
+  metadata: metadataInput,
+};
+
+const inputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("work.started"), ...commonInput, workScope: z.enum(["aws", "other"]).default("other") }),
+  z.object({ type: z.literal("work.closed"), ...commonInput, closureKind: z.enum(["success", "cancelled", "blocked", "unknown"]) }),
+  z.object({ type: z.literal("outcome.verified"), ...commonInput, evidenceRef: opaqueIdSchema }),
+  z.object({ type: z.literal("human.touch"), ...commonInput, touchKind: z.enum(["review", "edit", "approval", "override", "escalation", "other"]) }),
+  z.object({ type: z.literal("approval.requested"), ...commonInput, approvalKey: opaqueIdSchema }),
+  z.object({ type: z.literal("approval.decided"), ...commonInput, approvalKey: opaqueIdSchema, decision: z.enum(["approved", "rejected", "revoked"]), actor: z.literal("human") }),
+  z.object({ type: z.literal("interruption.classified"), ...commonInput, classification: z.enum(["false", "real", "unknown"]), reasonCode: opaqueIdSchema.optional() }),
+  z.object({ type: z.literal("rework.recorded"), ...commonInput, reasonCode: opaqueIdSchema }),
+  z.object({ type: z.literal("auth.failure"), ...commonInput, provider: opaqueIdSchema, service: opaqueIdSchema, failureCode: opaqueIdSchema }),
+  z.object({ type: z.literal("cost.reference"), ...commonInput, source: z.enum(["provider_reported", "billing_export", "estimate", "unavailable"]), reference: opaqueIdSchema, amountUsd: z.number().finite().min(0).max(1_000_000_000).optional() }),
+  z.object({ type: z.literal("coverage.asserted"), ...commonInput, coverageKind: z.literal("human_interactions"), coverageStatus: z.literal("complete") }),
+]);
+export type AutonomyTelemetryEventInput = z.input<typeof inputSchema>;
+
+const outputCommon = {
+  eventId: opaqueIdSchema,
+  workId: opaqueIdSchema,
+  idempotencyKey: idempotencyKeySchema,
+  observedAt: observedAtSchema,
+  metadata: metadataSchema.nullable(),
+};
+const eventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("work.started"), ...outputCommon, workScope: z.enum(["aws", "other"]) }),
+  z.object({ type: z.literal("work.closed"), ...outputCommon, closureKind: z.enum(["success", "cancelled", "blocked", "unknown"]) }),
+  z.object({ type: z.literal("outcome.verified"), ...outputCommon, evidenceRef: opaqueIdSchema }),
+  z.object({ type: z.literal("human.touch"), ...outputCommon, touchKind: z.enum(["review", "edit", "approval", "override", "escalation", "other"]) }),
+  z.object({ type: z.literal("approval.requested"), ...outputCommon, approvalKey: opaqueIdSchema }),
+  z.object({ type: z.literal("approval.decided"), ...outputCommon, approvalKey: opaqueIdSchema, decision: z.enum(["approved", "rejected", "revoked"]), actor: z.literal("human") }),
+  z.object({ type: z.literal("interruption.classified"), ...outputCommon, classification: z.enum(["false", "real", "unknown"]), reasonCode: opaqueIdSchema.optional() }),
+  z.object({ type: z.literal("rework.recorded"), ...outputCommon, reasonCode: opaqueIdSchema }),
+  z.object({ type: z.literal("auth.failure"), ...outputCommon, provider: opaqueIdSchema, service: opaqueIdSchema, failureCode: opaqueIdSchema }),
+  z.object({ type: z.literal("cost.reference"), ...outputCommon, source: z.enum(["provider_reported", "billing_export", "estimate", "unavailable"]), reference: opaqueIdSchema, amountUsd: z.number().finite().min(0).max(1_000_000_000).optional() }),
+  z.object({ type: z.literal("coverage.asserted"), ...outputCommon, coverageKind: z.literal("human_interactions"), coverageStatus: z.literal("complete") }),
+]);
+export type AutonomyTelemetryEvent = z.infer<typeof eventSchema>;
+
+export interface AutonomyTelemetrySummary {
+  retainedEvents: number;
+  observedWorkCount: number;
+  closedWorkCount: number;
+  verifiedOutcomeCount: number;
+  verifiedOutcomeRate: number | null;
+  humanTouchCount: number | null;
+  approvalRequestCount: number | null;
+  humanApprovalDecisionCount: number | null;
+  interruptionClassificationCount: number | null;
+  falseInterruptionCount: number | null;
+  falseInterruptionRate: number | null;
+  reworkCount: number | null;
+  authFailureCount: number | null;
+  timeToCloseMs: { count: number; median: number | null };
+  cost: { referenceCount: number; reportedUsd: number | null; estimatedUsd: number | null; unavailableUsdReferences: number | null };
+  /**
+   * Numerator = verified, successful AWS work with no observed human touch or
+   * human approval decision. Denominator = all verified, successful AWS work.
+   * Both are null unless complete human-interaction coverage was explicitly
+   * asserted for every denominator candidate.
+   */
+  awsAutonomousVerifiedShare: {
+    numerator: number | null;
+    denominator: number | null;
+    value: number | null;
+    coverage: "complete" | "partial" | "unavailable";
+  };
+  retention: { maxEvents: number; truncated: boolean };
+}
+export interface AutonomyTelemetryRecordResult {
+  status: "recorded" | "deduplicated";
+  event: AutonomyTelemetryEvent;
+}
+
+export interface AutonomyTelemetryInterface {
+  record(input: AutonomyTelemetryEventInput): AutonomyTelemetryRecordResult;
+  list(options?: { since?: number; until?: number; limit?: number }): AutonomyTelemetryEvent[];
+  summary(options?: { since?: number; until?: number }): AutonomyTelemetrySummary;
+  close(): void;
+}
+
+export class AutonomyTelemetryError extends Error {
+  readonly code: "idempotency_conflict";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "AutonomyTelemetryError";
+    this.code = "idempotency_conflict";
+  }
+}
+
+const eventRowSchema = z.object({
+  event_id: z.string(),
+  idempotency_key: z.string(),
+  request_hash: z.string(),
+  event_json: z.string(),
+});
+
+const countRowSchema = z.object({ count: z.number() });
+const retentionRowSchema = z.object({ value: z.string() });
+
+function stableJson(value: JsonValue): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const primitive = z.union([z.string(), z.number(), z.boolean()]).safeParse(value);
+  if (primitive.success) return JSON.stringify(primitive.data);
+  const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`).join(",")}}`;
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function finiteNumber(value: number | undefined): value is number {
+  return value !== undefined && Number.isFinite(value);
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] ?? null : ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+/**
+ * A bounded, append-only observation ledger for autonomy claims. Every metric
+ * is derived from an explicit event; absent evidence remains null. Payloads
+ * contain only allow-listed operational metadata, never transcript content or
+ * credentials.
+ */
+export class AutonomyTelemetry implements AutonomyTelemetryInterface {
+  private readonly db: DatabaseSync;
+  private readonly now: () => number;
+  private readonly maxEvents: number;
+
+  constructor(options: { file?: string; now?: () => number; maxEvents?: number } = {}) {
+    const file = options.file ?? join(DATA_DIR, "autonomy-telemetry.db");
+    mkdirSync(dirname(file), { recursive: true });
+    this.db = new DatabaseSync(file);
+    this.now = options.now ?? Date.now;
+    this.maxEvents = Math.max(1, Math.min(100_000, Math.trunc(options.maxEvents ?? 10_000)));
+    this.db.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS autonomy_telemetry_events (
+        event_id TEXT PRIMARY KEY,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        event_type TEXT NOT NULL,
+        work_id TEXT NOT NULL,
+        observed_at REAL NOT NULL,
+        request_hash TEXT NOT NULL,
+        event_json TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS autonomy_telemetry_observed ON autonomy_telemetry_events(observed_at ASC, event_id ASC);
+      CREATE TABLE IF NOT EXISTS autonomy_telemetry_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    `);
+  }
+
+  record(raw: AutonomyTelemetryEventInput): AutonomyTelemetryRecordResult {
+    const input = inputSchema.parse(raw);
+    const requestHash = hash(stableJson(input));
+    const existing = this.db.prepare("SELECT event_id, idempotency_key, request_hash, event_json FROM autonomy_telemetry_events WHERE idempotency_key = ?").get(input.idempotencyKey);
+    if (existing !== undefined) {
+      const row = eventRowSchema.parse(existing);
+      if (row.request_hash !== requestHash) throw new AutonomyTelemetryError(`Idempotency key already belongs to a different telemetry event: ${input.idempotencyKey}`);
+      return { status: "deduplicated", event: eventSchema.parse(JSON.parse(row.event_json)) };
+    }
+    const observedAt = input.observedAt ?? this.now();
+    const eventId = `omb_telemetry_${hash(`${input.idempotencyKey}\u001f${requestHash}`).slice(0, 48)}`;
+    const event = eventSchema.parse({ ...input, eventId, observedAt, metadata: input.metadata ?? null });
+    this.transaction(() => {
+      this.db.prepare("INSERT INTO autonomy_telemetry_events (event_id, idempotency_key, event_type, work_id, observed_at, request_hash, event_json) VALUES (?, ?, ?, ?, ?, ?, ?)")
+        .run(event.eventId, event.idempotencyKey, event.type, event.workId, event.observedAt, requestHash, stableJson(event));
+      const count = countRowSchema.parse(this.db.prepare("SELECT COUNT(*) AS count FROM autonomy_telemetry_events").get()).count;
+      const excess = count - this.maxEvents;
+      if (excess > 0) {
+        this.db.prepare("DELETE FROM autonomy_telemetry_events WHERE event_id IN (SELECT event_id FROM autonomy_telemetry_events ORDER BY observed_at ASC, event_id ASC LIMIT ?)").run(excess);
+        this.db.prepare("INSERT INTO autonomy_telemetry_meta (key, value) VALUES ('truncated', '1') ON CONFLICT(key) DO UPDATE SET value = '1'").run();
+      }
+    });
+    return { status: "recorded", event };
+  }
+
+  list(options: { since?: number; until?: number; limit?: number } = {}): AutonomyTelemetryEvent[] {
+    const clauses: string[] = [];
+    const values: Array<number> = [];
+    if (finiteNumber(options.since)) { clauses.push("observed_at >= ?"); values.push(options.since); }
+    if (finiteNumber(options.until)) { clauses.push("observed_at <= ?"); values.push(options.until); }
+    const limit = Math.max(1, Math.min(this.maxEvents, Math.trunc(options.limit ?? this.maxEvents)));
+    values.push(limit);
+    const where = clauses.length === 0 ? "" : `WHERE ${clauses.join(" AND ")}`;
+    const rows = this.db.prepare(`SELECT event_json FROM autonomy_telemetry_events ${where} ORDER BY observed_at ASC, event_id ASC LIMIT ?`).all(...values);
+    return rows.map((row) => eventSchema.parse(JSON.parse(z.object({ event_json: z.string() }).parse(row).event_json)));
+  }
+
+  summary(options: { since?: number; until?: number } = {}): AutonomyTelemetrySummary {
+    const events = this.list(options);
+    const workIds = new Set(events.map((event) => event.workId));
+    const closedWorkIds = new Set(events.filter((event): event is Extract<AutonomyTelemetryEvent, { type: "work.closed" }> => event.type === "work.closed").map((event) => event.workId));
+    const verifiedWorkIds = new Set(events.filter((event): event is Extract<AutonomyTelemetryEvent, { type: "outcome.verified" }> => event.type === "outcome.verified").map((event) => event.workId));
+    const verifiedClosedCount = [...verifiedWorkIds].filter((workId) => closedWorkIds.has(workId)).length;
+    const awsWorkIds = new Set(events.filter((event): event is Extract<AutonomyTelemetryEvent, { type: "work.started" }> => event.type === "work.started" && event.workScope === "aws").map((event) => event.workId));
+    const awsSuccessfulVerifiedWorkIds = new Set(events
+      .filter((event): event is Extract<AutonomyTelemetryEvent, { type: "work.closed" }> => event.type === "work.closed" && event.closureKind === "success")
+      .map((event) => event.workId)
+      .filter((workId) => awsWorkIds.has(workId) && verifiedWorkIds.has(workId)));
+    const completeCoverageWorkIds = new Set(events
+      .filter((event): event is Extract<AutonomyTelemetryEvent, { type: "coverage.asserted" }> => event.type === "coverage.asserted" && event.coverageKind === "human_interactions" && event.coverageStatus === "complete")
+      .map((event) => event.workId));
+    const awsCoverageComplete = awsSuccessfulVerifiedWorkIds.size > 0 && [...awsSuccessfulVerifiedWorkIds].every((workId) => completeCoverageWorkIds.has(workId));
+    const awsCoveragePartial = awsSuccessfulVerifiedWorkIds.size > 0 && !awsCoverageComplete;
+    const humanInteractedWorkIds = new Set(events
+      .filter((event): event is Extract<AutonomyTelemetryEvent, { type: "human.touch" }> => event.type === "human.touch")
+      .map((event) => event.workId));
+    const humanApprovedWorkIds = new Set(events
+      .filter((event): event is Extract<AutonomyTelemetryEvent, { type: "approval.decided" }> => event.type === "approval.decided" && event.actor === "human")
+      .map((event) => event.workId));
+    const autonomousAwsCount = [...awsSuccessfulVerifiedWorkIds]
+      .filter((workId) => !humanInteractedWorkIds.has(workId) && !humanApprovedWorkIds.has(workId)).length;
+    const starts = new Map<string, number>();
+    const closeDurations: number[] = [];
+    for (const event of events) {
+      if (event.type === "work.started" && !starts.has(event.workId)) starts.set(event.workId, event.observedAt);
+      if (event.type === "work.closed" && starts.has(event.workId)) {
+        const startedAt = starts.get(event.workId);
+        if (startedAt !== undefined && event.observedAt >= startedAt) closeDurations.push(event.observedAt - startedAt);
+      }
+    }
+    const interruptions = events.filter((event): event is Extract<AutonomyTelemetryEvent, { type: "interruption.classified" }> => event.type === "interruption.classified");
+    const costs = events.filter((event): event is Extract<AutonomyTelemetryEvent, { type: "cost.reference" }> => event.type === "cost.reference");
+    const reportedCosts = costs.filter((event) => event.source === "provider_reported" || event.source === "billing_export").map((event) => event.amountUsd).filter((value): value is number => finiteNumber(value));
+    const estimatedCosts = costs.filter((event) => event.source === "estimate").map((event) => event.amountUsd).filter((value): value is number => finiteNumber(value));
+    const unavailableCosts = costs.filter((event) => event.source === "unavailable" || !finiteNumber(event.amountUsd)).length;
+    const countOrNull = (count: number): number | null => count === 0 ? null : count;
+    const truncated = this.db.prepare("SELECT value FROM autonomy_telemetry_meta WHERE key = 'truncated'").get();
+    const isTruncated = truncated === undefined ? false : retentionRowSchema.parse(truncated).value === "1";
+    return {
+      retainedEvents: events.length,
+      observedWorkCount: workIds.size,
+      closedWorkCount: closedWorkIds.size,
+      verifiedOutcomeCount: verifiedWorkIds.size,
+      verifiedOutcomeRate: closedWorkIds.size === 0 ? null : verifiedClosedCount / closedWorkIds.size,
+      humanTouchCount: countOrNull(events.filter((event) => event.type === "human.touch").length),
+      approvalRequestCount: countOrNull(events.filter((event) => event.type === "approval.requested").length),
+      humanApprovalDecisionCount: countOrNull(events.filter((event) => event.type === "approval.decided").length),
+      interruptionClassificationCount: countOrNull(interruptions.length),
+      falseInterruptionCount: countOrNull(interruptions.filter((event) => event.classification === "false").length),
+      falseInterruptionRate: interruptions.length === 0 ? null : interruptions.filter((event) => event.classification === "false").length / interruptions.length,
+      reworkCount: countOrNull(events.filter((event) => event.type === "rework.recorded").length),
+      authFailureCount: countOrNull(events.filter((event) => event.type === "auth.failure").length),
+      timeToCloseMs: { count: closeDurations.length, median: median(closeDurations) },
+      cost: {
+        referenceCount: costs.length,
+        reportedUsd: reportedCosts.length === 0 ? null : reportedCosts.reduce((total, amount) => total + amount, 0),
+        estimatedUsd: estimatedCosts.length === 0 ? null : estimatedCosts.reduce((total, amount) => total + amount, 0),
+        unavailableUsdReferences: unavailableCosts === 0 ? null : unavailableCosts,
+      },
+      awsAutonomousVerifiedShare: {
+        numerator: awsCoverageComplete ? autonomousAwsCount : null,
+        denominator: awsCoverageComplete ? awsSuccessfulVerifiedWorkIds.size : null,
+        value: awsCoverageComplete ? autonomousAwsCount / awsSuccessfulVerifiedWorkIds.size : null,
+        coverage: awsCoverageComplete ? "complete" : awsCoveragePartial ? "partial" : "unavailable",
+      },
+      retention: { maxEvents: this.maxEvents, truncated: isTruncated },
+    };
+  }
+
+  close(): void { this.db.close(); }
+
+  private transaction<T>(operation: () => T): T {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = operation();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+

--- a/server/canonical-connector-action.ts
+++ b/server/canonical-connector-action.ts
@@ -1,0 +1,141 @@
+/* oxlint-disable anti-slop/no-runtime-typeof, anti-slop/no-unknown-parameters, anti-slop/no-unsafe-dictionary-type -- this seam validates provider JSON before constructing a typed proposal. */
+import type { ActionProposalInput } from "./action-policy.ts";
+import type { JsonObject, JsonValue } from "./schema.ts";
+
+/** Stable policy IDs for connector mutations. This closed catalog means an
+ * unknown write cannot inherit a permission by name similarity. */
+export const CANONICAL_CONNECTOR_OPERATIONS = {
+  GMAIL_CREATE_EMAIL_DRAFT: "gmail.drafts.create",
+  GMAIL_SEND_EMAIL: "gmail.send",
+  GMAIL_REPLY_TO_EMAIL: "gmail.reply",
+  GMAIL_REPLY_TO_THREAD: "gmail.reply",
+  GMAIL_REPLY_TO_THREAD_BY_ID: "gmail.reply",
+  GOOGLECALENDAR_CREATE_EVENT: "calendar.events.create",
+  GOOGLECALENDAR_UPDATE_EVENT: "calendar.events.update",
+  GOOGLECALENDAR_DELETE_EVENT: "calendar.events.delete",
+  GOOGLECALENDAR_RESPOND_TO_EVENT: "calendar.events.rsvp",
+  GOOGLECALENDAR_UPDATE_EVENT_ATTENDEE: "calendar.events.rsvp",
+  GOOGLECALENDAR_CREATE_AN_EVENT: "calendar.events.create",
+  GOOGLECALENDAR_UPDATE_AN_EVENT: "calendar.events.update",
+  GOOGLECALENDAR_DELETE_AN_EVENT: "calendar.events.delete",
+  GOOGLEDRIVE_CREATE_FILE: "drive.files.create",
+  GOOGLEDRIVE_UPLOAD_FILE: "drive.files.create",
+  GOOGLEDRIVE_UPDATE_FILE: "drive.files.update",
+  GOOGLEDRIVE_UPDATE_FILE_METADATA: "drive.files.update",
+  GOOGLEDRIVE_DELETE_FILE: "drive.files.delete",
+  GOOGLEDRIVE_MOVE_FILE: "drive.files.move",
+  GOOGLEDRIVE_COPY_FILE: "drive.files.copy",
+  GOOGLEDRIVE_CREATE_A_FILE: "drive.files.create",
+  GOOGLEDRIVE_DELETE_A_FILE: "drive.files.delete",
+  GITHUB_CREATE_ISSUE: "github.issues.create",
+  GITHUB_CREATE_AN_ISSUE: "github.issues.create",
+  GITHUB_UPDATE_ISSUE: "github.issues.update",
+  GITHUB_UPDATE_AN_ISSUE: "github.issues.update",
+  GITHUB_ADD_ISSUE_COMMENT: "github.issues.comment",
+  GITHUB_CREATE_ISSUE_COMMENT: "github.issues.comment",
+  GITHUB_CREATE_PULL_REQUEST: "github.pull_requests.create",
+  GITHUB_CREATE_A_PULL_REQUEST: "github.pull_requests.create",
+  GITHUB_UPDATE_PULL_REQUEST: "github.pull_requests.update",
+  GITHUB_MERGE_PULL_REQUEST: "github.pull_requests.merge",
+  GITHUB_MERGE_A_PULL_REQUEST: "github.pull_requests.merge",
+  GITHUB_CREATE_PULL_REQUEST_REVIEW: "github.pull_requests.review",
+} as const satisfies Readonly<Record<string, string>>;
+
+export type CanonicalConnectorOperation = (typeof CANONICAL_CONNECTOR_OPERATIONS)[keyof typeof CANONICAL_CONNECTOR_OPERATIONS];
+
+export type CanonicalConnectorActionResult =
+  | { fidelity: "canonical"; action: ActionProposalInput & { operation: CanonicalConnectorOperation } }
+  | { fidelity: "invalid"; reason: string }
+  | { fidelity: "unsupported" };
+
+const GUARDED_EXECUTOR = "COMPOSIO_MULTI_EXECUTE_TOOL";
+const ACCOUNT_FIELDS = new Set(["account", "account_id", "accountId", "connected_account_id", "connectedAccountId"]);
+const SECRET_FIELDS = /(?:^|[_-])(access[_-]?token|api[_-]?key|authorization|client[_-]?secret|password|private[_-]?key|refresh[_-]?token|secret|token)$/i;
+
+/** Convert a direct tool call or a single-tool Composio envelope into an
+ * immutable, exact-account proposal. Unknown writes remain unsupported. */
+export function canonicalConnectorAction(name: string, rawArguments: unknown): CanonicalConnectorActionResult {
+  const normalized = normalizeToolName(name);
+  if (normalized === GUARDED_EXECUTOR) {
+    const envelope = objectValue(rawArguments);
+    const tools = envelope?.tools;
+    if (!Array.isArray(tools) || tools.length !== 1) {
+      return { fidelity: "invalid", reason: "Canonical execution requires exactly one action" };
+    }
+    const item = objectValue(tools[0]);
+    if (!item) return { fidelity: "invalid", reason: "The connector action is malformed" };
+    const toolName = typeof item.tool_slug === "string" ? item.tool_slug : typeof item.name === "string" ? item.name : "";
+    const operation = operationForTool(toolName);
+    if (operation === undefined) return { fidelity: "unsupported" };
+    if (operation === null) return { fidelity: "invalid", reason: "The connector action name is malformed" };
+    const payload = jsonObject(item.arguments);
+    if (!payload) return { fidelity: "invalid", reason: "The connector payload is not valid JSON" };
+    return proposalFor(operation, item.account ?? accountField(payload), payload);
+  }
+
+  const operation = operationForTool(normalized);
+  if (operation === undefined) return { fidelity: "unsupported" };
+  if (operation === null) return { fidelity: "invalid", reason: "The connector action name is malformed" };
+  const payload = jsonObject(rawArguments);
+  if (!payload) return { fidelity: "invalid", reason: "The connector payload is not valid JSON" };
+  return proposalFor(operation, accountField(payload), payload);
+}
+export function canonicalConnectorOperationForTool(name: string): CanonicalConnectorOperation | null {
+  return operationForTool(name) ?? null;
+}
+
+function proposalFor(operation: CanonicalConnectorOperation, accountValue: unknown, payload: JsonObject): CanonicalConnectorActionResult {
+  const accountId = exactAccountId(accountValue);
+  if (!accountId) return { fidelity: "invalid", reason: "An exact connected account ID is required" };
+  if (containsSecretField(payload)) return { fidelity: "invalid", reason: "Credentials must stay in the provider connection, not an action payload" };
+  return { fidelity: "canonical", action: { operation, accountId, payload: omitAccountFields(payload) } };
+}
+
+function operationForTool(name: string): CanonicalConnectorOperation | null | undefined {
+  const normalized = normalizeToolName(name);
+  if (!normalized || normalized.includes(" ")) return null;
+  return Object.entries(CANONICAL_CONNECTOR_OPERATIONS).find(([key]) => key === normalized)?.[1];
+}
+
+function normalizeToolName(name: string): string { return name.trim().toUpperCase(); }
+
+function accountField(value: JsonObject): JsonValue | undefined {
+  for (const key of ACCOUNT_FIELDS) if (key in value) return value[key];
+  return undefined;
+}
+
+function exactAccountId(value: unknown): string | null {
+  const record = objectValue(value);
+  const candidate = typeof value === "string" ? value : record && typeof record.id === "string" ? record.id : "";
+  const normalized = candidate.trim();
+  return /^ca_[A-Za-z0-9_-]{2,200}$/.test(normalized) ? normalized : null;
+}
+
+function omitAccountFields(value: JsonObject): JsonObject {
+  return Object.fromEntries(Object.entries(value).filter(([key]) => !ACCOUNT_FIELDS.has(key)));
+}
+
+function containsSecretField(value: JsonValue): boolean {
+  if (Array.isArray(value)) return value.some(containsSecretField);
+  if (value === null || typeof value !== "object") return false;
+  return Object.entries(value).some(([key, child]) => SECRET_FIELDS.test(key) || containsSecretField(child));
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? Object.fromEntries(Object.entries(value)) : null;
+}
+
+function jsonObject(value: unknown): JsonObject | null { return isJsonObject(value) ? value : null; }
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value) && isJsonValue(value);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  const object = objectValue(value);
+  return object !== null && Object.values(object).every(isJsonValue);
+}
+

--- a/server/centipede-v3-runtime.test.ts
+++ b/server/centipede-v3-runtime.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createCentipedeV3Runtime } from "./centipede-v3-runtime.ts";
+
+const directories: string[] = [];
+const runtimes: Array<ReturnType<typeof createCentipedeV3Runtime>> = [];
+
+afterEach(() => {
+  for (const runtime of runtimes.splice(0)) runtime.close();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function capture(captureId = "capture-runtime-1", summary = "The requested Centipede receipt is ready.") {
+  return {
+    kind: "capture" as const,
+    evidence: {
+      captureId,
+      source: "local-fixture",
+      reference: `fixture:${captureId}`,
+      summary,
+      contentHash: captureId === "capture-runtime-1" ? "a".repeat(64) : "c".repeat(64),
+      confidence: "high" as const,
+      criterionIds: ["receipt"],
+      artifacts: [{ reference: `fixture:${captureId}`, kind: "receipt", contentHash: captureId === "capture-runtime-1" ? "b".repeat(64) : "d".repeat(64) }],
+      observedAt: 1_000,
+    },
+  };
+}
+
+describe("Centipede V3 runtime seam", () => {
+  it("captures into the graph, completes through real adapters, and recovers exactly", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "centipede-v3-runtime-"));
+    directories.push(directory);
+    const first = createCentipedeV3Runtime({ dataDir: directory, now: () => 1_000 });
+    runtimes.push(first);
+
+    const captured = await first.dispatch(capture());
+    expect(captured.status).toBe("ok");
+    if (captured.status !== "ok") throw new Error("capture did not complete");
+    expect(captured.view.state).toBe("running");
+
+    const verified = await first.dispatch({
+      kind: "verify",
+      outcomeId: captured.view.contract.outcomeId,
+      contractVersion: captured.view.contract.version,
+    });
+    expect(verified).toMatchObject({ status: "ok", view: { state: "completed" } });
+    if (verified.status !== "ok" || !verified.receipt) throw new Error("expected a verified runtime receipt");
+    const canonicalWork = first.inspectCanonicalWork("capture-runtime-1");
+    expect(canonicalWork).toHaveLength(1);
+    expect(canonicalWork[0]?.status).toBe("completed");
+    expect(canonicalWork[0]?.evidence[0]?.kind).toBe("worker-batch");
+    expect(verified.receipt.record.executionTrace.complete).toBe(true);
+    expect(verified.receipt.record.executionTrace.traceIdentity).toBe(verified.receipt.record.verifiedOutput.traceIdentity);
+    expect(verified.receipt.record.executionTrace.traceIdentity).toBe(verified.receipt.record.retrospective.traceIdentity);
+    expect(verified.receipt.record.retrospective.metrics.find((metric) => metric.name === "aws")?.value.status).toBe("unknown");
+    const graphBefore = first.inspectContext();
+    expect(graphBefore.nodes.some((node) => node.id === "capture:capture-runtime-1")).toBe(true);
+    expect(graphBefore.nodes.some((node) => node.type === "verified-outcome")).toBe(true);
+    expect(graphBefore.nodes.some((node) => node.id === "receipt:capture-runtime-1:v1")).toBe(true);
+    expect(graphBefore.nodes.some((node) => node.id === "learning:capture-runtime-1:v1")).toBe(true);
+    expect(graphBefore.edges).toContainEqual({
+      from: "capture:capture-runtime-1",
+      to: "outcome:capture-runtime-1",
+      kind: "supports",
+    });
+    const projectionBefore = first.inspectOutcome("capture-runtime-1");
+
+    const restarted = createCentipedeV3Runtime({ dataDir: directory, now: () => 1_000 });
+    runtimes.push(restarted);
+    expect(restarted.inspectOutcome("capture-runtime-1")).toEqual(projectionBefore);
+    expect(restarted.inspectOutcomeReceipt("capture-runtime-1")).toEqual(verified.receipt);
+    expect(restarted.inspectContext()).toEqual(graphBefore);
+    await expect(restarted.dispatch(capture())).resolves.toMatchObject({ status: "ok", view: { state: "completed" } });
+    expect(restarted.workExecutionCount()).toBe(1);
+
+    const later = await restarted.dispatch(capture("capture-runtime-2", "A second requested receipt is ready."));
+    expect(later).toMatchObject({ status: "ok", view: { state: "running" } });
+    if (later.status !== "ok") throw new Error("expected the later outcome to run");
+    const laterVerified = await restarted.dispatch({ kind: "verify", outcomeId: later.view.contract.outcomeId, contractVersion: later.view.contract.version });
+    expect(laterVerified).toMatchObject({ status: "ok", view: { state: "completed" } });
+    if (laterVerified.status !== "ok" || !laterVerified.receipt) throw new Error("expected the later outcome to verify");
+    expect(laterVerified.receipt.record.executionTrace.entries.some((entry) => entry.detail?.includes("route=known-safe"))).toBe(true);
+  });
+
+  it("keeps low-confidence captures fail-closed and supports declared user outcomes", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "centipede-v3-runtime-"));
+    directories.push(directory);
+    const runtime = createCentipedeV3Runtime({ dataDir: directory, now: () => 1_000 });
+    runtimes.push(runtime);
+    const lowConfidence = { ...capture(), evidence: { ...capture().evidence, confidence: "low" as const } };
+    await expect(runtime.dispatch(lowConfidence)).resolves.toMatchObject({ status: "blocked", reason: "capture_ambiguous" });
+
+    const declared = await runtime.dispatch({
+      kind: "declare",
+      contract: runtime.userContract("user-outcome", "Produce the user-stated result"),
+    });
+    expect(declared).toMatchObject({ status: "ok", view: { state: "declared" } });
+  });
+
+  it("ingests graph deltas and lets an explicit conflict defeat lexical relevance", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "centipede-v3-runtime-"));
+    directories.push(directory);
+    const runtime = createCentipedeV3Runtime({ dataDir: directory, now: () => 1_000 });
+    runtimes.push(runtime);
+    const first = await runtime.dispatch(capture("capture-graph-first", "The requested receipt is ready."));
+    expect(first).toMatchObject({ status: "ok", view: { state: "running", contract: { outcomeId: "capture-graph-first" } } });
+    const second = await runtime.dispatch({
+      ...capture("capture-graph-conflict", "The requested receipt is ready."),
+      evidence: {
+        ...capture("capture-graph-conflict", "The requested receipt is ready.").evidence,
+        contentHash: "e".repeat(64),
+        contextDelta: {
+          nodes: [{ id: "capture:capture-graph-conflict", type: "capture" }, { id: "outcome:capture-graph-first", type: "outcome" }],
+          edges: [{ from: "capture:capture-graph-conflict", to: "outcome:capture-graph-first", kind: "conflicts" }],
+        },
+      },
+    });
+    expect(second).toMatchObject({ status: "ok", view: { contract: { outcomeId: "capture-graph-conflict" } } });
+    expect(runtime.inspectContext().edges).toContainEqual({ from: "capture:capture-graph-conflict", to: "outcome:capture-graph-first", kind: "conflicts" });
+  });
+
+  it("reconciles a slow canonical worker when the public verify command arrives after dispatch", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "centipede-v3-runtime-"));
+    directories.push(directory);
+    const runtime = createCentipedeV3Runtime({
+      dataDir: directory,
+      now: () => 1_000,
+      workerRunner: async () => new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 20)),
+    });
+    runtimes.push(runtime);
+    const captured = await runtime.dispatch(capture("capture-runtime-slow", "A slow requested receipt is ready."));
+    expect(captured.status).toBe("blocked");
+    if (captured.status !== "blocked" || !captured.view) throw new Error("expected slow worker dispatch to remain observable");
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    const verified = await runtime.dispatch({ kind: "verify", outcomeId: captured.view.contract.outcomeId, contractVersion: captured.view.contract.version });
+    expect(verified).toMatchObject({ status: "ok", view: { state: "completed" } });
+  });
+});

--- a/server/centipede-v3-runtime.ts
+++ b/server/centipede-v3-runtime.ts
@@ -1,0 +1,436 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { AccountDirectory, JsonFileAccountDirectoryStore } from "./account-directory.ts";
+import { ActionPolicy } from "./action-policy.ts";
+import { AutonomyTelemetry } from "./autonomy-telemetry.ts";
+import { createExecutionLearning } from "./execution-learning.ts";
+import {
+  createOutcomeOrchestrator,
+  captureContextDelta,
+  projectOutcome,
+  type CaptureEvidence,
+  type CaptureContextDelta,
+  type CaptureInferenceInput,
+  type CaptureOutcomeInference,
+  type ContractualJudgment,
+  type ExistingWorkOrchestrator,
+  type OutcomeCommandResult,
+  type OutcomeContract,
+  type OutcomeOrchestrator,
+  type OutcomeProjection,
+  type OutcomeReceipt,
+  type OutcomeVerifier,
+  type OutcomeView,
+} from "./outcome-orchestrator.ts";
+import { createWorkerJobFileStore } from "./worker-job-file-store.ts";
+import { createWorkerJobs, type WorkerJobRecord, type WorkerJobStore } from "./worker-jobs.ts";
+import { createWorkLockStore, type WorkLockStoreInterface, type WorkObligation } from "./work-lock-store.ts";
+import { createWorkOrchestrator, type WorkOrchestrator } from "./work-orchestrator.ts";
+import type { JsonObject, JsonValue } from "./schema.ts";
+
+/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-unknown-returns,
+ * anti-slop/no-runtime-typeof, anti-slop/no-unsafe-dictionary-type,
+ * anti-slop/no-known-value-widening -- the public command seam is unknown by
+ * design; all durable and worker values are validated by their owning module. */
+
+export interface CentipedeV3RuntimeOptions {
+  readonly dataDir: string;
+  readonly now?: () => number;
+  /** Production desktop wiring supplies the existing turn runner. The
+   * default is a bounded local worker for the standalone runtime seam. */
+  readonly workerRunner?: (job: Readonly<WorkerJobRecord>) => JsonValue | undefined | Promise<JsonValue | undefined>;
+}
+
+export interface ContextGraph {
+  readonly nodes: readonly {
+    readonly id: string;
+    readonly type: "capture" | "outcome" | "verified-outcome" | "receipt" | "learning" | "entity" | "relationship" | "constraint" | "dependency";
+    readonly provenance?: {
+      readonly source: string;
+      readonly reference: string;
+      readonly contentHash: string;
+      readonly observedAt: number;
+    };
+    readonly contractId?: string;
+    readonly contractVersion?: number;
+    readonly receiptReference?: string;
+  }[];
+  readonly edges: readonly {
+    readonly from: string;
+    readonly to: string;
+    readonly kind: "supports" | "related-to" | "conflicts" | "depends-on" | "produced-by" | "learned-from";
+  }[];
+}
+
+export interface CentipedeV3Runtime {
+  dispatch(command: unknown): Promise<OutcomeCommandResult>;
+  inspectContext(): ContextGraph;
+  inspectOutcome(outcomeId: string): OutcomeProjection | null;
+  inspectOutcomeReceipt(outcomeId: string): OutcomeReceipt | null;
+  inspectCanonicalWork(outcomeId: string): readonly WorkObligation[];
+  userContract(outcomeId: string, objective: string): OutcomeContract;
+  workExecutionCount(): number;
+  close(): void;
+}
+
+const graphFileName = "centipede-v3-context.json";
+
+function emptyGraph(): ContextGraph {
+  return { nodes: [], edges: [] };
+}
+
+function loadGraph(file: string): ContextGraph {
+  if (!existsSync(file)) return emptyGraph();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!isRecord(parsed) || !Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return emptyGraph();
+    const nodes = parsed.nodes.filter(isGraphNode);
+    const edges = parsed.edges.filter(isGraphEdge);
+    return { nodes, edges };
+  } catch {
+    return emptyGraph();
+  }
+}
+
+function saveGraph(file: string, graph: ContextGraph): void {
+  writeFileSync(file, JSON.stringify(graph), { encoding: "utf8", mode: 0o600 });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isGraphNode(value: unknown): value is ContextGraph["nodes"][number] {
+  if (!isRecord(value) || typeof value.id !== "string") return false;
+  if (value.type !== "capture" && value.type !== "outcome" && value.type !== "verified-outcome" && value.type !== "receipt" && value.type !== "learning" && value.type !== "entity" && value.type !== "relationship" && value.type !== "constraint" && value.type !== "dependency") return false;
+  if (value.provenance !== undefined) {
+    if (!isRecord(value.provenance) || typeof value.provenance.source !== "string" || typeof value.provenance.reference !== "string" || typeof value.provenance.contentHash !== "string" || typeof value.provenance.observedAt !== "number") return false;
+  }
+  return value.contractId === undefined || typeof value.contractId === "string";
+}
+
+function mergeCaptureContext(graph: ContextGraph, delta: CaptureContextDelta | null): ContextGraph {
+  if (!delta) return graph;
+  const nodes = [...graph.nodes];
+  for (const node of delta.nodes) {
+    const index = nodes.findIndex((candidate) => candidate.id === node.id);
+    if (index < 0) nodes.push(node);
+    else nodes[index] = { ...nodes[index], ...node };
+  }
+  const edges = [...graph.edges];
+  for (const edge of delta.edges) {
+    if (!edges.some((candidate) => candidate.from === edge.from && candidate.to === edge.to && candidate.kind === edge.kind)) edges.push(edge);
+  }
+  return { nodes, edges };
+}
+
+function isGraphEdge(value: unknown): value is ContextGraph["edges"][number] {
+  return isRecord(value) && typeof value.from === "string" && typeof value.to === "string" && (value.kind === "supports" || value.kind === "related-to" || value.kind === "conflicts" || value.kind === "depends-on" || value.kind === "produced-by" || value.kind === "learned-from");
+}
+
+function normalizedTokens(value: string): ReadonlySet<string> {
+  return new Set(value.normalize("NFKC").toLocaleLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 2));
+}
+
+function tokenOverlap(left: string, right: string): number {
+  const a = normalizedTokens(left);
+  const b = normalizedTokens(right);
+  if (a.size === 0 || b.size === 0) return 0;
+  let matches = 0;
+  for (const token of a) if (b.has(token)) matches += 1;
+  return matches / Math.max(a.size, b.size);
+}
+
+function captureMatchesGraph(graph: ContextGraph, evidence: CaptureEvidence, outcomeId: string): boolean {
+  const captureNode = graph.nodes.find((node) => node.id === `capture:${evidence.captureId}`);
+  if (!captureNode) return false;
+  const relationship = graph.edges.filter((edge) => edge.from === captureNode.id && edge.to === `outcome:${outcomeId}`);
+  if (relationship.some((edge) => edge.kind === "conflicts")) return false;
+  return relationship.some((edge) => edge.kind === "supports" || edge.kind === "related-to" || edge.kind === "depends-on");
+}
+
+function captureConflictsWithOutcome(graph: ContextGraph, evidence: CaptureEvidence, outcomeId: string): boolean {
+  return graph.edges.some((edge) => edge.from === `capture:${evidence.captureId}` && edge.to === `outcome:${outcomeId}` && edge.kind === "conflicts");
+}
+
+function createCaptureInference(getGraph: () => ContextGraph, work: WorkLockStoreInterface): CaptureOutcomeInference {
+  return {
+    async infer(input: CaptureInferenceInput): Promise<unknown> {
+      const graph = mergeCaptureContext(getGraph(), input.evidence.contextDelta ?? null);
+      const active = input.existingOutcomes.filter((outcome) => outcome.state === "accepted" || outcome.state === "running" || outcome.state === "needs-you" || outcome.state === "verifying");
+      const related = active.find((outcome) => !captureConflictsWithOutcome(graph, input.evidence, outcome.outcomeId) && (captureMatchesGraph(graph, input.evidence, outcome.outcomeId) || tokenOverlap(input.evidence.summary, outcome.objective) >= 0.6));
+      const canonical = work.listOpenWork({ statuses: ["open", "in_progress", "blocked", "completed"], limit: 1_000 }).obligations.find((obligation) => {
+        if (!isRecord(obligation.metadata)) return false;
+        return obligation.metadata.captureContentHash === input.evidence.contentHash;
+      });
+      const metadata = canonical?.metadata;
+      if (metadata && isRecord(metadata) && typeof metadata.outcomeId === "string") {
+        const existing = input.existingOutcomes.find((candidate) => candidate.outcomeId === metadata.outcomeId);
+        if (existing) return { status: "existing", outcomeId: existing.outcomeId, contractVersion: existing.contractVersion };
+      }
+      if (related) return { status: "existing", outcomeId: related.outcomeId, contractVersion: related.contractVersion };
+      if (input.evidence.confidence !== "high") return { status: "ambiguous", reason: "Capture confidence is below the execution threshold." };
+
+      const outcomeId = input.evidence.captureId;
+      return {
+        status: "inferred",
+        contract: {
+          id: `${outcomeId}:v1`,
+          outcomeId,
+          version: 1,
+          ownerId: "shane",
+          objective: input.evidence.summary,
+          constraints: [
+            { kind: "scope", statement: "Use only the provenance-bearing Capture observation and canonical Work." },
+            { kind: "privacy", statement: "Do not disclose Capture content outside the bound local runtime." },
+          ],
+          successCriteria: [{ id: "receipt", statement: "Canonical Work is independently verified against this Contract version." }],
+          deadline: { at: input.evidence.observedAt + 86_400_000 },
+          budget: { currency: "USD", maxCostCents: 100, maxUnits: 10 },
+          qualityBar: "Exact Contract binding, bounded execution, and independent verification",
+          authority: { mode: "deny-by-default", grants: [] },
+          escalation: { channel: "needs-you", on: ["missing-input", "deadline-risk", "budget-risk", "quality-risk", "authority-required"] },
+          evidenceRequirements: { requiredCriterionIds: ["receipt"], requiredArtifactKinds: ["receipt"] },
+          rollback: { onCancel: "reversible-stop", onFailure: "stop" },
+          plan: [{
+            id: "capture-outcome",
+            label: "Close the captured outcome",
+            prompt: input.evidence.summary,
+            resumePolicy: "safe",
+            dependsOn: [],
+            needsYou: null,
+            requiredAuthority: null,
+            estimatedCostCents: 1,
+            estimatedUnits: 1,
+          }],
+        } satisfies OutcomeContract,
+      };
+    },
+  };
+}
+
+function createJudgment(now: () => number): ContractualJudgment {
+  return {
+    async judge(input): Promise<unknown> {
+      if (input.workIds.length === 0) return { color: "yellow", input: { inputKey: "missing-work", question: "Which canonical Work should close this outcome?", choices: [] } };
+      if (now() > input.contract.deadline.at) return { color: "red", reason: "The Outcome Contract deadline has passed." };
+      const estimatedCost = input.contract.plan.reduce((total, task) => total + task.estimatedCostCents, 0);
+      const estimatedUnits = input.contract.plan.reduce((total, task) => total + task.estimatedUnits, 0);
+      if (estimatedCost > input.contract.budget.maxCostCents || estimatedUnits > input.contract.budget.maxUnits) return { color: "red", reason: "The Contract budget cannot cover the planned Work." };
+      if (input.evidence.length === 0) return { color: "yellow", input: { inputKey: "missing-evidence", question: "Provide the provenance-bearing evidence needed to run this outcome.", choices: [] } };
+      if (input.evidence.some((evidence) => evidence.criterionIds.length === 0)) return { color: "red", reason: "Capture evidence does not cover a Contract criterion." };
+      return { color: "green" };
+    },
+  };
+}
+
+function createIndependentVerifier(work: WorkLockStoreInterface): OutcomeVerifier {
+  return {
+    async verify(input): Promise<unknown> {
+      if (input.workIds.length === 0) return { status: "not_verified", reason: "canonical_work_missing" };
+      const obligations = input.workIds.map((workId) => work.getObligation(workId));
+      if (obligations.some((obligation) => obligation === null || obligation.status !== "completed")) return { status: "not_verified", reason: "canonical_work_not_completed" };
+      const evidence = obligations.flatMap((obligation) => obligation?.evidence ?? []);
+      if (!evidence.some((item) => item.kind === "worker-batch")) return { status: "not_verified", reason: "independent_worker_evidence_missing" };
+      return {
+        status: "verified",
+        contractId: input.contract.id,
+        contractVersion: input.contract.version,
+        criteriaHash: input.criteriaHash,
+        traceIdentity: input.traceIdentity,
+        evidenceRefs: input.evidence.map((item) => item.reference),
+        artifactRefs: input.artifacts.map((item) => item.reference),
+        usage: { costCents: 1, units: 1 },
+      };
+    },
+  };
+}
+
+function defaultWorkerRunner(job: Readonly<WorkerJobRecord>): JsonValue {
+  const promptHash = createHash("sha256").update(job.prompt, "utf8").digest("hex");
+  return { kind: "bounded-worker-result", jobId: job.id, promptHash, completedAt: Date.now() } satisfies JsonObject;
+}
+
+function createCanonicalWorkStack(options: CentipedeV3RuntimeOptions, now: () => number): { readonly adapter: ExistingWorkOrchestrator; readonly work: WorkLockStoreInterface; readonly workerStore: WorkerJobStore; readonly recovery: Promise<unknown>; readonly close: () => void } {
+  const work = createWorkLockStore({ file: join(options.dataDir, "work-lock-store.db"), now });
+  const accounts = new AccountDirectory({ ownerId: "centipede-v3", store: new JsonFileAccountDirectoryStore(join(options.dataDir, "account-directory.json")) });
+  const policy = new ActionPolicy({ file: join(options.dataDir, "action-policy.db"), now, defaultOwnerId: "shane" });
+  const telemetry = new AutonomyTelemetry({ file: join(options.dataDir, "autonomy-telemetry.db"), now });
+  const workerStore = createWorkerJobFileStore(join(options.dataDir, "worker-jobs.json"));
+  const workers = createWorkerJobs({
+    store: workerStore,
+    now,
+    run: options.workerRunner ?? defaultWorkerRunner,
+    interrupt: async () => undefined,
+  }, { concurrency: 1 });
+  const orchestrator: WorkOrchestrator = createWorkOrchestrator({
+    work,
+    accounts,
+    policy,
+    telemetry,
+    journalFile: join(options.dataDir, "work-orchestrator.json"),
+    executor: { async execute() { throw new Error("V3 connector actions require a bound provider adapter"); } },
+    verifier: { async verify() { return { status: "not_verified", reason: "V3 connector verification requires a fresh provider read" }; } },
+    worker: {
+      async dispatch(event, batchId) {
+        const batch = await workers.launchBatch(event.taskId, event.tasks.map((task) => ({
+          key: task.key,
+          label: task.label,
+          prompt: task.prompt,
+          resumePolicy: task.resumePolicy,
+          dependsOn: task.dependsOn,
+          resourceLocks: task.resourceLocks,
+          approvalGate: task.approvalGate,
+          metadata: task.metadata,
+        })), { id: batchId, label: event.title });
+        return { batchId: batch.batchId, settled: batch.settled.then(() => undefined) };
+      },
+      async inspect(batchId, expectedTaskCount) {
+        const jobs = (await workerStore.list()).filter((job) => job.batchId === batchId);
+        if (jobs.length === 0) return { status: "missing" };
+        if (jobs.length !== expectedTaskCount) return { status: "failed", reason: "worker batch is incomplete" };
+        if (jobs.some((job) => job.status === "running")) return { status: "running" };
+        if (jobs.some((job) => job.status === "queued")) return { status: "queued" };
+        const failed = jobs.find((job) => job.status === "failed");
+        if (failed) return { status: "failed", reason: failed.error ?? "worker failed" };
+        const canceled = jobs.find((job) => job.status === "canceled");
+        if (canceled) return { status: "canceled", reason: canceled.error ?? "worker canceled" };
+        const recordedAt = Math.max(...jobs.map((job) => job.settledAt ?? job.createdAt));
+        return { status: "completed", reference: `worker-batch:${batchId}`, summary: `${jobs.length} bounded worker completed.`, recordedAt };
+      },
+    },
+    now,
+  });
+  return { adapter: orchestrator, work, workerStore, recovery: workers.recover(), close: () => { work.close(); policy.close(); telemetry.close(); } };
+}
+
+function graphForOutcome(graph: ContextGraph, outcome: OutcomeView, state: string): ContextGraph {
+  const outcomeNodeId = `outcome:${outcome.contract.outcomeId}`;
+  const nodes = [...graph.nodes];
+  const outcomeNode: {
+    id: string;
+    type: "verified-outcome" | "outcome";
+    contractId: string;
+    contractVersion: number;
+    receiptReference?: string;
+  } = {
+    id: outcomeNodeId,
+    type: state === "completed" ? "verified-outcome" : "outcome",
+    contractId: outcome.contract.id,
+    contractVersion: outcome.contract.version,
+  };
+  if (outcome.receipt) outcomeNode.receiptReference = `receipt:${outcome.receipt.outcomeId}:v${outcome.receipt.contractVersion}`;
+  const index = nodes.findIndex((node) => node.id === outcomeNodeId);
+  if (index < 0) nodes.push(outcomeNode);
+  else nodes[index] = { ...nodes[index], ...outcomeNode };
+  return { nodes, edges: [...graph.edges] };
+}
+
+export function createCentipedeV3Runtime(options: CentipedeV3RuntimeOptions): CentipedeV3Runtime {
+  mkdirSync(options.dataDir, { recursive: true, mode: 0o700 });
+  const now = options.now ?? Date.now;
+  const graphFile = join(options.dataDir, graphFileName);
+  let graph = loadGraph(graphFile);
+  const canonical = createCanonicalWorkStack(options, now);
+  const outcome: OutcomeOrchestrator = createOutcomeOrchestrator({
+    journalFile: join(options.dataDir, "outcomes.ndjson"),
+    work: canonical.adapter,
+    verifier: createIndependentVerifier(canonical.work),
+    captureInference: createCaptureInference(() => graph, canonical.work),
+    judgment: createJudgment(now),
+    learning: createExecutionLearning({ file: join(options.dataDir, "centipede-v3-learning.json") }),
+    now,
+  });
+
+  function updateGraph(result: OutcomeCommandResult): void {
+    if (!("view" in result) || result.view === undefined) return;
+    const view = result.view;
+    graph = graphForOutcome(graph, view, view.state);
+    for (const evidence of view.evidence) {
+      if (!evidence.evidenceId.startsWith("capture:")) continue;
+      const captureId = evidence.evidenceId.slice("capture:".length);
+      const captureNodeId = `capture:${captureId}`;
+      if (!graph.nodes.some((node) => node.id === captureNodeId)) {
+        graph = {
+          ...graph,
+          nodes: [...graph.nodes, {
+            id: captureNodeId,
+            type: "capture",
+            provenance: { source: "capture", reference: evidence.reference, contentHash: evidence.contentHash, observedAt: evidence.recordedAt },
+          }],
+        };
+      }
+      const edge: ContextGraph["edges"][number] = { from: captureNodeId, to: `outcome:${view.contract.outcomeId}`, kind: "supports" };
+      if (!graph.edges.some((candidate) => candidate.from === edge.from && candidate.to === edge.to && candidate.kind === edge.kind)) graph = { ...graph, edges: [...graph.edges, edge] };
+    }
+    if (view.state === "completed" && view.receipt) {
+      const receiptId = `receipt:${view.receipt.outcomeId}:v${view.receipt.contractVersion}`;
+      const learningId = `learning:${view.receipt.outcomeId}:v${view.receipt.contractVersion}`;
+      const feedbackNodes: ContextGraph["nodes"] = [
+        { id: receiptId, type: "receipt", contractId: view.receipt.contractId, contractVersion: view.receipt.contractVersion, receiptReference: receiptId },
+        { id: learningId, type: "learning", contractId: view.receipt.contractId, contractVersion: view.receipt.contractVersion },
+      ];
+      graph = { ...graph, nodes: [...graph.nodes.filter((node) => !feedbackNodes.some((candidate) => candidate.id === node.id)), ...feedbackNodes] };
+      const feedbackEdges: ContextGraph["edges"] = [
+        { from: receiptId, to: `outcome:${view.contract.outcomeId}`, kind: "produced-by" },
+        { from: learningId, to: receiptId, kind: "learned-from" },
+      ];
+      graph = { ...graph, edges: [...graph.edges.filter((edge) => !feedbackEdges.some((candidate) => candidate.from === edge.from && candidate.to === edge.to && candidate.kind === edge.kind)), ...feedbackEdges] };
+    }
+    saveGraph(graphFile, graph);
+  }
+
+  return {
+    async dispatch(command: unknown): Promise<OutcomeCommandResult> {
+      await canonical.recovery;
+      const delta = captureContextDelta(command);
+      if (delta) {
+        graph = mergeCaptureContext(graph, delta);
+        saveGraph(graphFile, graph);
+      }
+      const result = await outcome.dispatch(command);
+      updateGraph(result);
+      return result;
+    },
+    inspectContext(): ContextGraph { return graph; },
+    inspectOutcome(outcomeId: string): OutcomeProjection | null {
+      const inspected = outcome.inspect(outcomeId);
+      return inspected.status === "available" ? projectOutcome(inspected.view) : null;
+    },
+    inspectOutcomeReceipt(outcomeId: string): OutcomeReceipt | null {
+      const inspected = outcome.inspect(outcomeId);
+      return inspected.status === "available" && inspected.view.state === "completed" ? inspected.view.receipt : null;
+    },
+    inspectCanonicalWork(outcomeId: string): readonly WorkObligation[] {
+      const inspected = outcome.inspect(outcomeId);
+      if (inspected.status !== "available") return [];
+      return inspected.view.work.map((link) => canonical.work.getObligation(link.workId)).filter((obligation): obligation is WorkObligation => obligation !== null);
+    },
+    userContract(outcomeId: string, objective: string): OutcomeContract {
+      return {
+        id: `${outcomeId}:v1`,
+        outcomeId,
+        version: 1,
+        ownerId: "shane",
+        objective,
+        constraints: [{ kind: "scope", statement: "Use only local reversible work." }],
+        successCriteria: [{ id: "result", statement: "The user-stated result is independently verified." }],
+        deadline: { at: now() + 86_400_000 },
+        budget: { currency: "USD", maxCostCents: 100, maxUnits: 10 },
+        qualityBar: "Exact Contract binding and independent verification",
+        authority: { mode: "deny-by-default", grants: [] },
+        escalation: { channel: "needs-you", on: ["missing-input", "authority-required"] },
+        evidenceRequirements: { requiredCriterionIds: ["result"], requiredArtifactKinds: [] },
+        rollback: { onCancel: "reversible-stop", onFailure: "stop" },
+        plan: [{ id: "result", label: "Produce the result", prompt: objective, resumePolicy: "safe", dependsOn: [], needsYou: null, requiredAuthority: null, estimatedCostCents: 1, estimatedUnits: 1 }],
+      };
+    },
+    workExecutionCount(): number {
+      const jobs = canonical.workerStore.list();
+      return Array.isArray(jobs) ? jobs.filter((job) => job.status === "completed").length : 0;
+    },
+    close(): void { canonical.close(); },
+  };
+}

--- a/server/execution-learning.test.ts
+++ b/server/execution-learning.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createExecutionLearning,
+  type OutcomeRecord,
+  type RetrospectiveReview,
+} from "./execution-learning.ts";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function record(outcomeId: string, statement = "Use the previously verified safe route."): OutcomeRecord {
+  return {
+    recordId: `record:${outcomeId}:v1`,
+    links: {
+      inputContextId: `input:${outcomeId}:v1`,
+      executionTraceId: `trace:${outcomeId}:v1`,
+      verifiedOutputId: `verified:${outcomeId}:v1`,
+      retrospectiveId: `retrospective:${outcomeId}:v1`,
+      contractId: `${outcomeId}:v1`,
+      contractVersion: 1,
+      workIds: [`work:${outcomeId}`],
+      evidenceIds: [`evidence:${outcomeId}`],
+    },
+    inputContext: {
+      id: `input:${outcomeId}:v1`,
+      outcomeId,
+      contractId: `${outcomeId}:v1`,
+      contractVersion: 1,
+      contextRefs: ["context:fixture"],
+      evidenceRefs: [`evidence:${outcomeId}`],
+      presumedOutcome: "A verified result",
+      presumedOutcomeHash: "a".repeat(64),
+    },
+    executionTrace: {
+      id: `trace:${outcomeId}:v1`,
+      outcomeId,
+      contractId: `${outcomeId}:v1`,
+      contractVersion: 1,
+      traceIdentity: `trace-identity:${outcomeId}`,
+      complete: true,
+      entries: [{ seq: 1, at: 1_000, phase: "verification", action: "verified-output", refs: [`evidence:${outcomeId}`], detail: statement }],
+    },
+    verifiedOutput: {
+      id: `verified:${outcomeId}:v1`,
+      outcomeId,
+      contractId: `${outcomeId}:v1`,
+      contractVersion: 1,
+      traceIdentity: `trace-identity:${outcomeId}`,
+      status: "independently-verified",
+      evidenceRefs: [`evidence:${outcomeId}`],
+      artifactRefs: [`artifact:${outcomeId}`],
+      criteriaHash: "b".repeat(64),
+      verifiedAt: 2_000,
+      usage: { costCents: 4, units: 2 },
+    },
+    retrospective: {
+      id: `retrospective:${outcomeId}:v1`,
+      outcomeId,
+      contractId: `${outcomeId}:v1`,
+      contractVersion: 1,
+      traceIdentity: `trace-identity:${outcomeId}`,
+      metrics: [],
+      alternatives: [{ id: "route:known-safe", statement, evidenceRefs: [`trace:${outcomeId}:v1`], selected: false }],
+      learnings: [{ id: `learning:${outcomeId}:v1`, statement, boundedEffect: "routing-only", evidenceRefs: [`trace:${outcomeId}:v1`] }],
+      trusted: true,
+    },
+  };
+}
+
+describe("execution learning seam", () => {
+  it("persists only verified records, keeps retrospective values typed, and changes routing only", () => {
+    const directory = mkdtempSync(join(tmpdir(), "centipede-learning-"));
+    directories.push(directory);
+    const learning = createExecutionLearning({ file: join(directory, "learning.json") });
+
+    expect(learning.record(record("first"))).toBe(true);
+    const review = learning.review("first");
+    expect(review?.trusted).toBe(true);
+    expect(review?.metrics.every((metric: RetrospectiveReview["metrics"][number]) => ["measured", "derived", "unknown", "not-applicable"].includes(metric.value.status))).toBe(true);
+    expect(review?.metrics.find((metric) => metric.name === "aws")?.value.status).toBe("unknown");
+    expect(learning.chooseRoute({ outcomeId: "later", taskId: "task-1", candidates: ["default", "known-safe"] })).toEqual("known-safe");
+    const restarted = createExecutionLearning({ file: join(directory, "learning.json") });
+    expect(restarted.review("first")).toEqual(review);
+    expect(restarted.chooseRoute({ outcomeId: "later", taskId: "task-1", candidates: ["default", "known-safe"] })).toBe("known-safe");
+    expect(JSON.stringify(JSON.parse(readFileSync(join(directory, "learning.json"), "utf8")))).not.toContain("password");
+  });
+});

--- a/server/execution-learning.ts
+++ b/server/execution-learning.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-unsafe-dictionary-type,
+ * anti-slop/no-runtime-typeof -- the learning journal is an external JSON
+ * boundary; every value is checked before it becomes a domain record. */
+
+export type TelemetryValue =
+  | { readonly status: "measured"; readonly value: number }
+  | { readonly status: "derived"; readonly value: number; readonly from: readonly string[] }
+  | { readonly status: "unknown"; readonly reason: string }
+  | { readonly status: "not-applicable"; readonly reason: string };
+
+export interface RetrospectiveMetric {
+  readonly name: string;
+  readonly value: TelemetryValue;
+}
+
+export interface ExecutionTraceEntry {
+  readonly seq: number;
+  readonly at: number;
+  readonly phase: "intake" | "judgment" | "planning" | "execution" | "verification" | "terminal";
+  readonly action: string;
+  readonly refs: readonly string[];
+  readonly detail?: string;
+}
+
+export interface ExecutionTrace {
+  readonly id: string;
+  readonly outcomeId: string;
+  readonly contractId: string;
+  readonly contractVersion: number;
+  readonly traceIdentity: string;
+  readonly complete: true;
+  readonly entries: readonly ExecutionTraceEntry[];
+}
+
+export interface InputContextBasis {
+  readonly id: string;
+  readonly outcomeId: string;
+  readonly contractId: string;
+  readonly contractVersion: number;
+  readonly contextRefs: readonly string[];
+  readonly evidenceRefs: readonly string[];
+  readonly presumedOutcome: string;
+  readonly presumedOutcomeHash: string;
+}
+
+export interface VerifiedOutputRecord {
+  readonly id: string;
+  readonly outcomeId: string;
+  readonly contractId: string;
+  readonly contractVersion: number;
+  readonly traceIdentity: string;
+  readonly status: "independently-verified";
+  readonly evidenceRefs: readonly string[];
+  readonly artifactRefs: readonly string[];
+  readonly criteriaHash: string;
+  readonly verifiedAt: number;
+  readonly usage: { readonly costCents: number; readonly units: number };
+}
+
+export interface RetrospectiveAlternative {
+  readonly id: string;
+  readonly statement: string;
+  readonly evidenceRefs: readonly string[];
+  readonly selected: boolean;
+}
+
+export interface RetrospectiveLearning {
+  readonly id: string;
+  readonly statement: string;
+  readonly boundedEffect: "routing-only";
+  readonly evidenceRefs: readonly string[];
+}
+
+export interface RetrospectiveReview {
+  readonly id: string;
+  readonly outcomeId: string;
+  readonly contractId: string;
+  readonly contractVersion: number;
+  readonly traceIdentity: string;
+  readonly metrics: readonly RetrospectiveMetric[];
+  readonly alternatives: readonly RetrospectiveAlternative[];
+  readonly learnings: readonly RetrospectiveLearning[];
+  readonly trusted: boolean;
+}
+
+export interface OutcomeRecord {
+  readonly recordId: string;
+  readonly links: {
+    readonly inputContextId: string;
+    readonly executionTraceId: string;
+    readonly verifiedOutputId: string;
+    readonly retrospectiveId: string;
+    readonly contractId: string;
+    readonly contractVersion: number;
+    readonly workIds: readonly string[];
+    readonly evidenceIds: readonly string[];
+  };
+  readonly inputContext: InputContextBasis;
+  readonly executionTrace: ExecutionTrace;
+  readonly verifiedOutput: VerifiedOutputRecord;
+  readonly retrospective: RetrospectiveReview;
+}
+
+export interface OutcomeRecordInput {
+  readonly outcomeId: string;
+  readonly contractId: string;
+  readonly contractVersion: number;
+  readonly objective: string;
+  readonly contextRefs: readonly string[];
+  readonly evidenceRefs: readonly string[];
+  readonly evidenceIds: readonly string[];
+  readonly workIds: readonly string[];
+  readonly traceEntries: readonly ExecutionTraceEntry[];
+  readonly criteriaHash: string;
+  readonly artifactRefs: readonly string[];
+  readonly verifiedAt: number;
+  readonly usage: { readonly costCents: number; readonly units: number };
+  readonly startedAt: number | null;
+  readonly needsYouTouches: number;
+  readonly requiredContextCount: number;
+  readonly coveredContextCount: number;
+}
+
+export interface OutcomeLearning {
+  record(record: OutcomeRecord): boolean;
+  review(outcomeId: string): RetrospectiveReview | null;
+  chooseRoute(input: { readonly outcomeId: string; readonly taskId: string; readonly candidates: readonly string[] }): string | null;
+}
+
+export interface ExecutionLearningOptions {
+  readonly file: string;
+}
+
+const HASH_LENGTH = 64;
+
+function hash(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function redactText(value: string): string {
+  return value.replace(/\b(password|passwd|secret|token|api[_-]?key|authorization|bearer)\b\s*[:=]\s*[^\s,;]+/gi, "$1=[redacted]");
+}
+
+export function redactEvidenceReference(value: string): string {
+  return redactText(value).replace(/([?&](?:password|passwd|secret|token|api[_-]?key|authorization|code)=)[^&\s]+/gi, "$1[redacted]");
+}
+
+function metric(name: string, value: TelemetryValue): RetrospectiveMetric {
+  return { name, value };
+}
+
+function reviewFor(input: OutcomeRecordInput, traceIdentity: string, retrospectiveId: string): RetrospectiveReview {
+  const latency: TelemetryValue = input.startedAt === null ? { status: "unknown", reason: "execution start was not observed" } : { status: "derived", value: Math.max(0, input.verifiedAt - input.startedAt), from: ["execution-start", "verified-output"] };
+  const contextCoverage: TelemetryValue = input.requiredContextCount === 0
+    ? { status: "not-applicable", reason: "the outcome declared no required context references" }
+    : { status: "derived", value: input.coveredContextCount / input.requiredContextCount, from: ["input-context", "evidence"] };
+  return {
+    id: retrospectiveId,
+    outcomeId: input.outcomeId,
+    contractId: input.contractId,
+    contractVersion: input.contractVersion,
+    traceIdentity,
+    metrics: [
+      metric("correctness-quality", { status: "measured", value: 1 }),
+      metric("latency-ms", latency),
+      metric("cost-cents", { status: "measured", value: input.usage.costCents }),
+      metric("execution-units", { status: "measured", value: input.usage.units }),
+      metric("shane-touches", { status: "derived", value: input.needsYouTouches, from: ["needs-you-answers"] }),
+      metric("aws", { status: "unknown", reason: "AWS spend telemetry is not available at this seam" }),
+      metric("unnecessary-interruption", { status: "unknown", reason: "interruption intent is not observable at this seam" }),
+      metric("risk-reversibility", { status: "unknown", reason: "reversibility evidence was not supplied" }),
+      metric("context-coverage", contextCoverage),
+      metric("retry-recovery-efficiency", { status: "unknown", reason: "retry and recovery telemetry was not supplied" }),
+    ],
+    alternatives: [{
+      id: "route:known-safe",
+      statement: "A previously verified safe route could reduce routing uncertainty on a later equivalent outcome.",
+      evidenceRefs: [`trace:${input.outcomeId}:v${input.contractVersion}`],
+      selected: false,
+    }],
+    learnings: [{
+      id: `learning:${input.outcomeId}:v${input.contractVersion}`,
+      statement: "For a later equivalent outcome, prefer a previously verified safe route when it is available; this does not change judgment, authority, approval, or verification.",
+      boundedEffect: "routing-only",
+      evidenceRefs: [`trace:${input.outcomeId}:v${input.contractVersion}`],
+    }],
+    trusted: true,
+  };
+}
+
+export function traceIdentity(input: Pick<OutcomeRecordInput, "contractId" | "contractVersion" | "workIds" | "evidenceRefs" | "criteriaHash">): string {
+  return hash(stableJson({ contractId: input.contractId, contractVersion: input.contractVersion, workIds: input.workIds, evidenceRefs: input.evidenceRefs, criteriaHash: input.criteriaHash }));
+}
+
+export function buildOutcomeRecord(input: OutcomeRecordInput): OutcomeRecord {
+  const inputContextId = `input:${input.outcomeId}:v${input.contractVersion}`;
+  const executionTraceId = `trace:${input.outcomeId}:v${input.contractVersion}`;
+  const verifiedOutputId = `verified:${input.outcomeId}:v${input.contractVersion}`;
+  const retrospectiveId = `retrospective:${input.outcomeId}:v${input.contractVersion}`;
+  const identity = traceIdentity(input);
+  const trace: ExecutionTrace = {
+    id: executionTraceId,
+    outcomeId: input.outcomeId,
+    contractId: input.contractId,
+    contractVersion: input.contractVersion,
+    traceIdentity: identity,
+    complete: true,
+    entries: input.traceEntries,
+  };
+  const verifiedOutput: VerifiedOutputRecord = {
+    id: verifiedOutputId,
+    outcomeId: input.outcomeId,
+    contractId: input.contractId,
+    contractVersion: input.contractVersion,
+    traceIdentity: identity,
+    status: "independently-verified",
+    evidenceRefs: input.evidenceRefs.map(redactEvidenceReference),
+    artifactRefs: input.artifactRefs.map(redactEvidenceReference),
+    criteriaHash: input.criteriaHash,
+    verifiedAt: input.verifiedAt,
+    usage: input.usage,
+  };
+  return {
+    recordId: `record:${input.outcomeId}:v${input.contractVersion}`,
+    links: {
+      inputContextId,
+      executionTraceId,
+      verifiedOutputId,
+      retrospectiveId,
+      contractId: input.contractId,
+      contractVersion: input.contractVersion,
+      workIds: input.workIds,
+      evidenceIds: input.evidenceIds,
+    },
+    inputContext: {
+      id: inputContextId,
+      outcomeId: input.outcomeId,
+      contractId: input.contractId,
+      contractVersion: input.contractVersion,
+      contextRefs: input.contextRefs.map(redactEvidenceReference),
+      evidenceRefs: input.evidenceRefs.map(redactEvidenceReference),
+      presumedOutcome: redactText(input.objective),
+      presumedOutcomeHash: hash(input.objective),
+    },
+    executionTrace: trace,
+    verifiedOutput,
+    retrospective: reviewFor(input, identity, retrospectiveId),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isOutcomeRecord(value: unknown): value is OutcomeRecord {
+  if (!isRecord(value) || typeof value.recordId !== "string" || !isRecord(value.links) || !isRecord(value.inputContext) || !isRecord(value.executionTrace) || !isRecord(value.verifiedOutput) || !isRecord(value.retrospective)) return false;
+  return value.retrospective.trusted === true && value.verifiedOutput.status === "independently-verified" && value.executionTrace.complete === true && typeof value.executionTrace.traceIdentity === "string";
+}
+
+function loadRecords(file: string): readonly OutcomeRecord[] {
+  if (!existsSync(file)) return [];
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!isRecord(parsed) || !Array.isArray(parsed.records)) return [];
+    return parsed.records.filter(isOutcomeRecord);
+  } catch {
+    return [];
+  }
+}
+
+function saveRecords(file: string, records: readonly OutcomeRecord[]): void {
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+  writeFileSync(file, JSON.stringify({ records }), { encoding: "utf8", mode: 0o600 });
+}
+
+function hasRoutingLearning(record: OutcomeRecord): boolean {
+  return record.retrospective.trusted && record.retrospective.learnings.some((learning) => learning.boundedEffect === "routing-only");
+}
+
+function normaliseRetrospective(review: RetrospectiveReview): RetrospectiveReview {
+  const requiredUnknowns: readonly RetrospectiveMetric[] = [
+    metric("aws", { status: "unknown", reason: "AWS spend telemetry is not available at this seam" }),
+    metric("unnecessary-interruption", { status: "unknown", reason: "interruption intent is not observable at this seam" }),
+    metric("risk-reversibility", { status: "unknown", reason: "reversibility evidence was not supplied" }),
+    metric("retry-recovery-efficiency", { status: "unknown", reason: "retry and recovery telemetry was not supplied" }),
+  ];
+  const names = new Set(review.metrics.map((candidate) => candidate.name));
+  return { ...review, metrics: [...review.metrics, ...requiredUnknowns.filter((candidate) => !names.has(candidate.name))] };
+}
+
+export function createExecutionLearning(options: ExecutionLearningOptions): OutcomeLearning {
+  let records = loadRecords(options.file).map((record) => ({ ...record, retrospective: normaliseRetrospective(record.retrospective) }));
+  return {
+    record(record): boolean {
+      if (!isOutcomeRecord(record) || record.links.contractId !== record.inputContext.contractId || record.links.contractVersion !== record.inputContext.contractVersion || record.links.executionTraceId !== record.executionTrace.id || record.links.verifiedOutputId !== record.verifiedOutput.id || record.links.retrospectiveId !== record.retrospective.id || record.executionTrace.traceIdentity !== record.verifiedOutput.traceIdentity || record.retrospective.traceIdentity !== record.executionTrace.traceIdentity) return false;
+      const normalised = { ...record, retrospective: normaliseRetrospective(record.retrospective) };
+      const existing = records.find((candidate) => candidate.recordId === record.recordId);
+      if (existing) return stableJson(existing) === stableJson(normalised);
+      records = [...records, normalised];
+      saveRecords(options.file, records);
+      return true;
+    },
+    review(outcomeId): RetrospectiveReview | null {
+      return records.find((record) => record.links.contractId.startsWith(`${outcomeId}:`) || record.inputContext.outcomeId === outcomeId)?.retrospective ?? null;
+    },
+    chooseRoute(input): string | null {
+      const safe = input.candidates.find((candidate) => candidate === "known-safe");
+      return safe && records.some(hasRoutingLearning) ? safe : input.candidates[0] ?? null;
+    },
+  };
+}
+
+export const EXECUTION_LEARNING_HASH_LENGTH = HASH_LENGTH;

--- a/server/index.ts
+++ b/server/index.ts
@@ -145,6 +145,7 @@ import { loadBundledSkills, loadUserSkills, mergeSkills, renderSkillInstructions
 import { installedPlaybookInstructions } from "./installed-playbooks.ts";
 import { createBotPackageExport } from "./package-export.ts";
 import { shouldMountLocalComputer } from "./local-routing.ts";
+import { createCentipedeV3Runtime, type CentipedeV3Runtime } from "./centipede-v3-runtime.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
@@ -166,6 +167,10 @@ const registry = new ProviderRegistry(BUILT_IN_DRIVERS);
 await registry.load(instanceConfigs(cfg));
 const bundledSkills = loadBundledSkills();
 const availableSkills = () => mergeSkills(bundledSkills, loadUserSkills(join(DATA_DIR, "skills")));
+const centipedeV3: CentipedeV3Runtime | null =
+  process.env.OMB_PRODUCT_ID === "centipede-v3"
+    ? createCentipedeV3Runtime({ dataDir: DATA_DIR })
+    : null;
 
 // Electron's utility-process parent port is private to the desktop main
 // process. It lets a slow first-time managed Composio registration arrive
@@ -2718,6 +2723,22 @@ const server = createServer(async (req, res) => {
       return json(res, 403, { error: "forbidden: cross-origin request" });
     }
     // ── internal peer-agent comms (localhost + shared token only) ──────
+    if (centipedeV3 && method === "GET" && path === "/api/v3/context") {
+      return json(res, 200, centipedeV3.inspectContext());
+    }
+    if (centipedeV3 && method === "GET" && path.startsWith("/api/v3/outcomes/")) {
+      const outcomeId = decodeURIComponent(path.slice("/api/v3/outcomes/".length));
+      const projection = centipedeV3.inspectOutcome(outcomeId);
+      return projection ? json(res, 200, projection) : json(res, 404, { error: "no such outcome" });
+    }
+    if (centipedeV3 && method === "GET" && path.startsWith("/api/v3/receipts/")) {
+      const outcomeId = decodeURIComponent(path.slice("/api/v3/receipts/".length));
+      const receipt = centipedeV3.inspectOutcomeReceipt(outcomeId);
+      return receipt ? json(res, 200, receipt) : json(res, 404, { error: "no verified receipt" });
+    }
+    if (centipedeV3 && method === "POST" && path === "/api/v3/commands") {
+      return json(res, 200, await centipedeV3.dispatch(await readBody(req)));
+    }
     // The agents-proxy (spawned inside a bot's agent process) calls these to
     // discover peers and hand a message to one. Not part of the public API.
     if (path.startsWith("/api/internal/")) {
@@ -4716,7 +4737,7 @@ const server = createServer(async (req, res) => {
     // child proves it is OURS by echoing its pid (a stray dev server has
     // the same API shape but a different pid)
     if (method === "GET" && path === "/api/health") {
-      return json(res, 200, { app: "openmausbot", pid: process.pid, static: Boolean(STATIC_DIR) });
+      return json(res, 200, { app: process.env.OMB_PRODUCT_ID === "centipede-v3" ? "Centipede V3" : "openmausbot", pid: process.pid, static: Boolean(STATIC_DIR) });
     }
 
     // ── inspector: a thread's runtime events + native protocol tee ──

--- a/server/outcome-orchestrator.test.ts
+++ b/server/outcome-orchestrator.test.ts
@@ -1,0 +1,476 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type {
+  ContractualJudgment,
+  CaptureOutcomeInference,
+  OutcomeJudgment,
+  ExistingWorkOrchestrator,
+  OutcomeContract,
+  OutcomeEvidence,
+  OutcomeVerifier,
+} from "./outcome-orchestrator.ts";
+import { createOutcomeOrchestrator, projectOutcome } from "./outcome-orchestrator.ts";
+import type { OutcomeLearning, OutcomeRecord } from "./execution-learning.ts";
+
+/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-unknown-returns,
+ * anti-slop/no-runtime-typeof, anti-slop/no-known-value-widening -- this fake
+ * deliberately exercises the existing unknown V2 seam. */
+
+class FakeWork implements ExistingWorkOrchestrator {
+  readonly ingested = new Map<string, string>();
+  readonly executions: string[] = [];
+  reconcileStatus: "verified" | "awaiting_worker" | "not_verified" = "verified";
+  executeStatus: "dispatched" | "ambiguous" = "dispatched";
+
+  ingest(event: unknown): unknown {
+    if (typeof event !== "object" || event === null || Array.isArray(event) || !("externalId" in event) || typeof event.externalId !== "string") return { status: "denied" };
+    const existing = this.ingested.get(event.externalId);
+    if (existing) return { status: "unchanged", workId: existing };
+    const workId = `work-${this.ingested.size + 1}`;
+    this.ingested.set(event.externalId, workId);
+    return { status: "created", phase: "ingested", workId };
+  }
+
+  prepare(workId: string): unknown { return { status: "not_ready", workId }; }
+  decide(input: unknown): unknown { return { status: "denied", input }; }
+
+  async execute(workId: string): Promise<unknown> {
+    this.executions.push(workId);
+    return { status: this.executeStatus };
+  }
+
+  async reconcile(workId: string): Promise<unknown> {
+    return { status: this.reconcileStatus, workId };
+  }
+}
+
+class FakeVerifier implements OutcomeVerifier {
+  stale = false;
+  calls: number = 0;
+
+  async verify(input: Parameters<OutcomeVerifier["verify"]>[0]): Promise<unknown> {
+    this.calls += 1;
+    return {
+      status: "verified",
+      contractId: this.stale ? "old-contract" : input.contract.id,
+      contractVersion: input.contract.version,
+      criteriaHash: input.criteriaHash,
+      traceIdentity: input.traceIdentity,
+      evidenceRefs: input.evidence.map((evidence) => evidence.reference),
+      artifactRefs: input.artifacts.map((artifact) => artifact.reference),
+      usage: { costCents: 2, units: 1 },
+    };
+  }
+}
+
+class FakeCaptureInference implements CaptureOutcomeInference {
+  calls = 0;
+  constructor(private readonly inferredContract: OutcomeContract = contract({
+    id: "receipt-1:v1",
+    outcomeId: "receipt-1",
+    objective: "Collect the requested receipt",
+    plan: [{ ...contract().plan[0], needsYou: null }],
+  })) {}
+
+  async infer(): Promise<unknown> {
+    this.calls += 1;
+    return {
+      status: "inferred",
+      contract: this.inferredContract,
+    };
+  }
+}
+
+class AmbiguousCaptureInference implements CaptureOutcomeInference {
+  async infer(): Promise<unknown> {
+    return { status: "ambiguous", reason: "The evidence could describe more than one outcome." };
+  }
+}
+
+class FakeJudgment implements ContractualJudgment {
+  readonly colors: string[] = [];
+  constructor(private readonly verdict: OutcomeJudgment = { color: "green" }) {}
+
+  async judge(): Promise<unknown> {
+    this.colors.push(this.verdict.color);
+    return this.verdict;
+  }
+}
+
+class FakeLearning implements OutcomeLearning {
+  readonly records: OutcomeRecord[] = [];
+
+  record(record: OutcomeRecord): boolean {
+    this.records.push(record);
+    return true;
+  }
+
+  review(): null { return null; }
+
+  chooseRoute(input: { readonly outcomeId: string; readonly taskId: string; readonly candidates: readonly string[] }): string | null {
+    return input.candidates[1] ?? input.candidates[0] ?? null;
+  }
+}
+
+const temporaryDirectories: string[] = [];
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function harness(options: { now?: () => number; inference?: CaptureOutcomeInference; judgment?: ContractualJudgment; learning?: OutcomeLearning } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "openmausbot-v3-outcome-"));
+  temporaryDirectories.push(directory);
+  const work = new FakeWork();
+  const verifier = new FakeVerifier();
+  const journalFile = join(directory, "outcomes.json");
+  const create = () => createOutcomeOrchestrator({ journalFile, work, verifier, captureInference: options.inference, judgment: options.judgment, learning: options.learning, now: options.now });
+  return { directory, journalFile, work, verifier, create };
+}
+
+function contract(overrides: Partial<OutcomeContract> = {}): OutcomeContract {
+  return {
+    id: "outcome-1:v1",
+    outcomeId: "outcome-1",
+    version: 1,
+    ownerId: "shane",
+    objective: "Produce the internal dogfood receipt",
+    constraints: [{ kind: "scope", statement: "Use only local reversible work" }],
+    successCriteria: [{ id: "receipt", statement: "A receipt names the verified artifact" }],
+    deadline: { at: 2_000 },
+    budget: { currency: "USD", maxCostCents: 10, maxUnits: 4 },
+    qualityBar: "Exact contract binding and independently checked evidence",
+    authority: { mode: "deny-by-default", grants: [] },
+    escalation: { channel: "needs-you", on: ["missing-input", "authority-required"] },
+    evidenceRequirements: { requiredCriterionIds: ["receipt"], requiredArtifactKinds: ["receipt"] },
+    rollback: { onCancel: "reversible-stop", onFailure: "stop" },
+    plan: [{ id: "produce", label: "Produce receipt", prompt: "Write the local receipt", resumePolicy: "never", dependsOn: [], needsYou: { inputKey: "quality", question: "Which quality bar should the dogfood receipt use?", choices: ["Exact", "Concise"] }, requiredAuthority: null, estimatedCostCents: 2, estimatedUnits: 1 }],
+    ...overrides,
+  };
+}
+
+function evidence(): OutcomeEvidence {
+  return {
+    outcomeId: "outcome-1",
+    contractVersion: 1,
+    evidenceId: "evidence-1",
+    reference: "local:receipt-1",
+    summary: "The local dogfood artifact contains the requested receipt.",
+    contentHash: "a".repeat(64),
+    criterionIds: ["receipt"],
+    artifacts: [{ reference: "local:artifact-1", kind: "receipt", contentHash: "b".repeat(64) }],
+    recordedAt: 1_000,
+  };
+}
+
+describe("OutcomeOrchestrator", () => {
+  it("infers a high-confidence Capture into a canonical outcome through contractual judgment", async () => {
+    const judgment = new FakeJudgment();
+    const h = harness({ now: () => 1_000, inference: new FakeCaptureInference(), judgment });
+    const orchestrator = h.create();
+    await expect(orchestrator.dispatch({
+      kind: "capture",
+      evidence: {
+        captureId: "capture-1",
+        source: "gmail",
+        reference: "gmail:message-1",
+        summary: "The requested receipt is ready to collect.",
+        contentHash: "c".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-1", kind: "receipt", contentHash: "d".repeat(64) }],
+        observedAt: 1_000,
+      },
+    })).resolves.toMatchObject({
+      status: "ok",
+      view: { state: "running", contract: { outcomeId: "receipt-1" }, work: [{ status: "verified" }] },
+    });
+    expect(judgment.colors).toEqual(["green"]);
+    expect(h.work.executions).toEqual(["work-1"]);
+  });
+
+  it("deduplicates replayed Capture evidence and links it to the existing outcome", async () => {
+    const inference = new FakeCaptureInference();
+    const judgment = new FakeJudgment();
+    const h = harness({ now: () => 1_000, inference, judgment });
+    const capture = {
+      kind: "capture",
+      evidence: {
+        captureId: "capture-replayed",
+        source: "gmail",
+        reference: "gmail:message-replayed",
+        summary: "The requested receipt is ready to collect.",
+        contentHash: "e".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-replayed", kind: "receipt", contentHash: "f".repeat(64) }],
+        observedAt: 1_000,
+      },
+    };
+    const orchestrator = h.create();
+    await expect(orchestrator.dispatch(capture)).resolves.toMatchObject({ status: "ok", view: { contract: { outcomeId: "receipt-1" } } });
+    await expect(orchestrator.dispatch(capture)).resolves.toMatchObject({ status: "ok", view: { contract: { outcomeId: "receipt-1" }, evidence: [{ evidenceId: "capture:capture-replayed" }] } });
+    const restarted = h.create();
+    await expect(restarted.dispatch(capture)).resolves.toMatchObject({ status: "ok", view: { contract: { outcomeId: "receipt-1" } } });
+    const inspected = restarted.inspect("receipt-1");
+    if (inspected.status !== "available") throw new Error("expected the inferred outcome after replay");
+    expect(inspected.view.evidence).toHaveLength(1);
+    expect(inference.calls).toBe(1);
+    expect(judgment.colors).toEqual(["green"]);
+    expect(h.work.executions).toEqual(["work-1"]);
+  });
+
+  it("keeps a yellow Capture as durable Needs-you input without executing Work", async () => {
+    const judgment = new FakeJudgment({ color: "yellow", input: { inputKey: "recipient", question: "Which recipient should receive the receipt?", choices: ["Shane", "Team"] } });
+    const h = harness({ now: () => 1_000, inference: new FakeCaptureInference(), judgment });
+    const orchestrator = h.create();
+    await expect(orchestrator.dispatch({
+      kind: "capture",
+      evidence: {
+        captureId: "capture-yellow",
+        source: "gmail",
+        reference: "gmail:message-yellow",
+        summary: "A receipt is ready, but its recipient is unclear.",
+        contentHash: "1".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-yellow", kind: "receipt", contentHash: "2".repeat(64) }],
+        observedAt: 1_000,
+      },
+    })).resolves.toMatchObject({ status: "needs_you", view: { state: "needs-you" }, input: { inputKey: "recipient" } });
+    expect(h.work.executions).toEqual([]);
+    const restarted = h.create();
+    expect(restarted.inspect("receipt-1")).toMatchObject({ status: "available", view: { state: "needs-you", judgment: { color: "yellow" } } });
+    await expect(restarted.dispatch({ kind: "answer-needs-you", outcomeId: "receipt-1", contractVersion: 1, inputKey: "recipient", answer: "Shane", answeredBy: "Shane" })).resolves.toMatchObject({ status: "ok", view: { state: "running" } });
+    expect(h.work.executions).toEqual([]);
+  });
+
+  it("parks a red Capture judgment and never executes Work", async () => {
+    const judgment = new FakeJudgment({ color: "red", reason: "The inferred action is outside the contract authority." });
+    const h = harness({ now: () => 1_000, inference: new FakeCaptureInference(), judgment });
+    const orchestrator = h.create();
+    await expect(orchestrator.dispatch({
+      kind: "capture",
+      evidence: {
+        captureId: "capture-red",
+        source: "gmail",
+        reference: "gmail:message-red",
+        summary: "A receipt suggests an action outside the allowed scope.",
+        contentHash: "3".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-red", kind: "receipt", contentHash: "4".repeat(64) }],
+        observedAt: 1_000,
+      },
+    })).resolves.toMatchObject({ status: "blocked", reason: "judgment_red", view: { state: "running", judgment: { color: "red" } } });
+    expect(h.work.executions).toEqual([]);
+    const restarted = h.create();
+    expect(restarted.inspect("receipt-1")).toMatchObject({ status: "available", view: { state: "running", judgment: { color: "red", reason: "The inferred action is outside the contract authority." } } });
+  });
+
+  it("does not let green bypass a missing contract authority grant", async () => {
+    const inferredContract = contract({
+      id: "restricted-1:v1",
+      outcomeId: "restricted-1",
+      plan: [{ ...contract().plan[0], needsYou: null, requiredAuthority: { action: "publish", target: "prod", scope: "release", expiresAt: 2_000 } }],
+    });
+    const h = harness({ now: () => 1_000, inference: new FakeCaptureInference(inferredContract), judgment: new FakeJudgment() });
+    await expect(h.create().dispatch({
+      kind: "capture",
+      evidence: {
+        captureId: "capture-authority",
+        source: "gmail",
+        reference: "gmail:message-authority",
+        summary: "A receipt suggests publishing to production.",
+        contentHash: "5".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-authority", kind: "receipt", contentHash: "6".repeat(64) }],
+        observedAt: 1_000,
+      },
+    })).resolves.toMatchObject({ status: "blocked", reason: "authority_denied", view: { state: "failed", judgment: { color: "green" } } });
+    expect(h.work.executions).toEqual([]);
+  });
+
+  it("fails ambiguous Capture safely without inventing an outcome or asking Shane", async () => {
+    const judgment = new FakeJudgment();
+    const h = harness({ now: () => 1_000, inference: new AmbiguousCaptureInference(), judgment });
+    await expect(h.create().dispatch({
+      kind: "capture",
+      evidence: {
+        captureId: "capture-ambiguous",
+        source: "gmail",
+        reference: "gmail:message-ambiguous",
+        summary: "Several unrelated threads mention a receipt.",
+        contentHash: "7".repeat(64),
+        confidence: "high",
+        criterionIds: ["receipt"],
+        artifacts: [{ reference: "gmail:receipt-ambiguous", kind: "receipt", contentHash: "8".repeat(64) }],
+        observedAt: 1_000,
+      },
+    })).resolves.toEqual({ status: "blocked", reason: "capture_ambiguous" });
+    expect(h.create().inspect("receipt-1")).toEqual({ status: "missing" });
+    expect(judgment.colors).toEqual([]);
+    expect(h.work.executions).toEqual([]);
+  });
+
+  it("creates, accepts, pauses, resumes, executes, verifies, and replays one outcome", async () => {
+    const h = harness({ now: () => 1_000 });
+    const first = h.create();
+    await expect(first.dispatch({ kind: "declare", contract: contract() })).resolves.toMatchObject({ status: "ok", view: { state: "declared" } });
+    await expect(first.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 2 })).resolves.toMatchObject({ status: "denied", reason: "contract_version_mismatch_or_missing" });
+    await expect(first.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "ok", view: { state: "accepted", work: [{ workId: "work-1" }] } });
+
+    const restarted = h.create();
+    await expect(restarted.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "needs_you", input: { inputKey: "quality" } });
+    await expect(restarted.dispatch({ kind: "answer-needs-you", outcomeId: "outcome-1", contractVersion: 1, inputKey: "quality", answer: "password=never-store-this", answeredBy: "Shane" })).resolves.toMatchObject({ status: "ok", view: { state: "running" } });
+    expect(readFileSync(h.journalFile, "utf8")).not.toContain("never-store-this");
+    await expect(restarted.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "ok", view: { state: "running", work: [{ status: "verified" }] } });
+    await expect(restarted.dispatch({ kind: "record-evidence", evidence: evidence() })).resolves.toMatchObject({ status: "ok" });
+    const verified = await restarted.dispatch({ kind: "verify", outcomeId: "outcome-1", contractVersion: 1 });
+    expect(verified).toMatchObject({ status: "ok", view: { state: "completed", receipt: { kind: "outcome-completed", contractVersion: 1 } } });
+    if (verified.status !== "ok" || !verified.receipt) throw new Error("expected a verified receipt");
+    expect(verified.receipt.record.links).toMatchObject({ contractId: "outcome-1:v1", contractVersion: 1, workIds: ["work-1"], evidenceIds: ["evidence-1"] });
+    expect(verified.receipt.record.executionTrace.complete).toBe(true);
+    expect(verified.receipt.record.executionTrace.traceIdentity).toBe(verified.receipt.record.verifiedOutput.traceIdentity);
+    expect(verified.receipt.record.executionTrace.traceIdentity).toBe(verified.receipt.record.retrospective.traceIdentity);
+    expect(verified.receipt.record.retrospective.metrics.find((metric) => metric.name === "aws")?.value.status).toBe("unknown");
+
+    const replayed = h.create();
+    expect(replayed.inspect("outcome-1")).toMatchObject({ status: "available", view: { state: "completed" } });
+    const inspected = replayed.inspect("outcome-1");
+    if (inspected.status !== "available" || inspected.view.state !== "completed") throw new Error("expected the completed receipt after restart");
+    expect(inspected.view.receipt).toEqual(verified.receipt);
+    await expect(replayed.dispatch({ kind: "verify", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "denied", reason: "outcome_not_ready" });
+    expect(h.work.executions).toEqual(["work-1"]);
+    expect(h.verifier.calls).toBe(1);
+  });
+
+  it("rejects stale or conflicting evidence and stale verifier output", async () => {
+    const h = harness({ now: () => 1_000 });
+    const orchestrator = h.create();
+    await orchestrator.dispatch({ kind: "declare", contract: contract({ plan: [{ ...contract().plan[0], needsYou: null }] }) });
+    await orchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await orchestrator.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 });
+    await orchestrator.dispatch({ kind: "record-evidence", evidence: evidence() });
+    await expect(orchestrator.dispatch({ kind: "record-evidence", evidence: { ...evidence(), summary: "conflicting" } })).resolves.toMatchObject({ status: "denied", reason: "evidence_conflict" });
+    h.verifier.stale = true;
+    await expect(orchestrator.dispatch({ kind: "verify", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "stale_verifier" });
+    expect(orchestrator.inspect("outcome-1")).toMatchObject({ status: "available", view: { state: "verifying" } });
+  });
+
+  it("fails closed for authority, budget, deadline, partial work, and ambiguous execution", async () => {
+    const authority = harness({ now: () => 1_000 });
+    const restricted = authority.create();
+    const restrictedContract = contract({ plan: [{ ...contract().plan[0], needsYou: null, requiredAuthority: { action: "publish", target: "prod", scope: "release", expiresAt: 2_000 } }] });
+    await restricted.dispatch({ kind: "declare", contract: restrictedContract });
+    await restricted.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await expect(restricted.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "authority_denied" });
+
+    const budget = harness({ now: () => 1_000 });
+    const overBudget = budget.create();
+    await overBudget.dispatch({ kind: "declare", contract: contract({ budget: { currency: "USD", maxCostCents: 1, maxUnits: 1 }, plan: [{ ...contract().plan[0], needsYou: null }] }) });
+    await overBudget.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await expect(overBudget.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "budget_breached" });
+
+    const deadline = harness({ now: () => 3_000 });
+    const expired = deadline.create();
+    await expired.dispatch({ kind: "declare", contract: contract({ plan: [{ ...contract().plan[0], needsYou: null }] }) });
+    await expired.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await expect(expired.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "deadline_breached" });
+
+    const partial = harness({ now: () => 1_000 });
+    const partialOrchestrator = partial.create();
+    const twoTasks = contract({ plan: [
+      { ...contract().plan[0], needsYou: null },
+      { ...contract().plan[0], id: "second", label: "Second", needsYou: null },
+    ] });
+    await partialOrchestrator.dispatch({ kind: "declare", contract: twoTasks });
+    await partialOrchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    partial.work.reconcileStatus = "not_verified";
+    await expect(partialOrchestrator.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "work_not_verified" });
+
+    const ambiguous = harness({ now: () => 1_000 });
+    const ambiguousOrchestrator = ambiguous.create();
+    await ambiguousOrchestrator.dispatch({ kind: "declare", contract: contract({ plan: [{ ...contract().plan[0], needsYou: null }] }) });
+    await ambiguousOrchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    ambiguous.work.executeStatus = "ambiguous";
+    await expect(ambiguousOrchestrator.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "work_execution_ambiguous" });
+    const replacement = ambiguous.create();
+    await expect(replacement.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "work_execution_ambiguous" });
+    expect(ambiguous.work.executions).toEqual(["work-1"]);
+  });
+
+  it("persists rollback/cancellation and refuses corrupt or missing journals", async () => {
+    const h = harness({ now: () => 1_000 });
+    const orchestrator = h.create();
+    await orchestrator.dispatch({ kind: "declare", contract: contract() });
+    await orchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await expect(orchestrator.dispatch({ kind: "cancel", outcomeId: "outcome-1", contractVersion: 1, reason: "Stop the dogfood" })).resolves.toMatchObject({ status: "ok", view: { state: "rolled_back" } });
+    const restarted = h.create();
+    expect(restarted.inspect("outcome-1")).toMatchObject({ status: "available", view: { state: "rolled_back" } });
+
+    const missing = harness({ now: () => 1_000 });
+    const missingFirst = missing.create();
+    await missingFirst.dispatch({ kind: "declare", contract: contract({ outcomeId: "missing-journal", id: "missing-journal:v1" }) });
+    await missingFirst.dispatch({ kind: "accept", outcomeId: "missing-journal", contractVersion: 1 });
+    rmSync(missing.journalFile);
+    const missingRestart = missing.create();
+    expect(missingRestart.inspect("missing-journal")).toEqual({ status: "missing" });
+    await expect(missingRestart.dispatch({ kind: "run", outcomeId: "missing-journal", contractVersion: 1 })).resolves.toMatchObject({ status: "denied", reason: "outcome_not_ready" });
+    expect(missing.work.executions).toEqual([]);
+
+    writeFileSync(h.journalFile, "{corrupt", "utf8");
+    const corrupt = h.create();
+    await expect(corrupt.dispatch({ kind: "declare", contract: contract({ outcomeId: "outcome-2", id: "outcome-2:v1" }) })).resolves.toMatchObject({ status: "unavailable", reason: "journal_unavailable" });
+    expect(corrupt.inspect("outcome-1")).toEqual({ status: "unavailable" });
+  });
+
+  it("keeps a long trace complete and does not learn from unverified work", async () => {
+    const learning = new FakeLearning();
+    const h = harness({ now: () => 1_000, learning });
+    const orchestrator = h.create();
+    const template = contract().plan[0];
+    if (!template) throw new Error("expected a plan template");
+    const manyTasks = Array.from({ length: 18 }, (_, index) => ({ ...template, id: `task-${index}`, label: `Task ${index}`, needsYou: null }));
+    await orchestrator.dispatch({ kind: "declare", contract: contract({ budget: { currency: "USD", maxCostCents: 100, maxUnits: 40 }, plan: manyTasks }) });
+    await orchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    await orchestrator.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 });
+    await orchestrator.dispatch({ kind: "record-evidence", evidence: evidence() });
+    const verified = await orchestrator.dispatch({ kind: "verify", outcomeId: "outcome-1", contractVersion: 1 });
+    expect(verified).toMatchObject({ status: "ok", view: { state: "completed" } });
+    if (verified.status !== "ok" || !verified.receipt) throw new Error("expected the long outcome to complete");
+    expect(verified.receipt.record.executionTrace.entries.length).toBeGreaterThanOrEqual(60);
+    expect(verified.receipt.record.executionTrace.entries.at(-1)?.action).toBe("outcome-completed");
+    expect(learning.records).toHaveLength(1);
+
+    const failedLearning = new FakeLearning();
+    const failed = harness({ now: () => 1_000, learning: failedLearning });
+    const failedOrchestrator = failed.create();
+    await failedOrchestrator.dispatch({ kind: "declare", contract: contract({ plan: [{ ...template, needsYou: null }] }) });
+    await failedOrchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    failed.work.reconcileStatus = "not_verified";
+    await expect(failedOrchestrator.dispatch({ kind: "run", outcomeId: "outcome-1", contractVersion: 1 })).resolves.toMatchObject({ status: "blocked", reason: "work_not_verified" });
+    expect(failedLearning.records).toHaveLength(0);
+  });
+
+  it("projects one quiet outcome-first row for the right rail and chat", async () => {
+    const h = harness({ now: () => 1_000 });
+    const orchestrator = h.create();
+    await orchestrator.dispatch({ kind: "declare", contract: contract() });
+    await orchestrator.dispatch({ kind: "accept", outcomeId: "outcome-1", contractVersion: 1 });
+    const inspected = orchestrator.inspect("outcome-1");
+    if (inspected.status !== "available") throw new Error("expected an available outcome");
+    expect(projectOutcome(inspected.view)).toEqual({
+      outcomeId: "outcome-1",
+      title: "Produce the internal dogfood receipt",
+      state: "accepted",
+      quiet: true,
+      work: [{ workId: "work-1", label: "Produce receipt", state: "planned" }],
+      chatSummary: "Produce the internal dogfood receipt · accepted",
+    });
+  });
+});

--- a/server/outcome-orchestrator.ts
+++ b/server/outcome-orchestrator.ts
@@ -1,0 +1,1013 @@
+import { createHash } from "node:crypto";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { z } from "zod";
+import type { JsonObject } from "./schema.ts";
+import {
+  buildOutcomeRecord,
+  isOutcomeRecord,
+  redactEvidenceReference,
+  traceIdentity,
+  type ExecutionTraceEntry,
+  type OutcomeLearning,
+  type OutcomeRecord,
+} from "./execution-learning.ts";
+
+/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-unknown-returns,
+ * anti-slop/no-runtime-typeof, anti-slop/no-unsafe-dictionary-type,
+ * anti-slop/no-known-value-widening -- existing WorkOrchestrator and verifier
+ * seams are intentionally unknown here; values are parsed before use. */
+
+/** The V2 WorkOrchestrator seam. Outcome Mode consumes this interface; it does
+ * not add methods to it or create a second work lifecycle. */
+export interface ExistingWorkOrchestrator {
+  ingest(event: unknown): unknown;
+  prepare(workId: string): unknown;
+  decide(input: unknown): unknown;
+  execute(workId: string): Promise<unknown>;
+  reconcile(workId: string): Promise<unknown>;
+}
+
+export interface OutcomeVerifier {
+  verify(input: OutcomeVerificationInput): Promise<unknown>;
+}
+
+export interface CaptureOutcomeInference {
+  infer(input: CaptureInferenceInput): Promise<unknown>;
+}
+
+export interface ContractualJudgment {
+  judge(input: ContractualJudgmentInput): Promise<unknown>;
+}
+
+export type CaptureInferenceInput = {
+  readonly evidence: CaptureEvidence;
+  readonly existingOutcomes: readonly OutcomeIdentity[];
+};
+
+export type OutcomeIdentity = {
+  readonly outcomeId: string;
+  readonly contractVersion: number;
+  readonly objective: string;
+  readonly state: OutcomeView["state"];
+};
+
+export type ContractualJudgmentInput = {
+  readonly contract: OutcomeContract;
+  readonly workIds: readonly string[];
+  readonly evidence: readonly OutcomeEvidence[];
+};
+
+export type OutcomeJudgment =
+  | { readonly color: "green" }
+  | { readonly color: "yellow"; readonly input: NeedsYouInput }
+  | { readonly color: "red"; readonly reason: string };
+
+export type OutcomeCommand =
+  | { readonly kind: "declare"; readonly contract: OutcomeContract }
+  | { readonly kind: "capture"; readonly evidence: CaptureEvidence }
+  | { readonly kind: "accept"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly kind: "run"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly kind: "answer-needs-you"; readonly outcomeId: string; readonly contractVersion: number; readonly inputKey: string; readonly answer: string; readonly answeredBy: string }
+  | { readonly kind: "record-evidence"; readonly evidence: OutcomeEvidence }
+  | { readonly kind: "verify"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly kind: "cancel"; readonly outcomeId: string; readonly contractVersion: number; readonly reason: string };
+
+export type OutcomeContract = z.infer<typeof contractSchema>;
+export type CaptureEvidence = z.infer<typeof captureEvidenceSchema>;
+export type OutcomeEvidence = z.infer<typeof evidenceSchema>;
+export type OutcomeArtifact = z.infer<typeof artifactSchema>;
+export type WorkLink = z.infer<typeof workLinkSchema>;
+export type NeedsYouInput = z.infer<typeof needsYouSchema>;
+export type OutcomeReceipt = z.infer<typeof receiptSchema>;
+export type OutcomeVerificationInput = {
+  readonly contract: OutcomeContract;
+  readonly workIds: readonly string[];
+  readonly evidence: readonly OutcomeEvidence[];
+  readonly artifacts: readonly OutcomeArtifact[];
+  readonly criteriaHash: string;
+  readonly traceIdentity: string;
+};
+
+export type CaptureContextDelta = {
+  readonly nodes: readonly {
+    readonly id: string;
+    readonly type: "capture" | "outcome" | "verified-outcome" | "receipt" | "learning" | "entity" | "relationship" | "constraint" | "dependency";
+    readonly provenance?: { readonly source: string; readonly reference: string; readonly contentHash: string; readonly observedAt: number };
+    readonly contractId?: string;
+    readonly contractVersion?: number;
+    readonly receiptReference?: string;
+  }[];
+  readonly edges: readonly {
+    readonly from: string;
+    readonly to: string;
+    readonly kind: "supports" | "related-to" | "conflicts" | "depends-on" | "produced-by" | "learned-from";
+  }[];
+};
+
+export type OutcomeView =
+  | { readonly state: "declared"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: null }
+  | { readonly state: "accepted"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: null }
+  | { readonly state: "running"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: null }
+  | { readonly state: "needs-you"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: NeedsYouInput; readonly judgment: OutcomeJudgment | null; readonly receipt: null }
+  | { readonly state: "verifying"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: null }
+  | { readonly state: "completed"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: OutcomeReceipt }
+  | { readonly state: "failed" | "cancelled" | "rolled_back"; readonly contract: OutcomeContract; readonly work: readonly WorkLink[]; readonly evidence: readonly OutcomeEvidence[]; readonly needsYou: null; readonly judgment: OutcomeJudgment | null; readonly receipt: null; readonly reason: string };
+
+export type OutcomeCommandResult =
+  | { readonly status: "ok"; readonly view: OutcomeView; readonly receipt?: OutcomeReceipt }
+  | { readonly status: "needs_you"; readonly view: Extract<OutcomeView, { state: "needs-you" }>; readonly input: NeedsYouInput }
+  | { readonly status: "blocked"; readonly view?: OutcomeView; readonly reason: string }
+  | { readonly status: "denied"; readonly reason: string; readonly view?: OutcomeView }
+  | { readonly status: "unavailable"; readonly reason: "journal_unavailable" | "journal_write_failed" };
+
+export type OutcomeInspection =
+  | { readonly status: "available"; readonly view: OutcomeView }
+  | { readonly status: "missing" }
+  | { readonly status: "unavailable" };
+
+export interface OutcomeOrchestrator {
+  dispatch(command: unknown): Promise<OutcomeCommandResult>;
+  inspect(outcomeId: string): OutcomeInspection;
+}
+
+export interface OutcomeProjection {
+  readonly outcomeId: string;
+  readonly title: string;
+  readonly state: OutcomeView["state"];
+  readonly quiet: true;
+  readonly work: readonly { readonly workId: string; readonly label: string; readonly state: WorkLink["status"] }[];
+  readonly chatSummary: string;
+}
+
+export interface OutcomeOrchestratorOptions {
+  readonly journalFile: string;
+  readonly work: ExistingWorkOrchestrator;
+  readonly verifier: OutcomeVerifier;
+  readonly captureInference?: CaptureOutcomeInference;
+  readonly judgment?: ContractualJudgment;
+  readonly learning?: OutcomeLearning;
+  readonly now?: () => number;
+}
+
+const grantSchema = z.object({
+  action: z.string().trim().min(1).max(200),
+  target: z.string().trim().min(1).max(500),
+  scope: z.string().trim().min(1).max(500),
+  expiresAt: z.number().finite().nonnegative(),
+}).strict();
+
+const constraintSchema = z.object({
+  kind: z.enum(["time", "budget", "scope", "quality", "privacy", "authority"]),
+  statement: z.string().trim().min(1).max(2_000),
+}).strict();
+
+const criterionSchema = z.object({
+  id: z.string().trim().min(1).max(100),
+  statement: z.string().trim().min(1).max(2_000),
+}).strict();
+
+const needsYouSchema = z.object({
+  inputKey: z.string().trim().min(1).max(120),
+  question: z.string().trim().min(1).max(2_000),
+  choices: z.array(z.string().trim().min(1).max(300)).max(5),
+}).strict();
+
+const taskSchema = z.object({
+  id: z.string().trim().min(1).max(120),
+  label: z.string().trim().min(1).max(300),
+  prompt: z.string().trim().min(1).max(25_000),
+  resumePolicy: z.enum(["safe", "never"]),
+  dependsOn: z.array(z.string().trim().min(1).max(120)).max(8),
+  needsYou: needsYouSchema.nullable(),
+  requiredAuthority: grantSchema.nullable(),
+  estimatedCostCents: z.number().int().nonnegative().finite(),
+  estimatedUnits: z.number().int().nonnegative().finite(),
+}).strict();
+
+const contractSchema = z.object({
+  id: z.string().trim().min(1).max(200),
+  outcomeId: z.string().trim().min(1).max(200),
+  version: z.number().int().positive(),
+  ownerId: z.string().trim().min(1).max(200),
+  objective: z.string().trim().min(1).max(4_000),
+  constraints: z.array(constraintSchema).max(30),
+  successCriteria: z.array(criterionSchema).min(1).max(30),
+  deadline: z.object({ at: z.number().finite().nonnegative() }).strict(),
+  budget: z.object({ currency: z.literal("USD"), maxCostCents: z.number().int().nonnegative().finite(), maxUnits: z.number().int().nonnegative().finite() }).strict(),
+  qualityBar: z.string().trim().min(1).max(2_000),
+  authority: z.object({ mode: z.literal("deny-by-default"), grants: z.array(grantSchema).max(30) }).strict(),
+  escalation: z.object({ channel: z.literal("needs-you"), on: z.array(z.enum(["missing-input", "deadline-risk", "budget-risk", "quality-risk", "authority-required"])).min(1).max(10) }).strict(),
+  evidenceRequirements: z.object({ requiredCriterionIds: z.array(z.string().trim().min(1).max(100)).min(1).max(30), requiredArtifactKinds: z.array(z.string().trim().min(1).max(100)).max(20) }).strict(),
+  rollback: z.object({ onCancel: z.enum(["stop", "reversible-stop"]), onFailure: z.enum(["stop", "reversible-stop"]) }).strict(),
+  plan: z.array(taskSchema).min(1).max(30),
+}).strict();
+
+const artifactSchema = z.object({
+  reference: z.string().trim().min(1).max(2_000),
+  kind: z.string().trim().min(1).max(100),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/i),
+}).strict();
+
+const contextNodeSchema = z.object({
+  id: z.string().trim().min(1).max(300),
+  type: z.enum(["capture", "outcome", "verified-outcome", "receipt", "learning", "entity", "relationship", "constraint", "dependency"]),
+  provenance: z.object({ source: z.string().trim().min(1).max(200), reference: z.string().trim().min(1).max(2_000), contentHash: z.string().regex(/^[a-f0-9]{64}$/i), observedAt: z.number().finite().nonnegative() }).strict().optional(),
+  contractId: z.string().trim().min(1).max(200).optional(),
+  contractVersion: z.number().int().positive().optional(),
+  receiptReference: z.string().trim().min(1).max(2_000).optional(),
+}).strict();
+
+const contextEdgeSchema = z.object({
+  from: z.string().trim().min(1).max(300),
+  to: z.string().trim().min(1).max(300),
+  kind: z.enum(["supports", "related-to", "conflicts", "depends-on", "produced-by", "learned-from"]),
+}).strict();
+
+const contextDeltaSchema = z.object({ nodes: z.array(contextNodeSchema).max(200), edges: z.array(contextEdgeSchema).max(500) }).strict();
+
+const captureEvidenceSchema = z.object({
+  captureId: z.string().trim().min(1).max(200),
+  source: z.string().trim().min(1).max(200),
+  reference: z.string().trim().min(1).max(2_000),
+  summary: z.string().trim().min(1).max(4_000),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/i),
+  confidence: z.enum(["high", "medium", "low"]),
+  criterionIds: z.array(z.string().trim().min(1).max(100)).min(1).max(30),
+  artifacts: z.array(artifactSchema).max(20),
+  observedAt: z.number().finite().nonnegative(),
+  contextDelta: contextDeltaSchema.optional(),
+}).strict();
+
+const evidenceSchema = z.object({
+  outcomeId: z.string().trim().min(1).max(200),
+  contractVersion: z.number().int().positive(),
+  evidenceId: z.string().trim().min(1).max(200),
+  reference: z.string().trim().min(1).max(2_000),
+  summary: z.string().trim().min(1).max(4_000),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/i),
+  criterionIds: z.array(z.string().trim().min(1).max(100)).min(1).max(30),
+  artifacts: z.array(artifactSchema).max(20),
+  recordedAt: z.number().finite().nonnegative(),
+}).strict();
+
+const judgmentSchema = z.discriminatedUnion("color", [
+  z.object({ color: z.literal("green") }).strict(),
+  z.object({ color: z.literal("yellow"), input: needsYouSchema }).strict(),
+  z.object({ color: z.literal("red"), reason: z.string().trim().min(1).max(2_000) }).strict(),
+]);
+
+const inferenceSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("inferred"), contract: contractSchema }).strict(),
+  z.object({ status: z.literal("existing"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive() }).strict(),
+  z.object({ status: z.literal("ambiguous"), reason: z.string().trim().min(1).max(2_000) }).strict(),
+]);
+
+const workLinkSchema = z.object({
+  taskId: z.string().trim().min(1).max(120),
+  workId: z.string().trim().min(1).max(300),
+  status: z.enum(["planned", "executing", "verified", "failed", "ambiguous"]),
+  route: z.string().trim().min(1).max(120).optional(),
+}).strict();
+
+const usageSchema = z.object({ costCents: z.number().int().nonnegative().finite(), units: z.number().int().nonnegative().finite() }).strict();
+const receiptSchema = z.object({
+  kind: z.literal("outcome-completed"),
+  outcomeId: z.string(),
+  contractId: z.string(),
+  contractVersion: z.number().int().positive(),
+  criteriaHash: z.string().regex(/^[a-f0-9]{64}$/i),
+  workIds: z.array(z.string()),
+  evidenceRefs: z.array(z.string()),
+  artifactRefs: z.array(z.string()),
+  verifiedAt: z.number().finite().nonnegative(),
+  usage: usageSchema,
+  record: z.custom<OutcomeRecord>(isOutcomeRecord),
+}).strict();
+
+const verificationSchema = z.object({
+  status: z.literal("verified"),
+  contractId: z.string(),
+  contractVersion: z.number().int().positive(),
+  criteriaHash: z.string().regex(/^[a-f0-9]{64}$/i),
+  traceIdentity: z.string().regex(/^[a-f0-9]{64}$/i),
+  evidenceRefs: z.array(z.string()),
+  artifactRefs: z.array(z.string()),
+  usage: usageSchema,
+}).strict();
+
+const commandSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("declare"), contract: contractSchema }).strict(),
+  z.object({ kind: z.literal("capture"), evidence: captureEvidenceSchema }).strict(),
+  z.object({ kind: z.literal("accept"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive() }).strict(),
+  z.object({ kind: z.literal("run"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive() }).strict(),
+  z.object({ kind: z.literal("answer-needs-you"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive(), inputKey: z.string().trim().min(1), answer: z.string().trim().min(1).max(4_000), answeredBy: z.string().trim().min(1).max(200) }).strict(),
+  z.object({ kind: z.literal("record-evidence"), evidence: evidenceSchema }).strict(),
+  z.object({ kind: z.literal("verify"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive() }).strict(),
+  z.object({ kind: z.literal("cancel"), outcomeId: z.string().trim().min(1), contractVersion: z.number().int().positive(), reason: z.string().trim().min(1).max(2_000) }).strict(),
+]);
+
+export function captureContextDelta(command: unknown): CaptureContextDelta | null {
+  const parsed = commandSchema.safeParse(command);
+  return parsed.success && parsed.data.kind === "capture" ? parsed.data.evidence.contextDelta ?? null : null;
+}
+
+type OutcomeEvent =
+  | { readonly type: "declared"; readonly contract: OutcomeContract }
+  | { readonly type: "capture-linked"; readonly outcomeId: string; readonly contractVersion: number; readonly capture: CaptureEvidence }
+  | { readonly type: "accepted"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly type: "work-linked"; readonly outcomeId: string; readonly contractVersion: number; readonly link: WorkLink }
+  | { readonly type: "started"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly type: "needs-you-requested"; readonly outcomeId: string; readonly contractVersion: number; readonly input: NeedsYouInput }
+  | { readonly type: "needs-you-answered"; readonly outcomeId: string; readonly contractVersion: number; readonly inputKey: string; readonly answerHash: string; readonly answerLength: number; readonly answeredBy: string; readonly answeredAt: number }
+  | { readonly type: "judgment-recorded"; readonly outcomeId: string; readonly contractVersion: number; readonly judgment: OutcomeJudgment }
+  | { readonly type: "work-execution-started"; readonly outcomeId: string; readonly contractVersion: number; readonly workId: string }
+  | { readonly type: "work-verified"; readonly outcomeId: string; readonly contractVersion: number; readonly workId: string }
+  | { readonly type: "work-failed"; readonly outcomeId: string; readonly contractVersion: number; readonly workId: string; readonly reason: string }
+  | { readonly type: "evidence-recorded"; readonly evidence: OutcomeEvidence }
+  | { readonly type: "verification-recorded"; readonly outcomeId: string; readonly contractVersion: number }
+  | { readonly type: "terminal"; readonly outcomeId: string; readonly contractVersion: number; readonly state: "completed" | "failed" | "cancelled" | "rolled_back"; readonly reason?: string; readonly receipt?: OutcomeReceipt };
+
+interface StoredEvent {
+  readonly seq: number;
+  readonly at: number;
+  readonly idempotencyKey: string;
+  readonly event: OutcomeEvent;
+}
+
+type Folded = Map<string, OutcomeView>;
+type Journal = { readonly status: "ready"; readonly events: readonly StoredEvent[] } | { readonly status: "unavailable" };
+type ActiveOutcomeView = Extract<OutcomeView, { state: "accepted" | "running" | "needs-you" | "verifying" }>;
+
+const storedEventSchema = z.object({ seq: z.number().int().positive(), at: z.number().finite().nonnegative(), idempotencyKey: z.string().min(1), event: z.unknown() }).strict();
+function eventSchema(value: unknown): OutcomeEvent | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value) || !("type" in value)) return null;
+  const type = value.type;
+  if (type === "declared") {
+    const parsed = z.object({ type: z.literal("declared"), contract: contractSchema }).strict().safeParse(value);
+    return parsed.success ? parsed.data : null;
+  }
+  if (type === "capture-linked") return parseEvent(value, z.object({ type: z.literal("capture-linked"), outcomeId: z.string(), contractVersion: z.number().int().positive(), capture: captureEvidenceSchema }).strict());
+  if (type === "accepted") return parseEvent(value, z.object({ type: z.literal("accepted"), outcomeId: z.string(), contractVersion: z.number().int().positive() }).strict());
+  if (type === "work-linked") return parseEvent(value, z.object({ type: z.literal("work-linked"), outcomeId: z.string(), contractVersion: z.number().int().positive(), link: workLinkSchema }).strict());
+  if (type === "started") return parseEvent(value, z.object({ type: z.literal("started"), outcomeId: z.string(), contractVersion: z.number().int().positive() }).strict());
+  if (type === "needs-you-requested") return parseEvent(value, z.object({ type: z.literal("needs-you-requested"), outcomeId: z.string(), contractVersion: z.number().int().positive(), input: needsYouSchema }).strict());
+  if (type === "needs-you-answered") return parseEvent(value, z.object({ type: z.literal("needs-you-answered"), outcomeId: z.string(), contractVersion: z.number().int().positive(), inputKey: z.string(), answerHash: z.string().regex(/^[a-f0-9]{64}$/i), answerLength: z.number().int().nonnegative(), answeredBy: z.string(), answeredAt: z.number().finite().nonnegative() }).strict());
+  if (type === "judgment-recorded") return parseEvent(value, z.object({ type: z.literal("judgment-recorded"), outcomeId: z.string(), contractVersion: z.number().int().positive(), judgment: judgmentSchema }).strict());
+  if (type === "work-execution-started") return parseEvent(value, z.object({ type: z.literal("work-execution-started"), outcomeId: z.string(), contractVersion: z.number().int().positive(), workId: z.string() }).strict());
+  if (type === "work-verified") return parseEvent(value, z.object({ type: z.literal("work-verified"), outcomeId: z.string(), contractVersion: z.number().int().positive(), workId: z.string() }).strict());
+  if (type === "work-failed") return parseEvent(value, z.object({ type: z.literal("work-failed"), outcomeId: z.string(), contractVersion: z.number().int().positive(), workId: z.string(), reason: z.string() }).strict());
+  if (type === "evidence-recorded") return parseEvent(value, z.object({ type: z.literal("evidence-recorded"), evidence: evidenceSchema }).strict());
+  if (type === "verification-recorded") return parseEvent(value, z.object({ type: z.literal("verification-recorded"), outcomeId: z.string(), contractVersion: z.number().int().positive() }).strict());
+  if (type === "terminal") return parseEvent(value, z.object({ type: z.literal("terminal"), outcomeId: z.string(), contractVersion: z.number().int().positive(), state: z.enum(["completed", "failed", "cancelled", "rolled_back"]), reason: z.string().optional(), receipt: receiptSchema.optional() }).strict());
+  return null;
+}
+
+function parseEvent<T extends OutcomeEvent>(value: unknown, schema: z.ZodType<T>): T | null {
+  const parsed = schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function loadJournal(file: string): Journal {
+  if (!existsSync(file)) return { status: "ready", events: [] };
+  try {
+    const lines = readFileSync(file, "utf8").split("\n").filter((line) => line.length > 0);
+    const events: StoredEvent[] = [];
+    let expectedSeq = 1;
+    const keys = new Set<string>();
+    for (const line of lines) {
+      const parsed = storedEventSchema.safeParse(JSON.parse(line));
+      if (!parsed.success) return { status: "unavailable" };
+      const raw = parsed.data;
+      const event = eventSchema(raw.event);
+      if (!event || raw.seq !== expectedSeq || keys.has(raw.idempotencyKey)) return { status: "unavailable" };
+      keys.add(raw.idempotencyKey);
+      events.push({ seq: raw.seq, at: raw.at, idempotencyKey: raw.idempotencyKey, event });
+      expectedSeq += 1;
+    }
+    return { status: "ready", events };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+function criteriaHash(contract: OutcomeContract): string {
+  return createHash("sha256").update(JSON.stringify(contract.successCriteria), "utf8").digest("hex");
+}
+
+function terminal(state: OutcomeView["state"]): boolean {
+  return state === "completed" || state === "failed" || state === "cancelled" || state === "rolled_back";
+}
+
+function isActiveView(view: OutcomeView): view is ActiveOutcomeView {
+  return view.state === "accepted" || view.state === "running" || view.state === "needs-you" || view.state === "verifying";
+}
+
+function updateWork(view: ActiveOutcomeView, workId: string, status: WorkLink["status"]): OutcomeView {
+  const work = view.work.map((link) => link.workId === workId ? { ...link, status } : link);
+  return { ...view, work };
+}
+
+function captureAsEvidence(capture: CaptureEvidence, outcomeId: string, contractVersion: number): OutcomeEvidence {
+  return {
+    outcomeId,
+    contractVersion,
+    evidenceId: `capture:${capture.captureId}`,
+    reference: capture.reference,
+    summary: capture.summary,
+    contentHash: capture.contentHash,
+    criterionIds: capture.criterionIds,
+    artifacts: capture.artifacts,
+    recordedAt: capture.observedAt,
+  };
+}
+
+function terminalView(view: OutcomeView, event: Extract<OutcomeEvent, { type: "terminal" }>): OutcomeView {
+  if (event.state === "completed") {
+    if (!event.receipt) throw new Error("completed outcome requires receipt");
+    return { state: "completed", contract: view.contract, work: view.work, evidence: view.evidence, needsYou: null, judgment: view.judgment, receipt: event.receipt };
+  }
+  return { state: event.state, contract: view.contract, work: view.work, evidence: view.evidence, needsYou: null, judgment: view.judgment, receipt: null, reason: event.reason ?? "" };
+}
+
+function traceDetail(value: string): string {
+  return value.replace(/\b(password|passwd|secret|token|api[_-]?key|authorization|bearer)\b\s*[:=]\s*[^\s,;]+/gi, "$1=[redacted]");
+}
+
+function traceEntry(stored: StoredEvent): ExecutionTraceEntry {
+  const event = stored.event;
+  switch (event.type) {
+    case "declared":
+      return { seq: stored.seq, at: stored.at, phase: "intake", action: "contract-declared", refs: [`contract:${event.contract.id}`, `outcome:${event.contract.outcomeId}`].map(redactEvidenceReference), detail: traceDetail(`presumed-outcome=${event.contract.objective}; criteria=${event.contract.successCriteria.map((criterion) => criterion.id).join(",")}; plan=${event.contract.plan.map((task) => task.id).join(",")}`) };
+    case "capture-linked":
+      return { seq: stored.seq, at: stored.at, phase: "intake", action: "capture-linked", refs: [`capture:${event.capture.captureId}`, event.capture.reference, ...event.capture.artifacts.map((artifact) => artifact.reference)].map(redactEvidenceReference), detail: traceDetail(`source=${event.capture.source}; confidence=${event.capture.confidence}; contentHash=${event.capture.contentHash}`) };
+    case "accepted":
+      return { seq: stored.seq, at: stored.at, phase: "judgment", action: "contract-accepted", refs: [`contract:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference) };
+    case "work-linked":
+      return { seq: stored.seq, at: stored.at, phase: "planning", action: "canonical-work-linked", refs: [event.link.workId, `task:${event.link.taskId}`].map(redactEvidenceReference), detail: `route=${event.link.route ?? "unknown"}; worker=existing-work-orchestrator; model=unknown` };
+    case "started":
+      return { seq: stored.seq, at: stored.at, phase: "execution", action: "execution-started", refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference) };
+    case "needs-you-requested":
+      return { seq: stored.seq, at: stored.at, phase: "judgment", action: "needs-you-requested", refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`, `input:${event.input.inputKey}`].map(redactEvidenceReference), detail: traceDetail(event.input.question) };
+    case "needs-you-answered":
+      return { seq: stored.seq, at: stored.at, phase: "judgment", action: "needs-you-answered", refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`, `input:${event.inputKey}`, `answer:${event.answerHash}`].map(redactEvidenceReference), detail: `answeredBy=${traceDetail(event.answeredBy)}; answerLength=${event.answerLength}` };
+    case "judgment-recorded":
+      return { seq: stored.seq, at: stored.at, phase: "judgment", action: "contractual-judgment", refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference), detail: traceDetail(event.judgment.color === "red" ? `color=red; reason=${event.judgment.reason}` : event.judgment.color === "yellow" ? `color=yellow; inputKey=${event.judgment.input.inputKey}` : "color=green") };
+    case "work-execution-started":
+      return { seq: stored.seq, at: stored.at, phase: "execution", action: "work-dispatched", refs: [event.workId, `outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference), detail: "tool=existing-work-orchestrator.execute; worker=existing-work-orchestrator; model=unknown" };
+    case "work-verified":
+      return { seq: stored.seq, at: stored.at, phase: "verification", action: "work-reconciled", refs: [event.workId, `outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference), detail: "worker-receipt=verified" };
+    case "work-failed":
+      return { seq: stored.seq, at: stored.at, phase: "verification", action: "work-failed", refs: [event.workId, `outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference), detail: traceDetail(event.reason) };
+    case "evidence-recorded":
+      return { seq: stored.seq, at: stored.at, phase: "verification", action: "evidence-recorded", refs: [`evidence:${event.evidence.evidenceId}`, event.evidence.reference, ...event.evidence.artifacts.map((artifact) => artifact.reference)].map(redactEvidenceReference), detail: `criteria=${event.evidence.criterionIds.join(",")}; contentHash=${event.evidence.contentHash}` };
+    case "verification-recorded":
+      return { seq: stored.seq, at: stored.at, phase: "verification", action: "independent-verification-started", refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`].map(redactEvidenceReference), detail: "verifier=independent-verifier" };
+    case "terminal":
+      return { seq: stored.seq, at: stored.at, phase: "terminal", action: `outcome-${event.state}`, refs: [`outcome:${event.outcomeId}:v${event.contractVersion}`, ...(event.receipt?.record ? [event.receipt.record.recordId, event.receipt.record.links.executionTraceId, event.receipt.record.links.verifiedOutputId, event.receipt.record.links.retrospectiveId] : [])].map(redactEvidenceReference), detail: traceDetail(event.reason ?? "verified-output-persisted") };
+    default: {
+      const exhaustive: never = event;
+      throw new Error(`unknown trace event ${String(exhaustive)}`);
+    }
+  }
+}
+
+function fold(events: readonly StoredEvent[]): Folded {
+  const states: Folded = new Map();
+  for (const stored of events) {
+    const event = stored.event;
+    const outcomeId = event.type === "declared"
+      ? event.contract.outcomeId
+      : event.type === "evidence-recorded"
+        ? event.evidence.outcomeId
+        : event.outcomeId;
+    const current = event.type === "declared" ? undefined : states.get(outcomeId);
+    switch (event.type) {
+      case "declared":
+        if (states.has(event.contract.outcomeId)) throw new Error("duplicate outcome declaration");
+        states.set(event.contract.outcomeId, { state: "declared", contract: event.contract, work: [], evidence: [], needsYou: null, judgment: null, receipt: null });
+        break;
+      case "capture-linked":
+        if (!current || terminal(current.state) || current.contract.version !== event.contractVersion) throw new Error("illegal capture link transition");
+        if (current.evidence.some((item) => item.evidenceId === `capture:${event.capture.captureId}`)) throw new Error("duplicate capture link");
+        states.set(event.outcomeId, { ...current, evidence: [...current.evidence, captureAsEvidence(event.capture, event.outcomeId, event.contractVersion)] });
+        break;
+      case "accepted":
+        if (!current || current.state !== "declared" || current.contract.version !== event.contractVersion) throw new Error("illegal acceptance transition");
+        states.set(event.outcomeId, { state: "accepted", contract: current.contract, work: [], evidence: [], needsYou: null, judgment: null, receipt: null });
+        break;
+      case "work-linked":
+        if (!current || !isActiveView(current) || current.contract.version !== event.contractVersion) throw new Error("illegal work link transition");
+        if (current.work.some((link) => link.taskId === event.link.taskId || link.workId === event.link.workId)) throw new Error("duplicate work link");
+        states.set(event.outcomeId, { ...current, work: [...current.work, event.link] });
+        break;
+      case "started":
+        if (!current || current.state !== "accepted" || current.contract.version !== event.contractVersion || current.work.length !== current.contract.plan.length) throw new Error("illegal start transition");
+        states.set(event.outcomeId, { ...current, state: "running" });
+        break;
+      case "needs-you-requested":
+        if (!current || current.state !== "running" || current.contract.version !== event.contractVersion) throw new Error("illegal needs-you transition");
+        states.set(event.outcomeId, { ...current, state: "needs-you", needsYou: event.input });
+        break;
+      case "needs-you-answered":
+        if (!current || current.state !== "needs-you" || current.contract.version !== event.contractVersion || current.needsYou.inputKey !== event.inputKey) throw new Error("illegal needs-you answer");
+        states.set(event.outcomeId, { ...current, state: "running", needsYou: null, judgment: null });
+        break;
+      case "judgment-recorded":
+        if (!current || (current.state !== "accepted" && current.state !== "running" && current.state !== "needs-you") || current.contract.version !== event.contractVersion) throw new Error("illegal judgment transition");
+        states.set(event.outcomeId, { ...current, judgment: event.judgment });
+        break;
+      case "work-execution-started":
+        if (!current || (current.state !== "running" && current.state !== "verifying") || current.contract.version !== event.contractVersion) throw new Error("illegal work execution transition");
+        states.set(event.outcomeId, updateWork(current, event.workId, "executing"));
+        break;
+      case "work-verified":
+        if (!current || (current.state !== "running" && current.state !== "verifying") || current.contract.version !== event.contractVersion) throw new Error("illegal work verification transition");
+        states.set(event.outcomeId, updateWork(current, event.workId, "verified"));
+        break;
+      case "work-failed":
+        if (!current || !isActiveView(current) || current.contract.version !== event.contractVersion) throw new Error("illegal work failure transition");
+        states.set(event.outcomeId, { state: current.contract.rollback.onFailure === "reversible-stop" ? "rolled_back" : "failed", contract: current.contract, work: current.work, evidence: current.evidence, needsYou: null, judgment: current.judgment, receipt: null, reason: event.reason });
+        break;
+      case "evidence-recorded": {
+        const evidence = event.evidence;
+        const evidenceState = states.get(evidence.outcomeId);
+        if (!evidenceState || terminal(evidenceState.state) || evidenceState.contract.version !== evidence.contractVersion) throw new Error("illegal evidence transition");
+        if (evidenceState.evidence.some((item) => item.evidenceId === evidence.evidenceId)) throw new Error("duplicate evidence");
+        states.set(evidence.outcomeId, { ...evidenceState, evidence: [...evidenceState.evidence, evidence] });
+        break;
+      }
+      case "verification-recorded":
+        if (!current || (current.state !== "running" && current.state !== "verifying") || current.contract.version !== event.contractVersion) throw new Error("illegal verification transition");
+        states.set(event.outcomeId, { ...current, state: "verifying", needsYou: null });
+        break;
+      case "terminal":
+        if (!current || terminal(current.state) || current.contract.version !== event.contractVersion) throw new Error("illegal terminal transition");
+        states.set(event.outcomeId, terminalView(current, event));
+        break;
+      default: {
+        const exhaustive: never = event;
+        throw new Error(`unknown event ${String(exhaustive)}`);
+      }
+    }
+  }
+  return states;
+}
+
+function workBatchEvent(contract: OutcomeContract, task: OutcomeContract["plan"][number], route: string, captureContentHash?: string) {
+  const metadata: JsonObject = { outcomeId: contract.outcomeId, contractVersion: contract.version, taskId: task.id, route };
+  if (captureContentHash) metadata.captureContentHash = captureContentHash;
+  return {
+    type: "worker-batch",
+    source: "agent-centipede-v3",
+    externalId: `outcome:${contract.outcomeId}:v${contract.version}:task:${task.id}`,
+    title: `${contract.objective}: ${task.label}`,
+    ownerId: contract.ownerId,
+    taskId: `${contract.outcomeId}:v${contract.version}:${task.id}`,
+    tasks: [{
+      key: task.id,
+      label: task.label,
+      prompt: task.prompt,
+      resumePolicy: task.resumePolicy,
+      dependsOn: task.dependsOn,
+      resourceLocks: [`outcome:${contract.outcomeId}`],
+      metadata,
+    }],
+  };
+}
+
+function grantMatches(contract: OutcomeContract, required: NonNullable<OutcomeContract["plan"][number]["requiredAuthority"]>, now: number): boolean {
+  return contract.authority.grants.some((grant) => grant.action === required.action && grant.target === required.target && grant.scope === required.scope && grant.expiresAt >= now);
+}
+
+export function projectOutcome(view: OutcomeView): OutcomeProjection {
+  const labels = new Map(view.contract.plan.map((task) => [task.id, task.label]));
+  return {
+    outcomeId: view.contract.outcomeId,
+    title: view.contract.objective,
+    state: view.state,
+    quiet: true,
+    work: view.work.map((link) => ({ workId: link.workId, label: labels.get(link.taskId) ?? link.taskId, state: link.status })),
+    chatSummary: view.state === "completed"
+      ? `Outcome complete: ${view.contract.objective}`
+      : view.state === "needs-you"
+        ? `Needs you: ${view.needsYou.question}`
+        : view.state === "failed" || view.state === "cancelled" || view.state === "rolled_back"
+          ? `Outcome ${view.state}: ${view.reason}`
+          : `${view.contract.objective} · ${view.state}`,
+  };
+}
+
+export function createOutcomeOrchestrator(options: OutcomeOrchestratorOptions): OutcomeOrchestrator {
+  const now = options.now ?? Date.now;
+  const journal = loadJournal(options.journalFile);
+  let stored = journal.status === "ready" ? [...journal.events] : [];
+  let states: Folded = new Map();
+  let journalAvailable = journal.status === "ready";
+  if (journal.status === "ready") {
+    try { states = fold(stored); } catch { journalAvailable = false; }
+  }
+
+  function unavailable(): OutcomeCommandResult {
+    return { status: "unavailable", reason: "journal_unavailable" };
+  }
+
+  function save(next: StoredEvent): boolean {
+    let fd: number | null = null;
+    try {
+      mkdirSync(dirname(options.journalFile), { recursive: true });
+      fd = openSync(options.journalFile, "a", 0o600);
+      writeSync(fd, `${JSON.stringify(next)}\n`, undefined, "utf8");
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = null;
+      const nextStored = [...stored, next];
+      const nextStates = fold(nextStored);
+      stored = nextStored;
+      states = nextStates;
+      return true;
+    } catch {
+      if (fd !== null) {
+        try { closeSync(fd); } catch { /* best effort */ }
+      }
+      journalAvailable = false;
+      return false;
+    }
+  }
+
+  function append(event: OutcomeEvent, key: string): "appended" | "duplicate" | "conflict" | "failed" {
+    const existing = stored.find((entry) => entry.idempotencyKey === key);
+    if (existing) return JSON.stringify(existing.event) === JSON.stringify(event) ? "duplicate" : "conflict";
+    const next: StoredEvent = { seq: stored.length + 1, at: now(), idempotencyKey: key, event };
+    return save(next) ? "appended" : "failed";
+  }
+
+  function result(outcomeId: string, reason?: string, receipt?: OutcomeReceipt): OutcomeCommandResult {
+    const view = states.get(outcomeId);
+    if (!view) return { status: "denied", reason: "outcome_not_found" };
+    if (reason !== undefined) return { status: "blocked", view, reason };
+    if (receipt === undefined) return { status: "ok", view };
+    return { status: "ok", view, receipt };
+  }
+
+  function contractFor(outcomeId: string, version: number): OutcomeView | null {
+    const view = states.get(outcomeId);
+    if (!view) return null;
+    if (view.contract.version !== version || view.contract.outcomeId !== outcomeId) return null;
+    return view;
+  }
+
+  async function applyContractualJudgment(view: Extract<OutcomeView, { state: "running" }>): Promise<OutcomeCommandResult | null> {
+    if (view.judgment !== null) {
+      if (view.judgment.color === "red") return { status: "blocked", view, reason: "judgment_red" };
+      if (view.judgment.color === "yellow") return { status: "blocked", view, reason: "judgment_needs_you" };
+      return null;
+    }
+    if (!options.judgment) return null;
+    let raw: unknown;
+    try {
+      raw = await options.judgment.judge({
+        contract: view.contract,
+        workIds: view.work.map((link) => link.workId),
+        evidence: view.evidence,
+      });
+    } catch {
+      return { status: "blocked", view, reason: "judgment_unavailable" };
+    }
+    const parsed = judgmentSchema.safeParse(raw);
+    if (!parsed.success) return { status: "blocked", view, reason: "invalid_judgment" };
+    const judgment = parsed.data;
+    const recorded = append({ type: "judgment-recorded", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, judgment }, `judgment:${view.contract.id}`);
+    if (recorded === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+    if (recorded === "conflict") return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "judgment_conflict" };
+    const judged = states.get(view.contract.outcomeId);
+    if (!judged || judged.state !== "running") return { status: "blocked", view: judged ?? view, reason: "judgment_transition_failed" };
+    if (judgment.color === "green") return null;
+    if (judgment.color === "red") return { status: "blocked", view: judged, reason: "judgment_red" };
+    const requested = append({ type: "needs-you-requested", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, input: judgment.input }, `needs-you:${view.contract.id}:judgment`);
+    if (requested === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+    const waiting = states.get(view.contract.outcomeId);
+    if (!waiting || waiting.state !== "needs-you") return { status: "blocked", view: waiting ?? judged, reason: "needs_you_transition_failed" };
+    return { status: "needs_you", view: waiting, input: waiting.needsYou };
+  }
+
+  function ensureLinks(view: OutcomeView): OutcomeCommandResult | null {
+    if (!["accepted", "running", "needs-you", "verifying"].includes(view.state)) return { status: "blocked", view, reason: "outcome_not_ready_for_work" };
+    const existingTaskIds = new Set(view.work.map((link) => link.taskId));
+    for (const task of view.contract.plan) {
+      if (existingTaskIds.has(task.id)) continue;
+      const route = options.learning?.chooseRoute({ outcomeId: view.contract.outcomeId, taskId: task.id, candidates: ["default", "known-safe"] }) ?? "default";
+      const response = z.object({ status: z.enum(["created", "unchanged"]), workId: z.string().min(1) }).safeParse(options.work.ingest(workBatchEvent(view.contract, task, route, view.evidence[0]?.contentHash)));
+      if (!response.success) return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "canonical_work_ingest_denied" };
+      const event: OutcomeEvent = { type: "work-linked", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, link: { taskId: task.id, workId: response.data.workId, status: "planned", route } };
+      const appended = append(event, `work-linked:${view.contract.id}:${task.id}`);
+      if (appended === "conflict") return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "work_link_conflict" };
+      if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+      existingTaskIds.add(task.id);
+    }
+    return null;
+  }
+
+  async function run(view: OutcomeView): Promise<OutcomeCommandResult> {
+    if (view.state !== "accepted" && view.state !== "running") return { status: "blocked", view, reason: "outcome_not_ready" };
+    const linked = ensureLinks(view);
+    if (linked) return linked;
+    const current = states.get(view.contract.outcomeId);
+    if (!current || !["accepted", "running"].includes(current.state)) return { status: "blocked", view: current ?? view, reason: "outcome_changed_during_work_linking" };
+    if (current.state === "accepted") {
+      if (now() > current.contract.deadline.at) {
+        const event: OutcomeEvent = { type: "terminal", outcomeId: current.contract.outcomeId, contractVersion: current.contract.version, state: "failed", reason: "deadline_breached" };
+        const appended = append(event, `terminal:${current.contract.id}:deadline`);
+        return appended === "failed" ? { status: "unavailable", reason: "journal_write_failed" } : result(current.contract.outcomeId, "deadline_breached");
+      }
+      const estimatedCostCents = current.contract.plan.reduce((sum, task) => sum + task.estimatedCostCents, 0);
+      const estimatedUnits = current.contract.plan.reduce((sum, task) => sum + task.estimatedUnits, 0);
+      if (estimatedCostCents > current.contract.budget.maxCostCents || estimatedUnits > current.contract.budget.maxUnits) {
+        const event: OutcomeEvent = { type: "terminal", outcomeId: current.contract.outcomeId, contractVersion: current.contract.version, state: "failed", reason: "budget_breached" };
+        const appended = append(event, `terminal:${current.contract.id}:budget`);
+        return appended === "failed" ? { status: "unavailable", reason: "journal_write_failed" } : result(current.contract.outcomeId, "budget_breached");
+      }
+      const started: OutcomeEvent = { type: "started", outcomeId: current.contract.outcomeId, contractVersion: current.contract.version };
+      const startedAppend = append(started, `started:${current.contract.id}`);
+      if (startedAppend === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+      const required = current.contract.plan.find((task) => task.needsYou !== null);
+      if (required?.needsYou) {
+        const event: OutcomeEvent = { type: "needs-you-requested", outcomeId: current.contract.outcomeId, contractVersion: current.contract.version, input: required.needsYou };
+        const appended = append(event, `needs-you:${current.contract.id}:${required.needsYou.inputKey}`);
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        const next = states.get(current.contract.outcomeId);
+        if (!next || next.state !== "needs-you") return { status: "blocked", view: current, reason: "needs_you_transition_failed" };
+        return { status: "needs_you", view: next, input: next.needsYou };
+      }
+    }
+    const running = states.get(view.contract.outcomeId);
+    if (!running || running.state !== "running") return { status: "blocked", view: running ?? view, reason: "outcome_not_running" };
+    const judged = await applyContractualJudgment(running);
+    if (judged) return judged;
+    const judgedRunning = states.get(view.contract.outcomeId);
+    if (!judgedRunning || judgedRunning.state !== "running") return { status: "blocked", view: judgedRunning ?? running, reason: "outcome_not_running" };
+    for (const task of running.contract.plan) {
+      const link = judgedRunning.work.find((candidate) => candidate.taskId === task.id);
+      if (!link || link.status === "verified") continue;
+      if (link.status === "executing" || link.status === "ambiguous") return { status: "blocked", view: running, reason: "work_execution_ambiguous" };
+      if (task.requiredAuthority && !grantMatches(running.contract, task.requiredAuthority, now())) {
+        const event: OutcomeEvent = { type: "terminal", outcomeId: running.contract.outcomeId, contractVersion: running.contract.version, state: "failed", reason: "authority_denied" };
+        const appended = append(event, `terminal:${running.contract.id}:authority:${task.id}`);
+        return appended === "failed" ? { status: "unavailable", reason: "journal_write_failed" } : result(running.contract.outcomeId, "authority_denied");
+      }
+      const executionStarted: OutcomeEvent = { type: "work-execution-started", outcomeId: running.contract.outcomeId, contractVersion: running.contract.version, workId: link.workId };
+      const executionAppend = append(executionStarted, `work-execution-started:${running.contract.id}:${link.workId}`);
+      if (executionAppend === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+      if (executionAppend === "conflict") return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "work_execution_conflict" };
+      let executed: unknown;
+      try { executed = await options.work.execute(link.workId); } catch { return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "worker_timeout_or_crash" }; }
+      const executeStatus = z.object({ status: z.string() }).safeParse(executed);
+      if (!executeStatus.success || executeStatus.data.status === "ambiguous" || executeStatus.data.status === "replay_prevented") return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "work_execution_ambiguous" };
+      let reconciled: unknown;
+      try { reconciled = await options.work.reconcile(link.workId); } catch { return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "worker_reconcile_unavailable" }; }
+      const reconcileStatus = z.object({ status: z.string() }).safeParse(reconciled);
+      if (!reconcileStatus.success || reconcileStatus.data.status === "awaiting_worker") return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "worker_timeout_or_crash" };
+      if (reconcileStatus.data.status !== "verified") {
+        const failed: OutcomeEvent = { type: "work-failed", outcomeId: running.contract.outcomeId, contractVersion: running.contract.version, workId: link.workId, reason: reconcileStatus.data.status === "not_verified" ? "work_not_verified" : "work_reconcile_denied" };
+        const appended = append(failed, `work-failed:${running.contract.id}:${link.workId}`);
+        return appended === "failed" ? { status: "unavailable", reason: "journal_write_failed" } : result(running.contract.outcomeId, failed.reason);
+      }
+      const verified: OutcomeEvent = { type: "work-verified", outcomeId: running.contract.outcomeId, contractVersion: running.contract.version, workId: link.workId };
+      const verifiedAppend = append(verified, `work-verified:${running.contract.id}:${link.workId}`);
+      if (verifiedAppend === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+      if (verifiedAppend === "conflict") return { status: "blocked", view: states.get(running.contract.outcomeId) ?? running, reason: "work_verification_conflict" };
+    }
+    const final = states.get(running.contract.outcomeId);
+    return final ? { status: "ok", view: final } : { status: "denied", reason: "outcome_not_found" };
+  }
+
+  async function verify(view: OutcomeView): Promise<OutcomeCommandResult> {
+    if (view.state !== "running" && view.state !== "verifying") return { status: "blocked", view, reason: "outcome_not_ready" };
+    let reconciledWork = false;
+    for (const link of view.work) {
+      if (link.status === "verified") continue;
+      let raw: unknown;
+      try { raw = await options.work.reconcile(link.workId); } catch { return { status: "blocked", view, reason: "worker_reconcile_unavailable" }; }
+      const parsed = z.object({ status: z.string(), reason: z.string().optional() }).safeParse(raw);
+      if (!parsed.success || parsed.data.status === "awaiting_worker" || parsed.data.status === "awaiting_receipt") return { status: "blocked", view, reason: "work_incomplete" };
+      if (parsed.data.status === "replay_prevented") return { status: "blocked", view, reason: "work_execution_ambiguous" };
+      if (parsed.data.status === "not_verified") {
+        const failed: OutcomeEvent = { type: "work-failed", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, workId: link.workId, reason: parsed.data.reason ?? "work_not_verified" };
+        const appended = append(failed, `work-failed:${view.contract.id}:${link.workId}`);
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        return result(view.contract.outcomeId, failed.reason);
+      }
+      if (parsed.data.status !== "verified") return { status: "blocked", view, reason: "work_incomplete" };
+      const appended = append({ type: "work-verified", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, workId: link.workId }, `work-verified:${view.contract.id}:${link.workId}`);
+      if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+      if (appended === "conflict") return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "work_verification_conflict" };
+      reconciledWork = true;
+    }
+    if (reconciledWork) {
+      const refreshed = states.get(view.contract.outcomeId);
+      return refreshed ? verify(refreshed) : { status: "denied", reason: "outcome_not_found" };
+    }
+    const allVerified = view.work.length === view.contract.plan.length && view.work.every((link) => link.status === "verified");
+    if (!allVerified) return { status: "blocked", view, reason: "work_incomplete" };
+    const requiredCriteria = new Set(view.contract.evidenceRequirements.requiredCriterionIds);
+    const coveredCriteria = new Set(view.evidence.flatMap((evidence) => evidence.criterionIds));
+    if ([...requiredCriteria].some((criterion) => !coveredCriteria.has(criterion))) return { status: "blocked", view, reason: "evidence_missing" };
+    const artifacts = view.evidence.flatMap((evidence) => evidence.artifacts);
+    const requiredKinds = new Set(view.contract.evidenceRequirements.requiredArtifactKinds);
+    if ([...requiredKinds].some((kind) => !artifacts.some((artifact) => artifact.kind === kind))) return { status: "blocked", view, reason: "artifact_missing" };
+    const expectedWorkIds = view.work.map((link) => link.workId);
+    const expectedEvidenceRefs = view.evidence.map((evidence) => evidence.reference);
+    const expectedArtifactRefs = artifacts.map((artifact) => artifact.reference);
+    const expectedTraceIdentity = traceIdentity({ contractId: view.contract.id, contractVersion: view.contract.version, workIds: expectedWorkIds, evidenceRefs: expectedEvidenceRefs, criteriaHash: criteriaHash(view.contract) });
+    const verifying: OutcomeEvent = { type: "verification-recorded", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version };
+    const verifyingAppend = append(verifying, `verification-recorded:${view.contract.id}`);
+    if (verifyingAppend === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+    let raw: unknown;
+    try {
+      raw = await options.verifier.verify({ contract: view.contract, workIds: expectedWorkIds, evidence: view.evidence, artifacts, criteriaHash: criteriaHash(view.contract), traceIdentity: expectedTraceIdentity });
+    } catch { return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "verifier_unavailable" }; }
+    const verdict = verificationSchema.safeParse(raw);
+    if (!verdict.success || verdict.data.contractId !== view.contract.id || verdict.data.contractVersion !== view.contract.version || verdict.data.criteriaHash !== criteriaHash(view.contract) || verdict.data.traceIdentity !== expectedTraceIdentity || JSON.stringify(verdict.data.evidenceRefs) !== JSON.stringify(expectedEvidenceRefs) || JSON.stringify(verdict.data.artifactRefs) !== JSON.stringify(expectedArtifactRefs)) return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "stale_verifier" };
+    if (now() > view.contract.deadline.at) return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "deadline_breached" };
+    if (verdict.data.usage.costCents > view.contract.budget.maxCostCents || verdict.data.usage.units > view.contract.budget.maxUnits) return { status: "blocked", view: states.get(view.contract.outcomeId) ?? view, reason: "budget_breached" };
+    const verifiedAt = now();
+    const finalTraceEntry: ExecutionTraceEntry = { seq: stored.length + 1, at: verifiedAt, phase: "terminal", action: "outcome-completed", refs: [`outcome:${view.contract.outcomeId}:v${view.contract.version}`, `verified:${view.contract.outcomeId}:v${view.contract.version}`, `retrospective:${view.contract.outcomeId}:v${view.contract.version}`], detail: "independently-verified-output persisted; retrospective persisted" };
+    const record = buildOutcomeRecord({
+      outcomeId: view.contract.outcomeId,
+      contractId: view.contract.id,
+      contractVersion: view.contract.version,
+      objective: view.contract.objective,
+      contextRefs: [`contract:${view.contract.id}`, ...expectedEvidenceRefs],
+      evidenceRefs: expectedEvidenceRefs,
+      evidenceIds: view.evidence.map((evidence) => evidence.evidenceId),
+      workIds: expectedWorkIds,
+      traceEntries: [...stored.map(traceEntry), finalTraceEntry],
+      criteriaHash: verdict.data.criteriaHash,
+      artifactRefs: expectedArtifactRefs,
+      verifiedAt,
+      usage: verdict.data.usage,
+      startedAt: stored.find((entry) => entry.event.type === "started")?.at ?? null,
+      needsYouTouches: stored.filter((entry) => entry.event.type === "needs-you-answered").length,
+      requiredContextCount: 1,
+      coveredContextCount: expectedEvidenceRefs.length > 0 ? 1 : 0,
+    });
+    const receipt: OutcomeReceipt = { kind: "outcome-completed", outcomeId: view.contract.outcomeId, contractId: view.contract.id, contractVersion: view.contract.version, criteriaHash: verdict.data.criteriaHash, workIds: expectedWorkIds, evidenceRefs: expectedEvidenceRefs.map(redactEvidenceReference), artifactRefs: expectedArtifactRefs.map(redactEvidenceReference), verifiedAt, usage: verdict.data.usage, record };
+    const terminalEvent: OutcomeEvent = { type: "terminal", outcomeId: view.contract.outcomeId, contractVersion: view.contract.version, state: "completed", receipt };
+    const appended = append(terminalEvent, `terminal:${view.contract.id}:completed`);
+    if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+    if (options.learning) {
+      try { options.learning.record(record); } catch { /* the receipt remains the canonical durable learning record */ }
+    }
+    return result(view.contract.outcomeId, undefined, receipt);
+  }
+
+  async function capture(evidence: CaptureEvidence): Promise<OutcomeCommandResult> {
+    const prior = stored.find((entry) => entry.event.type === "capture-linked" && (
+      entry.event.capture.captureId === evidence.captureId ||
+      (entry.event.capture.source === evidence.source && entry.event.capture.contentHash === evidence.contentHash)
+    ));
+    if (prior && prior.event.type === "capture-linked") {
+      if (prior.event.capture.captureId === evidence.captureId && JSON.stringify(prior.event.capture) !== JSON.stringify(evidence)) return { status: "denied", reason: "capture_conflict" };
+      const replayed = states.get(prior.event.outcomeId);
+      if (!replayed) return { status: "denied", reason: "outcome_not_found" };
+      if (replayed.state === "needs-you") return { status: "needs_you", view: replayed, input: replayed.needsYou };
+      if (replayed.judgment?.color === "red") return { status: "blocked", view: replayed, reason: "judgment_red" };
+      return result(prior.event.outcomeId);
+    }
+    if (evidence.confidence !== "high") return { status: "blocked", reason: "capture_ambiguous" };
+    if (!options.captureInference) return { status: "blocked", reason: "capture_inference_unavailable" };
+    if (!options.judgment) return { status: "blocked", reason: "judgment_unavailable" };
+
+    let raw: unknown;
+    try {
+      raw = await options.captureInference.infer({
+        evidence,
+        existingOutcomes: [...states.values()].map((view) => ({
+          outcomeId: view.contract.outcomeId,
+          contractVersion: view.contract.version,
+          objective: view.contract.objective,
+          state: view.state,
+        })),
+      });
+    } catch {
+      return { status: "blocked", reason: "capture_inference_unavailable" };
+    }
+    const inferred = inferenceSchema.safeParse(raw);
+    if (!inferred.success) return { status: "blocked", reason: "capture_ambiguous" };
+    if (inferred.data.status === "ambiguous") return { status: "blocked", reason: "capture_ambiguous" };
+
+    let target: OutcomeView | null;
+    if (inferred.data.status === "inferred") {
+      const existing = states.get(inferred.data.contract.outcomeId);
+      if (existing) {
+        if (existing.contract.id !== inferred.data.contract.id || existing.contract.version !== inferred.data.contract.version) return { status: "denied", reason: "capture_contract_conflict", view: existing };
+        target = existing;
+      } else {
+        const declared = append({ type: "declared", contract: inferred.data.contract }, `declared:${inferred.data.contract.id}`);
+        if (declared === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        if (declared === "conflict") return { status: "denied", reason: "capture_contract_conflict" };
+        const accepted = append({ type: "accepted", outcomeId: inferred.data.contract.outcomeId, contractVersion: inferred.data.contract.version }, `accepted:${inferred.data.contract.id}`);
+        if (accepted === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        target = states.get(inferred.data.contract.outcomeId) ?? null;
+      }
+    } else {
+      target = contractFor(inferred.data.outcomeId, inferred.data.contractVersion);
+      if (!target) return { status: "blocked", reason: "capture_outcome_missing" };
+    }
+    if (!target || (target.state !== "accepted" && target.state !== "running")) return { status: "blocked", view: target ?? undefined, reason: "outcome_not_ready" };
+    const linked = ensureLinks(target);
+    if (linked) return linked;
+    const captureLink = append({ type: "capture-linked", outcomeId: target.contract.outcomeId, contractVersion: target.contract.version, capture: evidence }, `capture:${evidence.captureId}`);
+    if (captureLink === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+    if (captureLink === "conflict") return { status: "denied", reason: "capture_conflict", view: states.get(target.contract.outcomeId) };
+    const ready = states.get(target.contract.outcomeId);
+    if (!ready || (ready.state !== "accepted" && ready.state !== "running")) return { status: "blocked", view: ready ?? target, reason: "outcome_changed_during_capture" };
+    return run(ready);
+  }
+
+  async function dispatch(rawCommand: unknown): Promise<OutcomeCommandResult> {
+    if (!journalAvailable) return unavailable();
+    const parsed = commandSchema.safeParse(rawCommand);
+    if (!parsed.success) return { status: "denied", reason: "invalid_command" };
+    const command = parsed.data;
+    switch (command.kind) {
+      case "declare": {
+        if (states.has(command.contract.outcomeId)) return { status: "denied", reason: "outcome_already_exists", view: states.get(command.contract.outcomeId) };
+        const declared: OutcomeEvent = { type: "declared", contract: command.contract };
+        const appended = append(declared, `declared:${command.contract.id}`);
+        if (appended === "conflict") return { status: "denied", reason: "declaration_conflict" };
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        return result(command.contract.outcomeId);
+      }
+      case "capture":
+        return capture(command.evidence);
+      case "accept": {
+        const view = contractFor(command.outcomeId, command.contractVersion);
+        if (!view) return { status: "denied", reason: "contract_version_mismatch_or_missing" };
+        if (terminal(view.state)) return { status: "denied", reason: "terminal_state", view };
+        if (view.state === "declared") {
+          const appended = append({ type: "accepted", outcomeId: command.outcomeId, contractVersion: command.contractVersion }, `accepted:${view.contract.id}`);
+          if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        }
+        const accepted = states.get(command.outcomeId);
+        if (!accepted || !["accepted", "running", "needs-you", "verifying"].includes(accepted.state)) return { status: "blocked", view: accepted ?? view, reason: "contract_not_accepted" };
+        return ensureLinks(accepted) ?? result(command.outcomeId);
+      }
+      case "run": {
+        const view = contractFor(command.outcomeId, command.contractVersion);
+        if (!view) return { status: "denied", reason: "outcome_not_ready" };
+        if (view.state !== "accepted" && view.state !== "running") return { status: "denied", reason: "outcome_not_ready", view };
+        return run(view);
+      }
+      case "answer-needs-you": {
+        const view = contractFor(command.outcomeId, command.contractVersion);
+        if (!view) return { status: "denied", reason: "needs_you_mismatch" };
+        if (view.state !== "needs-you" || view.needsYou.inputKey !== command.inputKey) return { status: "denied", reason: "needs_you_mismatch", view };
+        const appended = append({ type: "needs-you-answered", outcomeId: command.outcomeId, contractVersion: command.contractVersion, inputKey: command.inputKey, answerHash: createHash("sha256").update(command.answer, "utf8").digest("hex"), answerLength: command.answer.length, answeredBy: command.answeredBy, answeredAt: now() }, `needs-you-answered:${view.contract.id}:${command.inputKey}`);
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        return result(command.outcomeId);
+      }
+      case "record-evidence": {
+        const evidence = command.evidence;
+        const view = contractFor(evidence.outcomeId, evidence.contractVersion);
+        if (!view) return { status: "denied", reason: "evidence_contract_mismatch" };
+        if (terminal(view.state)) return { status: "denied", reason: "terminal_state", view };
+        const duplicate = view.evidence.find((item) => item.evidenceId === evidence.evidenceId);
+        if (duplicate) return JSON.stringify(duplicate) === JSON.stringify(evidence) ? result(evidence.outcomeId) : { status: "denied", reason: "evidence_conflict", view };
+        const appended = append({ type: "evidence-recorded", evidence }, `evidence:${view.contract.id}:${evidence.evidenceId}`);
+        if (appended === "conflict") return { status: "denied", reason: "evidence_conflict", view };
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        return result(evidence.outcomeId);
+      }
+      case "verify": {
+        const view = contractFor(command.outcomeId, command.contractVersion);
+        if (!view) return { status: "denied", reason: "outcome_not_ready" };
+        if (view.state !== "running" && view.state !== "verifying") return { status: "denied", reason: "outcome_not_ready", view };
+        return verify(view);
+      }
+      case "cancel": {
+        const view = contractFor(command.outcomeId, command.contractVersion);
+        if (!view) return { status: "denied", reason: "terminal_state_or_missing" };
+        if (terminal(view.state)) return { status: "denied", reason: "terminal_state_or_missing", view };
+        const state = view.contract.rollback.onCancel === "reversible-stop" ? "rolled_back" : "cancelled";
+        const appended = append({ type: "terminal", outcomeId: command.outcomeId, contractVersion: command.contractVersion, state, reason: command.reason }, `terminal:${view.contract.id}:${state}`);
+        if (appended === "failed") return { status: "unavailable", reason: "journal_write_failed" };
+        return result(command.outcomeId);
+      }
+      default: {
+        const exhaustive: never = command;
+        return { status: "denied", reason: `unknown_command:${String(exhaustive)}` };
+      }
+    }
+  }
+
+  return {
+    dispatch,
+    inspect(outcomeId) {
+      if (!journalAvailable) return { status: "unavailable" };
+      const view = states.get(outcomeId);
+      return view ? { status: "available", view } : { status: "missing" };
+    },
+  };
+}

--- a/server/provider-action-adapter.ts
+++ b/server/provider-action-adapter.ts
@@ -1,0 +1,130 @@
+import type { AccountDirectory, LogicalIdentity } from "./account-directory.ts";
+import { canonicalConnectorAction, type CanonicalConnectorOperation } from "./canonical-connector-action.ts";
+import type { ActionPolicy, ActionProposal } from "./action-policy.ts";
+
+/** The only provider-facing execution seam. Drivers never receive raw model
+ * arguments; they receive this exact, policy-checked proposal. */
+export interface ProviderActionCall {
+  readonly toolName: string;
+  readonly arguments: unknown;
+  readonly identity: LogicalIdentity;
+  readonly provider: string;
+  readonly ownerId: string;
+  /** AccountDirectory is installation-scoped today while policy ownership is
+   * bot-scoped. Keep the two scopes explicit instead of accidentally treating
+   * a bot id as an account-directory owner. */
+  readonly accountOwnerId: string;
+  readonly authorizationId?: string;
+}
+export interface ProviderActionReceipt {
+  readonly ok: boolean;
+  readonly reference: string;
+  readonly observedAt?: string;
+}
+
+export interface ProviderActionExecutor {
+  execute(proposal: ActionProposal): Promise<ProviderActionReceipt>;
+}
+
+export interface PreparedProviderAction {
+  readonly proposal: ActionProposal;
+  readonly operation: CanonicalConnectorOperation;
+  readonly accountId: string;
+}
+
+export type ProviderActionExecutionResult =
+  | { readonly status: "executed"; readonly proposal: ActionProposal; readonly receipt: ProviderActionReceipt }
+  | { readonly status: "denied"; readonly reason: string; readonly proposal?: ActionProposal };
+
+export interface ProviderActionAdapter {
+  prepare(call: ProviderActionCall): PreparedProviderAction | { readonly status: "denied"; readonly reason: string };
+  execute(call: ProviderActionCall, executor: ProviderActionExecutor): Promise<ProviderActionExecutionResult>;
+}
+
+export class ProviderActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderActionError";
+  }
+}
+
+/**
+ * Deep adapter for all canonical connector mutations. It verifies account
+ * identity before policy evaluation, consumes one-time approvals atomically
+ * at the last safe seam, and never lets an unknown tool reach an executor.
+ */
+export function createProviderActionAdapter(options: {
+  readonly policy: ActionPolicy;
+  readonly accounts: AccountDirectory;
+}): ProviderActionAdapter {
+  const prepare = (call: ProviderActionCall): PreparedProviderAction | { readonly status: "denied"; readonly reason: string } => {
+      const canonical = canonicalConnectorAction(call.toolName, call.arguments);
+      if (canonical.fidelity !== "canonical") {
+        return { status: "denied", reason: canonical.fidelity === "unsupported" ? "This provider write has no canonical adapter" : canonical.reason };
+      }
+      if (operationProvider(canonical.action.operation) !== call.provider.trim().toLowerCase()) {
+        return { status: "denied", reason: "The provider does not match the canonical operation" };
+      }
+      const accountResolution = accountResolutionForIdentity(options.accounts, call, canonical.action.accountId);
+      if (accountResolution.status !== "resolved") {
+        const reason = accountResolution.status === "ambiguous"
+          ? "The selected identity has multiple provider accounts; choose one exact account"
+          : accountResolution.status === "not_found"
+            ? "The provider account is not bound to the selected identity"
+            : accountResolution.status === "forbidden"
+              ? "The account binding owner is not authorized"
+              : "The account binding is invalid";
+        return { status: "denied", reason };
+      }
+      const proposal = options.policy.prepareProposal({ ...canonical.action, ownerId: call.ownerId });
+      return { proposal, operation: canonical.action.operation, accountId: canonical.action.accountId };
+  };
+
+  return {
+    prepare,
+
+    async execute(call, executor) {
+      const prepared = prepare(call);
+      if ("status" in prepared) return prepared;
+      const authorizationId = call.authorizationId;
+      if (authorizationId) {
+        const authorization = options.policy.getAuthorization(authorizationId);
+        if (!authorization) return { status: "denied", reason: "One-time authorization was not found", proposal: prepared.proposal };
+        const decision = options.policy.consumeAuthorization(authorizationId, {
+          operation: prepared.proposal.operation,
+          accountId: prepared.proposal.accountId,
+          payload: prepared.proposal.payload,
+          ownerId: prepared.proposal.ownerId,
+        });
+        if (!decision.allowed) return { status: "denied", reason: decision.reason, proposal: prepared.proposal };
+        const authorizedProposal = options.policy.getProposal(authorization.proposalId);
+        if (!authorizedProposal) return { status: "denied", reason: "The authorized proposal no longer exists", proposal: prepared.proposal };
+        const receipt = await executor.execute(authorizedProposal);
+        return { status: "executed", proposal: authorizedProposal, receipt };
+      } else {
+        const decision = options.policy.evaluate(prepared.proposal);
+        if (decision.effect !== "allow") return { status: "denied", reason: decision.reason, proposal: prepared.proposal };
+      }
+      const receipt = await executor.execute(prepared.proposal);
+      return { status: "executed", proposal: prepared.proposal, receipt };
+    },
+  };
+}
+
+function operationProvider(operation: string): string {
+  return operation.slice(0, operation.indexOf("."));
+}
+
+function accountResolutionForIdentity(
+  accounts: AccountDirectory,
+  call: ProviderActionCall,
+  accountId: string,
+) {
+  return accounts.resolveExact({
+    ownerId: call.accountOwnerId,
+    identity: call.identity,
+    provider: call.provider,
+    accountId,
+  });
+}
+

--- a/server/v3-index.ts
+++ b/server/v3-index.ts
@@ -1,0 +1,8 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+process.env.OMB_PRODUCT_ID = "centipede-v3";
+process.env.OMB_PORT ??= "18899";
+process.env.OMB_WEBHOOK_PORT ??= "18900";
+process.env.OMB_DATA_DIR ??= join(homedir(), ".centipede-v3");
+await import("./index.ts");

--- a/server/work-lock-store.ts
+++ b/server/work-lock-store.ts
@@ -1,0 +1,645 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { z } from "zod";
+
+import { DATA_DIR } from "./config.ts";
+import { parseJson, type JsonValue } from "./schema.ts";
+
+export const WORK_OBLIGATION_STATUSES = ["open", "in_progress", "blocked", "completed", "cancelled"] as const;
+export type WorkObligationStatus = (typeof WORK_OBLIGATION_STATUSES)[number];
+export const WORK_APPROVAL_STATUSES = ["pending", "approved", "rejected", "revoked"] as const;
+export type WorkApprovalStatus = (typeof WORK_APPROVAL_STATUSES)[number];
+export const WORK_DEADLINE_STATUSES = ["active", "met", "missed", "cancelled"] as const;
+export type WorkDeadlineStatus = (typeof WORK_DEADLINE_STATUSES)[number];
+
+export interface WorkExternalIdentity {
+  source: string;
+  id: string;
+}
+export interface WorkOwner {
+  id: string;
+  label?: string;
+}
+
+export interface WorkEvidence {
+  id: string;
+  obligationId: string;
+  kind: string;
+  reference: string;
+  summary: string;
+  recordedAt: number;
+  metadata: JsonValue | null;
+}
+
+export interface WorkApproval {
+  id: string;
+  obligationId: string;
+  key: string;
+  prompt: string;
+  status: WorkApprovalStatus;
+  requestedBy: string | null;
+  decidedBy: string | null;
+  decidedAt: number | null;
+  payload: JsonValue | null;
+  payloadHash: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorkDeadline {
+  id: string;
+  obligationId: string;
+  key: string;
+  label: string;
+  dueAt: number;
+  status: WorkDeadlineStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorkObligation {
+  id: string;
+  externalIdentity: WorkExternalIdentity;
+  title: string;
+  description: string | null;
+  status: WorkObligationStatus;
+  owner: WorkOwner | null;
+  version: number;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  cancelledAt: number | null;
+  metadata: JsonValue | null;
+  approvals: WorkApproval[];
+  deadlines: WorkDeadline[];
+  evidence: WorkEvidence[];
+}
+
+export interface CreateObligationInput {
+  title: string;
+  description?: string;
+  externalIdentity?: WorkExternalIdentity;
+  /** Convenience aliases for callers importing an external record. */
+  source?: string;
+  externalId?: string;
+  externalKey?: string;
+  ownerId?: string | null;
+  ownerLabel?: string;
+  metadata?: JsonValue;
+  deadline?: { key?: string; label: string; dueAt: number };
+  /** Initial children are committed with the obligation so import adapters
+   * cannot expose a half-populated work record. */
+  approval?: AddApprovalInput;
+  evidence?: AddEvidenceInput;
+}
+
+export interface UpdateObligationInput {
+  expectedVersion?: number;
+  title?: string;
+  description?: string | null;
+  ownerId?: string | null;
+  ownerLabel?: string;
+  metadata?: JsonValue | null;
+}
+
+export interface AddApprovalInput {
+  key: string;
+  prompt: string;
+  requestedBy?: string;
+  payload?: JsonValue;
+}
+
+export interface AddDeadlineInput {
+  key?: string;
+  label: string;
+  dueAt: number;
+}
+
+export interface AddEvidenceInput {
+  kind: string;
+  reference: string;
+  summary: string;
+  recordedAt?: number;
+  metadata?: JsonValue;
+}
+
+export interface OpenWorkQuery {
+  ownerId?: string;
+  statuses?: WorkObligationStatus[];
+  asOf?: number;
+  limit?: number;
+}
+
+export interface OpenWorkProjection {
+  generatedAt: number;
+  obligations: WorkObligation[];
+  pendingApprovals: WorkApproval[];
+  deadlines: WorkDeadline[];
+}
+
+export interface WorkLockStoreInterface {
+  createObligation(input: CreateObligationInput): { status: "created" | "deduplicated"; obligation: WorkObligation };
+  getObligation(id: string): WorkObligation | null;
+  updateObligation(id: string, input: UpdateObligationInput): WorkObligation;
+  transitionObligation(id: string, status: WorkObligationStatus, expectedVersion?: number): WorkObligation;
+  completeObligation(id: string, expectedVersion?: number): WorkObligation;
+  cancelObligation(id: string, expectedVersion?: number): WorkObligation;
+  setOwner(id: string, owner: WorkOwner | null, expectedVersion?: number): WorkObligation;
+  addApproval(id: string, input: AddApprovalInput, expectedVersion?: number): { status: "created" | "deduplicated"; approval: WorkApproval; obligation: WorkObligation };
+  decideApproval(id: string, approvalId: string, status: "approved" | "rejected" | "revoked", decidedBy?: string, expectedVersion?: number): { approval: WorkApproval; obligation: WorkObligation };
+  addDeadline(id: string, input: AddDeadlineInput, expectedVersion?: number): { status: "created" | "deduplicated"; deadline: WorkDeadline; obligation: WorkObligation };
+  decideDeadline(id: string, deadlineId: string, status: "met" | "missed" | "cancelled", expectedVersion?: number): { deadline: WorkDeadline; obligation: WorkObligation };
+  recordEvidence(id: string, input: AddEvidenceInput, expectedVersion?: number): { status: "recorded" | "deduplicated"; evidence: WorkEvidence; obligation: WorkObligation };
+  listOpenWork(query?: OpenWorkQuery): OpenWorkProjection;
+  close(): void;
+}
+
+const identitySchema = z.object({ source: z.string().trim().min(1).max(200), id: z.string().trim().min(1).max(500) });
+const createInputSchema = z.object({
+  title: z.string().trim().min(1).max(1_000),
+  description: z.string().max(20_000).optional(),
+  externalIdentity: identitySchema.optional(),
+  source: z.string().trim().min(1).max(200).optional(),
+  externalId: z.string().trim().min(1).max(500).optional(),
+  externalKey: z.string().trim().min(1).max(700).optional(),
+  ownerId: z.string().trim().min(1).max(300).nullable().optional(),
+  ownerLabel: z.string().trim().max(500).optional(),
+  metadata: z.json().optional(),
+  deadline: z.object({ key: z.string().trim().min(1).max(300).optional(), label: z.string().trim().min(1).max(500), dueAt: z.number().finite() }).optional(),
+  approval: z.object({ key: z.string().trim().min(1).max(300), prompt: z.string().trim().min(1).max(4_000), requestedBy: z.string().trim().min(1).max(300).optional(), payload: z.json().optional() }).optional(),
+  evidence: z.object({ kind: z.string().trim().min(1).max(120), reference: z.string().trim().min(1).max(2_000), summary: z.string().trim().min(1).max(4_000), recordedAt: z.number().finite().optional(), metadata: z.json().optional() }).optional(),
+});
+const updateInputSchema = z.object({
+  expectedVersion: z.number().int().positive().optional(),
+  title: z.string().trim().min(1).max(1_000).optional(),
+  description: z.string().max(20_000).nullable().optional(),
+  ownerId: z.string().trim().min(1).max(300).nullable().optional(),
+  ownerLabel: z.string().trim().max(500).optional(),
+  metadata: z.json().nullable().optional(),
+});
+const approvalInputSchema = z.object({ key: z.string().trim().min(1).max(300), prompt: z.string().trim().min(1).max(4_000), requestedBy: z.string().trim().min(1).max(300).optional(), payload: z.json().optional() });
+const deadlineInputSchema = z.object({ key: z.string().trim().min(1).max(300).optional(), label: z.string().trim().min(1).max(500), dueAt: z.number().finite() });
+const evidenceInputSchema = z.object({ kind: z.string().trim().min(1).max(120), reference: z.string().trim().min(1).max(2_000), summary: z.string().trim().min(1).max(4_000), recordedAt: z.number().finite().optional(), metadata: z.json().optional() });
+
+const obligationRowSchema = z.object({
+  id: z.string(), external_namespace: z.string(), external_key: z.string(), title: z.string(), description: z.string().nullable(),
+  status: z.enum(WORK_OBLIGATION_STATUSES), owner_id: z.string().nullable(), owner_label: z.string().nullable(), version: z.number(),
+  created_at: z.number(), updated_at: z.number(), completed_at: z.number().nullable(), cancelled_at: z.number().nullable(), metadata_json: z.string().nullable(),
+});
+const approvalRowSchema = z.object({ id: z.string(), obligation_id: z.string(), approval_key: z.string(), prompt: z.string(), status: z.enum(WORK_APPROVAL_STATUSES), requested_by: z.string().nullable(), decided_by: z.string().nullable(), decided_at: z.number().nullable(), payload_json: z.string().nullable(), payload_hash: z.string().nullable(), created_at: z.number(), updated_at: z.number() });
+const deadlineRowSchema = z.object({ id: z.string(), obligation_id: z.string(), deadline_key: z.string(), label: z.string(), due_at: z.number(), status: z.enum(WORK_DEADLINE_STATUSES), created_at: z.number(), updated_at: z.number() });
+const evidenceRowSchema = z.object({ id: z.string(), obligation_id: z.string(), kind: z.string(), reference: z.string(), summary: z.string(), recorded_at: z.number(), metadata_json: z.string().nullable() });
+
+function normalized(value: string): string {
+  return value.normalize("NFKC").replace(/\s+/g, " ").trim().toLocaleLowerCase();
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function canonicalJson(value: JsonValue): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  const primitive = z.union([z.string(), z.number(), z.boolean()]).safeParse(value);
+  if (primitive.success) return JSON.stringify(primitive.data);
+  const object = z.record(z.string(), z.json()).parse(value);
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key] ?? null)}`).join(",")}}`;
+}
+
+function jsonText(value: JsonValue | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  const text = canonicalJson(value);
+  if (text.length > 100_000) throw new WorkLockError("payload_too_large", "Work-lock JSON is too large");
+  return text;
+}
+
+export class WorkLockError extends Error {
+  readonly code: "invalid" | "not_found" | "version_conflict" | "illegal_transition" | "approval_pending" | "evidence_required" | "duplicate" | "payload_too_large";
+  readonly status: number;
+
+  constructor(code: WorkLockError["code"], message: string) {
+    super(message);
+    this.name = "WorkLockError";
+    this.code = code;
+    this.status = code === "not_found" ? 404 : code === "version_conflict" || code === "illegal_transition" || code === "approval_pending" || code === "evidence_required" || code === "duplicate" ? 409 : 400;
+  }
+}
+
+const noObligationTransitions: readonly WorkObligationStatus[] = [];
+const legalObligationTransitions = {
+  open: ["in_progress", "blocked", "completed", "cancelled"],
+  in_progress: ["blocked", "completed", "cancelled"],
+  blocked: ["in_progress", "completed", "cancelled"],
+  completed: noObligationTransitions,
+  cancelled: noObligationTransitions,
+} satisfies { [status in WorkObligationStatus]: readonly WorkObligationStatus[] };
+
+/**
+ * Durable work locks: obligations and their approvals, deadlines, evidence,
+ * owner, and completion state. The interface deliberately returns a single
+ * projection for callers; identity, transactions, version checks, and
+ * lifecycle legality stay inside this module.
+ */
+export class WorkLockStore implements WorkLockStoreInterface {
+  private readonly db: DatabaseSync;
+  private readonly now: () => number;
+
+  constructor(options: { file?: string; now?: () => number } = {}) {
+    const file = options.file ?? join(DATA_DIR, "work-lock-store.db");
+    mkdirSync(dirname(file), { recursive: true });
+    this.db = new DatabaseSync(file);
+    this.now = options.now ?? Date.now;
+    this.db.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS work_obligations (
+        id TEXT PRIMARY KEY,
+        external_namespace TEXT NOT NULL,
+        external_key TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        status TEXT NOT NULL CHECK(status IN ('open','in_progress','blocked','completed','cancelled')),
+        owner_id TEXT,
+        owner_label TEXT,
+        version INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        cancelled_at INTEGER,
+        metadata_json TEXT,
+        UNIQUE(external_namespace, external_key)
+      );
+      CREATE INDEX IF NOT EXISTS work_obligations_open ON work_obligations(status, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS work_obligations_owner ON work_obligations(owner_id, status);
+      CREATE TABLE IF NOT EXISTS work_approvals (
+        id TEXT PRIMARY KEY,
+        obligation_id TEXT NOT NULL REFERENCES work_obligations(id) ON DELETE CASCADE,
+        approval_key TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('pending','approved','rejected','revoked')),
+        requested_by TEXT,
+        decided_by TEXT,
+        decided_at INTEGER,
+        payload_json TEXT,
+        payload_hash TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(obligation_id, approval_key)
+      );
+      CREATE INDEX IF NOT EXISTS work_approvals_pending ON work_approvals(status, obligation_id);
+      CREATE TABLE IF NOT EXISTS work_deadlines (
+        id TEXT PRIMARY KEY,
+        obligation_id TEXT NOT NULL REFERENCES work_obligations(id) ON DELETE CASCADE,
+        deadline_key TEXT NOT NULL,
+        label TEXT NOT NULL,
+        due_at INTEGER NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('active','met','missed','cancelled')),
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(obligation_id, deadline_key)
+      );
+      CREATE INDEX IF NOT EXISTS work_deadlines_due ON work_deadlines(status, due_at);
+      CREATE TABLE IF NOT EXISTS work_evidence (
+        id TEXT PRIMARY KEY,
+        obligation_id TEXT NOT NULL REFERENCES work_obligations(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL,
+        reference TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        recorded_at INTEGER NOT NULL,
+        metadata_json TEXT,
+        UNIQUE(obligation_id, kind, reference)
+      );
+      CREATE INDEX IF NOT EXISTS work_evidence_obligation ON work_evidence(obligation_id, recorded_at DESC);
+    `);
+  }
+
+  createObligation(raw: CreateObligationInput): { status: "created" | "deduplicated"; obligation: WorkObligation } {
+    const input = createInputSchema.parse(raw);
+    const identity = this.identity(input);
+    const id = `omb_lock_${hash(`${identity.source}\u001f${identity.id}`).slice(0, 48)}`;
+    const now = this.now();
+    return this.transaction(() => {
+      const existing = this.db.prepare("SELECT id FROM work_obligations WHERE external_namespace = ? AND external_key = ?").get(identity.source, identity.id);
+      if (existing !== undefined) {
+        const parsed = z.object({ id: z.string() }).parse(existing);
+        return { status: "deduplicated", obligation: this.obligationById(parsed.id) };
+      }
+      this.db.prepare(`INSERT INTO work_obligations (id, external_namespace, external_key, title, description, status, owner_id, owner_label, version, created_at, updated_at, completed_at, cancelled_at, metadata_json) VALUES (?, ?, ?, ?, ?, 'open', ?, ?, 1, ?, ?, NULL, NULL, ?)`).run(
+        id, identity.source, identity.id, input.title.trim(), input.description ?? null, input.ownerId ?? null, input.ownerLabel?.trim() ?? null, now, now, jsonText(input.metadata),
+      );
+      if (input.deadline) {
+        const key = normalized(input.deadline.key ?? "primary");
+        this.db.prepare("INSERT INTO work_deadlines (id, obligation_id, deadline_key, label, due_at, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'active', ?, ?)").run(
+          `omb_deadline_${hash(`${id}\u001f${key}`).slice(0, 40)}`, id, key, input.deadline.label.trim(), input.deadline.dueAt, now, now,
+        );
+      }
+      if (input.approval) {
+        const key = normalized(input.approval.key);
+        const approvalId = `omb_approval_${hash(`${id}\u001f${key}`).slice(0, 40)}`;
+        this.db.prepare("INSERT INTO work_approvals (id, obligation_id, approval_key, prompt, status, requested_by, decided_by, decided_at, payload_json, payload_hash, created_at, updated_at) VALUES (?, ?, ?, ?, 'pending', ?, NULL, NULL, ?, ?, ?, ?)").run(
+          approvalId,
+          id,
+          key,
+          input.approval.prompt.trim(),
+          input.approval.requestedBy?.trim() ?? null,
+          jsonText(input.approval.payload),
+          input.approval.payload === undefined ? null : hash(canonicalJson(input.approval.payload)),
+          now,
+          now,
+        );
+      }
+      if (input.evidence) {
+        const kind = input.evidence.kind.trim();
+        const reference = input.evidence.reference.trim();
+        const evidenceId = `omb_evidence_${hash(`${id}\u001f${kind}\u001f${reference}`).slice(0, 40)}`;
+        this.db.prepare("INSERT INTO work_evidence (id, obligation_id, kind, reference, summary, recorded_at, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?)").run(
+          evidenceId,
+          id,
+          kind,
+          reference,
+          input.evidence.summary.trim(),
+          input.evidence.recordedAt ?? now,
+          jsonText(input.evidence.metadata),
+        );
+      }
+      return { status: "created", obligation: this.obligationById(id) };
+    });
+  }
+
+  getObligation(id: string): WorkObligation | null {
+    const row = this.db.prepare("SELECT * FROM work_obligations WHERE id = ?").get(id);
+    if (row === undefined) return null;
+    return this.obligationFromRow(obligationRowSchema.parse(row));
+  }
+
+  updateObligation(id: string, raw: UpdateObligationInput): WorkObligation {
+    const input = updateInputSchema.parse(raw);
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, input.expectedVersion);
+      const sets: string[] = [];
+      const values: Array<string | number | null> = [];
+      if (input.title !== undefined) { sets.push("title = ?"); values.push(input.title.trim()); }
+      if (input.description !== undefined) { sets.push("description = ?"); values.push(input.description); }
+      if (input.ownerId !== undefined) { sets.push("owner_id = ?"); values.push(input.ownerId); }
+      if (input.ownerLabel !== undefined) { sets.push("owner_label = ?"); values.push(input.ownerLabel.trim() || null); }
+      if (input.metadata !== undefined) { sets.push("metadata_json = ?"); values.push(jsonText(input.metadata)); }
+      if (sets.length === 0) return current;
+      const now = this.now();
+      sets.push("version = version + 1", "updated_at = ?");
+      values.push(now, id);
+      this.db.prepare(`UPDATE work_obligations SET ${sets.join(", ")} WHERE id = ? AND version = ?`).run(...values, current.version);
+      return this.obligationById(id);
+    });
+  }
+
+  transitionObligation(id: string, status: WorkObligationStatus, expectedVersion?: number): WorkObligation {
+    if (!WORK_OBLIGATION_STATUSES.includes(status)) throw new WorkLockError("invalid", `Unknown obligation status: ${status}`);
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertVersion(current, expectedVersion);
+      if (current.status === status) return current;
+      this.assertMutable(current);
+      const allowedTransitions: readonly WorkObligationStatus[] = legalObligationTransitions[current.status];
+      if (!allowedTransitions.includes(status)) throw new WorkLockError("illegal_transition", `Cannot transition obligation from ${current.status} to ${status}`);
+      if (status === "completed" && current.approvals.some((approval) => approval.status === "pending")) throw new WorkLockError("approval_pending", "Resolve pending approvals before completing this obligation");
+      if (status === "completed" && current.evidence.length === 0) throw new WorkLockError("evidence_required", "Record completion evidence before completing this obligation");
+      const now = this.now();
+      const completedAt = status === "completed" ? now : null;
+      const cancelledAt = status === "cancelled" ? now : null;
+      this.db.prepare("UPDATE work_obligations SET status = ?, version = version + 1, updated_at = ?, completed_at = ?, cancelled_at = ? WHERE id = ? AND version = ?").run(status, now, completedAt, cancelledAt, id, current.version);
+      return this.obligationById(id);
+    });
+  }
+
+  completeObligation(id: string, expectedVersion?: number): WorkObligation { return this.transitionObligation(id, "completed", expectedVersion); }
+  cancelObligation(id: string, expectedVersion?: number): WorkObligation { return this.transitionObligation(id, "cancelled", expectedVersion); }
+
+  setOwner(id: string, owner: WorkOwner | null, expectedVersion?: number): WorkObligation {
+    if (owner && (!owner.id.trim() || owner.id.length > 300)) throw new WorkLockError("invalid", "Owner id must be non-empty and bounded");
+    const update: UpdateObligationInput = { expectedVersion, ownerId: owner?.id.trim() ?? null };
+    if (owner?.label !== undefined) update.ownerLabel = owner.label;
+    return this.updateObligation(id, update);
+  }
+
+  addApproval(id: string, raw: AddApprovalInput, expectedVersion?: number): { status: "created" | "deduplicated"; approval: WorkApproval; obligation: WorkObligation } {
+    const input = approvalInputSchema.parse(raw);
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, expectedVersion);
+      const key = normalized(input.key);
+      const existing = this.db.prepare("SELECT * FROM work_approvals WHERE obligation_id = ? AND approval_key = ?").get(id, key);
+      if (existing !== undefined) {
+        return { status: "deduplicated", approval: this.approvalFromRow(approvalRowSchema.parse(existing)), obligation: current };
+      }
+      const now = this.now();
+      const approvalId = `omb_approval_${hash(`${id}\u001f${key}`).slice(0, 40)}`;
+      this.db.prepare("INSERT INTO work_approvals (id, obligation_id, approval_key, prompt, status, requested_by, decided_by, decided_at, payload_json, payload_hash, created_at, updated_at) VALUES (?, ?, ?, ?, 'pending', ?, NULL, NULL, ?, ?, ?, ?)").run(
+        approvalId, id, key, input.prompt.trim(), input.requestedBy?.trim() ?? null, jsonText(input.payload), input.payload === undefined ? null : hash(canonicalJson(input.payload)), now, now,
+      );
+      const obligation = this.bumpObligation(current);
+      return { status: "created", approval: this.approvalById(approvalId), obligation };
+    });
+  }
+
+  decideApproval(id: string, approvalId: string, status: "approved" | "rejected" | "revoked", decidedBy?: string, expectedVersion?: number): { approval: WorkApproval; obligation: WorkObligation } {
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, expectedVersion);
+      const approval = this.approvalById(approvalId);
+      if (approval.obligationId !== id) throw new WorkLockError("not_found", `Approval not found for obligation: ${approvalId}`);
+      if (status === "revoked" && approval.status !== "approved" && approval.status !== "pending") throw new WorkLockError("illegal_transition", `Cannot revoke an approval already ${approval.status}`);
+      if (status !== "revoked" && approval.status !== "pending") throw new WorkLockError("illegal_transition", `Cannot decide an approval already ${approval.status}`);
+      const now = this.now();
+      this.db.prepare("UPDATE work_approvals SET status = ?, decided_by = ?, decided_at = ?, updated_at = ? WHERE id = ?").run(status, decidedBy?.trim() ?? null, now, now, approvalId);
+      const obligation = this.bumpObligation(current);
+      return { approval: this.approvalById(approvalId), obligation };
+    });
+  }
+
+  addDeadline(id: string, raw: AddDeadlineInput, expectedVersion?: number): { status: "created" | "deduplicated"; deadline: WorkDeadline; obligation: WorkObligation } {
+    const input = deadlineInputSchema.parse(raw);
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, expectedVersion);
+      const key = normalized(input.key ?? `deadline-${hash(`${input.label}\u001f${input.dueAt}`).slice(0, 16)}`);
+      const existing = this.db.prepare("SELECT * FROM work_deadlines WHERE obligation_id = ? AND deadline_key = ?").get(id, key);
+      if (existing !== undefined) return { status: "deduplicated", deadline: this.deadlineFromRow(deadlineRowSchema.parse(existing)), obligation: current };
+      const now = this.now();
+      const deadlineId = `omb_deadline_${hash(`${id}\u001f${key}`).slice(0, 40)}`;
+      this.db.prepare("INSERT INTO work_deadlines (id, obligation_id, deadline_key, label, due_at, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'active', ?, ?)").run(deadlineId, id, key, input.label.trim(), input.dueAt, now, now);
+      const obligation = this.bumpObligation(current);
+      return { status: "created", deadline: this.deadlineById(deadlineId), obligation };
+    });
+  }
+
+  decideDeadline(id: string, deadlineId: string, status: "met" | "missed" | "cancelled", expectedVersion?: number): { deadline: WorkDeadline; obligation: WorkObligation } {
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, expectedVersion);
+      const deadline = this.deadlineById(deadlineId);
+      if (deadline.obligationId !== id) throw new WorkLockError("not_found", `Deadline not found for obligation: ${deadlineId}`);
+      if (deadline.status !== "active") throw new WorkLockError("illegal_transition", `Cannot decide a deadline already ${deadline.status}`);
+      const now = this.now();
+      this.db.prepare("UPDATE work_deadlines SET status = ?, updated_at = ? WHERE id = ?").run(status, now, deadlineId);
+      const obligation = this.bumpObligation(current);
+      return { deadline: this.deadlineById(deadlineId), obligation };
+    });
+  }
+
+  recordEvidence(id: string, raw: AddEvidenceInput, expectedVersion?: number): { status: "recorded" | "deduplicated"; evidence: WorkEvidence; obligation: WorkObligation } {
+    const input = evidenceInputSchema.parse(raw);
+    return this.transaction(() => {
+      const current = this.requireObligation(id);
+      this.assertMutable(current);
+      this.assertVersion(current, expectedVersion);
+      const existing = this.db.prepare("SELECT * FROM work_evidence WHERE obligation_id = ? AND kind = ? AND reference = ?").get(id, input.kind.trim(), input.reference.trim());
+      if (existing !== undefined) return { status: "deduplicated", evidence: this.evidenceFromRow(evidenceRowSchema.parse(existing)), obligation: current };
+      const recordedAt = input.recordedAt ?? this.now();
+      const evidenceId = `omb_evidence_${hash(`${id}\u001f${input.kind.trim()}\u001f${input.reference.trim()}`).slice(0, 40)}`;
+      this.db.prepare("INSERT INTO work_evidence (id, obligation_id, kind, reference, summary, recorded_at, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?)").run(evidenceId, id, input.kind.trim(), input.reference.trim(), input.summary.trim(), recordedAt, jsonText(input.metadata));
+      const obligation = this.bumpObligation(current);
+      return { status: "recorded", evidence: this.evidenceById(evidenceId), obligation };
+    });
+  }
+
+  listOpenWork(query: OpenWorkQuery = {}): OpenWorkProjection {
+    const statuses = query.statuses ?? ["open", "in_progress", "blocked"];
+    const asOf = query.asOf ?? this.now();
+    if (statuses.length === 0) return { generatedAt: asOf, obligations: [], pendingApprovals: [], deadlines: [] };
+    const limit = Math.max(1, Math.min(query.limit ?? 200, 1_000));
+    const values: Array<string | number> = [];
+    const clauses = [`status IN (${statuses.map(() => "?").join(",")})`];
+    values.push(...statuses);
+    if (query.ownerId !== undefined) { clauses.push("owner_id = ?"); values.push(query.ownerId); }
+    values.push(limit);
+    const rows = this.db.prepare(`SELECT * FROM work_obligations WHERE ${clauses.join(" AND ")} ORDER BY updated_at DESC, id ASC LIMIT ?`).all(...values);
+    const obligations = rows.map((row) => {
+      const obligation = this.obligationFromRow(obligationRowSchema.parse(row));
+      return {
+        ...obligation,
+        approvals: obligation.approvals.map((approval) => ({ ...approval, payload: null })),
+      };
+    });
+    const pendingApprovals = obligations.flatMap((obligation) => obligation.approvals.filter((approval) => approval.status === "pending"));
+    // The projection exposes effective deadline state without mutating the
+    // canonical record during a read. A later explicit decision can persist
+    // "missed"; until then dueAt remains the durable source of truth.
+    const deadlines = obligations.flatMap((obligation) => obligation.deadlines
+      .map((deadline) => deadline.status === "active" && deadline.dueAt < asOf ? { ...deadline, status: "missed" as const } : deadline)
+      .filter((deadline) => deadline.status === "active" || deadline.status === "missed"));
+    return { generatedAt: asOf, obligations, pendingApprovals, deadlines };
+  }
+
+  close(): void { this.db.close(); }
+
+  private identity(input: z.infer<typeof createInputSchema>): WorkExternalIdentity {
+    if (input.externalIdentity) return { source: normalized(input.externalIdentity.source), id: normalized(input.externalIdentity.id) };
+    if (input.source && input.externalId) return { source: normalized(input.source), id: normalized(input.externalId) };
+    if (input.externalKey) return { source: normalized(input.source ?? "external"), id: normalized(input.externalKey) };
+    return { source: "local", id: randomUUID() };
+  }
+
+  private transaction<T>(work: () => T): T {
+    this.db.exec("BEGIN IMMEDIATE");
+    try { const result = work(); this.db.exec("COMMIT"); return result; }
+    catch (error) { try { this.db.exec("ROLLBACK"); } catch { /* preserve the original error */ } throw error; }
+  }
+
+  private assertVersion(obligation: WorkObligation, expectedVersion: number | undefined): void {
+    if (expectedVersion !== undefined && obligation.version !== expectedVersion) throw new WorkLockError("version_conflict", `Obligation ${obligation.id} is at version ${obligation.version}; expected ${expectedVersion}`);
+  }
+
+  private assertMutable(obligation: WorkObligation): void {
+    if (obligation.status === "completed" || obligation.status === "cancelled") {
+      throw new WorkLockError("illegal_transition", `Cannot mutate a ${obligation.status} obligation`);
+    }
+  }
+
+  private bumpObligation(obligation: WorkObligation): WorkObligation {
+    const now = this.now();
+    this.db.prepare("UPDATE work_obligations SET version = version + 1, updated_at = ? WHERE id = ? AND version = ?").run(now, obligation.id, obligation.version);
+    return this.obligationById(obligation.id);
+  }
+
+  private requireObligation(id: string): WorkObligation {
+    const obligation = this.getObligation(id);
+    if (!obligation) throw new WorkLockError("not_found", `Obligation not found: ${id}`);
+    return obligation;
+  }
+
+  private obligationById(id: string): WorkObligation {
+    const obligation = this.getObligation(id);
+    if (!obligation) throw new WorkLockError("not_found", `Obligation not found: ${id}`);
+    return obligation;
+  }
+
+  private obligationFromRow(row: z.infer<typeof obligationRowSchema>): WorkObligation {
+    const owner: WorkOwner | null = row.owner_id === null ? null : { id: row.owner_id };
+    if (owner && row.owner_label !== null) owner.label = row.owner_label;
+    return {
+      id: row.id,
+      externalIdentity: { source: row.external_namespace, id: row.external_key },
+      title: row.title,
+      description: row.description,
+      status: row.status,
+      owner,
+      version: row.version,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      completedAt: row.completed_at,
+      cancelledAt: row.cancelled_at,
+      metadata: row.metadata_json === null ? null : parseJson(row.metadata_json),
+      approvals: this.approvalsFor(row.id),
+      deadlines: this.deadlinesFor(row.id),
+      evidence: this.evidenceFor(row.id),
+    };
+  }
+
+  private approvalFromRow(row: z.infer<typeof approvalRowSchema>): WorkApproval {
+    return { id: row.id, obligationId: row.obligation_id, key: row.approval_key, prompt: row.prompt, status: row.status, requestedBy: row.requested_by, decidedBy: row.decided_by, decidedAt: row.decided_at, payload: row.payload_json === null ? null : parseJson(row.payload_json), payloadHash: row.payload_hash, createdAt: row.created_at, updatedAt: row.updated_at };
+  }
+
+  private deadlineFromRow(row: z.infer<typeof deadlineRowSchema>): WorkDeadline {
+    return { id: row.id, obligationId: row.obligation_id, key: row.deadline_key, label: row.label, dueAt: row.due_at, status: row.status, createdAt: row.created_at, updatedAt: row.updated_at };
+  }
+
+  private evidenceFromRow(row: z.infer<typeof evidenceRowSchema>): WorkEvidence {
+    return { id: row.id, obligationId: row.obligation_id, kind: row.kind, reference: row.reference, summary: row.summary, recordedAt: row.recorded_at, metadata: row.metadata_json === null ? null : parseJson(row.metadata_json) };
+  }
+
+  private approvalById(id: string): WorkApproval {
+    const row = this.db.prepare("SELECT * FROM work_approvals WHERE id = ?").get(id);
+    if (row === undefined) throw new WorkLockError("not_found", `Approval not found: ${id}`);
+    return this.approvalFromRow(approvalRowSchema.parse(row));
+  }
+
+  private deadlineById(id: string): WorkDeadline {
+    const row = this.db.prepare("SELECT * FROM work_deadlines WHERE id = ?").get(id);
+    if (row === undefined) throw new WorkLockError("not_found", `Deadline not found: ${id}`);
+    return this.deadlineFromRow(deadlineRowSchema.parse(row));
+  }
+
+  private evidenceById(id: string): WorkEvidence {
+    const row = this.db.prepare("SELECT * FROM work_evidence WHERE id = ?").get(id);
+    if (row === undefined) throw new WorkLockError("not_found", `Evidence not found: ${id}`);
+    return this.evidenceFromRow(evidenceRowSchema.parse(row));
+  }
+
+  private approvalsFor(id: string): WorkApproval[] { return this.db.prepare("SELECT * FROM work_approvals WHERE obligation_id = ? ORDER BY created_at ASC, id ASC").all(id).map((row) => this.approvalFromRow(approvalRowSchema.parse(row))); }
+  private deadlinesFor(id: string): WorkDeadline[] { return this.db.prepare("SELECT * FROM work_deadlines WHERE obligation_id = ? ORDER BY due_at ASC, id ASC").all(id).map((row) => this.deadlineFromRow(deadlineRowSchema.parse(row))); }
+  private evidenceFor(id: string): WorkEvidence[] { return this.db.prepare("SELECT * FROM work_evidence WHERE obligation_id = ? ORDER BY recorded_at ASC, id ASC").all(id).map((row) => this.evidenceFromRow(evidenceRowSchema.parse(row))); }
+}
+
+export function createWorkLockStore(options: { file?: string; now?: () => number } = {}): WorkLockStoreInterface {
+  return new WorkLockStore(options);
+}
+

--- a/server/work-orchestrator.ts
+++ b/server/work-orchestrator.ts
@@ -1,0 +1,854 @@
+/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-runtime-typeof,
+ * anti-slop/no-unsafe-dictionary-type, anti-slop/require-safety-comment-for-type-assertion
+ * -- provider events and journal bytes are untrusted JSON and are narrowed at
+ * this orchestration boundary. */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { z } from "zod";
+
+import { writeFileAtomic } from "./atomic.ts";
+import type { AccountDirectory } from "./account-directory.ts";
+import { canonicalizeActionPayload, type ActionPolicy, type ActionProposal } from "./action-policy.ts";
+import { createProviderActionAdapter } from "./provider-action-adapter.ts";
+import type { JsonObject, JsonValue } from "./schema.ts";
+import type { AutonomyTelemetryInterface } from "./autonomy-telemetry.ts";
+import type { WorkEvidence, WorkLockStoreInterface } from "./work-lock-store.ts";
+
+export interface WorkActionReceipt {
+  readonly ok: boolean;
+  readonly reference: string;
+  readonly observedAt?: number | string;
+  readonly [key: string]: JsonValue | undefined;
+}
+
+export type WorkActionExecutionResult =
+  | { readonly kind: "final"; readonly receipt: WorkActionReceipt }
+  | { readonly kind: "handoff"; readonly reference: string };
+
+export interface WorkActionExecutor {
+  execute(proposal: ActionProposal): Promise<WorkActionExecutionResult>;
+}
+
+export type WorkVerificationResult =
+  | { readonly status: "verified"; readonly evidence: Pick<WorkEvidence, "kind" | "reference" | "summary" | "recordedAt"> & { readonly metadata?: JsonValue | null } }
+  | { readonly status: "not_verified"; readonly reason: string };
+
+export interface WorkActionVerifier {
+  verify(proposal: ActionProposal, receipt: WorkActionReceipt): Promise<WorkVerificationResult>;
+}
+
+export interface WorkActionEvent {
+  readonly type: "action";
+  readonly source: string;
+  readonly externalId: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly ownerId: string;
+  readonly ownerLabel?: string;
+  readonly identity: string;
+  readonly provider: string;
+  readonly toolName: string;
+  readonly arguments: unknown;
+  readonly requestedBy?: string;
+  readonly workScope?: "aws" | "other";
+}
+
+export interface CaptureWorkEvent {
+  readonly type: "capture";
+  readonly source: string;
+  readonly sourceId: string;
+  readonly evidenceHash: string;
+  readonly title: string;
+  readonly summary?: string;
+  readonly ownerId: string;
+  readonly evidenceRef: string;
+  readonly captureRunId?: string;
+  readonly actionClass?: string;
+  readonly observedAt?: number;
+}
+
+/** A one-way legacy-profile record. It can create pending work metadata, but
+ * carries no provider operation, payload, authorization, or execution grant. */
+export interface ProfileWorkEvent {
+  readonly type: "profile-import";
+  readonly source: string;
+  readonly profileId: string;
+  readonly externalId: string;
+  readonly contentHash: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly ownerId: string;
+  readonly ownerLabel?: string;
+  readonly evidence: {
+    readonly reference: string;
+    readonly summary: string;
+    readonly observedAt: number;
+  };
+  readonly deadline?: {
+    readonly key: string;
+    readonly label: string;
+    readonly dueAt: number;
+  };
+  readonly approval?: {
+    readonly key: string;
+    readonly prompt: string;
+    readonly requestedBy?: string;
+  };
+  readonly guards: readonly string[];
+}
+
+export interface ExecutionResultEvent {
+  readonly type: "execution-result";
+  readonly workId: string;
+  readonly proposalId: string;
+  readonly proposalHash: string;
+  readonly ok: boolean;
+  readonly receiptHash: string;
+  readonly reference: string;
+  readonly observedAt?: number;
+}
+
+export interface WorkWorkerTask {
+  readonly key?: string;
+  readonly label: string;
+  readonly prompt: string;
+  readonly resumePolicy: "safe" | "never";
+  readonly dependsOn?: readonly string[];
+  readonly resourceLocks?: readonly string[];
+  readonly approvalGate?: string;
+  readonly metadata?: JsonObject;
+}
+
+export interface WorkWorkerEvent {
+  readonly type: "worker-batch";
+  readonly source: string;
+  readonly externalId: string;
+  readonly title: string;
+  readonly ownerId: string;
+  readonly taskId: string;
+  readonly tasks: readonly WorkWorkerTask[];
+  readonly metadata?: JsonObject;
+}
+
+export type WorkWorkerStatus =
+  | { readonly status: "queued" }
+  | { readonly status: "running" }
+  | { readonly status: "completed"; readonly reference: string; readonly summary: string; readonly recordedAt: number }
+  | { readonly status: "failed"; readonly reason: string }
+  | { readonly status: "canceled"; readonly reason: string }
+  | { readonly status: "missing" };
+
+export interface WorkWorkerExecutor {
+  dispatch(event: WorkWorkerEvent, batchId: string): Promise<{ readonly batchId: string; readonly settled: Promise<void> }>;
+  inspect(batchId: string, expectedTaskCount: number): WorkWorkerStatus | Promise<WorkWorkerStatus>;
+}
+
+export type WorkEvent = WorkActionEvent | CaptureWorkEvent | ProfileWorkEvent | WorkWorkerEvent | ExecutionResultEvent;
+
+type JournalPhase = "ingested" | "prepared" | "approved" | "executing" | "dispatched" | "executed" | "verified" | "rejected";
+interface JournalEntry {
+  readonly workId: string;
+  readonly kind: "action" | "capture" | "profile" | "worker";
+  readonly phase: JournalPhase;
+  readonly event: WorkEvent;
+  readonly proposalId?: string;
+  readonly proposal?: ActionProposal;
+  readonly approvalId?: string;
+  readonly authorizationId?: string;
+  readonly receipt?: WorkActionReceipt;
+  readonly receiptHash?: string;
+  readonly captureEvidenceHash?: string;
+  readonly workerBatchId?: string;
+  readonly updatedAt: number;
+}
+
+type JournalLoadResult =
+  | { readonly status: "ready"; readonly entries: readonly JournalEntry[] }
+  | { readonly status: "unavailable" };
+
+const receiptSchema = z.object({
+  ok: z.boolean(),
+  reference: z.string().min(1).max(2_000),
+  observedAt: z.union([z.number().finite(), z.string()]).optional(),
+}).passthrough();
+const proposalSchema = z.object({
+  id: z.string(), operation: z.string(), accountId: z.string(), accountHash: z.string(), payload: z.json(),
+  payloadHash: z.string(), proposalHash: z.string(), ownerId: z.string(), evidence: z.array(z.string()), createdAt: z.number(),
+});
+const journalEntrySchema = z.object({
+  workId: z.string(), kind: z.enum(["action", "capture", "profile", "worker"]), phase: z.enum(["ingested", "prepared", "approved", "executing", "dispatched", "executed", "verified", "rejected"]),
+  event: z.unknown(), proposalId: z.string().optional(), proposal: proposalSchema.optional(), approvalId: z.string().optional(), authorizationId: z.string().optional(),
+  receipt: receiptSchema.optional(), receiptHash: z.string().regex(/^[a-f0-9]{64}$/i).optional(), captureEvidenceHash: z.string().optional(), workerBatchId: z.string().optional(), updatedAt: z.number(),
+});
+const journalSchema = z.object({ version: z.literal(1), entries: z.array(journalEntrySchema) });
+const captureReceiptEventSchema = z.object({
+  type: z.literal("capture-receipt"),
+  ownerId: z.string().trim().min(1).max(300),
+  receipt: z.object({
+    report: z.object({
+      runId: z.string().trim().min(1).max(300),
+      kind: z.enum(["fast", "hourly", "manual"]),
+      scheduledFor: z.number().finite().nonnegative(),
+      status: z.enum(["completed", "degraded"]),
+      sourceHealth: z.array(z.object({
+        sourceId: z.string().trim().min(1).max(120),
+        required: z.boolean(),
+        status: z.enum(["ok", "empty", "failed", "needs-auth"]),
+        itemCount: z.number().finite().nonnegative(),
+        error: z.string().optional(),
+      })).max(100),
+      actionItems: z.array(z.object({
+        class: z.enum(["Build", "Money chase", "Collect then deliver", "Outbound follow-up", "Redline/legal", "Calendar/RSVP", "File a loop"]),
+        source: z.string().trim().min(1).max(120),
+        summary: z.string().trim().min(1).max(2_000),
+        ask: z.string().trim().min(1).max(1_000).optional(),
+        proposedMove: z.string().trim().min(1).max(1_000).optional(),
+        evidenceRef: z.string().trim().min(1).max(500).optional(),
+      }).strict()).max(100),
+    }).strict(),
+  }).passthrough(),
+}).strict();
+const workerEventSchema = z.object({
+  type: z.literal("worker-batch"),
+  source: z.string().trim().min(1).max(120),
+  externalId: z.string().trim().min(1).max(500),
+  title: z.string().trim().min(1).max(500),
+  ownerId: z.string().trim().min(1).max(300),
+  taskId: z.string().trim().min(1).max(300),
+  tasks: z.array(z.object({
+    key: z.string().trim().min(1).max(120).optional(),
+    label: z.string().trim().min(1).max(80),
+    prompt: z.string().trim().min(1).max(25_000),
+    resumePolicy: z.enum(["safe", "never"]),
+    dependsOn: z.array(z.string().trim().min(1).max(120)).max(8).optional(),
+    resourceLocks: z.array(z.string().trim().min(1).max(300)).max(8).optional(),
+    approvalGate: z.string().trim().min(1).max(300).optional(),
+    metadata: z.record(z.string(), z.json()).optional(),
+  }).strict()).min(1).max(8),
+  metadata: z.record(z.string(), z.json()).optional(),
+}).strict();
+const profileWorkEventSchema = z.object({
+  type: z.literal("profile-import"),
+  source: z.string().trim().min(1).max(80),
+  profileId: z.string().trim().min(1).max(64).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/),
+  externalId: z.string().trim().min(1).max(500),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  title: z.string().trim().min(1).max(1_000),
+  description: z.string().max(20_000).optional(),
+  ownerId: z.string().trim().min(1).max(300),
+  ownerLabel: z.string().trim().min(1).max(500).optional(),
+  evidence: z.object({
+    reference: z.string().trim().min(1).max(2_000),
+    summary: z.string().trim().min(1).max(4_000),
+    observedAt: z.number().finite(),
+  }).strict(),
+  deadline: z.object({
+    key: z.string().trim().min(1).max(300),
+    label: z.string().trim().min(1).max(500),
+    dueAt: z.number().finite(),
+  }).strict().optional(),
+  approval: z.object({
+    key: z.string().trim().min(1).max(300),
+    prompt: z.string().trim().min(1).max(4_000),
+    requestedBy: z.string().trim().min(1).max(300).optional(),
+  }).strict().optional(),
+  guards: z.array(z.string().trim().min(1).max(120)).max(30),
+}).strict();
+
+export interface WorkOrchestratorOptions {
+  readonly work: WorkLockStoreInterface;
+  readonly accounts: AccountDirectory;
+  readonly policy: ActionPolicy;
+  readonly telemetry: AutonomyTelemetryInterface;
+  readonly executor: WorkActionExecutor;
+  readonly verifier: WorkActionVerifier;
+  readonly worker?: WorkWorkerExecutor;
+  readonly journalFile: string;
+  /** AccountDirectory is installation-scoped while work owners are bot-scoped. */
+  readonly accountOwnerId?: string;
+  readonly now?: () => number;
+}
+
+export interface WorkOrchestrator {
+  ingest(event: unknown):
+    | { readonly status: "created"; readonly phase: "ingested"; readonly workId: string; readonly changed?: boolean }
+    | { readonly status: "unchanged"; readonly phase: "ingested"; readonly changed: false; readonly workId: string }
+    | { readonly status: "created"; readonly phase: "ingested"; readonly changed: true; readonly createdCount: number; readonly unchangedCount: number; readonly workIds: readonly string[] }
+    | { readonly status: "unchanged"; readonly phase: "ingested"; readonly changed: false; readonly createdCount: 0; readonly unchangedCount: number; readonly workIds: readonly string[] }
+    | { readonly status: "recorded"; readonly phase: "executed"; readonly workId: string }
+    | { readonly status: "denied"; readonly reason: string };
+  prepare(workId: string):
+    | { readonly status: "prepared"; readonly phase: "prepared"; readonly workId: string; readonly proposal: ActionProposal; readonly approvalId: string; readonly authorizationId?: string }
+    | { readonly status: "blocked"; readonly reason: string; readonly workId: string }
+    | { readonly status: "not_ready"; readonly reason: string; readonly workId: string };
+  decide(input: WorkApprovalDecisionInput):
+    | { readonly status: "approved"; readonly phase: "approved"; readonly workId: string; readonly authorizationId: string }
+    | { readonly status: "rejected"; readonly phase: "rejected"; readonly workId: string }
+    | { readonly status: "denied"; readonly reason: "decision_mismatch" | "not_ready"; readonly workId: string };
+  execute(workId: string): Promise<
+    | { readonly status: "executed"; readonly phase: "executed"; readonly workId: string }
+    | { readonly status: "dispatched"; readonly phase: "dispatched"; readonly workId: string }
+    | { readonly status: "replay_prevented"; readonly phase: JournalPhase; readonly workId: string }
+    | { readonly status: "not_ready"; readonly reason: string; readonly workId: string }
+    | { readonly status: "ambiguous"; readonly phase: "executing"; readonly workId: string }
+  >;
+  reconcile(workId: string): Promise<
+    | { readonly status: "verified"; readonly phase: "verified"; readonly workId: string }
+    | { readonly status: "not_verified"; readonly reason: string; readonly workId: string }
+    | { readonly status: "awaiting_receipt"; readonly phase: "dispatched"; readonly workId: string }
+    | { readonly status: "awaiting_worker"; readonly phase: "dispatched"; readonly workId: string }
+    | { readonly status: "replay_prevented"; readonly phase: "executing"; readonly workId: string }
+    | { readonly status: "not_ready"; readonly reason: string; readonly workId: string }
+  >;
+}
+
+export interface WorkApprovalDecisionInput {
+  readonly workId: string;
+  readonly approvalId: string;
+  readonly proposalId: string;
+  readonly proposalHash: string;
+  readonly payloadHash: string;
+  readonly accountId: string;
+  readonly decision: "approved" | "rejected";
+  readonly decidedBy: string;
+  readonly evidenceRef: string;
+}
+
+export function createWorkOrchestrator(options: WorkOrchestratorOptions): WorkOrchestrator {
+  const now = options.now ?? Date.now;
+  const entries = new Map<string, JournalEntry>();
+  const adapter = createProviderActionAdapter({ policy: options.policy, accounts: options.accounts });
+  const loadedJournal = loadJournal(options.journalFile);
+
+  if (loadedJournal.status === "ready") {
+    loadedJournal.entries.forEach((entry) => entries.set(entry.workId, entry));
+  }
+
+  function save(entry: JournalEntry): void {
+    entries.set(entry.workId, entry);
+    const payload = JSON.stringify({ version: 1, entries: [...entries.values()] });
+    mkdirSync(dirname(options.journalFile), { recursive: true });
+    writeFileAtomic(options.journalFile, payload, { mode: 0o600 });
+  }
+
+  function update(entry: JournalEntry, patch: Partial<JournalEntry>): JournalEntry {
+    const next = { ...entry, ...patch, updatedAt: now() };
+    save(next);
+    return next;
+  }
+
+  function actionEntry(workId: string): JournalEntry | null {
+    const entry = entries.get(workId);
+    return entry ?? null;
+  }
+
+  function ingest(rawEvent: unknown) {
+    if (loadedJournal.status === "unavailable") return { status: "denied" as const, reason: "journal_unavailable" };
+    const receiptEvent = captureReceiptEventSchema.safeParse(rawEvent);
+    if (receiptEvent.success) return ingestCaptureReceipt(receiptEvent.data);
+    const event = parseWorkEvent(rawEvent);
+    if (!event) return { status: "denied" as const, reason: "invalid_work_event" };
+    if (event.type === "execution-result") return recordExecutionResult(event);
+    if (event.type === "action") return ingestAction(event);
+    if (event.type === "worker-batch") return ingestWorker(event);
+    if (event.type === "profile-import") return ingestProfile(event);
+    return ingestCapture(event);
+  }
+
+  function ingestCaptureReceipt(event: z.infer<typeof captureReceiptEventSchema>) {
+    const healthySources = new Set(event.receipt.report.sourceHealth
+      .filter((source) => source.status === "ok" || source.status === "empty")
+      .map((source) => source.sourceId));
+    if (event.receipt.report.actionItems.some((action) => !healthySources.has(action.source))) {
+      return { status: "denied" as const, reason: "capture_action_source_not_healthy" };
+    }
+    const events = event.receipt.report.actionItems.map((action): CaptureWorkEvent => {
+      const identityMaterial = JSON.stringify([
+        action.class,
+        action.source,
+        action.summary,
+        action.ask ?? null,
+        action.proposedMove ?? null,
+        action.evidenceRef ?? null,
+      ]);
+      const evidenceHash = createHash("sha256").update(identityMaterial, "utf8").digest("hex");
+      const evidenceRef = action.evidenceRef ?? `capture:${action.source}:sha256:${evidenceHash}`;
+      const details = [
+        action.ask ? `Ask: ${action.ask}` : null,
+        action.proposedMove ? `Proposed move: ${action.proposedMove}` : null,
+      ].filter((detail): detail is string => detail !== null);
+      return {
+        type: "capture",
+        source: action.source,
+        sourceId: action.evidenceRef ?? `content:sha256:${evidenceHash}`,
+        evidenceHash,
+        title: action.summary,
+        summary: details.length > 0 ? details.join("\n") : undefined,
+        ownerId: event.ownerId,
+        evidenceRef,
+        captureRunId: event.receipt.report.runId,
+        actionClass: action.class,
+        observedAt: event.receipt.report.scheduledFor,
+      };
+    });
+    let createdCount = 0;
+    let unchangedCount = 0;
+    const workIds: string[] = [];
+    for (const captureEvent of events) {
+      const result = ingestCapture(captureEvent);
+      if (result.status === "denied") return result;
+      workIds.push(result.workId);
+      if (result.status === "created") createdCount += 1;
+      else unchangedCount += 1;
+    }
+    if (createdCount > 0) {
+      return { status: "created" as const, phase: "ingested" as const, changed: true as const, createdCount, unchangedCount, workIds };
+    }
+    return { status: "unchanged" as const, phase: "ingested" as const, changed: false as const, createdCount: 0 as const, unchangedCount, workIds };
+  }
+
+  function ingestAction(event: WorkActionEvent) {
+    const identity = { source: `action:${event.source}`, id: event.externalId };
+    const created = options.work.createObligation({
+      title: event.title,
+      description: event.description,
+      externalIdentity: identity,
+      ownerId: event.ownerId,
+      ownerLabel: event.ownerLabel,
+      metadata: { kind: "action", identity: event.identity, provider: event.provider, toolName: event.toolName },
+    });
+    const existing = entries.get(created.obligation.id);
+    if (existing) return { status: "unchanged" as const, phase: "ingested" as const, changed: false as const, workId: created.obligation.id };
+    if (created.status === "deduplicated") return { status: "denied" as const, reason: "journal_entry_missing_for_existing_work" };
+    const entry: JournalEntry = { workId: created.obligation.id, kind: "action", phase: "ingested", event, updatedAt: now() };
+    save(entry);
+    recordStarted(created.obligation.id, event.workScope ?? "other");
+    return { status: "created" as const, phase: "ingested" as const, workId: created.obligation.id };
+  }
+
+  function ingestCapture(event: CaptureWorkEvent) {
+    const source = `capture:${event.source}`;
+    const evidenceHash = event.evidenceHash.toLowerCase();
+    const sourceIdentityHash = createHash("sha256").update(event.sourceId, "utf8").digest("hex");
+    const id = `${sourceIdentityHash}:${evidenceHash}`;
+    const metadata = {
+      kind: "capture",
+      source: event.source,
+      sourceId: event.sourceId,
+      evidenceHash,
+      evidenceRef: event.evidenceRef,
+      captureRunId: event.captureRunId ?? null,
+      actionClass: event.actionClass ?? null,
+      observedAt: event.observedAt ?? null,
+    };
+    const created = options.work.createObligation({
+      title: event.title,
+      description: event.summary,
+      externalIdentity: { source, id },
+      ownerId: event.ownerId,
+      metadata,
+    });
+    const existing = entries.get(created.obligation.id);
+    if (existing) return { status: "unchanged" as const, phase: "ingested" as const, changed: false as const, workId: created.obligation.id };
+    if (created.status === "deduplicated") return { status: "denied" as const, reason: "journal_entry_missing_for_existing_work" };
+    const entry: JournalEntry = { workId: created.obligation.id, kind: "capture", phase: "ingested", event, captureEvidenceHash: evidenceHash, updatedAt: now() };
+    save(entry);
+    options.work.recordEvidence(created.obligation.id, {
+      kind: "capture",
+      reference: event.evidenceRef,
+      summary: event.summary ?? event.title,
+      recordedAt: event.observedAt ?? now(),
+      metadata: {
+        source: event.source,
+        sourceId: event.sourceId,
+        evidenceHash,
+        captureRunId: event.captureRunId ?? null,
+        actionClass: event.actionClass ?? null,
+        observedAt: event.observedAt ?? null,
+      },
+    });
+    recordStarted(created.obligation.id, "aws");
+    return { status: "created" as const, phase: "ingested" as const, changed: true as const, workId: created.obligation.id };
+  }
+
+  function ingestProfile(event: ProfileWorkEvent) {
+    if (profileEventHash(event) !== event.contentHash) {
+      return { status: "denied" as const, reason: "profile_event_hash_mismatch" };
+    }
+    const created = options.work.createObligation({
+      title: event.title,
+      description: event.description,
+      externalIdentity: { source: `profile:${event.profileId}:${event.source}`, id: event.externalId },
+      ownerId: event.ownerId,
+      ownerLabel: event.ownerLabel,
+      metadata: {
+        kind: "profile-import",
+        source: event.source,
+        profileId: event.profileId,
+        externalId: event.externalId,
+        contentHash: event.contentHash,
+        guards: [...event.guards],
+      },
+      deadline: event.deadline,
+      approval: event.approval,
+      evidence: {
+        kind: "legacy-profile",
+        reference: event.evidence.reference,
+        summary: event.evidence.summary,
+        recordedAt: event.evidence.observedAt,
+        metadata: {
+          source: event.source,
+          profileId: event.profileId,
+          externalId: event.externalId,
+          contentHash: event.contentHash,
+        },
+      },
+    });
+    const existing = entries.get(created.obligation.id);
+    if (existing) {
+      if (existing.kind !== "profile" || existing.event.type !== "profile-import" || profileEventHash(existing.event) !== event.contentHash) {
+        return { status: "denied" as const, reason: "profile_event_conflict" };
+      }
+      return { status: "unchanged" as const, phase: "ingested" as const, changed: false as const, workId: created.obligation.id };
+    }
+    if (created.status === "deduplicated") return { status: "denied" as const, reason: "journal_entry_missing_for_existing_work" };
+    const entry: JournalEntry = { workId: created.obligation.id, kind: "profile", phase: "ingested", event, updatedAt: now() };
+    save(entry);
+    recordStarted(created.obligation.id, "other");
+    return { status: "created" as const, phase: "ingested" as const, changed: true as const, workId: created.obligation.id };
+  }
+
+  function ingestWorker(event: WorkWorkerEvent) {
+    const created = options.work.createObligation({
+      title: event.title,
+      externalIdentity: { source: `worker:${event.source}`, id: event.externalId },
+      ownerId: event.ownerId,
+      metadata: { kind: "worker-batch", taskId: event.taskId, taskCount: event.tasks.length, ...event.metadata },
+    });
+    const existing = entries.get(created.obligation.id);
+    if (existing) {
+      if (existing.kind !== "worker" || existing.event.type !== "worker-batch" || workerEventHash(existing.event) !== workerEventHash(event)) {
+        return { status: "denied" as const, reason: "worker_event_conflict" };
+      }
+      return { status: "unchanged" as const, phase: "ingested" as const, changed: false as const, workId: created.obligation.id };
+    }
+    if (created.status === "deduplicated") return { status: "denied" as const, reason: "journal_entry_missing_for_existing_work" };
+    const entry: JournalEntry = { workId: created.obligation.id, kind: "worker", phase: "ingested", event, updatedAt: now() };
+    save(entry);
+    recordStarted(created.obligation.id, "other");
+    return { status: "created" as const, phase: "ingested" as const, workId: created.obligation.id };
+  }
+
+  function recordExecutionResult(event: ExecutionResultEvent) {
+    const entry = entries.get(event.workId);
+    if (!entry || entry.kind !== "action" || !entry.proposal || entry.proposal.id !== event.proposalId || entry.proposal.proposalHash !== event.proposalHash) {
+      return { status: "denied" as const, reason: "execution_result_mismatch" };
+    }
+    if (!/^[a-f0-9]{64}$/i.test(event.receiptHash) || event.reference !== `connector-receipt:sha256:${event.receiptHash.toLowerCase()}`) {
+      return { status: "denied" as const, reason: "execution_result_invalid" };
+    }
+    if (entry.phase === "verified" || entry.phase === "executed") {
+      const exactReplay = entry.receiptHash?.toLowerCase() === event.receiptHash.toLowerCase()
+        && entry.receipt?.ok === event.ok
+        && entry.receipt.reference === event.reference;
+      return exactReplay
+        ? { status: "recorded" as const, phase: "executed" as const, workId: event.workId }
+        : { status: "denied" as const, reason: "execution_result_conflict" };
+    }
+    if (entry.phase !== "dispatched") return { status: "denied" as const, reason: "execution_result_not_dispatched" };
+    const receipt: WorkActionReceipt = { ok: event.ok, reference: event.reference, observedAt: event.observedAt };
+    update(entry, { phase: "executed", receipt, receiptHash: event.receiptHash.toLowerCase() });
+    return { status: "recorded" as const, phase: "executed" as const, workId: event.workId };
+  }
+
+  function prepare(workId: string) {
+    if (loadedJournal.status === "unavailable") return { status: "not_ready" as const, reason: "journal_unavailable", workId };
+    const entry = actionEntry(workId);
+    if (entry?.kind === "worker") return { status: "not_ready" as const, reason: "worker_work_does_not_require_preparation", workId };
+    if (!entry || entry.kind !== "action" || entry.event.type !== "action") return { status: "not_ready" as const, reason: "work_not_found_or_not_action", workId };
+    if (entry.proposal && entry.phase === "approved" && entry.authorizationId) return { status: "prepared" as const, phase: "prepared" as const, workId, proposal: entry.proposal, approvalId: entry.approvalId ?? "policy-auto", authorizationId: entry.authorizationId };
+    if (entry.proposal && entry.approvalId && entry.phase === "prepared") return { status: "prepared" as const, phase: "prepared" as const, workId, proposal: entry.proposal, approvalId: entry.approvalId };
+    if (entry.proposal && ["executing", "dispatched", "executed", "verified"].includes(entry.phase)) return { status: "not_ready" as const, reason: "action_already_dispatched", workId };
+    const event = entry.event;
+    const prepared = adapter.prepare({ toolName: event.toolName, arguments: event.arguments, identity: event.identity, provider: event.provider, ownerId: event.ownerId, accountOwnerId: options.accountOwnerId ?? event.ownerId });
+    if ("status" in prepared) return { status: "blocked" as const, reason: prepared.reason.includes("account") ? "account_not_resolved" : prepared.reason, workId };
+    const proposal = prepared.proposal;
+    const updated = update(entry, { phase: "prepared", proposal, proposalId: proposal.id });
+    options.work.transitionObligation(workId, "in_progress");
+    const policyDecision = options.policy.evaluate(proposal);
+    if (policyDecision.effect === "allow" || (policyDecision.effect === "draft-only" && proposal.operation === "gmail.drafts.create")) {
+      const authorization = options.policy.authorizeOnce(proposal, {
+        approvedBy: "ActionPolicy",
+        approvalEvidence: `action-policy:${policyDecision.ruleId ?? "allow"}`,
+        approvedAt: now(),
+      });
+      update(entries.get(workId) ?? updated, { phase: "approved", authorizationId: authorization.id });
+      return { status: "prepared" as const, phase: "prepared" as const, workId, proposal, approvalId: "policy-auto", authorizationId: authorization.id };
+    }
+    const approval = options.work.addApproval(workId, {
+      key: proposal.proposalHash,
+      prompt: `Approve ${proposal.operation} for account ${proposal.accountId}`,
+      requestedBy: event.requestedBy ?? event.ownerLabel ?? event.ownerId,
+      payload: { operation: proposal.operation, accountId: proposal.accountId, payloadHash: proposal.payloadHash, proposalHash: proposal.proposalHash },
+    });
+    const approvalId = approval.approval.id;
+    update(updated, { approvalId });
+    recordApprovalRequested(workId, proposal.proposalHash);
+    return { status: "prepared" as const, phase: "prepared" as const, workId, proposal, approvalId };
+  }
+
+  function decide(input: WorkApprovalDecisionInput) {
+    if (loadedJournal.status === "unavailable") return { status: "denied" as const, reason: "not_ready" as const, workId: input.workId };
+    const entry = entries.get(input.workId);
+    const proposal = entry?.proposal;
+    if (!entry || !proposal || entry.approvalId !== input.approvalId || proposal.id !== input.proposalId || proposal.proposalHash !== input.proposalHash || proposal.payloadHash !== input.payloadHash || proposal.accountId !== input.accountId) {
+      return { status: "denied" as const, reason: "decision_mismatch" as const, workId: input.workId };
+    }
+    if (entry.phase !== "prepared") return { status: "denied" as const, reason: "not_ready" as const, workId: input.workId };
+    const current = options.work.getObligation(input.workId);
+    if (!current) return { status: "denied" as const, reason: "not_ready" as const, workId: input.workId };
+    const approval = current.approvals.find((candidate) => candidate.id === input.approvalId);
+    if (!approval || approval.status !== "pending") return { status: "denied" as const, reason: "not_ready" as const, workId: input.workId };
+    const decided = options.work.decideApproval(input.workId, input.approvalId, input.decision, input.decidedBy);
+    if (input.decision === "rejected") {
+      options.work.transitionObligation(input.workId, "blocked", decided.obligation.version);
+      update(entry, { phase: "rejected" });
+      recordApprovalDecision(input.workId, input.approvalId, "rejected");
+      return { status: "rejected" as const, phase: "rejected" as const, workId: input.workId };
+    }
+    const authorization = options.policy.authorizeOnce(proposal, { approvedBy: input.decidedBy, approvalEvidence: input.evidenceRef, approvedAt: now() });
+    update(entry, { phase: "approved", authorizationId: authorization.id });
+    recordApprovalDecision(input.workId, input.approvalId, "approved");
+    void decided;
+    return { status: "approved" as const, phase: "approved" as const, workId: input.workId, authorizationId: authorization.id };
+  }
+
+  async function execute(workId: string) {
+    if (loadedJournal.status === "unavailable") return { status: "not_ready" as const, reason: "journal_unavailable", workId };
+    const entry = entries.get(workId);
+    if (entry?.kind === "worker" && entry.event.type === "worker-batch") {
+      if (["executing", "dispatched", "verified", "rejected"].includes(entry.phase)) {
+        return { status: "replay_prevented" as const, phase: entry.phase, workId };
+      }
+      if (entry.phase !== "ingested") return { status: "not_ready" as const, reason: "worker_work_not_ready", workId };
+      if (!options.worker) return { status: "not_ready" as const, reason: "worker_executor_unavailable", workId };
+      options.work.transitionObligation(workId, "in_progress");
+      const executing = update(entry, { phase: "executing", workerBatchId: workId });
+      let dispatched: Awaited<ReturnType<WorkWorkerExecutor["dispatch"]>>;
+      try { dispatched = await options.worker.dispatch(entry.event, workId); }
+      catch { return { status: "ambiguous" as const, phase: "executing" as const, workId }; }
+      if (dispatched.batchId !== workId) return { status: "ambiguous" as const, phase: "executing" as const, workId };
+      update(executing, { phase: "dispatched" });
+      void dispatched.settled.then(() => reconcile(workId)).catch(() => undefined);
+      return { status: "dispatched" as const, phase: "dispatched" as const, workId };
+    }
+    if (!entry || entry.kind !== "action" || !entry.proposal) return { status: "not_ready" as const, reason: "work_not_found_or_not_prepared", workId };
+    if (["executing", "dispatched", "executed", "verified", "rejected"].includes(entry.phase)) return { status: "replay_prevented" as const, phase: entry.phase, workId };
+    if (entry.phase !== "approved" || !entry.authorizationId) return { status: "not_ready" as const, reason: "approval_required", workId };
+    const executing = update(entry, { phase: "executing" });
+    const decision = options.policy.consumeAuthorization(entry.authorizationId, entry.proposal);
+    if (!decision.allowed) {
+      update(executing, { phase: "rejected" });
+      return { status: "not_ready" as const, reason: decision.reason, workId };
+    }
+    let result: WorkActionExecutionResult;
+    try { result = await options.executor.execute(entry.proposal); }
+    catch { return { status: "ambiguous" as const, phase: "executing" as const, workId }; }
+    if (result.kind === "handoff") {
+      update(executing, { phase: "dispatched" });
+      return { status: "dispatched" as const, phase: "dispatched" as const, workId };
+    }
+    update(executing, { phase: "executed", receipt: result.receipt });
+    return { status: "executed" as const, phase: "executed" as const, workId };
+  }
+
+  async function reconcile(workId: string) {
+    if (loadedJournal.status === "unavailable") return { status: "not_ready" as const, reason: "journal_unavailable", workId };
+    const entry = entries.get(workId);
+    if (entry?.kind === "worker" && entry.event.type === "worker-batch") {
+      if (entry.phase === "verified") return { status: "verified" as const, phase: "verified" as const, workId };
+      if (!entry.workerBatchId || entry.phase === "ingested") return { status: "not_ready" as const, reason: "worker_dispatch_required", workId };
+      if (!options.worker) return { status: "not_ready" as const, reason: "worker_executor_unavailable", workId };
+      let status: WorkWorkerStatus;
+      try { status = await options.worker.inspect(entry.workerBatchId, entry.event.tasks.length); }
+      catch { return { status: "not_ready" as const, reason: "worker_status_unavailable", workId }; }
+      if (status.status === "missing") {
+        return entry.phase === "executing"
+          ? { status: "replay_prevented" as const, phase: "executing" as const, workId }
+          : { status: "not_ready" as const, reason: "worker_batch_unavailable", workId };
+      }
+      if (status.status === "queued" || status.status === "running") {
+        if (entry.phase === "executing") update(entry, { phase: "dispatched" });
+        return { status: "awaiting_worker" as const, phase: "dispatched" as const, workId };
+      }
+      if (status.status === "failed" || status.status === "canceled") {
+        return { status: "not_verified" as const, reason: status.reason, workId };
+      }
+      const evidence = options.work.recordEvidence(workId, {
+        kind: "worker-batch",
+        reference: status.reference,
+        summary: status.summary,
+        recordedAt: status.recordedAt,
+        metadata: { batchId: entry.workerBatchId, taskId: entry.event.taskId, taskCount: entry.event.tasks.length },
+      });
+      options.work.completeObligation(workId);
+      update(entry, { phase: "verified" });
+      options.telemetry.record({ type: "outcome.verified", workId, idempotencyKey: `outcome.verified:${workId}:${evidence.evidence.id}`, evidenceRef: evidence.evidence.reference, observedAt: evidence.evidence.recordedAt });
+      options.telemetry.record({ type: "work.closed", workId, idempotencyKey: `work.closed:${workId}`, observedAt: now(), closureKind: "success" });
+      return { status: "verified" as const, phase: "verified" as const, workId };
+    }
+    if (!entry || entry.kind !== "action" || !entry.proposal) return { status: "not_ready" as const, reason: "work_not_found_or_not_action", workId };
+    if (entry.phase === "dispatched") return { status: "awaiting_receipt" as const, phase: "dispatched" as const, workId };
+    if (entry.phase === "executing") return { status: "replay_prevented" as const, phase: "executing" as const, workId };
+    if (entry.phase === "verified") return { status: "verified" as const, phase: "verified" as const, workId };
+    if (entry.phase !== "executed" || !entry.receipt) return { status: "not_ready" as const, reason: "execution_receipt_required", workId };
+    if (!entry.receipt.ok) return { status: "not_verified" as const, reason: "provider_reported_failure", workId };
+    const result = await options.verifier.verify(entry.proposal, entry.receipt);
+    if (result.status !== "verified") return { status: "not_verified" as const, reason: result.reason, workId };
+    const evidence = options.work.recordEvidence(workId, {
+      kind: result.evidence.kind,
+      reference: result.evidence.reference,
+      summary: result.evidence.summary,
+      recordedAt: result.evidence.recordedAt,
+      metadata: result.evidence.metadata ?? undefined,
+    });
+    options.work.completeObligation(workId);
+    update(entry, { phase: "verified" });
+    options.telemetry.record({ type: "outcome.verified", workId, idempotencyKey: `outcome.verified:${workId}:${evidence.evidence.id}`, evidenceRef: evidence.evidence.reference, observedAt: evidence.evidence.recordedAt });
+    options.telemetry.record({ type: "work.closed", workId, idempotencyKey: `work.closed:${workId}`, observedAt: now(), closureKind: "success" });
+    return { status: "verified" as const, phase: "verified" as const, workId };
+  }
+
+  function recordStarted(workId: string, workScope: "aws" | "other") {
+    options.telemetry.record({ type: "work.started", workId, idempotencyKey: `work.started:${workId}`, observedAt: now(), workScope });
+  }
+  function recordApprovalRequested(workId: string, key: string) {
+    options.telemetry.record({ type: "approval.requested", workId, idempotencyKey: `approval.requested:${workId}:${key}`, observedAt: now(), approvalKey: key });
+  }
+  function recordApprovalDecision(workId: string, key: string, decision: "approved" | "rejected") {
+    options.telemetry.record({ type: "approval.decided", workId, idempotencyKey: `approval.decided:${workId}:${key}:${decision}`, observedAt: now(), approvalKey: key, decision, actor: "human" });
+  }
+  return { ingest, prepare, decide, execute, reconcile };
+}
+
+function loadJournal(file: string): JournalLoadResult {
+  if (!existsSync(file)) return { status: "ready", entries: [] };
+  try {
+    const raw: unknown = JSON.parse(readFileSync(file, "utf8"));
+    const parsed = journalSchema.safeParse(raw);
+    if (!parsed.success) return { status: "unavailable" };
+    const entries: JournalEntry[] = [];
+    const workIds = new Set<string>();
+    for (const entry of parsed.data.entries) {
+      if (!isWorkEvent(entry.event) || !isValidJournalEntry(entry, entry.event)) return { status: "unavailable" };
+      if (workIds.has(entry.workId)) return { status: "unavailable" };
+      workIds.add(entry.workId);
+      const receipt = entry.receipt === undefined ? undefined : safeReceipt(entry.receipt);
+      if (entry.receipt !== undefined && receipt === undefined) return { status: "unavailable" };
+      const { receipt: _rawReceipt, ...rest } = entry;
+      entries.push(receipt === undefined ? { ...rest, event: entry.event } : { ...rest, event: entry.event, receipt });
+    }
+    return { status: "ready", entries };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+function isValidJournalEntry(entry: z.infer<typeof journalEntrySchema>, event: WorkEvent): boolean {
+  if (entry.kind === "capture") return event.type === "capture" && entry.phase === "ingested";
+  if (entry.kind === "profile") return event.type === "profile-import" && entry.phase === "ingested" && profileEventHash(event) === event.contentHash;
+  if (entry.kind === "worker") {
+    if (event.type !== "worker-batch") return false;
+    if (entry.phase === "ingested") return entry.workerBatchId === undefined;
+    return (entry.phase === "executing" || entry.phase === "dispatched" || entry.phase === "verified" || entry.phase === "rejected")
+      && entry.workerBatchId === entry.workId;
+  }
+  if (event.type !== "action") return false;
+  if (entry.phase === "ingested") return entry.proposal === undefined && entry.proposalId === undefined;
+  if (entry.proposal === undefined || entry.proposalId !== entry.proposal.id) return false;
+  if (entry.phase === "prepared") return entry.approvalId !== undefined;
+  if (entry.phase === "approved" || entry.phase === "executing" || entry.phase === "dispatched") return entry.authorizationId !== undefined;
+  if (entry.phase === "executed" || entry.phase === "verified") return entry.authorizationId !== undefined && entry.receipt !== undefined;
+  return entry.phase === "rejected";
+}
+
+function safeReceipt(value: unknown): WorkActionReceipt | undefined {
+  const parsed = receiptSchema.safeParse(value);
+  if (!parsed.success) return undefined;
+  if (parsed.data.observedAt === undefined) return { ok: parsed.data.ok, reference: parsed.data.reference };
+  return { ok: parsed.data.ok, reference: parsed.data.reference, observedAt: parsed.data.observedAt };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isWorkEvent(value: unknown): value is WorkEvent {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "worker-batch") return workerEventSchema.safeParse(value).success;
+  if (value.type === "profile-import") return profileWorkEventSchema.safeParse(value).success;
+  if (value.type === "action") {
+    return typeof value.source === "string" && typeof value.externalId === "string" && typeof value.title === "string" &&
+      typeof value.ownerId === "string" && typeof value.identity === "string" && typeof value.provider === "string" &&
+      typeof value.toolName === "string" && "arguments" in value;
+  }
+  if (value.type === "capture") {
+    return typeof value.source === "string" && typeof value.sourceId === "string" && typeof value.evidenceHash === "string" &&
+      typeof value.title === "string" && typeof value.ownerId === "string" && typeof value.evidenceRef === "string";
+  }
+  if (value.type === "execution-result") {
+    return typeof value.workId === "string" && typeof value.proposalId === "string" && typeof value.proposalHash === "string" &&
+      typeof value.ok === "boolean" && typeof value.receiptHash === "string" && typeof value.reference === "string";
+  }
+  return false;
+}
+
+function parseWorkEvent(value: unknown): WorkEvent | null {
+  const worker = workerEventSchema.safeParse(value);
+  if (worker.success) return worker.data;
+  const profile = profileWorkEventSchema.safeParse(value);
+  if (profile.success) return profile.data;
+  return isWorkEvent(value) ? value : null;
+}
+
+export function profileEventHash(event: Omit<ProfileWorkEvent, "contentHash"> | ProfileWorkEvent): string {
+  const canonical = canonicalizeActionPayload({
+    type: event.type,
+    source: event.source,
+    profileId: event.profileId,
+    externalId: event.externalId,
+    title: event.title,
+    description: event.description ?? null,
+    ownerId: event.ownerId,
+    ownerLabel: event.ownerLabel ?? null,
+    evidence: event.evidence,
+    deadline: event.deadline ?? null,
+    approval: event.approval ?? null,
+    guards: [...event.guards],
+  });
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+function workerEventHash(event: WorkWorkerEvent): string {
+  const canonical = canonicalizeActionPayload({
+    type: event.type,
+    source: event.source,
+    externalId: event.externalId,
+    title: event.title,
+    ownerId: event.ownerId,
+    taskId: event.taskId,
+    tasks: event.tasks.map((task) => ({
+      key: task.key ?? null,
+      label: task.label,
+      prompt: task.prompt,
+      resumePolicy: task.resumePolicy,
+      dependsOn: task.dependsOn === undefined ? null : [...task.dependsOn],
+      resourceLocks: task.resourceLocks === undefined ? null : [...task.resourceLocks],
+      approvalGate: task.approvalGate ?? null,
+      metadata: task.metadata ?? null,
+    })),
+  });
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}

--- a/server/worker-batch-receipt.ts
+++ b/server/worker-batch-receipt.ts
@@ -1,0 +1,31 @@
+/* oxlint-disable anti-slop/no-runtime-typeof -- persisted worker JSON needs runtime narrowing at this boundary. */
+import type { WorkerJobRecord } from "./worker-jobs.ts";
+
+function resultText(job: Readonly<WorkerJobRecord>): string {
+  if (job.error?.trim()) return job.error.trim();
+  if (job.result === undefined || job.result === null) return "Completed without a text result.";
+  const value = typeof job.result === "string"
+    ? job.result
+    : !Array.isArray(job.result) && typeof job.result === "object" && typeof job.result.text === "string"
+      ? job.result.text
+      : JSON.stringify(job.result, null, 2) ?? "Completed without a text result.";
+  return value.trim() || "Completed without a text result.";
+}
+/** One final owner-thread receipt; private prompts and tool transcripts never enter it. */
+export function workerBatchReceiptText(label: string, jobs: readonly WorkerJobRecord[]): string {
+  const visible = jobs.filter((job) => job.status !== "canceled" || job.result !== undefined || Boolean(job.error));
+  if (visible.length === 0) return "";
+  const needsAttention = visible.some((job) => job.status === "failed");
+  const sections = visible.map((job) => {
+    const status = job.status === "failed"
+      ? " â€” failed"
+      : job.status === "canceled"
+        ? " â€” canceled"
+        : "";
+    return `**${job.label?.trim() || "Worker"}${status}**\n${resultText(job)}`;
+  });
+  return [
+    `${needsAttention ? "Parallel work needs attention" : "Parallel work finished"}: ${label}`,
+    ...sections,
+  ].join("\n\n");
+}

--- a/server/worker-job-file-store.ts
+++ b/server/worker-job-file-store.ts
@@ -1,0 +1,81 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { z } from "zod";
+
+import { writeFileAtomic } from "./atomic.ts";
+import type { WorkerJobRecord, WorkerJobStore } from "./worker-jobs.ts";
+
+const MAX_TERMINAL_RECORDS = 200;
+const workerJobRecordSchema = z.object({
+  id: z.string(),
+  taskId: z.string(),
+  prompt: z.string(),
+  key: z.string().optional(),
+  label: z.string().optional(),
+  batchId: z.string().optional(),
+  batchLabel: z.string().optional(),
+  metadata: z.record(z.string(), z.json()).optional(),
+  hidden: z.literal(true),
+  status: z.enum(["queued", "running", "completed", "failed", "canceled"]),
+  resumePolicy: z.enum(["safe", "never"]).optional(),
+  dependsOn: z.array(z.string()).optional(),
+  resourceLocks: z.array(z.string()).optional(),
+  approvalGate: z.string().optional(),
+  waitReason: z.string().optional(),
+  createdAt: z.number(),
+  startedAt: z.number().optional(),
+  settledAt: z.number().optional(),
+  result: z.json().optional(),
+  error: z.string().optional(),
+});
+
+/** Durable adapter for the worker-job module. Open jobs are retained until
+ * they settle; recent terminal receipts are bounded so unattended use cannot
+ * grow this file forever. */
+export function createWorkerJobFileStore(path: string): WorkerJobStore {
+  const records = new Map<string, WorkerJobRecord>();
+  if (existsSync(path)) {
+    try {
+      const parsed = z.array(workerJobRecordSchema).safeParse(JSON.parse(readFileSync(path, "utf8")));
+      if (parsed.success) {
+        for (const value of parsed.data) records.set(value.id, value);
+      }
+    } catch {
+      // A corrupt optional receipt file must not prevent the assistant from
+      // starting. New writes replace it atomically with valid state.
+    }
+  }
+
+  const save = () => {
+    const all = [...records.values()];
+    const open = all.filter((job) => job.status === "queued" || job.status === "running");
+    const terminal = all
+      .filter((job) => job.status !== "queued" && job.status !== "running")
+      .sort((a, b) => (b.settledAt ?? b.createdAt) - (a.settledAt ?? a.createdAt))
+      .slice(0, MAX_TERMINAL_RECORDS);
+    const retained = [...open, ...terminal];
+    records.clear();
+    for (const record of retained) records.set(record.id, record);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileAtomic(path, JSON.stringify(retained, null, 2), { mode: 0o600 });
+  };
+
+  return {
+    create(job) {
+      records.set(job.id, structuredClone(job));
+      save();
+    },
+    update(id, patch) {
+      const current = records.get(id);
+      if (!current) throw new Error(`missing worker job ${id}`);
+      records.set(id, { ...current, ...structuredClone(patch) });
+      save();
+    },
+    list() {
+      return [...records.values()].map((record) => structuredClone(record));
+    },
+    checkpoint() {
+      save();
+    },
+  };
+}

--- a/server/worker-jobs.ts
+++ b/server/worker-jobs.ts
@@ -1,0 +1,466 @@
+import { randomUUID } from "node:crypto";
+
+import type { JsonObject, JsonValue } from "./schema.ts";
+import type {
+  WorkerBatchCounts,
+  WorkerBatchJobProjection,
+  WorkerBatchLifecycle,
+  WorkerBatchProjection,
+} from "../shared/worker-batch.ts";
+
+export type {
+  WorkerBatchCounts,
+  WorkerBatchJobProjection,
+  WorkerBatchLifecycle,
+  WorkerBatchProjection,
+} from "../shared/worker-batch.ts";
+
+export const DEFAULT_WORKER_CONCURRENCY = 8;
+export const HARD_WORKER_CONCURRENCY_CAP = 8;
+
+export type WorkerJobStatus = "queued" | "running" | "completed" | "failed" | "canceled";
+/** A job may cross a process restart only when its owner has explicitly
+ * classified replay as safe. Absence is deliberately not permissive: a
+ * queued provider job can still have an externally visible effect if an
+ * earlier process accepted it before persisting its state. */
+export type WorkerJobResumePolicy = "safe" | "never";
+
+export interface WorkerJobRequest {
+  /** Stable request-local identity used by dependency edges. */
+  key?: string;
+  prompt: string;
+  label?: string;
+  /** All jobs launched together share this opaque grouping key. */
+  batchId?: string;
+  /** User-facing batch label; never contains worker transcripts. */
+  batchLabel?: string;
+  metadata?: JsonObject;
+  resumePolicy?: WorkerJobResumePolicy;
+  dependsOn?: readonly string[];
+  resourceLocks?: readonly string[];
+  approvalGate?: string;
+}
+export interface WorkerJobRecord extends WorkerJobRequest {
+  id: string;
+  taskId: string;
+  hidden: true;
+  status: WorkerJobStatus;
+  resumePolicy?: WorkerJobResumePolicy;
+  createdAt: number;
+  startedAt?: number;
+  settledAt?: number;
+  result?: JsonValue;
+  error?: string;
+  waitReason?: string;
+}
+
+export interface WorkerJobStore {
+  create: (job: WorkerJobRecord) => void | Promise<void>;
+  update: (id: string, patch: Partial<WorkerJobRecord>) => void | Promise<void>;
+  list: () => readonly WorkerJobRecord[] | Promise<readonly WorkerJobRecord[]>;
+  /** Flush a durable snapshot when the host is about to hand off. */
+  checkpoint?: () => void | Promise<void>;
+}
+
+export interface WorkerJobDependencies {
+  store: WorkerJobStore;
+  run: (job: Readonly<WorkerJobRecord>) => JsonValue | undefined | Promise<JsonValue | undefined>;
+  interrupt: (job: Readonly<WorkerJobRecord>) => void | Promise<void>;
+  createId?: () => string;
+  now?: () => number;
+}
+
+export interface WorkerJobsOptions {
+  concurrency?: number;
+}
+
+export interface WorkerJobBatch {
+  batchId: string;
+  jobs: WorkerJobRecord[];
+  projection: () => WorkerBatchProjection;
+  settled: Promise<WorkerJobRecord[]>;
+}
+
+export type WorkerBatchListener = (projection: WorkerBatchProjection) => void;
+
+export interface WorkerBatchOptions {
+  id?: string;
+  label?: string;
+}
+
+export interface WorkerJobs {
+  launchBatch(taskId: string, requests: readonly WorkerJobRequest[], options?: WorkerBatchOptions): Promise<WorkerJobBatch>;
+  cancelTask(taskId: string): Promise<number>;
+  checkpoint(): Promise<WorkerJobRecord[]>;
+  recover(): Promise<WorkerJobBatch>;
+  snapshot(taskId?: string): WorkerJobRecord[];
+  batchSnapshot(taskId?: string): WorkerBatchProjection[];
+  subscribe(listener: WorkerBatchListener): () => void;
+}
+
+interface RuntimeJob {
+  record: WorkerJobRecord;
+  resolve: (record: WorkerJobRecord) => void;
+  settled: Promise<WorkerJobRecord>;
+  isSettled: boolean;
+}
+
+export function createWorkerJobs(
+  dependencies: WorkerJobDependencies,
+  options: WorkerJobsOptions = {},
+): WorkerJobs {
+  return new WorkerJobController(dependencies, options);
+}
+
+class WorkerJobController implements WorkerJobs {
+  private dependencies: WorkerJobDependencies;
+  private concurrency: number;
+  private jobs = new Map<string, RuntimeJob>();
+  private queue: string[] = [];
+  private active = 0;
+  private readonly heldLocks = new Map<string, number>();
+  private listeners = new Set<WorkerBatchListener>();
+
+  constructor(dependencies: WorkerJobDependencies, options: WorkerJobsOptions) {
+    this.dependencies = dependencies;
+    const requested = Math.trunc(options.concurrency ?? DEFAULT_WORKER_CONCURRENCY);
+    this.concurrency = Math.max(1, Math.min(HARD_WORKER_CONCURRENCY_CAP, requested));
+  }
+
+  async launchBatch(taskId: string, requests: readonly WorkerJobRequest[], options: WorkerBatchOptions = {}): Promise<WorkerJobBatch> {
+    const batchId = options.id ?? randomUUID();
+    const batchLabel = options.label?.trim() || "Parallel work";
+    const runtimes: RuntimeJob[] = [];
+    for (const request of requests) {
+      const runtime = this.makeRuntime({
+        ...request,
+        id: this.dependencies.createId?.() ?? randomUUID(),
+        taskId,
+        batchId,
+        batchLabel,
+        hidden: true,
+        status: "queued",
+        createdAt: this.now(),
+      });
+      await this.dependencies.store.create(runtime.record);
+      this.jobs.set(runtime.record.id, runtime);
+      this.queue.push(runtime.record.id);
+      runtimes.push(runtime);
+    }
+    this.emitBatch(batchId);
+    this.pump();
+    return {
+      batchId,
+      jobs: runtimes.map((runtime) => structuredClone(runtime.record)),
+      settled: Promise.all(runtimes.map((runtime) => runtime.settled)),
+      projection: () => {
+        const projection = this.batchSnapshot().find((batch) => batch.id === batchId);
+        if (!projection) throw new Error("worker batch is no longer available");
+        return projection;
+      },
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<number> {
+    const targets = [...this.jobs.values()].filter(
+      (runtime) => runtime.record.taskId === taskId && !runtime.isSettled,
+    );
+    let canceled = 0;
+    await Promise.all(targets.map(async (runtime) => {
+      const wasRunning = runtime.record.status === "running";
+      if (await this.settle(runtime, "canceled", {})) canceled += 1;
+      if (!wasRunning) return;
+      try {
+        await this.dependencies.interrupt(structuredClone(runtime.record));
+      } catch {
+        // The durable cancellation already won the settle race. A provider
+        // that has disappeared cannot turn the job back into a failure.
+      }
+    }));
+    this.pump();
+    return canceled;
+  }
+
+  async checkpoint(): Promise<WorkerJobRecord[]> {
+    await this.dependencies.store.checkpoint?.();
+    return this.snapshot();
+  }
+
+  async recover(): Promise<WorkerJobBatch> {
+    const runtimes: RuntimeJob[] = [];
+    const persisted = await this.dependencies.store.list();
+    for (const job of persisted) {
+      if (job.status !== "queued" && job.status !== "running") continue;
+      if (this.jobs.has(job.id)) continue;
+      if (job.status === "running") {
+        const failed: WorkerJobRecord = {
+          ...job,
+          status: "failed",
+          settledAt: this.now(),
+          error: "interrupted by restart; not replayed",
+        };
+        await this.dependencies.store.update(job.id, {
+          status: failed.status,
+          settledAt: failed.settledAt,
+          error: failed.error,
+        });
+        this.rememberTerminal(failed);
+        continue;
+      }
+      if (job.resumePolicy !== "safe") {
+        const failed: WorkerJobRecord = {
+          ...job,
+          status: "failed",
+          settledAt: this.now(),
+          error: "queued job was not explicitly marked safe to resume; not replayed",
+        };
+        await this.dependencies.store.update(job.id, {
+          status: failed.status,
+          settledAt: failed.settledAt,
+          error: failed.error,
+        });
+        this.rememberTerminal(failed);
+        continue;
+      }
+      const record: WorkerJobRecord = {
+        ...job,
+        hidden: true,
+        status: "queued",
+        startedAt: undefined,
+        settledAt: undefined,
+        result: undefined,
+        error: undefined,
+      };
+      const runtime = this.makeRuntime(record);
+      await this.dependencies.store.update(record.id, {
+        hidden: true,
+        status: "queued",
+        startedAt: undefined,
+        settledAt: undefined,
+        result: undefined,
+        error: undefined,
+      });
+      this.jobs.set(record.id, runtime);
+      this.queue.push(record.id);
+      runtimes.push(runtime);
+    }
+    this.pump();
+    return {
+      batchId: runtimes[0]?.record.batchId ?? randomUUID(),
+      jobs: runtimes.map((runtime) => structuredClone(runtime.record)),
+      settled: Promise.all(runtimes.map((runtime) => runtime.settled)),
+      projection: () => {
+        const batchId = runtimes[0]?.record.batchId;
+        const projection = batchId ? this.batchSnapshot().find((batch) => batch.id === batchId) : undefined;
+        if (!projection) throw new Error("worker batch is no longer available");
+        return projection;
+      },
+    };
+  }
+
+  snapshot(taskId?: string): WorkerJobRecord[] {
+    return [...this.jobs.values()]
+      .map((runtime) => runtime.record)
+      .filter((job) => taskId === undefined || job.taskId === taskId)
+      .map((job) => structuredClone(job));
+  }
+
+  batchSnapshot(taskId?: string): WorkerBatchProjection[] {
+    const grouped = new Map<string, WorkerJobRecord[]>();
+    for (const runtime of this.jobs.values()) {
+      const job = runtime.record;
+      if (taskId !== undefined && job.taskId !== taskId) continue;
+      const batchId = job.batchId ?? job.id;
+      const jobs = grouped.get(batchId);
+      if (jobs) jobs.push(job);
+      else grouped.set(batchId, [job]);
+    }
+    return [...grouped.entries()].map(([id, jobs]) => makeBatchProjection(id, jobs));
+  }
+
+  subscribe(listener: WorkerBatchListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private makeRuntime(record: WorkerJobRecord): RuntimeJob {
+    let resolve!: (record: WorkerJobRecord) => void;
+    const settled = new Promise<WorkerJobRecord>((done) => {
+      resolve = done;
+    });
+    return { record, resolve, settled, isSettled: false };
+  }
+
+  private pump(): void {
+    this.failBlockedDependents();
+    while (this.active < this.concurrency) {
+      const index = this.queue.findIndex((id) => {
+        const runtime = this.jobs.get(id);
+        if (!runtime || runtime.isSettled) return false;
+        const reason = this.waitReason(runtime.record);
+        if (reason) {
+          if (runtime.record.waitReason !== reason) {
+            runtime.record = { ...runtime.record, waitReason: reason };
+            void this.dependencies.store.update(runtime.record.id, { waitReason: reason });
+          }
+          return false;
+        }
+        if (runtime.record.waitReason !== undefined) {
+          runtime.record = { ...runtime.record, waitReason: undefined };
+          void this.dependencies.store.update(runtime.record.id, { waitReason: undefined });
+        }
+        return true;
+      });
+      if (index < 0) return;
+      const [id] = this.queue.splice(index, 1);
+      if (!id) return;
+      const runtime = this.jobs.get(id);
+      if (!runtime || runtime.isSettled) continue;
+      for (const lock of runtime.record.resourceLocks ?? []) {
+        this.heldLocks.set(lock, (this.heldLocks.get(lock) ?? 0) + 1);
+      }
+      this.active += 1;
+      void this.execute(runtime);
+    }
+  }
+
+  private async execute(runtime: RuntimeJob): Promise<void> {
+    try {
+      runtime.record = {
+        ...runtime.record,
+        status: "running",
+        startedAt: this.now(),
+      };
+      await this.dependencies.store.update(runtime.record.id, {
+        status: "running",
+        startedAt: runtime.record.startedAt,
+      });
+      this.emitBatch(runtime.record.batchId);
+      const result = await this.dependencies.run(structuredClone(runtime.record));
+      await this.settle(runtime, "completed", { result });
+    } catch (error) {
+      const message = error instanceof Error
+        ? error.message
+        : "Worker failed with a non-Error rejection";
+      await this.settle(runtime, "failed", { error: message });
+    } finally {
+      for (const lock of runtime.record.resourceLocks ?? []) {
+        const holders = this.heldLocks.get(lock) ?? 0;
+        if (holders <= 1) this.heldLocks.delete(lock);
+        else this.heldLocks.set(lock, holders - 1);
+      }
+      this.active -= 1;
+      this.pump();
+    }
+  }
+
+  private async settle(
+    runtime: RuntimeJob,
+    status: Extract<WorkerJobStatus, "completed" | "failed" | "canceled">,
+    details: Partial<Pick<WorkerJobRecord, "result" | "error">>,
+  ): Promise<boolean> {
+    if (runtime.isSettled) return false;
+    runtime.isSettled = true;
+    runtime.record = {
+      ...runtime.record,
+      ...details,
+      status,
+      settledAt: this.now(),
+      waitReason: undefined,
+    };
+    await this.dependencies.store.update(runtime.record.id, {
+      ...details,
+      status,
+      settledAt: runtime.record.settledAt,
+    });
+    this.emitBatch(runtime.record.batchId);
+    runtime.resolve(structuredClone(runtime.record));
+    return true;
+  }
+
+  private waitReason(record: WorkerJobRecord): string | undefined {
+    for (const dependency of record.dependsOn ?? []) {
+      const prerequisite = [...this.jobs.values()].find((candidate) => candidate.record.id === dependency || candidate.record.key === dependency)?.record;
+      if (!prerequisite) return `Waiting for prerequisite ${dependency}`;
+      if (prerequisite.status === "failed" || prerequisite.status === "canceled") return `Prerequisite ${dependency} did not complete`;
+      if (prerequisite.status !== "completed") return `Waiting for prerequisite ${dependency}`;
+    }
+    if (record.approvalGate) return `Waiting for approval: ${record.approvalGate}`;
+    const held = record.resourceLocks?.find((lock) => this.heldLocks.has(lock));
+    return held ? `Waiting for shared resource ${held}` : undefined;
+  }
+
+  private failBlockedDependents(): void {
+    for (const id of this.queue) {
+      const runtime = this.jobs.get(id);
+      if (!runtime || runtime.isSettled) continue;
+      const failed = (runtime.record.dependsOn ?? []).find((dependency) => {
+        const prerequisite = [...this.jobs.values()].find((candidate) => candidate.record.id === dependency || candidate.record.key === dependency)?.record;
+        return prerequisite?.status === "failed" || prerequisite?.status === "canceled";
+      });
+      if (failed) void this.settle(runtime, "failed", { error: `prerequisite ${failed} did not complete` });
+    }
+  }
+
+  private now(): number {
+    return this.dependencies.now?.() ?? Date.now();
+  }
+
+  private emitBatch(batchId: string | undefined): void {
+    if (!batchId) return;
+    const projection = this.batchSnapshot().find((batch) => batch.id === batchId);
+    if (!projection) return;
+    for (const listener of this.listeners) {
+      try {
+        listener(structuredClone(projection));
+      } catch {
+        // Observability/UI subscribers must never change worker outcomes.
+      }
+    }
+  }
+
+  private rememberTerminal(record: WorkerJobRecord): void {
+    const runtime = this.makeRuntime(record);
+    runtime.isSettled = true;
+    this.jobs.set(record.id, runtime);
+    this.emitBatch(record.batchId);
+  }
+}
+
+function makeBatchProjection(id: string, jobs: readonly WorkerJobRecord[]): WorkerBatchProjection {
+  const counts: WorkerBatchCounts = {
+    total: jobs.length,
+    queued: jobs.filter((job) => job.status === "queued").length,
+    running: jobs.filter((job) => job.status === "running").length,
+    completed: jobs.filter((job) => job.status === "completed").length,
+    failed: jobs.filter((job) => job.status === "failed").length,
+    canceled: jobs.filter((job) => job.status === "canceled").length,
+  };
+  const terminalCount = counts.completed + counts.failed + counts.canceled;
+  const lifecycle: WorkerBatchLifecycle = counts.queued === counts.total
+    ? { status: "queued", terminal: false }
+    : terminalCount < counts.total
+      ? { status: "running", terminal: false }
+      : counts.failed > 0
+        ? { status: "failed", terminal: true }
+        : counts.canceled > 0
+          ? { status: "canceled", terminal: true }
+          : { status: "completed", terminal: true };
+  const first = jobs[0];
+  const updatedAt = Math.max(...jobs.map((job) => job.settledAt ?? job.startedAt ?? job.createdAt));
+  return {
+    id,
+    taskId: first?.taskId ?? "",
+    label: first?.batchLabel ?? first?.label ?? "Parallel work",
+    jobs: jobs.map((job) => {
+      const projection: WorkerBatchJobProjection = { id: job.id, label: job.label?.trim() || "Worker", status: job.status };
+      if (job.waitReason) projection.waitingReason = job.waitReason;
+      return projection;
+    }),
+    counts,
+    createdAt: Math.min(...jobs.map((job) => job.createdAt)),
+    updatedAt,
+    ...lifecycle,
+  };
+}
+

--- a/shared/worker-batch.ts
+++ b/shared/worker-batch.ts
@@ -1,0 +1,37 @@
+/** Client-safe progress projection for one temporary worker batch.
+ * Deliberately excludes prompts, results, errors, and worker transcripts. */
+
+export type WorkerBatchJobStatus = "queued" | "running" | "completed" | "failed" | "canceled";
+
+export interface WorkerBatchCounts {
+  total: number;
+  queued: number;
+  running: number;
+  completed: number;
+  failed: number;
+  canceled: number;
+}
+
+export type WorkerBatchLifecycle =
+  | { status: "queued"; terminal: false }
+  | { status: "running"; terminal: false }
+  | { status: "completed"; terminal: true }
+  | { status: "failed"; terminal: true }
+  | { status: "canceled"; terminal: true };
+
+export interface WorkerBatchJobProjection {
+  id: string;
+  label: string;
+  status: WorkerBatchJobStatus;
+  waitingReason?: string;
+}
+
+export type WorkerBatchProjection = WorkerBatchLifecycle & {
+  id: string;
+  taskId: string;
+  label: string;
+  jobs: WorkerBatchJobProjection[];
+  counts: WorkerBatchCounts;
+  createdAt: number;
+  updatedAt: number;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     // talks to /api — clients hold no transports
     proxy: {
       "/api": {
-        target: `http://127.0.0.1:${process.env.OMB_PORT || process.env.OGB_PORT || 8799}`,
+        target: `http://127.0.0.1:${process.env.OMB_PORT || process.env.OGB_PORT || 18899}`,
       },
     },
   },


### PR DESCRIPTION
## Purpose

Preserves the isolated Centipede V3 outcome-mode line of work as a draft for maintainer review.

This branch remains separate from the reconciled main preservation branch by design. It is currently 96 upstream commits behind main and 8 commits ahead of its base. Review and integrate selectively; do not merge it mechanically.

## Included

- outcome orchestration and execution learning
- bounded action and work runtime seams
- composed V3 runtime
- isolated server identity, ports, data root, and WorkLock database
- isolated desktop packaging and smoke probes
- verification receipt and generated-output ignore rules

## Validation

- TypeScript and Electron checks: pass
- targeted Node identity/package-link tests: 3/3
- targeted V3 Vitest: 17/17
- full suite: 2,002 passed; 86 expected skips
- UI and server builds: pass
- packaged V3 server smoke: pass
- V2/V3 coexistence smoke: pass with distinct identities, ports, data roots, PIDs, and WorkLock database

## Known gates

- Validation ran on Node 26.2.0; repeat on CI Node 24 before promotion.
- Project-wide lint has inherited findings; generated release-v3 output is now excluded and new V3 server files were clean in focused lint.
- No packaged desktop UI was launched during validation.