### PR TITLE
ask_bot to a busy peer queues a delegation instead of dead-ending

### DIFF
--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -83,8 +83,17 @@ describe("roomResponders", () => {
 describe("comms e2e (fake ACP fleet)", () => {
   let child: ChildProcess;
   let home: string;
+  let gateFile = "";
   let stderr = "";
 
+  const waitUntil = async (predicate: () => Promise<boolean>, timeout: number, what: string): Promise<void> => {
+    const deadline = Date.now() + timeout;
+    for (;;) {
+      if (await predicate()) return;
+      if (Date.now() > deadline) throw new Error(`${what}. stderr: ${stderr.slice(-2000)}`);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  };
   const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
     const res = await fetch(`${BASE}${path}`, {
       method,
@@ -98,6 +107,7 @@ describe("comms e2e (fake ACP fleet)", () => {
     chmodSync(FAKE_CLI, 0o755);
     chmodSync(FAKE_AGY_CLI, 0o755);
     home = mkdtempSync(join(tmpdir(), "omb-comms-test-"));
+    gateFile = join(home, "helper-gate");
     mkdirSync(join(home, ".openmausbot"), { recursive: true });
     writeFileSync(
       join(home, ".openmausbot", "config.json"),
@@ -152,6 +162,14 @@ describe("comms e2e (fake ACP fleet)", () => {
           helperHang: {
             driver: "grokAgent",
             environment: { FAKE_ACP_MODE: "hang" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
+          // a deterministic busy window: turns hold open until the gate
+          // file exists, then echo their prompt (the ask_bot busy-fallback
+          // e2e frees the peer by writing the file).
+          helperGate: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "echo-gated", FAKE_ACP_GATE_FILE: gateFile },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
         },
@@ -504,6 +522,75 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(askerBot.busy).toBeFalsy();
     },
     45_000,
+  );
+
+  // ── ask_bot busy fallback ───────────────────────────────────────────
+  // A used to get a flat "busy — try again later" when B was mid-turn: a
+  // dead-end that models rarely retry, so the exchange evaporated (#583).
+  // Now the harness demotes the ask into a durable delegation: A's reply
+  // carries the task id, the queue chip lands on A's thread, and once B's
+  // blocked turn settles the queued message actually runs on B.
+  it(
+    "queues an ask_bot to a busy peer as a delegation and delivers it once the peer frees up",
+    async () => {
+      // determinism: the ask-peer CLI asks the FIRST visible bot, so hide
+      // everything previous tests left behind before creating the pair.
+      for (const existing of (await api("GET", "/api/bots")).body.bots) {
+        await api("PATCH", `/api/bots/${existing.id}`, { hidden: true });
+      }
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "GateHelper",
+        modelSelection: { instanceId: "helperGate", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "GateAsker",
+        modelSelection: { instanceId: "grok", model: "fake-model" },
+      });
+
+      // make the peer busy: its echo-gated turn holds open until the gate
+      // file exists
+      expect((await api("POST", `/api/bots/${helper.id}/messages`, { text: "hold the line" })).status).toBe(202);
+      await waitUntil(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots.find((b: any) => b.id === helper.id);
+        return Boolean(current?.busy);
+      }, 10_000, "helper never went busy");
+
+      // A asks the busy peer — the proxy's reply must be the queued-as-
+      // delegation guidance, not a dead-end bounce
+      expect((await api("POST", `/api/bots/${asker.id}/messages`, { text: "ask @GateHelper something" })).status).toBe(202);
+      let askerBot: any;
+      await waitUntil(async () => {
+        askerBot = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        const reply = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
+        return Boolean(reply?.text?.includes("queued as a delegation") && !askerBot.busy);
+      }, 25_000, "asker never got the queued-fallback reply");
+      const askerReply = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
+      expect(askerReply.text).toContain("Task id:");
+      expect(askerReply.text).toContain("wait_delegation");
+      // the queue is visible on A's thread as the standard delegation chip
+      expect(askerBot.messages.some(
+        (m: any) => m.kind === "activity" && m.tool?.name === "Delegated to @GateHelper: asked while busy",
+      )).toBe(true);
+
+      // free the peer: its blocked turn completes, which triggers the
+      // drain retry, and the queued message runs as a real depth-1 turn
+      writeFileSync(gateFile, "go");
+      let helperBot: any;
+      await waitUntil(async () => {
+        helperBot = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === helper.id);
+        const delivered = helperBot.messages.some(
+          (m: any) => m.role === "user" && m.kind === "text" && m.text?.includes("ping from fake"),
+        );
+        return Boolean(delivered && !helperBot.busy);
+      }, 30_000, "queued message never reached the freed peer");
+      const inbound = helperBot.messages.find(
+        (m: any) => m.role === "user" && m.kind === "text" && m.text?.includes("ping from fake"),
+      );
+      expect(inbound.text).toContain("[Delegated by @GateAsker");
+    },
+    60_000,
   );
 
   // ── delegation terminal-state mirroring ─────────────────────────────

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -17,7 +17,9 @@ let stub: Server;
 let stubPort = 0;
 let lastAuth: string | undefined;
 let lastAskBody: any = null;
-let askResponse: unknown = { botName: "Helper", text: "hi from helper" };
+/** What the stub harness returns from /api/internal/ask-bot. */
+type StubAskResponse = { botName?: string; text?: string; busy?: boolean; taskId?: string; toBotName?: string; error?: string };
+let askResponse: StubAskResponse = { botName: "Helper", text: "hi from helper" };
 let lastDelegateBody: any = null;
 let lastDelegationUrl: string | null = null;
 let delegationStatusResponse: unknown = { status: "done", toBotName: "Helper", result: "All done." };
@@ -239,6 +241,18 @@ describe("agents-proxy MCP surface", () => {
     askResponse = { busy: true };
     const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
     expect(res.result.content[0].text).toContain("busy");
+    expect(res.result.isError).toBeFalsy();
+  });
+
+  it("turns a busy+queued reply into delegation guidance with the task id", async () => {
+    askResponse = { busy: true, taskId: "task-9", toBotName: "Helper" };
+    const res = await callTool("ask_bot", { bot_id: "bot-helper", message: "ping" });
+    const text = res.result.content[0].text;
+    expect(text).toContain("Helper is busy");
+    expect(text).toContain("queued as a delegation");
+    expect(text).toContain("task-9");
+    expect(text).toContain("check_delegation");
+    expect(text).toContain("wait_delegation");
     expect(res.result.isError).toBeFalsy();
   });
 

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -387,7 +387,17 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       method: "POST",
       body: JSON.stringify({ fromBotId: BOT_ID, fromThreadId: THREAD_ID, toBotId, message, depth: DEPTH }),
     });
-    if (r.busy) return { text: `That bot is busy right now — try again after it finishes.` };
+    if (r.busy) {
+      // The harness queues the message as a delegation when it can; the
+      // task id is the asker's claim ticket for the eventual reply.
+      const taskId = String(r.taskId ?? "").trim();
+      if (taskId) {
+        return {
+          text: `${r.toBotName ?? "That bot"} is busy right now, so your message was queued as a delegation instead — it runs after your current turn ends. Task id: ${taskId}. Next turn, read the outcome with check_delegation or block on it with wait_delegation.`,
+        };
+      }
+      return { text: `That bot is busy right now — try again after it finishes.` };
+    }
     if (r.error) return { text: `Couldn't reach that bot: ${r.error}`, isError: true };
     return { text: `${r.botName ?? "Bot"} replied:\n${r.text ?? "(no reply)"}` };
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -4075,7 +4075,6 @@ const server = createServer(async (req, res) => {
         if (depth >= MAX_COMMS_DEPTH) return json(res, 200, { error: "message chains are limited to one hop" });
         const target = store.bot(toBotId);
         if (!target) return json(res, 404, { error: "no such bot" });
-        if (target.busy) return json(res, 200, { busy: true });
         // An unknown sender used to fall through: no mirroring AND no
         // approval, while still running the peer turn. That made an
         // unresolvable id the cheapest way past the gate, so it is now a
@@ -4089,6 +4088,25 @@ const server = createServer(async (req, res) => {
         if (!store.taskByThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
         }
+        // A busy peer used to be a flat bounce ("try again later") — a
+        // dead-end mid-turn that models rarely retry, so the exchange just
+        // evaporated. Demote the synchronous ask into a durable handoff
+        // instead: the message waits in the delegation ledger (bounded busy
+        // retries, receipts, restart-safe) and the asker gets a task id it
+        // can check next turn. If the ledger refuses (cap/depth), fall back
+        // to the plain busy bounce rather than dropping the refusal reason.
+        const queueBusyFallback = () => {
+          const queued = queueDelegation(
+            commsBus,
+            from,
+            { toBotId, message, reason: "asked while busy", depth },
+            MAX_COMMS_DEPTH,
+            fromThreadId,
+          );
+          if (queued.result !== "ok" || !queued.id) return json(res, 200, { busy: true });
+          return json(res, 200, { busy: true, taskId: queued.id, toBotName: target.name });
+        };
+        if (target.busy) return queueBusyFallback();
         let currentFrom = from;
         let currentTarget = target;
 
@@ -4124,7 +4142,7 @@ const server = createServer(async (req, res) => {
           if (!store.taskByThread(freshFrom.id, fromThreadId)) {
             return json(res, 404, { error: "source task no longer exists" });
           }
-          if (freshTarget.busy) return json(res, 200, { busy: true });
+          if (freshTarget.busy) return queueBusyFallback();
           currentFrom = freshFrom;
           currentTarget = freshTarget;
         }


### PR DESCRIPTION
Fixes the other half of #583: "sometimes the communication between them breaks down or they don't respond to each other."

## What was happening

`ask_bot` to a busy peer returned a flat `busy: true` → the model was told "try again after it finishes" — a dead-end mid-turn that models rarely act on, so the exchange just evaporated. There were two such bounce points: the initial busy check and the post-approval re-check (the human card can sit open for minutes, plenty of time for the target to get busy).

## What this does

When the target is busy, the harness now **demotes the synchronous ask into a durable delegation** through the existing ledger (bounded busy retries, receipts, restart-safe, drains when the peer's blocking turn settles):

- The asker's tool reply carries the task id and what to do with it: *"…queued as a delegation instead — it runs after your current turn ends. Task id: X. Next turn, read the outcome with check_delegation or block on it with wait_delegation."*
- The standard "Delegated to @B: asked while busy" chip lands on the asker's thread, so the queue is visible to the human.
- If the ledger refuses (per-turn cap, depth), the old plain busy bounce is returned rather than dropping the refusal.
- The busy check also moved below sender validation, so an unknown/foreign sender gets its 403 before learning whether a bot is busy.

Approval gates are preserved: a queued fallback goes through the drain-time review gate like any delegation, and the post-approval bounce path queues too.

## How verified

- New e2e in the comms suite: a peer held busy by a gated turn → asker's reply contains the queued-fallback guidance + task id, the delegation chip appears, then writing the gate file frees the peer and the queued message actually arrives as a depth-1 turn ("[Delegated by @…" prefix asserted).
- New proxy test: `busy + taskId` renders the full guidance (name, task id, check_delegation/wait_delegation); plain `busy` keeps the legacy text.
- Mutation checks: reverting the route to the flat bounce fails the e2e; blanking the proxy's task id fails the proxy suite.
- `tsc` clean; proxy/delegations/comms/index suites green (50 + 22 + 127); lint parity with main exact on every touched file.

Part 2 of #583 (part 1: #584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages sent to busy peers are now queued as durable delegations instead of immediately bouncing.
  * Askers receive a task ID and guidance for checking or awaiting the delegated response.
  * Queued requests run automatically when the peer becomes available.

* **Bug Fixes**
  * Busy-peer responses now provide actionable delegation details while preserving fallback behavior when queuing is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->