### PR TITLE
Add isolated AutoRAG prompt retrieval canary

### DIFF
--- a/electron-builder.isolated-canary.yml
+++ b/electron-builder.isolated-canary.yml
@@ -1,0 +1,62 @@
+# Standalone by design: electron-builder concatenates inherited arrays, so an
+# `extends: electron-builder.yml` config could not clear the production
+# openmausbot protocol declaration.
+appId: com.openmausbot.isolated-canary
+productName: OpenMausBot Isolated Canary
+artifactName: OpenMausBot-Isolated-Canary-${version}-${arch}.${ext}
+publish: []
+
+extraMetadata:
+  version: 0.1.40-autorag-canary.1
+
+directories:
+  buildResources: build
+  output: release-isolated-canary
+
+afterPack: ./scripts/after-pack.mjs
+
+files:
+  - electron/**
+  - "!electron/**/*.test.*"
+  - "!electron/resources/speech-helper"
+  - "!electron/resources/speech-helper.swift"
+  - "!electron/resources/speech-helper-Info.plist"
+  - "!electron/resources/OpenMausBot Speech.app/**"
+  - "!electron/resources/recorder-helper"
+  - "!electron/resources/recorder-helper.swift"
+  - "!electron/resources/recorder-helper-Info.plist"
+  - "!electron/resources/OpenMausBot Recorder.app/**"
+  - "!**/node_modules/**"
+  - package.json
+
+asar: true
+
+extraResources:
+  - from: LICENSE
+    to: licenses/OpenMausBot-LICENSE.txt
+  - from: NOTICE
+    to: licenses/OpenMausBot-NOTICE.txt
+  - from: LICENSE
+    to: licenses/cloudflared-LICENSE.txt
+  - from: third_party/cloudflared/README.md
+    to: licenses/cloudflared-README.md
+  - from: dist
+    to: ui
+  - from: dist-server
+    to: server
+  - from: dist-companion
+    to: companion
+  - from: skills
+    to: skills
+  - from: dist-native/android-platform-tools
+    to: android-platform-tools
+
+win:
+  target:
+    - target: portable
+      arch: [x64]
+  executableName: OpenMausBot-Isolated-Canary
+  icon: build/icon.ico
+  extraResources:
+    - from: dist-native/cloudflared/win32-x64/cloudflared.exe
+      to: cloudflared/cloudflared.exe

--- a/electron/isolated-canary-package.test.mjs
+++ b/electron/isolated-canary-package.test.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("isolated Windows canary package identity", () => {
+  it("cannot register the production protocol or collide with the installed app", () => {
+    const config = parse(readFileSync(join(ROOT, "electron-builder.isolated-canary.yml"), "utf8"));
+    expect(config.extends).toBeUndefined();
+    expect(config.appId).toBe("com.openmausbot.isolated-canary");
+    expect(config.productName).toBe("OpenMausBot Isolated Canary");
+    expect(config.protocols).toBeUndefined();
+    expect(config.publish).toEqual([]);
+    expect(config.extraMetadata.version).toBe("0.1.40-autorag-canary.1");
+    expect(config.directories.output).toBe("release-isolated-canary");
+    expect(config.win.target).toEqual([{ target: "portable", arch: ["x64"] }]);
+    expect(config.win.executableName).toBe("OpenMausBot-Isolated-Canary");
+  });
+});

--- a/electron/isolated-canary.mjs
+++ b/electron/isolated-canary.mjs
@@ -16,8 +16,16 @@ export function desktopLaunchPolicy(env = {}, identity = {}) {
 }
 
 /** Resolve a canary-only Electron profile and server state tree. */
