### PR TITLE
feat(ios): support multiple paired computers

### DIFF
--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -18,6 +18,8 @@ The first version includes:
 - Nearby computers, a manual address, and a six-digit code under **Other ways
   to connect** when the QR path is unavailable.
 - Secure per-device trust, device listing, and revocation.
+- Multiple saved computers with a one-tap switcher. Each pairing has its own
+  Keychain credential, and only the selected computer is connected at a time.
 - Bot and room lists, paged transcripts, sending, interruption, and unread
   state.
 - Approvals and questions, including narrow “always allow” grants.
@@ -168,6 +170,13 @@ local port cannot inherit the public route.
 4. If scanning is unavailable, open **Other ways to connect** for a nearby
    computer, manual address, or six-digit code.
 5. Revoking the phone on the Mac removes its access and lets it pair again.
+
+To add another Mac, open **Settings → Computers → Connect another computer**
+on the iPhone and scan that Mac's QR. The existing computer stays usable if
+the new pairing fails or is cancelled. Switching computers replaces the live
+event stream and in-memory chat state, but keeps every saved pairing; removing
+one computer deletes only that computer's Keychain credential from the phone.
+An app upgrade migrates the previous single saved pairing automatically.
 
 The Mac must remain awake with OpenMausBot running for chats, approvals, and
 routines to work, including through hosted HTTPS or Tailscale.

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -44,8 +44,6 @@ struct RootView: View {
     @AppStorage("companion.onboarding.notificationsSeen") private var hasSeenNotificationPrompt = false
     @AppStorage(CompanionOnboardingPreferences.pendingNotificationOnboardingKey)
     private var notificationOnboardingPending = false
-    @State private var pairingRequested = false
-
     var body: some View {
         Group {
             switch route {
@@ -54,17 +52,17 @@ struct RootView: View {
                     onConnect: startPairing,
                     onSkip: {
                         hasSeenWelcome = true
-                        pairingRequested = false
+                        session.endPairing()
                     }
                 )
             case .pairing:
                 PairingView {
                     hasSeenWelcome = true
-                    pairingRequested = false
+                    session.endPairing()
                 }
                 .onAppear {
                     hasSeenWelcome = true
-                    pairingRequested = true
+                    session.beginPairing()
                 }
             case .unpairedHome:
                 UnpairedHomeView(onConnect: startPairing)
@@ -72,7 +70,7 @@ struct RootView: View {
                 NotificationOnboardingView {
                     hasSeenNotificationPrompt = true
                     notificationOnboardingPending = false
-                    pairingRequested = false
+                    session.endPairing()
                 }
                 .onAppear { hasSeenWelcome = true }
             case .chats:
@@ -82,20 +80,27 @@ struct RootView: View {
                         // This is either an existing pairing or a new pairing
                         // which needed no notification education. Do not let
                         // a later voluntary unpair reopen Pairing by itself.
-                        pairingRequested = false
+                        session.endPairing()
                         reconcileNotificationOnboarding()
                     }
             case .revoked:
-                UnpairedView {
-                    session.signOut()
-                    startPairing()
-                }
+                UnpairedView(
+                    onPairAgain: {
+                        session.signOut()
+                        startPairing()
+                    },
+                    onChooseAnother: session.connections.first(where: {
+                        $0.id != session.connection?.id
+                    }).map { computer in
+                        { session.switchComputer(to: computer.id) }
+                    }
+                )
             }
         }
         .onChange(of: session.pairingInvite) { _, invite in
             guard invite != nil else { return }
             hasSeenWelcome = true
-            pairingRequested = true
+            session.beginPairing()
         }
         .onAppear { reconcileNotificationOnboarding() }
         .onChange(of: session.notificationAuthorizationResolved) { _, _ in
@@ -133,7 +138,7 @@ struct RootView: View {
         return CompanionOnboardingRouter.route(for: .init(
             pairingState: pairingState,
             hasSeenWelcome: hasSeenWelcome,
-            pairingRequested: pairingRequested,
+            pairingRequested: session.pairingRequested,
             hasPendingPairingInvite: session.pairingInvite != nil,
             notificationOnboardingPending: notificationOnboardingPending,
             hasSeenNotificationPrompt: hasSeenNotificationPrompt,
@@ -161,7 +166,7 @@ struct RootView: View {
 
     private func startPairing() {
         hasSeenWelcome = true
-        pairingRequested = true
+        session.beginPairing()
     }
 }
 
@@ -170,6 +175,7 @@ struct RootView: View {
 /// honest thing is to say so and offer to pair again.
 struct UnpairedView: View {
     let onPairAgain: () -> Void
+    let onChooseAnother: (() -> Void)?
 
     var body: some View {
         NavigationStack {
@@ -181,6 +187,11 @@ struct UnpairedView: View {
                 Button("Pair again", action: onPairAgain)
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
+                if let onChooseAnother {
+                    Button("Use another computer", action: onChooseAnother)
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                }
             }
         }
     }

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -399,15 +399,17 @@ struct PairingView: View {
     @MainActor
     private func submit(_ connection: Connection, credential: String) async {
         failure = nil
+        var succeeded = false
         defer {
             submission.finish()
             // A deep link received during the commit cannot replace the
             // consent screen. If this request failed, present it only after
             // the in-flight request has fully settled.
-            if session.connection == nil {
-                accept(session.pairingInvite)
-            } else {
+            if succeeded {
                 session.consumePairingInvite()
+                onCancel()
+            } else {
+                accept(session.pairingInvite)
             }
         }
         let cameFromScanner = scannedCredential != nil
@@ -421,6 +423,7 @@ struct PairingView: View {
                 pairRequestId: requestId
             )
             pairRequestId = nil
+            succeeded = true
         } catch {
             if cameFromScanner {
                 if error is PairingRouteError {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -32,6 +32,7 @@ final class Session: ObservableObject {
 
     @Published private(set) var state = CompanionState()
     @Published private(set) var connection: Connection?
+    @Published private(set) var connections: [Connection] = []
     @Published private(set) var status: Status = .unpaired
     /// Transient, user-facing failures from an action they just took.
     @Published var actionError: String?
@@ -43,6 +44,9 @@ final class Session: ObservableObject {
     @Published private(set) var notificationAuthorizationResolved = false
     /// A short-lived desktop handoff waiting for PairingView to present it.
     @Published private(set) var pairingInvite: PairingInvite?
+    /// Pairing can be opened while another computer remains connected. The
+    /// working session is only replaced after the new credential commits.
+    @Published private(set) var pairingRequested = false
 
     /// A notification response that should be pushed by the roster's
     /// NavigationStack after the exact detached task has been activated.
@@ -92,7 +96,9 @@ final class Session: ObservableObject {
     /// paired client can be rebuilt after unlock.
     private var pendingNotification: NotificationTarget?
 
-    private static let connectionKey = "companion.connection"
+    private var registry = CompanionConnectionRegistry()
+    private static let connectionsKey = "companion.connections.v1"
+    private static let legacyConnectionKey = "companion.connection"
 
     // MARK: - Pairing
 
@@ -102,11 +108,33 @@ final class Session: ObservableObject {
             Task { @MainActor in await self?.openNotification(target) }
         }
 #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("-store-preview"),
+        let arguments = ProcessInfo.processInfo.arguments
+        if (arguments.contains("-store-preview") || arguments.contains("-computer-switcher-preview")),
            let url = Bundle.main.url(forResource: "StorePreview", withExtension: "json"),
            let data = try? Data(contentsOf: url),
            let fleet = try? JSONDecoder().decode(Fleet.self, from: data) {
-            connection = Connection(name: "Preview Mac", host: "preview.tailnet.ts.net", port: 8810)
+            let preview = Connection(
+                id: "preview-current",
+                name: "Milind’s MacBook Pro",
+                host: "preview.tailnet.ts.net",
+                port: 8810
+            )
+            connection = preview
+            if arguments.contains("-computer-switcher-preview") {
+                let other = Connection(
+                    id: "preview-other",
+                    name: "MacBook Air",
+                    host: "air.tailnet.ts.net",
+                    port: 8810
+                )
+                registry = CompanionConnectionRegistry(
+                    connections: [preview, other],
+                    activeConnectionID: preview.id
+                )
+                connections = registry.connections
+            } else {
+                connections = [preview]
+            }
             state.hydrate(fleet)
             status = .live
             return
@@ -116,7 +144,8 @@ final class Session: ObservableObject {
         Task { await refreshNotificationAuthorization() }
     }
 
-    /// Rebuild the last connection at launch.
+    /// Rebuild the selected connection at launch, migrating the previous
+    /// single-computer record the first time a multi-computer build runs.
     ///
     /// Three outcomes, and keeping them apart is the whole point. No saved
     /// connection: stay unpaired. A saved connection whose token reads back:
@@ -127,9 +156,27 @@ final class Session: ObservableObject {
     /// only the first should ever send someone back to the pairing screen.
     private func restore() {
         restorePending = false
-        guard let data = UserDefaults.standard.data(forKey: Self.connectionKey),
-              let saved = try? JSONDecoder().decode(Connection.self, from: data)
-        else { return }
+        let restored = CompanionConnectionRegistryMigration.restore(
+            registryData: UserDefaults.standard.data(forKey: Self.connectionsKey),
+            legacyConnectionData: UserDefaults.standard.data(forKey: Self.legacyConnectionKey)
+        )
+        registry = restored.registry
+        connections = registry.connections
+        if restored.migratedLegacyConnection {
+            persistRegistry()
+            UserDefaults.standard.removeObject(forKey: Self.legacyConnectionKey)
+        }
+        restoreSelectedConnection()
+    }
+
+    /// Find the first selected pairing whose Keychain token still exists.
+    /// A missing token is a genuinely unusable saved record; a locked
+    /// Keychain is temporary and must leave the record untouched.
+    private func restoreSelectedConnection() {
+        guard let saved = registry.activeConnection else {
+            clearActiveConnection()
+            return
+        }
 
         let stored: String?
         do {
@@ -148,17 +195,15 @@ final class Session: ObservableObject {
             )
             return
         }
-        guard let stored else { return } // no token: genuinely not paired
+        guard let stored else {
+            registry.remove(id: saved.id)
+            persistRegistry()
+            connections = registry.connections
+            restoreSelectedConnection()
+            return
+        }
 
-        connection = saved
-        token = stored
-        // New connections honor the desktop's transport policy. Automatic
-        // walking is credential-safe: protected routes stay protected, while
-        // a legacy/local route is only tried when it was the exact saved route.
-        rotation = CandidateRotation(endpoints: saved.orderedEndpoints)
-        let first = rotation.currentEndpoint.map(saved.dialing) ?? saved
-        client = CompanionClient(connection: first, token: stored)
-        status = .connecting
+        configureActiveConnection(saved, token: stored)
     }
 
     /// Redeem a one-time pairing credential. On success the device token goes
@@ -199,8 +244,14 @@ final class Session: ObservableObject {
         if stored.endpoints?.isEmpty != false {
             stored.hosts = Array(stored.orderedHosts.prefix(8))
         }
+        if let existing = registry.matchingConnection(for: stored) {
+            stored.id = existing.id
+        }
 
         try Keychain.save(paired.token, for: stored.id)
+        let firstPairing = registry.connections.isEmpty
+        var updatedRegistry = registry
+        updatedRegistry.upsert(stored)
         // Write the first-pair education marker before making the connection
         // restorable. If the process stops between these writes, an orphan
         // marker is harmless while unpaired; the reverse order could restore
@@ -208,21 +259,28 @@ final class Session: ObservableObject {
         // RootView may not have received iOS's notification status yet, and
         // the app may be relaunched before that asynchronous lookup finishes.
         CompanionPairingCommitSequence.persist {
-            UserDefaults.standard.set(
-                true,
-                forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
-            )
+            if firstPairing {
+                UserDefaults.standard.set(
+                    true,
+                    forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+                )
+            }
         } saveConnection: {
             UserDefaults.standard.set(
-                try? JSONEncoder().encode(stored),
-                forKey: Self.connectionKey
+                try? JSONEncoder().encode(updatedRegistry),
+                forKey: Self.connectionsKey
             )
         }
 
+        stopActiveRuntime()
         pairingInvite = CompanionPairingInvitePolicy.nextInvite(
             current: pairingInvite,
             after: .pairingSucceeded
         )
+        pairingRequested = false
+        registry = updatedRegistry
+        connections = registry.connections
+        UserDefaults.standard.removeObject(forKey: Self.legacyConnectionKey)
         self.connection = stored
         self.token = paired.token
         let liveRoutes = winner.map { route in
@@ -241,13 +299,6 @@ final class Session: ObservableObject {
     }
 
     func receivePairingURL(_ url: URL) {
-        guard CompanionPairingInvitePolicy.allowsIncomingInvite(
-            hasConnection: connection != nil,
-            pairingStateIsUnpaired: status == .unpaired
-        ) else {
-            actionError = "This phone is already paired. Unpair it in Settings before connecting it to another computer."
-            return
-        }
         guard let invite = PairingInvite.parse(url) else {
             actionError = "That pairing invitation is not valid. Start pairing again on your computer."
             return
@@ -256,6 +307,16 @@ final class Session: ObservableObject {
             current: pairingInvite,
             after: .received(invite)
         )
+        pairingRequested = true
+    }
+
+    func beginPairing() {
+        pairingRequested = true
+    }
+
+    func endPairing() {
+        pairingRequested = false
+        consumePairingInvite()
     }
 
     func consumePairingInvite() {
@@ -265,7 +326,73 @@ final class Session: ObservableObject {
         )
     }
 
+    func switchComputer(to id: String) {
+        guard let saved = registry.connection(id: id) else { return }
+        if connection?.id == id {
+            restartStream()
+            connect()
+            return
+        }
+
+        let stored: String?
+        do {
+            stored = try Keychain.token(for: id)
+        } catch {
+            actionError = (error as? KeychainError)?.isLocked == true
+                ? "Unlock this iPhone, then try switching computers again."
+                : error.localizedDescription
+            return
+        }
+        guard let stored else {
+            actionError = "This saved connection is no longer available on this iPhone. Remove it and pair again."
+            return
+        }
+
+        stopActiveRuntime()
+        registry.select(id: id)
+        persistRegistry()
+        connections = registry.connections
+        configureActiveConnection(saved, token: stored)
+        connect()
+    }
+
+    func forgetConnection(id: String) {
+        guard registry.connection(id: id) != nil else { return }
+        let wasActive = registry.activeConnectionID == id
+        if wasActive { stopActiveRuntime() }
+        Keychain.remove(id)
+        registry.remove(id: id)
+        persistRegistry()
+        connections = registry.connections
+        guard wasActive else { return }
+
+        connection = nil
+        client = nil
+        token = nil
+        rotation = CandidateRotation(hosts: [])
+        state = CompanionState()
+        resetAvatarCache()
+        NotificationCoordinator.shared.setBadge(0)
+        restoreSelectedConnection()
+        if connection != nil { connect() }
+        if connections.isEmpty {
+            UserDefaults.standard.removeObject(
+                forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
+            )
+        }
+    }
+
+    /// Compatibility for the existing revoked-pairing and detail actions:
+    /// sign out now means remove only the selected computer.
     func signOut() {
+        guard let id = connection?.id ?? registry.activeConnectionID else {
+            clearActiveConnection()
+            return
+        }
+        forgetConnection(id: id)
+    }
+
+    private func clearActiveConnection() {
         streamTask?.cancel()
         streamTask = nil
         endpointRefreshTask?.cancel()
@@ -276,11 +403,7 @@ final class Session: ObservableObject {
             current: pairingInvite,
             after: .signedOut
         )
-        if let id = connection?.id { Keychain.remove(id) }
-        UserDefaults.standard.removeObject(forKey: Self.connectionKey)
-        UserDefaults.standard.removeObject(
-            forKey: CompanionOnboardingPreferences.pendingNotificationOnboardingKey
-        )
+        pairingRequested = false
         connection = nil
         client = nil
         token = nil
@@ -289,6 +412,53 @@ final class Session: ObservableObject {
         resetAvatarCache()
         NotificationCoordinator.shared.setBadge(0)
         status = .unpaired
+    }
+
+    private func configureActiveConnection(_ saved: Connection, token stored: String) {
+        connection = saved
+        token = stored
+        // New connections honor the desktop's transport policy. Automatic
+        // walking is credential-safe: protected routes stay protected, while
+        // a legacy/local route is only tried when it was the exact saved route.
+        rotation = CandidateRotation(endpoints: saved.orderedEndpoints)
+        let first = rotation.currentEndpoint.map(saved.dialing) ?? saved
+        client = CompanionClient(connection: first, token: stored)
+        status = .connecting
+    }
+
+    private func stopActiveRuntime() {
+        streamGeneration += 1
+        streamTask?.cancel()
+        streamTask = nil
+        endpointRefreshTask?.cancel()
+        endpointRefreshTask = nil
+        restorePending = false
+        endLinger()
+        pendingNotification = nil
+        screenWatchers = 0
+        client = nil
+        token = nil
+        state = CompanionState()
+        resetAvatarCache()
+        NotificationCoordinator.shared.setBadge(0)
+    }
+
+    private func persistRegistry() {
+        if registry.connections.isEmpty {
+            UserDefaults.standard.removeObject(forKey: Self.connectionsKey)
+        } else {
+            UserDefaults.standard.set(
+                try? JSONEncoder().encode(registry),
+                forKey: Self.connectionsKey
+            )
+        }
+    }
+
+    private func persistActiveConnection(_ updated: Connection) {
+        registry.upsert(updated, makeActive: false)
+        connection = updated
+        connections = registry.connections
+        persistRegistry()
     }
 
     // MARK: - Lifecycle
@@ -530,8 +700,7 @@ final class Session: ObservableObject {
         guard let winner = rotation.currentEndpoint, var updated = connection,
               updated.activeEndpoint?.url != winner.url else { return }
         updated.promote(winner)
-        connection = updated
-        UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
+        persistActiveConnection(updated)
     }
 
     /// Learn routes enabled after this phone originally paired. The endpoint
@@ -554,11 +723,7 @@ final class Session: ObservableObject {
                 else { return }
 
                 updated.reconcile(metadata)
-                self.connection = updated
-                UserDefaults.standard.set(
-                    try? JSONEncoder().encode(updated),
-                    forKey: Self.connectionKey
-                )
+                self.persistActiveConnection(updated)
 
                 // Keep the currently live route first until this stream ends.
                 // CandidateRotation applies the same no-downgrade policy used
@@ -588,8 +753,7 @@ final class Session: ObservableObject {
             priority: 0
         ) else { return false }
         updated.resetRoutePolicy(selecting: endpoint)
-        connection = updated
-        UserDefaults.standard.set(try? JSONEncoder().encode(updated), forKey: Self.connectionKey)
+        persistActiveConnection(updated)
         rotation = CandidateRotation(endpoints: updated.orderedEndpoints)
         if let token {
             client = CompanionClient(connection: updated.dialing(endpoint), token: token)

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -18,11 +18,11 @@ struct SettingsView: View {
             Section("Computer") {
                 if let connection = session.connection {
                     NavigationLink {
-                        ConnectionSecurityView()
+                        ConnectedComputersView()
                     } label: {
                         ComputerSettingsRow(
                             name: connection.name,
-                            status: statusText,
+                            status: computerStatusText,
                             connected: session.status == .live
                         )
                     }
@@ -120,6 +120,11 @@ struct SettingsView: View {
     }
 
     private var statusText: String { session.status.settingsText }
+
+    private var computerStatusText: String {
+        guard session.connections.count > 1 else { return statusText }
+        return "\(statusText) · \(session.connections.count) saved"
+    }
 }
 
 private struct ComputerSettingsRow: View {
@@ -169,6 +174,98 @@ private struct SettingsIcon: View {
             .frame(width: 28, height: 28)
             .background(color, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
             .accessibilityHidden(true)
+    }
+}
+
+struct ConnectedComputersView: View {
+    @EnvironmentObject private var session: Session
+    @State private var pendingRemoval: Connection?
+
+    private var otherComputers: [Connection] {
+        session.connections.filter { $0.id != session.connection?.id }
+    }
+
+    var body: some View {
+        List {
+            if let active = session.connection {
+                Section("Current computer") {
+                    NavigationLink {
+                        ConnectionSecurityView()
+                    } label: {
+                        ComputerSettingsRow(
+                            name: active.name,
+                            status: session.status.settingsText,
+                            connected: session.status == .live
+                        )
+                    }
+                }
+            }
+
+            if !otherComputers.isEmpty {
+                Section("Other computers") {
+                    ForEach(otherComputers) { computer in
+                        Button {
+                            Haptics.selection()
+                            session.switchComputer(to: computer.id)
+                        } label: {
+                            HStack(spacing: 12) {
+                                ProfileAvatar(name: computer.name, size: 38)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(computer.name)
+                                        .foregroundStyle(.primary)
+                                        .lineLimit(1)
+                                    Text("Tap to switch")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text("Use")
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(MausPalette.color("blue"))
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .swipeActions {
+                            Button("Remove", role: .destructive) {
+                                pendingRemoval = computer
+                            }
+                        }
+                        .accessibilityHint("Switches OpenMausMobile to this computer")
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    Haptics.selection()
+                    session.beginPairing()
+                } label: {
+                    Label("Connect another computer", systemImage: "plus.circle.fill")
+                }
+            } footer: {
+                Text("Each computer is paired separately. Only the selected computer is active at a time.")
+            }
+        }
+        .navigationTitle("Computers")
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "Remove \(pendingRemoval?.name ?? "this computer")?",
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Remove from this iPhone", role: .destructive) {
+                guard let pendingRemoval else { return }
+                session.forgetConnection(id: pendingRemoval.id)
+                self.pendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { pendingRemoval = nil }
+        } message: {
+            Text("This removes the saved connection from this iPhone only.")
+        }
     }
 }
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -69,7 +69,7 @@ ios/
     SpeechDictation.swift        on-device speech recognition, press-to-stop
     ComputerView.swift           opt-in live view of a bot's computer
     MarkdownText.swift           the supported Markdown presentation layer
-    SettingsView.swift           status, and unpair
+    SettingsView.swift           status, computer switcher, and pairing removal
 ```
 
 ## Building

--- a/ios/Sources/CompanionCore/ConnectionRegistry.swift
+++ b/ios/Sources/CompanionCore/ConnectionRegistry.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// The non-secret index of computers this iPhone knows about.
+///
+/// Device tokens remain in Keychain, one per connection id. This value is
+/// safe to keep in UserDefaults and makes changing computers an ordinary
+/// selection rather than a destructive unpair-and-repair cycle.
+public struct CompanionConnectionRegistry: Codable, Equatable, Sendable {
+    public private(set) var connections: [Connection]
+    public private(set) var activeConnectionID: String?
+
+    public init(connections: [Connection] = [], activeConnectionID: String? = nil) {
+        var seen = Set<String>()
+        self.connections = connections.filter { seen.insert($0.id).inserted }
+        if let activeConnectionID,
+           self.connections.contains(where: { $0.id == activeConnectionID }) {
+            self.activeConnectionID = activeConnectionID
+        } else {
+            self.activeConnectionID = self.connections.first?.id
+        }
+    }
+
+    public var activeConnection: Connection? {
+        guard let activeConnectionID else { return nil }
+        return connections.first { $0.id == activeConnectionID }
+    }
+
+    public func connection(id: String) -> Connection? {
+        connections.first { $0.id == id }
+    }
+
+    /// Recognize a computer already saved under an older pairing id. A
+    /// shared advertised route is stronger evidence than a display name and
+    /// lets re-pairing refresh the existing Keychain item instead of drawing
+    /// a duplicate row.
+    public func matchingConnection(for candidate: Connection) -> Connection? {
+        let candidateRoutes = Set(candidate.orderedEndpoints.map(\.url))
+        guard !candidateRoutes.isEmpty else { return nil }
+        return connections.first { saved in
+            !candidateRoutes.isDisjoint(with: saved.orderedEndpoints.map(\.url))
+        }
+    }
+
+    /// Insert or refresh one computer and optionally make it the live one.
+    public mutating func upsert(_ connection: Connection, makeActive: Bool = true) {
+        if let index = connections.firstIndex(where: { $0.id == connection.id }) {
+            connections[index] = connection
+        } else {
+            connections.append(connection)
+        }
+        if makeActive || activeConnectionID == nil {
+            activeConnectionID = connection.id
+        }
+    }
+
+    @discardableResult
+    public mutating func select(id: String) -> Bool {
+        guard connections.contains(where: { $0.id == id }) else { return false }
+        activeConnectionID = id
+        return true
+    }
+
+    /// Remove one computer. When it was active, the oldest remaining saved
+    /// computer becomes active so the app never lands in a false unpaired
+    /// state while another valid pairing still exists.
+    @discardableResult
+    public mutating func remove(id: String) -> Connection? {
+        guard let index = connections.firstIndex(where: { $0.id == id }) else { return nil }
+        let removed = connections.remove(at: index)
+        if activeConnectionID == id {
+            activeConnectionID = connections.first?.id
+        }
+        return removed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case connections, activeConnectionID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            connections: try container.decode([Connection].self, forKey: .connections),
+            activeConnectionID: try container.decodeIfPresent(String.self, forKey: .activeConnectionID)
+        )
+    }
+}
+
+public struct CompanionConnectionRegistryRestore: Equatable, Sendable {
+    public let registry: CompanionConnectionRegistry
+    public let migratedLegacyConnection: Bool
+
+    public init(registry: CompanionConnectionRegistry, migratedLegacyConnection: Bool) {
+        self.registry = registry
+        self.migratedLegacyConnection = migratedLegacyConnection
+    }
+}
+
+/// Decode the new registry or lift the previous single saved connection into
+/// it. Kept pure so upgrades can be tested without touching UserDefaults.
+public enum CompanionConnectionRegistryMigration {
+    public static func restore(
+        registryData: Data?,
+        legacyConnectionData: Data?
+    ) -> CompanionConnectionRegistryRestore {
+        let decoder = JSONDecoder()
+        if let registryData,
+           let registry = try? decoder.decode(CompanionConnectionRegistry.self, from: registryData) {
+            return CompanionConnectionRegistryRestore(
+                registry: registry,
+                migratedLegacyConnection: false
+            )
+        }
+        if let legacyConnectionData,
+           let connection = try? decoder.decode(Connection.self, from: legacyConnectionData) {
+            return CompanionConnectionRegistryRestore(
+                registry: CompanionConnectionRegistry(
+                    connections: [connection],
+                    activeConnectionID: connection.id
+                ),
+                migratedLegacyConnection: true
+            )
+        }
+        return CompanionConnectionRegistryRestore(
+            registry: CompanionConnectionRegistry(),
+            migratedLegacyConnection: false
+        )
+    }
+}

--- a/ios/Sources/CompanionCore/Onboarding.swift
+++ b/ios/Sources/CompanionCore/Onboarding.swift
@@ -57,17 +57,10 @@ public enum CompanionPairingInviteEvent: Equatable, Sendable {
     case signedOut
 }
 
-/// Pure invite lifecycle shared by Session and sequence tests. In particular,
-/// a connection published just before status changes must still reject a new
-/// invite, and terminal pairing/account events always empty the queue.
+/// Pure invite lifecycle shared by Session and sequence tests. A paired phone
+/// may receive another computer's invite; PairingView keeps the current
+/// connection alive until the new credential is safely committed.
 public enum CompanionPairingInvitePolicy {
-    public static func allowsIncomingInvite(
-        hasConnection: Bool,
-        pairingStateIsUnpaired: Bool
-    ) -> Bool {
-        !hasConnection && pairingStateIsUnpaired
-    }
-
     public static func nextInvite(
         current: PairingInvite?,
         after event: CompanionPairingInviteEvent
@@ -156,6 +149,9 @@ public enum CompanionOnboardingRouter {
         case .revoked:
             return .revoked
         case .paired:
+            if context.pairingRequested || context.hasPendingPairingInvite {
+                return .pairing
+            }
             if context.notificationOnboardingPending,
                !context.hasSeenNotificationPrompt,
                context.notificationAuthorization == .notDetermined {

--- a/ios/Tests/CompanionCoreTests/ConnectionRegistryTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionRegistryTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+final class ConnectionRegistryTests: XCTestCase {
+    private let first = Connection(id: "first", name: "MacBook Air", host: "air.local", port: 8810)
+    private let second = Connection(id: "second", name: "MacBook Pro", host: "pro.local", port: 8810)
+
+    func testUpsertAndSelectKeepIndependentComputers() {
+        var registry = CompanionConnectionRegistry()
+        registry.upsert(first)
+        registry.upsert(second)
+
+        XCTAssertEqual(registry.connections, [first, second])
+        XCTAssertEqual(registry.activeConnection, second)
+        XCTAssertTrue(registry.select(id: first.id))
+        XCTAssertEqual(registry.activeConnection, first)
+        XCTAssertFalse(registry.select(id: "missing"))
+        XCTAssertEqual(registry.activeConnection, first)
+    }
+
+    func testRefreshingAConnectionDoesNotCreateADuplicate() {
+        var registry = CompanionConnectionRegistry(connections: [first], activeConnectionID: first.id)
+        var refreshed = first
+        refreshed.name = "Office Mac"
+        refreshed.host = "office.local"
+
+        registry.upsert(refreshed, makeActive: false)
+
+        XCTAssertEqual(registry.connections.count, 1)
+        XCTAssertEqual(registry.activeConnection?.name, "Office Mac")
+        XCTAssertEqual(registry.activeConnection?.host, "office.local")
+    }
+
+    func testMatchingUsesRoutesInsteadOfAComputerName() {
+        let renamed = Connection(
+            id: "new-pairing-id",
+            name: "Renamed laptop",
+            host: "air.local",
+            port: 8810
+        )
+        let sameNameElsewhere = Connection(
+            id: "other",
+            name: first.name,
+            host: "somewhere-else.local",
+            port: 8810
+        )
+        let registry = CompanionConnectionRegistry(
+            connections: [first, sameNameElsewhere],
+            activeConnectionID: first.id
+        )
+
+        XCTAssertEqual(registry.matchingConnection(for: renamed)?.id, first.id)
+        XCTAssertNil(registry.matchingConnection(for: Connection(
+            name: first.name,
+            host: "third.local",
+            port: 8810
+        )))
+    }
+
+    func testRemovingActiveComputerFallsBackToAnotherSavedComputer() {
+        var registry = CompanionConnectionRegistry(
+            connections: [first, second],
+            activeConnectionID: second.id
+        )
+
+        XCTAssertEqual(registry.remove(id: second.id), second)
+        XCTAssertEqual(registry.connections, [first])
+        XCTAssertEqual(registry.activeConnection, first)
+    }
+
+    func testDecodeNormalizesDuplicatesAndMissingActiveSelection() throws {
+        let data = try JSONEncoder().encode(RegistryFixture(
+            connections: [first, first, second],
+            activeConnectionID: "missing"
+        ))
+        let registry = try JSONDecoder().decode(CompanionConnectionRegistry.self, from: data)
+
+        XCTAssertEqual(registry.connections, [first, second])
+        XCTAssertEqual(registry.activeConnection, first)
+    }
+
+    func testMigrationLiftsTheLegacySingleConnection() throws {
+        let restored = CompanionConnectionRegistryMigration.restore(
+            registryData: nil,
+            legacyConnectionData: try JSONEncoder().encode(first)
+        )
+
+        XCTAssertTrue(restored.migratedLegacyConnection)
+        XCTAssertEqual(restored.registry.connections, [first])
+        XCTAssertEqual(restored.registry.activeConnection, first)
+    }
+
+    func testValidRegistryWinsOverLegacyData() throws {
+        let current = CompanionConnectionRegistry(
+            connections: [second],
+            activeConnectionID: second.id
+        )
+        let restored = CompanionConnectionRegistryMigration.restore(
+            registryData: try JSONEncoder().encode(current),
+            legacyConnectionData: try JSONEncoder().encode(first)
+        )
+
+        XCTAssertFalse(restored.migratedLegacyConnection)
+        XCTAssertEqual(restored.registry, current)
+    }
+}
+
+private struct RegistryFixture: Encodable {
+    let connections: [Connection]
+    let activeConnectionID: String?
+}

--- a/ios/Tests/CompanionCoreTests/OnboardingTests.swift
+++ b/ios/Tests/CompanionCoreTests/OnboardingTests.swift
@@ -52,6 +52,25 @@ final class OnboardingTests: XCTestCase {
         )
     }
 
+    func testPairedUserCanAddAnotherComputer() {
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true,
+                pairingRequested: true
+            )),
+            .pairing
+        )
+        XCTAssertEqual(
+            CompanionOnboardingRouter.route(for: .init(
+                pairingState: .paired,
+                hasSeenWelcome: true,
+                hasPendingPairingInvite: true
+            )),
+            .pairing
+        )
+    }
+
     func testJustPairedUserSeesNotificationExplanationOnceThenChats() {
         XCTAssertEqual(
             CompanionOnboardingRouter.route(for: .init(
@@ -224,11 +243,6 @@ final class OnboardingTests: XCTestCase {
             after: .pairingSucceeded
         )
         XCTAssertNil(pending)
-        XCTAssertFalse(CompanionPairingInvitePolicy.allowsIncomingInvite(
-            hasConnection: true,
-            pairingStateIsUnpaired: true
-        ), "a published connection closes the deep-link race before status updates")
-
         pending = CompanionPairingInvitePolicy.nextInvite(
             current: deferred,
             after: .signedOut


### PR DESCRIPTION
## What changed

- replace the single saved pairing with a versioned multi-computer registry
- migrate existing iPhone pairings without requiring a new QR scan
- keep one independently secured Keychain token per computer
- add a clean Settings → Computers switcher with add, switch, and remove flows
- allow a paired phone to scan another Mac while keeping the working connection intact until the new pairing succeeds
- recognize re-pairing the same Mac by its advertised routes instead of creating a duplicate
- keep only one event stream and one active computer at a time

## Verification

- `cd ios && swift test` — 196 passed
- generated Xcode project and built `OpenMausCompanion` for iPhone 17 Pro simulator
- simulator UI pass for Settings, computer switcher, add/cancel flow, and paired second-Mac deep link
- `pnpm typecheck`
- `pnpm build:companion`
- `pnpm check:electron`
- `pnpm test` — 2,536 counted; packaging smoke tests passed

Physical-device verification remains pending because the connected iPhone was unavailable to Xcode and iPhone Mirroring during this pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving and switching between multiple connected computers.
  * Added a Computers settings screen to connect, switch, and remove saved computers.
  * Added one-tap pairing for another computer without disconnecting the current one.
  * Automatically migrates existing single-computer pairings after upgrading.

* **Bug Fixes**
  * Pairing views now dismiss correctly after a successful connection.
  * Incoming pairing invites can be accepted while another computer is connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->