### PR TITLE
Routines proposed for another bot now schedule on that bot

### DIFF
--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -395,6 +395,21 @@ describe("agents-proxy MCP surface", () => {
     expect(res.result.isError).toBeFalsy();
   });
 
+  it("forwards for_bot_id when the routine is for another bot", async () => {
+    lastRoutineRequestBody = null;
+    const res = await callTool("propose_routine", {
+      name: "Teammate brief",
+      instructions: "Summarize for the teammate.",
+      schedule: { type: "weekly", time: "08:00", weekdays: ["tuesday"] },
+      for_bot_id: "bot-helper",
+    });
+    expect(lastRoutineRequestBody.forBotId).toBe("bot-helper");
+    // the target rides beside the routine definition, never inside it
+    expect(lastRoutineRequestBody.routine).not.toHaveProperty("forBotId");
+    expect(lastRoutineRequestBody.routine).not.toHaveProperty("for_bot_id");
+    expect(res.result.isError).toBeFalsy();
+  });
+
   it("proposes a one-time routine with the explicit-offset timestamp intact", async () => {
     await callTool("propose_routine", {
       name: "Send follow-up",

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -283,11 +283,18 @@ const TOOLS = [
   {
     name: "propose_routine",
     description:
-      "Prepare a new routine after the user explicitly asks to schedule recurring or future work. Call list_routines first for relative dates or times so you use its authoritative current time and timezone. This only creates a durable confirmation card; it does NOT enable the routine. Resolve ambiguous dates, times, timezone, destination, or instructions with the user first, and always give one-time schedules an explicit RFC3339 offset. After calling it, end the turn and do not claim the routine exists until the user confirms the card.",
+      "Prepare a new routine after the user explicitly asks to schedule recurring or future work. Call list_routines first for relative dates or times so you use its authoritative current time and timezone. This only creates a durable confirmation card; it does NOT enable the routine. Resolve ambiguous dates, times, timezone, destination, or instructions with the user first, and always give one-time schedules an explicit RFC3339 offset. After calling it, end the turn and do not claim the routine exists until the user confirms the card. If the user asks for the routine to run as ANOTHER bot in your section, call list_bots and pass that bot's id as for_bot_id.",
     inputSchema: {
       type: "object",
       additionalProperties: false,
-      properties: ROUTINE_FIELDS_SCHEMA,
+      properties: {
+        ...ROUTINE_FIELDS_SCHEMA,
+        for_bot_id: {
+          type: "string",
+          description:
+            "Only when the user asks to schedule this routine for ANOTHER bot in your section: that bot's id from list_bots. Omit to schedule it for yourself. The routine then belongs to that bot and each run uses its engine and permissions.",
+        },
+      },
       required: ["name", "instructions", "schedule"],
     },
   },
@@ -500,6 +507,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     if (!routine.name || !routine.instructions || !routine.schedule) {
       return { text: "propose_routine needs name, instructions, and schedule.", isError: true };
     }
+    const forBotId = String(args.for_bot_id ?? "").trim();
     const r = await api("/api/internal/routine-requests", {
       method: "POST",
       body: JSON.stringify({
@@ -507,6 +515,8 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
         fromThreadId: THREAD_ID,
         action: "create",
         routine,
+        // JSON.stringify drops the key entirely when no target was named
+        forBotId: forBotId || undefined,
       }),
     });
     return confirmationResult(r, `the new routine “${routine.name}”`);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3660,6 +3660,62 @@ describe("harness HTTP API", () => {
       expect((await api("GET", "/api/routines")).body.routines
         .filter((routine: { botId: string }) => routine.botId === bot.id)).toHaveLength(1);
 
+      // A routine proposed "for another bot" binds to that bot, not the sender.
+      const badTarget = await fetch(`${BASE}/api/internal/routine-requests`, {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({
+          fromBotId: bot.id,
+          fromThreadId: bot.threadId,
+          action: "create",
+          forBotId: "bot-that-does-not-exist",
+          routine: {
+            name: "Nowhere brief",
+            instructions: "Should never be scheduled.",
+            schedule: { type: "weekly", time: "09:00", weekdays: ["monday"] },
+            runOn: "maus",
+          },
+        }),
+      });
+      expect(badTarget.status).toBe(404);
+      expect(z.object({ error: z.string() }).parse(await badTarget.json()).error).toMatch(/list_bots/);
+
+      const teammate = (await api("POST", "/api/bots", {})).body.bot;
+      const crossProposed = await fetch(`${BASE}/api/internal/routine-requests`, {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({
+          fromBotId: bot.id,
+          fromThreadId: bot.threadId,
+          action: "create",
+          forBotId: teammate.id,
+          routine: {
+            name: "Teammate brief",
+            instructions: "Summarize for the teammate every weekday.",
+            schedule: { type: "weekly", time: "08:30", weekdays: ["monday"] },
+            runOn: "maus",
+            durationMinutes: 30,
+          },
+        }),
+      });
+      expect(crossProposed.status).toBe(201);
+      const crossProposal = z.object({ requestId: z.string() }).passthrough().parse(await crossProposed.json());
+      // the card is confirmed in the proposer's conversation and says who it is for
+      const crossState = (await api("GET", "/api/bots")).body;
+      const crossCard = crossState.bots
+        .find((candidate: { id: string }) => candidate.id === bot.id)
+        ?.messages.find((message: { card?: { requestId?: string } }) => message.card?.requestId === crossProposal.requestId);
+      expect(crossCard?.card.title).toContain(`for @${teammate.name}`);
+      const crossConfirmed = await api("POST", `/api/threads/${bot.threadId}/respond`, {
+        requestId: crossProposal.requestId,
+        behavior: "allow",
+      });
+      expect(crossConfirmed).toMatchObject({ status: 200, body: { routineAction: "create" } });
+      const crossRoutine = (await api("GET", "/api/routines")).body.routines
+        .find((routine: { id: string }) => routine.id === crossConfirmed.body.resultId);
+      expect(crossRoutine).toMatchObject({ botId: teammate.id, sourceThreadId: bot.threadId });
+      await api("DELETE", `/api/bots/${teammate.id}`);
+
       // The initial fixture turn is deliberately hung. Once it is stopped,
       // force a deterministic dispatch failure by choosing the configured
       // but unavailable ghost provider. The execution stays detached, while one source card is

--- a/server/index.ts
+++ b/server/index.ts
@@ -564,7 +564,7 @@ const routineRequestSourceSchema = {
   fromThreadId: z.string().min(1).max(128),
 };
 const routineRequestEnvelopeSchema = z.discriminatedUnion("action", [
-  z.object({ ...routineRequestSourceSchema, action: z.literal("create"), routine: z.unknown() }).strict(),
+  z.object({ ...routineRequestSourceSchema, action: z.literal("create"), routine: z.unknown(), forBotId: z.unknown().optional() }).strict(),
   z.object({
     ...routineRequestSourceSchema,
     action: z.literal("update"),
@@ -2809,6 +2809,17 @@ const routineRequests = new RoutineRequestService({
   routines,
   cloudReady: cloudRoutineReadiness,
   canPersist: routineProposalPersistence,
+  // Cross-bot routines: the confirmation card can sit open indefinitely, so
+  // the target is re-authorized when the user confirms, not just at proposal.
+  validateTarget: (proposerBotId, target) => {
+    const proposer = store.bot(proposerBotId);
+    const targetBot = store.bot(target.botId);
+    if (!targetBot) return `@${target.name} no longer exists, so this routine cannot be scheduled for it`;
+    if (!proposer || sectionKey(targetBot.section) !== sectionKey(proposer.section)) {
+      return `@${target.name} is no longer in this section, so this routine cannot be scheduled for it`;
+    }
+    return null;
+  },
 });
 const ROUTINE_WEEKDAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
 const routineTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -4034,12 +4045,33 @@ const server = createServer(async (req, res) => {
         const fromThreadId = body.fromThreadId;
         const owner = connectorThread(from.id, fromThreadId);
         if (!owner) return json(res, 403, { error: "source conversation does not belong to sender" });
+        // "Make a routine for @B": resolve the target up front so the model
+        // gets a teaching error now, not a mis-bound routine later. Omitted
+        // (or the sender's own id) keeps the schedule-for-self path unchanged.
+        let forBot: { botId: string; name: string } | undefined;
+        if (body.action === "create" && body.forBotId !== undefined) {
+          const parsedForBotId = z.string().max(128).safeParse(body.forBotId);
+          const forBotId = parsedForBotId.success ? parsedForBotId.data.trim() : "";
+          if (!forBotId) {
+            return json(res, 400, { error: 'for_bot_id must be a bot id from list_bots, e.g. { "for_bot_id": "bot-abc123" }' });
+          }
+          if (forBotId !== from.id) {
+            const target = store.bot(forBotId);
+            if (!target) {
+              return json(res, 404, { error: "no bot with that id — call list_bots and copy the exact id from the result" });
+            }
+            if (sectionKey(target.section) !== sectionKey(from.section)) {
+              return json(res, 403, { error: "that bot belongs to a different section" });
+            }
+            forBot = { botId: target.id, name: target.name };
+          }
+        }
         const persistence = routineProposalPersistence(from.id, fromThreadId);
         if (!persistence.ok) {
           return json(res, persistence.status, { error: persistence.error });
         }
         const proposedInput = body.action === "create"
-          ? { action: body.action, routine: body.routine }
+          ? { action: body.action, routine: body.routine, forBot }
           : body.action === "update"
             ? { action: body.action, routineId: body.routineId, changes: body.changes }
             : { action: body.action, routineId: body.routineId };

--- a/server/routine-requests.test.ts
+++ b/server/routine-requests.test.ts
@@ -945,6 +945,6 @@ describe("cross-bot routine targeting", () => {
     expect(result).toMatchObject({ claimed: true, state: "invalid", status: 404 });
     expect(routines.listRoutines()).toHaveLength(0);
     // the refusal is written back onto the card so the user sees why
-    expect(store.messagesFor("thread-a")[0]?.card.held).toMatch(/no longer exists/);
+    expect(store.messagesFor("thread-a")[0]?.card?.held).toMatch(/no longer exists/);
   });
 });

--- a/server/routine-requests.test.ts
+++ b/server/routine-requests.test.ts
@@ -861,3 +861,90 @@ describe("RoutineRequestService", () => {
     })).rejects.toThrow(/new future time/);
   });
 });
+
+describe("cross-bot routine targeting", () => {
+  function targetedHarness(validateTarget?: (proposerBotId: string, target: { botId: string; name: string }) => string | null) {
+    const clock = { now: Date.parse("2026-08-28T10:00:00Z") };
+    const dir = mkdtempSync(join(tmpdir(), "omb-routine-target-"));
+    tempDirs.push(dir);
+    const routines = new RoutineManager({
+      file: join(dir, "routines.json"),
+      now: () => clock.now,
+      botState: () => "busy",
+      createTask: () => null,
+      startTurn: async () => {},
+    });
+    const store = new MemoryStore();
+    const service = new RoutineRequestService({
+      store,
+      routines,
+      now: () => clock.now,
+      timeZone: () => "Asia/Kolkata",
+      validateTarget,
+    });
+    return { routines, service, store };
+  }
+
+  const forOps = { forBot: { botId: "bot-b", name: "Ops" } };
+
+  it("binds the confirmed routine to the named target bot, not the proposer", async () => {
+    const { routines, service, store } = targetedHarness();
+    const proposed = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: { ...createProposal(), ...forOps },
+    });
+    const card = store.messagesFor("thread-a")[0]?.card;
+    expect(card?.title).toContain("for @Ops");
+    expect(card?.subtitle).toContain("engine and permissions");
+    expect(card?.routineRequest?.operation).toMatchObject({ action: "create", forBot: forOps.forBot });
+
+    const result = service.resolve({
+      botId: "bot-a",
+      threadId: "thread-a",
+      requestId: proposed.requestId,
+      behavior: "allow",
+    });
+    expect(result).toMatchObject({ claimed: true, state: "applied", action: "create" });
+    const created = routines.listRoutines();
+    expect(created).toHaveLength(1);
+    expect(created[0].botId).toBe("bot-b");
+  });
+
+  it("still schedules for the proposer when no target is named", async () => {
+    const { routines, service } = targetedHarness();
+    const proposed = await service.propose({ botId: "bot-a", threadId: "thread-a", proposal: createProposal() });
+    service.resolve({ botId: "bot-a", threadId: "thread-a", requestId: proposed.requestId, behavior: "allow" });
+    expect(routines.listRoutines()[0]?.botId).toBe("bot-a");
+  });
+
+  it("refuses at propose time when the target fails authorization", async () => {
+    const { service } = targetedHarness(() => "@Ops belongs to a different section");
+    await expect(service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: { ...createProposal(), ...forOps },
+    })).rejects.toMatchObject({ message: "@Ops belongs to a different section", status: 403 });
+  });
+
+  it("re-checks the target at confirm time — a deleted bot refuses without creating anything", async () => {
+    let gone = false;
+    const { routines, service, store } = targetedHarness(() => (gone ? "@Ops no longer exists, so this routine cannot be scheduled for it" : null));
+    const proposed = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: { ...createProposal(), ...forOps },
+    });
+    gone = true;
+    const result = service.resolve({
+      botId: "bot-a",
+      threadId: "thread-a",
+      requestId: proposed.requestId,
+      behavior: "allow",
+    });
+    expect(result).toMatchObject({ claimed: true, state: "invalid", status: 404 });
+    expect(routines.listRoutines()).toHaveLength(0);
+    // the refusal is written back onto the card so the user sees why
+    expect(store.messagesFor("thread-a")[0]?.card.held).toMatch(/no longer exists/);
+  });
+});

