### PR TITLE
feat(computer): wait_for — one box-side poll loop instead of a model inference per peek

### DIFF
--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -74,6 +74,10 @@ describe("computer proxy (fake box)", () => {
                 })
               : command.includes("openmausbot-cdp.mjs click") || command.includes("openmausbot-cdp.mjs fill")
                 ? `GEOM 1920 1080\nHASH ${hash}\nSIZE ${size}\nB64 ${JPEG}\nSEM ok\n`
+            : command.includes('echo "WAIT')
+              ? command.includes("/dev/tcp/")
+                ? "WAIT no ELAPSED 5\n"
+                : `WAIT yes ELAPSED 3\nGEOM 1920 1080\nHASH ${hash}\nSIZE ${size}\nB64 ${JPEG}\nACT ok\n`
             : cropFails && /convert "\$f" -crop/.test(command)
               ? `GEOM 1920 1080\nHASH ${hash}\nCROP_FAILED\n`
               : /GEOM/.test(command)
@@ -149,6 +153,84 @@ describe("computer proxy (fake box)", () => {
     expect(click.description).toMatch(/return the resulting screen/i);
     const screenshot = res.result.tools.find((t: any) => t.name === "screenshot");
     expect(screenshot.inputSchema.properties.region).toBeTruthy();
+  });
+
+  it("wait_for publishes a flat schema and answers bad input with guidance, not a box call", async () => {
+    rpc({ jsonrpc: "2.0", id: 70, method: "tools/list" });
+    const list = await waitFor(70);
+    const tool = list.result.tools.find((t: any) => t.name === "wait_for");
+    expect(tool.inputSchema.properties.condition.enum).toEqual([
+      "http_ready",
+      "tcp_ready",
+      "output_matches",
+      "file_exists",
+    ]);
+    // composition keywords do not survive provider schema conversion (#544)
+    expect(JSON.stringify(tool.inputSchema)).not.toMatch(/"(oneOf|anyOf|allOf|const|format)":/);
+
+    const before = commands.length;
+    rpc({ jsonrpc: "2.0", id: 71, method: "tools/call", params: { name: "wait_for", arguments: { condition: "http_ready" } } });
+    const missing = await waitFor(71);
+    expect(missing.result.isError).toBe(true);
+    expect(missing.result.content[0].text).toContain('"url"');
+    rpc({ jsonrpc: "2.0", id: 72, method: "tools/call", params: { name: "wait_for", arguments: { condition: "every_5_minutes" } } });
+    const unknown = await waitFor(72);
+    expect(unknown.result.isError).toBe(true);
+    expect(unknown.result.content[0].text).toContain("http_ready");
+    expect(commands.length).toBe(before); // guidance is free
+  });
+
+  it("wait_for runs the whole poll box-side in ONE round trip and returns the settled frame", async () => {
+    hash = "wait1111";
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 73,
+      method: "tools/call",
+      params: {
+        name: "wait_for",
+        arguments: { condition: "http_ready", url: "http://localhost:3000/health", timeout_seconds: 90 },
+      },
+    });
+    const res = await waitFor(73);
+    expect(commands.length - before).toBe(1);
+    const command = commands.at(-1)!;
+    if (process.platform !== "win32") expect(spawnSync("/bin/bash", ["-n", "-c", command]).status).toBe(0);
+    expect(command).toContain("'http://localhost:3000/health'");
+    expect(command).toContain("END=$((SECONDS+90))");
+    expect(command).toMatch(/while \[ \$SECONDS -lt \$END \]/);
+    expect(res.result.content[0].text).toContain("condition met");
+    expect(res.result.content[1].type).toBe("image");
+    hash = "aaaa1111"; // restore: later tests assert their own frame changes
+  });
+
+  it("wait_for reports a timeout as advice, and builds sound shells for every condition", async () => {
+    rpc({
+      jsonrpc: "2.0",
+      id: 74,
+      method: "tools/call",
+      params: { name: "wait_for", arguments: { condition: "tcp_ready", port: 5432, observe: false, timeout_seconds: 5 } },
+    });
+    const timedOut = await waitFor(74);
+    expect(timedOut.result.isError).toBe(true);
+    expect(timedOut.result.content[0].text).toContain("timed out after 5s");
+    expect(timedOut.result.content[0].text).toContain("computer_exec");
+
+    rpc({
+      jsonrpc: "2.0",
+      id: 75,
+      method: "tools/call",
+      params: {
+        name: "wait_for",
+        arguments: { condition: "output_matches", command: "tail -1 /tmp/build.log", pattern: "done|failed", observe: false },
+      },
+    });
+    const matched = await waitFor(75);
+    expect(matched.result.content[0].text).toContain("condition met");
+    const command = commands.at(-1)!;
+    if (process.platform !== "win32") expect(spawnSync("/bin/bash", ["-n", "-c", command]).status).toBe(0);
+    expect(command).toContain("grep -Eq");
+    expect(command).toContain("done|failed");
   });
 
   it("clicks and returns the frame in ONE round trip, scaled box-side", async () => {

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -642,6 +642,30 @@ const TOOLS = [
     },
   },
   {
+    name: "wait_for",
+    description:
+      "Wait on the bot's cloud computer until a condition holds, then return — ONE call instead of polling with repeated computer_exec or screenshot calls while a server boots or a job finishes. Give only the fields your chosen condition needs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        condition: {
+          type: "string",
+          enum: ["http_ready", "tcp_ready", "output_matches", "file_exists"],
+          description:
+            "http_ready = a URL answers; tcp_ready = a local port accepts; output_matches = a command's output matches a pattern; file_exists = a path appears",
+        },
+        url: { type: "string", description: "http_ready only: the URL to poll, e.g. http://localhost:3000" },
+        port: { type: "integer", description: "tcp_ready only: the local TCP port, e.g. 5432" },
+        command: { type: "string", description: "output_matches only: shell command whose combined output is checked each poll" },
+        pattern: { type: "string", description: "output_matches only: extended regex the output must match, e.g. ready|listening" },
+        path: { type: "string", description: "file_exists only: absolute path on the computer" },
+        timeout_seconds: { type: "integer", description: "give up after this many seconds; default 60, max 240" },
+        ...OBSERVE_PROPS,
+      },
+      required: ["condition"],
+    },
+  },
+  {
     name: "open_url",
     description:
       "Open a URL in the computer's own Chrome, verify the exact destination when DevTools is available, and return the resulting screen.",
@@ -989,6 +1013,60 @@ async function call(id: unknown, name: string, args: any) {
     if (args.observe !== true) return text(id, note);
     const shot = await runOnBox([ENV, GEOMETRY, ensureRemoteCuaCommand(), captureBlock()].join("; "), 60_000);
     return observed(id, note, await frameFrom(shot));
+  }
+  if (name === "wait_for") {
+    const condition = String(args.condition ?? "").trim().toLowerCase();
+    const timeout = Math.min(Math.max(Math.trunc(Number(args.timeout_seconds) || 60), 1), 240);
+    let check = "";
+    let label = "";
+    if (condition === "http_ready") {
+      const url = String(args.url ?? "").trim();
+      if (!/^https?:\/\//i.test(url)) {
+        return text(id, 'http_ready needs "url", e.g. {"condition":"http_ready","url":"http://localhost:3000"}.', true);
+      }
+      check = `[ "$(curl -s -o /dev/null -m 2 -w '%{http_code}' ${shellQuote(url)})" != "000" ]`;
+      label = url;
+    } else if (condition === "tcp_ready") {
+      const portNumber = Math.trunc(Number(args.port));
+      if (!Number.isInteger(portNumber) || portNumber < 1 || portNumber > 65535) {
+        return text(id, 'tcp_ready needs "port" 1-65535, e.g. {"condition":"tcp_ready","port":5432}.', true);
+      }
+      check = `(echo > /dev/tcp/127.0.0.1/${portNumber}) 2>/dev/null`;
+      label = `port ${portNumber}`;
+    } else if (condition === "output_matches") {
+      const probe = String(args.command ?? "").slice(0, 2000);
+      const pattern = String(args.pattern ?? "").slice(0, 500);
+      if (!probe.trim() || !pattern.trim()) {
+        return text(id, 'output_matches needs "command" and "pattern", e.g. {"condition":"output_matches","command":"tail -1 /tmp/build.log","pattern":"done|failed"}.', true);
+      }
+      check = `bash -c ${shellQuote(probe)} 2>&1 | grep -Eq ${shellQuote(pattern)}`;
+      label = `/${pattern}/ in ${probe.slice(0, 80)}`;
+    } else if (condition === "file_exists") {
+      const target = String(args.path ?? "").trim();
+      if (!target.startsWith("/")) {
+        return text(id, 'file_exists needs an absolute "path", e.g. {"condition":"file_exists","path":"/tmp/render.done"}.', true);
+      }
+      check = `[ -e ${shellQuote(target)} ]`;
+      label = target;
+    } else {
+      return text(id, 'wait_for needs "condition": http_ready, tcp_ready, output_matches, or file_exists.', true);
+    }
+    // The whole wait runs box-side in ONE round trip — a 2s poll loop, then
+    // (by default) the settled screen — instead of the model burning an
+    // inference per poll while a server boots or a job finishes.
+    const loop = `MET=no; END=$((SECONDS+${timeout})); while [ $SECONDS -lt $END ]; do if ${check}; then MET=yes; break; fi; sleep 2; done; echo "WAIT $MET ELAPSED $SECONDS"`;
+    observations.noteAction();
+    const observe = wantsFrame(args);
+    const out = observe
+      ? await runOnBox([ENV, GEOMETRY, loop, ensureRemoteCuaCommand(), captureBlock(settleOf(args))].join("; "), (timeout + 60) * 1000)
+      : await runOnBox(loop, (timeout + 30) * 1000);
+    const met = /WAIT yes/.test(out.stdout);
+    const elapsed = out.stdout.match(/ELAPSED (\d+)/)?.[1];
+    const note = met
+      ? `condition met: ${label}${elapsed ? ` (~${elapsed}s)` : ""}`
+      : `timed out after ${timeout}s waiting for ${label} — it may not be coming up; inspect with computer_exec (logs, process list) before waiting again.`;
+    if (!observe) return text(id, note, !met);
+    return observed(id, note, await frameFrom(out));
   }
   if (name === "open_url") {
     const url = String(args.url ?? "");

--- a/server/index.ts
+++ b/server/index.ts
@@ -1092,7 +1092,7 @@ bus.subscribe((event: RuntimeEvent) => {
         // computer tools can change the screen, and each capture competes
         // with the agent for the box's command endpoint, so a bot grinding
         // through file edits must not trigger one per tool.
-        if (bot && /computer|screenshot|click|type_text|press_key|scroll|open_url/i.test(toolName)) {
+        if (bot && /computer|screenshot|click|type_text|press_key|scroll|open_url|wait_for/i.test(toolName)) {
           pokeScreenPoller(bot.id);
         }
       }


### PR DESCRIPTION
## What changed

A new `wait_for` tool on the cloud-box computer surface (`server/computer-proxy.ts`), borrowed from vercel-labs/fx's terminal monitors:

- Conditions: `http_ready` (URL answers), `tcp_ready` (local port accepts), `output_matches` (command output matches an extended regex), `file_exists` — each with only its own fields, timeout 1–240s (default 60).
- The whole wait runs **box-side in one round trip**: a 2s poll loop, then the settled screen rides back in the same tool result (same act-and-observe contract as the rest of the file; `observe:false` skips the frame).
- Flat schema + guiding errors per the CONTRIBUTING **MCP tool schemas** rules (#544): bad input returns a copyable example without touching the box; a timeout returns *advice* (inspect with `computer_exec`) instead of an invitation to keep waiting.
- `pokeScreenPoller`'s tool-name regex learns `wait_for` so the live panel refreshes after the wait.

## Why

A bot that launches a dev server or starts a long job today polls with repeated `computer_exec`/`screenshot` calls — **one model inference per peek**, plus a frame each time. This was the highest-value borrow from the fx architecture review: fx's `terminal` tool ships declarative monitors (`tcp_ready`, `http_ready`, `output_matches`) for exactly this. One `wait_for` call replaces the whole poll conversation.

## How it was verified

- `npx vitest run server/computer-proxy.test.ts` — 22/22. New cases: schema flatness guard (`/"(oneOf|anyOf|allOf|const|format)":/` never appears — the #544 regression fence), guidance-is-free (bad input produces no box command), single round trip carrying loop + frame, timeout-as-advice, and `bash -n` syntax validation of every generated shell (the suite's existing convention).
- Mutation check: renaming the loop's `WAIT` sentinel fails 3 tests.
- `tsc -p tsconfig.server.json` clean; lint parity with main on the touched file (14 findings before, 14 after — nothing new).

## Siblings from the same fx review

- #563 proposes the second borrow (fx's `auto` permission mode — one narrow safety review per unresolved action) as an issue first, since it crosses the approval trust boundary.
- The third (durable agent-message ledger) overlaps #503/#516 already in flight, so no PR.

## Checklist

- [x] `pnpm typecheck` and the touched test file pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] No macOS-only code; no `shell: true` (commands travel through the existing box command API)
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `wait_for` tool that waits for HTTP, TCP, command-output, or file-existence conditions.
  * Supports configurable timeouts up to 240 seconds and optional screenshots after success.
  * Provides validation guidance for missing or invalid condition parameters.

* **Bug Fixes**
  * Live previews now refresh after completed `wait_for` actions.
  * Timeout responses include guidance for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->