### PR TITLE
fix(chat): drop emoji reactions from the bubble hover bar

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -56,7 +56,7 @@ import { AttachedImageGallery } from "./AttachmentPreview";
 import { ModelPicker } from "./ModelPicker";
 import { RenameTitle } from "./RenameTitle";
 import { TaskPicker } from "./TaskPicker";
-import { ReactionBar, ReactionChips } from "./Reactions";
+
 import { SpeakButton } from "./SpeakButton";
 import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
@@ -349,7 +349,6 @@ function Bubble({
             <Pencil size={14} />
           </button>
         )}
-        {user && message.kind === "text" && <ReactionBar threadId={bot.threadId} message={message} />}
         {user && <CopyButton text={visibleText} />}
         {user && (
           <>
@@ -498,7 +497,6 @@ function Bubble({
             </button>
           </>
         )}
-        {!user && message.kind === "text" && <ReactionBar threadId={bot.threadId} message={message} />}
         <span
           className={cn(
             "self-end pb-1 text-[11px] tabular-nums text-ink-secondary/70 opacity-0 transition-opacity group-hover:opacity-100",
@@ -508,7 +506,6 @@ function Bubble({
           {formatTime(message.at)}
         </span>
       </div>
-      <ReactionChips threadId={bot.threadId} message={message} align={user ? "right" : "left"} />
       {versions.length > 1 && (
         <div className="mt-1 flex items-center gap-0.5 pr-1 text-[12px] text-ink-secondary">
           <button

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -30,7 +30,7 @@ import { SecretRequestCard } from "./SecretRequestCard";
 import { hasRoutineExecutionTask, RoutineRunCard } from "./RoutineRunCard";
 import { AttachedImageGallery } from "./AttachmentPreview";
 import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
-import { ReactionBar, ReactionChips } from "./Reactions";
+
 import { ApprovalCard } from "./ApprovalCard";
 import { ManageMembersPanel } from "./ManageMembersPanel";
 import { groupActivityRuns } from "@/lib/activity-runs";
@@ -216,7 +216,6 @@ const Transcript = memo(function Transcript({
           ) : m.kind === "text" && m.text ? (
             <div className={cn("group flex w-full flex-col", user ? "items-end" : "items-start")}>
               <div className={cn("flex w-full items-end gap-1.5", user ? "justify-end" : "justify-start")}>
-                {user && <ReactionBar threadId={group.threadId} message={m} />}
                 {user && (
                   <>
                     <button
@@ -274,14 +273,12 @@ const Transcript = memo(function Transcript({
                       <MessageSquareReply size={14} />
                     </button>
                     <PinToggle group={group} message={m} />
-                    <ReactionBar threadId={group.threadId} message={m} />
                   </>
                 )}
                 <span className="self-end pb-1 text-[11px] tabular-nums text-ink-secondary/70 opacity-0 transition-opacity group-hover:opacity-100">
                   {formatTime(m.at)}
                 </span>
               </div>
-              <ReactionChips threadId={group.threadId} message={m} members={members} align={user ? "right" : "left"} />
             </div>
           ) : null;
         if (!row) return null;


### PR DESCRIPTION
## Why

Hovering a bubble shows a palette of 👍 ❤️ 😂 🎉 👀 plus a more-reactions picker. Those controls do not earn their chrome next to reply and pin.

## What

Remove the hover reaction bar and the chips under bubbles in 1:1 chat and rooms. Reply, pin, copy, and regenerate stay. The reaction API and store are unchanged.

## Test plan

- [ ] Hover a user bubble: no emoji strip; reply and pin still appear
- [ ] Hover a bot bubble: same
- [ ] In a room, same on both sides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed message reaction controls and reaction indicators from chat transcripts and group conversations.
  * Reply, pin, and timestamp controls remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->