--- a/server/routine-requests.ts
+++ b/server/routine-requests.ts
@@ -70,8 +70,14 @@ const routineToolChangesSchema = routineToolDefinitionSchema.partial().refine(
   "Choose at least one routine field to update",
 );
 
+/** Resolved and authorized by the harness route (existence + same section)
+ * before it reaches this service; re-authorized again at confirm time. */
+const targetBotSchema = z.object({
+  botId: z.string().min(1).max(128),
+  name: z.string().min(1).max(80),
+}).strict();
 const routineProposalSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("create"), routine: routineToolDefinitionSchema }).strict(),
+  z.object({ action: z.literal("create"), routine: routineToolDefinitionSchema, forBot: targetBotSchema.optional() }).strict(),
   z.object({ action: z.literal("update"), routineId: z.string().max(128), changes: routineToolChangesSchema }).strict(),
   z.object({ action: z.literal("pause"), routineId: z.string().max(128) }).strict(),
   z.object({ action: z.literal("resume"), routineId: z.string().max(128) }).strict(),
@@ -107,7 +113,7 @@ const storedManageBase = {
   expectedUpdatedAt: z.number().int().nonnegative(),
 };
 const storedOperationSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("create"), routine: storedDefinitionSchema }).strict(),
+  z.object({ action: z.literal("create"), routine: storedDefinitionSchema, forBot: targetBotSchema.optional() }).strict(),
   z.object({ action: z.literal("update"), ...storedManageBase, changes: storedChangesSchema }).strict(),
   z.object({ action: z.literal("pause"), ...storedManageBase }).strict(),
   z.object({ action: z.literal("resume"), ...storedManageBase }).strict(),
