### PR TITLE
feat(ios): add copy action to message menu

### DIFF
--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -773,6 +773,12 @@ struct MessageRow: View {
             ForEach(Self.reactionChoices, id: \.self) { emoji in
                 Button(emoji) { Task { await session.react(to: message, in: chat.threadId, emoji: emoji) } }
             }
+            if let text = message.text, !text.isEmpty {
+                Divider()
+                Button("Copy", systemImage: "doc.on.doc") {
+                    PlatformBridge.copyToPasteboard(text)
+                }
+            }
             if message.role == .user, message.kind == .text, case let .bot(bot) = chat {
                 Divider()
                 Button("Edit and retry", systemImage: "pencil") {

--- a/ios/TESTING.md
+++ b/ios/TESTING.md
@@ -282,7 +282,8 @@ Not built yet, so not bugs:
   APNs relay with project-owned Apple credentials.
 - **No call mode, spoken replies, or routine management.** Composer dictation,
   tasks, SQLite transcript search/export,
-  reactions, and edit/version switching are available from the conversation UI.
+  reactions, message copying, and edit/version switching are available from
+  the conversation UI.
 
 (Two entries that used to sit on this list have since shipped: replies stream
 token by token as the provider emits them, and each bot has a computer panel —


### PR DESCRIPTION
Long-press any text message now shows **Copy** beneath the reactions; it copies the message text to the iOS clipboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy” option to message context menus, allowing message text to be copied to the pasteboard.
  * The option appears only for messages containing text.

* **Documentation**
  * Updated iOS testing guidance to reflect that message copying is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->