### PR TITLE
feat(ios): add tactile action feedback

### DIFF
--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -54,7 +54,10 @@ struct ChatListView: View {
                             ForEach(searchHits) { hit in
                                 Button {
                                     Task {
-                                        if let chat = await session.open(hit) { path.append(chat) }
+                                        if let chat = await session.open(hit) {
+                                            Haptics.selection()
+                                            path.append(chat)
+                                        }
                                     }
                                 } label: {
                                     SearchHitRow(hit: hit)
@@ -154,10 +157,14 @@ struct ChatListView: View {
                     return
                 }
                 searching = true
+                defer {
+                    if query == expected { searching = false }
+                }
                 try? await Task.sleep(for: .milliseconds(250))
                 guard !Task.isCancelled, query == expected else { return }
-                searchHits = await session.search(expected)
-                searching = false
+                let hits = await session.search(expected)
+                guard !Task.isCancelled, query == expected else { return }
+                searchHits = hits
             }
         }
     }
@@ -228,6 +235,7 @@ struct ChatListView: View {
                         .buttonStyle(.plain)
                     }
                     Button {
+                        Haptics.selection()
                         showingNewGroup = true
                     } label: {
                         GroupTile(room: nil)
@@ -280,10 +288,14 @@ struct ChatListView: View {
                     .frame(height: 52)
                     .glassCapsule()
                 } else {
-                    UpdatesPill(updates: session.state.updates) { showingUpdates = true }
+                    UpdatesPill(updates: session.state.updates) {
+                        Haptics.selection()
+                        showingUpdates = true
+                    }
                         .frame(height: 52)
 
                     GlassButton(systemImage: "magnifyingglass", size: 48, weight: .semibold) {
+                        Haptics.selection()
                         searchOpen = true
                         searchFocused = true
                     }
@@ -291,7 +303,10 @@ struct ChatListView: View {
 
                     GlassButton(systemImage: "square.and.pencil", size: 48, weight: .medium) {
                         Task {
-                            if let bot = await session.createBot() { path.append(Chat.bot(bot)) }
+                            if let bot = await session.createBot() {
+                                Haptics.success()
+                                path.append(Chat.bot(bot))
+                            }
                         }
                     }
                     .accessibilityLabel("New bot")

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -755,6 +755,7 @@ struct MessageRow: View {
                 HStack(spacing: 6) {
                     ForEach(reactionGroups(reactions), id: \.emoji) { group in
                         Button("\(group.emoji) \(group.count)") {
+                            Haptics.selection()
                             Task { await session.react(to: message, in: chat.threadId, emoji: group.emoji) }
                         }
                         .font(.system(size: 13))
@@ -784,7 +785,10 @@ struct MessageRow: View {
         }
         .contextMenu {
             ForEach(Self.reactionChoices, id: \.self) { emoji in
-                Button(emoji) { Task { await session.react(to: message, in: chat.threadId, emoji: emoji) } }
+                Button(emoji) {
+                    Haptics.selection()
+                    Task { await session.react(to: message, in: chat.threadId, emoji: emoji) }
+                }
             }
             if message.role == .user, message.kind == .text, case let .bot(bot) = chat {
                 Divider()
@@ -1063,6 +1067,7 @@ struct CardView: View {
                     HStack(spacing: 8) {
                         ForEach(card.options, id: \.self) { option in
                             Button {
+                                Haptics.selection()
                                 answering = true
                                 Task {
                                     await session.answer(chat: chat, card: card, choice: option)
@@ -1091,6 +1096,7 @@ struct CardView: View {
                     // never a string invented here.
                     if card.allowKey != nil, let allow = allowChoice, case let .bot(bot) = chat {
                         Button("Always allow this tool") {
+                            Haptics.selection()
                             answering = true
                             Task {
                                 await session.alwaysAllow(bot: bot, card: card)

--- a/ios/App/Island.swift
+++ b/ios/App/Island.swift
@@ -120,6 +120,7 @@ struct NeedsYouIsland: View {
                             HStack(spacing: 8) {
                                 ForEach(card.options, id: \.self) { option in
                                     Button {
+                                        Haptics.selection()
                                         answering = true
                                         Task {
                                             await session.answer(chat: shown.chat, card: card, choice: option)

--- a/ios/App/NewGroupSheet.swift
+++ b/ios/App/NewGroupSheet.swift
@@ -26,6 +26,7 @@ struct NewGroupSheet: View {
                     ForEach(bots) { bot in
                         Button {
                             if members.contains(bot.id) { members.remove(bot.id) } else { members.insert(bot.id) }
+                            Haptics.selection()
                         } label: {
                             HStack(spacing: 12) {
                                 BotAvatarView(bot: bot, size: 36, state: .idle, animated: false)
@@ -59,6 +60,7 @@ struct NewGroupSheet: View {
                             // it defaults) follows the first bot you picked
                             let ordered = bots.map(\.id).filter(members.contains)
                             if let room = await session.createRoom(name: name, memberIds: ordered) {
+                                Haptics.success()
                                 created(room)
                             }
                             creating = false

--- a/ios/App/UpdatesSheet.swift
+++ b/ios/App/UpdatesSheet.swift
@@ -96,6 +96,7 @@ private struct UpdateRow: View {
                         HStack(spacing: 8) {
                             ForEach(card.options, id: \.self) { option in
                                 Button {
+                                    Haptics.selection()
                                     answering = true
                                     Task {
                                         await session.answer(chat: update.chat, card: card, choice: option)


### PR DESCRIPTION
## What changed

- adds light haptic feedback to search, navigation choices, reactions, and approval actions
- confirms successful bot and group creation with success feedback
- fixes stale search tasks leaving the loading indicator in the wrong state

This selectively brings over the useful haptics idea from #283 without its Catalyst, split-navigation, zoom, or sound changes.

## Validation

- 188 Swift tests pass
- full OpenMausCompanion iOS Simulator build succeeds
- git diff --check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added tactile feedback when selecting search results, opening chats, toggling bots, choosing answer options, reacting to messages, and using key navigation controls.
  * Added confirmation feedback after successfully creating a new group or bot.
  * Improved search interaction handling so loading state remains accurate when the search query changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->