### PR TITLE
Keep Chiefs available during delegated work

### DIFF
--- a/server/chief-of-staff.test.ts
+++ b/server/chief-of-staff.test.ts
@@ -51,7 +51,12 @@ describe("chiefOfStaffSystemPrompt", () => {
     expect(prompt).not.toContain("Secret");
     expect(prompt).not.toContain("Scout");
     expect(prompt).not.toContain("Atlas —");
-    expect(prompt).toContain("Use ask_bot");
+    expect(prompt).toContain("use delegate_bot");
+    expect(prompt).toContain("keeps you available to the user");
+    expect(prompt).toContain("delivers the teammate's completed result back into this conversation automatically");
+    expect(prompt).toContain("Do not call wait_delegation");
+    expect(prompt).toContain("Use ask_bot only for a brief consultation");
+    expect(prompt).toContain("Never use ask_bot for an assigned task");
     expect(prompt).toContain("use create_bot");
   });
 
@@ -59,7 +64,7 @@ describe("chiefOfStaffSystemPrompt", () => {
     const prompt = chiefOfStaffSystemPrompt("chief", bots, false);
 
     expect(prompt).toContain("cannot contact teammates");
-    expect(prompt).not.toContain("Use ask_bot");
+    expect(prompt).not.toContain("delegate_bot");
   });
 
   it("includes trusted OpenMaus status only when the Chief caller supplies it", () => {

--- a/server/chief-of-staff.ts
+++ b/server/chief-of-staff.ts
@@ -54,10 +54,12 @@ export function chiefOfStaffSystemPrompt(
 
   const delegation = canDelegate
     ? [
-        "Use list_bots to confirm the live roster and IDs. Use ask_bot when a teammate is better suited to part of the request.",
+        "Use list_bots to confirm the live roster and IDs. When assigning work to a teammate, use delegate_bot: it returns immediately, keeps you available to the user, and delivers the teammate's completed result back into this conversation automatically.",
+        "After delegate_bot accepts the task, acknowledge the handoff and continue with any independent work or end your turn. Do not call wait_delegation or repeatedly poll check_delegation in the same turn.",
+        "Use ask_bot only for a brief consultation whose answer you must have before writing your current response. Never use ask_bot for an assigned task, background work, or anything potentially long-running.",
         "When the user asks you to assemble a team, use create_bot for each genuinely useful specialist. Give each one a clear role and instructions, then use delegate_bot to assign its work. Do not create duplicate or unnecessary bots.",
-        "Delegate with a clear, self-contained brief and wait for the teammate's actual reply before claiming its work is complete.",
-        "You may consult more than one teammate when the request genuinely benefits, then combine their results into one coherent answer.",
+        "Delegate with a clear, self-contained brief. Say that the task is assigned, not completed; only claim completion after the teammate's result has actually arrived.",
+        "You may assign work to more than one teammate when the request genuinely benefits. Stay responsive while they work, then combine their returned results when the user asks for a synthesis.",
       ].join(" ")
     : "Your current engine cannot contact teammates. Be honest about that limitation and ask the user to choose a delegation-compatible engine before promising coordinated work.";
 

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -614,6 +614,21 @@ describe("comms e2e (fake ACP fleet)", () => {
               && message.text?.includes("long delegated task"),
           );
         }, 20_000, "worker result did not return to the Chief conversation");
+
+        // The result is not only visible in storage/UI. It was appended
+        // outside the Chief provider's native session, so the next resumed
+        // turn must replay it into model context before answering.
+        expect((await api("POST", `/api/bots/${chief.id}/messages`, {
+          text: "CHIEF_RESULT_CONTEXT: what did LongWorker report?",
+        })).status).toBe(202);
+        await waitUntil(async () => {
+          chiefBot = (await api("GET", "/api/bots")).body.bots.find((bot: any) => bot.id === chief.id);
+          return chiefBot.messages.some(
+            (message: any) =>
+              message.kind === "text"
+              && message.text === "chief saw delegated result: long delegated task",
+          );
+        }, 20_000, "Chief provider did not receive the delegated result on its next turn");
       } finally {
         writeFileSync(gateFile, "go");
         await waitUntil(async () => {

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -138,6 +138,13 @@ describe("comms e2e (fake ACP fleet)", () => {
             environment: { FAKE_ACP_MODE: "delegate-peer" },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
+          // A Chief that delegates only on the first assignment prompt, then
+          // answers ordinary follow-ups while the worker remains gated.
+          chiefAsync: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "chief-delegate" },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
           chiefCreator: {
             driver: "grokAgent",
             environment: { FAKE_ACP_MODE: "create-peer" },
@@ -541,6 +548,84 @@ describe("comms e2e (fake ACP fleet)", () => {
     45_000,
   );
 
+  it(
+    "keeps a Chief available while its delegated teammate is still working",
+    async () => {
+      for (const existing of (await api("GET", "/api/bots")).body.bots) {
+        await api("PATCH", `/api/bots/${existing.id}`, { hidden: true });
+      }
+      rmSync(gateFile, { force: true });
+
+      const helper = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${helper.id}`, {
+        name: "LongWorker",
+        section: "Operations",
+        modelSelection: { instanceId: "helperGate", model: "fake-model" },
+      });
+      const chief = (await api("POST", "/api/bots")).body.bot;
+      await api("PATCH", `/api/bots/${chief.id}`, {
+        name: "Atlas",
+        section: "Operations",
+        chiefOfStaff: true,
+        modelSelection: { instanceId: "chiefAsync", model: "fake-model" },
+      });
+
+      try {
+        expect((await api("POST", `/api/bots/${chief.id}/messages`, {
+          text: "ASSIGN_TO_PEER: have @LongWorker handle the long task.",
+        })).status).toBe(202);
+
+        let chiefBot: any;
+        let helperBot: any;
+        await waitUntil(async () => {
+          const state = (await api("GET", "/api/bots")).body.bots;
+          chiefBot = state.find((bot: any) => bot.id === chief.id);
+          helperBot = state.find((bot: any) => bot.id === helper.id);
+          const acknowledged = chiefBot.messages.some(
+            (message: any) => message.kind === "text" && message.text?.includes("assigned: Delegation queued"),
+          );
+          return Boolean(acknowledged && !chiefBot.busy && helperBot.busy);
+        }, 30_000, "Chief did not become available while its teammate worked");
+
+        // The worker is deliberately held open. A second message must start
+        // and finish on the Chief before that worker is released.
+        expect(helperBot.busy).toBe(true);
+        expect((await api("POST", `/api/bots/${chief.id}/messages`, {
+          text: "CHIEF_FOLLOW_UP: are you still available while that runs?",
+        })).status).toBe(202);
+        await waitUntil(async () => {
+          const state = (await api("GET", "/api/bots")).body.bots;
+          chiefBot = state.find((bot: any) => bot.id === chief.id);
+          helperBot = state.find((bot: any) => bot.id === helper.id);
+          const answeredFollowUp = chiefBot.messages.some(
+            (message: any) => message.kind === "text" && message.text?.includes("hello from fake acp"),
+          );
+          return Boolean(answeredFollowUp && !chiefBot.busy && helperBot.busy);
+        }, 20_000, "Chief stayed tied to the delegated worker");
+
+        writeFileSync(gateFile, "go");
+        await waitUntil(async () => {
+          chiefBot = (await api("GET", "/api/bots")).body.bots.find((bot: any) => bot.id === chief.id);
+          return chiefBot.messages.some(
+            (message: any) =>
+              message.kind === "text"
+              && message.from?.botId === helper.id
+              && message.text?.includes("replied to the delegated task")
+              && message.text?.includes("long delegated task"),
+          );
+        }, 20_000, "worker result did not return to the Chief conversation");
+      } finally {
+        writeFileSync(gateFile, "go");
+        await waitUntil(async () => {
+          const current = (await api("GET", "/api/bots?messages=0")).body.bots.find((bot: any) => bot.id === helper.id);
+          return !current?.busy;
+        }, 10_000, "gated helper did not settle during cleanup").catch(() => {});
+        rmSync(gateFile, { force: true });
+      }
+    },
+    60_000,
+  );
+
   // ── ask_bot busy fallback ───────────────────────────────────────────
   // A used to get a flat "busy — try again later" when B was mid-turn: a
   // dead-end that models rarely retry, so the exchange evaporated (#583).
@@ -585,7 +670,8 @@ describe("comms e2e (fake ACP fleet)", () => {
       }, 25_000, "asker never got the queued-fallback reply");
       const askerReply = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
       expect(askerReply.text).toContain("Task id:");
-      expect(askerReply.text).toContain("wait_delegation");
+      expect(askerReply.text).toContain("delivered to this conversation automatically");
+      expect(askerReply.text).not.toContain("wait_delegation");
       // the queue is visible on A's thread as the standard delegation chip
       expect(askerBot.messages.some(
         (m: any) => m.kind === "activity" && m.tool?.name === "Delegated to @GateHelper: asked while busy",
@@ -733,7 +819,8 @@ describe("comms e2e (fake ACP fleet)", () => {
       }, 30_000, "asker never got the timeout-conversion reply");
       const conversionReply = askerBot.messages.findLast((m: any) => m.kind === "text" && m.role === "bot");
       expect(conversionReply.text).toContain("Task id:");
-      expect(conversionReply.text).toContain("wait_delegation");
+      expect(conversionReply.text).toContain("delivered to this conversation automatically");
+      expect(conversionReply.text).not.toContain("wait_delegation");
       expect(askerBot.messages.some(
         (m: any) => m.kind === "activity" && m.tool?.name === "@SlowHelper is still working — ask converted to a delegation",
       )).toBe(true);

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -265,6 +265,13 @@ describe("agents-proxy MCP surface", () => {
     expect(text).toContain("delivered to this conversation automatically");
     expect(text).not.toContain("wait_delegation");
     expect(res.result.isError).toBeFalsy();
+
+    lastDelegationUrl = null;
+    const check = await callTool("check_delegation", { task_id: "task-9" });
+    expect(check.result.isError).toBe(true);
+    expect(check.result.content[0].text).toContain("delegated during this turn");
+    expect(check.result.content[0].text).toContain("Finish your response now");
+    expect(lastDelegationUrl).toBeNull();
   });
 
   it("renders a timeout conversion with the task id and guidance", async () => {
@@ -278,6 +285,13 @@ describe("agents-proxy MCP surface", () => {
     expect(text).toContain("delivered to this conversation automatically");
     expect(text).not.toContain("wait_delegation");
     expect(res.result.isError).toBeFalsy();
+
+    lastDelegationUrl = null;
+    const wait = await callTool("wait_delegation", { task_id: "task-42", timeout_seconds: 240 });
+    expect(wait.result.isError).toBe(true);
+    expect(wait.result.content[0].text).toContain("delegated during this turn");
+    expect(wait.result.content[0].text).toContain("delivered to this conversation automatically");
+    expect(lastDelegationUrl).toBeNull();
   });
 
   it("surfaces the harness's depth refusal as a tool error", async () => {
@@ -351,7 +365,7 @@ describe("agents-proxy MCP surface", () => {
     expect(lastCredentialBody).toBeNull();
   });
 
-  it("hands the delegator its task id without inviting a same-turn wait", async () => {
+  it("hands back the task id and rejects sequential same-turn status calls", async () => {
     delegateResponse = {
       queued: true,
       taskId: "task-abc123",
@@ -362,6 +376,16 @@ describe("agents-proxy MCP surface", () => {
     expect(res.result.content[0].text).toContain("delivered to this conversation automatically");
     expect(res.result.content[0].text).toContain("Do not check or wait for it in this turn");
     expect(res.result.content[0].text).not.toContain("wait_delegation");
+
+    lastDelegationUrl = null;
+    for (const name of ["check_delegation", "wait_delegation"]) {
+      const status = await callTool(name, { task_id: "task-abc123", timeout_seconds: 240 });
+      expect(status.result.isError).toBe(true);
+      expect(status.result.content[0].text).toContain("delegated during this turn");
+      expect(status.result.content[0].text).toContain("Finish your response now");
+      expect(status.result.content[0].text).toContain("delivered to this conversation automatically");
+    }
+    expect(lastDelegationUrl).toBeNull();
     delegateResponse = { queued: true, message: "Delegation queued." };
   });
 
@@ -378,15 +402,15 @@ describe("agents-proxy MCP surface", () => {
     expect(bad.result.content[0].text).toContain('"task_id"');
     expect(lastDelegationUrl).toBeNull(); // guidance is free
 
-    const done = await callTool("check_delegation", { task_id: "task-abc123" });
-    expect(done.result.content[0].text).toContain("@Helper finished task task-abc123");
+    const done = await callTool("check_delegation", { task_id: "task-earlier123" });
+    expect(done.result.content[0].text).toContain("@Helper finished task task-earlier123");
     expect(done.result.content[0].text).toContain("All done.");
-    expect(lastDelegationUrl).toContain("/api/internal/delegations/task-abc123?");
+    expect(lastDelegationUrl).toContain("/api/internal/delegations/task-earlier123?");
     expect(lastDelegationUrl).toContain("wait_ms=0");
     expect(lastDelegationUrl).toContain("fromBotId=bot-asker");
 
     delegationStatusResponse = { status: "queued", toBotName: "Helper" };
-    const waiting = await callTool("wait_delegation", { task_id: "task-abc123", timeout_seconds: 45 });
+    const waiting = await callTool("wait_delegation", { task_id: "task-earlier123", timeout_seconds: 45 });
     expect(waiting.result.content[0].text).toContain("still queued");
     expect(waiting.result.content[0].text).toContain("after 45s");
     expect(lastDelegationUrl).toContain("wait_ms=45000");

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -172,7 +172,7 @@ afterAll(async () => {
 });
 
 describe("agents-proxy MCP surface", () => {
-  it("answers the MCP handshake and lists all eight tools", async () => {
+  it("answers the MCP handshake and lists the coordination tools", async () => {
     const init = await rpc("initialize", { protocolVersion: "2024-11-05" });
     expect(init.result.serverInfo.name).toContain("agents");
     const list = await rpc("tools/list");
@@ -188,6 +188,14 @@ describe("agents-proxy MCP surface", () => {
       "propose_routine",
       "propose_routine_action",
     ]);
+    const ask = list.result.tools.find((tool: { name: string }) => tool.name === "ask_bot");
+    const delegate = list.result.tools.find((tool: { name: string }) => tool.name === "delegate_bot");
+    const wait = list.result.tools.find((tool: { name: string }) => tool.name === "wait_delegation");
+    expect(ask.description).toContain("SYNCHRONOUS consultation");
+    expect(ask.description).toContain("Do not use for assigning work");
+    expect(delegate.description).toContain("DEFAULT FOR ASSIGNING WORK");
+    expect(delegate.description).toContain("delivered automatically");
+    expect(wait.description).toContain("Never call it in the same turn as delegate_bot");
   });
 
   it("publishes a flat routine schedule schema that survives provider conversion", async () => {
@@ -220,6 +228,8 @@ describe("agents-proxy MCP surface", () => {
     const text = res.result.content[0].text;
     expect(text).toContain("Helper");
     expect(text).toContain("bot-helper");
+    expect(text).toContain("Assign work with delegate_bot");
+    expect(text).toContain("Use ask_bot only for a short answer");
     expect(lastAuth).toBe(`Bearer ${TOKEN}`);
   });
 
@@ -252,7 +262,8 @@ describe("agents-proxy MCP surface", () => {
     expect(text).toContain("queued as a delegation");
     expect(text).toContain("task-9");
     expect(text).toContain("check_delegation");
-    expect(text).toContain("wait_delegation");
+    expect(text).toContain("delivered to this conversation automatically");
+    expect(text).not.toContain("wait_delegation");
     expect(res.result.isError).toBeFalsy();
   });
 
@@ -264,7 +275,8 @@ describe("agents-proxy MCP surface", () => {
     expect(text).toContain("converted to a delegation");
     expect(text).toContain("task-42");
     expect(text).toContain("check_delegation");
-    expect(text).toContain("wait_delegation");
+    expect(text).toContain("delivered to this conversation automatically");
+    expect(text).not.toContain("wait_delegation");
     expect(res.result.isError).toBeFalsy();
   });
 
@@ -339,7 +351,7 @@ describe("agents-proxy MCP surface", () => {
     expect(lastCredentialBody).toBeNull();
   });
 
-  it("hands the delegator its task id and the tools to read the outcome", async () => {
+  it("hands the delegator its task id without inviting a same-turn wait", async () => {
     delegateResponse = {
       queued: true,
       taskId: "task-abc123",
@@ -347,7 +359,9 @@ describe("agents-proxy MCP surface", () => {
     };
     const res = await callTool("delegate_bot", { bot_id: "bot-helper", message: "do the thing" });
     expect(res.result.content[0].text).toContain("Task id: task-abc123");
-    expect(res.result.content[0].text).toContain("wait_delegation");
+    expect(res.result.content[0].text).toContain("delivered to this conversation automatically");
+    expect(res.result.content[0].text).toContain("Do not check or wait for it in this turn");
+    expect(res.result.content[0].text).not.toContain("wait_delegation");
     delegateResponse = { queued: true, message: "Delegation queued." };
   });
 

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -35,6 +35,7 @@ const TOKEN = process.env.OMB_COMMS_TOKEN ?? "";
 const DEPTH = Number(process.env.OMB_TURN_DEPTH ?? "0") || 0;
 const MAX_CREATED_PER_TURN = 4;
 let createdThisTurn = 0;
+const delegationTaskIdsThisTurn = new Set<string>();
 
 const WEEKDAYS = [
   "monday",
@@ -400,6 +401,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       // The peer's turn outlived the synchronous wait, so the harness
       // converted the ask into a delegation — the reply is not lost.
       const taskId = String(r.taskId ?? "").trim();
+      if (taskId) delegationTaskIdsThisTurn.add(taskId);
       const waitedMinutes = Math.max(1, Math.round((Number(r.waitedMs) || 0) / 60_000));
       return {
         text: `${r.toBotName ?? "That bot"} is still working after ${waitedMinutes} minute${waitedMinutes === 1 ? "" : "s"} — the ask was converted to a delegation so the reply is not lost. Task id: ${taskId}. Finish your turn now; the result will be delivered to this conversation automatically. Use check_delegation in a later turn only if the user asks for status.`,
@@ -410,6 +412,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       // task id is the asker's claim ticket for the eventual reply.
       const taskId = String(r.taskId ?? "").trim();
       if (taskId) {
+        delegationTaskIdsThisTurn.add(taskId);
         return {
           text: `${r.toBotName ?? "That bot"} is busy right now, so your message was queued as a delegation instead — it runs after your current turn ends. Task id: ${taskId}. Finish your turn now; the result will be delivered to this conversation automatically. Use check_delegation in a later turn only if the user asks for status.`,
         };
@@ -438,8 +441,10 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     // peer turn runs after our current turn finishes. The task id is the
     // bot's claim ticket for the outcome.
     const note = typeof r.message === "string" ? r.message : "Delegation queued.";
-    const suffix = typeof r.taskId === "string" && r.taskId
-      ? ` Task id: ${r.taskId}. Acknowledge the assignment and finish your turn; the result will be delivered to this conversation automatically. Do not check or wait for it in this turn.`
+    const taskId = typeof r.taskId === "string" ? r.taskId.trim() : "";
+    if (taskId) delegationTaskIdsThisTurn.add(taskId);
+    const suffix = taskId
+      ? ` Task id: ${taskId}. Acknowledge the assignment and finish your turn; the result will be delivered to this conversation automatically. Do not check or wait for it in this turn.`
       : "";
     return { text: `${note}${suffix}` };
   }
@@ -447,6 +452,12 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     const taskId = String(args.task_id ?? "").trim();
     if (!/^[\w-]{4,64}$/.test(taskId)) {
       return { text: `${name} needs the "task_id" that delegate_bot returned, e.g. {"task_id":"1f0c2f4e-..."}.`, isError: true };
+    }
+    if (delegationTaskIdsThisTurn.has(taskId)) {
+      return {
+        text: `Task ${taskId} was delegated during this turn. Finish your response now so the other bot can work; its result will be delivered to this conversation automatically. Do not check or wait for a newly delegated task until a later turn.`,
+        isError: true,
+      };
     }
     const timeout = Math.min(Math.max(Math.trunc(Number(args.timeout_seconds) || 60), 1), 240);
     const waitMs = name === "wait_delegation" ? timeout * 1000 : 0;

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -2,14 +2,14 @@
 // agent process (via the "agents" integration). Exposes eight tools that
 // let one bot talk to another, routed back through the harness so the
 // harness stays the single owner of turns, permissions, and recursion
-// limits:
+// limits. The coordination tools are:
 //
 //   list_bots()                          → the other bots in this section + their status
 //   ask_bot(bot_id, msg)                 → send msg to that bot, wait, return its reply
 //   delegate_bot(bot_id, msg, reason?)   → hand the task to a peer ASYNC: returns
 //                                          immediately, the peer runs after your
-//                                          current turn finishes, the user sees
-//                                          the peer's reply as its own turn
+//                                          current turn finishes, the result is
+//                                          delivered to the source conversation
 //   create_bot(name, role, instructions) → Chiefs can add a specialist to
 //                                          their own section
 //   request_credential(id, reason?)       → show a secure, allowlisted key card
@@ -185,13 +185,13 @@ const TOOLS = [
   {
     name: "list_bots",
     description:
-      "List the other bots (agents) in your OpenMausBot section you can message, with their model and whether they're busy. Call this before ask_bot to discover who's available.",
+      "List the other bots (agents) in your OpenMausBot section, with their model and whether they're busy. Call this before delegate_bot or ask_bot to discover who's available. Use delegate_bot for assignments; use ask_bot only for a short consultation needed inline.",
     inputSchema: { type: "object", properties: {} },
   },
   {
     name: "ask_bot",
     description:
-      "Send a message to another bot in your section and wait for its reply. Use it to delegate a subtask to a specialist bot or ask a peer a question. The other bot runs a full turn under its own model and permissions; the reply is returned to you as text. Returns promptly with a note if that bot is busy.",
+      "SYNCHRONOUS consultation: send a short question to another bot and stay blocked until its reply is returned inline. Use only when that reply is required to write your current response. Do not use for assigning work, background tasks, or potentially long work; use delegate_bot for those. Returns promptly with a note if that bot is busy.",
     inputSchema: {
       type: "object",
       properties: {
@@ -204,7 +204,7 @@ const TOOLS = [
   {
     name: "delegate_bot",
     description:
-      "Hand a task to another bot ASYNCHRONOUSLY: returns immediately and the peer runs after your current turn finishes. Use this when you want to keep working or hand off a long-running subtask without waiting. The user sees the peer's reply as its own turn; you do NOT receive the reply inline.",
+      "DEFAULT FOR ASSIGNING WORK. Hand a task to another bot asynchronously: this returns immediately, your turn can end, and you remain available while the peer works. The peer starts after your current turn finishes and its result is delivered automatically to the originating conversation. Acknowledge the assignment; do not call check_delegation or wait_delegation in this same turn.",
     inputSchema: {
       type: "object",
       properties: {
@@ -218,7 +218,7 @@ const TOOLS = [
   {
     name: "check_delegation",
     description:
-      "Check what happened to a delegation you queued with delegate_bot, without waiting: still queued, running, or finished — and the peer's reply once it is done.",
+      "In a later turn, check what happened to a delegation without waiting: still queued, running, or finished. Do not poll this immediately after delegate_bot; completion is delivered to the conversation automatically.",
     inputSchema: {
       type: "object",
       properties: {
@@ -230,7 +230,7 @@ const TOOLS = [
   {
     name: "wait_delegation",
     description:
-      "Wait until a delegation you queued finishes and return the peer's reply — ONE call instead of repeated checks. Use it after your own remaining work is done; it returns immediately if the task already finished.",
+      "BLOCKING status tool for a delegation from an earlier turn. Use only when the user explicitly asks you to wait for that earlier task. Never call it in the same turn as delegate_bot: a fresh delegation cannot start until your current turn ends, and its result will arrive automatically.",
     inputSchema: {
       type: "object",
       properties: {
@@ -384,7 +384,9 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       const about = b.description ? ` (${String(b.description).slice(0, 120)})` : "";
       return `- ${b.name}${role}${about} [id: ${b.id}, model: ${b.model}${b.busy ? ", busy" : ""}]`;
     });
-    return { text: `Other bots you can message with ask_bot:\n${lines.join("\n")}` };
+    return {
+      text: `Other bots in your section:\n${lines.join("\n")}\n\nAssign work with delegate_bot. Use ask_bot only for a short answer you need inline.`,
+    };
   }
   if (name === "ask_bot") {
     const toBotId = String(args.bot_id ?? "").trim();
@@ -400,7 +402,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       const taskId = String(r.taskId ?? "").trim();
       const waitedMinutes = Math.max(1, Math.round((Number(r.waitedMs) || 0) / 60_000));
       return {
-        text: `${r.toBotName ?? "That bot"} is still working after ${waitedMinutes} minute${waitedMinutes === 1 ? "" : "s"} — the ask was converted to a delegation so the reply is not lost. Task id: ${taskId}. Finish your own turn; next turn read the outcome with check_delegation or block on it with wait_delegation.`,
+        text: `${r.toBotName ?? "That bot"} is still working after ${waitedMinutes} minute${waitedMinutes === 1 ? "" : "s"} — the ask was converted to a delegation so the reply is not lost. Task id: ${taskId}. Finish your turn now; the result will be delivered to this conversation automatically. Use check_delegation in a later turn only if the user asks for status.`,
       };
     }
     if (r.busy) {
@@ -409,7 +411,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       const taskId = String(r.taskId ?? "").trim();
       if (taskId) {
         return {
-          text: `${r.toBotName ?? "That bot"} is busy right now, so your message was queued as a delegation instead — it runs after your current turn ends. Task id: ${taskId}. Next turn, read the outcome with check_delegation or block on it with wait_delegation.`,
+          text: `${r.toBotName ?? "That bot"} is busy right now, so your message was queued as a delegation instead — it runs after your current turn ends. Task id: ${taskId}. Finish your turn now; the result will be delivered to this conversation automatically. Use check_delegation in a later turn only if the user asks for status.`,
         };
       }
       return { text: `That bot is busy right now — try again after it finishes.` };
@@ -437,7 +439,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     // bot's claim ticket for the outcome.
     const note = typeof r.message === "string" ? r.message : "Delegation queued.";
     const suffix = typeof r.taskId === "string" && r.taskId
-      ? ` Task id: ${r.taskId} — after your own work is done, read the outcome with check_delegation or block on it with wait_delegation.`
+      ? ` Task id: ${r.taskId}. Acknowledge the assignment and finish your turn; the result will be delivered to this conversation automatically. Do not check or wait for it in this turn.`
       : "";
     return { text: `${note}${suffix}` };
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2541,8 +2541,8 @@ async function startTurn(
         integrations.agents = agentsIntegration(bot.id, threadId, commsDepth);
       }
       // @mentions in the user's message (the composer's tagging UI) become
-      // an explicit delegation nudge — the agent still does the ask_bot call
-      // itself, so the harness stays the single owner of turns/permissions
+      // an explicit coordination nudge. The agent still chooses the matching
+      // peer tool, so the harness stays the single owner of turns/permissions.
       const tagged = integrations.agents
         ? mentionedBots(
             text,
@@ -2557,7 +2557,7 @@ async function startTurn(
             openMausStatusSystemPrompt(),
           )
         : integrations.agents && sectionPeers.length > 0
-          ? "You can work with the other bots in your section through the agents tools — list_bots shows who's available, ask_bot sends one of them a message and returns their reply."
+          ? "You can work with the other bots in your section through the agents tools. list_bots shows who's available. Use delegate_bot for assigned or independent work so you remain available; use ask_bot only for a short consultation whose reply is required in your current answer."
           : "";
       const credentialPrompt = integrations.agents
         ? " If a supported API key is missing, use request_credential to show the secure in-app card. Never ask the user to paste credentials into chat."
@@ -2651,8 +2651,8 @@ async function startTurn(
             : "") +
           (tagged.length
             ? ` The user tagged ${tagged
-                .map((t) => `@${t.name} (ask_bot bot_id ${t.id})`)
-                .join(" and ")} in their message — bring them in with ask_bot and fold their reply into your answer.`
+                .map((t) => `@${t.name} (bot_id ${t.id})`)
+                .join(" and ")} in their message. If they assigned independent work, use delegate_bot and finish your turn without waiting; use ask_bot only if their short reply is required in this answer.`
             : ""),
         integrations,
         cwd,

--- a/server/index.ts
+++ b/server/index.ts
@@ -118,6 +118,7 @@ import {
   roomResponders,
   sectionKey,
   Store,
+  type BotRecord,
   type GroupDefaultResponder,
   type GroupRecord,
   type Message,
@@ -1833,6 +1834,31 @@ const delegationWatch = new Map<string, {
   sourceThreadId?: string;
 }>();
 
+// Provider-native sessions only know about messages produced inside their
+// own turns. A delegated result is appended later by the harness, so mark the
+// source task with a persisted, impossible-to-resume owner. Its next turn
+// will replay the active branch once before replacing this marker with the
+// real provider instance id. A unique suffix also closes the setup race: if
+// another result arrives while that replay is launching, the newer marker is
+// left intact for one more replay instead of being accidentally consumed.
+const EXTERNAL_CONTEXT_MARKER_PREFIX = "__openmaus_external_context__:";
+
+function isExternalContextMarker(value: string | undefined): boolean {
+  return Boolean(value?.startsWith(EXTERNAL_CONTEXT_MARKER_PREFIX));
+}
+
+function markTaskContextExternallyUpdated(bot: BotRecord, threadId: string): void {
+  const task = store.taskByThread(bot.id, threadId);
+  if (!task) return;
+  task.resumeCursors = {};
+  task.lastInstanceId = `${EXTERNAL_CONTEXT_MARKER_PREFIX}${randomUUID()}`;
+  // patchBot persists the task mutation and broadcasts unread/context state.
+  // The legacy cursor mirror follows only the task currently open in chat.
+  const patch: Partial<BotRecord> = { unread: true };
+  if (bot.threadId === threadId) patch.resumeCursors = {};
+  store.patchBot(bot.id, patch);
+}
+
 /** Consume one delegated-turn watch and mirror exactly one terminal state.
  * Some harness paths settle a busy bot without a provider turn.completed
  * event, so they call this same finalizer explicitly. */
@@ -1882,7 +1908,7 @@ function finalizeDelegationWatch(
         },
       });
     }
-    store.patchBot(source.id, { unread: true });
+    markTaskContextExternallyUpdated(source, watched.sourceThreadId);
   }
   const channel = watched.channelId ? store.group(watched.channelId) : undefined;
   if (!target || !channel) return true;
@@ -2282,16 +2308,26 @@ async function startTurn(
   // rewound: the OTHER instances' cursors are left alone (a rewind wipes
   // them all), and "fresh" is decided by who ran the last turn, not by
   // whether we hold a cursor — see engineIsFresh.
+  const externalContextMarker = isExternalContextMarker(task.lastInstanceId)
+    ? task.lastInstanceId
+    : undefined;
   const fresh =
     !rewound &&
+    !externalContextMarker &&
     engineIsFresh({ instanceId, lastInstanceId: task.lastInstanceId, resumeCursors: task.resumeCursors, transcript });
   const { turnText, resume } = buildTurnContext({
     text: promptWithReply(text, opts?.replyTo, cfg.profile?.name?.trim() || "User"),
     transcript,
     rewound,
     fresh,
+    externallyUpdated: Boolean(externalContextMarker),
     replaysNatively: instance.driverKind === "grok",
   });
+  // Snapshot the cursor alongside the context decision. An external result
+  // can arrive during async computer/setup work and clear the task cursor;
+  // this already-built turn must either keep its old session or replay on the
+  // following turn, never start a blank session with no transcript.
+  const resumeCursor = resume ? task.resumeCursors[instanceId] : undefined;
 
   const persona = [
     `You are ${bot.name}, a personal bot in OpenMausBot.`,
@@ -2615,7 +2651,7 @@ async function startTurn(
         // a rewound thread never resumes the abandoned branch's session
         // the active task's own session — another task's cursor would
         // resume the wrong conversation and defeat the context bubble
-        resumeCursor: resume ? task.resumeCursors[instanceId] : undefined,
+        resumeCursor,
         transcript,
         system:
           persona +
@@ -2667,7 +2703,12 @@ async function startTurn(
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchBot(bot.id, { rewound: false, resumeCursors: {} });
       // and this engine now owns the thread's most recent turn
-      store.markTaskDispatched(bot.id, threadId, instanceId);
+      // Consume exactly the external-update generation this turn replayed.
+      // If a newer delegated result landed during setup, its unique marker
+      // differs and must survive so the next turn also receives that update.
+      if (!isExternalContextMarker(task.lastInstanceId) || task.lastInstanceId === externalContextMarker) {
+        store.markTaskDispatched(bot.id, threadId, instanceId);
+      }
       // a turn can settle before dispatch returns, and a poller started
       // after its own turn.completed would never be torn down — it would
       // keep polling the box forever, carrying dead per-turn state. busy

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -386,6 +386,27 @@ function handle(msg: any) {
         );
       };
       const promptText = String(msg.params?.prompt?.[0]?.text ?? "");
+      if (mode === "chief-delegate" && promptText.includes("CHIEF_RESULT_CONTEXT")) {
+        const sawDelegatedResult =
+          promptText.includes("@LongWorker replied to the delegated task")
+          && promptText.includes("long delegated task");
+        out({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                text: sawDelegatedResult
+                  ? "chief saw delegated result: long delegated task"
+                  : "chief did not see delegated result",
+              },
+            },
+          },
+        });
+        complete();
+        return;
+      }
       if (
         mode === "chief-delegate"
         && agentsMcp

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -14,6 +14,8 @@
 //                     peer, and reply with what the peer said — the comms e2e)
 //                   | delegate-peer (same as ask-peer but uses delegate_bot —
 //                     returns immediately, the peer runs after our turn)
+//                   | chief-delegate (delegates only for an ASSIGN_TO_PEER
+//                     prompt; ordinary follow-ups stay responsive)
 //                   | create-peer (a Chief creates a specialist, then delegates
 //                     work to it through the returned id)
 //                   | echo-gated (reply by echoing the full prompt, and when
@@ -383,6 +385,35 @@ function handle(msg: any) {
             : { stopReason: "end_turn", _meta: { inputTokens: 10, outputTokens: 5 } },
         );
       };
+      const promptText = String(msg.params?.prompt?.[0]?.text ?? "");
+      if (
+        mode === "chief-delegate"
+        && agentsMcp
+        && promptText.includes("ASSIGN_TO_PEER")
+        && !promptText.includes("CHIEF_FOLLOW_UP")
+      ) {
+        void driveMcp(agentsMcp, [
+          { name: "list_bots", args: () => ({}) },
+          {
+            name: "delegate_bot",
+            args: (list) => ({
+              bot_id: /id: ([\w-]+)/.exec(list)?.[1] ?? "",
+              message: "long delegated task",
+              reason: "background assignment",
+            }),
+          },
+        ])
+          .then((reply) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `assigned: ${reply}` } } } });
+            complete();
+          })
+          .catch((e) => {
+            const message = e instanceof Error ? e.message : String(e);
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `delegate error: ${message}` } } } });
+            complete();
+          });
+        return;
+      }
       if (mode === "ask-peer" && agentsMcp) {
         // the comms e2e: reach a peer bot through the injected agents proxy
         // and reply with whatever it said (the peer's fake runs plain happy
@@ -438,7 +469,6 @@ function handle(msg: any) {
         // echoing the WHOLE prompt (system + turn text) lets a test assert
         // both what a drained turn was sent and what it was NOT sent (e.g.
         // the webhook untrusted-data paragraph a steered turn must not get)
-        const promptText = String(msg.params?.prompt?.[0]?.text ?? "");
         const finish = () => {
           out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `echo: ${promptText}` } } } });
           complete();