-export function isolatedCanaryDataPaths(env = {}, pathApi) {
-  const raw = env.OMB_ISOLATED_CANARY_DATA_ROOT?.trim();
+export function isolatedCanaryDataPaths(env = {}, pathApi, defaults = {}) {
+  const explicit = env.OMB_ISOLATED_CANARY_DATA_ROOT?.trim();
+  const version = String(defaults.appVersion ?? "unknown")
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "_") || "unknown";
+  const raw = explicit || (
+    defaults.tempRoot
+      ? pathApi?.join(defaults.tempRoot, "OpenMausBot-Isolated-Canary", version)
+      : ""
+  );
   if (!raw || !pathApi?.isAbsolute(raw)) {
     throw new Error("OMB_ISOLATED_CANARY_DATA_ROOT must be an absolute canary-only directory");
   }

--- a/electron/isolated-canary.mjs
+++ b/electron/isolated-canary.mjs
@@ -1,0 +1,80 @@
+/** Keep a side-by-side packaged canary from mutating global or hosted state. */
+export function desktopLaunchPolicy(env = {}, identity = {}) {
+  const isolated =
+    env.OMB_ISOLATED_CANARY === "1"
+    || /^\d+\.\d+\.\d+-autorag-canary\.\d+$/.test(identity.appVersion ?? "");
+  return {
+    isolated,
+    companionIpc: !isolated,
+    companionAccountIpc: !isolated,
+    registerProtocol: !isolated,
+    restoreCompanion: !isolated,
+    restoreHostedAccount: !isolated,
+    registerHostedApps: !isolated,
+    updater: !isolated,
+  };
+}
+
+/** Resolve a canary-only Electron profile and server state tree. */
+export function isolatedCanaryDataPaths(env = {}, pathApi) {
+  const raw = env.OMB_ISOLATED_CANARY_DATA_ROOT?.trim();
+  if (!raw || !pathApi?.isAbsolute(raw)) {
+    throw new Error("OMB_ISOLATED_CANARY_DATA_ROOT must be an absolute canary-only directory");
+  }
+  const root = pathApi.resolve(raw);
+  if (pathApi.parse(root).root === root) {
+    throw new Error("OMB_ISOLATED_CANARY_DATA_ROOT cannot be a filesystem root");
+  }
+  return {
+    root,
+    userData: pathApi.join(root, "electron-user-data"),
+    serverData: pathApi.join(root, "server-data"),
+  };
+}
+
+const isolatedCompanionState = () => ({
+  enabled: false,
+  keepAwake: false,
+  port: 0,
+  devices: [],
+  connectedDeviceIds: [],
+  pairing: null,
+  error: "Phone access is disabled in this isolated canary.",
+});
+
+const isolatedCompanionAccountState = () => ({
+  available: false,
+  status: "signed-out",
+  message: "Secure phone access is disabled in this isolated canary.",
+});
+
+/**
+ * Register inert renderer bridges for a packaged canary.
+ *
+ * PhoneSetupFlow probes both state channels when it mounts. Keeping the
+ * channels present avoids renderer errors while guaranteeing that neither a
+ * state read nor a mutation can construct the production account client,
+ * probe accounts.openmausbot.com, start the companion, or alter its settings.
+ */
+export function registerIsolatedCompanionIpc(ipc) {
+  for (const channel of [
+    "companion:state",
+    "companion:start",
+    "companion:stop",
+    "companion:keep-awake",
+    "companion:pairing",
+    "companion:cloud-desktop",
+    "companion:revoke",
+  ]) {
+    ipc.handle(channel, isolatedCompanionState);
+  }
+  for (const channel of [
+    "companion-account:state",
+    "companion-account:request-code",
+    "companion-account:verify-code",
+    "companion-account:retry",
+    "companion-account:sign-out",
+  ]) {
+    ipc.handle(channel, isolatedCompanionAccountState);
+  }
+}

--- a/electron/isolated-canary.test.mjs
+++ b/electron/isolated-canary.test.mjs
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+
+import {
+  desktopLaunchPolicy,
+  isolatedCanaryDataPaths,
+  registerIsolatedCompanionIpc,
+} from "./isolated-canary.mjs";
+
+describe("isolated packaged canary policy", () => {
+  it("preserves every normal packaged startup integration by default", () => {
+    expect(desktopLaunchPolicy({})).toEqual({
+      isolated: false,
+      companionIpc: true,
+      companionAccountIpc: true,
+      registerProtocol: true,
+      restoreCompanion: true,
+      restoreHostedAccount: true,
+      registerHostedApps: true,
+      updater: true,
+    });
+  });
+
+  it("disables global, hosted, companion, and updater side effects explicitly", () => {
+    expect(desktopLaunchPolicy({ OMB_ISOLATED_CANARY: "1" })).toEqual({
+      isolated: true,
+      companionIpc: false,
+      companionAccountIpc: false,
+      registerProtocol: false,
+      restoreCompanion: false,
+      restoreHostedAccount: false,
+      registerHostedApps: false,
+      updater: false,
+    });
+  });
+
+  it("does not accept truthy lookalikes", () => {
+    expect(desktopLaunchPolicy({ OMB_ISOLATED_CANARY: "true" }).isolated).toBe(false);
+  });
+
+  it("fails closed from the packaged canary version even if its env flag is omitted", () => {
+    expect(desktopLaunchPolicy({}, { appVersion: "0.1.40-autorag-canary.1" })).toMatchObject({
+      isolated: true,
+      registerProtocol: false,
+      companionIpc: false,
+      companionAccountIpc: false,
+      updater: false,
+    });
+    expect(desktopLaunchPolicy({}, { appVersion: "0.1.40" }).isolated).toBe(false);
+  });
+
+  it("requires a distinct absolute state root before an isolated launch", () => {
+    expect(() => isolatedCanaryDataPaths({}, path)).toThrow(/must be an absolute/);
+    expect(() => isolatedCanaryDataPaths({ OMB_ISOLATED_CANARY_DATA_ROOT: "." }, path))
+      .toThrow(/must be an absolute/);
+    expect(() => isolatedCanaryDataPaths({ OMB_ISOLATED_CANARY_DATA_ROOT: path.parse(process.cwd()).root }, path))
+      .toThrow(/filesystem root/);
+    const resolved = isolatedCanaryDataPaths({
+      OMB_ISOLATED_CANARY_DATA_ROOT: path.join(process.cwd(), ".canary-state"),
+    }, path);
+    expect(resolved.userData).toBe(path.join(resolved.root, "electron-user-data"));
+    expect(resolved.serverData).toBe(path.join(resolved.root, "server-data"));
+    expect(resolved.userData).not.toBe(resolved.serverData);
+  });
+
+  it("keeps every companion and account IPC call inert without a hosted probe", async () => {
+    const handlers = new Map();
+    registerIsolatedCompanionIpc({
+      handle: (channel, handler) => handlers.set(channel, handler),
+    });
+
+    expect([...handlers.keys()].sort()).toEqual([
+      "companion-account:request-code",
+      "companion-account:retry",
+      "companion-account:sign-out",
+      "companion-account:state",
+      "companion-account:verify-code",
+      "companion:cloud-desktop",
+      "companion:keep-awake",
+      "companion:pairing",
+      "companion:revoke",
+      "companion:start",
+      "companion:state",
+      "companion:stop",
+    ]);
+    for (const channel of handlers.keys()) {
+      const state = await handlers.get(channel)();
+      if (channel.startsWith("companion-account:")) {
+        expect(state).toEqual({
+          available: false,
+          status: "signed-out",
+          message: "Secure phone access is disabled in this isolated canary.",
+        });
+      } else {
+        expect(state).toMatchObject({ enabled: false, port: 0, devices: [], pairing: null });
+      }
+    }
+  });
+});

--- a/electron/isolated-canary.test.mjs
+++ b/electron/isolated-canary.test.mjs
@@ -49,15 +49,35 @@ describe("isolated packaged canary policy", () => {
     expect(desktopLaunchPolicy({}, { appVersion: "0.1.40" }).isolated).toBe(false);
   });
 
-  it("requires a distinct absolute state root before an isolated launch", () => {
+  it("derives a distinct absolute state root for an auto-detected packaged canary", () => {
+    const tempRoot = path.join(path.parse(process.cwd()).root, "tmp");
+    const resolved = isolatedCanaryDataPaths({}, path, {
+      tempRoot,
+      appVersion: "0.1.40-autorag-canary.1",
+    });
+    expect(resolved.root).toBe(path.join(
+      tempRoot,
+      "OpenMausBot-Isolated-Canary",
+      "0.1.40-autorag-canary.1",
+    ));
+    expect(resolved.userData).toBe(path.join(resolved.root, "electron-user-data"));
+    expect(resolved.serverData).toBe(path.join(resolved.root, "server-data"));
+  });
+
+  it("preserves an explicit canary state root and rejects unsafe roots", () => {
     expect(() => isolatedCanaryDataPaths({}, path)).toThrow(/must be an absolute/);
     expect(() => isolatedCanaryDataPaths({ OMB_ISOLATED_CANARY_DATA_ROOT: "." }, path))
       .toThrow(/must be an absolute/);
     expect(() => isolatedCanaryDataPaths({ OMB_ISOLATED_CANARY_DATA_ROOT: path.parse(process.cwd()).root }, path))
       .toThrow(/filesystem root/);
+    const explicitRoot = path.join(process.cwd(), ".canary-state");
     const resolved = isolatedCanaryDataPaths({
-      OMB_ISOLATED_CANARY_DATA_ROOT: path.join(process.cwd(), ".canary-state"),
-    }, path);
+      OMB_ISOLATED_CANARY_DATA_ROOT: explicitRoot,
+    }, path, {
+      tempRoot: path.join(path.parse(process.cwd()).root, "tmp"),
+      appVersion: "0.1.40-autorag-canary.1",
+    });
+    expect(resolved.root).toBe(explicitRoot);
     expect(resolved.userData).toBe(path.join(resolved.root, "electron-user-data"));
     expect(resolved.serverData).toBe(path.join(resolved.root, "server-data"));
     expect(resolved.userData).not.toBe(resolved.serverData);

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -23,6 +23,11 @@ import { activateExistingWindow } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
+import {
+  desktopLaunchPolicy,
+  isolatedCanaryDataPaths,
+  registerIsolatedCompanionIpc,
+} from "./isolated-canary.mjs";
 import { defaultSaveName, withSavableFile } from "./save-file.mjs";
 import {
   ensureManagedComposioCredentials,
@@ -65,6 +70,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // resolve to ::1 and paint a black window
 const DEV_URL = process.env.ELECTRON_START_URL ?? "http://127.0.0.1:5199";
 const DEFAULT_COMPOSIO_BROKER_URL = "https://openmausbot-composio.milindsoni201.workers.dev";
+const launchPolicy = desktopLaunchPolicy(process.env, { appVersion: app.getVersion() });
+if (launchPolicy.isolated) {
+  // This runs before the single-instance lock. The canary therefore cannot
+  // focus, reuse, or inherit the installed app's profile, lock, or server
+  // state even when both executables run at the same time.
+  const canaryPaths = isolatedCanaryDataPaths(process.env, path);
+  fs.mkdirSync(canaryPaths.userData, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(canaryPaths.serverData, { recursive: true, mode: 0o700 });
+  app.setPath("userData", canaryPaths.userData);
+  process.env.OMB_DATA_DIR = canaryPaths.serverData;
+}
 let SERVER_PORT = 8799;
 const APP_ICON = path.join(__dirname, "resources/app-icon.png");
 let desktopViewerWindow = null;
@@ -1409,37 +1425,43 @@ ipcMain.handle("skill-recorder:stop", () => stopRecorder());
 ipcMain.handle("skill-recorder:save", (_event, payload) => saveSkillRecording(payload));
 
 // ── companion sidecar ──────────────────────────────────────────────────
-// The renderer gets these five and nothing else: it can turn the companion
-// on and off, look at it, open or cancel a pairing window, and remove a
-// device. It cannot reach the sidecar's control port itself.
-ipcMain.handle("companion:state", () => desktopCompanionState());
-ipcMain.handle("companion:start", () => startDesktopCompanion());
-ipcMain.handle("companion:stop", () => stopDesktopCompanion());
-ipcMain.handle("companion:keep-awake", async (_event, enabled) => {
-  rememberCompanionKeepAwake(Boolean(enabled));
-  return desktopCompanionState();
-});
-ipcMain.handle("companion:pairing", (_event, open, expectedToken) =>
-  companionPairing(Boolean(open), expectedToken).then(decorateDesktopCompanionState),
-);
-ipcMain.handle("companion:cloud-desktop", (_event, deviceId, allowed) =>
-  companionCloudDesktopAccess(deviceId, Boolean(allowed)).then(() => desktopCompanionState()),
-);
-ipcMain.handle("companion:revoke", (_event, deviceId) =>
-  companionRevoke(deviceId).then(() => desktopCompanionState()),
-);
+if (!launchPolicy.companionIpc || !launchPolicy.companionAccountIpc) {
+  // The renderer probes these bridges when PhoneSetupFlow mounts. Isolated
+  // canaries receive complete inert states; no production account client,
+  // health probe, companion process, or settings mutation is reachable.
+  registerIsolatedCompanionIpc(ipcMain);
+} else {
+  // The renderer gets these narrow methods and cannot reach the sidecar's
+  // control port or account credentials itself.
+  ipcMain.handle("companion:state", () => desktopCompanionState());
+  ipcMain.handle("companion:start", () => startDesktopCompanion());
+  ipcMain.handle("companion:stop", () => stopDesktopCompanion());
+  ipcMain.handle("companion:keep-awake", async (_event, enabled) => {
+    rememberCompanionKeepAwake(Boolean(enabled));
+    return desktopCompanionState();
+  });
+  ipcMain.handle("companion:pairing", (_event, open, expectedToken) =>
+    companionPairing(Boolean(open), expectedToken).then(decorateDesktopCompanionState),
+  );
+  ipcMain.handle("companion:cloud-desktop", (_event, deviceId, allowed) =>
+    companionCloudDesktopAccess(deviceId, Boolean(allowed)).then(() => desktopCompanionState()),
+  );
+  ipcMain.handle("companion:revoke", (_event, deviceId) =>
+    companionRevoke(deviceId).then(() => desktopCompanionState()),
+  );
 
-// Auth and connector credentials never cross this boundary. Every handler
-// returns the same deliberately tiny, secret-free public account state.
-ipcMain.handle("companion-account:state", () => ensureCompanionAccountService().state());
-ipcMain.handle("companion-account:request-code", (_event, email) =>
-  ensureCompanionAccountService().requestCode(email),
-);
-ipcMain.handle("companion-account:verify-code", (_event, email, code) =>
-  ensureCompanionAccountService().verifyCode(email, code),
-);
-ipcMain.handle("companion-account:retry", () => ensureCompanionAccountService().retry());
-ipcMain.handle("companion-account:sign-out", () => ensureCompanionAccountService().signOut());
+  // Auth and connector credentials never cross this boundary. Every handler
+  // returns the same deliberately tiny, secret-free public account state.
+  ipcMain.handle("companion-account:state", () => ensureCompanionAccountService().state());
+  ipcMain.handle("companion-account:request-code", (_event, email) =>
+    ensureCompanionAccountService().requestCode(email),
+  );
+  ipcMain.handle("companion-account:verify-code", (_event, email, code) =>
+    ensureCompanionAccountService().verifyCode(email, code),
+  );
+  ipcMain.handle("companion-account:retry", () => ensureCompanionAccountService().retry());
+  ipcMain.handle("companion-account:sign-out", () => ensureCompanionAccountService().signOut());
+}
 
 ipcMain.handle("desktop:capabilities", async () =>
   desktopCapabilities({
@@ -1539,7 +1561,9 @@ setCuaStateListener((connection) => {
 });
 
 app.whenReady().then(async () => {
-  if (app.isPackaged) app.setAsDefaultProtocolClient("openmausbot");
+  if (app.isPackaged && launchPolicy.registerProtocol) {
+    app.setAsDefaultProtocolClient("openmausbot");
+  }
   if (process.platform === "darwin") app.dock.setIcon(APP_ICON);
   secureCredentials = await loadSecureCredentials();
   if (app.isPackaged) {
@@ -1553,7 +1577,9 @@ app.whenReady().then(async () => {
     writable: !credentialStoreUnavailable,
   });
   secureCredentials = secureCredentialState.read();
-  const hostedAccount = ensureCompanionAccountService();
+  const hostedAccount = launchPolicy.restoreHostedAccount
+    ? ensureCompanionAccountService()
+    : null;
   // Display capture remains user-initiated. The renderer first sends a
   // short-lived one-shot intent, then calls getDisplayMedia in the same click.
   // The handler binds that request to the same frame/origin, rejects audio,
@@ -1607,7 +1633,7 @@ app.whenReady().then(async () => {
   }
   registerCuaIpc();
   androidDevice.registerIpc(ipcMain);
-  registerUpdaterIpc();
+  if (launchPolicy.updater) registerUpdaterIpc();
   // Start the CUA daemon before the window so the harness can pick up the
   // connection descriptor on first render. Never blocks window creation on
   // failure — computer use degrades to "unavailable", the rest still works.
@@ -1624,14 +1650,14 @@ app.whenReady().then(async () => {
   // exact options the IPC handler uses. A failure surfaces in companionState
   // (the panel shows the error) rather than retrying; and it never delays
   // the window.
-  if (serverReady && companionEnabledAtRest()) {
+  if (launchPolicy.restoreCompanion && serverReady && companionEnabledAtRest()) {
     void startDesktopCompanion({ waitForHosted: false, remember: false });
   }
   const win = createWindow();
   // Reconcile incomplete setup and resume interrupted sign-out only after the
   // local app is usable. This background network work never gates LAN pairing
   // or the first window.
-  void hostedAccount.restore().catch(() => {});
+  if (hostedAccount) void hostedAccount.restore().catch(() => {});
   // Registration is optional network work. Start it only after the local
   // server and first window are usable, then update the server child over its
   // private parent port so Connected Apps becomes available without restart.
@@ -1641,7 +1667,12 @@ app.whenReady().then(async () => {
   if (credentialStoreUnavailable) {
     slog("skipping connected-apps registration: the credential store was unreadable this launch");
   }
-  if (app.isPackaged && composioBrokerUrl() && !credentialStoreUnavailable) {
+  if (
+    launchPolicy.registerHostedApps
+    && app.isPackaged
+    && composioBrokerUrl()
+    && !credentialStoreUnavailable
+  ) {
     void updateSecureCredentialDocument(async (credentials) => {
       await ensureManagedComposioCredentials({
         brokerUrl: composioBrokerUrl(),
@@ -1656,7 +1687,7 @@ app.whenReady().then(async () => {
   }
   // in-app auto-update (packaged only) — checks GitHub releases, downloads on
   // the user's click, installs on "Restart to update"
-  startUpdater(win);
+  if (launchPolicy.updater) startUpdater(win);
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -75,7 +75,10 @@ if (launchPolicy.isolated) {
   // This runs before the single-instance lock. The canary therefore cannot
   // focus, reuse, or inherit the installed app's profile, lock, or server
   // state even when both executables run at the same time.
-  const canaryPaths = isolatedCanaryDataPaths(process.env, path);
+  const canaryPaths = isolatedCanaryDataPaths(process.env, path, {
+    tempRoot: app.getPath("temp"),
+    appVersion: app.getVersion(),
+  });
   fs.mkdirSync(canaryPaths.userData, { recursive: true, mode: 0o700 });
   fs.mkdirSync(canaryPaths.serverData, { recursive: true, mode: 0o700 });
   app.setPath("userData", canaryPaths.userData);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "package:prepare": "pnpm build && pnpm build:server && pnpm build:companion && pnpm build:updater && pnpm build:android-tools && pnpm build:cloudflared",
     "package:mac": "pnpm package:prepare && pnpm build:speech && pnpm build:recorder && pnpm build:cua && electron-builder --mac --publish never",
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
+    "package:win:isolated-canary": "pnpm package:prepare && electron-builder --config electron-builder.isolated-canary.yml --win portable --x64 --publish never",
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "package:prepare": "pnpm build && pnpm build:server && pnpm build:companion && pnpm build:updater && pnpm build:android-tools && pnpm build:cloudflared",
     "package:mac": "pnpm package:prepare && pnpm build:speech && pnpm build:recorder && pnpm build:cua && electron-builder --mac --publish never",
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
-    "package:win:isolated-canary": "pnpm package:prepare && electron-builder --config electron-builder.isolated-canary.yml --win portable --x64 --publish never",
+    "package:win:isolated-canary": "pnpm package:prepare && node scripts/prepare-cloudflared.mjs --target win32-x64 && electron-builder --config electron-builder.isolated-canary.yml --win portable --x64 --publish never",
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",

--- a/scripts/prepare-cloudflared.mjs
+++ b/scripts/prepare-cloudflared.mjs
@@ -70,14 +70,24 @@ export function targetsForPreparation({
   current = false,
   platform = process.platform,
   arch = process.arch,
+  target,
 } = {}) {
+  if (target !== undefined) {
+    if (!Object.hasOwn(CLOUDFLARED_ASSETS, target)) {
+      throw new Error(`Cloudflare Tunnel packaging is unsupported for ${target}`);
+    }
+    return [target];
+  }
   return current ? [targetForCurrentHost(platform, arch)] : targetsForHost(platform);
 }
 
 export function parsePrepareCloudflaredArgs(args = []) {
   if (args.length === 0) return { current: false };
   if (args.length === 1 && args[0] === "--current") return { current: true };
-  throw new Error("Usage: node scripts/prepare-cloudflared.mjs [--current]");
+  if (args.length === 2 && args[0] === "--target") {
+    return { current: false, target: args[1] };
+  }
+  throw new Error("Usage: node scripts/prepare-cloudflared.mjs [--current | --target <platform-arch>]");
 }
 
 export function sha256(value) {
@@ -275,9 +285,10 @@ export async function prepareCloudflared({
   platform = process.platform,
   arch = process.arch,
   current = false,
+  target,
 } = {}) {
-  for (const target of targetsForPreparation({ current, platform, arch })) {
-    await stageTarget(root, target);
+  for (const preparationTarget of targetsForPreparation({ current, platform, arch, target })) {
+    await stageTarget(root, preparationTarget);
   }
 }
 

--- a/scripts/prepare-cloudflared.test.mjs
+++ b/scripts/prepare-cloudflared.test.mjs
@@ -83,9 +83,20 @@ describe("pinned cloudflared packaging", () => {
     expect(() => targetForCurrentHost("linux", "arm64")).toThrow(/unsupported/);
   });
 
-  it("accepts only the documented current-target CLI option", () => {
+  it("stages an explicit cross-package target without depending on the build host", () => {
+    expect(targetsForPreparation({ target: "win32-x64", platform: "darwin", arch: "arm64" })).toEqual([
+      "win32-x64",
+    ]);
+    expect(() => targetsForPreparation({ target: "freebsd-x64" })).toThrow(/unsupported/);
+  });
+
+  it("accepts only the documented current-target and cross-package CLI options", () => {
     expect(parsePrepareCloudflaredArgs([])).toEqual({ current: false });
     expect(parsePrepareCloudflaredArgs(["--current"])).toEqual({ current: true });
+    expect(parsePrepareCloudflaredArgs(["--target", "win32-x64"])).toEqual({
+      current: false,
+      target: "win32-x64",
+    });
     expect(() => parsePrepareCloudflaredArgs(["--all"])).toThrow(/Usage:/);
     expect(() => parsePrepareCloudflaredArgs(["--current", "--current"])).toThrow(/Usage:/);
   });
@@ -96,6 +107,9 @@ describe("pinned cloudflared packaging", () => {
     );
     expect(packageJson.scripts["build:cloudflared"]).toBe(
       "node scripts/prepare-cloudflared.mjs",
+    );
+    expect(packageJson.scripts["package:win:isolated-canary"]).toContain(
+      "node scripts/prepare-cloudflared.mjs --target win32-x64",
     );
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,6 +122,7 @@ import {
   retrievePromptContext,
   type PromptRetrievalRequestKind,
 } from "./prompt-retrieval.ts";
+import { completeAcceptedProviderDispatch } from "./provider-dispatch-completion.ts";
 import { TurnWatchdog } from "./turn-watchdog.ts";
 import {
   ensureWorkspace,
@@ -2187,11 +2188,12 @@ async function startTurn(
         integrations,
         cwd,
       });
-      if (pendingDispatch.cancelled) {
-        await instance.adapter.interruptTurn(threadId).catch(() => {});
-      }
-      assertDirectDispatch(pendingDispatch, threadId);
-      finishDirectDispatch(pendingDispatch, threadId);
+      await completeAcceptedProviderDispatch({
+        cancelled: pendingDispatch.cancelled,
+        interrupt: () => instance.adapter.interruptTurn(threadId),
+        assertOwned: () => assertDirectDispatch(pendingDispatch, threadId),
+        finish: () => finishDirectDispatch(pendingDispatch, threadId),
+      });
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
       // and this engine now owns the thread's most recent turn

--- a/server/index.ts
+++ b/server/index.ts
@@ -116,6 +116,12 @@ import {
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { buildTurnContext, engineIsFresh } from "./turn-context.ts";
+import {
+  appendPromptRetrievalContext,
+  promptRetrievalConfiguration,
+  retrievePromptContext,
+  type PromptRetrievalRequestKind,
+} from "./prompt-retrieval.ts";
 import { TurnWatchdog } from "./turn-watchdog.ts";
 import {
   ensureWorkspace,
@@ -797,6 +803,43 @@ const groupSpeakers = new Map<string, { botId: string; name: string; color: stri
 // Providers report cumulative-within-turn numbers; the final value is folded
 // into the task's tally when the turn settles.
 const turnUsage = new Map<string, { input: number; output: number; cachedInput?: number }>();
+
+// A direct turn is marked busy before its asynchronous retrieval/integration
+// setup begins. Stop must own that pre-provider window too: otherwise an
+// adapter with no session yet acknowledges the interrupt, then the delayed
+// setup starts a provider turn after the user pressed Stop.
+interface PendingDirectDispatch {
+  botId: string;
+  cancelled: boolean;
+}
+const pendingDirectDispatches = new Map<string, PendingDirectDispatch>();
+
+class DirectDispatchCancelled extends Error {}
+
+function beginDirectDispatch(botId: string, threadId: string): PendingDirectDispatch {
+  const pending = { botId, cancelled: false };
+  pendingDirectDispatches.set(threadId, pending);
+  return pending;
+}
+
+function cancelDirectDispatch(threadId: string): boolean {
+  const pending = pendingDirectDispatches.get(threadId);
+  if (!pending) return false;
+  pending.cancelled = true;
+  return true;
+}
+
+function assertDirectDispatch(pending: PendingDirectDispatch, threadId: string) {
+  if (pending.cancelled || pendingDirectDispatches.get(threadId) !== pending) {
+    throw new DirectDispatchCancelled("turn stopped before provider dispatch");
+  }
+}
+
+function finishDirectDispatch(pending: PendingDirectDispatch, threadId: string) {
+  if (pendingDirectDispatches.get(threadId) === pending) {
+    pendingDirectDispatches.delete(threadId);
+  }
+}
 
 // Bounded per active turn. OpenHands uses a bounded recent-event scan for
 // the same class of stuck-loop detection; retaining an unlimited set of
@@ -1808,9 +1851,39 @@ async function startTurn(
   store.setActivity(bot.id, "working");
   store.patchBot(bot.id, { unread: false });
   turnUsage.delete(threadId);
+  const pendingDispatch = beginDirectDispatch(bot.id, threadId);
 
   void (async () => {
     try {
+      // Resolve the task's pinned native cwd before retrieval. The retrieval
+      // adapter may run on another host, so it also derives a stable repository
+      // identity from this exact checkout rather than guessing from a path.
+      const worksInWorkspace = instance.driverKind !== "grok" && instance.driverKind !== "boxAgent";
+      const privateWorkspace = worksInWorkspace ? ensureWorkspace(bot.id) : undefined;
+      if (opts?.runOn === "cloud") store.pinTaskCwd(bot.id, threadId, undefined, { none: true });
+      const pinnedCwd =
+        privateWorkspace && opts?.runOn !== "cloud"
+          ? store.pinTaskCwd(bot.id, threadId, privateWorkspace)
+          : null;
+      const cwd = pinnedCwd ?? undefined;
+      const retrievalRequestKind: PromptRetrievalRequestKind =
+        opts?.automationSource || opts?.unattended
+          ? "automation"
+          : opts?.cardContinuation
+            ? "continuation"
+            : opts?.commsDepth
+              ? "delegation"
+              : "user_task";
+      const retrievalContext = await retrievePromptContext(text, threadId, {
+        cwd,
+        eventId: userMessage.id,
+        requestKind: retrievalRequestKind,
+      });
+      assertDirectDispatch(pendingDispatch, threadId);
+      const providerTurnText = appendPromptRetrievalContext(
+        turnText,
+        retrievalContext,
+      );
       const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
       const selectedSkills = selectBundledSkills(
         text,
@@ -1832,8 +1905,6 @@ async function startTurn(
       // than the user's home: a bot with file tools and acceptEdits gets a
       // desk, not the whole house — and the workspace is where its
       // MEMORY.md lives. API/box engines have no local filesystem story.
-      const worksInWorkspace = instance.driverKind !== "grok" && instance.driverKind !== "boxAgent";
-      const privateWorkspace = worksInWorkspace ? ensureWorkspace(bot.id) : undefined;
       const skillInstructions = renderSkillInstructions(selectedSkills, {
         includeRoot: worksInWorkspace && opts?.runOn !== "cloud",
       });
@@ -1845,12 +1916,6 @@ async function startTurn(
       // A cloud run happens on the box, where a host folder means nothing:
       // pin the task to the default so the header chip never shows the
       // bot's folder for a task that runs elsewhere.
-      if (opts?.runOn === "cloud") store.pinTaskCwd(bot.id, threadId, undefined, { none: true });
-      const pinnedCwd =
-        privateWorkspace && opts?.runOn !== "cloud"
-          ? store.pinTaskCwd(bot.id, threadId, privateWorkspace)
-          : null;
-      const cwd = pinnedCwd ?? undefined;
       // Checkpoint explicit project folders, where a bot can overwrite the
       // user's work. Its private OpenMaus workspace is app-owned and changes
       // on nearly every ordinary chat; snapshotting it would add hidden disk
@@ -2069,11 +2134,13 @@ async function startTurn(
       // the engine cannot edit the project until the snapshot has settled.
       // snapshot() absorbs failures, so checkpointing may delay but never fail
       // a turn.
+      assertDirectDispatch(pendingDispatch, threadId);
       if (checkpointCwd) await checkpoints.snapshot(bot.id, checkpointCwd, `turn ${threadId.slice(0, 8)}`);
+      assertDirectDispatch(pendingDispatch, threadId);
       watchdog.watch(threadId, bot.id);
       await instance.adapter.sendTurn({
         threadId,
-        text: turnText,
+        text: providerTurnText,
         model,
         effort,
         // a rewound thread never resumes the abandoned branch's session
@@ -2120,6 +2187,11 @@ async function startTurn(
         integrations,
         cwd,
       });
+      if (pendingDispatch.cancelled) {
+        await instance.adapter.interruptTurn(threadId).catch(() => {});
+      }
+      assertDirectDispatch(pendingDispatch, threadId);
+      finishDirectDispatch(pendingDispatch, threadId);
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
       // and this engine now owns the thread's most recent turn
@@ -2136,6 +2208,13 @@ async function startTurn(
       if (activeVpsThreads.get(bot.id) === threadId) activeVpsThreads.delete(bot.id);
       watchdog.settle(threadId);
       turnUsage.delete(threadId);
+      if (e instanceof DirectDispatchCancelled) {
+        if (store.bot(bot.id)?.busy) store.setActivity(bot.id, "idle");
+        drainQueuedSends();
+        drainConnectorResumes();
+        drainSecretResumes();
+        return;
+      }
       const message = e instanceof Error ? e.message : String(e);
       store.appendMessage(threadId, {
         role: "bot",
@@ -2149,6 +2228,8 @@ async function startTurn(
       drainQueuedSends();
       drainConnectorResumes();
       drainSecretResumes();
+    } finally {
+      finishDirectDispatch(pendingDispatch, threadId);
     }
   })();
   return userMessage;
@@ -2173,6 +2254,7 @@ routines = new RoutineManager({
     startTurn(botId, prompt, { threadId, runOn, automationSource: triggerSource, onDispatchError })
       .then(() => undefined),
   interruptTurn: async (botId, threadId, runOn) => {
+    cancelDirectDispatch(threadId);
     const bot = store.bot(botId);
     const instance = runOn === "cloud"
       ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
@@ -2371,6 +2453,12 @@ function serializeRoomContext(threadId: string, userName: string): string {
     .join("\n");
 }
 
+function latestRoomUserMessage(threadId: string): Message | undefined {
+  return [...store.messagesFor(threadId)]
+    .reverse()
+    .find((message) => message.role === "user" && message.kind === "text" && message.text);
+}
+
 
 // comms bus: passed into the visibility helpers in comms-visibility.ts so
 // they can mirror messages + chips without re-deriving SSE plumbing. Same
@@ -2525,7 +2613,6 @@ async function runGroupMemberTurn(
   const text = `${serializeRoomContext(threadId, userName)}\n\n(Reply to the conversation above as ${bot.name}.)${
     cardContinuation ? `\n\n${cardContinuation}` : ""
   }`;
-
   // same workspace + memory as a 1:1 turn — the room is a different
   // conversation, not a different bot
   const worksInWorkspace = instance.driverKind !== "grok" && instance.driverKind !== "boxAgent";
@@ -2537,6 +2624,25 @@ async function runGroupMemberTurn(
   // but must not decide the pin: the room's desk is a property of the
   // room, not of whichever member happened to speak first.
   const cwd = groupTurnCwd(workspace, () => store.pinGroupCwd(group.id, threadId));
+  const nativeUserMessage = latestRoomUserMessage(threadId);
+  const retrievalContext = await retrievePromptContext(
+    nativeUserMessage?.text ?? "",
+    threadId,
+    {
+      cwd: cwd ?? undefined,
+      eventId: nativeUserMessage?.id,
+      requestKind: "room_turn",
+    },
+  );
+  if (isCancelled?.()) {
+    groupSpeakers.delete(threadId);
+    if (store.group(group.id)?.busyBotId === bot.id) {
+      store.patchGroup(group.id, { busyBotId: null, unread: true });
+    }
+    if (store.bot(bot.id)?.busy) store.setActivity(bot.id, "idle");
+    return false;
+  }
+  const providerTurnText = appendPromptRetrievalContext(text, retrievalContext);
   const roomSystem =
     system +
     sectionContextSystemPrompt(bot.section) +
@@ -2586,11 +2692,19 @@ async function runGroupMemberTurn(
     instance.adapter
       .sendTurn({
         threadId,
-        text,
+        text: providerTurnText,
         system: roomSystem,
         cwd,
         integrations,
         ...memberTurnSelection(bot.modelSelection),
+      })
+      .then(() => {
+        // Stop can land after the pre-dispatch check but before an adapter has
+        // created its native session. Re-issue it after sendTurn establishes
+        // ownership so a late provider cannot escape the room cancellation.
+        if (isCancelled?.()) {
+          void instance.adapter.interruptTurn(threadId).catch(() => {});
+        }
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : "turn failed";
@@ -4969,6 +5083,7 @@ const server = createServer(async (req, res) => {
         patch.alwaysAllow = [...new Set(body.alwaysAllow as string[])].slice(0, 200);
       }
       if (existingBot?.computer === "local" && body.computer !== undefined && body.computer !== "local") {
+        cancelDirectDispatch(existingBot.threadId);
         await registry
           .get(existingBot.modelSelection.instanceId)
           ?.adapter.interruptTurn(existingBot.threadId)
@@ -4992,6 +5107,9 @@ const server = createServer(async (req, res) => {
     if (method === "POST" && path === "/api/local-computer/interrupt") {
       if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
         return json(res, 415, { error: "content-type must be application/json" });
+      }
+      for (const bot of store.bots.filter((candidate) => candidate.computer === "local")) {
+        cancelDirectDispatch(bot.threadId);
       }
       await Promise.allSettled(
         store.bots
@@ -5023,6 +5141,7 @@ const server = createServer(async (req, res) => {
         }
       }
       // a running turn dies with its bot
+      cancelDirectDispatch(bot.threadId);
       await registry.get(bot.modelSelection.instanceId)?.adapter.interruptTurn(bot.threadId).catch(() => {});
       stopScreenPoller(bot.id);
       activeVpsThreads.delete(bot.id);
@@ -5299,8 +5418,23 @@ const server = createServer(async (req, res) => {
             const instance = registry.get(currentAtStart.modelSelection.instanceId);
             let steered = false;
             if (instance?.adapter.capabilities.queueing && instance.adapter.steer) {
+              const eventId = sendId ?? `steer-${randomUUID()}`;
+              const taskCwd = store.taskByThread(currentAtStart.id, threadId)?.cwd ?? undefined;
+              // A failed steer falls back to a normal queued/new turn. Give
+              // the attempt its own dedup scope so that ordinary fallback can
+              // still retrieve instead of inheriting a topic it never used.
+              const steerRetrievalSession = `${threadId}:steer:${eventId}`;
+              const retrievalContext = await retrievePromptContext(text, steerRetrievalSession, {
+                cwd: taskCwd,
+                eventId,
+                requestKind: "steer_attempt",
+              });
+              const providerSteerText = appendPromptRetrievalContext(
+                promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"),
+                retrievalContext,
+              );
               steered = await instance.adapter
-                .steer(threadId, promptWithReply(text, replyTo, cfg.profile?.name?.trim() || "User"))
+                .steer(threadId, providerSteerText)
                 .catch(() => false);
             }
             // steer() is awaited adapter work. The turn can settle, the task can
@@ -5513,12 +5647,14 @@ const server = createServer(async (req, res) => {
         if (expectedThreadId !== undefined && busyGroup.threadId !== expectedThreadId) {
           return json(res, 409, { error: `this bot is working in channel ${busyGroup.id}` });
         }
+        cancelGroupTurnOperations(busyGroup.id, busyGroup.threadId);
         await instance?.adapter.interruptTurn(busyGroup.threadId).catch(() => {});
         closeOpenApprovals(busyGroup.threadId);
       }
       if (expectedThreadId !== undefined && !busyGroup && bot.threadId !== expectedThreadId) {
         return json(res, 409, { error: "the bot switched tasks before it could be interrupted" });
       }
+      cancelDirectDispatch(bot.threadId);
       await instance?.adapter.interruptTurn(bot.threadId).catch(() => {});
       closeOpenApprovals(bot.threadId);
       return json(res, 200, { ok: true });
@@ -5708,7 +5844,12 @@ const server = createServer(async (req, res) => {
     // child proves it is OURS by echoing its pid (a stray dev server has
     // the same API shape but a different pid)
     if (method === "GET" && path === "/api/health") {
-      return json(res, 200, { app: "openmausbot", pid: process.pid, static: Boolean(STATIC_DIR) });
+      return json(res, 200, {
+        app: "openmausbot",
+        pid: process.pid,
+        static: Boolean(STATIC_DIR),
+        promptRetrieval: promptRetrievalConfiguration(),
+      });
     }
 
     // ── inspector: a thread's runtime events + native protocol tee ──

--- a/server/prompt-retrieval.test.ts
+++ b/server/prompt-retrieval.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+
+import {
+  appendPromptRetrievalContext,
+  normalizeRepositoryRemote,
+  promptRetrievalConfiguration,
+  retrievePromptContext,
+} from "./prompt-retrieval.ts";
+
+const CONTEXT = [
+  '<fleet-retrieval-evidence trust="untrusted" instruction-authority="false">',
+  '{"hits":[]}',
+  "</fleet-retrieval-evidence>",
+].join("\n");
+
+interface ResponseOverrides {
+  schema?: string;
+  status?: string;
+  surface?: string;
+  interface?: string;
+  context?: string;
+  content_trust?: string;
+  instruction_authority?: boolean;
+  tool_authority?: boolean;
+  write_authority?: boolean;
+  selector_authority?: boolean;
+  promotion_authority?: boolean;
+  prompt_or_content_recorded_by_adapter?: boolean;
+  native_event?: string;
+  native_event_id?: string;
+  session_key_hash?: string;
+  request_kind?: string;
+  source_marker?: string;
+}
+
+function response(overrides: ResponseOverrides = {}): Response {
+  return new Response(JSON.stringify({
+    schema: "aos.openmausbot-retrieval-adapter.v1",
+    status: "context_ready",
+    surface: "openmausbot",
+    interface: "loopback",
+    context: CONTEXT,
+    content_trust: "untrusted_retrieval_evidence",
+    instruction_authority: false,
+    tool_authority: false,
+    write_authority: false,
+    selector_authority: false,
+    promotion_authority: false,
+    prompt_or_content_recorded_by_adapter: false,
+    native_event: "pre_llm_call",
+    native_event_id: "openmaus-message-1",
+    session_key_hash: createHash("sha256").update("openmaus-thread-1").digest("hex"),
+    request_kind: "user_task",
+    source_marker: "openmausbot-native-v1",
+    ...overrides,
+  }), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("guarded OpenMaus prompt retrieval", () => {
+  it("reports the immutable native hook and only a valid loopback endpoint as configured", () => {
+    expect(promptRetrievalConfiguration("")).toEqual({
+      configured: false,
+      interface: "loopback",
+      endpoint: null,
+      native_event: "pre_llm_call",
+      source_marker: "openmausbot-native-v1",
+      context_ceiling_bytes: 768,
+    });
+    expect(promptRetrievalConfiguration("http://127.0.0.1:8798")).toMatchObject({
+      configured: true,
+      endpoint: "http://127.0.0.1:8798/v1/retrieve",
+      native_event: "pre_llm_call",
+      context_ceiling_bytes: 768,
+    });
+    expect(promptRetrievalConfiguration("https://127.0.0.1:8798").configured).toBe(false);
+  });
+
+  it("stays disabled without an explicit loopback endpoint", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint: "",
+      fetchImpl,
+    })).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "https://127.0.0.1:8798",
+    "http://192.168.1.2:8798",
+    "http://user@127.0.0.1:8798",
+    "http://127.0.0.1:8798/other",
+  ])("rejects a non-loopback or ambiguous endpoint: %s", async (endpoint) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint,
+      fetchImpl,
+    })).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("passes the native project identity without retaining it in the transcript", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response());
+    const repositoryRemoteResolver = vi.fn().mockResolvedValue(
+      "lightcloud00/claudecode-workspace",
+    );
+    const context = await retrievePromptContext(
+      "Find the exact implementation",
+      "openmaus-thread-1",
+      {
+        cwd: "D:\\AOSCanaries\\claudecode-workspace",
+        endpoint: "http://127.0.0.1:8798",
+        eventId: "openmaus-message-1",
+        fetchImpl,
+        requestKind: "user_task",
+        repositoryRemoteResolver,
+      },
+    );
+
+    expect(context).toBe(CONTEXT);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(String(url)).toBe("http://127.0.0.1:8798/v1/retrieve");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      prompt: "Find the exact implementation",
+      session_id: "openmaus-thread-1",
+      cwd: "D:\\AOSCanaries\\claudecode-workspace",
+      native_event: "pre_llm_call",
+      native_event_id: "openmaus-message-1",
+      repository_remote: "lightcloud00/claudecode-workspace",
+      request_kind: "user_task",
+      source_marker: "openmausbot-native-v1",
+    });
+    expect(repositoryRemoteResolver).toHaveBeenCalledWith(
+      "D:\\AOSCanaries\\claudecode-workspace",
+    );
+    expect(init?.cache).toBe("no-store");
+    expect(appendPromptRetrievalContext("user text", context)).toBe(
+      `user text\n\n${CONTEXT}`,
+    );
+  });
+
+  it.each([
+    ["lightcloud00/claudecode-workspace", "lightcloud00/claudecode-workspace"],
+    ["https://github.com/lightcloud00/claudecode-workspace.git", "lightcloud00/claudecode-workspace"],
+    ["git@github.com:lightcloud00/claudecode-workspace.git", "lightcloud00/claudecode-workspace"],
+    ["ssh://git@github.com/lightcloud00/claudecode-workspace", "lightcloud00/claudecode-workspace"],
+  ])("normalizes a stable repository identity from %s", (remote, expected) => {
+    expect(normalizeRepositoryRemote(remote)).toBe(expected);
+  });
+
+  it.each([
+    "https://gitlab.com/lightcloud00/claudecode-workspace.git",
+    "github.com/lightcloud00/claudecode-workspace/extra",
+    "claudecode-workspace",
+  ])("rejects a non-authoritative repository remote %s", (remote) => {
+    expect(normalizeRepositoryRemote(remote)).toBeNull();
+  });
+
+  it.each([
+    { instruction_authority: true },
+    { tool_authority: true },
+    { write_authority: true },
+    { selector_authority: true },
+    { promotion_authority: true },
+    { prompt_or_content_recorded_by_adapter: true },
+    { native_event_id: "another-message" },
+    { session_key_hash: "0".repeat(64) },
+    { request_kind: "automation" },
+    { context: "unwrapped" },
+  ])("drops an unsafe adapter response: %j", async (unsafe) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response(unsafe));
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint: "http://localhost:8798/v1/retrieve",
+      eventId: "openmaus-message-1",
+      fetchImpl,
+      requestKind: "user_task",
+    })).toBeNull();
+  });
+
+  it("fails open on transport errors and oversize prompts", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error("offline"));
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint: "http://127.0.0.1:8798",
+      eventId: "openmaus-message-1",
+      fetchImpl,
+      requestKind: "user_task",
+    })).toBeNull();
+    expect(await retrievePromptContext("x".repeat(8_193), "thread-1", {
+      endpoint: "http://127.0.0.1:8798",
+      eventId: "openmaus-message-1",
+      fetchImpl,
+      requestKind: "user_task",
+    })).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("requires a bounded native event id and explicit request kind", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response());
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint: "http://127.0.0.1:8798", fetchImpl,
+    })).toBeNull();
+    expect(await retrievePromptContext("find source", "thread-1", {
+      endpoint: "http://127.0.0.1:8798",
+      eventId: "invalid event id", fetchImpl, requestKind: "user_task",
+    })).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/server/prompt-retrieval.ts
+++ b/server/prompt-retrieval.ts
@@ -1,0 +1,230 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+const RESPONSE_SCHEMA = "aos.openmausbot-retrieval-adapter.v1";
+const CONTENT_TRUST = "untrusted_retrieval_evidence";
+const DEFAULT_TIMEOUT_MS = 2_500;
+const MAX_PROMPT_BYTES = 8_192;
+const MAX_CONTEXT_BYTES = 768;
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const NATIVE_EVENT = "pre_llm_call";
+const NATIVE_SOURCE_MARKER = "openmausbot-native-v1";
+const NATIVE_EVENT_ID = /^[A-Za-z0-9_.:-]{1,160}$/;
+
+export type PromptRetrievalRequestKind =
+  | "user_task"
+  | "automation"
+  | "continuation"
+  | "delegation"
+  | "room_turn"
+  | "steer_attempt";
+
+export interface PromptRetrievalOptions {
+  cwd?: string;
+  endpoint?: string;
+  eventId?: string;
+  fetchImpl?: typeof fetch;
+  requestKind?: PromptRetrievalRequestKind;
+  repositoryRemote?: string;
+  repositoryRemoteResolver?: (cwd: string) => Promise<string | null>;
+  timeoutMs?: number;
+}
+
+interface PromptRetrievalRequest {
+  prompt: string;
+  session_id: string;
+  cwd?: string;
+  native_event: typeof NATIVE_EVENT;
+  native_event_id: string;
+  repository_remote?: string;
+  request_kind: PromptRetrievalRequestKind;
+  source_marker: typeof NATIVE_SOURCE_MARKER;
+}
+
+export function normalizeRepositoryRemote(raw: string): string | null {
+  let value = raw.trim();
+  const hasControlCharacter = [...value].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint < 32 || codePoint === 127;
+  });
+  if (!value || value.length > 300 || hasControlCharacter) return null;
+  value = value.replace(/^git@github\.com:/i, "");
+  value = value.replace(/^(?:https?|ssh|git):\/\/(?:git@)?github\.com\//i, "");
+  value = value.replace(/^github\.com\//i, "");
+  value = value.replace(/\.git$/i, "").replace(/^\/+|\/+$/g, "").toLowerCase();
+  return /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(value) ? value : null;
+}
+
+export async function repositoryRemoteForCwd(cwd: string): Promise<string | null> {
+  // Resolve on every native event. A task may deliberately change its origin
+  // in the same cwd; a path-only cache would then leak the prior project's
+  // identity into retrieval until process restart.
+  return new Promise<string | null>((resolve) => {
+    execFile(
+      "git",
+      ["-C", cwd, "remote", "get-url", "origin"],
+      { encoding: "utf8", maxBuffer: 4_096, timeout: 350, windowsHide: true },
+      (error, stdout) => resolve(error ? null : normalizeRepositoryRemote(stdout)),
+    );
+  });
+}
+
+const AdapterResponseSchema = z.object({
+  schema: z.literal(RESPONSE_SCHEMA),
+  status: z.literal("context_ready"),
+  surface: z.literal("openmausbot"),
+  interface: z.literal("loopback"),
+  context: z.string(),
+  content_trust: z.literal(CONTENT_TRUST),
+  instruction_authority: z.literal(false),
+  tool_authority: z.literal(false),
+  write_authority: z.literal(false),
+  selector_authority: z.literal(false),
+  promotion_authority: z.literal(false),
+  prompt_or_content_recorded_by_adapter: z.literal(false),
+  native_event: z.literal(NATIVE_EVENT),
+  native_event_id: z.string(),
+  session_key_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  request_kind: z.enum([
+    "user_task", "automation", "continuation", "delegation", "room_turn",
+    "steer_attempt",
+  ]),
+  source_marker: z.literal(NATIVE_SOURCE_MARKER),
+});
+
+type AdapterResponse = z.infer<typeof AdapterResponseSchema>;
+
+function adapterUrl(raw: string | undefined): URL | null {
+  if (!raw?.trim()) return null;
+  try {
+    const endpoint = new URL(raw.trim());
+    if (
+      endpoint.protocol !== "http:" ||
+      !LOOPBACK_HOSTS.has(endpoint.hostname) ||
+      endpoint.username ||
+      endpoint.password ||
+      endpoint.search ||
+      endpoint.hash ||
+      !["", "/", "/v1/retrieve"].includes(endpoint.pathname)
+    ) {
+      return null;
+    }
+    endpoint.pathname = "/v1/retrieve";
+    return endpoint;
+  } catch {
+    return null;
+  }
+}
+
+export function promptRetrievalConfiguration(raw = process.env.OMB_PROMPT_RETRIEVAL_URL) {
+  const endpoint = adapterUrl(raw);
+  return {
+    configured: endpoint !== null,
+    interface: "loopback",
+    endpoint: endpoint ? endpoint.href : null,
+    native_event: NATIVE_EVENT,
+    source_marker: NATIVE_SOURCE_MARKER,
+    context_ceiling_bytes: MAX_CONTEXT_BYTES,
+  };
+}
+
+function acceptedContext(value: AdapterResponse): string | null {
+  if (
+    Buffer.byteLength(value.context, "utf8") > MAX_CONTEXT_BYTES ||
+    !value.context.startsWith(
+      '<fleet-retrieval-evidence trust="untrusted" instruction-authority="false">',
+    ) ||
+    !value.context.endsWith("</fleet-retrieval-evidence>")
+  ) {
+    return null;
+  }
+  return value.context;
+}
+
+/**
+ * Fetch one bounded, non-authoritative retrieval block for an OpenMaus turn.
+ *
+ * The adapter is optional and loopback-only. Every configuration, transport,
+ * timeout, or response-contract failure returns null without logging or
+ * retaining the prompt. The caller appends accepted context only to the
+ * provider-bound turn text, never to OpenMaus's durable transcript.
+ */
+export async function retrievePromptContext(
+  prompt: string,
+  sessionId: string,
+  options: PromptRetrievalOptions = {},
+): Promise<string | null> {
+  const endpoint = adapterUrl(
+    options.endpoint ?? process.env.OMB_PROMPT_RETRIEVAL_URL,
+  );
+  const eventId = options.eventId?.trim();
+  const requestKind = options.requestKind;
+  if (
+    !endpoint ||
+    !prompt.trim() ||
+    Buffer.byteLength(prompt, "utf8") > MAX_PROMPT_BYTES ||
+    !sessionId.trim() ||
+    !eventId ||
+    !NATIVE_EVENT_ID.test(eventId) ||
+    !requestKind
+  ) {
+    return null;
+  }
+  const normalizedCwd = options.cwd?.trim();
+  const cwd = normalizedCwd && normalizedCwd.length <= 2_048 ? normalizedCwd : undefined;
+  const explicitRemote = options.repositoryRemote
+    ? normalizeRepositoryRemote(options.repositoryRemote)
+    : null;
+  const resolvedRemote = (
+    cwd
+      ? await (options.repositoryRemoteResolver ?? repositoryRemoteForCwd)(cwd).catch(() => null)
+      : null
+  );
+  const repositoryRemote = explicitRemote ?? (
+    resolvedRemote ? normalizeRepositoryRemote(resolvedRemote) : null
+  );
+  const timeoutMs = Math.max(
+    100,
+    Math.min(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+  );
+  try {
+    const body: PromptRetrievalRequest = {
+      prompt,
+      session_id: sessionId,
+      native_event: NATIVE_EVENT,
+      native_event_id: eventId,
+      request_kind: requestKind,
+      source_marker: NATIVE_SOURCE_MARKER,
+    };
+    if (cwd) body.cwd = cwd;
+    if (repositoryRemote) body.repository_remote = repositoryRemote;
+    const response = await (options.fetchImpl ?? fetch)(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify(body),
+      cache: "no-store",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return null;
+    const value = AdapterResponseSchema.safeParse(await response.json());
+    if (!value.success) return null;
+    if (
+      value.data.native_event_id !== eventId ||
+      value.data.request_kind !== requestKind ||
+      value.data.session_key_hash !== createHash("sha256").update(sessionId).digest("hex")
+    ) {
+      return null;
+    }
+    return acceptedContext(value.data);
+  } catch {
+    return null;
+  }
+}
+
+export function appendPromptRetrievalContext(
+  turnText: string,
+  context: string | null,
+): string {
+  return context ? `${turnText}\n\n${context}` : turnText;
+}

--- a/server/provider-dispatch-completion.test.ts
+++ b/server/provider-dispatch-completion.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { completeAcceptedProviderDispatch } from "./provider-dispatch-completion.ts";
+
+describe("accepted provider dispatch completion", () => {
+  it("interrupts a post-acceptance cancellation and preserves normal completion", async () => {
+    const interrupt = vi.fn(async () => {});
+    const assertOwned = vi.fn();
+    const finish = vi.fn();
+
+    await completeAcceptedProviderDispatch({ cancelled: true, interrupt, assertOwned, finish });
+
+    expect(interrupt).toHaveBeenCalledOnce();
+    expect(assertOwned).not.toHaveBeenCalled();
+    expect(finish).toHaveBeenCalledOnce();
+  });
+
+  it("checks ownership for an uncancelled accepted dispatch", async () => {
+    const interrupt = vi.fn(async () => {});
+    const assertOwned = vi.fn();
+    const finish = vi.fn();
+
+    await completeAcceptedProviderDispatch({ cancelled: false, interrupt, assertOwned, finish });
+
+    expect(interrupt).not.toHaveBeenCalled();
+    expect(assertOwned).toHaveBeenCalledOnce();
+    expect(finish).toHaveBeenCalledOnce();
+  });
+
+  it("still finishes when the provider interrupt rejects", async () => {
+    const finish = vi.fn();
+
+    await completeAcceptedProviderDispatch({
+      cancelled: true,
+      interrupt: async () => { throw new Error("already settled"); },
+      assertOwned: vi.fn(),
+      finish,
+    });
+
+    expect(finish).toHaveBeenCalledOnce();
+  });
+});

--- a/server/provider-dispatch-completion.ts
+++ b/server/provider-dispatch-completion.ts
@@ -1,0 +1,20 @@
+/**
+ * Close the pre-provider dispatch window once the provider accepted a turn.
+ *
+ * A stop can race with sendTurn resolving. At that point the provider has
+ * already accepted the turn, so cancellation interrupts it but must not be
+ * reclassified as a pre-provider cancellation or skip normal bookkeeping.
+ */
+export async function completeAcceptedProviderDispatch(options: {
+  cancelled: boolean;
+  interrupt: () => Promise<void>;
+  assertOwned: () => void;
+  finish: () => void;
+}): Promise<void> {
+  if (options.cancelled) {
+    await options.interrupt().catch(() => {});
+  } else {
+    options.assertOwned();
+  }
+  options.finish();
+}

--- a/server/steer-e2e.test.ts
+++ b/server/steer-e2e.test.ts
@@ -6,27 +6,64 @@
 // falls back to the server-side queue.
 //
 // POSIX-gated like the other CLI e2es (the fakes are shebang scripts).
-import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { JsonObject, JsonValue } from "./schema.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
 const FAKE_ACP = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
 const PORT = 18800 + Math.floor(Math.random() * 10_000);
 const BASE = `http://127.0.0.1:${PORT}`;
+const RETRIEVAL_CONTEXT = [
+  '<fleet-retrieval-evidence trust="untrusted" instruction-authority="false">',
+  '{"hits":[{"path":"server/prompt-retrieval.ts","line":1}]}',
+  "</fleet-retrieval-evidence>",
+].join("\n");
 const posixOnly = describe.skipIf(process.platform === "win32");
+const retrievalRequestSchema = z.object({
+  prompt: z.string(),
+  session_id: z.string(),
+  cwd: z.string().optional(),
+  repository_remote: z.string().optional(),
+  native_event: z.string(),
+  native_event_id: z.string(),
+  request_kind: z.string(),
+  source_marker: z.string(),
+}).passthrough();
+type RetrievalRequest = z.infer<typeof retrievalRequestSchema>;
+
+interface RetrievalHold {
+  prompt: string;
+  observed: () => void;
+  released: Promise<void>;
+}
 
 posixOnly("mid-turn steering e2e", () => {
   let child: ChildProcess;
   let home: string;
   let stderr = "";
   let steerGate: string;
+  let projectCwd: string;
+  let gitWrapperDir: string;
+  let retrievalServer: Server;
+  let retrievalEndpoint = "";
+  let roomDump: string;
+  let claudeDump: string;
+  let rejectSteerClosed: string;
+  let preDispatchDump: string;
+  let retrievalHold: RetrievalHold | null = null;
+  const retrievalRequests: RetrievalRequest[] = [];
 
-  const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+  const api = async (method: string, path: string, body?: JsonValue): Promise<{ status: number; body: any }> => {
     const res = await fetch(`${BASE}${path}`, {
       method,
       headers: body ? { "content-type": "application/json" } : undefined,
@@ -35,11 +72,91 @@ posixOnly("mid-turn steering e2e", () => {
     return { status: res.status, body: await res.json() };
   };
   const getBot = async (id: string) => (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === id);
+  const getGroup = async (id: string) => (await api("GET", "/api/bots")).body.groups.find((g: any) => g.id === id);
   const waitFor = async (predicate: () => Promise<boolean>, what: string, ms = 30_000) => {
     const deadline = Date.now() + ms;
     while (!(await predicate())) {
       if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}. stderr: ${stderr.slice(-2000)}`);
       await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+  const holdRetrieval = (prompt: string) => {
+    let observe: () => void = () => {};
+    const observed = new Promise<void>((resolve) => { observe = resolve; });
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    retrievalHold = { prompt, observed: observe, released };
+    return {
+      observed,
+      release: () => {
+        retrievalHold = null;
+        release();
+      },
+    };
+  };
+  const exercisePreDispatchCancellation = async (
+    mode: "bot-stop" | "bot-delete" | "local-stop" | "local-disable",
+  ) => {
+    retrievalRequests.length = 0;
+    rmSync(preDispatchDump, { force: true });
+    const created = (await api("POST", "/api/bots")).body.bot;
+    const prompt = `held retrieval ${mode}`;
+    const hold = holdRetrieval(prompt);
+    try {
+      const patch: JsonObject = {
+        cwd: projectCwd,
+        modelSelection: { instanceId: "claudePreDispatch", model: "claude-fake" },
+      };
+      if (mode === "local-stop" || mode === "local-disable") patch.computer = "local";
+      expect((await api("PATCH", `/api/bots/${created.id}`, patch)).status).toBe(200);
+      const accepted = await api("POST", `/api/bots/${created.id}/messages`, {
+        text: prompt,
+        sendId: `pre-dispatch-${mode}`,
+      });
+      expect(accepted.status).toBe(202);
+      await hold.observed;
+
+      const nativeMessage = accepted.body.message;
+      expect(nativeMessage?.id).toBeTruthy();
+
+      const stopped = mode === "bot-delete"
+        ? await api("DELETE", `/api/bots/${created.id}`)
+        : mode === "local-stop"
+          ? await api("POST", "/api/local-computer/interrupt", {})
+          : mode === "local-disable"
+            ? await api("PATCH", `/api/bots/${created.id}`, { computer: "off" })
+          : await api("POST", `/api/bots/${created.id}/interrupt`, {
+              threadId: created.threadId,
+            });
+      expect(stopped.status).toBe(200);
+      hold.release();
+
+      if (mode !== "bot-delete") {
+        await waitFor(async () => (await getBot(created.id)).busy === false, `${mode} cancellation to settle`);
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 750));
+      }
+      expect(existsSync(preDispatchDump)).toBe(false);
+      expect(retrievalRequests).toHaveLength(1);
+      expect(retrievalRequests[0]).toMatchObject({
+        prompt,
+        session_id: created.threadId,
+        native_event_id: nativeMessage.id,
+        request_kind: "user_task",
+      });
+      const survivor = await getBot(created.id);
+      if (mode === "bot-delete") {
+        expect(survivor).toBeUndefined();
+      } else {
+        expect(survivor.messages.some(
+          (message: any) => message.role === "bot"
+            && message.kind === "text"
+            && message.text.startsWith("reply to:"),
+        )).toBe(false);
+      }
+    } finally {
+      hold.release();
+      await api("DELETE", `/api/bots/${created.id}`).catch(() => undefined);
     }
   };
 
@@ -48,15 +165,120 @@ posixOnly("mid-turn steering e2e", () => {
     chmodSync(FAKE_ACP, 0o755);
     home = mkdtempSync(join(tmpdir(), "omb-steer-"));
     mkdirSync(join(home, ".openmausbot"), { recursive: true });
+    projectCwd = join(home, "canary-project");
+    execFileSync("git", ["init", "--quiet", projectCwd]);
+    execFileSync("git", ["-C", projectCwd, "remote", "add", "origin", "https://github.com/lightcloud00/claudecode-workspace.git"]);
+    const realGit = (process.env.PATH ?? "")
+      .split(":")
+      .map((directory) => join(directory, "git"))
+      .find((candidate) => existsSync(candidate));
+    if (!realGit) throw new Error("git is required for the retrieval fixture");
+    gitWrapperDir = join(home, "test-bin");
+    mkdirSync(gitWrapperDir);
+    const shellQuote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+    const gitWrapper = join(gitWrapperDir, "git");
+    writeFileSync(gitWrapper, [
+      "#!/bin/sh",
+      `if [ "$1" = "-C" ] && [ "$2" = ${shellQuote(projectCwd)} ] && [ "$3" = "remote" ] && [ "$4" = "get-url" ] && [ "$5" = "origin" ]; then`,
+      "  printf '%s\\n' 'https://github.com/lightcloud00/claudecode-workspace.git'",
+      "  exit 0",
+      "fi",
+      `exec ${shellQuote(realGit)} "$@"`,
+      "",
+    ].join("\n"));
+    chmodSync(gitWrapper, 0o755);
+    retrievalServer = createServer((req, res) => {
+      let raw = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => { raw += chunk; });
+      req.on("end", async () => {
+        const body = retrievalRequestSchema.parse(JSON.parse(raw));
+        retrievalRequests.push(body);
+        // Mirror the real fail-closed project-identity boundary. A bot's
+        // private scratch workspace is not a mapped repository, so it gets
+        // no evidence and the unrelated queueing fixture stays byte-identical.
+        if (!body.repository_remote) {
+          res.writeHead(204, { "cache-control": "no-store" });
+          res.end();
+          return;
+        }
+        const hold = retrievalHold;
+        if (hold?.prompt === body.prompt) {
+          hold.observed();
+          await hold.released;
+        }
+        const value = {
+          schema: "aos.openmausbot-retrieval-adapter.v1",
+          status: "context_ready",
+          surface: "openmausbot",
+          interface: "loopback",
+          context: RETRIEVAL_CONTEXT,
+          content_trust: "untrusted_retrieval_evidence",
+          instruction_authority: false,
+          tool_authority: false,
+          write_authority: false,
+          selector_authority: false,
+          promotion_authority: false,
+          prompt_or_content_recorded_by_adapter: false,
+          native_event: body.native_event,
+          native_event_id: body.native_event_id,
+          session_key_hash: createHash("sha256").update(String(body.session_id)).digest("hex"),
+          request_kind: body.request_kind,
+          source_marker: body.source_marker,
+        };
+        res.writeHead(200, { "content-type": "application/json", "cache-control": "no-store" });
+        res.end(JSON.stringify(value));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      retrievalServer.once("error", reject);
+      retrievalServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const retrievalAddress = retrievalServer.address();
+    if (!retrievalAddress) throw new Error("retrieval fixture did not bind");
+    // SAFETY: listen() used an IP host and numeric port, so Node returns AddressInfo here.
+    const retrievalPort = (retrievalAddress as AddressInfo).port;
+    retrievalEndpoint = `http://127.0.0.1:${retrievalPort}/v1/retrieve`;
+    roomDump = join(home, "room-provider-prompt.json");
+    claudeDump = join(home, "claude-provider-prompt.json");
+    preDispatchDump = join(home, "pre-dispatch-provider-prompt.json");
+    rejectSteerClosed = join(home, "reject-steer-closed.marker");
     steerGate = join(home, "delayed-steer.gate");
     writeFileSync(
       join(home, ".openmausbot", "config.json"),
       JSON.stringify({
         instances: {
-          claude: { driver: "claudeAgent", environment: { FAKE_CLAUDE_MODE: "slow" }, config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" } },
+          claude: {
+            driver: "claudeAgent",
+            environment: {
+              FAKE_CLAUDE_MODE: "slow",
+              FAKE_CLAUDE_SLOW_MS: "2000",
+              FAKE_CLAUDE_WAIT_FOR_STEER: "1",
+              FAKE_CLAUDE_DUMP: claudeDump,
+            },
+            config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
+          },
           claudeRace: {
             driver: "claudeAgent",
             environment: { FAKE_CLAUDE_MODE: "slow", FAKE_CLAUDE_STEER_GATE: steerGate },
+            config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
+          },
+          claudeReject: {
+            driver: "claudeAgent",
+            environment: {
+              FAKE_CLAUDE_MODE: "reject-steer",
+              FAKE_CLAUDE_STEER_CLOSED_MARKER: rejectSteerClosed,
+            },
+            config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
+          },
+          claudeRoom: {
+            driver: "claudeAgent",
+            environment: { FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: roomDump },
+            config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
+          },
+          claudePreDispatch: {
+            driver: "claudeAgent",
+            environment: { FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: preDispatchDump },
             config: { cli: FAKE_CLAUDE, permissionMode: "bypassPermissions" },
           },
           // no live session: a message while busy uses the server-side queue
@@ -64,13 +286,22 @@ posixOnly("mid-turn steering e2e", () => {
         },
       }),
     );
+    const childEnv: NodeJS.ProcessEnv = {
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(PORT),
+      OMB_PROMPT_RETRIEVAL_URL: retrievalEndpoint,
+    };
+    childEnv.PATH = process.env.PATH
+      ? `${gitWrapperDir}:${process.env.PATH}`
+      : gitWrapperDir;
     child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
       cwd: join(SERVER_DIR, ".."),
-      env: { ...(process.env.PATH ? { PATH: process.env.PATH } : {}), HOME: home, USERPROFILE: home, OMB_PORT: String(PORT) },
+      env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
     child.stderr!.on("data", (c) => (stderr += c));
-    const deadline = Date.now() + 20_000;
+    const deadline = Date.now() + 45_000;
     for (;;) {
       try {
         if ((await fetch(`${BASE}/api/health`)).ok) break;
@@ -81,7 +312,7 @@ posixOnly("mid-turn steering e2e", () => {
       if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}. stderr:\n${stderr}`);
       await new Promise((r) => setTimeout(r, 150));
     }
-  }, 30_000);
+  }, 60_000);
 
   afterAll(async () => {
     child?.kill("SIGTERM");
@@ -90,40 +321,88 @@ posixOnly("mid-turn steering e2e", () => {
       child.on("close", () => resolve());
       setTimeout(() => (child.kill("SIGKILL"), resolve()), 5_000).unref?.();
     });
+    await new Promise<void>((resolve) => retrievalServer?.close(() => resolve()));
     rmSync(home, { recursive: true, force: true });
   });
 
   it(
     "a message during a Claude turn is steered into it: 202, in the transcript in order and marked, folded into the reply",
     async () => {
+      retrievalRequests.length = 0;
       const created = (await api("POST", "/api/bots")).body.bot;
-      await api("PATCH", `/api/bots/${created.id}`, { modelSelection: { instanceId: "claude", model: "claude-fake" } });
+      await api("PATCH", `/api/bots/${created.id}`, {
+        cwd: projectCwd,
+        modelSelection: { instanceId: "claude", model: "claude-fake" },
+      });
       const instances = (await api("GET", "/api/instances")).body.instances;
       expect(instances.find((i: any) => i.instanceId === "claude").capabilities.queueing).toBe(true);
 
-      expect((await api("POST", `/api/bots/${created.id}/messages`, { text: "first" })).status).toBe(202);
+      expect((await api("POST", `/api/bots/${created.id}/messages`, {
+        text: "first",
+        sendId: "retrieval-first-0001",
+      })).status).toBe(202);
       await waitFor(async () => (await getBot(created.id)).busy === true, "the turn to start");
+      await waitFor(async () => existsSync(claudeDump), "the Claude fixture environment dump");
+      const fixtureEnvironment = z.object({
+        env: z.object({
+          FAKE_CLAUDE_SLOW_MS: z.literal("2000"),
+          FAKE_CLAUDE_WAIT_FOR_STEER: z.literal("1"),
+        }).passthrough(),
+        prompt: z.object({
+          message: z.object({ content: z.string() }).passthrough(),
+        }).passthrough(),
+      }).parse(JSON.parse(readFileSync(claudeDump, "utf8")));
+      expect(fixtureEnvironment.env.FAKE_CLAUDE_WAIT_FOR_STEER).toBe("1");
+      expect(fixtureEnvironment.prompt.message.content).toContain(RETRIEVAL_CONTEXT);
       // the fake pauses after its tool result; this lands inside that gap
       await waitFor(async () => (await getBot(created.id)).messages.some((m: any) => m.kind === "activity"), "the tool chip");
-      const second = await api("POST", `/api/bots/${created.id}/messages`, { text: "and also this" });
+      const second = await api("POST", `/api/bots/${created.id}/messages`, {
+        text: "and also this",
+        sendId: "retrieval-steer-0001",
+      });
       expect(second.status).toBe(202);
       expect(second.body.steered).toBe(true);
 
       await waitFor(async () => (await getBot(created.id)).busy === false, "the turn to settle");
       const bot = await getBot(created.id);
-      const texts = bot.messages.filter((m: any) => m.kind === "text").map((m: any) => `${m.role}:${m.text}`);
-      // order: greeting, first, the fake's opening line, the steered message
-      // (appended when it was sent — mid-turn), then ONE reply carrying it
-      expect(texts.slice(1)).toEqual([
-        "user:first",
-        "bot:hello from fake claude",
-        "user:and also this",
-        "bot:reply to: first + steered: and also this",
-      ]);
+      const textMessages = bot.messages.filter((m: any) => m.kind === "text");
+      // Retrieval evidence reaches the provider-bound prompt but never the
+      // two durable user transcript messages.
+      expect(textMessages.filter((m: any) => m.role === "user").map((m: any) => m.text))
+        .toEqual(["first", "and also this"]);
+      expect(textMessages.filter((m: any) => m.role === "user").every(
+        (m: any) => !m.text.includes("fleet-retrieval-evidence"),
+      )).toBe(true);
+      const finalReply = textMessages.find((m: any) => m.text.startsWith("reply to:"));
+      expect(finalReply.text).toContain(RETRIEVAL_CONTEXT);
+      expect(finalReply.text).toContain(`steered: and also this\n\n${RETRIEVAL_CONTEXT}`);
       const steered = bot.messages.find((m: any) => m.text === "and also this");
       expect(steered.steered).toBe(true);
       // one turn, not two: exactly one reply
       expect(bot.messages.filter((m: any) => m.role === "bot" && m.kind === "text" && m.text.startsWith("reply to:"))).toHaveLength(1);
+      expect(retrievalRequests).toHaveLength(2);
+      expect(retrievalRequests[0]).toMatchObject({
+        prompt: "first",
+        session_id: created.threadId,
+        cwd: projectCwd,
+        repository_remote: "lightcloud00/claudecode-workspace",
+        native_event: "pre_llm_call",
+        request_kind: "user_task",
+        source_marker: "openmausbot-native-v1",
+      });
+      expect(retrievalRequests[0]?.native_event_id).toBe(
+        textMessages.find((m: any) => m.role === "user" && m.text === "first")?.id,
+      );
+      expect(retrievalRequests[1]).toMatchObject({
+        prompt: "and also this",
+        session_id: `${created.threadId}:steer:retrieval-steer-0001`,
+        cwd: projectCwd,
+        repository_remote: "lightcloud00/claudecode-workspace",
+        native_event: "pre_llm_call",
+        native_event_id: "retrieval-steer-0001",
+        request_kind: "steer_attempt",
+        source_marker: "openmausbot-native-v1",
+      });
     },
     40_000,
   );
@@ -154,7 +433,9 @@ posixOnly("mid-turn steering e2e", () => {
     ]);
     expect(prematurelySettled).toBe(false);
 
-    await waitFor(async () => (await getBot(created.id))?.busy === false, "the original race turn to settle");
+    // Delete while the adapter write is still held. Waiting for the original
+    // turn to settle first leaves a polling race where a buffered write can
+    // acknowledge between the busy read and deletion.
     expect((await api("DELETE", `/api/bots/${created.id}`)).status).toBe(200);
     writeFileSync(steerGate, "open");
 
@@ -162,6 +443,141 @@ posixOnly("mid-turn steering e2e", () => {
     expect(rejected.status).toBe(404);
     expect(rejected.body.error).toMatch(/no such bot/i);
   }, 40_000);
+
+  it("Stop during held retrieval never starts the provider", async () => {
+    await exercisePreDispatchCancellation("bot-stop");
+  }, 30_000);
+
+  it("deleting a bot during held retrieval never starts its provider", async () => {
+    await exercisePreDispatchCancellation("bot-delete");
+  }, 30_000);
+
+  it("local-computer Stop during held retrieval never starts the provider", async () => {
+    await exercisePreDispatchCancellation("local-stop");
+  }, 30_000);
+
+  it("disabling local computer during held retrieval never starts the provider", async () => {
+    await exercisePreDispatchCancellation("local-disable");
+  }, 30_000);
+
+  it("routine cancellation owns pending retrieval before adapter interruption", () => {
+    const source = readFileSync(join(SERVER_DIR, "index.ts"), "utf8");
+    expect(source).toMatch(
+      /interruptTurn: async \(botId, threadId, runOn\) => \{\s+cancelDirectDispatch\(threadId\);\s+const bot/,
+    );
+  });
+
+  it("a room turn uses its pinned project and keeps retrieval out of the transcript", async () => {
+    retrievalRequests.length = 0;
+    rmSync(roomDump, { force: true });
+    const created = (await api("POST", "/api/bots")).body.bot;
+    let room: any;
+    try {
+      await api("PATCH", `/api/bots/${created.id}`, {
+        modelSelection: { instanceId: "claudeRoom", model: "claude-fake" },
+      });
+      room = (await api("POST", "/api/groups", {
+        name: "Retrieval room",
+        memberIds: [created.id],
+        setup: {
+          bulletin: "",
+          defaultResponder: { kind: "member", botId: created.id },
+        },
+      })).body.group;
+      expect((await api("PATCH", `/api/groups/${room.id}`, { cwd: projectCwd })).status).toBe(200);
+      expect((await api("POST", `/api/groups/${room.id}/messages`, {
+        text: "room project lookup",
+        sendId: "room-retrieval-0001",
+      })).status).toBe(202);
+
+      await waitFor(async () => existsSync(roomDump), "the room provider prompt");
+      await waitFor(async () => (await getGroup(room.id)).busyBotId == null, "the room turn to settle");
+      const settled = await getGroup(room.id);
+      const userMessage = settled.messages.find((m: any) => m.role === "user" && m.text === "room project lookup");
+      expect(userMessage).toBeTruthy();
+      expect(settled.messages.filter((m: any) => m.kind === "text").every(
+        (m: any) => !m.text.includes("fleet-retrieval-evidence"),
+      )).toBe(true);
+
+      expect(retrievalRequests).toHaveLength(1);
+      expect(retrievalRequests[0]).toMatchObject({
+        prompt: "room project lookup",
+        session_id: room.threadId,
+        cwd: projectCwd,
+        repository_remote: "lightcloud00/claudecode-workspace",
+        native_event: "pre_llm_call",
+        native_event_id: userMessage.id,
+        request_kind: "room_turn",
+        source_marker: "openmausbot-native-v1",
+      });
+      const providerDump = JSON.parse(readFileSync(roomDump, "utf8"));
+      expect(providerDump.prompt.message.content).toContain(RETRIEVAL_CONTEXT);
+    } finally {
+      if (room) {
+        await api("POST", `/api/groups/${room.id}/interrupt`, {}).catch(() => undefined);
+        await api("DELETE", `/api/groups/${room.id}`).catch(() => undefined);
+      }
+      await api("DELETE", `/api/bots/${created.id}`).catch(() => undefined);
+    }
+  }, 30_000);
+
+  it("a failed steer leaves the normal thread key available for the queued turn", async () => {
+    retrievalRequests.length = 0;
+    const created = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${created.id}`, {
+      cwd: projectCwd,
+      modelSelection: { instanceId: "claudeReject", model: "claude-fake" },
+    });
+
+    expect((await api("POST", `/api/bots/${created.id}/messages`, {
+      text: "first rejected steer turn",
+      sendId: "reject-first-0001",
+    })).status).toBe(202);
+    await waitFor(async () => (await getBot(created.id)).busy === true, "the reject fixture turn to start");
+    await waitFor(
+      async () => (await getBot(created.id)).messages.some((m: any) => m.kind === "activity"),
+      "the reject fixture tool chip",
+    );
+    await waitFor(async () => existsSync(rejectSteerClosed), "the reject fixture stdin to close");
+
+    const second = await api("POST", `/api/bots/${created.id}/messages`, {
+      text: "queued after rejected steer",
+      sendId: "reject-second-0001",
+    });
+    expect(second.status).toBe(202);
+    expect(second.body.steered).not.toBe(true);
+    expect(second.body.queued === true || second.body.message).toBeTruthy();
+
+    await waitFor(async () => {
+      const bot = await getBot(created.id);
+      return bot.busy === false
+        && bot.messages.filter((m: any) => m.kind === "text" && m.text.startsWith("reply to:")).length >= 2;
+    }, "the queued fallback turn to settle", 40_000);
+    const bot = await getBot(created.id);
+    const fallbackMessage = bot.messages.find((m: any) => m.role === "user" && m.text === "queued after rejected steer");
+    expect(fallbackMessage).toBeTruthy();
+    expect(fallbackMessage.text).not.toContain("fleet-retrieval-evidence");
+
+    expect(retrievalRequests).toHaveLength(3);
+    expect(retrievalRequests[1]).toMatchObject({
+      prompt: "queued after rejected steer",
+      session_id: `${created.threadId}:steer:reject-second-0001`,
+      native_event_id: "reject-second-0001",
+      request_kind: "steer_attempt",
+    });
+    expect(retrievalRequests[2]).toMatchObject({
+      prompt: "queued after rejected steer",
+      session_id: created.threadId,
+      cwd: projectCwd,
+      repository_remote: "lightcloud00/claudecode-workspace",
+      native_event_id: fallbackMessage.id,
+      request_kind: "user_task",
+    });
+    const fallbackReply = bot.messages
+      .filter((m: any) => m.kind === "text" && m.text.startsWith("reply to:"))
+      .at(-1);
+    expect(fallbackReply.text).toContain(RETRIEVAL_CONTEXT);
+  }, 50_000);
 
   it("an engine without a live session preserves the message in the server-side queue", async () => {
     const created = (await api("POST", "/api/bots")).body.bot;
@@ -179,5 +595,5 @@ posixOnly("mid-turn steering e2e", () => {
     );
     await api("POST", `/api/bots/${created.id}/interrupt`);
     await waitFor(async () => (await getBot(created.id)).busy === false, "the queued turn to settle");
-  }, 30_000);
+  }, 45_000);
 });

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -17,7 +17,7 @@
 //                      inherited-api-key — what `auth status` reports
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CLAUDE_MODE ?? "happy";
 
@@ -201,15 +201,26 @@ const playTurn = (prompt: JsonValue) => {
     turnRunning = false;
     finishIfDone();
   };
-  if (mode === "slow") {
+  if (mode === "slow" || mode === "reject-steer") {
     // a gap a test can steer into; the closing reply carries anything that
     // was folded in, the way the real CLI includes a mid-turn message in
     // the same turn's next model call
-    setTimeout(() => {
+    const slowMs = Math.max(100, Number(process.env.FAKE_CLAUDE_SLOW_MS) || 800);
+    const steerDeadline = Date.now() + 10_000;
+    const finishSlowTurn = () => {
+      if (
+        process.env.FAKE_CLAUDE_WAIT_FOR_STEER === "1"
+        && steered.length === 0
+        && Date.now() < steerDeadline
+      ) {
+        setTimeout(finishSlowTurn, 25);
+        return;
+      }
       const tail = steered.length ? ` + steered: ${steered.join(" | ")}` : "";
       out({ type: "assistant", message: { content: [{ type: "text", text: `reply to: ${promptText(prompt)}${tail}` }] } });
       finish();
-    }, 800);
+    };
+    setTimeout(finishSlowTurn, slowMs);
   } else {
     finish();
   }
@@ -233,6 +244,16 @@ process.stdin.on("data", (c) => {
     else {
       playTurn(prompt);
       armSteerGate();
+      // Keep the first turn alive but close its input pipe. The harness sees
+      // a real failed steer acknowledgement and must queue the message for a
+      // fresh ordinary turn rather than consuming its retrieval dedup scope.
+      if (mode === "reject-steer") {
+        process.stdin.destroy();
+        try { closeSync(0); } catch {}
+        if (process.env.FAKE_CLAUDE_STEER_CLOSED_MARKER) {
+          writeFileSync(process.env.FAKE_CLAUDE_STEER_CLOSED_MARKER, "closed");
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary

- add project-identity-aware prompt retrieval to native OpenMaus turns
- preserve byte-identical persisted prompts while supplying bounded provider-only context
- correlate attended native events without recording prompt or retrieved content
- add a side-by-side isolated Windows canary package that cannot touch the installed app, updater, protocol, companion, account, or user sessions

## Verification

- Node 24 full gate: 2,328 passed, 19 skipped
- focused native/retrieval composite: 50 passed
- exact `server/index.test.ts` retry: 112 passed
- typecheck, focused lint, syntax, package-policy validation, and `git diff --check`: passed

## Safety

The canary uses a distinct app/package identity, portable target, data root, Chromium user-data root, and loopback retrieval endpoint. It does not install over or migrate the production app and it keeps prompt/retrieved content out of durable retrieval receipts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an isolated Windows portable canary build with separate application data and no production integrations.
  - Added optional prompt context retrieval for tasks, automations, continuations, delegations, room turns, and steering.
  - Added targeted cloudflared preparation for Windows canary packaging.

- **Bug Fixes**
  - Stopping, deleting, or disabling a task now cancels it before processing begins.
  - Improved handling when steering requests are rejected or interrupted.
  - Retrieved context is validated, bounded, and excluded from durable transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->