### PR TITLE
Queued sends as ghost transcript rows + duty-cycled working indicators

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -12,7 +12,6 @@ import {
   Crown,
   Folder,
   ListTree,
-  Loader2,
   Monitor,
   MessageSquareReply,
   Pencil,
@@ -24,6 +23,7 @@ import {
   Webhook,
   X,
 } from "lucide-react";
+import { WorkingDots } from "@/components/WorkingIndicator";
 import { cachedInput, costCaption, formatTokens, formatUsd, hasFiniteCost, usageChip, usageDetail } from "@/lib/usage";
 import {
   useStore,
@@ -131,7 +131,7 @@ function TaskTimeline({ messages, busy }: { messages: Message[]; busy: boolean }
                     : event.state === "complete"
                       ? "bg-success"
                       : event.state === "running"
-                        ? "animate-pulse bg-accent"
+                        ? "animate-status-pulse bg-accent"
                         : "bg-ink-secondary",
                 )}
               />
@@ -508,22 +508,6 @@ function Bubble({
           {formatTime(message.at)}
         </span>
       </div>
-      {/* busy-gated so a flag stranded by a server restart shows nothing */}
-      {user && message.queued && bot.busy && (
-        <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
-          <Clock size={11} aria-hidden="true" />
-          <span>Queued — sends when this turn finishes</span>
-          <button
-            type="button"
-            onClick={() => dispatch({ type: "cancelQueued", botId: bot.id, queueId: message.queueId ?? message.id })}
-            aria-label="Cancel queued message"
-            title="Cancel queued message"
-            className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
-          >
-            <X size={11} strokeWidth={2.5} />
-          </button>
-        </div>
-      )}
       <ReactionChips threadId={bot.threadId} message={message} align={user ? "right" : "left"} />
       {versions.length > 1 && (
         <div className="mt-1 flex items-center gap-0.5 pr-1 text-[12px] text-ink-secondary">
@@ -584,7 +568,7 @@ function ActivityChip({ message }: { message: Message }) {
         )}
       >
         {tool.ok === undefined ? (
-          <Loader2 size={13} className="animate-spin" />
+          <WorkingDots size={3.5} />
         ) : failed ? (
           <X size={13} />
         ) : (
@@ -927,6 +911,12 @@ export function ChatView({ bot }: { bot: Bot }) {
     return () => clearTimeout(timer);
   }, [lastMessage?.id, lastMessage?.role, lastMessage?.kind, lastMessage?.text]);
   const presenceVisible = waiting || popping !== null;
+  // Wall-clock anchor for the working row's elapsed readout — set when the
+  // turn starts, cleared when it settles, reset on bot switch.
+  const [busySince, setBusySince] = useState<number | null>(null);
+  useEffect(() => {
+    setBusySince(bot.busy ? Date.now() : null);
+  }, [bot.busy, bot.id]);
 
   // regenerate = fork the last user message with the same text — reuses the
   // existing branch machinery, so the old answer stays reachable via ‹ ›
@@ -1009,11 +999,13 @@ export function ChatView({ bot }: { bot: Bot }) {
     setTranscriptWindow((w) => ({ ...w, end: nextEnd >= messages.length ? null : nextEnd }));
   };
 
-  // keyboard is a scroll gesture too (upstream lesson): PageUp/Home break
-  // follow like an upward wheel; the at-end onScroll check re-arms it
+  // keyboard is a scroll gesture too (upstream lesson): PageUp/Home/ArrowUp
+  // break follow like an upward wheel; the at-end onScroll check re-arms it.
+  // ArrowUp only counts outside inputs — in the composer it edits, not scrolls.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "PageUp" || (e.key === "Home" && !(e.target instanceof HTMLTextAreaElement))) {
+      const typing = e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement;
+      if (e.key === "PageUp" || ((e.key === "Home" || e.key === "ArrowUp") && !typing)) {
         setBottomFollow(false);
       }
     };
@@ -1075,7 +1067,7 @@ export function ChatView({ bot }: { bot: Bot }) {
               <Crown size={11} /> Chief of Staff
             </span>
           )}
-          {bot.busy && <Loader2 size={14} className="animate-spin text-ink-secondary" />}
+          {bot.busy && <WorkingDots className="text-ink-secondary" />}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <button
@@ -1164,7 +1156,13 @@ export function ChatView({ bot }: { bot: Bot }) {
       <div className="relative min-h-0 flex-1">
       <div
         ref={scrollRef}
-        className="h-full overflow-x-hidden overflow-y-auto px-5 [overflow-anchor:none]"
+        className="h-full overflow-x-hidden overflow-y-auto overscroll-y-contain px-5 [overflow-anchor:none]"
+        onPointerDown={(e) => {
+          // grabbing the scrollbar is a scroll gesture too — the lane lives
+          // past the content box (clientWidth excludes it)
+          const el = scrollRef.current;
+          if (el && e.target === el && e.nativeEvent.offsetX >= el.clientWidth) setBottomFollow(false);
+        }}
         onWheel={(e) => {
           if (e.deltaY < 0) setBottomFollow(false);
           else if (atEnd()) setBottomFollow(true);
@@ -1234,7 +1232,7 @@ export function ChatView({ bot }: { bot: Bot }) {
           {provisioning && (
             <div className="flex justify-start">
               <div className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary">
-                <Loader2 size={13} className="animate-spin" />
+                <WorkingDots size={3.5} />
                 Setting up this bot's computer…
               </div>
             </div>
@@ -1253,6 +1251,7 @@ export function ChatView({ bot }: { bot: Bot }) {
             visible={presenceVisible}
             label={activityLabel}
             answering={popping !== null}
+            since={busySince}
           >
             {popping ? (
               <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed text-ink">
@@ -1262,6 +1261,33 @@ export function ChatView({ bot }: { bot: Bot }) {
               </div>
             ) : null}
           </TurnPresence>
+          {/* Ghost tail: 1:1 sends made mid-turn wait in the server's steer
+              queue and stay off the transcript until drain (they must never
+              become the active leaf). These rows are that queue made visible,
+              in send order, each with its own cancel. */}
+          {bot.busy &&
+            (state.pendingQueued[bot.threadId] ?? []).map((entry) => (
+              <div key={entry.queueId} className="flex flex-col items-end">
+                <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl border border-dashed border-hairline/70 bg-panel/60 px-4 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap text-ink-secondary">
+                  {entry.text}
+                </div>
+                <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
+                  <Clock size={11} aria-hidden="true" />
+                  <span>Queued — sends when this turn finishes</span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      dispatch({ type: "cancelQueued", botId: bot.id, queueId: entry.queueId })
+                    }
+                    aria-label="Cancel queued message"
+                    title="Cancel queued message"
+                    className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
+                  >
+                    <X size={11} strokeWidth={2.5} />
+                  </button>
+                </div>
+              </div>
+            ))}
         </div>
       </div>
 

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -348,11 +348,10 @@ export function Composer({
     },
     [draftId, restoreDraft],
   );
-  const pendingChip = group
-    ? queued?.text
-    : bot
-      ? state.pendingQueued?.[bot.threadId]?.map((entry) => entry.text).join("\n")
-      : undefined;
+  // 1:1 queued sends render as ghost rows in the transcript tail (each with
+  // its own cancel); the composer chip remains only for rooms, whose queue
+  // is local to this component.
+  const pendingChip = group ? queued?.text : undefined;
   // a chip on its own is a message: the send control has to appear for it
   const fileInput = useRef<HTMLInputElement>(null);
   const [autoWarn, setAutoWarn] = useState(false);
@@ -580,16 +579,7 @@ export function Composer({
             </span>
             <button
               type="button"
-              onClick={() => {
-                if (group) {
-                  clearQueued();
-                  return;
-                }
-                if (!bot) return;
-                for (const entry of state.pendingQueued?.[bot.threadId] ?? []) {
-                  dispatch({ type: "cancelQueued", botId: bot.id, queueId: entry.queueId });
-                }
-              }}
+              onClick={clearQueued}
               aria-label="Cancel queued message"
               title="Cancel queued message"
               className="ml-auto flex size-5 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"

--- a/src/components/TurnPresence.tsx
+++ b/src/components/TurnPresence.tsx
@@ -3,18 +3,22 @@
 // the full bubble pops in above the mascot (same left edge).
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/cn";
+import { WorkingTimer } from "@/components/WorkingIndicator";
 
 export function TurnPresence({
   avatar,
   visible,
   label = "Thinking",
   answering = false,
+  since = null,
   children,
 }: {
   avatar: ReactNode;
   visible: boolean;
   label?: string;
   answering?: boolean;
+  /** Turn start (epoch ms) — shows a self-ticking elapsed readout while working. */
+  since?: number | null;
   children?: ReactNode;
 }) {
   const [mounted, setMounted] = useState(visible);
@@ -56,8 +60,13 @@ export function TurnPresence({
       >
         {avatar}
         {showWorking ? (
-          <span className="thinking-shimmer animate-shimmer text-[13px] leading-none" aria-live="polite">
-            {label}
+          <span className="flex items-baseline gap-2 leading-none">
+            <span className="thinking-shimmer animate-shimmer text-[13px]" aria-live="polite">
+              {label}
+            </span>
+            {since !== null && (
+              <WorkingTimer since={since} className="text-[11.5px] text-ink-secondary/70" />
+            )}
           </span>
         ) : null}
       </div>

--- a/src/components/WorkingIndicator.tsx
+++ b/src/components/WorkingIndicator.tsx
@@ -1,0 +1,35 @@
+// Duty-cycled activity indicators. A spinner repaints every vsync for its
+// whole lifetime; these dots step through a few opacity holds per cycle,
+// and the timer mutates its own text node once a second instead of
+// committing through React. Long-lived indicators must stay this cheap.
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/cn";
+import { formatElapsed } from "@/lib/working-time";
+
+export function WorkingDots({ size = 4, className }: { size?: number; className?: string }) {
+  return (
+    <span className={cn("flex items-center gap-1", className)} aria-hidden="true">
+      {[0, 200, 400].map((delay) => (
+        <span
+          key={delay}
+          className="animate-status-pulse rounded-full bg-current"
+          style={{ width: size, height: size, animationDelay: `${delay}ms` }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/** Self-ticking elapsed readout — counts up from `since` (epoch ms). */
+export function WorkingTimer({ since, className }: { since: number; className?: string }) {
+  const node = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    const tick = () => {
+      if (node.current) node.current.textContent = formatElapsed(Date.now() - since);
+    };
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [since]);
+  return <span ref={node} className={cn("tabular-nums", className)} />;
+}

--- a/src/lib/working-time.test.ts
+++ b/src/lib/working-time.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatElapsed } from "./working-time";
+
+describe("formatElapsed", () => {
+  it("counts whole seconds below a minute", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(999)).toBe("0s");
+    expect(formatElapsed(42_000)).toBe("42s");
+    expect(formatElapsed(59_999)).toBe("59s");
+  });
+
+  it("switches to zero-padded minutes at 60s", () => {
+    expect(formatElapsed(60_000)).toBe("1m 00s");
+    expect(formatElapsed(125_000)).toBe("2m 05s");
+    expect(formatElapsed(3_600_000)).toBe("60m 00s");
+  });
+
+  it("clamps clock skew to zero instead of going negative", () => {
+    expect(formatElapsed(-5_000)).toBe("0s");
+  });
+});

--- a/src/lib/working-time.ts
+++ b/src/lib/working-time.ts
@@ -1,0 +1,8 @@
+/** Elapsed wall-clock as a compact human string: 42s, 1m 05s, 12m 40s. */
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,6 +27,7 @@
   --animate-caret: caret-blink 1s step-end infinite;
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-shimmer: shimmer 2s linear infinite;
+  --animate-status-pulse: status-pulse 1.6s steps(2, jump-none) infinite;
 
   /* Defaults = Midnight. Kept here so the app is never unstyled. */
   --color-app: #070707;
@@ -381,6 +382,14 @@ body {
   0%, 100% { opacity: 0.45; }
   50% { opacity: 1; }
 }
+/* Long-lived activity dots: steps() + holds draw a handful of compositor
+   frames per cycle instead of one per vsync. Indicators that run for
+   minutes must not continuously repaint; stagger via animation-delay. */
+@keyframes status-pulse {
+  0%, 100% { opacity: 0.25; }
+  30% { opacity: 1; }
+  60% { opacity: 0.25; }
+}
 .thinking-shimmer {
   background: linear-gradient(90deg, var(--color-ink-secondary) 40%, var(--color-ink) 50%, var(--color-ink-secondary) 60%);
   background-size: 200% 100%;
@@ -390,6 +399,7 @@ body {
 }
 @media (prefers-reduced-motion: reduce) {
   .animate-caret, .animate-msg-in, .animate-shimmer { animation: none; }
+  .animate-status-pulse { animation: none; opacity: 0.6; }
   .thinking-shimmer { background: none; color: var(--color-ink-secondary); }
   .turn-mascot-in, .turn-mascot-out, .turn-answer { animation: none; }
   /* The drawer still moves, it just arrives instantly. */


### PR DESCRIPTION
## What

Chat-surface polish around how a busy turn looks and how mid-turn sends are shown:

1. **Queued sends are now visible in the transcript.** A 1:1 message sent while the bot is busy waits in the server steer queue and — by design — must stay off the transcript until drain (it must never become the active leaf mid-turn). Until now the only trace was a chip above the composer. The queue is now rendered as ghost rows at the transcript tail: dashed right-aligned bubbles in send order, each with a "Queued — sends when this turn finishes" caption and its own cancel. The composer chip remains only for rooms, whose queue is local to the composer.
2. **Duty-cycled activity indicators.** Continuous `animate-spin` / `animate-pulse` repaint every vsync for the whole life of a turn. New `status-pulse` keyframes use `steps()` + long opacity holds (a handful of compositor frames per cycle), driving a three-dot `WorkingDots` cluster that replaces the header spinner, the tool-chip spinner, the provisioning spinner, and the task-timeline pulse. Reduced-motion gets a static dot.
3. **Working timer.** The mascot's shimmer label now carries a self-ticking elapsed readout (`42s`, `1m 05s`). It mutates its own text node once a second instead of committing through React.
4. **Follow-break parity for the remaining scroll gestures.** Grabbing the scrollbar lane (pointerdown past `clientWidth`) and `ArrowUp` outside inputs now break bottom-follow the same way wheel-up / PageUp / Home already did, and the scroller gets `overscroll-y-contain` so an overscrolled trackpad doesn't chain to the page.

Also removes the dead `message.queued` caption in `MessageRow` — the server has not set that flag on transcript messages since steering moved to the memory queue, so the block could never render.

## Why

Follow-up to #578: the ordering fix put late artifacts in the right place; this makes the queue itself visible so a mid-turn send never looks lost, and brings the long-lived indicators in line with a no-continuous-repaint rule.

## How verified

- `tsc --noEmit` clean; full suite green (232 files, 2515 tests) including new `formatElapsed` unit tests.
- Mutation check: dropping the `padStart` in `formatElapsed` fails the minutes test.
- Lint parity with `origin/main`: 1866 → 1866 total, and every touched file has identical per-file counts (the 4 pre-existing `Composer.tsx` hits are untouched lines).

## Scope notes

- Rooms keep their existing composer-chip queue (it is component-local, not server-steered); giving rooms ghost rows is a separate change.
- `TurnPresence` gains an optional `since` prop; the rooms surface passes nothing and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated working indicators and elapsed-time displays for active tasks.
  * Queued one-to-one messages now appear in the conversation with individual cancel controls.
  * Improved chat scrolling behavior, including scrollbar interaction and keyboard navigation.
* **Bug Fixes**
  * Refined queued-message handling so composer indicators are limited to room conversations.
  * Added reduced-motion support for activity animations.
* **Tests**
  * Added coverage for elapsed-time formatting across short, long, zero, and negative durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->