--- a/server/turn-context.test.ts
+++ b/server/turn-context.test.ts
@@ -9,12 +9,12 @@ const transcript = [
 
 describe("buildTurnContext", () => {
   it("passes text through untouched on a plain resumed turn", () => {
-    const out = buildTurnContext({ text: "hi", transcript, rewound: false, fresh: false, replaysNatively: false });
+    const out = buildTurnContext({ text: "hi", transcript, rewound: false, fresh: false, externallyUpdated: false, replaysNatively: false });
     expect(out).toEqual({ turnText: "hi", resume: true });
   });
 
   it("replays inline on rewind, exactly like the existing behaviour", () => {
-    const out = buildTurnContext({ text: "hi", transcript, rewound: true, fresh: false, replaysNatively: false });
+    const out = buildTurnContext({ text: "hi", transcript, rewound: true, fresh: false, externallyUpdated: false, replaysNatively: false });
     expect(out.resume).toBe(false);
     expect(out.turnText).toContain("rewound this conversation");
     expect(out.turnText).toContain("User: my dog is named Biscuit");
@@ -22,7 +22,7 @@ describe("buildTurnContext", () => {
   });
 
   it("replays inline for a fresh engine with prior history — the model-switch fix", () => {
-    const out = buildTurnContext({ text: "hi", transcript, rewound: false, fresh: true, replaysNatively: false });
+    const out = buildTurnContext({ text: "hi", transcript, rewound: false, fresh: true, externallyUpdated: false, replaysNatively: false });
     expect(out.resume).toBe(false);
     expect(out.turnText).toContain("joining this conversation");
     expect(out.turnText).not.toContain("rewound"); // distinct marker, distinct preamble
@@ -31,15 +31,39 @@ describe("buildTurnContext", () => {
   });
 
   it("never wraps for native-replay drivers — they get history via SendTurnInput.transcript", () => {
-    for (const flags of [{ rewound: true, fresh: false }, { rewound: false, fresh: true }]) {
+    for (const flags of [
+      { rewound: true, fresh: false, externallyUpdated: false },
+      { rewound: false, fresh: true, externallyUpdated: false },
+      { rewound: false, fresh: false, externallyUpdated: true },
+    ]) {
       const out = buildTurnContext({ text: "hi", transcript, ...flags, replaysNatively: true });
       expect(out.turnText).toBe("hi");
+      expect(out.resume).toBe(false);
     }
   });
 
   it("does not wrap a fresh engine on an empty thread — nothing to replay", () => {
-    const out = buildTurnContext({ text: "hi", transcript: [], rewound: false, fresh: true, replaysNatively: false });
+    const out = buildTurnContext({ text: "hi", transcript: [], rewound: false, fresh: true, externallyUpdated: false, replaysNatively: false });
     expect(out).toEqual({ turnText: "hi", resume: false });
+  });
+
+  it("replays an out-of-band teammate result before the next user turn", () => {
+    const updated = [
+      ...transcript,
+      { role: "assistant" as const, text: "@Worker replied to the delegated task:\n\nfinished the report" },
+    ];
+    const out = buildTurnContext({
+      text: "what did they find?",
+      transcript: updated,
+      rewound: false,
+      fresh: false,
+      externallyUpdated: true,
+      replaysNatively: false,
+    });
+    expect(out.resume).toBe(false);
+    expect(out.turnText).toContain("received an update outside your provider session");
+    expect(out.turnText).toContain("@Worker replied to the delegated task");
+    expect(out.turnText.endsWith("what did they find?")).toBe(true);
   });
 });
 

--- a/server/turn-context.ts
+++ b/server/turn-context.ts
@@ -1,9 +1,9 @@
-// Building the text a driver actually receives. Two situations force an
-// inline replay of the active branch: a rewind (the visible branch
-// changed) and a fresh engine (this instance has no session here — the
-// user switched the bot's model mid-thread). They coincide today but are
-// distinct markers on purpose: rewound also invalidates OTHER instances'
-// cursors, fresh does not.
+// Building the text a driver actually receives. Three situations force an
+// inline replay of the active branch: a rewind (the visible branch changed),
+// a fresh engine (this instance has no session here — the user switched the
+// bot's model mid-thread), and an update appended outside the provider's own
+// turn. The first two coincide today but are distinct markers on purpose:
+// rewound also invalidates OTHER instances' cursors, fresh does not.
 export interface TurnContextInput {
   /** the user's new message */
   text: string;
@@ -13,6 +13,10 @@ export interface TurnContextInput {
   rewound: boolean;
   /** this driver instance has no session cursor for this thread */
   fresh: boolean;
+  /** a message was appended outside the provider's own turn (for example,
+   * a delegated teammate returned a result). Native resume state cannot
+   * contain it, so the active branch must be replayed once. */
+  externallyUpdated: boolean;
   /** transcript-replay drivers get history via SendTurnInput.transcript instead */
   replaysNatively: boolean;
 }
@@ -43,19 +47,21 @@ const REWOUND_PREAMBLE =
   "[The user rewound this conversation (edited a message or switched to another version). Everything before this point was replaced by the following history:]";
 const FRESH_PREAMBLE =
   "[You are joining this conversation mid-thread (the user switched this bot over to you). The conversation so far:]";
+const EXTERNAL_UPDATE_PREAMBLE =
+  "[This conversation received an update outside your provider session. The complete current history follows so you can use that update in your next response:]";
 
 export function buildTurnContext(input: TurnContextInput): {
   turnText: string;
   /** false when the native session must not be resumed */
   resume: boolean;
 } {
-  const { text, transcript, rewound, fresh, replaysNatively } = input;
-  const resume = !rewound && !fresh;
+  const { text, transcript, rewound, fresh, externallyUpdated, replaysNatively } = input;
+  const resume = !rewound && !fresh && !externallyUpdated;
   const replay = !resume && !replaysNatively && transcript.length > 0;
   if (!replay) return { turnText: text, resume };
   return {
     turnText: [
-      rewound ? REWOUND_PREAMBLE : FRESH_PREAMBLE,
+      rewound ? REWOUND_PREAMBLE : externallyUpdated ? EXTERNAL_UPDATE_PREAMBLE : FRESH_PREAMBLE,
       "",
       ...transcript.map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.text}`),
       "",

--- a/src/lib/live-activity.test.ts
+++ b/src/lib/live-activity.test.ts
@@ -27,6 +27,8 @@ describe("liveActivityLabel", () => {
     expect(liveActivityLabel(activity("Bash: pnpm test"))).toBe("Running a command");
     expect(liveActivityLabel(activity("mcp__computer__click"))).toBe("Using the computer");
     expect(liveActivityLabel(activity("web_search"))).toBe("Searching the web");
+    expect(liveActivityLabel(activity("delegate_bot"))).toBe("Handing off a task");
+    expect(liveActivityLabel(activity("ask_bot"))).toBe("Asking a teammate");
   });
 
   it("does not present bot-to-bot communication chips as the active action", () => {

--- a/src/lib/live-activity.ts
+++ b/src/lib/live-activity.ts
@@ -12,7 +12,8 @@ const FALLBACK_LABELS: Array<[RegExp, string]> = [
   [/\b(?:click|type|keypress|press|scroll|computer)\b/i, "Using the computer"],
   [/\b(?:open_url|navigate)\b/i, "Opening a page"],
   [/\b(?:list_bots|list_agents)\b/i, "Checking who's around"],
-  [/\b(?:ask_bot|delegate_bot|send_message)\b/i, "Asking a teammate"],
+  [/\bdelegate_bot\b/i, "Handing off a task"],
+  [/\b(?:ask_bot|send_message)\b/i, "Asking a teammate"],
 ];
 
 function sentenceCase(value: string): string {


### PR DESCRIPTION
## What changed

- Makes `delegate_bot` the default for assignments and independent work, while reserving `ask_bot` for short inline consultations.
- Tells Chiefs to acknowledge an accepted handoff and finish their turn instead of calling `wait_delegation` or polling immediately.
- Enforces that rule in the tool proxy: newly delegated task IDs cannot be checked or waited on until a later turn.
- Replays asynchronously returned teammate results into the Chief's provider context, so the Chief can use them on its next turn instead of only showing them in the UI.
- Updates tagged-bot and general coordination guidance to choose async delegation for assigned work.
- Makes queued and timed-out handoffs say that completion will arrive automatically in the originating conversation.
- Labels async work as “Handing off a task” instead of “Asking a teammate.”

## Regression coverage

- Adds an end-to-end gated-worker test proving a Chief becomes idle, accepts and completes a second user message while the worker is still busy, receives the attributed worker result later, and sees that result in its next provider turn.
- Adds sequential tool-call coverage proving same-turn status checks are rejected for direct delegations and busy/timeout ask conversions.
- Pins the Chief prompt and agent-tool descriptions against same-turn waiting guidance.
- Preserves the existing synchronous `ask_bot` tests for deliberate inline consultations.

## Local verification

- `pnpm exec vitest run server/chief-of-staff.test.ts server/turn-context.test.ts server/delegations.test.ts src/lib/live-activity.test.ts` — 50 passed
- `pnpm typecheck` — passed
- `git diff --check` — passed

The sandbox blocks loopback listeners, so the process-level proxy and comms suites are left to the repository CI runners.
