### PR TITLE
fix(openai-compat): flag catalog models as custom so the picker shows them

### DIFF
--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -78,11 +78,14 @@ describe("OpenAICompatDriver", () => {
 
     await inst.refreshModels?.();
 
+    // Every option carries `custom: true`: this engine advertises
+    // `access: "custom"`, and the picker renders only custom-flagged options
+    // for such engines — an unflagged one is invisible in its own picker.
     expect(inst.models).toEqual({
       default: "vendor/model-a",
       options: [
-        { id: "vendor/model-a", label: "Model A" },
-        { id: "vendor/model-b", label: "vendor/model-b" },
+        { id: "vendor/model-a", label: "Model A", custom: true },
+        { id: "vendor/model-b", label: "vendor/model-b", custom: true },
       ],
     });
     await inst.dispose();

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -24,11 +24,15 @@ const DRIVER_KIND = "openai-compat";
 
 // Default catalog — overwritten by /models when the endpoint answers.
 // Free-tier-friendly defaults so the picker is never empty.
+// Every option here is `custom`: this engine advertises `access: "custom"`,
+// and the picker renders only custom-flagged options for such engines. An
+// unflagged option lands in the official list the picker never shows, which
+// reads as "no models found" on a perfectly configured endpoint.
 const DEFAULT_MODELS: ModelCatalog = {
   default: "meta-llama/llama-3.3-70b-instruct",
   options: [
-    { id: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B (OpenRouter)" },
-    { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B (Groq)" },
+    { id: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B (OpenRouter)", custom: true },
+    { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B (Groq)", custom: true },
   ],
 };
 
@@ -122,7 +126,7 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
           default: config.model,
           options: DEFAULT_MODELS.options.some((o) => o.id === config.model)
             ? DEFAULT_MODELS.options
-            : [{ id: config.model, label: config.model }, ...DEFAULT_MODELS.options],
+            : [{ id: config.model, label: config.model, custom: true }, ...DEFAULT_MODELS.options],
         }
       : DEFAULT_MODELS;
 
@@ -259,14 +263,14 @@ export const OpenAICompatDriver: ProviderDriver<OpenAICompatConfig> = {
             typeof row.name === "string" && row.name.trim()
               ? row.name
               : id;
-          options.push({ id, label });
+          options.push({ id, label, custom: true });
         }
         if (options.length) {
           // Keep a configured default selected; surface it even if the
           // endpoint's catalog omits it.
           const preferred =
             config.model && (options.some((o) => o.id === config.model) ? config.model : null);
-          if (config.model && !preferred) options.unshift({ id: config.model, label: config.model });
+          if (config.model && !preferred) options.unshift({ id: config.model, label: config.model, custom: true });
           catalog = { default: config.model ?? options[0].id, options };
         }
       } catch {


### PR DESCRIPTION
### The bug

Pick the **OpenAI-compatible** engine for a bot, point it at a working endpoint, and the model picker says **"No local models found"** — even though the endpoint answers and the driver works fine.

### Why

The driver advertises `access: "custom"`. For such engines the picker renders **only** options carrying `custom: true`; everything else goes into the official list, which is never shown for a custom-access engine. None of the driver's options carried the flag, so the picker had nothing left to render.

### The fix

Flag the options at all three places they originate:

- `DEFAULT_MODELS` — the built-in fallback catalog
- the configured `config.model`, when it isn't already in that catalog
- the catalog fetched from the endpoint's `/models`

Three lines plus a comment stating the invariant, so the next option added doesn't silently drop the flag again.

### Impact

Any OpenAI-compatible setup is affected — OpenRouter and Groq included, not just self-hosted gateways. Found while wiring four bots to a self-hosted gateway: every one of them showed an empty picker on a perfectly good endpoint.

### Verification

`server/drivers/openai-compat.test.ts` — 16 passed. The catalog test now asserts the flag, so a regression fails the suite instead of quietly emptying the picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI-compatible model options are now consistently available in the model picker.
  * Configured defaults, catalog entries, fallback models, and models retrieved from the service are correctly marked for custom access.
  * Updated validation ensures all exposed model options include the required custom-access setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->