### PR TITLE
chore(release): bump version to 0.1.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop release version from 0.1.39 to 0.1.40 so the next release workflow publishes a new version. Confirmed that v0.1.40 is not already published in the release repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.1.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->