### PR TITLE
fix(rooms): refuse a room whose every member is archived

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -486,6 +486,28 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("refuses a room whose every member is archived", async () => {
+    const [archived, active] = await Promise.all([api("POST", "/api/bots"), api("POST", "/api/bots")]).then(
+      (created) => created.map((response) => response.body.bot),
+    );
+    await api("PATCH", `/api/bots/${archived.id}`, { hidden: true });
+    try {
+      const refused = await api("POST", "/api/groups", { name: "All archived", memberIds: [archived.id] });
+      expect(refused.status).toBe(400);
+      expect(refused.body.error).toMatch(/at least one active bot/i);
+
+      // one active member is enough — the archived one may still ride along
+      const created = await api("POST", "/api/groups", {
+        name: "Mixed roster",
+        memberIds: [archived.id, active.id],
+      });
+      expect(created.status).toBe(201);
+      await api("DELETE", `/api/groups/${created.body.group.id}`);
+    } finally {
+      for (const bot of [archived, active]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("deduplicates repeated room members while preserving their first-seen order", async () => {
     const [first, second] = await Promise.all([api("POST", "/api/bots"), api("POST", "/api/bots")]).then(
       (created) => created.map((response) => response.body.bot),

--- a/server/index.ts
+++ b/server/index.ts
@@ -722,6 +722,15 @@ function checkedMemberIds(value: unknown): { ok: true; memberIds: string[] } | {
   }
   const memberIds = [...new Set(value as string[])];
   if (!memberIds.length) return { ok: false, error: "a channel needs at least one bot" };
+  // A room whose every member is archived accepts messages and answers none of
+  // them — the failure only surfaces later, as "… is archived and can't
+  // respond" on the first turn. Refuse it here, where the mistake is made.
+  if (memberIds.every((id) => store.bot(id)?.hidden)) {
+    return {
+      ok: false,
+      error: "a channel needs at least one active bot — every member given is archived",
+    };
+  }
   return { ok: true, memberIds };
 }
 let bootSelection = { instanceId: "", model: "" };


### PR DESCRIPTION
### The bug

Create a room whose members are all archived bots — it succeeds. The room is dead: it accepts messages and answers none of them. Nothing says so until the first turn, which comes back as

> … is archived and can't respond — restore it or mention an active room member.

### Why it's easy to hit

`checkedMemberIds` validates that each id **exists**, not that the bot can answer. When you build a room from the API — scripted setup, an import, a restored backup — archived bots pass every check. `hidden` is right there in the `GET /api/bots` payload, but nothing points at it while the roster is being assembled, and the names look exactly like the active ones.

That's how I hit it: four members, all archived namesakes of the bots I meant to use. Room created, everything green, dead on arrival.

### The fix

Refuse the roster when **every** member is archived, at the moment the mistake is made:

```
a channel needs at least one active bot — every member given is archived
```

A mixed roster still passes — an archived bot may ride along, it just can't be the only one. That keeps the existing behaviour for rooms where someone archives a member later; only the all-archived case is rejected.

### Verification

`server/index.test.ts` — 128 passed, including a new case asserting both halves: the all-archived roster is refused with 400, and a roster with one active member still returns 201.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room creation and member updates now reject rosters containing only archived members.
  * Mixed rosters with at least one active member continue to be accepted.
  * Validation errors now appear immediately instead of waiting until the first interaction.

* **Tests**
  * Added coverage for all-archived and mixed archived/active room rosters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->