### PR TITLE
feat(drivers): add OrcaRouter as a named provider driver

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -375,6 +375,14 @@ describe("default fleet", () => {
     });
   });
 
+  it("injects the saved OrcaRouter key into the live default instance", () => {
+    const map = instanceConfigs({
+      orcarouter: { key: "orc-secret" },
+    });
+    expect(map.orcarouter.driver).toBe("orcarouter");
+    expect(map.orcarouter.environment).toEqual({ ORCAROUTER_API_KEY: "orc-secret" });
+  });
+
   it("preserves a per-instance OpenAI-compatible URL override", () => {
     const map = instanceConfigs({
       openaiCompat: { url: "https://workspace.example.test/v1" },
@@ -416,6 +424,7 @@ describe("default fleet", () => {
     expect(map.hermes?.driver).toBe("hermesAgent");
     expect(map.cursor?.driver).toBe("cursorAgent");
     expect(map.openaiCompat?.driver).toBe("openai-compat");
+    expect(map.orcarouter?.driver).toBe("orcarouter");
   });
 
   it("does not expand a one-off shadow fleet", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -236,6 +236,8 @@ const appConfigSchema = z.object({
   openaiCompat: z
     .object({ key: optionalText, url: optionalText, model: optionalText, provider: optionalText })
     .optional(),
+  /** OrcaRouter gateway key. Non-secret url override is optional. */
+  orcarouter: z.object({ key: optionalText, url: optionalText }).optional(),
   /** Project key used for Sessions, catalog and agent tools. userId/sessionId
    * are non-secret local identifiers used to reuse one Composio Session. */
   composio: z.object({ apiKey: optionalText, userId: optionalText, sessionId: optionalText }).optional(),
@@ -266,6 +268,7 @@ const jsonObjectSchema = z.record(z.string(), z.json());
 export interface AppConfig {
   xai?: { key?: string; url?: string };
   openaiCompat?: { key?: string; url?: string; model?: string; provider?: string };
+  orcarouter?: { key?: string; url?: string };
   composio?: { apiKey?: string; userId?: string; sessionId?: string };
   box?: { token?: string };
   /** A named host from the user's SSH config. Authentication stays with SSH. */
@@ -459,6 +462,9 @@ export function loadConfig(): AppConfig {
   if (process.env.OPENAI_COMPAT_URL !== undefined) cfg.openaiCompat.url = process.env.OPENAI_COMPAT_URL;
   if (process.env.OPENAI_COMPAT_MODEL !== undefined) cfg.openaiCompat.model = process.env.OPENAI_COMPAT_MODEL;
   if (process.env.OPENAI_COMPAT_PROVIDER !== undefined) cfg.openaiCompat.provider = process.env.OPENAI_COMPAT_PROVIDER;
+  cfg.orcarouter = { ...cfg.orcarouter };
+  if (process.env.ORCAROUTER_API_KEY !== undefined) cfg.orcarouter.key = process.env.ORCAROUTER_API_KEY;
+  if (process.env.ORCAROUTER_BASE_URL !== undefined) cfg.orcarouter.url = process.env.ORCAROUTER_BASE_URL;
   cfg.composio = { ...cfg.composio };
   if (process.env.COMPOSIO_API_KEY !== undefined) cfg.composio.apiKey = process.env.COMPOSIO_API_KEY;
   cfg.box = { ...cfg.box };
@@ -483,6 +489,7 @@ export function syncCredentialEnv(patch: Partial<AppConfig>): void {
   const secrets: Array<[value: string | undefined, name: string]> = [
     [patch.xai?.key, "XAI_API_KEY"],
     [patch.openaiCompat?.key, "OPENAI_COMPAT_API_KEY"],
+    [patch.orcarouter?.key, "ORCAROUTER_API_KEY"],
     [patch.composio?.apiKey, "COMPOSIO_API_KEY"],
     [patch.box?.token, "BOX_TOKEN"],
     [patch.opencodeGo?.apiKey, "OPENCODE_API_KEY"],
@@ -517,6 +524,7 @@ export const WORKSPACE_CREDENTIAL_ENV = [
   "XAI_API_KEY",
   "OPENAI_COMPAT_API_KEY",
   "OPENAI_COMPAT_URL",
+  "ORCAROUTER_API_KEY",
   "BOX_TOKEN",
   "OPENCODE_API_KEY",
   "OMB_TTS_KEY",
@@ -547,6 +555,7 @@ export const PROVIDER_CREDENTIAL_ENV = [
   "KIMI_API_KEY",
   "MOONSHOT_API_KEY",
   "MINIMAX_API_KEY",
+  "ORCAROUTER_API_KEY",
   "OPENAI_API_KEY",
   "OPENCODE_API_KEY",
   "XAI_API_KEY",
@@ -679,6 +688,8 @@ function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string
     environment.set("OPENAI_COMPAT_API_KEY", cfg.openaiCompat.key);
   if (driver === "openai-compat" && cfg.openaiCompat?.url)
     environment.set("OPENAI_COMPAT_URL", cfg.openaiCompat.url);
+  if (driver === "orcarouter" && cfg.orcarouter?.key)
+    environment.set("ORCAROUTER_API_KEY", cfg.orcarouter.key);
   if (driver === "boxAgent" && cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
   if (driver === "opencodeGo" && cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
   return environment;
@@ -714,6 +725,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     opencodeGo: { driver: "opencodeGo" },
     computer: { driver: "boxAgent" },
     openaiCompat: { driver: "openai-compat" },
+    orcarouter: { driver: "orcarouter" },
     qwen: { driver: "qwenAgent" },
     hermes: { driver: "hermesAgent" },
     pi: { driver: "piAgent" },
@@ -729,6 +741,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   const PRODUCT_FLEET_ADDITIONS = {
     cursor: { driver: "cursorAgent" },
     openaiCompat: { driver: "openai-compat" },
+    orcarouter: { driver: "orcarouter" },
     ...CUSTOM_ONLY,
   } as const;
   const configured = cfg.instances && Object.keys(cfg.instances).length ? cfg.instances : null;

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -15,6 +15,7 @@ import { OpenCodeDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
+import { OrcaRouterDriver } from "./orcarouter.ts";
 import { PiDriver } from "./pi.ts";
 import { MinimaxDriver } from "./minimax.ts";
 
@@ -30,6 +31,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   HermesAgentDriver,
   PiDriver,
   OpenAICompatDriver,
+  OrcaRouterDriver,
   ClaudeDriver,
   CodexDriver,
   AntigravityDriver,

--- a/server/drivers/orcarouter.test.ts
+++ b/server/drivers/orcarouter.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { recordEvents } from "../testing/events.ts";
+import { OrcaRouterDriver, decodeOrcaRouterConfig } from "./orcarouter.ts";
+
+describe("OrcaRouterDriver", () => {
+  const savedKey = process.env.ORCAROUTER_API_KEY;
+  const savedUrl = process.env.ORCAROUTER_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.ORCAROUTER_API_KEY;
+    delete process.env.ORCAROUTER_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedKey === undefined) delete process.env.ORCAROUTER_API_KEY;
+    else process.env.ORCAROUTER_API_KEY = savedKey;
+    if (savedUrl === undefined) delete process.env.ORCAROUTER_BASE_URL;
+    else process.env.ORCAROUTER_BASE_URL = savedUrl;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("registers with the orcarouter kind and a display name", () => {
+    expect(OrcaRouterDriver.driverKind).toBe("orcarouter");
+    expect(OrcaRouterDriver.metadata.displayName).toMatch(/OrcaRouter/);
+  });
+
+  it("defaults to the OrcaRouter endpoint", () => {
+    const cfg = OrcaRouterDriver.defaultConfig();
+    expect(cfg.url).toBe("https://api.orcarouter.ai/v1");
+  });
+
+  it("normalizes an env base URL to a /v1 root", () => {
+    process.env.ORCAROUTER_BASE_URL = "https://gateway.example.test";
+    const cfg = OrcaRouterDriver.defaultConfig();
+    expect(cfg.url).toBe("https://gateway.example.test/v1");
+  });
+
+  it("honours an explicit url override", () => {
+    const cfg = decodeOrcaRouterConfig({ url: "https://api.orcarouter.ai/v1/" });
+    expect(cfg.url).toBe("https://api.orcarouter.ai/v1");
+  });
+
+  it("reports unavailable without an API key", async () => {
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-1",
+      displayName: "OrcaRouter",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: {},
+    });
+    const snap = await inst.snapshot();
+    expect(snap.state).toBe("unavailable");
+    await inst.dispose();
+  });
+
+  it("exposes a refreshed model catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              { id: "orcarouter/fusion", name: "Fusion" },
+              { id: "deepseek/deepseek-chat" },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-models",
+      displayName: "Models",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: { ORCAROUTER_API_KEY: "secret" },
+    });
+
+    await inst.refreshModels?.();
+
+    expect(inst.models).toEqual({
+      default: "orcarouter/fusion",
+      options: [
+        { id: "orcarouter/fusion", label: "Fusion" },
+        { id: "deepseek/deepseek-chat", label: "deepseek/deepseek-chat" },
+      ],
+    });
+    await inst.dispose();
+  });
+
+  it("includes streamed token totals in turn.completed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/models")) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hello"}}]}\n' +
+            'data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":3}}\n' +
+            "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-turn",
+      displayName: "Turn",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: { ORCAROUTER_API_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "thread", text: "private prompt", model: "orcarouter/fusion" });
+    const completed = await recorder.until((event) => event.type === "turn.completed");
+
+    expect(completed).toMatchObject({ ok: true, usage: { input: 12, output: 3 } });
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("streams reasoning separately and completes only actual assistant text", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input).endsWith("/models")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        return new Response(
+          'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n' +
+            'data: {"choices":[{"delta":{"content":"answer"}}]}\n' +
+            "data: [DONE]\n",
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-reasoning-stream",
+      displayName: "Reasoning",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: { ORCAROUTER_API_KEY: "secret" },
+    });
+    const recorder = recordEvents(inst.adapter);
+
+    await inst.adapter.sendTurn({ threadId: "reasoning-thread", text: "question", model: "orcarouter/fusion" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    expect(recorder.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "content.delta", streamKind: "reasoning_text", delta: "thinking" }),
+      expect.objectContaining({ type: "content.delta", streamKind: "assistant_text", delta: "answer" }),
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "answer" }),
+    ]));
+    expect(recorder.events).not.toContainEqual(
+      expect.objectContaining({ type: "item.completed", itemType: "assistant_text", text: "thinking" }),
+    );
+    recorder.stop();
+    await inst.dispose();
+  });
+
+  it("uses reasoning as a helper-model fallback when normal content is whitespace", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input).endsWith("/models")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: "  ", reasoning_content: "usable result" } }],
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }),
+    );
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-reasoning-helper",
+      displayName: "Reasoning helper",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: { ORCAROUTER_API_KEY: "secret" },
+    });
+
+    await expect(inst.generateText?.("question")).resolves.toBe("usable result");
+    await inst.dispose();
+  });
+
+  it("seeds the picker with the static default model", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 })),
+    );
+    const inst = await OrcaRouterDriver.create({
+      instanceId: "test-default-model",
+      displayName: "Default model",
+      enabled: true,
+      config: { url: "https://api.orcarouter.ai/v1" },
+      environment: { ORCAROUTER_API_KEY: "secret" },
+    });
+    expect(inst.models.default).toBe("orcarouter/fusion");
+    expect(inst.models.options.some((o) => o.id === "orcarouter/fusion")).toBe(true);
+    await inst.dispose();
+  });
+});

