### PR TITLE
fix(browser): keep compact viewport stable

### DIFF
--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -495,6 +495,16 @@ function createBrowserSurfaceManager({
     };
   };
 
+  const sameBounds = (left, right) =>
+    Boolean(
+      left &&
+        right &&
+        left.x === right.x &&
+        left.y === right.y &&
+        left.width === right.width &&
+        left.height === right.height,
+    );
+
   const emitState = (entry) => {
     if (active.get(entry.botId) === entry) emit(stateFor(entry));
   };
@@ -858,6 +868,7 @@ function createBrowserSurfaceManager({
       visible: false,
       bounds: null,
       mode: null,
+      emulationKey: null,
       refs: null,
       refKind: "ax",
       refIntegrity: null,
@@ -1320,6 +1331,9 @@ function createBrowserSurfaceManager({
     entry.mode = mode;
     if (mode === "compact" && entry.bounds) {
       const scale = Math.min(entry.bounds.width / VIEWPORT.width, entry.bounds.height / VIEWPORT.height);
+      const boundedScale = Math.max(0.1, Math.min(1, scale));
+      const emulationKey = `compact:${boundedScale}`;
+      if (entry.emulationKey === emulationKey) return;
       try {
         contents.enableDeviceEmulation({
           screenPosition: "desktop",
@@ -1327,12 +1341,15 @@ function createBrowserSurfaceManager({
           viewPosition: { x: 0, y: 0 },
           deviceScaleFactor: 0,
           viewSize: { ...VIEWPORT },
-          scale: Math.max(0.1, Math.min(1, scale)),
+          scale: boundedScale,
         });
+        entry.emulationKey = emulationKey;
       } catch {}
     } else {
+      if (entry.emulationKey === "expanded") return;
       try {
         contents.disableDeviceEmulation();
+        entry.emulationKey = "expanded";
       } catch {}
     }
   };
@@ -1679,17 +1696,23 @@ function createBrowserSurfaceManager({
       if (bounds === null || bounds === undefined) {
         const entry = active.get(botIdOf(botId));
         if (!entry) return closedState(botIdOf(botId));
-        entry.visible = false;
-        entry.view.setVisible(false);
+        if (entry.visible) {
+          entry.visible = false;
+          entry.view.setVisible(false);
+        }
         return stateFor(entry);
       }
       const entry = ensure(botId, profile);
       const normalized = normalizeDesktopWorkspaceBounds(bounds, owner.getContentSize());
-      entry.bounds = normalized;
-      entry.view.setBounds(normalized);
+      if (!sameBounds(entry.bounds, normalized)) {
+        entry.bounds = normalized;
+        entry.view.setBounds(normalized);
+      }
       applyMode(entry, mode === "expanded" ? "expanded" : "compact");
-      entry.visible = true;
-      entry.view.setVisible(true);
+      if (!entry.visible) {
+        entry.visible = true;
+        entry.view.setVisible(true);
+      }
       return stateFor(entry);
     },
 

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -158,11 +158,15 @@ function fakeView(partition) {
     webContents,
     bounds: null,
     visible: null,
+    setBoundsCalls: [],
+    setVisibleCalls: [],
     setBounds: (bounds) => {
       view.bounds = bounds;
+      view.setBoundsCalls.push(bounds);
     },
     setVisible: (visible) => {
       view.visible = visible;
+      view.setVisibleCalls.push(visible);
     },
     getBounds: () => view.bounds ?? { x: 0, y: 0, width: 800, height: 600 },
     calls,
@@ -338,6 +342,38 @@ describe("browser surface manager", () => {
     manager.layout("bot-a", { x: 0, y: 0, width: 1100, height: 700 }, "", "expanded");
     expect(views[0].calls.at(-1)).toEqual(["disableDeviceEmulation"]);
     expect(manager.state("bot-a").mode).toBe("expanded");
+  });
+
+  it("does not reapply unchanged bounds, visibility, or compact emulation", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    const view = views[0];
+    const initialBoundsCalls = view.setBoundsCalls.length;
+    const initialVisibleCalls = view.setVisibleCalls.length;
+    const initialEmulationCalls = view.calls.filter(([name]) => name === "enableDeviceEmulation").length;
+
+    manager.layout("bot-a", { ...BOUNDS }, "", "compact");
+    manager.layout("bot-a", { ...BOUNDS }, "", "compact");
+
+    expect(view.setBoundsCalls).toHaveLength(initialBoundsCalls);
+    expect(view.setVisibleCalls).toHaveLength(initialVisibleCalls);
+    expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(initialEmulationCalls);
+  });
+
+  it("moves without resetting emulation and reapplies it only when compact scale changes", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    const view = views[0];
+
+    manager.layout("bot-a", { ...BOUNDS, x: 80, y: 90 }, "", "compact");
+    expect(view.setBoundsCalls.at(-1)).toEqual({ ...BOUNDS, x: 80, y: 90 });
+    expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(1);
+
+    manager.layout("bot-a", { ...BOUNDS, x: 80, y: 90, width: 320 }, "", "compact");
+    const emulationCalls = view.calls.filter(([name]) => name === "enableDeviceEmulation");
+    expect(emulationCalls).toHaveLength(2);
+    expect(emulationCalls.at(-1)[1].viewSize).toEqual(VIEWPORT);
+    expect(emulationCalls.at(-1)[1].scale).toBeCloseTo(0.25, 4);
   });
 
   it("navigates only to web pages and answers with the page's elements plus a scroll hint", async () => {

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -71,6 +71,24 @@ function mutationAffectsOverlay(record: MutationRecord): boolean {
   );
 }
 
+function sameSurfaceState(left: BrowserSurfaceState | null, right: BrowserSurfaceState): boolean {
+  return Boolean(
+    left &&
+      left.botId === right.botId &&
+      left.open === right.open &&
+      left.url === right.url &&
+      left.title === right.title &&
+      left.loading === right.loading &&
+      left.canGoBack === right.canGoBack &&
+      left.canGoForward === right.canGoForward &&
+      left.visible === right.visible &&
+      left.partition === right.partition &&
+      left.profile === right.profile &&
+      left.mode === right.mode &&
+      left.code === right.code,
+  );
+}
+
 /** "Work Microsoft" → "work-microsoft"; collisions get a numeric suffix. */
 export function profileIdFor(name: string, taken: BrowserProfile[]): string {
   const base = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 32) || "profile";
@@ -134,6 +152,9 @@ export function BrowserPanel({
   const [addingProfile, setAddingProfile] = useState(false);
   const [newProfileName, setNewProfileName] = useState("");
   const [profileBusy, setProfileBusy] = useState(false);
+  const acceptSurface = useCallback((next: BrowserSurfaceState) => {
+    setSurface((current) => (sameSurfaceState(current, next) ? current : next));
+  }, []);
   const botId = bot.id;
   const profiles = state.config?.browserProfiles ?? [];
   // a profile that was deleted falls back to the bot's own session; Guest is
@@ -162,7 +183,7 @@ export function BrowserPanel({
       bridge
         .layout(botId, target, activePartition, size)
         .then((next) => {
-          if (alive) setSurface(next);
+          if (alive) acceptSurface(next);
         })
         .catch((cause) => {
           if (alive) setError(cause instanceof Error ? cause.message : String(cause));
@@ -202,14 +223,14 @@ export function BrowserPanel({
       // but nothing may paint over the chat.
       void bridge.layout(botId, null).catch(() => {});
     };
-  }, [bridge, botId, pageVisible, activePartition, size]);
+  }, [bridge, botId, pageVisible, activePartition, size, acceptSurface]);
 
   useEffect(() => {
     if (!bridge) return;
     return bridge.onState((next) => {
-      if (next.botId === botId) setSurface(next);
+      if (next.botId === botId) acceptSurface(next);
     });
-  }, [bridge, botId]);
+  }, [bridge, botId, acceptSurface]);
 
   useEffect(() => {
     // Keep the synchronous guard set until React has folded the successful


### PR DESCRIPTION
## What changed
- avoid resetting WebContentsView bounds and visibility when layout is unchanged
- apply compact device emulation only when its effective scale changes
- ignore identical browser-surface snapshots in the React panel
- add regressions for repeated layout events, movement, and real size changes

## Validation
- 75 browser-related tests pass
- TypeScript typecheck passes
- production build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary browser view updates when layout, visibility, or emulation settings remain unchanged.
  * Preserved browser view state when views are hidden or repositioned.
  * Prevented redundant interface state updates when no values have changed.

* **Tests**
  * Added coverage for repeated layouts, view movement, visibility changes, and compact-mode scaling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->