### PR TITLE
Make queued bot replies return reliably

### DIFF
--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -10,7 +10,7 @@
 // turned it into `node <script>` on Windows too, so the e2e half now runs
 // everywhere alongside the mention-resolution units.
 import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -461,7 +461,15 @@ describe("comms e2e (fake ACP fleet)", () => {
         const helperReplied = helperBot.messages.some(
           (m: any) => m.role === "bot" && m.kind === "text" && m.text?.includes("hello from fake acp"),
         );
-        if (askerDelegated && note && helperReplied && !helperBot.busy) break;
+        const resultReturned = askerBot.messages.some(
+          (m: any) =>
+            m.role === "bot"
+            && m.kind === "text"
+            && m.from?.botId === helper.id
+            && m.text?.includes("replied to the delegated task")
+            && m.text?.includes("hello from fake acp"),
+        );
+        if (askerDelegated && note && helperReplied && resultReturned && !helperBot.busy) break;
         if (Date.now() > deadline) {
           throw new Error(
             `delegate handoff never settled. asker busy=${askerBot.busy} helper busy=${helperBot.busy}\n` +
@@ -473,10 +481,16 @@ describe("comms e2e (fake ACP fleet)", () => {
         await new Promise((r) => setTimeout(r, 250));
       }
 
-      // A's reply is the queue-ack text the proxy returns, NOT a peer reply
-      const askerFinal = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
-      expect(askerFinal.text).toContain("delegated:");
-      expect(askerFinal.text).not.toContain("hello from fake acp");
+      // A first writes the queue acknowledgement; when B finishes, a
+      // separate attributed result arrives in the same source conversation.
+      const queueAck = askerBot.messages.find(
+        (m: any) => m.kind === "text" && m.role === "bot" && m.text?.includes("delegated:"),
+      );
+      expect(queueAck.text).not.toContain("hello from fake acp");
+      const returnedResult = askerBot.messages.find(
+        (m: any) => m.kind === "text" && m.from?.botId === helper.id && m.text?.includes("replied to the delegated task"),
+      );
+      expect(returnedResult.text).toContain("hello from fake acp");
 
       // A's comm chip links to the channel, attributed to @Helper
       expect(note).toBeTruthy();
@@ -589,15 +603,103 @@ describe("comms e2e (fake ACP fleet)", () => {
         (m: any) => m.role === "user" && m.kind === "text" && m.text?.includes("ping from fake"),
       );
       expect(inbound.text).toContain("[Delegated by @GateAsker");
+      await waitUntil(async () => {
+        askerBot = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        return askerBot.messages.some(
+          (m: any) =>
+            m.kind === "text"
+            && m.from?.botId === helper.id
+            && m.text?.includes("replied to the delegated task")
+            && m.text?.includes("ping from fake"),
+        );
+      }, 10_000, "queued peer reply never returned to the initiating chat");
     },
     60_000,
   );
 
+  it(
+    "retries a busy fallback after provider reload without asking for approval twice",
+    async () => {
+      rmSync(gateFile, { force: true });
+      for (const existing of (await api("GET", "/api/bots")).body.bots) {
+        await api("PATCH", `/api/bots/${existing.id}`, { hidden: true });
+      }
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "ReloadHelper",
+        modelSelection: { instanceId: "helperGate", model: "fake-model" },
+      });
+      const asker = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${asker.id}`, {
+        name: "ReloadAsker",
+        modelSelection: { instanceId: "grok", model: "fake-model" },
+        approvePeerComms: true,
+      });
+
+      // Start the ask while B is idle so the normal ask_bot approval card is
+      // the first and only human decision for this exact peer message.
+      expect((await api("POST", `/api/bots/${asker.id}/messages`, { text: "ask @ReloadHelper something" })).status).toBe(202);
+      let approvalCard: any;
+      await waitUntil(async () => {
+        const current = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        approvalCard = current.messages.find(
+          (m: any) => m.kind === "options" && m.card?.tool === "ask_bot" && !m.card?.answered,
+        );
+        return Boolean(approvalCard);
+      }, 20_000, "initial ask_bot approval card never appeared");
+
+      // B becomes busy while the approval is open. After Allow, ask_bot has
+      // to fall back to the durable queue, but that queue inherits Allow.
+      expect((await api("POST", `/api/bots/${helper.id}/messages`, { text: "hold until reload" })).status).toBe(202);
+      await waitUntil(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots.find((b: any) => b.id === helper.id);
+        return Boolean(current?.busy);
+      }, 10_000, "helper never became busy behind the approval card");
+      expect((await api("POST", `/api/bots/${asker.id}/respond`, {
+        requestId: approvalCard.card.requestId,
+        behavior: "allow",
+      })).status).toBe(200);
+
+      await waitUntil(async () => {
+        const current = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        const queued = current.messages.some(
+          (m: any) => m.kind === "text" && m.text?.includes("queued as a delegation"),
+        );
+        const waiting = current.messages.some(
+          (m: any) => m.kind === "activity" && m.tool?.name?.includes("waiting — they're busy"),
+        );
+        return queued && waiting && !current.busy;
+      }, 25_000, "approved ask was not retained as a waiting delegation");
+
+      // Provider reload releases B without turn.completed. The explicit idle
+      // retry must still pick up the waiting handoff on the rebuilt fleet.
+      expect((await api("PUT", "/api/config", { xai: { key: `xai_retry_${Date.now()}` } })).status).toBe(200);
+      writeFileSync(gateFile, "go");
+
+      let finalAsker: any;
+      await waitUntil(async () => {
+        finalAsker = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        return finalAsker.messages.some(
+          (m: any) =>
+            m.kind === "text"
+            && m.from?.botId === helper.id
+            && m.text?.includes("replied to the delegated task")
+            && m.text?.includes("ping from fake"),
+        );
+      }, 30_000, "provider reload left the waiting delegation stranded");
+
+      const approvalCards = finalAsker.messages.filter((m: any) => m.kind === "options");
+      expect(approvalCards.filter((m: any) => m.card?.tool === "ask_bot")).toHaveLength(1);
+      expect(approvalCards.some((m: any) => m.card?.tool === "delegate_bot")).toBe(false);
+    },
+    90_000,
+  );
+
   // ── delegation terminal-state mirroring ─────────────────────────────
-  // A delegated turn is fire-and-forget: nobody waits for B, so the ONLY
-  // place a human would ever see how it ended is the A⇄B channel. These
-  // tests pin a successful empty reply plus both non-happy terminal states:
-  // the delegated turn crashed, and the delegated turn never started.
+  // A delegated turn is fire-and-forget. Its result is returned to the
+  // initiating chat and mirrored into the A⇄B channel. These tests pin a
+  // successful empty reply plus both non-happy terminal states: the
+  // delegated turn crashed, and the delegated turn never started.
   it(
     "mirrors a successful delegated turn with no reply as a completed terminal chip",
     async () => {

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -5,7 +5,7 @@
 // stays out of these — the integration happens in comms.test.ts (the full
 // e2e through the agents proxy + fake ACP CLI).
 import { rmSync } from "node:fs";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CommsBus } from "./comms-visibility.ts";
 import { DATA_DIR } from "./config.ts";
@@ -18,6 +18,7 @@ import {
   pendingDelegationSnapshot,
   queueDelegation,
   recordDelegationReceipt,
+  releaseDelegationsWaitingOn,
   threadsWaitingOn,
   _pendingCount,
 } from "./delegations.ts";
@@ -617,6 +618,9 @@ describe("busy retries and receipts", () => {
     for (let round = 1; round < MAX_BUSY_ATTEMPTS; round++) {
       drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
       await waitFor(() => chipCount(`retry ${round}/`) === 1);
+      // One retry is charged per distinct busy period. Releasing the wait
+      // models that turn settling before another turn claims the target.
+      expect(releaseDelegationsWaitingOn(target.id)).toEqual([from.threadId]);
     }
     drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
     await waitFor(() => _pendingCount(from.threadId) === 0);
@@ -626,6 +630,30 @@ describe("busy retries and receipts", () => {
       toBotName: "Helper",
       sourceThreadId: from.threadId,
     });
+  });
+
+  it("does not burn busy retries when an unrelated drain is requested", async () => {
+    store.patchBot(target.id, { busy: true });
+    const queued = queueDelegation(commsBus, from, { toBotId: target.id, message: "later", depth: 0 }, 1);
+    const taskId = queued.id!;
+    const runTarget = vi.fn();
+
+    drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
+    await waitFor(() => chipCount("retry 1/") === 1);
+
+    // A source-thread redrain can happen while an approval for another
+    // item settles. It must not count the same continuously busy turn again.
+    for (let index = 0; index < MAX_BUSY_ATTEMPTS + 1; index++) {
+      drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(pendingDelegationInfo(taskId)?.attempts).toBe(1);
+    expect(chipCount("canceled — still busy after")).toBe(0);
+
+    store.patchBot(target.id, { busy: false });
+    expect(releaseDelegationsWaitingOn(target.id)).toEqual([from.threadId]);
+    drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
+    await waitFor(() => runTarget.mock.calls.length === 1);
   });
 
   it("persists receipts across a restart and prunes the drawer by count", () => {

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -367,6 +367,23 @@ describe("drainDelegations", () => {
     expect(runTargetCalls[0]!.commsDepth).toBe(1);
   });
 
+  it("does not ask twice when this exact fallback was already approved as ask_bot", async () => {
+    store.patchBot(from.id, { approvePeerComms: true });
+    queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "do this",
+      depth: 0,
+      approvalAlreadyGranted: true,
+    }, 1);
+    drainDelegations(commsBus, approvalBus, from.threadId, (toBotId, message, commsDepth) => {
+      runTargetCalls.push({ toBotId, message, commsDepth });
+    });
+
+    await waitFor(() => runTargetCalls.length === 1);
+    expect(runTargetCalls[0]).toMatchObject({ toBotId: target.id, commsDepth: 1 });
+    expect(store.messagesFor(from.threadId).some((message) => message.card?.tool === "delegate_bot")).toBe(false);
+  });
+
   it("emits a denial chip and skips runTarget when the user denies", async () => {
     store.patchBot(from.id, { approvePeerComms: true });
     queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1);
@@ -446,11 +463,20 @@ describe("delegations survive a restart", () => {
   afterEach(() => _resetPending());
 
   it("writes the queue to disk on queue, and clears it on drain and discard", async () => {
-    expect(queueDelegation(buses.commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1)).toMatchObject({ result: "ok" });
+    expect(queueDelegation(buses.commsBus, from, {
+      toBotId: target.id,
+      message: "do this",
+      depth: 0,
+      approvalAlreadyGranted: true,
+    }, 1)).toMatchObject({ result: "ok" });
     expect(existsSync(file())).toBe(true);
     const onDisk = JSON.parse(readFileSync(file(), "utf8")) as Record<string, unknown[]>;
     expect(onDisk[from.threadId]).toHaveLength(1);
-    expect(onDisk[from.threadId][0]).toMatchObject({ toBotId: target.id, message: "do this" });
+    expect(onDisk[from.threadId][0]).toMatchObject({
+      toBotId: target.id,
+      message: "do this",
+      approvalAlreadyGranted: true,
+    });
 
     discardDelegations(buses.commsBus, from.threadId);
     expect(JSON.parse(readFileSync(file(), "utf8"))[from.threadId]).toBeUndefined();

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -44,6 +44,10 @@ interface PendingDelegationItem extends DelegationItem {
    * the target is busy, and is retried when any of the target's turns
    * settles — up to MAX_BUSY_ATTEMPTS. */
   attempts: number;
+  /** True after this item observed the target's current busy period. Other
+   * queue activity must not count that same period again; the target's idle
+   * transition clears this marker before the next retry. */
+  waitingOnBusy?: boolean;
 }
 
 export type DelegationOutcome = "done" | "failed" | "denied" | "busy_gave_up" | "dropped" | "error";
@@ -131,14 +135,28 @@ export function pendingDelegationInfo(id: string): { sourceThreadId: string; toB
   return null;
 }
 
-/** Source threads holding a handoff that already waited on this busy bot at
- * least once — the set a target's settling turn re-drains. Fresh items
- * (attempts 0) are excluded: they run when their SOURCE turn settles, and
- * draining them early would start the peer before the delegator finished. */
+/** Source threads currently waiting for this busy bot — the set its idle
+ * transition re-drains. Fresh items are excluded: they run when their SOURCE
+ * turn settles, and draining them early would start the peer too soon. */
 export function threadsWaitingOn(toBotId: string): string[] {
   return [...pendingDelegations.entries()]
-    .filter(([, items]) => items.some((item) => item.toBotId === toBotId && item.attempts > 0))
+    .filter(([, items]) => items.some((item) => item.toBotId === toBotId && item.waitingOnBusy === true))
     .map(([threadId]) => threadId);
+}
+
+/** Mark a target's observed busy period as finished and return the source
+ * threads that should be retried. This makes retries count distinct busy
+ * periods, not unrelated drain requests on the same source thread. */
+export function releaseDelegationsWaitingOn(toBotId: string): string[] {
+  const threads = threadsWaitingOn(toBotId);
+  if (!threads.length) return threads;
+  for (const threadId of threads) {
+    for (const item of pendingDelegations.get(threadId) ?? []) {
+      if (item.toBotId === toBotId) delete item.waitingOnBusy;
+    }
+  }
+  savePending();
+  return threads;
 }
 
 function savePending(): void {
@@ -173,6 +191,7 @@ export function _loadPending(): void {
           attempts: Number.isFinite(item.attempts) ? Math.max(0, Math.trunc(item.attempts!)) : 0,
         };
         if (item.approvalAlreadyGranted === true) loaded.approvalAlreadyGranted = true;
+        if (item.waitingOnBusy === true) loaded.waitingOnBusy = true;
         return [loaded];
       });
       if (items.length) pendingDelegations.set(threadId, items);
@@ -412,7 +431,9 @@ async function processOne(
     return "settled";
   }
   if (target.busy) {
+    if (item.waitingOnBusy) return "requeued";
     item.attempts += 1;
+    item.waitingOnBusy = true;
     if (item.attempts < MAX_BUSY_ATTEMPTS) {
       savePending();
       bus.store.appendMessage(sourceThreadId, {
@@ -436,6 +457,10 @@ async function processOne(
       tool: { name: `Delegation to @${target.name} canceled — still busy after ${MAX_BUSY_ATTEMPTS} retries`, ok: false },
     });
     return "settled";
+  }
+  if (item.waitingOnBusy) {
+    delete item.waitingOnBusy;
+    savePending();
   }
   if (sender.approvePeerComms && !item.approvalAlreadyGranted) {
     const verdict = await requestPeerApproval(
@@ -470,7 +495,9 @@ async function processOne(
     const currentSender = bus.store.bot(from.id);
     if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return "settled";
     if (current.busy) {
+      if (item.waitingOnBusy) return "requeued";
       item.attempts += 1;
+      item.waitingOnBusy = true;
       if (item.attempts < MAX_BUSY_ATTEMPTS) {
         savePending();
         bus.store.appendMessage(sourceThreadId, {

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -25,6 +25,10 @@ export interface DelegationItem {
   toBotId: string;
   message: string;
   reason?: string;
+  /** The user already approved this exact peer message while it was still
+   * an ask_bot request. If that peer became busy before dispatch, the
+   * fallback handoff must not ask them to approve the same action twice. */
+  approvalAlreadyGranted?: boolean;
   /** The source bot's comms depth (0 for a user-initiated turn). The
    * delegated-to bot runs at `depth + 1`, which equals MAX_COMMS_DEPTH
    * (= 1) for a user turn — so the peer has no agents integration, and
@@ -160,14 +164,16 @@ export function _loadPending(): void {
           typeof item.message !== "string" ||
           !Number.isFinite(item.depth)
         ) return [];
-        return [{
+        const loaded: PendingDelegationItem = {
           id: typeof item.id === "string" && item.id ? item.id : newId(),
           toBotId: item.toBotId,
           message: item.message,
           ...(typeof item.reason === "string" ? { reason: item.reason } : {}),
           depth: Math.max(0, Math.trunc(item.depth!)),
           attempts: Number.isFinite(item.attempts) ? Math.max(0, Math.trunc(item.attempts!)) : 0,
-        }];
+        };
+        if (item.approvalAlreadyGranted === true) loaded.approvalAlreadyGranted = true;
+        return [loaded];
       });
       if (items.length) pendingDelegations.set(threadId, items);
     }
@@ -431,7 +437,7 @@ async function processOne(
     });
     return "settled";
   }
-  if (sender.approvePeerComms) {
+  if (sender.approvePeerComms && !item.approvalAlreadyGranted) {
     const verdict = await requestPeerApproval(
       approvalBus,
       sender,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1193,6 +1193,7 @@ const watchdog = new TurnWatchdog({
         stopScreenPoller(currentBot.id);
         if (activeVpsThreads.get(currentBot.id) === turn.threadId) activeVpsThreads.delete(currentBot.id);
         store.setActivity(currentBot.id, "idle");
+        retryDelegationsWaitingOn(currentBot.id);
         // The grace fallback replaces a missing turn.completed event. Release
         // every kind of work that may have queued behind this bot, including
         // connector and credential continuations.
@@ -1778,6 +1779,7 @@ bus.subscribe((event: RuntimeEvent) => {
         if (speakingBot?.busy) {
           store.setActivity(speakingBot.id, "idle");
           store.patchBot(speakingBot.id, { unread: true });
+          retryDelegationsWaitingOn(speakingBot.id);
         }
       }
       // A delegated turn's terminal state belongs in the A⇄B channel:
@@ -1797,7 +1799,13 @@ bus.subscribe((event: RuntimeEvent) => {
 // (target threadId → channel) lets the main fold mirror the delegated
 // turn's TERMINAL state into the A⇄B channel when it completes — the
 // channel stays the full record of the handoff, not just its request.
-const delegationWatch = new Map<string, { channelId?: string; toBotId: string; taskId?: string; sourceThreadId?: string }>();
+const delegationWatch = new Map<string, {
+  channelId?: string;
+  toBotId: string;
+  toBotName?: string;
+  taskId?: string;
+  sourceThreadId?: string;
+}>();
 
 /** Consume one delegated-turn watch and mirror exactly one terminal state.
  * Some harness paths settle a busy bot without a provider turn.completed
@@ -1825,6 +1833,31 @@ function finalizeDelegationWatch(
     });
   }
   const target = store.bot(watched.toBotId);
+  const targetName = target?.name ?? watched.toBotName ?? watched.toBotId;
+  const source = watched.sourceThreadId ? store.botByThread(watched.sourceThreadId) : undefined;
+  if (source && watched.sourceThreadId) {
+    if (ok && reply.trim()) {
+      const sourceReply: Omit<Message, "id" | "at"> = {
+        role: "bot",
+        kind: "text",
+        text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
+      };
+      if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
+      store.appendMessage(watched.sourceThreadId, sourceReply);
+    } else {
+      store.appendMessage(watched.sourceThreadId, {
+        role: "bot",
+        kind: "activity",
+        tool: {
+          name: ok
+            ? `Delegation to @${targetName} completed without a text reply`
+            : `Delegation to @${targetName} failed — ${failureName}`,
+          ok,
+        },
+      });
+    }
+    store.patchBot(source.id, { unread: true });
+  }
   const channel = watched.channelId ? store.group(watched.channelId) : undefined;
   if (!target || !channel) return true;
   if (ok && reply.trim()) mirrorReply(commsBus, target, reply, channel);
@@ -1874,7 +1907,16 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
     // harness (Node's default), which in the packaged app kills the server
     // child. Every delegation failure has to land as a chip instead.
     const targetThreadId = store.bot(toBotId)?.threadId;
-    if (targetThreadId) delegationWatch.set(targetThreadId, { channelId: channel?.id, toBotId, taskId, sourceThreadId });
+    const target = store.bot(toBotId);
+    if (targetThreadId) {
+      delegationWatch.set(targetThreadId, {
+        channelId: channel?.id,
+        toBotId,
+        toBotName: target?.name,
+        taskId,
+        sourceThreadId,
+      });
+    }
     let failureReported = false;
     const reportStartFailure = (error: unknown) => {
       if (failureReported) return;
@@ -1882,12 +1924,13 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
       const bot = store.bot(toBotId);
       const why = error instanceof Error ? error.message : String(error);
       if (targetThreadId) {
-        finalizeDelegationWatch(
+        const finalized = finalizeDelegationWatch(
           targetThreadId,
           false,
           "",
           `Delegated turn could not start — ${why.slice(0, 120)}`,
         );
+        if (finalized) return;
       }
       const source = store.botByThread(sourceThreadId);
       if (!source) return;
@@ -1909,6 +1952,24 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
     });
 };
 
+// Most waiting handoffs retry from a target's turn.completed event. Some
+// setup, cancellation, room, watchdog, and provider-reload paths release a
+// bot without that event, so every explicit idle release calls this same
+// coalesced retry hook. The microtask lets the releasing state machine finish
+// before another turn claims the bot.
+const delegationRetryBots = new Set<string>();
+function retryDelegationsWaitingOn(botId: string): void {
+  if (delegationRetryBots.has(botId)) return;
+  delegationRetryBots.add(botId);
+  queueMicrotask(() => {
+    delegationRetryBots.delete(botId);
+    if (store.bot(botId)?.busy) return;
+    for (const waitingThread of threadsWaitingOn(botId)) {
+      drainDelegations(commsBus, approvalBus, waitingThread, runDelegatedTurn);
+    }
+  });
+}
+
 bus.subscribe((event: RuntimeEvent) => {
   if (shouldIgnoreProviderEvent(event)) return;
   if (event.type !== "turn.completed") return;
@@ -1921,11 +1982,7 @@ bus.subscribe((event: RuntimeEvent) => {
   // found it busy earlier were kept queued (bounded retries) on their own
   // source threads, and this is the moment they get their retry.
   const settledBot = store.botByThread(event.threadId);
-  if (settledBot) {
-    for (const waitingThread of threadsWaitingOn(settledBot.id)) {
-      if (waitingThread !== event.threadId) drainDelegations(commsBus, approvalBus, waitingThread, runDelegatedTurn);
-    }
-  }
+  if (settledBot) retryDelegationsWaitingOn(settledBot.id);
 });
 
 // ── steer-queue drain: messages sent while the bot was busy ────────────
@@ -2611,6 +2668,7 @@ async function startTurn(
         opts?.onDispatchError?.(e.message);
         if (ownsLatestGeneration && store.bot(bot.id)?.busy) {
           store.setActivity(bot.id, "idle");
+          retryDelegationsWaitingOn(bot.id);
         }
         if (ownsLatestGeneration) {
           drainQueuedSends();
@@ -2627,6 +2685,7 @@ async function startTurn(
         tool: { name: `error: ${message.slice(0, 160)}`, ok: false },
       });
       store.setActivity(bot.id, "idle");
+      retryDelegationsWaitingOn(bot.id);
       opts?.onDispatchError?.(message);
       // a dispatch failure never emits turn.completed, so the settle-driven
       // drain would strand anything queued behind this turn
@@ -3136,7 +3195,10 @@ async function runGroupMemberTurn(
   const browserReadyBot = store.bot(readyBot.id);
   if (isCancelled?.() || !browserReadyBot || !browserReadyBot.busy) {
     await releaseBrowserCapabilityForThread(threadId);
-    if (browserReadyBot?.busy) store.setActivity(browserReadyBot.id, "idle");
+    if (browserReadyBot?.busy) {
+      store.setActivity(browserReadyBot.id, "idle");
+      retryDelegationsWaitingOn(browserReadyBot.id);
+    }
     return false;
   }
 
@@ -3279,7 +3341,10 @@ async function runGroupMemberTurn(
       store.patchGroup(currentGroup.id, { busyBotId: null, unread: true });
     }
     const currentBot = store.bot(bot.id);
-    if (currentBot?.busy) store.setActivity(currentBot.id, "idle");
+    if (currentBot?.busy) {
+      store.setActivity(currentBot.id, "idle");
+      retryDelegationsWaitingOn(currentBot.id);
+    }
     watchdog.settle(threadId);
     drainQueuedSends();
     drainConnectorResumes();
@@ -3293,7 +3358,10 @@ async function runGroupMemberTurn(
   if (store.group(group.id)?.busyBotId === bot.id) {
     groupSpeakers.delete(threadId);
     store.patchGroup(group.id, { busyBotId: null, unread: true });
-    if (store.bot(bot.id)?.busy) store.setActivity(bot.id, "idle");
+    if (store.bot(bot.id)?.busy) {
+      store.setActivity(bot.id, "idle");
+      retryDelegationsWaitingOn(bot.id);
+    }
   }
   if (outcome === "dispatch_failed") {
     await releaseBrowserCapabilityForThread(threadId);
@@ -3871,6 +3939,7 @@ async function reloadProviders() {
       tool: { name: "error: turn interrupted — provider settings changed", ok: false },
     });
     store.setActivity(b.id, "idle");
+    retryDelegationsWaitingOn(b.id);
   }
   // killed turns settle here without a turn.completed event, so anything
   // queued behind them drains now — onto the freshly loaded fleet
@@ -4127,11 +4196,11 @@ const server = createServer(async (req, res) => {
         // retries, receipts, restart-safe) and the asker gets a task id it
         // can check next turn. If the ledger refuses (cap/depth), fall back
         // to the plain busy bounce rather than dropping the refusal reason.
-        const queueBusyFallback = () => {
+        const queueBusyFallback = (approvalAlreadyGranted = false) => {
           const queued = queueDelegation(
             commsBus,
             from,
-            { toBotId, message, reason: "asked while busy", depth },
+            { toBotId, message, reason: "asked while busy", depth, approvalAlreadyGranted },
             MAX_COMMS_DEPTH,
             fromThreadId,
           );
@@ -4174,7 +4243,10 @@ const server = createServer(async (req, res) => {
           if (!store.taskByThread(freshFrom.id, fromThreadId)) {
             return json(res, 404, { error: "source task no longer exists" });
           }
-          if (freshTarget.busy) return queueBusyFallback();
+          // The user just approved this exact ask_bot request. Preserve that
+          // decision if it has to become an async handoff; asking twice makes
+          // the fallback look stuck behind a second, surprising card.
+          if (freshTarget.busy) return queueBusyFallback(true);
           currentFrom = freshFrom;
           currentTarget = freshTarget;
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -96,7 +96,7 @@ import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
-import { _loadPending, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, threadsWaitingOn, type QueueResult } from "./delegations.ts";
+import { _loadPending, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, type QueueResult } from "./delegations.ts";
 import {
   cancelSteeredMessage,
   drainSteeredMessages,
@@ -1964,7 +1964,7 @@ function retryDelegationsWaitingOn(botId: string): void {
   queueMicrotask(() => {
     delegationRetryBots.delete(botId);
     if (store.bot(botId)?.busy) return;
-    for (const waitingThread of threadsWaitingOn(botId)) {
+    for (const waitingThread of releaseDelegationsWaitingOn(botId)) {
       drainDelegations(commsBus, approvalBus, waitingThread, runDelegatedTurn);
     }
   });


### PR DESCRIPTION
Follow-up to #583, #584, and #585.

## What this fixes

- Returns every delegated bot's terminal reply or failure to the conversation that initiated it, while keeping the existing bot-to-bot channel mirror and durable receipt.
- Retries handoffs waiting on a busy bot when that bot becomes idle through setup cancellation, dispatch failure, room cleanup, watchdog release, or provider reload — including paths that do not emit `turn.completed`.
- Preserves an approval already granted to `ask_bot` when the target becomes busy while the approval card is open, so the asynchronous fallback does not ask the user twice.

## Regression coverage

- Normal async delegation returns the peer response to the source conversation.
- Busy `ask_bot` fallback returns the eventual result to the source conversation.
- Approval-open → peer becomes busy → provider reload releases peer → queued work retries and responds, without a second approval card.
- The inherited approval flag is persisted with the durable queue.

## Verified locally

- `pnpm exec vitest run server/delegations.test.ts server/comms.test.ts server/drivers/agents-proxy.test.ts` — 75 passed
- `pnpm exec vitest run server/index.test.ts` — 127 passed
- `pnpm typecheck` — passed
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegated requests now retry automatically after a provider reload or other temporary interruption.
  * Approved delegation requests no longer prompt for approval a second time.
  * Delegated responses and failures are reflected in the originating conversation and marked as unread.
  * Improved handling of delegation recovery after cancellations, dispatch errors, and stalled activity.
* **Tests**
  * Expanded coverage for delegation handoffs, retries, approval persistence, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->