--- a/server/drivers/orcarouter.ts
+++ b/server/drivers/orcarouter.ts
@@ -1,0 +1,372 @@
+// OrcaRouter driver — OpenAI-compatible chat/completions API with SSE
+// streaming. OrcaRouter is an OpenAI-compatible AI gateway exposing a
+// provider/model namespace like OpenRouter, plus adaptive routing, automatic
+// failover, zero-markup inference, observability, guardrails, and agent-tool
+// governance on the same endpoint.
+//
+// Model ids carry the full `provider/model` slug (e.g. `orcarouter/fusion`,
+// `deepseek/deepseek-v4-flash-0731`); the endpoint resolves routing itself.
+// Like the other API-key drivers, this one reads its key from the instance
+// environment or process.env and reports unavailable until one is present.
+//
+// API: https://api.orcarouter.ai/v1/chat/completions
+// Models: https://api.orcarouter.ai/v1/models
+
+import { z } from "zod";
+
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  ProviderSnapshot,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { appendNative } from "./native.ts";
+
+const DRIVER_KIND = "orcarouter";
+const API_KEY_ENV = "ORCAROUTER_API_KEY";
+const DEFAULT_URL = "https://api.orcarouter.ai/v1";
+
+// Default catalog — the endpoint's live /models refresh overwrites this
+// whenever a key is present. These are the stable gateway slugs.
+const MODELS: ModelCatalog = {
+  default: "orcarouter/fusion",
+  options: [
+    { id: "orcarouter/fusion", label: "OrcaRouter Fusion" },
+    { id: "orcarouter/fusion-flash", label: "OrcaRouter Fusion Flash" },
+    { id: "orcarouter/fusion-mini", label: "OrcaRouter Fusion Mini" },
+    { id: "orcarouter/free", label: "OrcaRouter Free" },
+  ],
+};
+
+export interface OrcaRouterConfig {
+  /** Base URL, no trailing /v1 assumed — we append /chat/completions. */
+  url: string;
+}
+
+const driverConfigSchema = z.object({
+  url: z.string().optional(),
+});
+
+function normalizedApiUrl(value: string): string {
+  const root = value.trim().replace(/\/+$/, "");
+  return root.endsWith("/v1") ? root : `${root}/v1`;
+}
+
+export function decodeOrcaRouterConfig(raw: unknown): OrcaRouterConfig {
+  // Decode is the I/O boundary: invalid config throws (registry downgrades
+  // it to an unavailable shadow), never silently falls back.
+  const { url } = driverConfigSchema.parse(raw ?? {});
+  const envUrl = process.env.ORCAROUTER_BASE_URL?.trim();
+  return {
+    url: normalizedApiUrl(url?.trim() || envUrl || DEFAULT_URL),
+  };
+}
+
+export const OrcaRouterDriver: ProviderDriver<OrcaRouterConfig> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "OrcaRouter (AI gateway)",
+    supportsMultipleInstances: true,
+    access: "custom",
+  },
+  models: MODELS,
+  install: {
+    docsUrl: "https://www.orcarouter.ai",
+    command: {
+      darwin:
+        "Get a free key at https://www.orcarouter.ai then add it to ~/.openmausbot/config.json under orcarouter.key (or set ORCAROUTER_API_KEY)",
+      linux:
+        "Get a free key at https://www.orcarouter.ai then add it to ~/.openmausbot/config.json under orcarouter.key (or set ORCAROUTER_API_KEY)",
+      win32:
+        "Get a free key at https://www.orcarouter.ai then add it to %USERPROFILE%\\.openmausbot\\config.json under orcarouter.key (or set ORCAROUTER_API_KEY)",
+    },
+    signInCommand: "add {\"orcarouter\":{\"key\":\"…\"}} to ~/.openmausbot/config.json (or set ORCAROUTER_API_KEY)",
+  },
+  decodeConfig: decodeOrcaRouterConfig,
+  defaultConfig: () => decodeOrcaRouterConfig({}),
+
+  async create(input: DriverCreateInput<OrcaRouterConfig>): Promise<ProviderInstance> {
+    const { instanceId, config } = input;
+    const apiKey =
+      input.environment[API_KEY_ENV]?.trim() ||
+      input.environment["ORCAROUTER_API_KEY"]?.trim() ||
+      process.env[API_KEY_ENV]?.trim() ||
+      process.env["ORCAROUTER_API_KEY"]?.trim() ||
+      "";
+
+    const listeners = new Set<RuntimeEventListener>();
+    const active = new Map<string, { abort: AbortController; turnId: string }>();
+    let catalog: ModelCatalog = MODELS;
+
+    const emit = (event: RuntimeEvent) => {
+      for (const l of [...listeners]) l(event);
+    };
+
+    const base = (threadId: string, turnId: string) => ({
+      eventId: newEventId(),
+      provider: DRIVER_KIND,
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+    });
+
+    const complete = async (
+      messages: Array<{ role: string; content: string }>,
+      model: string,
+      opts: { stream: boolean; signal?: AbortSignal; onDelta?: (d: string, streamKind?: "assistant_text" | "reasoning_text") => void },
+    ): Promise<{ text: string; reasoning: string; usage: { input: number; output: number } | null }> => {
+      const timeout = AbortSignal.timeout(180_000);
+      const signal = opts.signal ? AbortSignal.any([opts.signal, timeout]) : timeout;
+      const res = await fetch(`${config.url}/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          messages,
+          stream: opts.stream,
+          stream_options: opts.stream ? { include_usage: true } : undefined,
+        }),
+        signal,
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`OrcaRouter HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+      }
+
+      if (!opts.stream) {
+        const json: any = await res.json();
+        const msg = json.choices?.[0]?.message;
+        const mainContent = typeof msg?.content === "string" ? msg.content : "";
+        const reasoningContent = typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "";
+        return {
+          text: mainContent,
+          reasoning: reasoningContent,
+          usage: json.usage
+            ? {
+                input: json.usage.prompt_tokens ?? 0,
+                output: json.usage.completion_tokens ?? 0,
+              }
+            : null,
+        };
+      }
+
+      let text = "";
+      let reasoning = "";
+      let usage: { input: number; output: number } | null = null;
+      if (!res.body) throw new Error("OrcaRouter returned no response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          let nl;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            if (!line.startsWith("data:")) continue;
+            const data = line.slice(5).trim();
+            if (data === "[DONE]") continue;
+            let chunk: any;
+            try {
+              chunk = JSON.parse(data);
+            } catch {
+              continue;
+            }
+            const delta = chunk.choices?.[0]?.delta;
+            const contentDelta = typeof delta?.content === "string" ? delta.content : undefined;
+            const reasoningDelta = typeof delta?.reasoning_content === "string" ? delta.reasoning_content : undefined;
+            if (reasoningDelta) {
+              reasoning += reasoningDelta;
+              opts.onDelta?.(reasoningDelta, "reasoning_text");
+            }
+            if (contentDelta) {
+              text += contentDelta;
+              opts.onDelta?.(contentDelta, "assistant_text");
+            }
+            if (chunk.usage) {
+              usage = {
+                input: chunk.usage.prompt_tokens ?? 0,
+                output: chunk.usage.completion_tokens ?? 0,
+              };
+            }
+          }
+        }
+      } finally {
+        await reader.cancel().catch(() => {});
+      }
+      return { text, reasoning, usage };
+    };
+
+    const fetchModels = async (): Promise<void> => {
+      if (!apiKey) return;
+      try {
+        const res = await fetch(`${config.url}/models`, {
+          headers: { authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(8_000),
+        });
+        if (!res.ok) return;
+        const json: any = await res.json();
+        const rows: Array<{ id?: unknown; name?: unknown }> = Array.isArray(json)
+          ? json
+          : Array.isArray(json?.data)
+            ? json.data
+            : [];
+        const seen = new Set<string>();
+        const options: ModelCatalog["options"] = [];
+        for (const row of rows) {
+          const id = typeof row.id === "string" ? row.id : "";
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+          const label = typeof row.name === "string" && row.name.trim() ? row.name : id;
+          options.push({ id, label });
+        }
+        if (options.length) {
+          catalog = {
+            default: options.some((o) => o.id === MODELS.default) ? MODELS.default : options[0]?.id ?? MODELS.default,
+            options,
+          };
+        }
+      } catch {
+        // keep MODELS — never fail the instance on a catalog miss
+      }
+    };
+    if (apiKey) void fetchModels();
+
+    const sendTurn = async (turn: SendTurnInput) => {
+      const { threadId } = turn;
+      if (!apiKey) {
+        throw new Error(`no OrcaRouter key — set ${API_KEY_ENV} or add it to the instance config`);
+      }
+      if (active.has(threadId)) {
+        throw new Error("a turn is already running on this thread");
+      }
+
+      const turnId = newId();
+      const abort = new AbortController();
+      active.set(threadId, { abort, turnId });
+
+      const messages = [
+        ...(turn.system ? [{ role: "system", content: turn.system }] : []),
+        ...(turn.transcript ?? []).map((m) => ({
+          role: m.role === "assistant" ? "assistant" : "user",
+          content: m.text,
+        })),
+        { role: "user", content: turn.text },
+      ];
+
+      appendNative(threadId, {
+        dir: "out",
+        source: "orcarouter.chat.completions",
+        msg: { model: turn.model ?? catalog.default, messageCount: messages.length },
+      });
+
+      emit({ ...base(threadId, turnId), type: "turn.started" });
+      emit({ ...base(threadId, turnId), type: "session.started", sessionId: null, model: turn.model ?? catalog.default });
+
+      (async () => {
+        try {
+          const { text, reasoning, usage } = await complete(messages, turn.model || catalog.default, {
+            stream: true,
+            signal: abort.signal,
+            onDelta: (delta, streamKind = "assistant_text") =>
+              emit({ ...base(threadId, turnId), type: "content.delta", streamKind, delta }),
+          });
+
+          appendNative(threadId, {
+            dir: "in",
+            source: "orcarouter.chat.completions",
+            msg: { textLength: text.length, reasoningLength: reasoning.length, usage },
+          });
+
+          const replyText = text.trim() ? text : reasoning;
+          if (replyText.trim()) {
+            emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: replyText });
+          }
+          if (usage) {
+            emit({ ...base(threadId, turnId), type: "thread.token-usage.updated", ...usage });
+          }
+          active.delete(threadId);
+          const completed: RuntimeEvent = {
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: true,
+            stopReason: null,
+            cost: null,
+          };
+          emit(usage ? { ...completed, usage } : completed);
+        } catch (e) {
+          active.delete(threadId);
+          const error = e instanceof Error ? e : new Error(String(e));
+          const aborted = error.name === "AbortError";
+          if (!aborted) {
+            emit({ ...base(threadId, turnId), type: "runtime.error", message: error.message });
+          }
+          emit({
+            ...base(threadId, turnId),
+            type: "turn.completed",
+            ok: false,
+            stopReason: aborted ? "interrupted" : "error",
+            cost: null,
+          });
+        }
+      })();
+
+      return { turnId };
+    };
+
+    const snapshot = async (): Promise<ProviderSnapshot> => {
+      if (!apiKey) {
+        return {
+          state: "unavailable",
+          reason: `no OrcaRouter key — set ${API_KEY_ENV} or add it to the instance config`,
+        };
+      }
+      return { state: "available", authenticated: true, version: null, billing: "metered" };
+    };
+
+    return {
+      instanceId,
+      driverKind: DRIVER_KIND,
+      displayName: input.displayName,
+      enabled: input.enabled,
+      get models() {
+        return catalog;
+      },
+      refreshModels: fetchModels,
+      snapshot,
+      adapter: {
+        provider: DRIVER_KIND,
+        capabilities: { sessionModelSwitch: "in-session" },
+        sendTurn,
+        interruptTurn: async (threadId) => active.get(threadId)?.abort.abort(),
+        respondToRequest: async (): Promise<"unavailable"> => "unavailable",
+        hasSession: (threadId) => active.has(threadId),
+        stopAll: async () => { for (const { abort } of active.values()) abort.abort(); },
+        onEvent: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      generateText: async (prompt: string) => {
+        const { text, reasoning } = await complete([{ role: "user", content: prompt }], catalog.default, { stream: false });
+        return text.trim() ? text : reasoning;
+      },
+      dispose: async () => {
+        for (const { abort } of active.values()) abort.abort();
+        listeners.clear();
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What changed

Adds OrcaRouter as a first-class named provider driver, mirroring how the existing `openai-compat` / MiniMax API drivers plug into the driver registry. `server/drivers/orcarouter.ts` implements the same `ProviderDriver` SPI — OpenAI-compatible chat/completions with SSE streaming, `reasoning_content` passthrough, a live `/models` catalog — and registers in `builtIn.ts` plus the default fleet. `ORCAROUTER_API_KEY` is wired through `config.ts` exactly like `OPENAI_COMPAT_API_KEY` so the key reaches only the orcarouter instance.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How it was verified

- `pnpm typecheck` passes; `vitest run server/drivers/orcarouter.test.ts server/config.test.ts` — 69 passed
- Live-tested the driver against `api.orcarouter.ai/v1` with a real key: snapshot → available, `/models` returned 204 models, `generateText` and streaming `sendTurn` both returned 200 with token usage

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter — I'm an engineer on the OrcaRouter team.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a built-in provider option.
  * Added support for API key and custom endpoint configuration.
  * Added model discovery and model selection for OrcaRouter.
  * Added streaming responses with separate reasoning and assistant text.
  * Added usage reporting, interruption handling, and concurrent conversations.

* **Bug Fixes**
  * Ensured OrcaRouter credentials are applied only to the appropriate provider instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->