### PR TITLE
Improve Antigravity regional network routing

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,16 +1,22 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { customMcpServers,
+import {
+  ANTIGRAVITY_NETWORK_ROUTE_ENV,
+  DEFAULT_ANTIGRAVITY_PROXY_URL,
+  customMcpServers,
   DATA_DIR,
+  antigravityNetworkRoute,
+  antigravityProxySettings,
   instanceConfigs,
   isValidSshAlias,
   loadBrowserProfileIdAliases,
   loadConfig,
   localVmMaxInstances,
   localVmMode,
+  normalizeAntigravityProxyUrl,
   parseConfigPatch,
   parseStoredConfig,
   roomTurnTimeoutMinutes,
@@ -343,6 +349,97 @@ describe("configuration boundaries", () => {
     expect(showToolCallsEnabled({ features: { showToolCalls: true } })).toBe(true);
   });
 
+  it("accepts only explicit loopback HTTP(S) proxy URLs and migrates the three network modes", () => {
+    expect(antigravityProxySettings({})).toEqual({ mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL });
+    expect(normalizeAntigravityProxyUrl(" HTTPS://LOCALHOST:08080/ ")).toBe("https://localhost:8080");
+    expect(parseConfigPatch({
+      features: { antigravityProxy: { enabled: true, url: "http://[::1]:10808/" } },
+    })).toEqual({
+      features: { antigravityProxy: { mode: "proxy", url: "http://[::1]:10808" } },
+    });
+    expect(parseStoredConfig({ features: { antigravityProxy: { enabled: true, url: "http://127.0.0.1:10808" } } }))
+      .toMatchObject({ features: { antigravityProxy: { mode: "proxy", url: DEFAULT_ANTIGRAVITY_PROXY_URL } } });
+    expect(parseStoredConfig({ features: { antigravityProxy: { enabled: false } } }))
+      .toMatchObject({ features: { antigravityProxy: { mode: "tun", url: DEFAULT_ANTIGRAVITY_PROXY_URL } } });
+    expect(parseStoredConfig({})).toEqual({});
+    for (const url of [
+      "http://user:password@127.0.0.1:10808", // secret-scan: allow-test-fixture
+      "http://127.0.0.1:10808/path",
+      "http://127.0.0.1:10808?token=secret", // secret-scan: allow-test-fixture
+      "http://127.0.0.1:10808#fragment",
+      "https://192.168.1.20:10808",
+      "socks5://127.0.0.1:10808",
+      "http://127.0.0.1",
+      "http://127.0.0.1:0",
+      "http://127.0.0.1:65536",
+    ]) {
+      try {
+        parseConfigPatch({ features: { antigravityProxy: { enabled: true, url } } });
+        throw new Error("expected invalid proxy URL");
+      } catch (error) {
+        expect(String(error)).toMatch(/features\.antigravityProxy\.url|Invalid configuration/);
+        expect(String(error)).not.toContain(url);
+      }
+    }
+    expect(() => parseConfigPatch({ features: { antigravityProxy: { mode: "proxy" } } })).toThrow(
+      "features.antigravityProxy.url",
+    );
+  });
+
+  it("builds one off/tun/proxy route signal without accepting user proxy values", () => {
+    expect(antigravityNetworkRoute({})).toBe("off");
+    const defaultInstances = instanceConfigs({
+      instances: {
+        agyA: { driver: "antigravityAgent" },
+        agyB: { driver: "antigravityAgent" },
+      },
+    });
+    expect(defaultInstances.agyA.environment).toEqual({ [ANTIGRAVITY_NETWORK_ROUTE_ENV]: "off" });
+    expect(defaultInstances.agyB.environment).toEqual({ [ANTIGRAVITY_NETWORK_ROUTE_ENV]: "off" });
+    const cfg: AppConfig = {
+      features: { antigravityProxy: { mode: "proxy", url: "http://localhost:08080/" } },
+      instances: {
+        agyA: { driver: "antigravityAgent", environment: { HTTP_PROXY: "http://user:secret@remote.invalid:1" } },
+        agyB: { driver: "antigravityAgent" },
+      },
+    };
+    expect(antigravityNetworkRoute(cfg)).toBe("proxy|http://localhost:8080");
+    const instances = instanceConfigs(cfg);
+    expect(instances.agyA.environment).toEqual({
+      HTTP_PROXY: "http://user:secret@remote.invalid:1",
+      [ANTIGRAVITY_NETWORK_ROUTE_ENV]: "proxy|http://localhost:8080",
+    });
+    expect(instances.agyB.environment).toEqual({
+      [ANTIGRAVITY_NETWORK_ROUTE_ENV]: "proxy|http://localhost:8080",
+    });
+    expect(instances.agyA.environment?.[ANTIGRAVITY_NETWORK_ROUTE_ENV]).not.toContain("secret");
+  });
+
+  it("persists normalized mode state through the existing config path", () => {
+    const path = join(DATA_DIR, "config.json");
+    const hadFile = existsSync(path);
+    const original = hadFile ? readFileSync(path) : undefined;
+    mkdirSync(DATA_DIR, { recursive: true });
+    try {
+      saveConfig({ features: { antigravityProxy: { enabled: true, url: "http://localhost:08080/" } } });
+      expect(JSON.parse(readFileSync(path, "utf8")).features.antigravityProxy).toEqual({
+        mode: "proxy",
+        url: "http://localhost:8080",
+      });
+      expect(antigravityProxySettings(loadConfig())).toEqual({ mode: "proxy", url: "http://localhost:8080" });
+
+      saveConfig({ features: { antigravityProxy: { mode: "tun" } } });
+      expect(JSON.parse(readFileSync(path, "utf8")).features.antigravityProxy).toEqual({
+        mode: "tun",
+        url: "http://localhost:8080",
+      });
+      expect(antigravityNetworkRoute(loadConfig())).toBe("tun");
+    } finally {
+      if (original === undefined) rmSync(path, { force: true });
+      else writeFileSync(path, original);
+    }
+  });
+
   it.each([0, 1.5, 5, "2", null])("rejects an invalid per-bot VM limit: %j", (maxInstances) => {
     expect(() => parseConfigPatch({ localVm: { maxInstances } })).toThrow("localVm.maxInstances");
   });
@@ -529,6 +626,7 @@ describe("credential env narrowing", () => {
     const instances = instanceConfigs(cfg);
     for (const [id, entry] of Object.entries(instances)) {
       if (id === "computer") expect(entry.environment).toEqual({ BOX_TOKEN: "SECRET-BOX" });
+      else if (entry.driver === "antigravityAgent") expect(entry.environment).toEqual({ [ANTIGRAVITY_NETWORK_ROUTE_ENV]: "off" });
       else expect(entry.environment).toEqual({});
     }
   });

--- a/server/config.ts
+++ b/server/config.ts
@@ -212,6 +212,90 @@ const browserProfilesSchema = z.array(browserProfileSchema).max(20).superRefine(
     });
   });
 });
