### PR TITLE
fix(chat): settle screenshots chain-insert at the turn instead of after your next message

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1750,10 +1750,19 @@ bus.subscribe((event: RuntimeEvent) => {
           // the screenshot-in-chat moment. One fresh capture first, so the
           // frame shows the turn's END state (the final tool's poke may
           // still be in flight).
+          //
+          // The capture is slow (a real screenshot round trip) and the bot
+          // is already idle, so a fast follow-up send or the steer-queue
+          // drain can land BEFORE the frame does. Anchor the frame to the
+          // turn's actual last message now, and chain-insert it there when
+          // it arrives — otherwise the user's next message ends up stranded
+          // above the screenshot (the browser-mode ordering bug).
+          const settleLeafId = store.activePath(event.threadId).at(-1)?.id;
           void finalScreenFrame(bot.id).then((frame) => {
             // the bot may have been deleted while the capture ran
             if (frame && store.bot(bot.id)) {
-              pushMessage({ role: "bot", kind: "screen", png: frame.png, mime: frame.mime });
+              if (group) pushMessage({ role: "bot", kind: "screen", png: frame.png, mime: frame.mime });
+              else store.insertMessageAfter(event.threadId, settleLeafId, { role: "bot", kind: "screen", png: frame.png, mime: frame.mime });
             }
           }).finally(clearVpsTurn);
         } else if (vpsTurn) {

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -98,6 +98,39 @@ describe("Store", () => {
     });
   });
 
+  it("chain-inserts a late turn artifact after its anchor without stealing the leaf", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const turnEnd = store.appendMessage(bot.threadId, { role: "bot", kind: "text", text: "done with the task" });
+    // the world moves on while the settle-time capture is still in flight
+    const followUp = store.appendMessage(bot.threadId, { role: "user", kind: "text", text: "next question" });
+    const patches: string[] = [];
+    store.onChange((change) => {
+      if (change.type === "message.patch") patches.push(change.message.id);
+    });
+
+    const artifact = store.insertMessageAfter(bot.threadId, turnEnd.id, { role: "bot", kind: "screen", png: "abc" });
+
+    const path = store.activePath(bot.threadId).map((m) => m.id);
+    // turn → artifact → follow-up: the user's message stays the last message
+    expect(path.slice(-3)).toEqual([turnEnd.id, artifact.id, followUp.id]);
+    expect(store.activePath(bot.threadId).at(-1)?.id).toBe(followUp.id);
+    expect(artifact.parentId).toBe(turnEnd.id);
+    // the re-parented child was announced so live clients converge
+    expect(patches).toContain(followUp.id);
+  });
+
+  it("insertMessageAfter is a plain append when the anchor is still the leaf, or unknown", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const turnEnd = store.appendMessage(bot.threadId, { role: "bot", kind: "text", text: "done" });
+    const artifact = store.insertMessageAfter(bot.threadId, turnEnd.id, { role: "bot", kind: "screen", png: "abc" });
+    expect(store.activePath(bot.threadId).at(-1)?.id).toBe(artifact.id); // became the leaf
+
+    const orphan = store.insertMessageAfter(bot.threadId, "no-such-message", { role: "bot", kind: "text", text: "x" });
+    expect(store.activePath(bot.threadId).at(-1)?.id).toBe(orphan.id);
+  });
+
   it("persists the per-bot composio gate", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -983,6 +983,34 @@ export class Store {
     return full;
   }
 
+  /** Insert a message into the active chain directly after `anchorId` — the
+   * home for turn artifacts that finish AFTER the world moved on (the
+   * settle-time screen capture races a fast follow-up send, which used to
+   * leave the user's message stranded above the screenshot). When the anchor
+   * is still the leaf this is a plain append; otherwise the anchor's
+   * children are re-parented onto the inserted message, so the transcript
+   * reads turn → artifact → follow-up and the leaf stays where it was. */
+  insertMessageAfter(threadId: string, anchorId: string | undefined, message: Omit<Message, "id" | "at">): Message {
+    const t = this.thread(threadId);
+    const anchorExists = anchorId !== undefined && t.messages.some((m) => m.id === anchorId);
+    if (!anchorExists || t.activeLeafId === anchorId) return this.appendMessage(threadId, message);
+    const full: Message = { id: newId(), at: Date.now(), ...redactBotAuthored(message), parentId: anchorId };
+    const children = t.messages.filter((m) => m.parentId === anchorId);
+    t.messages.push(full);
+    mdb.appendMessage(threadId, full);
+    if (full.kind === "screen") {
+      for (const pruned of this.pruneScreenFrames(t)) {
+        mdb.updateMessage(threadId, pruned);
+        this.emit({ type: "message.patch", threadId, message: pruned });
+      }
+    }
+    this.emit({ type: "message", threadId, message: full });
+    // announced after the insert so no client ever sees two siblings
+    // claiming the same parent
+    for (const child of children) this.patchMessage(threadId, child.id, { parentId: full.id });
+    return full;
+  }
+
   /** Hide the first-run quiz on this thread, if it is still open. */
   dismissOnboardingCard(threadId: string): Message | null {
     const t = this.thread(threadId);

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -660,3 +660,36 @@ describe("pending queued chip", () => {
     expect(cancelled.pendingQueued).toEqual({});
   });
 });
