### PR TITLE
fix(drivers): explicitly emit runtime.error for non-SUCCESS results

### DIFF
--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -687,7 +687,19 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             const reason = result?.stopReason;
             if (reason === "end_turn") settle(true, null);
             else if (reason === "cancelled") settle(true, "cancelled");
-            else settle(false, reason ?? "failed");
+            else {
+              const errorMessage = typeof result?.error === "string" && result.error
+                ? result.error
+                : typeof result?.message === "string" && result.message
+                  ? result.message
+                  : `Model turn failed: ${reason ?? "unknown error"}`;
+              emit({
+                ...base(threadId, turnId),
+                type: "runtime.error",
+                message: errorMessage,
+              });
+              settle(false, reason ?? "failed");
+            }
           } catch (e) {
             if (!state.settled) {
               const message = e instanceof Error ? e.message : String(e);

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -610,6 +610,18 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
                 output: payload.usage.output_tokens || 0,
               });
             }
+            if (payload.status !== "SUCCESS") {
+              const errorMessage = typeof payload.message === "string" && payload.message 
+                ? payload.message 
+                : typeof payload.error === "string" && payload.error 
+                  ? payload.error 
+                  : `Model turn failed: ${payload.status || "unknown reason"}`;
+              emit({
+                ...base(threadId, turnId),
+                type: "runtime.error",
+                message: errorMessage,
+              });
+            }
             // result.usage is the turn total (the per-step agent_response
             // figures above are its parts, not additions to it)
             settle(


### PR DESCRIPTION
This fixes a bug where providers that hit usage/rate limits (like Anti-Gravity and Opencode) would silently settle the turn as failed without rendering any error message to the user. Because no text output or `runtime.error` was forwarded to the UI, the frontend's working indicator would just abruptly disappear and the user was left thinking the bot simply ignored them or was still hung. By catching non-SUCCESS results (or failed stopReasons in the ACP core) and explicitly calling `emit({ type: \"runtime.error\", message: ... })`, the `server/index.ts` wiring can now correctly transform it into an `error:` activity chip that is displayed in the `ErrorRow` UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when AI requests fail or return unexpected statuses.
  * Displays clearer error messages based on available failure details instead of generic failures.
  * Failed requests now consistently emit runtime error notifications before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->