+export const DEFAULT_ANTIGRAVITY_PROXY_URL = "http://127.0.0.1:10808";
+export const ANTIGRAVITY_NETWORK_ROUTE_ENV = "OPENMAUSBOT_ANTIGRAVITY_NETWORK_ROUTE";
+export const ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR = "|";
+export type AntigravityNetworkMode = "off" | "tun" | "proxy";
+
+/** Normalize only an explicitly-portioned loopback HTTP(S) proxy URL. */
+export function normalizeAntigravityProxyUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const input = value.trim();
+  const match = /^(https?):\/\/(\[[0-9a-f:.]+\]|[a-z0-9.-]+):(\d{1,5})(\/?)$/i.exec(input);
+  if (!match) return null;
+  const protocol = match[1]!.toLowerCase();
+  const host = match[2]!.toLowerCase();
+  if (host !== "127.0.0.1" && host !== "localhost" && host !== "[::1]") return null;
+  const port = Number(match[3]);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return null;
+  try {
+    const parsed = new URL(input);
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return null;
+    if (parsed.pathname !== "" && parsed.pathname !== "/") return null;
+  } catch {
+    return null;
+  }
+  return `${protocol}://${host}:${port}`;
+}
+
+/** Resolve legacy and explicit network settings to one canonical route. */
+function canonicalAntigravityProxySettings(raw: {
+  mode?: AntigravityNetworkMode;
+  enabled?: boolean;
+  url?: string;
+} | undefined): { mode: AntigravityNetworkMode; url: string } {
+  const normalizedUrl = normalizeAntigravityProxyUrl(raw?.url);
+  if (raw?.url !== undefined && normalizedUrl === null) throw new Error("Invalid Antigravity proxy URL");
+  // `enabled` is accepted only to migrate configs written by the two-state
+  // implementation. An explicit mode is the single live representation.
+  const mode = raw?.mode
+    ?? (raw?.enabled === true ? "proxy" : raw?.enabled === false ? "tun" : "off");
+  if (mode === "proxy" && normalizedUrl === null) throw new Error("Antigravity proxy URL is required in Proxy mode");
+  return { mode, url: normalizedUrl ?? DEFAULT_ANTIGRAVITY_PROXY_URL };
+}
+
+/** Normalize a partial network-mode patch without forcing an absent URL. */
+function canonicalAntigravityProxyPatch(raw: {
+  mode?: AntigravityNetworkMode;
+  enabled?: boolean;
+  url?: string;
+}): { mode: AntigravityNetworkMode; url?: string } {
+  const settings = canonicalAntigravityProxySettings(raw);
+  return settings.mode === "proxy" || raw.url !== undefined
+    ? settings
+    : { mode: settings.mode };
+}
+
+/** Return canonical Antigravity proxy settings, failing closed to Off. */
+export function antigravityProxySettings(cfg: Pick<AppConfig, "features">): {
+  mode: AntigravityNetworkMode;
+  url: string;
+} {
+  try {
+    return canonicalAntigravityProxySettings(cfg.features?.antigravityProxy);
+  } catch {
+    return { mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL };
+  }
+}
+
+/** One stable launcher value: `off`, `tun`, or `proxy|<safe normalized URL>`. */
+export function antigravityNetworkRoute(cfg: Pick<AppConfig, "features">): string {
+  const settings = antigravityProxySettings(cfg);
+  return settings.mode === "proxy"
+    ? `proxy${ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR}${settings.url}`
+    : settings.mode;
+}
+
+/** Fail closed when a direct adapter caller supplies an unknown route value. */
+export function normalizeAntigravityNetworkRoute(value: unknown): string {
+  // `system` was the two-state route for legacy instance environments. Its
+  // behavior was the old enabled:false path, so it maps to TUN, not Off.
+  if (value === "system") return "tun";
+  if (value === "off" || value === "tun") return value;
+  if (typeof value !== "string" || !value.startsWith(`proxy${ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR}`)) return "off";
+  const url = normalizeAntigravityProxyUrl(value.slice(`proxy${ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR}`.length));
+  return url ? `proxy${ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR}${url}` : "off";
+}
 const featureConfigSchema = z.object({
   /** Experimental desktop workflow recorder. Hidden unless explicitly enabled. */
   skillRecorder: z.boolean().optional(),
@@ -220,6 +304,19 @@ const featureConfigSchema = z.object({
   /** Experimental built-in browser. Off until explicitly enabled; each bot
    * also has its own switch. */
   browser: z.boolean().optional(),
+  /** Shared Antigravity launcher route. `enabled` is a read-compatibility migration input. */
+  antigravityProxy: z.object({
+    mode: z.enum(["off", "tun", "proxy"]).optional(),
+    enabled: z.boolean().optional(),
+    url: z.string().optional().refine(
+      (value) => value === undefined || normalizeAntigravityProxyUrl(value) !== null,
+      "must be a local HTTP(S) proxy URL with an explicit port",
+    ),
+  }).strict().superRefine((value, ctx) => {
+    if ((value.mode === "proxy" || value.enabled === true) && value.url === undefined) {
+      ctx.addIssue({ code: "custom", path: ["url"], message: "is required when proxy routing is enabled" });
+    }
+  }).optional(),
 });
 const instanceConfigSchema = z.object({
   driver: z.string().min(1),
@@ -290,7 +387,12 @@ export interface AppConfig {
    * separate container, durable workspace, viewer and lease. */
   localVm?: { mode?: "shared" | "per-bot"; maxInstances?: number };
   /** Opt-in product experiments. Every flag defaults to disabled. */
-  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: {
+    skillRecorder?: boolean;
+    showToolCalls?: boolean;
+    browser?: boolean;
+    antigravityProxy?: { mode?: AntigravityNetworkMode; enabled?: boolean; url?: string };
+  };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
   instances?: InstanceConfigMap;
@@ -371,10 +473,20 @@ export function browserProfilePartitionTarget(
   return profile ? { profileId: profile.id, partitionId: browserProfilePartitionId(profile) } : null;
 }
 
+/** Validate stored configuration and canonicalize its Antigravity route. */
 export function parseStoredConfig(value: JsonValue): AppConfig {
   const parsed = storedAppConfigSchema.safeParse(value);
   if (!parsed.success) throw new Error(schemaIssue(parsed.error, "Invalid stored configuration"));
-  return parsed.data;
+  const proxy = parsed.data.features?.antigravityProxy;
+  if (proxy === undefined) return parsed.data;
+  try {
+    return {
+      ...parsed.data,
+      features: { ...parsed.data.features, antigravityProxy: canonicalAntigravityProxySettings(proxy) },
+    };
+  } catch {
+    throw new Error("Invalid stored configuration");
+  }
 }
 
 /** Exact old→canonical profile ids from #567's persisted config. Store
@@ -392,12 +504,22 @@ export function loadBrowserProfileIdAliases(): ReadonlyMap<string, string> {
   }
 }
 
+/** Validate a config patch and canonicalize its Antigravity route. */
 export function parseConfigPatch(value: JsonValue): ConfigPatch {
   const parsed = appConfigPatchSchema.safeParse(value);
   if (!parsed.success) {
     throw Object.assign(new Error(schemaIssue(parsed.error, "Invalid configuration")), { status: 400 });
   }
-  return parsed.data;
+  const proxy = parsed.data.features?.antigravityProxy;
+  if (proxy === undefined) return parsed.data;
+  try {
+    return {
+      ...parsed.data,
+      features: { ...parsed.data.features, antigravityProxy: canonicalAntigravityProxyPatch(proxy) },
+    };
+  } catch {
+    throw Object.assign(new Error("Invalid configuration"), { status: 400 });
+  }
 }
 
 export function vpsSshAlias(cfg: AppConfig): string | null {
@@ -577,6 +699,13 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     /* first write */
   }
   const checkedPatch = appConfigSchema.partial().parse(patch);
+  const proxy = checkedPatch.features?.antigravityProxy;
+  if (proxy !== undefined) {
+    checkedPatch.features = {
+      ...checkedPatch.features,
+      antigravityProxy: canonicalAntigravityProxyPatch(proxy),
+    };
+  }
   // A write is the durable migration point. Preserve every other raw key in
   // config.json, but never write #567's mixed-case or duplicate profile ids
   // back after we have successfully recognized the legacy list.
@@ -587,7 +716,21 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     if (!section) continue;
     const current = jsonObjectSchema.safeParse(disk[key]);
     const merged: JsonObject = current.success ? { ...current.data } : {};
-    Object.assign(merged, section);
+    const featureSection = key === "features"
+      ? section as NonNullable<AppConfig["features"]>
+      : undefined;
+    if (featureSection?.antigravityProxy) {
+      const currentProxy = jsonObjectSchema.safeParse(merged.antigravityProxy);
+      const mergedProxy = {
+        ...(currentProxy.success ? currentProxy.data : {}),
+        ...featureSection.antigravityProxy,
+      };
+      merged.antigravityProxy = canonicalAntigravityProxySettings(mergedProxy);
+      const { antigravityProxy: _ignored, ...otherFeatures } = featureSection;
+      Object.assign(merged, otherFeatures);
+    } else {
+      Object.assign(merged, section);
+    }
     disk[key] = merged;
   }
   if (checkedPatch.vps !== undefined) disk.vps = normalizeVpsConfig(checkedPatch.vps);
@@ -699,6 +842,9 @@ function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string
     environment.set("OPENAI_COMPAT_URL", cfg.openaiCompat.url);
   if (driver === "boxAgent" && cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
   if (driver === "opencodeGo" && cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
+  if (driver === "antigravityAgent") {
+    environment.set(ANTIGRAVITY_NETWORK_ROUTE_ENV, antigravityNetworkRoute(cfg));
+  }
   return environment;
 }
 

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -5,12 +5,13 @@
 // The fake CLI is a shebang script Windows cannot exec directly;
 // spawnCli resolves it to `node <script>`, so these run everywhere.
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createServer, Socket, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { ensureDirs } from "../config.ts";
+import { ANTIGRAVITY_NETWORK_ROUTE_ENV, ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
@@ -22,6 +23,7 @@ import {
   antigravityAgentsMcpServer,
   antigravityComputerMcpServer,
   antigravityMcpServers,
+  antigravityProxyUnavailableReason,
   supportsAntigravityStreamInput,
   ensureAntigravityMcpServers,
   readAntigravityModelCatalog,
@@ -29,6 +31,17 @@ import {
 } from "./antigravity.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-agy-cli.ts");
+
+async function loopbackServer(): Promise<{ server: Server; port: number }> {
+  const server = createServer((socket) => socket.end());
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, port: (server.address() as { port: number }).port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
 
 describe("Antigravity stream input compatibility", () => {
   it("requires the release that introduced stream-JSON stdin", () => {
@@ -281,6 +294,158 @@ describe("Antigravity snapshot", () => {
       }
       rmSync(scratch, { recursive: true, force: true });
     }
+  });
+
+  it("applies Off, TUN, and Proxy to every Antigravity child environment", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-agy-route-"));
+    const { server, port } = await loopbackServer();
+    const inherited = {
+      HTTP_PROXY: "http://inherited-http",
+      http_proxy: "http://inherited-http",
+      HTTPS_PROXY: "http://inherited-https",
+      https_proxy: "http://inherited-https",
+      ALL_PROXY: "http://inherited-all",
+      all_proxy: "http://inherited-all",
+      NO_PROXY: "inherited-no-proxy",
+      no_proxy: "inherited-no-proxy",
+      GODEBUG: "custom=1,http2client=0,other=2",
+    };
+    const cases = [
+      { route: "off", expectedRoute: "off", expected: inherited },
+      {
+        route: "system",
+        expectedRoute: "tun",
+        expected: { GODEBUG: "custom=1,other=2" },
+      },
+      {
+        route: `proxy|HTTP://127.0.0.1:${port}`,
+        expectedRoute: `proxy|http://127.0.0.1:${port}`,
+        expected: {
+          HTTP_PROXY: `http://127.0.0.1:${port}`,
+          http_proxy: `http://127.0.0.1:${port}`,
+          HTTPS_PROXY: `http://127.0.0.1:${port}`,
+          https_proxy: `http://127.0.0.1:${port}`,
+          ALL_PROXY: `http://127.0.0.1:${port}`,
+          all_proxy: `http://127.0.0.1:${port}`,
+          NO_PROXY: "127.0.0.1,localhost,[::1]",
+          no_proxy: "127.0.0.1,localhost,[::1]",
+          GODEBUG: "custom=1,other=2,http2client=0",
+        },
+      },
+    ] as const;
+    try {
+      for (const [index, testCase] of cases.entries()) {
+        const dumps = [join(scratch, `${index}-a.json`), join(scratch, `${index}-b.json`)];
+        const instances = await Promise.all(dumps.map((dump, childIndex) => AntigravityDriver.create({
+          instanceId: `agy-route-${index}-${childIndex}`,
+          displayName: undefined,
+          environment: {
+            ...inherited,
+            [ANTIGRAVITY_NETWORK_ROUTE_ENV]: testCase.route,
+            FAKE_AGY_DUMP: dump,
+          },
+          enabled: true,
+          config: { cli: FAKE_CLI, fullAuto: false },
+        })));
+        const recorders = instances.map((instance) => recordEvents(instance.adapter));
+        await Promise.all(instances.map((instance, childIndex) =>
+          instance.adapter.sendTurn({ threadId: `agy-route-thread-${index}-${childIndex}`, text: "route probe" }),
+        ));
+        await Promise.all(recorders.map((recorder) => recorder.until((event) => event.type === "turn.completed")));
+        for (const dump of dumps) {
+          const invocation = JSON.parse(readFileSync(dump, "utf8")) as { env: Record<string, string | undefined> };
+          expect(invocation.env[ANTIGRAVITY_NETWORK_ROUTE_ENV]).toBe(testCase.expectedRoute);
+          for (const [name, value] of Object.entries(testCase.expected)) {
+            expect(invocation.env[name] ?? invocation.env[name.toUpperCase()]).toBe(value);
+          }
+          if (testCase.expectedRoute === "tun") {
+            for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"]) {
+              expect(invocation.env[name] ?? invocation.env[name.toLowerCase()]).toBeUndefined();
+            }
+          }
+        }
+        await Promise.all(instances.map((instance) => instance.dispose()));
+      }
+    } finally {
+      await closeServer(server);
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("checks a Proxy endpoint before probe/turn spawn and reports a drop before result", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-agy-dead-proxy-"));
+    const dump = join(scratch, "spawn.json");
+    const unused = await loopbackServer();
+    const deadPort = unused.port;
+    await closeServer(unused.server);
+    const deadRoute = `proxy|http://127.0.0.1:${deadPort}`;
+    const dead = await AntigravityDriver.create({
+      instanceId: "agy-dead-proxy",
+      displayName: undefined,
+      environment: { [ANTIGRAVITY_NETWORK_ROUTE_ENV]: deadRoute, FAKE_AGY_DUMP: dump },
+      enabled: true,
+      config: { cli: "definitely-not-a-real-agy-binary", fullAuto: false },
+    });
+    const deadRecorder = recordEvents(dead.adapter);
+    try {
+      const expected = `Proxy unavailable: nothing is listening on 127.0.0.1:${deadPort}. Start the proxy or choose TUN/Off.`;
+      expect(await dead.snapshot()).toMatchObject({ state: "unavailable", reason: expected });
+      await dead.adapter.sendTurn({ threadId: "agy-dead-proxy-turn", text: "must not spawn" });
+      await deadRecorder.until((event) => event.type === "turn.completed");
+      expect(deadRecorder.events.find((event) => event.type === "runtime.error")).toMatchObject({ message: expected });
+      expect(deadRecorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: false, stopReason: "proxy_unavailable" });
+      expect(existsSync(dump)).toBe(false);
+    } finally {
+      await dead.dispose();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+
+    const dropped = await loopbackServer();
+    const droppedRoute = `proxy|http://127.0.0.1:${dropped.port}`;
+    const dropScratch = mkdtempSync(join(tmpdir(), "omb-agy-mid-turn-drop-"));
+    const ready = join(dropScratch, "mid-turn-ready");
+    const dropInstance = await AntigravityDriver.create({
+      instanceId: "agy-mid-turn-drop",
+      displayName: undefined,
+      environment: {
+        [ANTIGRAVITY_NETWORK_ROUTE_ENV]: droppedRoute,
+        FAKE_AGY_DELAY_MS: "1000",
+        FAKE_AGY_READY_FILE: ready,
+      },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    const dropRecorder = recordEvents(dropInstance.adapter);
+    try {
+      await dropInstance.adapter.sendTurn({ threadId: "agy-mid-turn-drop-thread", text: "proxy drops" });
+      await expect.poll(() => existsSync(ready), { timeout: 5_000 }).toBe(true);
+      await closeServer(dropped.server);
+      await dropInstance.adapter.interruptTurn("agy-mid-turn-drop-thread");
+      await dropRecorder.until((event) => event.type === "turn.completed");
+      const expected = `Proxy unavailable: nothing is listening on 127.0.0.1:${dropped.port}. Start the proxy or choose TUN/Off.`;
+      expect(dropRecorder.events.find((event) => event.type === "runtime.error")).toMatchObject({ message: expected });
+      expect(dropRecorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: false, stopReason: "proxy_unavailable" });
+      expect(dropRecorder.events.some((event) => event.type === "runtime.error" && String((event as any).message).includes("agy exited"))).toBe(false);
+    } finally {
+      await dropInstance.dispose();
+      await closeServer(dropped.server);
+      rmSync(dropScratch, { recursive: true, force: true });
+    }
+  });
+
+  it("reports protocol default ports for explicit loopback proxy URLs", async () => {
+    const ports: number[] = [];
+    const unavailable = (route: string) => antigravityProxyUnavailableReason(route, ({ port }) => {
+      ports.push(port);
+      const socket = new Socket();
+      queueMicrotask(() => socket.emit("error", new Error("simulated unavailable proxy")));
+      return socket;
+    });
+    await expect(unavailable("proxy|http://127.0.0.1:80"))
+      .resolves.toBe("Proxy unavailable: nothing is listening on 127.0.0.1:80. Start the proxy or choose TUN/Off.");
+    await expect(unavailable("proxy|https://127.0.0.1:443"))
+      .resolves.toBe("Proxy unavailable: nothing is listening on 127.0.0.1:443. Start the proxy or choose TUN/Off.");
+    expect(ports).toEqual([80, 443]);
   });
 
   it("keeps long generateText prompts off argv too", async () => {

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -308,7 +308,7 @@ describe("Antigravity snapshot", () => {
       all_proxy: "http://inherited-all",
       NO_PROXY: "inherited-no-proxy",
       no_proxy: "inherited-no-proxy",
-      GODEBUG: "custom=1,http2client=0,other=2",
+      GODEBUG: "custom=1,http2client=1,other=2",
     };
     const cases = [
       { route: "off", expectedRoute: "off", expected: inherited },

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -98,7 +98,7 @@ export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
 /** Remove the HTTP/2 workaround token before applying a new network route. */
 function removeAntigravityGodebugToken(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
-  const remaining = value.split(",").filter((token) => token.trim() !== "http2client=0");
+  const remaining = value.split(",").filter((token) => !token.trim().startsWith("http2client="));
   return remaining.length > 0 ? remaining.join(",") : undefined;
 }
 

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -18,11 +18,18 @@
 // mode, ever).
 import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { z } from "zod";
 
-import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
+import {
+  ANTIGRAVITY_NETWORK_ROUTE_ENV,
+  ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR,
+  DATA_DIR,
+  normalizeAntigravityNetworkRoute,
+  stripWorkspaceCredentialEnv,
+} from "../config.ts";
 import { computerProxyEnv } from "../container-computer.ts";
 import { augmentedPath } from "../env-path.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
@@ -43,6 +50,14 @@ import { newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "antigravityAgent";
+const ANTIGRAVITY_PROXY_ENV_NAMES = [
+  "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy",
+] as const;
+const ANTIGRAVITY_LOOPBACK_NO_PROXY = "127.0.0.1,localhost,[::1]";
+const ANTIGRAVITY_PROXY_ROUTE_PREFIX = `proxy${ANTIGRAVITY_NETWORK_ROUTE_SEPARATOR}`;
+type ProxyConnectionFactory = (options: { host: string; port: number }) => ReturnType<typeof createConnection>;
+const ANTIGRAVITY_PROXY_REACHABILITY_TIMEOUT_MS = 750;
+
 export const ANTIGRAVITY_STREAM_INPUT_MIN_VERSION = "1.1.15";
 
 export function supportsAntigravityStreamInput(version: string | null): boolean {
@@ -80,8 +95,85 @@ export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   ],
 };
 
+/** Remove the HTTP/2 workaround token before applying a new network route. */
+function removeAntigravityGodebugToken(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const remaining = value.split(",").filter((token) => token.trim() !== "http2client=0");
+  return remaining.length > 0 ? remaining.join(",") : undefined;
+}
+
+/** Apply the normalized Off, TUN, or explicit proxy route to a child env. */
+function applyAntigravityNetworkRoute(env: NodeJS.ProcessEnv, rawRoute: unknown): string {
+  const route = normalizeAntigravityNetworkRoute(rawRoute);
+  env[ANTIGRAVITY_NETWORK_ROUTE_ENV] = route;
+  if (route === "off") return route;
+  if (route === "tun") {
+    for (const name of ANTIGRAVITY_PROXY_ENV_NAMES) delete env[name];
+    const godebug = removeAntigravityGodebugToken(env.GODEBUG);
+    if (godebug === undefined) delete env.GODEBUG;
+    else env.GODEBUG = godebug;
+    return route;
+  }
+  const proxyUrl = route.slice(ANTIGRAVITY_PROXY_ROUTE_PREFIX.length);
+  env.HTTP_PROXY = proxyUrl;
+  env.http_proxy = proxyUrl;
+  env.HTTPS_PROXY = proxyUrl;
+  env.https_proxy = proxyUrl;
+  env.ALL_PROXY = proxyUrl;
+  env.all_proxy = proxyUrl;
+  env.NO_PROXY = ANTIGRAVITY_LOOPBACK_NO_PROXY;
+  env.no_proxy = ANTIGRAVITY_LOOPBACK_NO_PROXY;
+  const godebug = removeAntigravityGodebugToken(env.GODEBUG);
+  env.GODEBUG = godebug === undefined ? "http2client=0" : `${godebug},http2client=0`;
+  return route;
+}
+
+/** Probe the selected proxy endpoint and return a user-actionable failure. */
+export function antigravityProxyUnavailableReason(
+  rawRoute: unknown,
+  connect: ProxyConnectionFactory = createConnection,
+): Promise<string | null> {
+  const route = normalizeAntigravityNetworkRoute(rawRoute);
+  if (!route.startsWith(ANTIGRAVITY_PROXY_ROUTE_PREFIX)) return Promise.resolve(null);
+  const parsed = new URL(route.slice(ANTIGRAVITY_PROXY_ROUTE_PREFIX.length));
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  const port = Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80));
+  const reason = `Proxy unavailable: nothing is listening on ${host}:${port}. Start the proxy or choose TUN/Off.`;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let socket: ReturnType<typeof createConnection>;
+    try {
+      socket = connect({ host, port });
+    } catch {
+      finish(reason);
+      return;
+    }
+    socket.setTimeout(ANTIGRAVITY_PROXY_REACHABILITY_TIMEOUT_MS, () => {
+      socket.destroy();
+      finish(reason);
+    });
+    socket.once("connect", () => {
+      socket.destroy();
+      finish(null);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      finish(reason);
+    });
+  });
+}
+
+/** Build the isolated Antigravity child environment and apply its route. */
 function antigravityEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath(), ...overrides };
+  // The launcher consumes one stable, non-secret route value. Normalize direct
+  // adapter callers too, so arbitrary proxy text can never become its signal.
+  applyAntigravityNetworkRoute(env, env[ANTIGRAVITY_NETWORK_ROUTE_ENV]);
   // The harness process may hold workspace credentials injected by the
   // desktop shell. Antigravity uses its own login, so none belong in any of
   // its turn, snapshot, or helper children.
@@ -458,6 +550,14 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       pending.add(threadId);
       const turnId = newId();
 
+      const earlyProxyUnavailable = await antigravityProxyUnavailableReason(env[ANTIGRAVITY_NETWORK_ROUTE_ENV]);
+      if (earlyProxyUnavailable) {
+        emit({ ...base(threadId, turnId), type: "runtime.error", message: earlyProxyUnavailable });
+        emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "proxy_unavailable", cost: null });
+        pending.delete(threadId);
+        return { turnId };
+      }
+
       const version = await versionForTurn();
       if (!supportsAntigravityStreamInput(version)) {
         pending.delete(threadId);
@@ -756,14 +856,17 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         clearTimeout(postSettleReaper);
         clearTimeout(terminationEscalation);
         finalizeMcp();
-        if (!settled) {
+        void (async () => {
+          if (settled) return;
+          const proxyUnavailable = await antigravityProxyUnavailableReason(env[ANTIGRAVITY_NETWORK_ROUTE_ENV]);
+          if (settled) return;
           emit({
             ...base(threadId, turnId),
             type: "runtime.error",
-            message: `agy exited ${code} before result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
+            message: proxyUnavailable ?? `agy exited ${code} before result${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
           });
-          settle(false, "exit_before_result");
-        }
+          settle(false, proxyUnavailable ? "proxy_unavailable" : "exit_before_result");
+        })();
       });
 
       active.set(threadId, { stop, turnId });
@@ -804,6 +907,8 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
     };
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
+      const proxyUnavailable = await antigravityProxyUnavailableReason(env[ANTIGRAVITY_NETWORK_ROUTE_ENV]);
+      if (proxyUnavailable) return { state: "unavailable", reason: proxyUnavailable };
       const version = await readVersion();
       verifiedVersion = version;
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
@@ -821,6 +926,8 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
     };
 
     const generateText = async (prompt: string): Promise<string> => {
+      const proxyUnavailable = await antigravityProxyUnavailableReason(env[ANTIGRAVITY_NETWORK_ROUTE_ENV]);
+      if (proxyUnavailable) throw new Error(proxyUnavailable);
       const version = await versionForTurn();
       if (!supportsAntigravityStreamInput(version)) {
         throw new Error(

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -18,6 +18,7 @@ import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { freePortBlock } from "./testing/ports.ts";
 import { openSse } from "./testing/sse.ts";
 import { FILE_MAX_BYTES, IMAGE_MAX_BYTES } from "./attachments.ts";
+import { DEFAULT_ANTIGRAVITY_PROXY_URL } from "./config.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
@@ -3333,22 +3334,70 @@ describe("harness HTTP API", () => {
   it("keeps Teach a skill off by default and persists an explicit opt-in", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);
-    expect(before.body.features).toEqual({ browser: false, skillRecorder: false, showToolCalls: false });
+    expect(before.body.features).toEqual({
+      antigravityProxy: { mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL },
+      browser: false,
+      skillRecorder: false,
+      showToolCalls: false,
+    });
 
     const saved = await api("PATCH", "/api/config", {
       features: { skillRecorder: true },
     });
     expect(saved.status).toBe(200);
-    expect(saved.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: false });
+    expect(saved.body.features).toEqual({
+      antigravityProxy: { mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL },
+      browser: false,
+      skillRecorder: true,
+      showToolCalls: false,
+    });
 
     const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
     expect(disk.features).toEqual({ skillRecorder: true });
 
     const tools = await api("PATCH", "/api/config", { features: { showToolCalls: true } });
     expect(tools.status).toBe(200);
-    expect(tools.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: true });
+    expect(tools.body.features).toEqual({
+      antigravityProxy: { mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL },
+      browser: false,
+      skillRecorder: true,
+      showToolCalls: true,
+    });
 
     await api("PATCH", "/api/config", { features: { skillRecorder: false, showToolCalls: false } });
+  });
+
+  it("validates and persists the shared Antigravity local proxy route", async () => {
+    const before = await api("GET", "/api/config");
+    expect(before.body.features.antigravityProxy).toEqual({
+      mode: "off",
+      url: DEFAULT_ANTIGRAVITY_PROXY_URL,
+    });
+
+    const unsafe = "http://user:secret@remote.example:8080/path?token=secret#fragment"; // secret-scan: allow-test-fixture
+    const rejected = await api("PATCH", "/api/config", {
+      features: { antigravityProxy: { enabled: true, url: unsafe } },
+    });
+    expect(rejected.status).toBe(400);
+    expect(String(rejected.body.error)).not.toContain(unsafe);
+
+    const enabled = await api("PATCH", "/api/config", {
+      features: { antigravityProxy: { enabled: true, url: "HTTPS://LOCALHOST:08080/" } },
+    });
+    expect(enabled.status).toBe(200);
+    expect(enabled.body.features.antigravityProxy).toEqual({ mode: "proxy", url: "https://localhost:8080" });
+    expect(JSON.stringify(enabled.body)).not.toContain("secret");
+
+    const tun = await api("PATCH", "/api/config", {
+      features: { antigravityProxy: { mode: "tun" } },
+    });
+    expect(tun.status).toBe(200);
+    expect(tun.body.features.antigravityProxy).toEqual({ mode: "tun", url: "https://localhost:8080" });
+    expect(JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8")).features.antigravityProxy)
+      .toEqual({ mode: "tun", url: "https://localhost:8080" });
+    await api("PATCH", "/api/config", {
+      features: { antigravityProxy: { mode: "off", url: DEFAULT_ANTIGRAVITY_PROXY_URL } },
+    });
   });
 
   it("refuses to delete a bot while it owns an active channel turn", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -97,6 +97,7 @@ import {
   DATA_DIR,
   EVENTS_DIR,
   NATIVE_DIR,
+  antigravityProxySettings,
   customMcpServers,
 } from "./config.ts";
 import { ComputerControl } from "./computer-control.ts";
@@ -5731,6 +5732,7 @@ function configStatus() {
       skillRecorder: skillRecorderEnabled(cfg),
       showToolCalls: showToolCallsEnabled(cfg),
       browser: builtInBrowserEnabled(cfg),
+      antigravityProxy: antigravityProxySettings(cfg),
     },
     // partitionId is non-secret routing metadata. The renderer needs it to
     // show the same durable session as an agent, but config PATCH validation
@@ -9523,21 +9525,13 @@ const server = createServer(async (req, res) => {
           browserReferenceCleanupError = error;
         }
       }
-      // Provider keys change the fleet. Profile, language, voice, VPS, and
-      // room timeout changes do not rebuild it: no driver reads them, and they
-      // should not interrupt in-flight turns.
-      const reloadKeys = Object.keys(patch).filter(
-        (key) =>
-          key !== "profile" &&
-          key !== "language" &&
-          key !== "tts" &&
-          key !== "imageGen" &&
-          key !== "vps" &&
-          key !== "rooms" &&
-          key !== "localVm" &&
-          key !== "features" &&
-          key !== "browserProfiles",
-      );
+      // Provider keys change the fleet. Profile, voice, VPS, and room timeout
+      // changes do not rebuild it: no driver reads them, and they should not
+      // interrupt in-flight turns.
+      const reloadKeys = Object.keys(patch).filter((key) => {
+        if (key === "features") return patch.features?.antigravityProxy !== undefined;
+        return !["profile", "language", "tts", "imageGen", "vps", "rooms", "localVm", "browserProfiles"].includes(key);
+      });
       // The cleanup marker becomes committed only after both pieces of durable
       // application state agree. Commit/ACK failures are deferred until every
       // mandatory consequence of the config write has run: no journal I/O

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -123,6 +123,9 @@ export function ModelPicker({
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [agyProxyDraft, setAgyProxyDraft] = useState("http://127.0.0.1:10808");
+  const [agyProxySaving, setAgyProxySaving] = useState(false);
+  const [agyProxyError, setAgyProxyError] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const refreshingRef = useRef(false);
 
@@ -130,6 +133,14 @@ export function ModelPicker({
   const active = state.instances.find((instance) => instance.instanceId === selection.instanceId);
   const railInstance =
     state.instances.find((instance) => instance.instanceId === (railId ?? selection.instanceId)) ?? state.instances[0];
+  const antigravityProxy = state.config?.features?.antigravityProxy ?? {
+    mode: "off" as const,
+    url: "http://127.0.0.1:10808",
+  };
+
+  useEffect(() => {
+    if (open) setAgyProxyDraft(antigravityProxy.url);
+  }, [open, antigravityProxy.url]);
 
   const refreshModels = useCallback(() => {
     if (refreshingRef.current) return;
@@ -203,6 +214,43 @@ export function ModelPicker({
       selection: nextSelection,
     });
     setOpen(false);
+  };
+
+  /** Persist one Antigravity network-mode or proxy-URL change. */
+  const saveAgyProxy = async (patch: { mode?: "off" | "tun" | "proxy"; url?: string }) => {
+    if (agyProxySaving) return;
+    setAgyProxySaving(true);
+    setAgyProxyError(null);
+    try {
+      const config = await fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ features: { antigravityProxy: patch } }),
+      }).then(async (response) => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error ?? "Could not save the Antigravity network mode.");
+        return body;
+      });
+      dispatch({ type: "configStatus", config });
+    } catch (error) {
+      setAgyProxyError(error instanceof Error ? error.message : "Could not save the Antigravity network mode.");
+    } finally {
+      setAgyProxySaving(false);
+    }
+  };
+
+  /** Select Off, TUN, or Proxy and persist the route when it changes. */
+  const selectAgyProxyMode = (mode: "off" | "tun" | "proxy") => {
+    if (mode === antigravityProxy.mode) return;
+    void saveAgyProxy(mode === "proxy"
+      ? { mode, url: agyProxyDraft.trim() || antigravityProxy.url }
+      : { mode });
+  };
+
+  /** Persist a changed proxy URL after the input loses focus. */
+  const saveAgyProxyUrl = () => {
+    if (antigravityProxy.mode !== "proxy" || agyProxyDraft.trim() === antigravityProxy.url) return;
+    void saveAgyProxy({ mode: "proxy", url: agyProxyDraft });
   };
 
   const official = railInstance?.models.options.filter((option) => !option.custom) ?? [];
@@ -384,6 +432,54 @@ export function ModelPicker({
                       ? "Run this agent with a model already on your machine."
                       : "Choose a model for this bot."}
                   </div>
+                  {railInstance.driverKind === "antigravityAgent" && (
+                    <div className="mt-3 rounded-lg border border-hairline/40 bg-inset px-2.5 py-2.5">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-[12px] font-medium text-ink">VPN mode</div>
+                        <div role="radiogroup" aria-label="VPN mode" className="flex rounded-md bg-card p-0.5">
+                          {[
+                            { label: "Off", mode: "off" as const },
+                            { label: "TUN", mode: "tun" as const },
+                            { label: "Proxy", mode: "proxy" as const },
+                          ].map((mode) => (
+                            <button
+                              key={mode.label}
+                              type="button"
+                              role="radio"
+                              aria-checked={antigravityProxy.mode === mode.mode}
+                              disabled={agyProxySaving}
+                              onClick={() => selectAgyProxyMode(mode.mode)}
+                              className={cn(
+                                "rounded px-2 py-1 text-[10.5px] font-medium transition-colors",
+                                antigravityProxy.mode === mode.mode
+                                  ? "bg-control text-ink"
+                                  : "text-ink-secondary hover:text-ink",
+                                agyProxySaving && "cursor-wait opacity-50",
+                              )}
+                            >
+                              {mode.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      {antigravityProxy.mode === "proxy" && (
+                        <label className="mt-2 block text-[10.5px] text-ink-secondary">
+                          Proxy URL
+                          <input
+                            type="url"
+                            value={agyProxyDraft}
+                            onChange={(event) => setAgyProxyDraft(event.target.value)}
+                            onBlur={saveAgyProxyUrl}
+                            disabled={agyProxySaving}
+                            placeholder="http://127.0.0.1:10808"
+                            aria-label="Proxy URL"
+                            className="mt-1 w-full rounded-md border border-hairline/40 bg-card px-2 py-1.5 text-[11.5px] text-ink placeholder:text-ink-secondary focus:border-accent/60 focus:outline-none disabled:opacity-50"
+                          />
+                        </label>
+                      )}
+                      {agyProxyError && <div className="mt-1.5 text-[10.5px] text-warning">{agyProxyError}</div>}
+                    </div>
+                  )}
                 </div>
 
                 {pane === "custom" && canReturnToOfficial && (

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -345,7 +345,12 @@ export interface ConfigStatus {
   /** UI language override; "" (or absent) follows the system language. */
   language?: string;
   /** Opt-in flags. Absent means off. */
-  features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: {
+    skillRecorder: boolean;
+    showToolCalls?: boolean;
+    browser?: boolean;
+    antigravityProxy?: { mode: "off" | "tun" | "proxy"; url: string };
+  };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
 }


### PR DESCRIPTION
## What changed

Adds explicit, bounded Antigravity network routing for users whose normal route is unavailable or unsuitable in their region:

- **Off** preserves the inherited process environment.
- **TUN** clears proxy variables and uses the operating system route.
- **Proxy** accepts only loopback HTTP(S) endpoints with an explicit port.
- Proxy URLs containing credentials, paths, queries, fragments, or remote hosts are rejected.
- Snapshot, turn, and helper calls probe the configured local proxy first and fail with a safe actionable message when it is unavailable.
- The selected route is applied consistently to every Antigravity child process.
- Existing unrelated `GODEBUG` options are preserved while the required HTTP/2 setting is replaced deterministically.
- The route selector and proxy field are available in the model picker.

## Safety and scope

This PR improves user-controlled regional network routing only. It does not store provider credentials, ship or modify provider binaries, bypass provider access checks, or alter account eligibility.

The change is limited to route configuration, validation, UI, persistence, and driver enforcement.

## Verification

- 3 focused test files passed: **243 passed, 1 skipped**.
- Client and server TypeScript checks passed.
- Production Vite build passed.
- Electron syntax check passed across **90 modules**.
- `git diff --check` passed.
- Restricted-content scan found no private paths, binaries, credentials, eligibility patches, or private keys. The only secret-like match is the repository's explicit fake `SECRET-BOX` test fixture.
- Rebased through official main `9f4cdc520a1652c84b56712efa9abbd6b8dddefe`.
- Accepted head: `d28a928bd878a8271dc22cb5a20f5beb6db34884`.

## Visual acceptance

No fresh screenshot is attached, so visual acceptance is not claimed.

## External checks

Vercel authorization for the upstream team remains outside this contribution and is not a code failure.