### PR TITLE
feat(engines): add Unsloth Studio as a Local inject engine

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -123,10 +123,11 @@ describe("configuration boundaries", () => {
 });
 
 describe("default fleet", () => {
-  it("ships Qwen and Hermes as custom-only engines", () => {
+  it("ships Qwen, Hermes, and Unsloth as custom-only engines", () => {
     const map = instanceConfigs({});
     expect(map.qwen).toEqual({ driver: "qwenAgent", environment: {} });
     expect(map.hermes).toEqual({ driver: "hermesAgent", environment: {} });
+    expect(map.unsloth).toEqual({ driver: "unslothAgent", environment: {} });
   });
 
   it("ships Cursor as a default-fleet subscription engine", () => {
@@ -184,6 +185,7 @@ describe("default fleet", () => {
     expect(map.claude.driver).toBe("claudeAgent");
     expect(map.qwen?.driver).toBe("qwenAgent");
     expect(map.hermes?.driver).toBe("hermesAgent");
+    expect(map.unsloth?.driver).toBe("unslothAgent");
     expect(map.cursor?.driver).toBe("cursorAgent");
     expect(map.openaiCompat?.driver).toBe("openai-compat");
   });

--- a/server/config.ts
+++ b/server/config.ts
@@ -456,11 +456,13 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
     pi: { driver: "piAgent" },
+    unsloth: { driver: "unslothAgent" },
   };
   const CUSTOM_ONLY = {
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
     pi: { driver: "piAgent" },
+    unsloth: { driver: "unslothAgent" },
   } as const;
   // New default-fleet engines that existing product configs would otherwise
   // never see. Custom-only engines stay in CUSTOM_ONLY so a one-off test map

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -14,6 +14,7 @@ import { CursorAgentDriver } from "./acp/cursor.ts";
 import { OpenCodeDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
+import { UnslothStudioDriver } from "./unsloth.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
 import { PiDriver } from "./pi.ts";
 import { MinimaxDriver } from "./minimax.ts";
@@ -28,6 +29,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   OpenCodeDriver,
   QwenAgentDriver,
   HermesAgentDriver,
+  UnslothStudioDriver,
   PiDriver,
   OpenAICompatDriver,
   ClaudeDriver,

--- a/server/drivers/local-inject-matrix.test.ts
+++ b/server/drivers/local-inject-matrix.test.ts
@@ -14,6 +14,7 @@ import { HermesAgentDriver, ensureHermesInjectProvider, hermesAcpModelId } from 
 import { ensureKimiInjectAlias, KimiAgentDriver } from "./acp/kimi.ts";
 import { ensureOpenCodeInjectModel } from "./acp/opencode-go.ts";
 import { ensureQwenInjectModel, QwenAgentDriver } from "./acp/qwen.ts";
+import { UnslothStudioDriver } from "./unsloth.ts";
 import { ensurePiInjectModel, PiDriver } from "./pi.ts";
 import { recordEvents } from "../testing/events.ts";
 import {
@@ -571,10 +572,11 @@ describe("Pi writer × hosts", () => {
 });
 
 describe("Cloud vs Local catalog access", () => {
-  it("Qwen, Hermes, and pi advertise access=custom", () => {
+  it("Qwen, Hermes, pi, and Unsloth advertise access=custom", () => {
     expect(QwenAgentDriver.metadata.access).toBe("custom");
     expect(HermesAgentDriver.metadata.access).toBe("custom");
     expect(PiDriver.metadata.access).toBe("custom");
+    expect(UnslothStudioDriver.metadata.access).toBe("custom");
   });
 
   it("Kimi and Droid stay Cloud (subscription catalog + Custom)", () => {

--- a/server/drivers/unsloth.test.ts
+++ b/server/drivers/unsloth.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recordEvents } from "../testing/events.ts";
+import { UnslothStudioDriver } from "./unsloth.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("UnslothStudioDriver", () => {
+  it("is a custom-only Local engine", () => {
+    expect(UnslothStudioDriver.driverKind).toBe("unslothAgent");
+    expect(UnslothStudioDriver.metadata.access).toBe("custom");
+    expect(UnslothStudioDriver.metadata.displayName).toBe("Unsloth Studio");
+  });
+
+  it("defaults to the Studio OpenAI-compat URL", () => {
+    expect(UnslothStudioDriver.defaultConfig()).toEqual({ url: "http://127.0.0.1:8888/v1" });
+  });
+
+  it("sends Studio server-side tools for a unsloth:: pick", async () => {
+    const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        seen.push({ url, body });
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"42"}}]}\ndata: [DONE]\n',
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await UnslothStudioDriver.create({
+      instanceId: "unsloth",
+      displayName: "Unsloth Studio",
+      enabled: true,
+      config: { url: "http://127.0.0.1:8888/v1" },
+      environment: { UNSLOTH_STUDIO_AUTH_TOKEN: "sk-unsloth-test" },
+    });
+    const recorder = recordEvents(inst.adapter);
+    try {
+      await inst.adapter.sendTurn({
+        threadId: "t-unsloth",
+        text: "search the web",
+        model: "unsloth::Qwen3.8-27B",
+      });
+      await recorder.until((e) => e.type === "turn.completed");
+      expect(seen[0]?.url).toBe("http://127.0.0.1:8888/v1/chat/completions");
+      expect(seen[0]?.body.model).toBe("Qwen3.8-27B");
+      expect(seen[0]?.body.enable_tools).toBe(true);
+      expect(seen[0]?.body.enabled_tools).toEqual(["python", "web_search", "terminal"]);
+      expect(seen[0]?.body.session_id).toBe("t-unsloth");
+    } finally {
+      recorder.stop();
+      await inst.dispose();
+    }
+  });
+
+  it("injects oMLX without Studio server-side tools", async () => {
+    const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        seen.push({ url, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\ndata: [DONE]\n',
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await UnslothStudioDriver.create({
+      instanceId: "unsloth",
+      displayName: "Unsloth Studio",
+      enabled: true,
+      config: { url: "http://127.0.0.1:8888/v1" },
+      environment: { UNSLOTH_STUDIO_AUTH_TOKEN: "sk-unsloth-test" },
+    });
+    const recorder = recordEvents(inst.adapter);
+    try {
+      await inst.adapter.sendTurn({
+        threadId: "t-omlx",
+        text: "hi",
+        model: "omlx::GLM-5.3-Flash-oQ4e",
+      });
+      await recorder.until((e) => e.type === "turn.completed");
+      expect(seen[0]?.url).toBe("http://127.0.0.1:8080/v1/chat/completions");
+      expect(seen[0]?.body.model).toBe("GLM-5.3-Flash-oQ4e");
+      expect(seen[0]?.body.enable_tools).toBeUndefined();
+    } finally {
+      recorder.stop();
+      await inst.dispose();
+    }
+  });
+});

--- a/server/drivers/unsloth.ts
+++ b/server/drivers/unsloth.ts
@@ -1,0 +1,397 @@
+// Unsloth Studio — custom-only Local-rail engine. Catalog is the same
+// host::model inject as Qwen / Hermes / pi / BotAgent (oMLX, Ollama,
+// LM Studio, Unsloth, …). Turns POST OpenAI-compat /v1/chat/completions
+// at the injected host. When the pick is Unsloth Studio itself, we opt
+// into Studio's server-side agent tools (python, bash, web search).
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+import {
+  applyOpenAIInject,
+  decodeInjectId,
+  hostApiKey,
+  localHost,
+  mergeLocalInject,
+} from "./local-inject.ts";
+
+const DRIVER_KIND = "unslothAgent";
+const DEFAULT_URL = "http://127.0.0.1:8888/v1";
+const EMPTY: ModelCatalog = { default: "", options: [] };
+const STUDIO_TOOLS = ["python", "web_search", "terminal"] as const;
+
+export interface UnslothConfig {
+  url: string;
+}
+
+export function decodeUnslothConfig(raw: unknown): UnslothConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const url = typeof o.url === "string" && o.url ? o.url.replace(/\/+$/, "") : DEFAULT_URL;
+  return { url };
+}
+
+function isUnslothHost(modelId: string | undefined): boolean {
+  const host = decodeInjectId(modelId)?.host;
+  return host === "unsloth" || host === "unsloth_api";
+}
+
+export const UnslothStudioDriver: ProviderDriver<UnslothConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Unsloth Studio",
+    supportsMultipleInstances: true,
+    access: "custom",
+  },
+  install: {
+    docsUrl: "https://unsloth.ai/docs",
+    command: {
+      darwin: "curl -fsSL https://unsloth.ai/install.sh | sh",
+      linux: "curl -fsSL https://unsloth.ai/install.sh | sh",
+      win32: "irm https://unsloth.ai/install.ps1 | iex",
+    },
+  },
+  models: EMPTY,
+  decodeConfig: decodeUnslothConfig,
+  defaultConfig: () => decodeUnslothConfig({}),
+
+  async create(input: DriverCreateInput<UnslothConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const env: Record<string, string | undefined> = { ...process.env, ...input.environment };
+    let models = EMPTY;
+    const refreshModels = async () => {
+      try {
+        const resolved = await mergeLocalInject(EMPTY, env);
+        if (resolved.options.length) models = resolved;
+      } catch {
+        // keep last usable catalog
+      }
+    };
+    await refreshModels();
+
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string }>();
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const endpointFor = (modelId: string | undefined) => {
+      const overlay: Record<string, string | undefined> = { ...env };
+      const applied = applyOpenAIInject(overlay, modelId);
+      const studio = localHost("unsloth")!;
+      const url = (overlay.OPENAI_BASE_URL || config.url).replace(/\/+$/, "");
+      const key = overlay.OPENAI_API_KEY || hostApiKey(studio, env);
+      const apiModel = applied.model || models.default || "";
+      return {
+        url,
+        key,
+        apiModel,
+        enableTools: isUnslothHost(modelId) || (!decodeInjectId(modelId) && url.includes(":8888")),
+      };
+    };
+
+    const complete = async (
+      messages: Array<{ role: string; content: string }>,
+      turn: SendTurnInput,
+      opts: {
+        stream: boolean;
+        signal?: AbortSignal;
+        onDelta?: (d: string, streamKind?: "assistant_text" | "reasoning_text") => void;
+        onTool?: (name: string, phase: "start" | "end", ok?: boolean) => void;
+      },
+    ): Promise<{ text: string; reasoning: string; usage: { input: number; output: number } | null }> => {
+      const ep = endpointFor(turn.model);
+      if (!ep.apiModel) throw new Error("no Unsloth / local model selected");
+      const body: Record<string, unknown> = {
+        model: ep.apiModel,
+        messages,
+        stream: opts.stream,
+        session_id: turn.threadId,
+      };
+      if (ep.enableTools) {
+        body.enable_tools = true;
+        body.enabled_tools = [...STUDIO_TOOLS];
+      }
+      const res = await fetch(`${ep.url}/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${ep.key}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: opts.signal ?? AbortSignal.timeout(180_000),
+      });
+      if (!res.ok) {
+        const errBody = await res.text().catch(() => "");
+        throw new Error(`Unsloth HTTP ${res.status}${errBody ? `: ${errBody.slice(0, 240)}` : ""}`);
+      }
+      if (!opts.stream) {
+        const json = (await res.json()) as {
+          choices?: Array<{ message?: { content?: string; reasoning_content?: string } }>;
+          usage?: { prompt_tokens?: number; completion_tokens?: number };
+        };
+        const msg = json.choices?.[0]?.message;
+        return {
+          text: typeof msg?.content === "string" ? msg.content : "",
+          reasoning: typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "",
+          usage: json.usage
+            ? { input: json.usage.prompt_tokens ?? 0, output: json.usage.completion_tokens ?? 0 }
+            : null,
+        };
+      }
+      return readSse(res, opts);
+    };
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (active.has(threadId)) throw new Error("a turn is already running on this thread");
+      const turnId = newId();
+      const abort = new AbortController();
+      active.set(threadId, { abort, turnId });
+      const ep = endpointFor(turn.model);
+      const messages = [
+        ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+        ...(turn.transcript ?? []).map((m) => ({
+          role: m.role === "assistant" ? "assistant" : "user",
+          content: m.text,
+        })),
+        { role: "user", content: turn.text },
+      ];
+      appendNative(threadId, {
+        dir: "out",
+        source: "unsloth.chat.completions",
+        msg: { model: ep.apiModel, url: ep.url, enableTools: ep.enableTools, messageCount: messages.length },
+      });
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({
+        ...base(threadId, turnId),
+        type: "session.started",
+        sessionId: null,
+        model: turn.model ?? ep.apiModel,
+      });
+      void (async () => {
+        try {
+          const { text, reasoning, usage } = await complete(messages, turn, {
+            stream: true,
+            signal: abort.signal,
+            onDelta: (delta, streamKind = "assistant_text") =>
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind, delta }),
+            onTool: (name, phase, ok) => {
+              if (phase === "start") {
+                emit({
+                  ...base(threadId, turnId),
+                  type: "item.started",
+                  itemType: "tool",
+                  itemId: name,
+                  title: name,
+                });
+              } else {
+                emit({
+                  ...base(threadId, turnId),
+                  type: "item.completed",
+                  itemType: "tool",
+                  itemId: name,
+                  ok: ok !== false,
+                });
+              }
+            },
+          });
+          appendNative(threadId, {
+            dir: "in",
+            source: "unsloth.chat.completions",
+            msg: { textLength: text.length, reasoningLength: reasoning.length, usage },
+          });
+          const replyText = text.trim() ? text : reasoning;
+          if (replyText.trim()) {
+            emit({
+              ...base(threadId, turnId),
+              type: "item.completed",
+              itemType: "assistant_text",
+              text: replyText,
+            });
+          }
+          if (usage) emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+          active.delete(threadId);
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: true,
+            stopReason: null,
+            cost: null,
+            ...(usage ? { usage } : {}),
+          });
+        } catch (e) {
+          active.delete(threadId);
+          const aborted = (e as Error).name === "AbortError";
+          if (!aborted) {
+            emit({ ...base(threadId, turnId), type: "runtime.error", message: (e as Error).message });
+          }
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: false,
+            stopReason: aborted ? "interrupted" : "error",
+            cost: null,
+          });
+        }
+      })();
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      const studio = localHost("unsloth")!;
+      const key = hostApiKey(studio, env);
+      try {
+        const res = await fetch(`${config.url}/models`, {
+          headers: { authorization: `Bearer ${key}` },
+          signal: AbortSignal.timeout(4_000),
+        });
+        if (res.ok) return { state: "available", authenticated: true, version: "Unsloth Studio" };
+        if (res.status === 401) {
+          return { state: "available", authenticated: false, version: "Unsloth Studio" };
+        }
+        return {
+          state: "unavailable",
+          reason: `Unsloth Studio answered HTTP ${res.status}`,
+        };
+      } catch {
+        return {
+          state: "unavailable",
+          reason: "Start Unsloth Studio (`unsloth studio`) and load a model",
+        };
+      }
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      get models() {
+        return models;
+      },
+      refreshModels,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "in-session" },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+        respondToRequest: async () => "unavailable" as const,
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => {
+          for (const { abort } of active.values()) abort.abort();
+        },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      generateText: async (prompt: string) => {
+        const { text, reasoning } = await complete(
+          [{ role: "user", content: prompt }],
+          { threadId: "generateText", text: prompt },
+          { stream: false },
+        );
+        return text.trim() ? text : reasoning;
+      },
+      dispose: async () => {
+        for (const { abort } of active.values()) abort.abort();
+        listeners.clear();
+      },
+    };
+  },
+};
+
+async function readSse(
+  res: Response,
+  opts: {
+    onDelta?: (d: string, streamKind?: "assistant_text" | "reasoning_text") => void;
+    onTool?: (name: string, phase: "start" | "end", ok?: boolean) => void;
+  },
+): Promise<{ text: string; reasoning: string; usage: { input: number; output: number } | null }> {
+  if (!res.body) return { text: "", reasoning: "", usage: null };
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let text = "";
+  let reasoning = "";
+  let usage: { input: number; output: number } | null = null;
+  const seenTool = new Set<string>();
+
+  const consume = (block: string) => {
+    for (const line of block.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const data = trimmed.slice(5).trim();
+      if (!data || data === "[DONE]") continue;
+      let json: Record<string, unknown>;
+      try {
+        json = JSON.parse(data) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const eventName = typeof json.event === "string" ? json.event : typeof json.type === "string" ? json.type : "";
+      if (eventName === "tool_result" || eventName === "tool_call") {
+        const name = String((json.name ?? json.tool ?? "tool") as string);
+        opts.onTool?.(name, eventName === "tool_call" ? "start" : "end", json.isError !== true);
+        continue;
+      }
+      const usageRec = json.usage as { prompt_tokens?: number; completion_tokens?: number } | undefined;
+      if (usageRec) usage = { input: usageRec.prompt_tokens ?? 0, output: usageRec.completion_tokens ?? 0 };
+      const choices = json.choices as Array<{ delta?: Record<string, unknown> }> | undefined;
+      const delta = choices?.[0]?.delta;
+      if (!delta) continue;
+      const content = delta.content;
+      if (typeof content === "string" && content) {
+        text += content;
+        opts.onDelta?.(content, "assistant_text");
+      }
+      const think = delta.reasoning_content;
+      if (typeof think === "string" && think) {
+        reasoning += think;
+        opts.onDelta?.(think, "reasoning_text");
+      }
+      const toolCalls = delta.tool_calls;
+      if (Array.isArray(toolCalls)) {
+        for (const tc of toolCalls) {
+          const fn = tc && typeof tc === "object" ? (tc as { function?: { name?: string } }).function : undefined;
+          const name = fn?.name;
+          if (name && !seenTool.has(name)) {
+            seenTool.add(name);
+            opts.onTool?.(name, "start");
+          }
+        }
+      }
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let sep;
+    while ((sep = buf.indexOf("\n\n")) !== -1) {
+      const block = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      consume(block);
+    }
+  }
+  if (buf.trim()) consume(buf);
+  for (const name of seenTool) opts.onTool?.(name, "end", true);
+  return { text, reasoning, usage };
+}

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -109,6 +109,18 @@ export function QwenMark({ size = 16, className }: IconProps) {
   );
 }
 
+/** Unsloth Studio mark — a U in Unsloth orange. */
+export function UnslothMark({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className={className} aria-hidden>
+      <path
+        fill="#FF6B35"
+        d="M6 4h4v12.5c0 2.3 1.5 3.5 4 3.5s4-1.2 4-3.5V4h4v12.7C22 20.4 18.6 23 14 23s-8-2.6-8-6.3V4z"
+      />
+    </svg>
+  );
+}
+
 /** Official pi (pi.dev) mark — geometric "Pi" wordmark from pi.dev/logo.svg. */
 export function PiMark({ size = 16, className }: IconProps) {
   return (
@@ -151,6 +163,8 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <ComputerMark size={size} className={className} />;
     case "piAgent":
       return <PiMark size={size} className={className} />;
+    case "unslothAgent":
+      return <UnslothMark size={size} className={className} />;
     default:
       return (
         <span className="flex size-full items-center justify-center text-[10px] font-semibold tracking-tight text-ink-secondary">

--- a/src/lib/engine-rail.test.ts
+++ b/src/lib/engine-rail.test.ts
@@ -9,9 +9,10 @@ describe("splitEngineRail", () => {
       { access: "custom", instanceId: "hermes" },
       { instanceId: "grok" },
       { access: "custom", instanceId: "qwen" },
+      { access: "custom", instanceId: "unsloth" },
     ]);
     expect(subscription.map((row) => row.instanceId)).toEqual(["claude", "grok"]);
-    expect(custom.map((row) => row.instanceId)).toEqual(["hermes", "qwen"]);
+    expect(custom.map((row) => row.instanceId)).toEqual(["hermes", "qwen", "unsloth"]);
   });
 
   it("hides the second group when nothing is custom-only", () => {


### PR DESCRIPTION
## What

Unsloth Studio is a first-class **Local** engine, same inject path as Qwen / Hermes / pi.

The picker lists live `host::model` rows (oMLX, Ollama, LM Studio, Unsloth, …). Turns POST OpenAI-compat `/v1/chat/completions` at the injected host.

- A **Unsloth** pick (`unsloth::…`) hits Studio at `http://127.0.0.1:8888/v1` with `enable_tools` and `python` / `web_search` / `terminal` — Studio's own server-side agent tools.
- An **oMLX / Ollama / LM Studio** pick injects that host's `/v1` without those extras.
- Auth is `UNSLOTH_STUDIO_AUTH_TOKEN` or the minted key in `~/.unsloth/studio/auth/agent_api_key.json`.

No new fork: this is a branch on the existing `maxkongerskov/OpenMausBot` remote, opened against `milind-soni/OpenMausBot`.

## Testing

- `pnpm exec vitest run server/drivers/unsloth.test.ts server/config.test.ts server/drivers/local-inject-matrix.test.ts src/lib/engine-rail.test.ts` (162 passed)
- `pnpm exec tsc -p tsconfig.server.json` and `pnpm exec tsc -b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Unsloth Studio as a built-in local engine.
  - Added support for Unsloth Studio chat completions, streaming responses, model discovery, tool use, and session handling.
  - Added routing for both Unsloth and oMLX models.
  - Added the Unsloth provider icon and included the engine in local engine listings.

- **Bug Fixes**
  - Ensured Unsloth appears consistently in default and product engine configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->