### PR TITLE
feat(gemini): let Gemini bots call teammates

### DIFF
--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -10,7 +10,7 @@
 // turned it into `node <script>` on Windows too, so the e2e half now runs
 // everywhere alongside the mention-resolution units.
 import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,6 +22,7 @@ import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const FAKE_CLI = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+const FAKE_AGY_CLI = join(SERVER_DIR, "testing", "fake-agy-cli.ts");
 const PORT = 18800 + Math.floor(Math.random() * 10_000);
 const BASE = `http://127.0.0.1:${PORT}`;
 
@@ -95,6 +96,7 @@ describe("comms e2e (fake ACP fleet)", () => {
 
   beforeAll(async () => {
     chmodSync(FAKE_CLI, 0o755);
+    chmodSync(FAKE_AGY_CLI, 0o755);
     home = mkdtempSync(join(tmpdir(), "omb-comms-test-"));
     mkdirSync(join(home, ".openmausbot"), { recursive: true });
     writeFileSync(
@@ -108,6 +110,14 @@ describe("comms e2e (fake ACP fleet)", () => {
             driver: "grokAgent",
             environment: { FAKE_ACP_MODE: "ask-peer" },
             config: { cli: FAKE_CLI, fullAuto: true },
+          },
+          // Normal Gemini 3.x bots use Antigravity print mode rather than
+          // the standalone Gemini ACP driver. This instance proves its
+          // leased global MCP mount reaches the same agents proxy safely.
+          geminiAsker: {
+            driver: "antigravityAgent",
+            environment: { FAKE_AGY_MODE: "ask-peer" },
+            config: { cli: FAKE_AGY_CLI, fullAuto: true },
           },
           // a separate asker instance for the async-handoff e2e. B can stay
           // on `grok` because its depth-1 turn runs without the agents
@@ -253,6 +263,93 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(helperBot.busy).toBeFalsy();
     },
     40_000,
+  );
+
+  it(
+    "lets a Gemini Antigravity bot call a peer through the temporary agents MCP mount",
+    async () => {
+      // A unique section makes list_bots deterministic even though this
+      // suite deliberately keeps earlier bots around to exercise the real
+      // persisted fleet. Only these two teammates can see one another.
+      const section = "Gemini agents MCP e2e";
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "Gemini Helper",
+        section,
+        modelSelection: { instanceId: "grok", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "Gemini Asker",
+        section,
+        modelSelection: { instanceId: "geminiAsker", model: "gemini-3.7-flash-high" },
+      });
+
+      const send = await api("POST", `/api/bots/${asker.id}/messages`, {
+        text: "Ask the other bot for a status check.",
+      });
+      expect(send.status).toBe(202);
+
+      const deadline = Date.now() + 30_000;
+      let state: any;
+      let askerBot: any;
+      let helperBot: any;
+      for (;;) {
+        state = (await api("GET", "/api/bots")).body;
+        askerBot = state.bots.find((bot: any) => bot.id === asker.id);
+        helperBot = state.bots.find((bot: any) => bot.id === helper.id);
+        const peerReply = askerBot.messages.some(
+          (message: any) =>
+            message.kind === "text"
+            && message.role === "bot"
+            && message.text?.includes("peer says: Gemini Helper replied:"),
+        );
+        const helperReplied = helperBot.messages.some(
+          (message: any) =>
+            message.kind === "text"
+            && message.role === "bot"
+            && message.text?.includes("hello from fake acp"),
+        );
+        if (peerReply && helperReplied && !askerBot.busy && !helperBot.busy) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `Gemini never got its peer reply. asker tail: ${JSON.stringify(askerBot.messages.slice(-8))}\n`
+              + `helper tail: ${JSON.stringify(helperBot.messages.slice(-6))}\n`
+              + `stderr: ${stderr.slice(-2000)}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+
+      // This is the peer's actual depth-1 output, not a mocked bridge
+      // acknowledgement. The lack of a nested "peer says" also pins the
+      // one-hop recursion guard: the invoked helper received no agents MCP.
+      const askerReply = askerBot.messages.findLast(
+        (message: any) => message.kind === "text" && message.role === "bot",
+      );
+      expect(askerReply.text).toContain("peer says: Gemini Helper replied:");
+      expect(askerReply.text).toContain("hello from fake acp");
+      const helperReply = helperBot.messages.findLast(
+        (message: any) => message.kind === "text" && message.role === "bot",
+      );
+      expect(helperReply.text).toContain("hello from fake acp");
+      expect(helperReply.text).not.toContain("peer says:");
+
+      const inbound = helperBot.messages.find(
+        (message: any) => message.kind === "text" && message.role === "user",
+      );
+      expect(inbound.text).toContain("[Message from @Gemini Asker");
+      expect(inbound.text).toContain("ping from fake Gemini");
+
+      // Antigravity's global MCP config briefly carries a bearer token for
+      // this one process. It must be gone once the turn exits so neither a
+      // later bot nor the user's own agy session can inherit the capability.
+      await expect.poll(
+        () => existsSync(join(home, ".gemini", "config", "mcp_config.json")),
+        { timeout: 5_000 },
+      ).toBe(false);
+    },
+    45_000,
   );
 
   it(

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -522,6 +522,18 @@ describe("ACP turns (fake CLI)", () => {
     expect(recorder.events.some((e) => e.provider === "geminiAgent")).toBe(true);
   });
 
+  it("starts Gemini CLI on its stable ACP surface", async () => {
+    const dump = join(scratch, "gemini-acp.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await create(GeminiAgentDriver);
+    await instance.adapter.sendTurn({ threadId: "t-gemini-acp", text: "go", model: "gemini-test" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const argv = JSON.parse(readFileSync(dump, "utf8")).argv as string[];
+    expect(argv).toEqual(["--acp", "-m", "gemini-test"]);
+    expect(argv).not.toContain("--experimental-acp");
+  });
+
   it("rejects a second turn while one is in flight", async () => {
     await create(GrokAgentDriver, "hang");
     await instance.adapter.sendTurn({ threadId: "t-busy", text: "one" });

--- a/server/drivers/acp/gemini.ts
+++ b/server/drivers/acp/gemini.ts
@@ -1,5 +1,5 @@
 // Gemini CLI harness support — Google's `gemini` CLI over ACP stdio
-// (`gemini --experimental-acp`). Rides the generic runtime in acp/core.ts.
+// (`gemini --acp`). Rides the generic runtime in acp/core.ts.
 //
 // RETIRED FROM THE DEFAULT FLEET: Google stopped serving Gemini CLI requests
 // for the free/Pro/Ultra tiers on 2026-06-18 and pointed everyone at the
@@ -88,7 +88,9 @@ const support: AcpSupport = {
   loginNote:
     "Gemini CLI needs a GEMINI_API_KEY, a Vertex AI setup, or an enterprise Code Assist login — consumer Google logins stopped working on 2026-06-18 (use the Antigravity engine for those accounts)",
 
-  spawnArgs: (_config, turn) => ["--experimental-acp", ...(turn.model ? ["-m", turn.model] : [])],
+  // --acp is the stable Gemini CLI surface. --experimental-acp remains an
+  // alias for older releases, but using it now emits a deprecation warning.
+  spawnArgs: (_config, turn) => ["--acp", ...(turn.model ? ["-m", turn.model] : [])],
   credentialEnv: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
 
   pickAuthMethod: (methods) => {

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -15,10 +15,13 @@ import type { ProviderInstance } from "../contracts.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import {
+  ANTIGRAVITY_AGENTS_MCP_KEY,
   ANTIGRAVITY_COMPUTER_MCP_KEY,
   AntigravityDriver,
+  antigravityAgentsMcpServer,
   antigravityComputerMcpServer,
-  ensureAntigravityComputerMcp,
+  antigravityMcpServers,
+  ensureAntigravityMcpServers,
   readAntigravityModelCatalog,
   STATIC_ANTIGRAVITY_MODELS,
 } from "./antigravity.ts";
@@ -207,7 +210,7 @@ describe("Antigravity snapshot", () => {
   });
 });
 
-describe("Antigravity computer MCP config", () => {
+describe("Antigravity OpenMaus MCP config", () => {
   const configPath = (home: string) => join(home, ".gemini", "config", "mcp_config.json");
   const readConfig = (home: string) => JSON.parse(readFileSync(configPath(home), "utf8"));
   const boxIntegrations = {
@@ -219,6 +222,32 @@ describe("Antigravity computer MCP config", () => {
     },
   };
   const boxEntry = () => antigravityComputerMcpServer(boxIntegrations)!;
+  const agentsIntegrations = (token = "agents-tok") => ({
+    agents: {
+      command: process.execPath,
+      args: [SPAWNED_PROXIES.agents],
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        OMB_HARNESS_URL: "http://127.0.0.1:8799",
+        OMB_COMMS_TOKEN: token,
+        OMB_BOT_ID: "gemini-bot",
+        OMB_THREAD_ID: "thread-1",
+        OMB_TURN_DEPTH: "0",
+      },
+    },
+  });
+  const agentsEntry = (token = "agents-tok") => ({
+    command: process.execPath,
+    args: [SPAWNED_PROXIES.agents],
+    env: {
+      ELECTRON_RUN_AS_NODE: "1",
+      OMB_HARNESS_URL: "http://127.0.0.1:8799",
+      OMB_COMMS_TOKEN: token,
+      OMB_BOT_ID: "gemini-bot",
+      OMB_THREAD_ID: "thread-1",
+      OMB_TURN_DEPTH: "0",
+    },
+  });
 
   it("builds the cloud-box spec on the shared computer proxy (never path-resolved locally)", () => {
     expect(antigravityComputerMcpServer(boxIntegrations)).toEqual({
@@ -234,6 +263,16 @@ describe("Antigravity computer MCP config", () => {
     });
   });
 
+  it("builds the teammate proxy spec and combines it atomically with the computer mount", () => {
+    const integrations = { ...boxIntegrations, ...agentsIntegrations("turn-secret") };
+    expect(antigravityAgentsMcpServer(integrations)).toEqual(agentsEntry("turn-secret"));
+    expect(antigravityMcpServers(integrations)).toEqual({
+      [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+      [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry("turn-secret"),
+    });
+    expect(antigravityMcpServers(undefined)).toEqual({});
+  });
+
   it("passes a Local VM / VPS stdio connection through unchanged, and yields null without a computer", () => {
     expect(
       antigravityComputerMcpServer({
@@ -244,7 +283,7 @@ describe("Antigravity computer MCP config", () => {
     expect(antigravityComputerMcpServer(undefined)).toBeNull();
   });
 
-  it("upserts only its own key — the user's servers and unknown top-level keys survive", () => {
+  it("upserts only its reserved keys — the user's servers and unknown top-level keys survive", () => {
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpcfg-"));
     try {
       mkdirSync(join(home, ".gemini", "config"), { recursive: true });
@@ -255,19 +294,33 @@ describe("Antigravity computer MCP config", () => {
           futureTopLevelKey: { keep: true },
         }),
       );
-      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      ensureAntigravityMcpServers(
+        {
+          [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+          [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry(),
+        },
+        { HOME: home },
+      );
       let config = readConfig(home);
       expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
       expect(config.futureTopLevelKey).toEqual({ keep: true });
       expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(config.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry());
 
-      // A later turn on a different computer overwrites the key in place.
-      ensureAntigravityComputerMcp(
-        { command: "/opt/cua", args: ["--mcp"], env: { CUA_SOCKET: "/tmp/cua.sock" } },
+      // A later turn overwrites its present key and removes its absent key.
+      ensureAntigravityMcpServers(
+        {
+          [ANTIGRAVITY_COMPUTER_MCP_KEY]: {
+            command: "/opt/cua",
+            args: ["--mcp"],
+            env: { CUA_SOCKET: "/tmp/cua.sock" },
+          },
+        },
         { HOME: home },
       );
       config = readConfig(home);
       expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY].command).toBe("/opt/cua");
+      expect(config.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
       expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
       expect(config.futureTopLevelKey).toEqual({ keep: true });
     } finally {
@@ -280,8 +333,15 @@ describe("Antigravity computer MCP config", () => {
     try {
       mkdirSync(join(home, ".gemini", "config"), { recursive: true });
       writeFileSync(configPath(home), "{{{ not json");
-      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      ensureAntigravityMcpServers(
+        {
+          [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+          [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry(),
+        },
+        { HOME: home },
+      );
       expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry());
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -295,7 +355,10 @@ describe("Antigravity computer MCP config", () => {
       mkdirSync(directory, { recursive: true, mode: 0o755 });
       writeFileSync(configPath(home), "{}\n", { mode: 0o644 });
 
-      ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      ensureAntigravityMcpServers(
+        { [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry("permission-secret") },
+        { HOME: home },
+      );
 
       expect(statSync(directory).mode & 0o777).toBe(0o700);
       expect(statSync(configPath(home)).mode & 0o777).toBe(0o600);
@@ -304,10 +367,16 @@ describe("Antigravity computer MCP config", () => {
     }
   });
 
-  it("preserves concurrent config edits while restoring only its own MCP entry", () => {
+  it("preserves concurrent config edits while restoring only its reserved MCP entries", () => {
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpconcurrent-"));
     try {
-      const restoreNewFile = ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      const restoreNewFile = ensureAntigravityMcpServers(
+        {
+          [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+          [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry("new-file-secret"),
+        },
+        { HOME: home },
+      );
       const concurrentlyCreated = readConfig(home);
       concurrentlyCreated.mcpServers["external-helper"] = { command: "external-mcp" };
       concurrentlyCreated.futureTopLevelKey = { keep: true };
@@ -317,33 +386,47 @@ describe("Antigravity computer MCP config", () => {
       expect(existsSync(configPath(home))).toBe(true);
       let restored = readConfig(home);
       expect(restored.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(restored.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
       expect(restored.mcpServers["external-helper"]).toEqual({ command: "external-mcp" });
       expect(restored.futureTopLevelKey).toEqual({ keep: true });
 
-      const originalEntry = { command: "user-owned-mcp", args: ["--serve"] };
+      const originalComputerEntry = { command: "user-owned-computer-mcp", args: ["--serve"] };
+      const originalAgentsEntry = { command: "user-owned-agents-mcp", args: ["--serve"] };
       writeFileSync(
         configPath(home),
-        JSON.stringify({ mcpServers: { [ANTIGRAVITY_COMPUTER_MCP_KEY]: originalEntry } }),
+        JSON.stringify({
+          mcpServers: {
+            [ANTIGRAVITY_COMPUTER_MCP_KEY]: originalComputerEntry,
+            [ANTIGRAVITY_AGENTS_MCP_KEY]: originalAgentsEntry,
+          },
+        }),
       );
-      const restoreExistingEntry = ensureAntigravityComputerMcp(boxEntry(), { HOME: home });
+      const restoreExistingEntries = ensureAntigravityMcpServers(
+        {
+          [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+          [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry("replacement-secret"),
+        },
+        { HOME: home },
+      );
       const concurrentlyEdited = readConfig(home);
       concurrentlyEdited.mcpServers["another-helper"] = { command: "another-mcp" };
       writeFileSync(configPath(home), JSON.stringify(concurrentlyEdited));
 
-      restoreExistingEntry();
+      restoreExistingEntries();
       restored = readConfig(home);
-      expect(restored.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(originalEntry);
+      expect(restored.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(originalComputerEntry);
+      expect(restored.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(originalAgentsEntry);
       expect(restored.mcpServers["another-helper"]).toEqual({ command: "another-mcp" });
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("a computer-less turn removes only its own key, and never creates the file just to remove", () => {
+  it("a tool-less turn removes both reserved keys, and never creates the file just to remove", () => {
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcprm-"));
     try {
       // No file at all: removal is a no-op, not an empty file in the user's home.
-      ensureAntigravityComputerMcp(null, { HOME: home });
+      ensureAntigravityMcpServers({}, { HOME: home });
       expect(existsSync(configPath(home))).toBe(false);
 
       mkdirSync(join(home, ".gemini", "config"), { recursive: true });
@@ -353,19 +436,21 @@ describe("Antigravity computer MCP config", () => {
           mcpServers: {
             "sqlite-helper": { command: "sqlite-mcp-server", args: ["/db"] },
             [ANTIGRAVITY_COMPUTER_MCP_KEY]: boxEntry(),
+            [ANTIGRAVITY_AGENTS_MCP_KEY]: agentsEntry("stale-secret"),
           },
         }),
       );
-      ensureAntigravityComputerMcp(null, { HOME: home });
+      ensureAntigravityMcpServers({}, { HOME: home });
       const config = readConfig(home);
       expect(config.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(config.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
       expect(config.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("advertises computerMcp only on full-auto instances, and never localComputerMcp", async () => {
+  it("advertises computer and teammate MCP only on full-auto instances, and never localComputerMcp", async () => {
     const fullAuto = await AntigravityDriver.create({
       instanceId: "agy-caps-full",
       displayName: undefined,
@@ -382,9 +467,11 @@ describe("Antigravity computer MCP config", () => {
     });
     try {
       expect(fullAuto.adapter.capabilities.computerMcp).toBe(true);
+      expect(fullAuto.adapter.capabilities.agentsMcp).toBe(true);
       // accept-edits print mode auto-denies tools that would prompt, so a
       // mount there could never fire — the capability must not be offered.
       expect(acceptEdits.adapter.capabilities.computerMcp).toBe(false);
+      expect(acceptEdits.adapter.capabilities.agentsMcp).toBe(false);
       // The host desktop needs per-action human approval; print mode has no
       // approval channel in any mode.
       expect(fullAuto.adapter.capabilities.localComputerMcp).toBeUndefined();
@@ -392,6 +479,38 @@ describe("Antigravity computer MCP config", () => {
     } finally {
       await fullAuto.dispose();
       await acceptEdits.dispose();
+    }
+  });
+
+  it("does not mount token-bearing OpenMaus tools in safe mode even when a caller supplies them", async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpsafe-"));
+    const dump = join(home, "mcp-at-spawn.json");
+    const instance = await AntigravityDriver.create({
+      instanceId: "agy-mcp-safe",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_AGY_MCP_DUMP: dump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    const recorder = recordEvents(instance.adapter);
+    try {
+      await instance.adapter.sendTurn({
+        threadId: "t-mcp-safe",
+        text: "do not expose tools",
+        integrations: { ...boxIntegrations, ...agentsIntegrations("must-not-leak") },
+      });
+      await recorder.until((event) => event.type === "turn.completed");
+
+      const atSpawn = JSON.parse(readFileSync(dump, "utf8"));
+      expect(atSpawn?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(atSpawn?.mcpServers?.[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
+      expect(JSON.stringify(atSpawn)).not.toContain("must-not-leak");
+    } finally {
+      recorder.stop();
+      await instance.dispose();
+      rmSync(home, { recursive: true, force: true });
     }
   });
 
@@ -415,15 +534,18 @@ describe("Antigravity computer MCP config", () => {
       await instance.adapter.sendTurn({
         threadId: "t-mcp-on",
         text: "click things",
-        integrations: boxIntegrations,
+        integrations: { ...boxIntegrations, ...agentsIntegrations("spawn-secret") },
       });
       // sendTurn resolves after the child is spawned; the write happens
       // synchronously before that spawn, so this IS the spawn-time content.
       const mounted = readConfig(home);
       expect(mounted.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(mounted.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("spawn-secret"));
       expect(mounted.mcpServers["sqlite-helper"]).toEqual({ command: "sqlite-mcp-server", args: ["/db"] });
       await recorder.until((e) => e.type === "turn.completed");
-      expect(JSON.parse(readFileSync(dump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      const atSpawn = JSON.parse(readFileSync(dump, "utf8"));
+      expect(atSpawn.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(atSpawn.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("spawn-secret"));
       await expect.poll(() => readFileSync(configPath(home), "utf8")).toBe(original);
     } finally {
       recorder.stop();
@@ -432,7 +554,7 @@ describe("Antigravity computer MCP config", () => {
     }
   });
 
-  it("serializes overlapping turns so each child sees only its own computer mount", async () => {
+  it("serializes overlapping turns so each child sees only its own MCP mounts and tokens", async () => {
     ensureDirs();
     chmodSync(FAKE_CLI, 0o755);
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcplease-"));
@@ -455,12 +577,22 @@ describe("Antigravity computer MCP config", () => {
     const firstRecorder = recordEvents(first.adapter);
     const secondRecorder = recordEvents(second.adapter);
     try {
-      await first.adapter.sendTurn({ threadId: "t-mcp-first", text: "first", integrations: boxIntegrations });
-      let secondSpawned = false;
-      const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-second", text: "second" }).then((result) => {
-        secondSpawned = true;
-        return result;
+      await first.adapter.sendTurn({
+        threadId: "t-mcp-first",
+        text: "first",
+        integrations: { ...boxIntegrations, ...agentsIntegrations("first-secret") },
       });
+      let secondSpawned = false;
+      const secondTurn = second.adapter
+        .sendTurn({
+          threadId: "t-mcp-second",
+          text: "second",
+          integrations: agentsIntegrations("second-secret"),
+        })
+        .then((result) => {
+          secondSpawned = true;
+          return result;
+        });
 
       await new Promise((resolve) => setTimeout(resolve, 30));
       expect(secondSpawned).toBe(false);
@@ -468,8 +600,13 @@ describe("Antigravity computer MCP config", () => {
       await secondTurn;
       await secondRecorder.until((event) => event.type === "turn.completed");
 
-      expect(JSON.parse(readFileSync(firstDump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
-      expect(JSON.parse(readFileSync(secondDump, "utf8"))?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      const firstConfig = JSON.parse(readFileSync(firstDump, "utf8"));
+      const secondConfig = JSON.parse(readFileSync(secondDump, "utf8"));
+      expect(firstConfig.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(firstConfig.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("first-secret"));
+      expect(secondConfig?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(secondConfig.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("second-secret"));
+      expect(JSON.stringify(secondConfig)).not.toContain("first-secret");
       await expect.poll(() => existsSync(configPath(home))).toBe(false);
     } finally {
       firstRecorder.stop();
@@ -508,9 +645,14 @@ describe("Antigravity computer MCP config", () => {
     const firstRecorder = recordEvents(first.adapter);
     const secondRecorder = recordEvents(second.adapter);
     try {
-      await first.adapter.sendTurn({ threadId: "t-mcp-zombie", text: "first", integrations: boxIntegrations });
+      await first.adapter.sendTurn({
+        threadId: "t-mcp-zombie",
+        text: "first",
+        integrations: { ...boxIntegrations, ...agentsIntegrations("zombie-secret") },
+      });
       await firstRecorder.until((event) => event.type === "turn.completed");
       expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("zombie-secret"));
 
       let secondSpawned = false;
       const secondTurn = second.adapter.sendTurn({ threadId: "t-mcp-after-zombie", text: "second" }).then((result) => {
@@ -524,8 +666,12 @@ describe("Antigravity computer MCP config", () => {
       await secondTurn;
       await secondRecorder.until((event) => event.type === "turn.completed");
 
-      expect(JSON.parse(readFileSync(firstDump, "utf8")).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
-      expect(JSON.parse(readFileSync(secondDump, "utf8"))?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      const zombieConfig = JSON.parse(readFileSync(firstDump, "utf8"));
+      const afterZombieConfig = JSON.parse(readFileSync(secondDump, "utf8"));
+      expect(zombieConfig.mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(zombieConfig.mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("zombie-secret"));
+      expect(afterZombieConfig?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(afterZombieConfig?.mcpServers?.[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
       await expect.poll(() => existsSync(configPath(home))).toBe(false);
     } finally {
       firstRecorder.stop();
@@ -541,6 +687,7 @@ describe("Antigravity computer MCP config", () => {
     chmodSync(FAKE_CLI, 0o755);
     const home = mkdtempSync(join(tmpdir(), "omb-agy-mcpinterrupt-"));
     const readyFile = join(home, "ready");
+    const secondDump = join(home, "second.json");
     const first = await AntigravityDriver.create({
       instanceId: "agy-mcp-interrupted",
       displayName: undefined,
@@ -556,14 +703,19 @@ describe("Antigravity computer MCP config", () => {
     const second = await AntigravityDriver.create({
       instanceId: "agy-mcp-after-interrupt",
       displayName: undefined,
-      environment: { HOME: home },
+      environment: { HOME: home, FAKE_AGY_MCP_DUMP: secondDump },
       enabled: true,
       config: { cli: FAKE_CLI, fullAuto: true },
     });
     const secondRecorder = recordEvents(second.adapter);
     try {
-      await first.adapter.sendTurn({ threadId: "t-mcp-interrupted", text: "first", integrations: boxIntegrations });
+      await first.adapter.sendTurn({
+        threadId: "t-mcp-interrupted",
+        text: "first",
+        integrations: { ...boxIntegrations, ...agentsIntegrations("interrupt-secret") },
+      });
       expect(readConfig(home).mcpServers[ANTIGRAVITY_COMPUTER_MCP_KEY]).toEqual(boxEntry());
+      expect(readConfig(home).mcpServers[ANTIGRAVITY_AGENTS_MCP_KEY]).toEqual(agentsEntry("interrupt-secret"));
       await expect.poll(() => existsSync(readyFile), { timeout: 2_000 }).toBe(true);
       await first.adapter.interruptTurn("t-mcp-interrupted");
 
@@ -578,6 +730,9 @@ describe("Antigravity computer MCP config", () => {
       }
       await secondTurn;
       await secondRecorder.until((event) => event.type === "turn.completed");
+      const afterInterruptConfig = JSON.parse(readFileSync(secondDump, "utf8"));
+      expect(afterInterruptConfig?.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY]).toBeUndefined();
+      expect(afterInterruptConfig?.mcpServers?.[ANTIGRAVITY_AGENTS_MCP_KEY]).toBeUndefined();
       await expect.poll(() => existsSync(configPath(home)), { timeout: 6_000 }).toBe(false);
     } finally {
       secondRecorder.stop();

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -11,11 +11,12 @@
 // approves everything. Real per-action approval cards are a future path via
 // native ACP (agy issue #31), which would reuse acp/core.ts like grok/gemini.
 //
-// Computer use: agy has no per-turn MCP flag, so the bot's computer (cloud
-// box / Local VM / VPS) is mounted by upserting one key into the global
-// `~/.gemini/config/mcp_config.json` before each spawn — see
-// ensureAntigravityComputerMcp below. Full-auto instances only; the host
-// desktop stays off (no approval channel in print mode, ever).
+// MCP tools: agy has no per-turn MCP flag, so the bot's computer (cloud box /
+// Local VM / VPS) and its OpenMaus teammate tools are mounted by upserting
+// OpenMaus-owned keys into the global `~/.gemini/config/mcp_config.json`
+// before each spawn — see ensureAntigravityMcpServers below. Full-auto
+// instances only; the host desktop stays off (no approval channel in print
+// mode, ever).
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -124,29 +125,44 @@ export function readAntigravityModelCatalog(env: Record<string, string | undefin
 // against agy 1.1.19, whose embedded docs list exactly two locations — the
 // global `~/.gemini/config/mcp_config.json` and per-plugin files — and whose
 // `agy mcp list` ignores `.gemini/{settings,mcp_config}.json` in the cwd.
-// So the bot's computer is mounted by upserting ONE key into the global file
+// So OpenMaus tools are mounted by upserting two reserved keys into the global file
 // right before each spawn: every other byte of the user's config is
 // preserved, and a malformed file starts from a fresh object instead of
 // failing the turn (the ensureOpenCodeInjectModel discipline).
 export const ANTIGRAVITY_COMPUTER_MCP_KEY = "openmausbot-computer";
+export const ANTIGRAVITY_AGENTS_MCP_KEY = "openmausbot-agents";
 
-export interface AntigravityComputerMcpServer {
+export interface AntigravityMcpServer {
   command: string;
   args: string[];
   env: Record<string, string>;
 }
 
-// agy's MCP file is machine-global. Hold this lease for the complete child
-// lifetime so two Antigravity turns cannot see each other's computer tokens.
-let antigravityComputerMcpLease: Promise<void> = Promise.resolve();
+/** Backward-compatible name retained for callers of the computer-only helper. */
+export type AntigravityComputerMcpServer = AntigravityMcpServer;
 
-async function acquireAntigravityComputerMcpLease(): Promise<() => void> {
-  const previous = antigravityComputerMcpLease;
+const ANTIGRAVITY_OWNED_MCP_KEYS = [
+  ANTIGRAVITY_COMPUTER_MCP_KEY,
+  ANTIGRAVITY_AGENTS_MCP_KEY,
+] as const;
+type AntigravityOwnedMcpKey = (typeof ANTIGRAVITY_OWNED_MCP_KEYS)[number];
+export interface AntigravityMcpServers {
+  [ANTIGRAVITY_COMPUTER_MCP_KEY]?: AntigravityMcpServer;
+  [ANTIGRAVITY_AGENTS_MCP_KEY]?: AntigravityMcpServer;
+}
+
+// agy's MCP file is machine-global. Hold this lease for the complete child
+// lifetime so two Antigravity turns cannot see each other's computer, control,
+// or bot-communication tokens.
+let antigravityMcpLease: Promise<void> = Promise.resolve();
+
+async function acquireAntigravityMcpLease(): Promise<() => void> {
+  const previous = antigravityMcpLease;
   let unlock: (() => void) | undefined;
   const current = new Promise<void>((resolve) => {
     unlock = resolve;
   });
-  antigravityComputerMcpLease = previous.then(() => current);
+  antigravityMcpLease = previous.then(() => current);
   await previous;
   let released = false;
   return () => {
@@ -192,12 +208,28 @@ export function antigravityComputerMcpServer(
   return null;
 }
 
-/** Upsert (server) or remove (null) the openmausbot-computer entry in the
- * global mcp_config.json. Only that one key is ever written; a turn without
- * a computer removes it so a previous turn's mount cannot leak tools — or
- * box/control tokens — into later turns or the user's own agy sessions. */
-export function ensureAntigravityComputerMcp(
-  server: AntigravityComputerMcpServer | null,
+/** The teammate MCP server for this turn, or null when the turn has none. */
+export function antigravityAgentsMcpServer(
+  integrations: SendTurnInput["integrations"],
+): AntigravityMcpServer | null {
+  const agents = integrations?.agents;
+  if (!agents) return null;
+  return { command: agents.command, args: [...agents.args], env: { ...agents.env } };
+}
+
+/** Build every OpenMaus-owned agy MCP entry for one turn. */
+export function antigravityMcpServers(integrations: SendTurnInput["integrations"]): AntigravityMcpServers {
+  const servers: AntigravityMcpServers = {};
+  const computer = antigravityComputerMcpServer(integrations);
+  const agents = antigravityAgentsMcpServer(integrations);
+  if (computer) servers[ANTIGRAVITY_COMPUTER_MCP_KEY] = computer;
+  if (agents) servers[ANTIGRAVITY_AGENTS_MCP_KEY] = agents;
+  return servers;
+}
+
+function ensureAntigravityOwnedMcpServers(
+  desired: AntigravityMcpServers,
+  ownedKeys: readonly AntigravityOwnedMcpKey[],
   env: Record<string, string | undefined> = process.env,
 ): () => void {
   const home = env.HOME || env.USERPROFILE || homedir();
@@ -213,12 +245,15 @@ export function ensureAntigravityComputerMcp(
   }
   const servers = { ...config.mcpServers };
   // Nothing to remove and nothing to add: leave the user's file untouched
-  // (don't create or reformat it on every computer-less turn).
-  if (!server && !(ANTIGRAVITY_COMPUTER_MCP_KEY in servers)) return () => {};
-  if (server) {
-    servers[ANTIGRAVITY_COMPUTER_MCP_KEY] = { command: server.command, args: server.args, env: server.env };
-  } else {
-    delete servers[ANTIGRAVITY_COMPUTER_MCP_KEY];
+  // (don't create or reformat it on every tool-less turn).
+  if (!ownedKeys.some((key) => desired[key] || key in servers)) return () => {};
+  for (const key of ownedKeys) {
+    const server = desired[key];
+    if (server) {
+      servers[key] = { command: server.command, args: [...server.args], env: { ...server.env } };
+    } else {
+      delete servers[key];
+    }
   }
   const directory = dirname(path);
   mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -228,13 +263,17 @@ export function ensureAntigravityComputerMcp(
   writeFileSync(path, mounted, { mode: 0o600 });
   chmodSync(path, 0o600);
 
-  const hadOriginalEntry = ANTIGRAVITY_COMPUTER_MCP_KEY in (config.mcpServers ?? {});
-  const originalEntry = config.mcpServers?.[ANTIGRAVITY_COMPUTER_MCP_KEY];
+  const originalEntries = new Map(
+    ownedKeys.map((key) => [
+      key,
+      { had: key in (config.mcpServers ?? {}), value: config.mcpServers?.[key] },
+    ] as const),
+  );
 
   // Restore exactly what was present before this turn when nobody else touched
   // the file. A user's own agy process is outside our module-wide lease, so if
   // it edited the config concurrently, preserve that edit and restore only our
-  // one key instead of replacing (or deleting) the whole file.
+  // reserved keys instead of replacing (or deleting) the whole file.
   let restored = false;
   return () => {
     if (restored) return;
@@ -268,8 +307,11 @@ export function ensureAntigravityComputerMcp(
     if (!parsed.success) return;
     const currentConfig = parsed.data;
     const currentServers = { ...currentConfig.mcpServers };
-    if (hadOriginalEntry) currentServers[ANTIGRAVITY_COMPUTER_MCP_KEY] = originalEntry;
-    else delete currentServers[ANTIGRAVITY_COMPUTER_MCP_KEY];
+    for (const key of ownedKeys) {
+      const originalEntry = originalEntries.get(key)!;
+      if (originalEntry.had) currentServers[key] = originalEntry.value;
+      else delete currentServers[key];
+    }
     writeFileSync(
       path,
       `${JSON.stringify({ ...currentConfig, mcpServers: currentServers }, null, 2)}\n`,
@@ -277,6 +319,28 @@ export function ensureAntigravityComputerMcp(
     );
     chmodSync(path, 0o600);
   };
+}
+
+/** Upsert the current turn's OpenMaus MCP entries and remove absent ones.
+ * Both reserved keys are owned as one atomic mount, so a previous turn's
+ * computer or teammate token can never leak into the next agy process. */
+export function ensureAntigravityMcpServers(
+  servers: AntigravityMcpServers,
+  env: Record<string, string | undefined> = process.env,
+): () => void {
+  return ensureAntigravityOwnedMcpServers(servers, ANTIGRAVITY_OWNED_MCP_KEYS, env);
+}
+
+/** Backward-compatible computer-only mount helper. */
+export function ensureAntigravityComputerMcp(
+  server: AntigravityComputerMcpServer | null,
+  env: Record<string, string | undefined> = process.env,
+): () => void {
+  return ensureAntigravityOwnedMcpServers(
+    server ? { [ANTIGRAVITY_COMPUTER_MCP_KEY]: server } : {},
+    [ANTIGRAVITY_COMPUTER_MCP_KEY],
+    env,
+  );
 }
 
 function decodeConfig(raw: unknown): AntigravityConfig {
@@ -432,11 +496,11 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         return { turnId };
       }
 
-      // agy's config is global, so every turn — including one without a
-      // computer — owns the mount for its complete child lifetime. This keeps
+      // agy's config is global, so every turn — including one without any
+      // OpenMaus tools — owns the mount for its complete child lifetime. This keeps
       // overlapping turns from inheriting, replacing, or removing each
       // other's tools and credentials.
-      const releaseMcpLease = await acquireAntigravityComputerMcpLease();
+      const releaseMcpLease = await acquireAntigravityMcpLease();
       if (disposed) {
         releaseMcpLease();
         pending.delete(threadId);
@@ -445,7 +509,12 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       }
       let restoreMcp = () => {};
       try {
-        restoreMcp = ensureAntigravityComputerMcp(antigravityComputerMcpServer(turn.integrations), env);
+        // The capability gate in server/index.ts normally withholds these
+        // integrations in safe mode. Enforce the same boundary here so a
+        // direct adapter caller cannot expose token-bearing tools to a child
+        // that has no interactive permission channel.
+        const mountedIntegrations = config.fullAuto ? turn.integrations : undefined;
+        restoreMcp = ensureAntigravityMcpServers(antigravityMcpServers(mountedIntegrations), env);
       } catch (error) {
         releaseMcpLease();
         pending.delete(threadId);
@@ -724,6 +793,10 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           // approval (see contracts.ts), which print mode cannot deliver in
           // any mode; that returns with the native ACP path (agy issue #31).
           computerMcp: config.fullAuto,
+          // The same approval limitation applies to bot-to-bot calls. The
+          // harness only injects the short-lived agents proxy when this flag
+          // is true, so safe-mode turns never expose a token they cannot use.
+          agentsMcp: config.fullAuto,
         },
         sendTurn,
         interruptTurn: async (threadId) => active.get(threadId)?.stop(),

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -119,7 +119,11 @@ function driveMcp(
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
-      params: { protocolVersion: "2024-11-05" },
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "openmausbot-fake-antigravity", version: "1.0.0" },
+      },
     });
   });
 }

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -7,9 +7,122 @@
 // step (ACTIVE then DONE) → agent_response step with usage → result with
 // status SUCCESS. Deterministic, no network.
 //
+//   FAKE_AGY_MODE=ask-peer
+//     reads OpenMausBot's temporary `openmausbot-agents` entry from agy's
+//     global MCP config, calls list_bots then ask_bot, and returns the peer's
+//     real reply. This pins the Antigravity/Gemini comms path end to end.
+//
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
+import { spawn } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+const mode = process.env.FAKE_AGY_MODE ?? "happy";
+
+type McpEntry = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
+function agentsMcpEntry(): McpEntry | null {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  try {
+    const config = JSON.parse(
+      readFileSync(join(home, ".gemini", "config", "mcp_config.json"), "utf8"),
+    );
+    const entry = config.mcpServers?.["openmausbot-agents"];
+    if (!entry?.command) return null;
+    return {
+      command: String(entry.command),
+      args: Array.isArray(entry.args) ? entry.args.map(String) : [],
+      env: Object.fromEntries(
+        Object.entries(entry.env ?? {}).map(([name, value]) => [name, String(value)]),
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Minimal MCP stdio client matching the real config shape used by agy. */
+function driveMcp(
+  entry: McpEntry,
+  calls: Array<{ name: string; args: (previous: string) => object }>,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env, ...entry.env };
+    const child = spawn(entry.command, entry.args ?? [], {
+      env,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    let settled = false;
+    let step = -1; // -1 = initialize in flight
+    let last = "";
+
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill();
+      if (error) reject(error);
+      else resolve(last);
+    };
+    const timer = setTimeout(() => finish(new Error("mcp timeout")), 60_000);
+    const write = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+    const next = () => {
+      step += 1;
+      if (step >= calls.length) return finish();
+      const call = calls[step];
+      write({
+        jsonrpc: "2.0",
+        id: step + 2,
+        method: "tools/call",
+        params: { name: call.name, arguments: call.args(last) },
+      });
+    };
+
+    child.on("error", (error) => finish(error));
+    child.on("exit", (code) => {
+      if (!settled) finish(new Error(`mcp exited before completing (code ${code ?? "unknown"})`));
+    });
+    child.stdin.on("error", (error) => finish(error));
+    let buffer = "";
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk;
+      let newline;
+      while ((newline = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line.trim()) continue;
+        let message: any;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id === undefined) continue;
+        if (message.error) {
+          finish(new Error(String(message.error.message ?? "MCP call failed")));
+          return;
+        }
+        if (step === -1) {
+          write({ jsonrpc: "2.0", method: "notifications/initialized" });
+          next();
+          continue;
+        }
+        last = String(message.result?.content?.[0]?.text ?? "");
+        next();
+      }
+    });
+    write({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+  });
+}
 
 const argv = process.argv.slice(2);
 if (process.env.FAKE_AGY_IGNORE_SIGTERM === "1") {
@@ -48,11 +161,37 @@ const printIdx = argv.indexOf("--print");
 const prompt = printIdx !== -1 ? argv[printIdx + 1] : undefined;
 if (!prompt) process.exit(0);
 
-out({ event: "init", conversation_id: CONV, init: { cwd: process.cwd(), tools: ["run_command", "write_to_file"], permission_mode: "accept-edits" } });
-out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 0, state: "ACTIVE", step_type: "tool", tool_name: "write_to_file", tool_info: { name: "write_to_file", parameters: {} } } });
-out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 0, state: "DONE", step_type: "tool", tool_name: "write_to_file", tool_info: { name: "write_to_file", parameters: {} } } });
+const toolName = mode === "ask-peer" ? "ask_bot" : "write_to_file";
+out({ event: "init", conversation_id: CONV, init: { cwd: process.cwd(), tools: ["run_command", "write_to_file", ...(mode === "ask-peer" ? ["list_bots", "ask_bot"] : [])], permission_mode: "accept-edits" } });
+out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 0, state: "ACTIVE", step_type: "tool", tool_name: toolName, tool_info: { name: toolName, parameters: {} } } });
+
+let response = "done from fake agy";
+if (mode === "ask-peer") {
+  const agents = agentsMcpEntry();
+  if (!agents) {
+    response = "peer error: agents MCP not mounted";
+  } else {
+    try {
+      const reply = await driveMcp(agents, [
+        { name: "list_bots", args: () => ({}) },
+        {
+          name: "ask_bot",
+          args: (list) => ({
+            bot_id: /id: ([\w-]+)/.exec(list)?.[1] ?? "",
+            message: "ping from fake Gemini",
+          }),
+        },
+      ]);
+      response = `peer says: ${reply}`;
+    } catch (error) {
+      response = `peer error: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+}
+
+out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 0, state: "DONE", step_type: "tool", tool_name: toolName, tool_info: { name: toolName, parameters: {} } } });
 out({ event: "step_update", conversation_id: CONV, step_update: { conversation_id: CONV, step_index: 1, state: "DONE", step_type: "agent_response", usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 0, cache_read_tokens: 5, total_tokens: 125 } } });
-out({ event: "result", conversation_id: CONV, result: { conversation_id: CONV, status: "SUCCESS", response: "done from fake agy", duration_seconds: 1, num_turns: 1, usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 0, cache_read_tokens: 5, total_tokens: 125 } } });
+out({ event: "result", conversation_id: CONV, result: { conversation_id: CONV, status: "SUCCESS", response, duration_seconds: 1, num_turns: 1, usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 0, cache_read_tokens: 5, total_tokens: 125 } } });
 const postResultDelayMs = Number(process.env.FAKE_AGY_POST_RESULT_DELAY_MS ?? 0);
 if (Number.isFinite(postResultDelayMs) && postResultDelayMs > 0) {
   await new Promise((resolve) => setTimeout(resolve, postResultDelayMs));


### PR DESCRIPTION
## What changed

- give normal Gemini 3.x / Antigravity bots the existing OpenMaus teammate tools
- mount the short-lived agents MCP under a leased, app-owned config key and restore the user config exactly after the turn
- keep coordination restricted to full-auto mode, with direct safe-mode enforcement
- move the standalone Gemini CLI driver to the stable `--acp` flag
- add a real server E2E for `list_bots` → `ask_bot` → peer response plus token cleanup

## Safety

- same-section and one-hop delegation rules remain enforced by the existing agents proxy
- overlapping Antigravity turns cannot inherit each other tokens
- normal exit, interruption, and hung-child cleanup all restore the MCP config
- unrelated and concurrently edited user MCP entries are preserved

## Validation

- 2,507 tests passed, 19 skipped
- broker, updater, desktop viewer, package-link, save-file, boot-probe, and packaged-server smoke suites passed
- TypeScript typecheck passed
- Electron syntax check passed
- independent code review found no blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Antigravity sessions now support both computer and teammate integrations in full-auto mode.
  - Peer conversations can receive responses through the teammate integration.

- **Improvements**
  - Gemini now launches using the stable ACP option, replacing the deprecated experimental option.
  - Safe-mode sessions avoid exposing token-bearing integration tools.
  - MCP configuration preserves existing settings while managing session-specific integrations safely and reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->