### PR TITLE
Add Avatar Lab for generated mascot bodies

### DIFF
--- a/src/components/AvatarLabDialog.test.ts
+++ b/src/components/AvatarLabDialog.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { MAUS_COLOR_NAMES, PICKABLE_STATES } from "@/lib/mascot";
+import { AVATAR_LAB_BODY_IDS, randomizeAvatarLabDraft } from "@/lib/avatar-lab";
+import { MASCOT_BODY_IDS } from "../../shared/mascot-bodies";
+
+describe("Avatar Lab catalog", () => {
+  it("keeps exactly one cursor and omits the retired hexagon and nonexistent moon", () => {
+    expect(AVATAR_LAB_BODY_IDS.filter((id) => id === "cursor")).toHaveLength(1);
+    expect(AVATAR_LAB_BODY_IDS).not.toContain("hexagon");
+    expect(AVATAR_LAB_BODY_IDS).not.toContain("moon");
+    expect(new Set(AVATAR_LAB_BODY_IDS).size).toBe(AVATAR_LAB_BODY_IDS.length);
+  });
+
+  it("keeps retired values valid in storage while hiding them from new choices", () => {
+    expect(MASCOT_BODY_IDS).toContain("hexagon");
+    expect(AVATAR_LAB_BODY_IDS).not.toContain("hexagon");
+  });
+
+  it("randomizes only visible bodies, supported colors, and distinct resting faces", () => {
+    const draft = { bodyId: "cursor" as const, color: "green" as const, expression: "idle" as const };
+    const values = [0.999, 0.999, 0.999];
+    const next = randomizeAvatarLabDraft(draft, () => values.shift() ?? 0);
+
+    expect(AVATAR_LAB_BODY_IDS).toContain(next.bodyId);
+    expect(MAUS_COLOR_NAMES).toContain(next.color);
+    expect(PICKABLE_STATES).toContain(next.expression);
+  });
+});