@@ -180,6 +186,10 @@ export interface RoutineRequestServiceOptions {
     botId: string,
     threadId: string,
   ) => { ok: true } | { ok: false; status: number; error: string };
+  /** Re-authorizes a cross-bot target (the card can sit open while the target
+   * bot is deleted or moved to another section). Returns the sentence to
+   * refuse with, or null to allow. Checked at propose AND confirm time. */
+  validateTarget?: (proposerBotId: string, target: { botId: string; name: string }) => string | null;
 }
 
 export interface ProposeRoutineRequestArgs {
@@ -343,7 +353,12 @@ function normalizedOperation(
   now: number,
 ): RoutineRequestOperation {
   if (validated.action === "create") {
-    return { action: "create", routine: normalizeDefinition(validated.routine, now) };
+    const operation: Extract<RoutineRequestOperation, { action: "create" }> = {
+      action: "create",
+      routine: normalizeDefinition(validated.routine, now),
+    };
+    if (validated.forBot) operation.forBot = validated.forBot;
+    return operation;
   }
   const id = routineId(validated.routineId);
   const current = ownedRoutine(manager, id, botId);
@@ -426,7 +441,9 @@ function cardCopy(
   const actionCopy = ACTION_COPY[operation.action];
   const actionLabel = actionCopy.title;
   const name = redactSecretsInText(definition?.name ?? "routine");
-  const title = `${actionLabel} “${name}”?`;
+  const forBot = operation.action === "create" ? operation.forBot : undefined;
+  const forSuffix = forBot ? ` for @${redactSecretsInText(forBot.name)}` : "";
+  const title = `${actionLabel} “${name}”${forSuffix}?`;
   if (!definition) {
     return {
       title,
@@ -459,10 +476,11 @@ function cardCopy(
   const visibleInstructions = redactSecretsInText(definition.instructions);
   return {
     title,
-    summary: `${actionLabel} “${name}” · ${when} · ${destination} · ${definition.durationMinutes} min${status}`,
+    summary: `${actionLabel} “${name}”${forSuffix} · ${when} · ${destination} · ${definition.durationMinutes} min${status}`,
     detail: [
       `Action: ${actionCopy.detail}`,
       `Name: ${name}`,
+      ...(forBot ? [`For: @${redactSecretsInText(forBot.name)} — each run uses that bot's engine and permissions`] : []),
       `Schedule: ${when}`,
       `Next run: ${nextDescription}`,
       `Runs on: ${destination}`,
@@ -587,6 +605,7 @@ export class RoutineRequestService {
   private readonly timeZone: () => string;
   private readonly cloudReady?: () => Promise<{ ready: boolean; reason?: string }>;
   private readonly canPersist?: RoutineRequestServiceOptions["canPersist"];
+  private readonly validateTarget?: RoutineRequestServiceOptions["validateTarget"];
 
   constructor(options: RoutineRequestServiceOptions) {
     this.store = options.store;
@@ -595,6 +614,7 @@ export class RoutineRequestService {
     this.timeZone = options.timeZone ?? (() => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC");
     this.cloudReady = options.cloudReady;
     this.canPersist = options.canPersist;
+    this.validateTarget = options.validateTarget;
   }
 
   async propose(args: ProposeRoutineRequestArgs): Promise<RoutineProposalResult> {
@@ -606,6 +626,10 @@ export class RoutineRequestService {
       throw new RoutineRequestError(schemaIssue(parsedProposal.error, "Invalid routine proposal"));
     }
     const operation = normalizedOperation(this.routines, botId, parsedProposal.data, at);
+    if (operation.action === "create" && operation.forBot && this.validateTarget) {
+      const refusal = this.validateTarget(botId, operation.forBot);
+      if (refusal) throw new RoutineRequestError(refusal, 403);
+    }
     await this.requireCloudReadiness(operation);
     // The readiness probe is asynchronous. Another request can edit or
     // delete the routine while it is in flight, so re-check the captured
@@ -768,6 +792,10 @@ export class RoutineRequestService {
         return { claimed: true, state: "denied" };
       }
       revalidateOperation(payload.operation, this.routines, payload.botId, this.now());
+      if (payload.operation.action === "create" && payload.operation.forBot && this.validateTarget) {
+        const refusal = this.validateTarget(payload.botId, payload.operation.forBot);
+        if (refusal) throw new RoutineRequestError(refusal, 404);
+      }
       const resultId = this.apply(payload, message.id, fingerprint);
       return this.settleApplied(args.threadId, message.id, card, payload, resultId);
     } catch (error) {
@@ -859,7 +887,7 @@ export class RoutineRequestService {
     const operation = payload.operation;
     switch (operation.action) {
       case "create":
-        return this.routines.create(inputFromDefinition(operation.routine, payload.botId), {
+        return this.routines.create(inputFromDefinition(operation.routine, operation.forBot?.botId ?? payload.botId), {
           requestId: payload.requestId,
           messageId,
           botId: payload.botId,

--- a/shared/routine-request.ts
+++ b/shared/routine-request.ts
@@ -24,8 +24,17 @@ export interface RoutineRequestDefinition {
 
 export type RoutineRequestChanges = Partial<RoutineRequestDefinition>;
 
+/** Another bot in the proposer's section that the routine is scheduled for.
+ * Captured (id + display name) when the card is created so the card stays
+ * meaningful if the bot is later renamed; authority over the card remains
+ * with the proposing conversation. */
+export interface RoutineRequestTargetBot {
+  botId: string;
+  name: string;
+}
+
 export type RoutineRequestOperation =
-  | { action: "create"; routine: RoutineRequestDefinition }
+  | { action: "create"; routine: RoutineRequestDefinition; forBot?: RoutineRequestTargetBot }
   | { action: "update"; routineId: string; expectedUpdatedAt: number; changes: RoutineRequestChanges }
   | { action: "pause"; routineId: string; expectedUpdatedAt: number }
   | { action: "resume"; routineId: string; expectedUpdatedAt: number }


### PR DESCRIPTION
Fixes half of #583: ask bot A to "make a routine for bot B" and A would create the routine — **scheduled on itself**. The `propose_routine` tool had no way to name a target (the model literally could not express "for @B"), and the API then hard-bound the card and routine to the sender.

## What

- `propose_routine` gains an optional flat `for_bot_id` (id from `list_bots`; omitted = schedule for yourself, byte-for-byte the old behavior — the key is absent from the POST body).
- The route resolves and authorizes the target up front with teaching errors: unknown id → 404 "call list_bots and copy the exact id", different section → 403 (same rule as `ask_bot`). Passing your own id is the same as omitting it.
- The target rides **inside the card's fingerprinted `operation`** (`forBot: { botId, name }`), so a confirmed card cannot be redirected after it is shown — same immutability the rest of the payload already has.
- Card authority stays with the proposing conversation (quota, thread ownership, resolve checks all unchanged); the card says who it's for: "Schedule "X" **for @B**?" plus a "For: @B — each run uses that bot's engine and permissions" line.
- On confirm, the routine is created with the **target's** `botId`, so the scheduler runs it as that bot. `sourceThreadId` still points at the proposing conversation.
- The target is authorized **twice**: at propose time and again at confirm time (`validateTarget` hook) — the card can sit open indefinitely while the target bot is deleted or moved to another section; the refusal lands on the card as held text.

## Scope notes

- `propose_routine_action` (update/pause/…) stays owner-only; managing another bot's routine is done from that bot's own chat.
- `list_routines` still lists only the calling bot's routines — B sees the routine, A doesn't own it.

## How verified

- New service tests: target binding on confirm, self-schedule unchanged, propose-time refusal, confirm-time refusal after target deletion (nothing created, refusal written onto the card).
- Route-level integration: unknown target → 404 with `list_bots` guidance; happy path across two bots asserts card title + `botId: teammate.id` + `sourceThreadId` on the created routine.
- Proxy test: `for_bot_id` forwarded beside (never inside) the routine definition; omitted case still sends the exact legacy body.
- Mutation checks: reverting the apply-time binding, either authorization check, or the proxy forwarding each fails the suite.
- `tsc` clean; routine/proxy/index suites green (48 + 127); lint parity with main exact on every touched file.

Part 1 of #583 — the ask_bot busy-peer dead-end is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routines can now be proposed for another bot in the same section.
  * Confirmation cards identify the bot assigned to the routine.
  * Target bots are validated when proposed and confirmed.

* **Bug Fixes**
  * Invalid or unauthorized targets are rejected with clear errors.
  * Routines are no longer incorrectly assigned to the proposer when a target is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->