+
+describe("messageAdded leaf adoption", () => {
+  const baseBot = {
+    id: "bot-1",
+    threadId: "thread-1",
+    messages: [
+      { id: "m1", at: 1, role: "bot", kind: "text", text: "turn done" },
+      { id: "m2", at: 2, parentId: "m1", role: "user", kind: "text", text: "next question" },
+    ],
+    activeLeafId: "m2",
+  } as never as Bot;
+  const state = { ...initialState, bots: [baseBot] };
+
+  it("adopts the leaf for a message chaining onto it", () => {
+    const next = reducer(state, {
+      type: "messageAdded",
+      threadId: "thread-1",
+      message: { id: "m3", at: 3, parentId: "m2", role: "bot", kind: "text", text: "reply" } as never as Message,
+    });
+    expect(next.bots[0].activeLeafId).toBe("m3");
+  });
+
+  it("keeps the leaf when a late artifact is chain-inserted mid-branch", () => {
+    // the settle-time screenshot arrives parented to m1 while m2 is the leaf
+    const next = reducer(state, {
+      type: "messageAdded",
+      threadId: "thread-1",
+      message: { id: "shot", at: 3, parentId: "m1", role: "bot", kind: "screen", png: "x" } as never as Message,
+    });
+    expect(next.bots[0].activeLeafId).toBe("m2"); // the user's message stays the tail
+    expect(next.bots[0].messages.map((m) => m.id)).toContain("shot");
+  });
+});

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -934,6 +934,11 @@ export function reducer(state: AppState, action: Action): AppState {
       if (bot.messages.some((message) => message.id === action.message.id)) return state;
       // every server-side append chains onto (and becomes) the active leaf
       const next = updateBot(state, bot.id, (b) => {
+        // A message chains onto the leaf → it becomes the leaf (the normal
+        // append). A message parented elsewhere is a chain-insert of a late
+        // turn artifact (settle-time screenshot) — the leaf must stay put,
+        // or the follow-up send it raced would fall off the active branch.
+        const adoptsLeaf = (action.message.parentId ?? null) === (b.activeLeafId ?? null);
         let messages = [...b.messages, action.message];
         // base64 screen frames are big; a long computer-use session would
         // grow memory without bound. Keep the newest few frames' pixels and
@@ -946,7 +951,7 @@ export function reducer(state: AppState, action: Action): AppState {
             messages = messages.map((m) => (dropIds.has(m.id) ? { ...m, png: undefined } : m));
           }
         }
-        return { ...b, messages, activeLeafId: action.message.id };
+        return { ...b, messages, activeLeafId: adoptsLeaf ? action.message.id : b.activeLeafId };
       });
       const motion =
         action.message.kind === "options"


### PR DESCRIPTION
## What changed

- `server/index.ts` turn.completed fold: the settle-time screen capture records the turn's real last message (`store.activePath(...).at(-1)`) **before** the async capture, and delivers the frame via chain-insert instead of a plain append.
- `server/store.ts`: new `insertMessageAfter(threadId, anchorId, message)` — plain append when the anchor is still the leaf (or unknown); otherwise the artifact is parented to the anchor and the anchor's children are re-parented onto it, announced as `message` + `message.patch` so live clients converge. Screen-frame pruning still applies.
- `src/state/store.tsx`: `messageAdded` adopts the incoming message as `activeLeafId` **only when it chains onto the current leaf** — a mid-branch insert leaves the leaf (the user's follow-up) in place.

## Why

Field report: with browser mode on, a message sent right after a turn appeared **above** the last message. Root cause: `void finalScreenFrame(...).then(pushMessage)` runs after `busy` clears, so a quick send (or the steer-queue drain) appends first and the screenshot then chains after it — and browser/computer turns end with that capture, making it near-deterministic.

After: the transcript reads `turn → screenshot → your message`, and your message stays the tail.

## How it was verified

- `server/store.test.ts`: mid-chain insert yields `anchor → artifact → follow-up` with the leaf preserved and the re-parent announced; anchor-still-leaf and unknown-anchor degrade to plain appends.
- `src/state/store.test.ts`: reducer keeps the leaf for a mid-branch insert, adopts it for a chaining message.
- Mutation check: forcing the plain-append path fails the chain-insert test.
- `pnpm typecheck` clean; lint parity with main on every touched file.
- Rebased onto current main (0.1.40): the reducer's new early duplicate-return kept; only the leaf-adoption rule grafted in.

## Known scope cut

Room threads render by array order, not parent chains, so a room's settle frame keeps the old append (noted in the fold comment).

## Checklist

- [x] `pnpm typecheck` and the touched test files pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits · no macOS-only code · no `shell: true` · no secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed final screenshots occasionally appearing above a user’s follow-up message during fast responses.
  * Preserved the active conversation branch when late screenshots or other artifacts arrive.
  * Improved transcript consistency across live clients when messages are inserted into an existing conversation chain.
* **Tests**
  * Added coverage for message ordering, branch updates, and late-arriving screenshot handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->