--- a/src/components/AvatarLabDialog.tsx
+++ b/src/components/AvatarLabDialog.tsx
@@ -1,0 +1,289 @@
+import { Check, Dice5, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/cn";
+import {
+  AVATAR_LAB_BODY_IDS,
+  randomizeAvatarLabDraft,
+  type AvatarLabDraft,
+} from "@/lib/avatar-lab";
+import {
+  MAUS_COLORS,
+  MAUS_COLOR_NAMES,
+  PICKABLE_STATES,
+  type MausColor,
+  type MausMotion,
+  type MausState,
+} from "@/lib/mascot";
+import {
+  MASCOT_BODIES,
+  botMascotBody,
+  type MascotBodyId,
+} from "../../shared/mascot-bodies";
+import { MausAvatar } from "./Avatar";
+
+export interface AvatarLabPatch {
+  avatarCrop: "mascot";
+  color: MausColor;
+  mascotBody: MascotBodyId;
+  mascotExpression: MausState;
+}
+
+export interface AvatarLabBot {
+  id: string;
+  name: string;
+  color: MausColor;
+  mascotBody?: MascotBodyId | null;
+  mascotExpression?: string | null;
+}
+
+function initialDraft(bot: AvatarLabBot, activeState: MausState): AvatarLabDraft {
+  const storedExpression = PICKABLE_STATES.find((state) => state === bot.mascotExpression);
+  return {
+    bodyId: botMascotBody(bot.mascotBody),
+    color: bot.color,
+    expression: storedExpression ?? activeState,
+  };
+}
+
+/**
+ * A single live preview plus static cards. Every surface uses MausAvatar, so
+ * the list and preview cannot drift to different body, gradient, or face rigs.
+ */
+export function AvatarLabDialog({
+  open,
+  bot,
+  activeState,
+  mascotMotion,
+  onApply,
+  onClose,
+}: {
+  open: boolean;
+  bot: AvatarLabBot;
+  activeState: MausState;
+  mascotMotion: { kind: Exclude<MausMotion, "none">; nonce: number } | null;
+  onApply: (patch: AvatarLabPatch) => void;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const botRef = useRef(bot);
+  botRef.current = bot;
+  const activeStateRef = useRef(activeState);
+  activeStateRef.current = activeState;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const [draft, setDraft] = useState(() => initialDraft(bot, activeState));
+
+  useEffect(() => {
+    // Runtime states can change while the dialog is open. They must not erase
+    // a person's unsaved body, face, or color choices.
+    if (open) setDraft(initialDraft(botRef.current, activeStateRef.current));
+  }, [bot.id, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    requestAnimationFrame(() => dialogRef.current?.focus());
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (!focusable.length) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+      const first = focusable[0]!;
+      const last = focusable.at(-1)!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      previousFocus?.focus();
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/65 p-3 backdrop-blur-sm sm:p-6"
+      onMouseDown={(event) => event.target === event.currentTarget && onClose()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="avatar-lab-title"
+        tabIndex={-1}
+        className="animate-pop-in flex max-h-[min(780px,92vh)] w-full max-w-[780px] flex-col overflow-hidden rounded-2xl border border-hairline/50 bg-panel shadow-2xl outline-none"
+      >
+        <header className="flex shrink-0 items-center gap-3 border-b border-hairline/40 px-4 py-3.5">
+          <div className="min-w-0 flex-1">
+            <h2 id="avatar-lab-title" className="text-[15px] font-semibold text-ink">Avatar Lab</h2>
+            <p className="mt-0.5 text-[12px] text-ink-secondary">
+              One face engine, generated safe zones, and local animation previews.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close Avatar Lab"
+            className="flex size-9 items-center justify-center rounded-lg text-ink-secondary hover:bg-control hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className="grid items-start gap-4 md:grid-cols-[220px_minmax(0,1fr)]">
+            <div className="flex self-start flex-col items-center justify-center rounded-2xl border border-hairline/40 bg-inset p-4 md:sticky md:top-4 md:min-h-[300px]">
+              <MausAvatar
+                key={draft.bodyId}
+                color={draft.color}
+                bodyId={draft.bodyId}
+                state={draft.expression}
+                size={152}
+                motion={mascotMotion?.kind ?? "none"}
+                motionKey={mascotMotion?.nonce ?? 0}
+                trackPointer={false}
+                label={`${bot.name} avatar preview`}
+              />
+              <div className="mt-3 text-center">
+                <div className="text-[13px] font-medium text-ink">{bot.name}</div>
+                <div className="mt-0.5 text-[11px] leading-relaxed text-ink-secondary">
+                  Alerts, glyph morphs, blinking, and success confetti stay automatic in the app.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDraft((current) => randomizeAvatarLabDraft(current))}
+                className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border border-hairline/50 bg-control px-3 py-2.5 text-[13px] font-medium text-ink hover:bg-raised-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                <Dice5 size={16} />
+                Randomize
+              </button>
+            </div>
+
+            <div className="min-w-0 space-y-5">
+              <section>
+                <div className="mb-2 flex items-baseline justify-between gap-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">Body</div>
+                  <div className="text-[11px] text-ink-tertiary">{AVATAR_LAB_BODY_IDS.length} generated bodies</div>
+                </div>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {AVATAR_LAB_BODY_IDS.map((bodyId) => {
+                    const selected = draft.bodyId === bodyId;
+                    return (
+                      <button
+                        key={bodyId}
+                        type="button"
+                        aria-pressed={selected}
+                        aria-label={`Use the ${MASCOT_BODIES[bodyId].name} body`}
+                        onClick={() => setDraft((current) => ({ ...current, bodyId }))}
+                        className={cn(
+                          "relative flex min-w-0 flex-col items-center gap-1.5 rounded-xl border bg-inset px-2 py-2.5 hover:bg-control focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+                          selected ? "border-accent bg-accent/10" : "border-hairline/45",
+                        )}
+                      >
+                        <MausAvatar
+                          color={draft.color}
+                          bodyId={bodyId}
+                          state={draft.expression}
+                          size={66}
+                          animated={false}
+                          trackPointer={false}
+                        />
+                        <span className="truncate text-[11px] text-ink">{MASCOT_BODIES[bodyId].name}</span>
+                        {selected ? <Check size={13} className="absolute right-2 top-2 text-accent" /> : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <section>
+                <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">Resting face</div>
+                <div className="grid grid-cols-5 gap-2">
+                  {PICKABLE_STATES.map((expression) => {
+                    const selected = draft.expression === expression;
+                    return (
+                      <button
+                        key={expression}
+                        type="button"
+                        aria-pressed={selected}
+                        aria-label={`Use ${expression} expression`}
+                        title={expression}
+                        onClick={() => setDraft((current) => ({ ...current, expression }))}
+                        className={cn(
+                          "relative flex h-[58px] items-center justify-center rounded-xl border bg-inset hover:bg-control focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+                          selected ? "border-accent bg-accent/10" : "border-hairline/45",
+                        )}
+                      >
+                        <MausAvatar color={draft.color} bodyId={draft.bodyId} state={expression} size={42} animated={false} trackPointer={false} />
+                        {selected ? <Check size={12} className="absolute right-1.5 top-1.5 text-accent" /> : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <section>
+                <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">Color</div>
+                <div className="flex flex-wrap gap-2">
+                  {MAUS_COLOR_NAMES.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      aria-label={`Use ${color} mascot color`}
+                      aria-pressed={draft.color === color}
+                      onClick={() => setDraft((current) => ({ ...current, color }))}
+                      className={cn(
+                        "relative size-9 rounded-full border-2 border-panel shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+                        draft.color === color && "ring-2 ring-accent-border ring-offset-2 ring-offset-panel",
+                      )}
+                      style={{ backgroundColor: MAUS_COLORS[color] }}
+                    >
+                      {draft.color === color ? <Check size={14} className="absolute inset-0 m-auto text-white drop-shadow" /> : null}
+                    </button>
+                  ))}
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+
+        <footer className="flex shrink-0 items-center justify-end gap-2 border-t border-hairline/40 px-4 py-3">
+          <button type="button" onClick={onClose} className="rounded-lg px-3 py-2 text-[13px] text-ink-secondary hover:bg-control hover:text-ink">Cancel</button>
+          <button
+            type="button"
+            onClick={() => {
+              onApply({ avatarCrop: "mascot", color: draft.color, mascotBody: draft.bodyId, mascotExpression: draft.expression });
+              onClose();
+            }}
+            className="min-w-[150px] rounded-lg bg-accent px-4 py-2 text-[13px] font-medium text-accent-foreground hover:brightness-110"
+          >
+            Save avatar
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/BotProfileAvatarCard.test.ts
+++ b/src/components/BotProfileAvatarCard.test.ts
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { StoreProvider, type Bot } from "@/state/store";
-import { MASCOT_BODY_IDS, MASCOT_BODIES } from "../../shared/mascot-bodies";
+import { MASCOT_BODIES } from "../../shared/mascot-bodies";
 import { BotProfileAvatarCard } from "./BotProfileAvatarCard";
 
 function makeBot(overrides: Partial<Bot> = {}): Bot {
@@ -38,41 +38,34 @@ function renderCard(bot: Bot) {
 }
 
 describe("BotProfileAvatarCard body picker", () => {
-  it("renders one option per body catalog entry, labeled by name", () => {
+  it("shows one current style entry point instead of duplicate inline body renderers", () => {
     const markup = renderCard(makeBot());
 
-    expect(markup).toContain(">Body<");
-    for (const id of MASCOT_BODY_IDS) {
-      expect(markup).toContain(`aria-label="Use the ${MASCOT_BODIES[id].name} body"`);
-    }
-  });
-
-  it("marks the current body pressed and the rest unpressed, defaulting to cursor", () => {
-    const markup = renderCard(makeBot());
-
-    expect(markup).toContain(`aria-pressed="true" aria-label="Use the ${MASCOT_BODIES.cursor.name} body"`);
-    expect(markup).toContain(`aria-pressed="false" aria-label="Use the ${MASCOT_BODIES.star.name} body"`);
+    expect(markup).toContain("Current mascot style");
+    expect(markup).toContain(`>${MASCOT_BODIES.cursor.name}<`);
+    expect(markup).toContain(">Edit<");
+    expect(markup).not.toContain("Use the Hexagon body");
   });
 
   it("reflects an explicitly chosen body", () => {
     const markup = renderCard(makeBot({ mascotBody: "star" }));
 
-    expect(markup).toContain(`aria-pressed="true" aria-label="Use the ${MASCOT_BODIES.star.name} body"`);
-    expect(markup).toContain(`aria-pressed="false" aria-label="Use the ${MASCOT_BODIES.cursor.name} body"`);
+    expect(markup).toContain(`>${MASCOT_BODIES.star.name}<`);
+    expect(markup).not.toContain(`>${MASCOT_BODIES.cursor.name}<`);
   });
 
   it("hides the body picker for flat crops that have no mascot to wear one", () => {
     const markup = renderCard(makeBot({ avatarCrop: "circle" }));
 
-    expect(markup).not.toContain(">Body<");
-    expect(markup).not.toContain(`aria-label="Use the ${MASCOT_BODIES.cursor.name} body"`);
+    expect(markup).not.toContain("Current mascot style");
+    expect(markup).not.toContain(">Edit<");
   });
 
   it("hides the body picker for every flat crop, not just circle", () => {
     for (const crop of ["rounded", "square"] as const) {
       const markup = renderCard(makeBot({ avatarCrop: crop }));
 
-      expect(markup).not.toContain(">Body<");
+      expect(markup).not.toContain("Current mascot style");
     }
   });
 });

--- a/src/components/BotProfileAvatarCard.tsx
+++ b/src/components/BotProfileAvatarCard.tsx
@@ -16,8 +16,9 @@ import {
   botAvatarUrlFromStoredPath,
   type BotAvatarCrop,
 } from "../../shared/bot-avatar";
-import { MASCOT_BODIES, MASCOT_BODY_IDS } from "../../shared/mascot-bodies";
+import { MASCOT_BODIES, botMascotBody } from "../../shared/mascot-bodies";
 import { BotAvatar, MausAvatar } from "./Avatar";
+import { AvatarLabDialog } from "./AvatarLabDialog";
 
 type AvatarPatch = Partial<
   Pick<Bot, "avatarCrop" | "avatarUrl" | "color" | "mascotExpression" | "mascotBody">
@@ -48,6 +49,7 @@ export function BotProfileAvatarCard({
   const [savingKey, setSavingKey] = useState(false);
   const [direction, setDirection] = useState("");
   const [generating, setGenerating] = useState(false);
+  const [avatarLabOpen, setAvatarLabOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const crop = bot.avatarCrop ?? "mascot";
   const cropRef = useRef(crop);
@@ -252,27 +254,29 @@ export function BotProfileAvatarCard({
               ))}
             </div>
 
-            <div className="mb-2 mt-4 text-[12px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-              Body
-            </div>
-            <div className="grid grid-cols-5 gap-1.5">
-              {MASCOT_BODY_IDS.map((id) => (
-                <button
-                  key={id}
-                  type="button"
-                  aria-pressed={(bot.mascotBody ?? "cursor") === id}
-                  aria-label={`Use the ${MASCOT_BODIES[id].name} body`}
-                  onClick={() => onPatch({ mascotBody: id })}
-                  className={cn(
-                    "flex items-center justify-center rounded-lg py-1.5",
-                    (bot.mascotBody ?? "cursor") === id
-                      ? "bg-control text-ink"
-                      : "text-ink-secondary hover:bg-control/60",
-                  )}
-                >
-                  <MausAvatar color={bot.color} bodyId={id} size={34} animated={false} trackPointer={false} />
-                </button>
-              ))}
+            <div className="mt-4 flex min-w-0 items-center gap-3 rounded-xl border border-hairline/40 bg-inset px-3 py-2.5">
+              <MausAvatar
+                color={bot.color}
+                bodyId={botMascotBody(bot.mascotBody)}
+                state={activeState}
+                size={48}
+                animated={false}
+                trackPointer={false}
+                label="Current mascot style"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="text-[12px] font-medium text-ink">Current mascot style</div>
+                <div className="truncate text-[11px] text-ink-secondary">
+                  {MASCOT_BODIES[botMascotBody(bot.mascotBody)].name}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAvatarLabOpen(true)}
+                className="shrink-0 rounded-lg px-2 py-1.5 text-[11.5px] font-medium text-accent hover:bg-control"
+              >
+                Edit
+              </button>
             </div>
           </>
         )}
@@ -360,6 +364,15 @@ export function BotProfileAvatarCard({
 
         {error && <div role="alert" className="mt-3 text-[12px] text-danger">{error}</div>}
       </div>
+
+      <AvatarLabDialog
+        open={avatarLabOpen}
+        bot={bot}
+        activeState={activeState}
+        mascotMotion={mascotMotion}
+        onApply={onPatch}
+        onClose={() => setAvatarLabOpen(false)}
+      />
     </div>
   );
 }

--- a/src/lib/avatar-lab.ts
+++ b/src/lib/avatar-lab.ts
@@ -1,0 +1,41 @@
+import {
+  MAUS_COLOR_NAMES,
+  PICKABLE_STATES,
+  type MausColor,
+  type MausState,
+} from "./mascot";
+import {
+  MASCOT_BODY_IDS,
+  type MascotBodyId,
+} from "../../shared/mascot-bodies";
+
+/**
+ * Hexagon remains a valid stored value for backward compatibility, but it is
+ * intentionally absent from the picker. Moon was never part of the official
+ * generated catalog.
+ */
+export const AVATAR_LAB_BODY_IDS = MASCOT_BODY_IDS.filter(
+  (id): id is Exclude<MascotBodyId, "hexagon"> => id !== "hexagon",
+);
+
+export interface AvatarLabDraft {
+  bodyId: MascotBodyId;
+  color: MausColor;
+  expression: MausState;
+}
+
+/** Randomizes only choices that the dialog visibly offers. */
+export function randomizeAvatarLabDraft(
+  draft: AvatarLabDraft,
+  random: () => number = Math.random,
+): AvatarLabDraft {
+  const pickDifferent = <T,>(items: readonly T[], current: T) => {
+    const alternatives = items.filter((item) => item !== current);
+    return alternatives[Math.min(alternatives.length - 1, Math.floor(random() * alternatives.length))] ?? current;
+  };
+  return {
+    bodyId: pickDifferent(AVATAR_LAB_BODY_IDS, draft.bodyId),
+    color: pickDifferent(MAUS_COLOR_NAMES, draft.color),
+    expression: pickDifferent(PICKABLE_STATES, draft.expression),
+  };
+}


### PR DESCRIPTION
## What changed

Adds an Avatar Lab on top of the current official OpenMaus mascot-body generator instead of introducing a second avatar engine.

The old 33-file / 36-commit implementation was replaced with one current-main commit touching five files.

## Behavior

- One live preview and static choice cards all render through the same `MausAvatar` / `CursorAvatar` path.
- Body, resting face, and color can be previewed together and saved atomically.
- Randomize only selects visible supported choices and avoids immediately repeating each current value.
- Escape, backdrop click, Cancel, and focus restoration are supported.
- Runtime state changes do not erase unsaved choices while the dialog is open.
- The profile card shows one current-style entry point instead of a second inline body catalog.

## Shape and face consistency

- Uses the official generated body catalog, shared face scale, solved safe zones, gradients, and native animation engine.
- Cursor appears exactly once.
- Moon is not present.
- Hexagon is hidden from new choices, while old stored `hexagon` values remain valid so existing bots are not corrupted.
- Alert glyph morphs, blinking, state motion, and success confetti remain native `CursorAvatar` behavior.

## Verification

- Focused avatar/profile suite: 28 tests passed.
- Client and server TypeScript checks passed.
- Production renderer build passed.
- Electron syntax check: 90 modules.
- Targeted lint and `git diff --check` passed.
- Added-line secret scan: 405 lines passed.
- Full Vitest run: 2,784 passed, 101 skipped, 1 unrelated Windows Electron sandbox test failed.
- The same `electron/browser-closed-shadow.electron.test.mjs` failure reproduces on untouched official main with exit code `2147483651`.

## Live UI check

Checked the current local app at 1000×720: opened profile → Avatar Lab, selected Diamond + Curious + Coral, verified preview/card parity, then cancelled without changing bot data.

## Maintainer follow-up

Vercel authorization was not attempted, and no CodeRabbit command was triggered.

Accepted head: `b7c67da38fe3f2db177995d1b36a9351f9bfe2c4`.