### PR TITLE
fix(browser): make embedded browsing stable and deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Prepare Electron test runtime
+        # Electron 43 lazily downloads its runtime on first import. Resolve it
+        # before Vitest starts so a cold download cannot consume the fixture
+        # timeout.
+        run: node --input-type=commonjs -e "require('electron')"
       - run: pnpm typecheck
       - name: Run tests
         run: pnpm test

--- a/electron/browser-closed-shadow.electron.test.mjs
+++ b/electron/browser-closed-shadow.electron.test.mjs
@@ -232,6 +232,7 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
   ].join("\n");
   expect(result, diagnostics).toMatchObject({ code: 0, signal: null });
   expect(result.stdout).toContain("sandboxed-preload-bridge-loaded");
+  expect(result.stdout).toContain("compact-viewport-stable-after-navigation");
   expect(result.stdout).toContain("closed-shadow-screenshot-refused");
   expect(result.stdout).toContain("closed-shadow-nested-name-source-redacted");
   expect(result.stdout).toContain("transformed-secret-taint");

--- a/electron/browser-closed-shadow.electron.test.mjs
+++ b/electron/browser-closed-shadow.electron.test.mjs
@@ -16,6 +16,7 @@ const canRun = process.platform !== "linux" || Boolean(process.env.DISPLAY) || B
 const canRunRealElectronFixture = canRun
   && !(process.platform === "win32" && process.env.OMB_SKIP_REAL_ELECTRON_BROWSER_FIXTURE === "1");
 const windowsSandboxSid = "S-1-15-2-2";
+const fixtureTimeoutMs = 45_000;
 
 function windowsSandboxRootAclCommand(executable) {
   return {
@@ -211,13 +212,25 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
       const stderr = [];
       child.stdout.on("data", (chunk) => stdout.push(chunk));
       child.stderr.on("data", (chunk) => stderr.push(chunk));
-      child.once("error", reject);
-      child.once("exit", (code, signal) => resolve({
-        code,
-        signal,
-        stdout: Buffer.concat(stdout).toString("utf8"),
-        stderr: Buffer.concat(stderr).toString("utf8"),
-      }));
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill();
+      }, fixtureTimeoutMs);
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.once("exit", (code, signal) => {
+        clearTimeout(timer);
+        resolve({
+          code,
+          signal,
+          timedOut,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+        });
+      });
     });
     if (chromiumLogFile && existsSync(chromiumLogFile)) chromiumLog = readFileSync(chromiumLogFile, "utf8");
   } finally {
@@ -225,12 +238,13 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
   }
   const diagnostics = [
     `Electron exit code: ${result.code}; signal: ${result.signal ?? "none"}`,
+    `Fixture deadline exceeded: ${result.timedOut}`,
     `stdout:\n${result.stdout || "<empty>"}`,
     `stderr:\n${result.stderr || "<empty>"}`,
     `Chromium log:\n${chromiumLog || "<empty>"}`,
     `Windows sandbox ACLs:\n${sandboxAclDiagnostics}`,
   ].join("\n");
-  expect(result, diagnostics).toMatchObject({ code: 0, signal: null });
+  expect(result, diagnostics).toMatchObject({ code: 0, signal: null, timedOut: false });
   expect(result.stdout).toContain("sandboxed-preload-bridge-loaded");
   expect(result.stdout).toContain("compact-viewport-stable-after-navigation");
   expect(result.stdout).toContain("closed-shadow-screenshot-refused");
@@ -246,4 +260,5 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
   expect(result.stdout).toContain("protected-focused-keys-refused");
   expect(result.stdout).toContain("late-overlay-click-refused");
   expect(result.stdout).toContain("relabelled-ref-refused");
+  expect(result.stdout).toContain("root-scroll-lock-preserved");
 }, 60_000);

--- a/electron/browser-closed-shadow.electron.test.mjs
+++ b/electron/browser-closed-shadow.electron.test.mjs
@@ -246,4 +246,4 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
   expect(result.stdout).toContain("protected-focused-keys-refused");
   expect(result.stdout).toContain("late-overlay-click-refused");
   expect(result.stdout).toContain("relabelled-ref-refused");
-}, 30_000);
+}, 60_000);

--- a/electron/browser-closed-shadow.electron.test.mjs
+++ b/electron/browser-closed-shadow.electron.test.mjs
@@ -237,6 +237,12 @@ it.runIf(canRunRealElectronFixture)("protects closed-shadow values and revalidat
   expect(result.stdout).toContain("closed-shadow-nested-name-source-redacted");
   expect(result.stdout).toContain("transformed-secret-taint");
   expect(result.stdout).toContain("rich-nested-name-source-redacted");
+  expect(result.stdout).toContain("compact-known-coordinate-click");
+  expect(result.stdout).toContain("compact-known-coordinate-scroll");
+  expect(result.stdout).toContain("expanded-known-coordinate-click");
+  expect(result.stdout).toContain("expanded-known-coordinate-scroll");
+  expect(result.stdout).toContain("real-double-click-sequence");
+  expect(result.stdout).toContain("fixed-screenshot-pixel-size");
   expect(result.stdout).toContain("protected-focused-keys-refused");
   expect(result.stdout).toContain("late-overlay-click-refused");
   expect(result.stdout).toContain("relabelled-ref-refused");

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -2064,6 +2064,11 @@ function createBrowserSurfaceManager({
         const pixels = Number.isFinite(Number(amount)) && Number(amount) > 0 ? Math.min(Number(amount), 5_000) : 600;
         const { x, y } = viewportCenter();
         await assertNoPopulatedProtectedFields(entry, lease);
+        // Chromium's Linux input path can dispatch a wheel gesture at the
+        // last known pointer target even when the wheel packet includes new
+        // coordinates. Move first so nested scroll containers are targeted
+        // consistently on every desktop platform.
+        await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseMoved", x, y }, lease);
         await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseWheel", x, y, deltaX: direction[0] * pixels, deltaY: direction[1] * pixels }, lease);
         return observe(entry);
       });

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -109,6 +109,40 @@ const SCROLL_METRICS_EXPRESSION = `(() => {
   const el = document.scrollingElement || document.documentElement;
   return { top: Math.round(el.scrollTop), height: Math.round(el.scrollHeight), view: Math.round(window.innerHeight) };
 })()`;
+const SCROLL_AT_POINT_FUNCTION = `function __ombScrollAtPoint({ x, y, deltaX, deltaY }) {
+  const root = document.scrollingElement || document.documentElement;
+  const candidates = [];
+  const seen = new Set();
+  let current = document.elementFromPoint(x, y);
+  while (current instanceof Element) {
+    if (!seen.has(current)) {
+      seen.add(current);
+      candidates.push(current);
+    }
+    const tree = current.getRootNode && current.getRootNode();
+    current = current.parentElement || (tree && tree.host instanceof Element ? tree.host : null);
+  }
+  if (root && !seen.has(root)) candidates.push(root);
+  for (const candidate of candidates) {
+    const horizontal = deltaX !== 0;
+    const currentOffset = horizontal ? candidate.scrollLeft : candidate.scrollTop;
+    const maximum = horizontal
+      ? Math.max(0, candidate.scrollWidth - candidate.clientWidth)
+      : Math.max(0, candidate.scrollHeight - candidate.clientHeight);
+    const delta = horizontal ? deltaX : deltaY;
+    const canMove = delta > 0 ? currentOffset < maximum : currentOffset > 0;
+    if (!canMove) continue;
+    const overflow = getComputedStyle(candidate)[horizontal ? "overflowX" : "overflowY"];
+    if (candidate === root) {
+      if (["hidden", "clip"].includes(overflow)) continue;
+    } else if (!["auto", "scroll", "overlay"].includes(overflow)) continue;
+    if (horizontal) candidate.scrollLeft = currentOffset + delta;
+    else candidate.scrollTop = currentOffset + delta;
+    const nextOffset = horizontal ? candidate.scrollLeft : candidate.scrollTop;
+    if (nextOffset !== currentOffset) return true;
+  }
+  return false;
+}`;
 const SENSITIVE_FIELD_SOURCE = "password|passwd|passcode|client.?secret|api.?key|secret.?key|private.?key|signing.?key|webhook.?secret|secret.?access.?key|access.?token|auth.?token|refresh.?token|bearer.?token|one.?time|otp|verification.?code|recovery.?code|seed.?phrase|mnemonic|recovery.?phrase|security.?answer|cc-.+|card.?(number|security|cvv|cvc)|cvv|cvc|bank.?(account|routing)|routing.?(number|code)|account.?(number|no)|social.?(security|insurance)|ssn|tax.?id";
 const SENSITIVE_FIELD_PATTERN = new RegExp(SENSITIVE_FIELD_SOURCE, "i");
 
@@ -2064,12 +2098,30 @@ function createBrowserSurfaceManager({
         const pixels = Number.isFinite(Number(amount)) && Number(amount) > 0 ? Math.min(Number(amount), 5_000) : 600;
         const { x, y } = viewportCenter();
         await assertNoPopulatedProtectedFields(entry, lease);
-        // Chromium's Linux input path can dispatch a wheel gesture at the
-        // last known pointer target even when the wheel packet includes new
-        // coordinates. Move first so nested scroll containers are targeted
-        // consistently on every desktop platform.
+        // Move first so hover-driven layouts settle around the same point the
+        // user sees. Standard DOM scrollers are moved in the isolated world:
+        // Chromium's Linux/X11 compositor can acknowledge a mouseWheel packet
+        // while dropping it, which made this tool silently do nothing. Keep a
+        // real wheel fallback for canvas and virtual surfaces with no native
+        // scroll container at the pointer.
         await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseMoved", x, y }, lease);
-        await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseWheel", x, y, deltaX: direction[0] * pixels, deltaY: direction[1] * pixels }, lease);
+        let pageScrolled = false;
+        if (platform === "linux") {
+          try {
+            pageScrolled = await evaluate(entry, `(${SCROLL_AT_POINT_FUNCTION})(${JSON.stringify({
+              x,
+              y,
+              deltaX: direction[0] * pixels,
+              deltaY: direction[1] * pixels,
+            })})`) === true;
+            assertAgentLease(entry, lease);
+          } catch {
+            assertAgentLease(entry, lease);
+          }
+        }
+        if (!pageScrolled) {
+          await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseWheel", x, y, deltaX: direction[0] * pixels, deltaY: direction[1] * pixels }, lease);
+        }
         return observe(entry);
       });
     },
@@ -2174,34 +2226,40 @@ function createBrowserSurfaceManager({
         await assertScreenshotHasNoProtectedValues(entry, lease);
         assertAgentLease(entry, lease);
         let shot = null;
-        try {
-          let deviceScaleFactor = 1;
+        // Electron's CDP screenshot command can remain pending forever under
+        // Linux/X11 software compositing. Native capturePage is reliable in
+        // that environment and is normalized to the same fixed pixel size
+        // below; other platforms keep the sharper fixed-viewport CDP path.
+        if (platform !== "linux") {
           try {
-            const reported = Number(await evaluate(entry, "window.devicePixelRatio"));
-            if (Number.isFinite(reported) && reported >= 0.25 && reported <= 8) deviceScaleFactor = reported;
-          } catch {}
-          assertAgentLease(entry, lease);
-          shot = await cdp(entry, "Page.captureScreenshot", {
-            format: "jpeg",
-            quality: SCREENSHOT_QUALITY,
-            // captureScreenshot applies this scale before rasterizing at the
-            // page's device pixel ratio. Divide by DPR so the encoded JPEG —
-            // not just its metadata — is always exactly 1024x640.
-            clip: {
-              x: 0,
-              y: 0,
-              width: VIEWPORT.width,
-              height: VIEWPORT.height,
-              scale: SCREENSHOT_WIDTH / (VIEWPORT.width * deviceScaleFactor),
-            },
-          });
-          assertAgentLease(entry, lease);
-        } catch {
-          // A control transition invalidates the result even if Chromium
-          // already captured pixels. Never fall back and accidentally return
-          // a frame that overlapped the user's typing.
-          assertAgentLease(entry, lease);
-          shot = null;
+            let deviceScaleFactor = 1;
+            try {
+              const reported = Number(await evaluate(entry, "window.devicePixelRatio"));
+              if (Number.isFinite(reported) && reported >= 0.25 && reported <= 8) deviceScaleFactor = reported;
+            } catch {}
+            assertAgentLease(entry, lease);
+            shot = await cdp(entry, "Page.captureScreenshot", {
+              format: "jpeg",
+              quality: SCREENSHOT_QUALITY,
+              // captureScreenshot applies this scale before rasterizing at the
+              // page's device pixel ratio. Divide by DPR so the encoded JPEG —
+              // not just its metadata — is always exactly 1024x640.
+              clip: {
+                x: 0,
+                y: 0,
+                width: VIEWPORT.width,
+                height: VIEWPORT.height,
+                scale: SCREENSHOT_WIDTH / (VIEWPORT.width * deviceScaleFactor),
+              },
+            });
+            assertAgentLease(entry, lease);
+          } catch {
+            // A control transition invalidates the result even if Chromium
+            // already captured pixels. Never fall back and accidentally return
+            // a frame that overlapped the user's typing.
+            assertAgentLease(entry, lease);
+            shot = null;
+          }
         }
         if (shot?.data) {
           // The page can populate an API key/OTP/card field asynchronously
@@ -2213,7 +2271,15 @@ function createBrowserSurfaceManager({
           return { png: buffer.toString("base64"), format: "jpeg", width: SCREENSHOT_WIDTH, height: Math.round((VIEWPORT.height * SCREENSHOT_WIDTH) / VIEWPORT.width) };
         }
         assertAgentLease(entry, lease);
-        const image = await entry.view.webContents.capturePage();
+        const nativeBounds = entry.bounds ?? { width: VIEWPORT.width, height: VIEWPORT.height };
+        const nativeScale = Number.isFinite(entry.presentationScale) ? entry.presentationScale : 1;
+        const captureRect = {
+          x: 0,
+          y: 0,
+          width: Math.max(1, Math.min(nativeBounds.width, Math.round(VIEWPORT.width * nativeScale))),
+          height: Math.max(1, Math.min(nativeBounds.height, Math.round(VIEWPORT.height * nativeScale))),
+        };
+        const image = await entry.view.webContents.capturePage(captureRect);
         assertAgentLease(entry, lease);
         await assertScreenshotHasNoProtectedValues(entry, lease);
         const screenshotHeight = Math.round((VIEWPORT.height * SCREENSHOT_WIDTH) / VIEWPORT.width);

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -797,16 +797,26 @@ function createBrowserSurfaceManager({
       // taint the document.
       if (human && ["mouseDown", "contextMenu"].includes(mouse?.type)) entry.documentTainted = true;
     });
-    for (const signal of ["did-navigate", "did-navigate-in-page", "did-stop-loading", "page-title-updated"]) {
+    for (const signal of ["did-navigate-in-page", "did-stop-loading", "page-title-updated"]) {
       contents.on(signal, () => emitState(entry));
     }
     contents.on("did-navigate", () => {
+      // Chromium drops WebContents device emulation when a main-frame
+      // navigation commits. Keeping the previous emulationKey made later
+      // layout calls believe the 1280x800 compact viewport was still active,
+      // so every newly-opened site fell back to the small panel's CSS size.
+      // Reapply the current presentation mode after the new document exists.
+      if (entry.mode) {
+        entry.emulationKey = null;
+        applyMode(entry, entry.mode);
+      }
       // refs name nodes of the page that just went away
       entry.documentTainted = false;
       entry.refs = null;
       entry.refIntegrity = null;
       entry.isolatedContextId = null;
       entry.isolatedContextReady = null;
+      emitState(entry);
     });
     contents.on("render-process-gone", () => remove(entry, "renderer-gone"));
     contents.debugger.on("detach", () => {
@@ -947,9 +957,21 @@ function createBrowserSurfaceManager({
       } catch {}
       // a Guest session is for one visit: switching away forgets it
       if (previous.profile === GUEST_PROFILE) remove(previous);
-      // the new view takes the old one's place on screen
-      if (previous.bounds && !entry.bounds) entry.bounds = previous.bounds;
-      if (previous.mode && !entry.mode) applyMode(entry, previous.mode);
+      // The new view takes the old one's place on screen. Keep the logical
+      // bounds and the native WebContentsView bounds in lockstep even when
+      // React hid the old profile just before selecting the new one. Without
+      // this, a freshly-created view keeps its 1280x800 hidden viewport while
+      // `entry.bounds` says it already has the compact panel rectangle; the
+      // following layout then skips setBounds and the native view covers the
+      // app from the top-left corner.
+      if (previous.bounds) {
+        entry.bounds = { ...previous.bounds };
+        entry.view.setBounds(entry.bounds);
+      }
+      // A reused profile may have last been shown in the other presentation
+      // mode. Match the surface it replaces before it becomes visible so
+      // there is no one-frame scale jump during profile switches.
+      if (previous.mode) applyMode(entry, previous.mode);
     }
     active.set(botId, entry);
     touch(entry);
@@ -1691,11 +1713,14 @@ function createBrowserSurfaceManager({
     },
 
     /** Position the bot's active view over the renderer's rectangle (or hide
-     * it: null). `profile` switches views; `mode` picks the scaling. */
+     * it: null). `profile` switches views; `mode` picks the scaling. A
+     * profile-scoped hide is ignored after another profile has become active,
+     * which makes React effect cleanup safe during profile switches. */
     layout(botId, bounds, profile, mode) {
       if (bounds === null || bounds === undefined) {
         const entry = active.get(botIdOf(botId));
         if (!entry) return closedState(botIdOf(botId));
+        if (profile !== undefined && entry.profile !== profileIdOf(profile)) return stateFor(entry);
         if (entry.visible) {
           entry.visible = false;
           entry.view.setVisible(false);

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -51,6 +51,7 @@ const MAX_PAGE_NOTICES = 20;
 const DNS_CACHE_MS = 10_000;
 const MAX_DNS_CACHE = 256;
 const AGENT_INPUT_SUPPRESS_MS = 100;
+const COMPACT_GESTURE_GUARD_MS = 400;
 const AX_TREE_DEPTH = 24;
 /** The page lays out at this size whatever the panel's rectangle is. Both
  * compact and expanded surfaces scale the same desktop viewport to fit, so
@@ -467,7 +468,7 @@ function createBrowserSurfaceManager({
   const keyOf = (botId, partition) => `${botId}\0${partition}`;
   const controlFor = (botId) => botControl.get(botId) ?? { held: false, epoch: 0, agentEpoch: 0 };
 
-  const closedState = (botId) => ({
+  const closedState = (botId, entry) => ({
     botId,
     open: false,
     url: "",
@@ -476,9 +477,9 @@ function createBrowserSurfaceManager({
     canGoBack: false,
     canGoForward: false,
     visible: false,
-    partition: null,
-    profile: null,
-    mode: null,
+    partition: entry?.partition ?? null,
+    profile: entry?.profile ?? null,
+    mode: entry?.mode ?? null,
   });
 
   const stateFor = (entry) => {
@@ -668,7 +669,10 @@ function createBrowserSurfaceManager({
       if (!entry.view.webContents.isDestroyed()) entry.view.webContents.close({ waitForBeforeUnload: false });
     } catch {}
     if (wasActive) {
-      const state = closedState(entry.botId);
+      // Preserve the removed entry's identity. A terminal event can race a
+      // profile switch; without this, the renderer can pin the old page's
+      // crash/eviction onto whichever profile is selected now.
+      const state = closedState(entry.botId, entry);
       if (code) state.code = code;
       emit(state);
     }
@@ -782,7 +786,23 @@ function createBrowserSurfaceManager({
       callback();
       pushBounded(entry.notices, "Blocked a client-certificate prompt in the built-in browser");
     });
-    contents.on("focus", () => claimHumanControl(entry, "focus"));
+    const beginCompactGestureGuard = (wasHeld) => {
+      const current = now();
+      const alreadyGuarded = current < entry.blockCompactGestureUntil;
+      entry.blockCompactGestureUntil = current + COMPACT_GESTURE_GUARD_MS;
+      if (wasHeld && !alreadyGuarded) {
+        emitUserInteraction({ botId: entry.botId, profile: entry.profile });
+      }
+    };
+    contents.on("focus", () => {
+      const wasHeld = controlFor(entry.botId).held;
+      const human = claimHumanControl(entry, "focus");
+      // A newly acquired hold emits above and may expand before Electron
+      // delivers its mouse event, so latch that gesture. An already-held view
+      // must wait for a concrete pointer event; merely restoring its focus
+      // while shrinking should not bounce the workspace open again.
+      if (human && !wasHeld && entry.mode === "compact") beginCompactGestureGuard(false);
+    });
     contents.on("before-input-event", (_event, input) => {
       const human = claimHumanControl(entry, "keyboard", input);
       // A page can transform/copy a password on input and immediately clear
@@ -798,25 +818,33 @@ function createBrowserSurfaceManager({
       // web page. Keep the matching mouse-up blocked even if the renderer has
       // already switched this entry to expanded mode in response to the
       // takeover notification.
-      if (mouse?.type === "mouseDown" && entry.blockCompactMouseUp && entry.mode !== "compact") {
-        entry.blockCompactMouseUp = false;
-      }
       if (mouse?.type === "mouseUp" && entry.blockCompactMouseUp) {
         entry.blockCompactMouseUp = false;
         event.preventDefault();
         return;
       }
       if (!["mouseDown", "contextMenu", "mouseWheel"].includes(mouse?.type)) return;
+      // Focus can reach Electron before layout IPC expands the panel. Keep the
+      // whole originating gesture watch-only even after mode changes: this
+      // catches the following context-menu event and trackpad inertia. Exact
+      // synthetic echoes remain agent input and must never be swallowed.
+      if (now() < entry.blockCompactGestureUntil) {
+        if (agentEchoMatches(entry, "mouse", mouse)) return;
+        event.preventDefault();
+        if (mouse.type === "mouseDown") entry.blockCompactMouseUp = true;
+        if (mouse.type === "mouseWheel") beginCompactGestureGuard(false);
+        return;
+      }
       const wasHeld = controlFor(entry.botId).held;
       const human = claimHumanControl(entry, "mouse", mouse);
       const compactTakeover = human && entry.mode === "compact";
       if (compactTakeover) {
         event.preventDefault();
         if (mouse.type === "mouseDown") entry.blockCompactMouseUp = true;
-        // claimHumanControl emits only for the transition into human control.
-        // A user may have shrunk an already-controlled browser, and its next
-        // compact click still needs to reopen the workspace.
-        if (wasHeld) emitUserInteraction({ botId: entry.botId, profile: entry.profile });
+        // claimHumanControl emits only for the transition into human control;
+        // an already-controlled compact page still has to reopen. The guard
+        // also suppresses the remainder of this pointer/wheel gesture.
+        beginCompactGestureGuard(wasHeld);
         return;
       }
       // A click can submit or copy an autofilled password without producing a
@@ -930,6 +958,7 @@ function createBrowserSurfaceManager({
       pressedKeys: new Map(),
       presentationScale: 1,
       blockCompactMouseUp: false,
+      blockCompactGestureUntil: 0,
       neutralizingInput: null,
       documentTainted: false,
       operationDepth: 0,

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -52,9 +52,10 @@ const DNS_CACHE_MS = 10_000;
 const MAX_DNS_CACHE = 256;
 const AGENT_INPUT_SUPPRESS_MS = 100;
 const AX_TREE_DEPTH = 24;
-/** The page lays out at this size whatever the panel's rectangle is; the
- * compact preview scales it down, the expanded view shows it 1:1. Bots see
- * one consistent desktop viewport regardless of how wide the panel is. */
+/** The page lays out at this size whatever the panel's rectangle is. Both
+ * compact and expanded surfaces scale the same desktop viewport to fit, so
+ * responsive pages, refs, screenshots and scroll positions do not change
+ * merely because the person opened the larger workspace. */
 const VIEWPORT = Object.freeze({ width: 1280, height: 800 });
 
 /** Keys a bot may press by name → CDP key event fields. `text` is what makes
@@ -459,6 +460,10 @@ function createBrowserSurfaceManager({
     browserProfilePartition(wanted);
     return wanted;
   };
+  const layoutOwnerIdOf = (ownerId) =>
+    Object.prototype.toString.call(ownerId) === "[object String]" && ownerId.length > 0 && ownerId.length <= 128
+      ? ownerId
+      : undefined;
   const keyOf = (botId, partition) => `${botId}\0${partition}`;
   const controlFor = (botId) => botControl.get(botId) ?? { held: false, epoch: 0, agentEpoch: 0 };
 
@@ -786,9 +791,34 @@ function createBrowserSurfaceManager({
       // blocked until a committed navigation replaces the document.
       if (human && input?.type !== "keyUp") entry.documentTainted = true;
     });
-    contents.on("before-mouse-event", (_event, mouse) => {
+    contents.on("before-mouse-event", (event, mouse) => {
+      // The compact surface is a watch-only preview. A person's first
+      // pointer gesture takes control and asks the renderer to expand it, but
+      // must not also activate whatever happens to be under that point on the
+      // web page. Keep the matching mouse-up blocked even if the renderer has
+      // already switched this entry to expanded mode in response to the
+      // takeover notification.
+      if (mouse?.type === "mouseDown" && entry.blockCompactMouseUp && entry.mode !== "compact") {
+        entry.blockCompactMouseUp = false;
+      }
+      if (mouse?.type === "mouseUp" && entry.blockCompactMouseUp) {
+        entry.blockCompactMouseUp = false;
+        event.preventDefault();
+        return;
+      }
       if (!["mouseDown", "contextMenu", "mouseWheel"].includes(mouse?.type)) return;
+      const wasHeld = controlFor(entry.botId).held;
       const human = claimHumanControl(entry, "mouse", mouse);
+      const compactTakeover = human && entry.mode === "compact";
+      if (compactTakeover) {
+        event.preventDefault();
+        if (mouse.type === "mouseDown") entry.blockCompactMouseUp = true;
+        // claimHumanControl emits only for the transition into human control.
+        // A user may have shrunk an already-controlled browser, and its next
+        // compact click still needs to reopen the workspace.
+        if (wasHeld) emitUserInteraction({ botId: entry.botId, profile: entry.profile });
+        return;
+      }
       // A click can submit or copy an autofilled password without producing a
       // keyboard event. A hostile page can then clear the protected control
       // and echo a transformed secret into ordinary DOM/title text before the
@@ -797,9 +827,17 @@ function createBrowserSurfaceManager({
       // taint the document.
       if (human && ["mouseDown", "contextMenu"].includes(mouse?.type)) entry.documentTainted = true;
     });
-    for (const signal of ["did-navigate-in-page", "did-stop-loading", "page-title-updated"]) {
+    for (const signal of ["did-navigate-in-page", "page-title-updated"]) {
       contents.on(signal, () => emitState(entry));
     }
+    contents.on("did-stop-loading", () => {
+      // A commit-time emulation call can briefly race Chromium's renderer
+      // replacement. Retry once the document is stable instead of leaving
+      // this page at the native panel's responsive resolution until some
+      // later React layout happens to run.
+      if (entry.mode && entry.emulationKey === null) applyMode(entry, entry.mode);
+      emitState(entry);
+    });
     contents.on("did-navigate", () => {
       // Chromium drops WebContents device emulation when a main-frame
       // navigation commits. Keeping the previous emulationKey made later
@@ -878,6 +916,7 @@ function createBrowserSurfaceManager({
       visible: false,
       bounds: null,
       mode: null,
+      layoutOwner: null,
       emulationKey: null,
       refs: null,
       refKind: "ax",
@@ -889,6 +928,8 @@ function createBrowserSurfaceManager({
       agentEchoes: [],
       pressedMouse: new Map(),
       pressedKeys: new Map(),
+      presentationScale: 1,
+      blockCompactMouseUp: false,
       neutralizingInput: null,
       documentTainted: false,
       operationDepth: 0,
@@ -934,9 +975,7 @@ function createBrowserSurfaceManager({
     return entry;
   };
 
-  const withOperation = async (entry, operation) => {
-    entry.operationDepth += 1;
-    touch(entry);
+  const runOperation = async (entry, operation) => {
     try {
       return await operation();
     } catch (error) {
@@ -946,6 +985,20 @@ function createBrowserSurfaceManager({
       entry.operationDepth = Math.max(0, entry.operationDepth - 1);
       touch(entry);
     }
+  };
+
+  /** Agent operations on one page are deliberately serialized. Without a
+   * small per-entry queue, two tool calls can interleave their privacy
+   * preflights and pointer/key sequences, making otherwise valid refs land on
+   * the wrong post-action document. Different profiles and bots still run in
+   * parallel. */
+  const withOperation = (entry, operation) => {
+    entry.operationDepth += 1;
+    touch(entry);
+    const previous = entry.operationTail ?? Promise.resolve();
+    const pending = previous.catch(() => {}).then(() => runOperation(entry, operation));
+    entry.operationTail = pending.catch(() => {});
+    return pending;
   };
 
   const activate = (botId, entry, previous) => {
@@ -1222,6 +1275,21 @@ function createBrowserSurfaceManager({
     }
   };
 
+  const presentationMouseParams = (entry, params) => {
+    if (params?.type === undefined) return params;
+    const scale = Number.isFinite(entry.presentationScale) ? entry.presentationScale : 1;
+    if (scale === 1 || (!Number.isFinite(params.x) && !Number.isFinite(params.y))) return params;
+    // Electron's WebContents device-emulation `scale` is a presentation
+    // transform outside the page's CSS viewport. DOM boxes and hit testing
+    // remain in 1280x800 page coordinates, while Input.dispatchMouseEvent is
+    // received in the scaled native view. Only the event position is scaled;
+    // wheel deltas intentionally remain CSS scroll distances.
+    const mapped = { ...params };
+    if (Number.isFinite(params.x)) mapped.x = params.x * scale;
+    if (Number.isFinite(params.y)) mapped.y = params.y * scale;
+    return mapped;
+  };
+
   const cdp = async (entry, method, params = {}, lease) => {
     const dbg = entry.view.webContents.debugger;
     await ensureProtocol(entry);
@@ -1229,6 +1297,9 @@ function createBrowserSurfaceManager({
     if (method === "Runtime.evaluate" && params.contextId === undefined) {
       const contextId = await ensureIsolatedContext(entry);
       commandParams = { ...params, contextId };
+    }
+    if (method === "Input.dispatchMouseEvent") {
+      commandParams = presentationMouseParams(entry, commandParams);
     }
     const isAgentInput = method.startsWith("Input.");
     if (isAgentInput) {
@@ -1346,16 +1417,22 @@ function createBrowserSurfaceManager({
     }
   };
 
-  /** Fit the fixed desktop viewport into the rectangle the panel gave us:
-   * scaled down for the compact preview, 1:1 when expanded. */
+  /** Fit the fixed desktop viewport into either rectangle the panel gives us.
+   * Expanded is a larger presentation of the exact same page viewport, not a
+   * responsive-layout transition. */
   const applyMode = (entry, mode) => {
     const contents = entry.view.webContents;
     entry.mode = mode;
-    if (mode === "compact" && entry.bounds) {
+    if (entry.bounds) {
       const scale = Math.min(entry.bounds.width / VIEWPORT.width, entry.bounds.height / VIEWPORT.height);
-      const boundedScale = Math.max(0.1, Math.min(1, scale));
-      const emulationKey = `compact:${boundedScale}`;
-      if (entry.emulationKey === emulationKey) return;
+      // Very large workspaces may legitimately enlarge the desktop viewport;
+      // keep a generous ceiling only to avoid pathological native values.
+      const boundedScale = Math.max(0.1, Math.min(2, scale));
+      const emulationKey = `fixed:${boundedScale}`;
+      if (entry.emulationKey === emulationKey) {
+        entry.presentationScale = boundedScale;
+        return;
+      }
       try {
         contents.enableDeviceEmulation({
           screenPosition: "desktop",
@@ -1365,14 +1442,16 @@ function createBrowserSurfaceManager({
           viewSize: { ...VIEWPORT },
           scale: boundedScale,
         });
+        entry.presentationScale = boundedScale;
         entry.emulationKey = emulationKey;
-      } catch {}
+      } catch {
+        // Keep the retry sentinel and coordinate conversion honest. A failed
+        // emulation call means Input coordinates still use the native view.
+        entry.presentationScale = 1;
+        entry.emulationKey = null;
+      }
     } else {
-      if (entry.emulationKey === "expanded") return;
-      try {
-        contents.disableDeviceEmulation();
-        entry.emulationKey = "expanded";
-      } catch {}
+      entry.presentationScale = 1;
     }
   };
 
@@ -1716,18 +1795,25 @@ function createBrowserSurfaceManager({
      * it: null). `profile` switches views; `mode` picks the scaling. A
      * profile-scoped hide is ignored after another profile has become active,
      * which makes React effect cleanup safe during profile switches. */
-    layout(botId, bounds, profile, mode) {
+    layout(botId, bounds, profile, mode, layoutOwner) {
+      const ownerId = layoutOwnerIdOf(layoutOwner);
       if (bounds === null || bounds === undefined) {
         const entry = active.get(botIdOf(botId));
         if (!entry) return closedState(botIdOf(botId));
         if (profile !== undefined && entry.profile !== profileIdOf(profile)) return stateFor(entry);
+        // Compact and expanded BrowserPanel instances can overlap briefly
+        // during React handoff. Cleanup from the old owner must never hide
+        // the newer native surface for the same bot and profile.
+        if (ownerId !== undefined && entry.layoutOwner !== ownerId) return stateFor(entry);
         if (entry.visible) {
           entry.visible = false;
           entry.view.setVisible(false);
         }
+        entry.layoutOwner = null;
         return stateFor(entry);
       }
       const entry = ensure(botId, profile);
+      entry.layoutOwner = ownerId ?? null;
       const normalized = normalizeDesktopWorkspaceBounds(bounds, owner.getContentSize());
       if (!sameBounds(entry.bounds, normalized)) {
         entry.bounds = normalized;
@@ -1735,6 +1821,12 @@ function createBrowserSurfaceManager({
       }
       applyMode(entry, mode === "expanded" ? "expanded" : "compact");
       if (!entry.visible) {
+        // A hidden sibling may have been added after this view (profile
+        // switch, workspace overlay, another bot). Re-adding raises this
+        // native child before it becomes visible, matching DOM stacking.
+        try {
+          owner.contentView.addChildView(entry.view);
+        } catch {}
         entry.visible = true;
         entry.view.setVisible(true);
       }
@@ -1786,6 +1878,16 @@ function createBrowserSurfaceManager({
       });
     },
 
+    async reload(botId, profile, { source } = {}) {
+      const entry = ensure(botId, profile);
+      return withOperation(entry, async () => {
+        const lease = beginAgentAction(entry, source);
+        assertAgentLease(entry, lease, source);
+        entry.view.webContents.reload();
+        return observe(entry);
+      });
+    },
+
     async snapshot(botId, profile) {
       const entry = ensure(botId, profile);
       return withOperation(entry, async () => {
@@ -1802,11 +1904,17 @@ function createBrowserSurfaceManager({
         const target = await centerOf(entry, ref, lease);
         const { x, y } = target;
         const which = button === "right" ? "right" : button === "middle" ? "middle" : "left";
+        const clicks = Math.min(3, Math.max(1, Math.trunc(Number(clickCount)) || 1));
         await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseMoved", x, y }, lease);
         await assertRefHitTarget(entry, target, lease);
         await assertNoPopulatedProtectedFields(entry, lease);
-        await cdp(entry, "Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: which, clickCount }, lease);
-        await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: which, clickCount }, lease);
+        // Chromium derives click and dblclick DOM events from a sequence whose
+        // detail rises 1, 2, ...; sending only one down/up pair marked as 2
+        // skips the first click and behaves differently from a real pointer.
+        for (let detail = 1; detail <= clicks; detail += 1) {
+          await cdp(entry, "Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: which, clickCount: detail }, lease);
+          await cdp(entry, "Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: which, clickCount: detail }, lease);
+        }
         return observe(entry);
       });
     },
@@ -1841,6 +1949,7 @@ function createBrowserSurfaceManager({
             x: from.x + (to.x - from.x) * step,
             y: from.y + (to.y - from.y) * step,
             button: "left",
+            buttons: 1,
           }, lease);
         }
         await assertRefHitTarget(entry, { ...to, ref: String(toRef) }, lease);
@@ -2032,10 +2141,25 @@ function createBrowserSurfaceManager({
         assertAgentLease(entry, lease);
         let shot = null;
         try {
+          let deviceScaleFactor = 1;
+          try {
+            const reported = Number(await evaluate(entry, "window.devicePixelRatio"));
+            if (Number.isFinite(reported) && reported >= 0.25 && reported <= 8) deviceScaleFactor = reported;
+          } catch {}
+          assertAgentLease(entry, lease);
           shot = await cdp(entry, "Page.captureScreenshot", {
             format: "jpeg",
             quality: SCREENSHOT_QUALITY,
-            clip: { x: 0, y: 0, width: VIEWPORT.width, height: VIEWPORT.height, scale: SCREENSHOT_WIDTH / VIEWPORT.width },
+            // captureScreenshot applies this scale before rasterizing at the
+            // page's device pixel ratio. Divide by DPR so the encoded JPEG —
+            // not just its metadata — is always exactly 1024x640.
+            clip: {
+              x: 0,
+              y: 0,
+              width: VIEWPORT.width,
+              height: VIEWPORT.height,
+              scale: SCREENSHOT_WIDTH / (VIEWPORT.width * deviceScaleFactor),
+            },
           });
           assertAgentLease(entry, lease);
         } catch {

--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -2211,8 +2211,12 @@ function createBrowserSurfaceManager({
         const image = await entry.view.webContents.capturePage();
         assertAgentLease(entry, lease);
         await assertScreenshotHasNoProtectedValues(entry, lease);
-        const size = image.getSize();
-        const scaled = size.width > SCREENSHOT_WIDTH ? image.resize({ width: SCREENSHOT_WIDTH }) : image;
+        const screenshotHeight = Math.round((VIEWPORT.height * SCREENSHOT_WIDTH) / VIEWPORT.width);
+        // capturePage() reflects the native panel rectangle, which can be
+        // smaller than the model-facing screenshot contract in compact mode.
+        // Normalize both dimensions even when this means upscaling so callers
+        // never receive pixels whose size disagrees with the fixed metadata.
+        const scaled = image.resize({ width: SCREENSHOT_WIDTH, height: screenshotHeight });
         return { png: scaled.toJPEG(SCREENSHOT_QUALITY).toString("base64"), format: "jpeg", width: scaled.getSize().width, height: scaled.getSize().height };
       });
     },

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -32,6 +32,8 @@ function fakeView(partition) {
   let hitRelated = true;
   let richRefsValid = true;
   let richHit = true;
+  let devicePixelRatio = 2;
+  let emulationFailures = 0;
   const injectedContexts = new Set();
   let mainWorldSpoofed = false;
   const fieldClassifications = new Map([
@@ -81,7 +83,14 @@ function fakeView(partition) {
       url = next;
       title = next === "about:blank" ? "" : "Loaded";
     },
-    enableDeviceEmulation: (options) => calls.push(["enableDeviceEmulation", options]),
+    reload: () => calls.push(["reload"]),
+    enableDeviceEmulation: (options) => {
+      calls.push(["enableDeviceEmulation", options]);
+      if (emulationFailures > 0) {
+        emulationFailures -= 1;
+        throw new Error("fixture emulation failure");
+      }
+    },
     disableDeviceEmulation: () => calls.push(["disableDeviceEmulation"]),
     close: () => calls.push(["close"]),
     capturePage: async () => ({
@@ -128,6 +137,7 @@ function fakeView(partition) {
         if (method === "Runtime.callFunctionOn") return { result: { value: { chosen: ["India"] } } };
         if (method === "Runtime.evaluate") {
           const expression = String(params.expression);
+          if (expression === "window.devicePixelRatio") return { result: { value: devicePixelRatio } };
           if (expression.includes("document.activeElement")) return { result: { objectId: "active-element" } };
           if (expression === "/*injected*/") {
             injectedContexts.add(params.contextId);
@@ -198,6 +208,12 @@ function fakeView(partition) {
     },
     setRichHit: (hit) => {
       richHit = hit === true;
+    },
+    setDevicePixelRatio: (value) => {
+      devicePixelRatio = Number(value);
+    },
+    failNextEmulation: () => {
+      emulationFailures += 1;
     },
     setSensitive: (objectId, value = true) => {
       fieldClassifications.set(objectId, value ? "sensitive" : "ordinary");
@@ -332,7 +348,7 @@ describe("browser surface manager", () => {
     expect(() => manager.layout("../bad", BOUNDS)).toThrow(/bot id/);
   });
 
-  it("scales the fixed desktop viewport into the compact box and shows it 1:1 when expanded", () => {
+  it("scales the same fixed desktop viewport to fit compact and expanded boxes", () => {
     const { manager, views } = harness();
     manager.layout("bot-a", BOUNDS, "", "compact");
     const emulation = views[0].calls.find(([name]) => name === "enableDeviceEmulation")[1];
@@ -340,7 +356,11 @@ describe("browser surface manager", () => {
     // 400/1280 = 0.3125 and 250/800 = 0.3125 — fit on both axes
     expect(emulation.scale).toBeCloseTo(0.3125, 4);
     manager.layout("bot-a", { x: 0, y: 0, width: 1100, height: 700 }, "", "expanded");
-    expect(views[0].calls.at(-1)).toEqual(["disableDeviceEmulation"]);
+    const expanded = views[0].calls.filter(([name]) => name === "enableDeviceEmulation").at(-1)[1];
+    expect(expanded.viewSize).toEqual(VIEWPORT);
+    expect(expanded.screenSize).toEqual(VIEWPORT);
+    expect(expanded.scale).toBeCloseTo(0.859375, 6);
+    expect(views[0].calls.some(([name]) => name === "disableDeviceEmulation")).toBe(false);
     expect(manager.state("bot-a").mode).toBe("expanded");
   });
 
@@ -358,6 +378,18 @@ describe("browser surface manager", () => {
     expect(view.setBoundsCalls).toHaveLength(initialBoundsCalls);
     expect(view.setVisibleCalls).toHaveLength(initialVisibleCalls);
     expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(initialEmulationCalls);
+  });
+
+  it("raises a hidden native view when its surface becomes visible again", () => {
+    const { manager, owner, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    manager.layout("bot-a", null, "", "compact");
+    manager.layout("bot-b", BOUNDS, "", "compact");
+    expect(owner.contentView.children).toEqual([views[0], views[1]]);
+
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    expect(owner.contentView.children).toEqual([views[1], views[0]]);
+    expect(views[0].visible).toBe(true);
   });
 
   it("moves without resetting emulation and reapplies it only when compact scale changes", () => {
@@ -392,6 +424,38 @@ describe("browser surface manager", () => {
     });
   });
 
+  it("reapplies expanded fixed-viewport emulation after a main-frame navigation commits", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", { x: 10, y: 20, width: 960, height: 700 }, "", "expanded");
+    const view = views[0];
+    expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(1);
+
+    view.listeners.get("did-navigate")?.();
+
+    const emulationCalls = view.calls.filter(([name]) => name === "enableDeviceEmulation");
+    expect(emulationCalls).toHaveLength(2);
+    expect(emulationCalls.at(-1)[1]).toMatchObject({
+      viewSize: VIEWPORT,
+      screenSize: VIEWPORT,
+      scale: 0.75,
+    });
+  });
+
+  it("retries a commit-time emulation failure when loading finishes", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    const view = views[0];
+    view.failNextEmulation();
+
+    view.listeners.get("did-navigate")?.();
+    expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(2);
+    view.listeners.get("did-stop-loading")?.();
+
+    const emulationCalls = view.calls.filter(([name]) => name === "enableDeviceEmulation");
+    expect(emulationCalls).toHaveLength(3);
+    expect(emulationCalls.at(-1)[1]).toMatchObject({ viewSize: VIEWPORT, scale: 0.3125 });
+  });
+
   it("navigates only to web pages and answers with the page's elements plus a scroll hint", async () => {
     const { manager, views } = harness();
     await expect(manager.navigate("bot-a", "file:///etc/passwd")).rejects.toThrow(/http and https/);
@@ -409,6 +473,16 @@ describe("browser surface manager", () => {
     const untrustedLoadAt = views[0].calls.findIndex(([name, url]) => name === "loadURL" && url === "https://example.com/");
     expect(protocolReadyAt).toBeGreaterThanOrEqual(0);
     expect(untrustedLoadAt).toBeGreaterThan(protocolReadyAt);
+  });
+
+  it("reloads the active page without manufacturing a new history entry", async () => {
+    const { manager, views } = harness();
+    await manager.navigate("bot-a", "https://example.com");
+
+    await manager.reload("bot-a", "", { source: "user" });
+
+    expect(views[0].calls.filter(([name]) => name === "reload")).toHaveLength(1);
+    expect(views[0].calls.filter(([name]) => name === "loadURL")).toHaveLength(2);
   });
 
   it("blocks DNS-private redirects without replaying public redirects or form navigations as GETs", async () => {
@@ -563,6 +637,19 @@ describe("browser surface manager", () => {
     expect(views[1].visible).toBe(false);
   });
 
+  it("ignores cleanup from an older layout owner on the same profile", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact", "compact-owner");
+    manager.layout("bot-a", { ...BOUNDS, width: 800, height: 500 }, "", "expanded", "expanded-owner");
+
+    const state = manager.layout("bot-a", null, "", "compact", "compact-owner");
+
+    expect(state).toMatchObject({ profile: "", visible: true, mode: "expanded" });
+    expect(views[0].visible).toBe(true);
+    manager.layout("bot-a", null, "", "expanded", "expanded-owner");
+    expect(views[0].visible).toBe(false);
+  });
+
   it("reuses a cold own-profile view after the active shared profile is removed", async () => {
     const { manager, views } = harness();
     manager.layout("bot-a", BOUNDS, "", "compact");
@@ -647,6 +734,38 @@ describe("browser surface manager", () => {
     expect(manager.list().map(({ botId }) => botId)).toEqual(["bot-b"]);
   });
 
+  it("serializes concurrent agent operations on the same browser entry", async () => {
+    const { manager, views } = harness();
+    await manager.navigate("bot-a", "https://example.com");
+    const original = views[0].webContents.debugger.sendCommand;
+    let resume;
+    let markStarted;
+    const started = new Promise((resolve) => { markStarted = resolve; });
+    let paused = false;
+    views[0].webContents.debugger.sendCommand = async (method, params) => {
+      if (!paused && method === "Input.dispatchMouseEvent" && params?.type === "mouseMoved") {
+        paused = true;
+        markStarted();
+        await new Promise((resolve) => { resume = resolve; });
+      }
+      return original(method, params);
+    };
+
+    const first = manager.click("bot-a", "b11");
+    await started;
+    const second = manager.click("bot-a", "b11");
+    await Promise.resolve();
+    // The first movement is paused before the fake records it. If the second
+    // operation interleaved, its movement would already be visible here.
+    expect(cdpCalls(views[0]).filter(([name]) => name === "Input.dispatchMouseEvent")).toHaveLength(0);
+    resume();
+    await Promise.all([first, second]);
+    expect(cdpCalls(views[0]).filter(([name]) => name === "Input.dispatchMouseEvent").map(([, params]) => params.type)).toEqual([
+      "mouseMoved", "mousePressed", "mouseReleased",
+      "mouseMoved", "mousePressed", "mouseReleased",
+    ]);
+  });
+
   it("clicks at the centre of a known ref and refuses stale or unknown ones", async () => {
     const { manager, views } = harness();
     await manager.navigate("bot-a", "https://example.com");
@@ -662,6 +781,55 @@ describe("browser surface manager", () => {
     // a navigation invalidates every ref until the next snapshot
     views[0].listeners.get("did-navigate")?.();
     await expect(manager.click("bot-a", "b11")).rejects.toThrow(/changed since/);
+  });
+
+  it("maps fixed-viewport CSS coordinates into compact and expanded native surfaces", async () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    await manager.navigate("bot-a", "https://example.com");
+    await manager.click("bot-a", "b11");
+
+    let pointer = cdpCalls(views[0]).filter(([name]) => name === "Input.dispatchMouseEvent").map(([, params]) => params);
+    expect(pointer.slice(-3)).toEqual([
+      { type: "mouseMoved", x: 18.75, y: 12.5 },
+      { type: "mousePressed", x: 18.75, y: 12.5, button: "left", clickCount: 1 },
+      { type: "mouseReleased", x: 18.75, y: 12.5, button: "left", clickCount: 1 },
+    ]);
+    const compactHitTest = cdpCalls(views[0]).filter(([name]) => name === "DOM.getNodeForLocation").at(-1)[1];
+    expect(compactHitTest).toMatchObject({ x: 60, y: 40 });
+
+    manager.layout("bot-a", { x: 0, y: 0, width: 800, height: 600 }, "", "expanded");
+    await manager.click("bot-a", "b11");
+    pointer = cdpCalls(views[0]).filter(([name]) => name === "Input.dispatchMouseEvent").map(([, params]) => params);
+    expect(pointer.slice(-3)).toEqual([
+      { type: "mouseMoved", x: 37.5, y: 25 },
+      { type: "mousePressed", x: 37.5, y: 25, button: "left", clickCount: 1 },
+      { type: "mouseReleased", x: 37.5, y: 25, button: "left", clickCount: 1 },
+    ]);
+
+    await manager.scroll("bot-a", "down", 600);
+    expect(cdpCalls(views[0]).findLast(([name, params]) =>
+      name === "Input.dispatchMouseEvent" && params.type === "mouseWheel")[1]).toMatchObject({
+      x: 400,
+      y: 250,
+      deltaX: 0,
+      deltaY: 600,
+    });
+  });
+
+  it("emits a real double-click sequence instead of only a detail-2 pair", async () => {
+    const { manager, views } = harness();
+    await manager.navigate("bot-a", "https://example.com");
+    await manager.click("bot-a", "b11", { clickCount: 2 });
+    const pointer = cdpCalls(views[0])
+      .filter(([name, params]) => name === "Input.dispatchMouseEvent" && params.type !== "mouseMoved")
+      .map(([, params]) => ({ type: params.type, clickCount: params.clickCount }));
+    expect(pointer).toEqual([
+      { type: "mousePressed", clickCount: 1 },
+      { type: "mouseReleased", clickCount: 1 },
+      { type: "mousePressed", clickCount: 2 },
+      { type: "mouseReleased", clickCount: 2 },
+    ]);
   });
 
   it("invalidates relabelled refs and refuses a late overlay before mouse-down", async () => {
@@ -689,6 +857,64 @@ describe("browser surface manager", () => {
     await manager.navigate("bot-a", "https://example.org", "", { source: "user" });
     expect(manager.setHumanControl("bot-a", false, "")).toBe(true);
     await expect(manager.click("bot-a", "b11")).resolves.toBeTruthy();
+  });
+
+  it.each(["mouseDown", "contextMenu", "mouseWheel"])("keeps compact human %s input watch-only while expanding", async (type) => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    await manager.navigate("bot-a", "https://example.com");
+    const event = { preventDefault: vi.fn() };
+    views[0].listeners.get("before-mouse-event")?.(event, {
+      type,
+      button: type === "contextMenu" ? "right" : "left",
+      x: 300,
+      y: 180,
+    });
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
+    if (type === "mouseDown") {
+      // Model the renderer responding immediately to the takeover before the
+      // native release for the same gesture arrives.
+      manager.layout("bot-a", { x: 0, y: 0, width: 900, height: 650 }, "", "expanded");
+      const release = { preventDefault: vi.fn() };
+      views[0].listeners.get("before-mouse-event")?.(release, { type: "mouseUp", button: "left", x: 300, y: 180 });
+      expect(release.preventDefault).toHaveBeenCalledOnce();
+    }
+    manager.setHumanControl("bot-a", false, "");
+    await expect(manager.read("bot-a")).resolves.toMatchObject({ title: "Loaded" });
+  });
+
+  it("reopens an already-controlled compact browser without activating its page", async () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    manager.setHumanControl("bot-a", true, "");
+    const event = { preventDefault: vi.fn() };
+    views[0].listeners.get("before-mouse-event")?.(event, { type: "mouseDown", button: "left", x: 200, y: 100 });
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
+  });
+
+  it("does not shield synthetic agent clicks in the compact surface", async () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    await manager.navigate("bot-a", "https://example.com");
+    await manager.click("bot-a", "b11");
+    const pressed = cdpCalls(views[0]).findLast(([name, params]) =>
+      name === "Input.dispatchMouseEvent" && params.type === "mousePressed")[1];
+    const event = { preventDefault: vi.fn() };
+    views[0].listeners.get("before-mouse-event")?.(event, {
+      type: "mouseDown",
+      button: pressed.button,
+      x: pressed.x,
+      y: pressed.y,
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(interactions).toEqual([]);
+    expect(manager.controlLease("bot-a", "")).toMatchObject({ held: false });
   });
 
   it("does not mistake a just-finished CDP input event for a human click", async () => {
@@ -947,6 +1173,11 @@ describe("browser surface manager", () => {
     await expect(manager.scroll("bot-a", "sideways")).rejects.toThrow(/direction/);
     const shot = await manager.screenshot("bot-a");
     expect(shot).toMatchObject({ format: "jpeg", width: 1024, height: 640, png: Buffer.from("cdp-jpeg").toString("base64") });
+    expect(cdpCalls(views[0]).find(([name]) => name === "Page.captureScreenshot")[1].clip).toMatchObject({
+      width: 1280,
+      height: 800,
+      scale: 0.4,
+    });
   });
 
   it("refuses screenshots with populated protected fields and discards captures that overlap takeover", async () => {

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -34,6 +34,7 @@ function fakeView(partition) {
   let richHit = true;
   let devicePixelRatio = 2;
   let emulationFailures = 0;
+  let domScrollAtPoint = false;
   const injectedContexts = new Set();
   let mainWorldSpoofed = false;
   const fieldClassifications = new Map([
@@ -155,6 +156,7 @@ function fakeView(partition) {
           }
           if (expression.includes("focusRef")) return { result: { value: true } };
           if (expression.includes("elementForRef")) return { result: { objectId: "obj-e1" } };
+          if (expression.includes("__ombScrollAtPoint")) return { result: { value: domScrollAtPoint } };
           if (expression.includes("scrollingElement")) return { result: { value: { top: 0, height: 2400, view: 800 } } };
           return { result: { value: pageText } };
         }
@@ -214,6 +216,9 @@ function fakeView(partition) {
     },
     failNextEmulation: () => {
       emulationFailures += 1;
+    },
+    setDomScrollAtPoint: (value) => {
+      domScrollAtPoint = value === true;
     },
     setSensitive: (objectId, value = true) => {
       fieldClassifications.set(objectId, value ? "sensitive" : "ordinary");
@@ -814,6 +819,20 @@ describe("browser surface manager", () => {
     ]);
   });
 
+  it("scrolls a standard DOM container deterministically before using the compositor fallback", async () => {
+    const { manager, views } = harness({ platform: "linux" });
+    await manager.navigate("bot-a", "https://example.com");
+    views[0].setDomScrollAtPoint(true);
+
+    await manager.scroll("bot-a", "down", 600);
+
+    const scrollEvaluation = cdpCalls(views[0]).findLast(([name, params]) =>
+      name === "Runtime.evaluate" && String(params.expression).includes("__ombScrollAtPoint"));
+    expect(scrollEvaluation?.[1].expression).toContain('{"x":640,"y":400,"deltaX":0,"deltaY":600}');
+    expect(cdpCalls(views[0]).filter(([name, params]) =>
+      name === "Input.dispatchMouseEvent" && params.type === "mouseWheel")).toHaveLength(0);
+  });
+
   it("emits a real double-click sequence instead of only a detail-2 pair", async () => {
     const { manager, views } = harness();
     await manager.navigate("bot-a", "https://example.com");
@@ -1234,6 +1253,31 @@ describe("browser surface manager", () => {
       height: 640,
       png: Buffer.from("fallback-jpeg").toString("base64"),
     });
+    expect(resize).toHaveBeenCalledWith({ width: 1024, height: 640 });
+  });
+
+  it("uses normalized native capture on Linux without issuing a hanging CDP screenshot", async () => {
+    const { manager, views } = harness({ platform: "linux" });
+    manager.layout("bot-a", { x: 10, y: 20, width: 820, height: 600 }, "", "expanded");
+    await manager.navigate("bot-a", "https://example.com");
+    const resize = vi.fn(({ width, height }) => ({
+      getSize: () => ({ width, height }),
+      toJPEG: () => Buffer.from("linux-native-jpeg"),
+    }));
+    views[0].webContents.capturePage = vi.fn(async () => ({
+      getSize: () => ({ width: 400, height: 250 }),
+      resize,
+      toJPEG: () => Buffer.from("unscaled-jpeg"),
+    }));
+
+    await expect(manager.screenshot("bot-a")).resolves.toMatchObject({
+      format: "jpeg",
+      width: 1024,
+      height: 640,
+      png: Buffer.from("linux-native-jpeg").toString("base64"),
+    });
+    expect(cdpCalls(views[0]).some(([name]) => name === "Page.captureScreenshot")).toBe(false);
+    expect(views[0].webContents.capturePage).toHaveBeenCalledWith({ x: 0, y: 0, width: 820, height: 513 });
     expect(resize).toHaveBeenCalledWith({ width: 1024, height: 640 });
   });
 

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -897,6 +897,37 @@ describe("browser surface manager", () => {
     expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
   });
 
+  it("shields the inertial tail of a compact wheel gesture after expansion", () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    manager.layout("bot-a", BOUNDS, "", "compact");
+
+    const first = { preventDefault: vi.fn() };
+    views[0].listeners.get("before-mouse-event")?.(first, { type: "mouseWheel", deltaY: 120 });
+    manager.layout("bot-a", { x: 0, y: 0, width: 900, height: 650 }, "", "expanded");
+    const inertia = { preventDefault: vi.fn() };
+    views[0].listeners.get("before-mouse-event")?.(inertia, { type: "mouseWheel", deltaY: 80 });
+
+    expect(first.preventDefault).toHaveBeenCalledOnce();
+    expect(inertia.preventDefault).toHaveBeenCalledOnce();
+    expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
+  });
+
+  it("preserves the originating profile on terminal surface events", () => {
+    const { manager, views, states } = harness();
+    manager.layout("bot-a", BOUNDS, "work", "compact");
+    views[0].listeners.get("render-process-gone")?.();
+
+    expect(states.at(-1)).toMatchObject({
+      botId: "bot-a",
+      open: false,
+      profile: "work",
+      partition: "persist:openmausbot-browser-profile-work",
+      mode: "compact",
+      code: "renderer-gone",
+    });
+  });
+
   it("does not shield synthetic agent clicks in the compact surface", async () => {
     const interactions = [];
     const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -1211,6 +1211,33 @@ describe("browser surface manager", () => {
     });
   });
 
+  it("normalizes a narrow capturePage fallback to the fixed screenshot size", async () => {
+    const { manager, views } = harness();
+    await manager.navigate("bot-a", "https://example.com");
+    const originalSendCommand = views[0].webContents.debugger.sendCommand;
+    views[0].webContents.debugger.sendCommand = async (method, params) => {
+      if (method === "Page.captureScreenshot") throw new Error("fixture protocol capture failure");
+      return originalSendCommand(method, params);
+    };
+    const resize = vi.fn(({ width, height }) => ({
+      getSize: () => ({ width, height }),
+      toJPEG: () => Buffer.from("fallback-jpeg"),
+    }));
+    views[0].webContents.capturePage = async () => ({
+      getSize: () => ({ width: 400, height: 250 }),
+      resize,
+      toJPEG: () => Buffer.from("unscaled-jpeg"),
+    });
+
+    await expect(manager.screenshot("bot-a")).resolves.toMatchObject({
+      format: "jpeg",
+      width: 1024,
+      height: 640,
+      png: Buffer.from("fallback-jpeg").toString("base64"),
+    });
+    expect(resize).toHaveBeenCalledWith({ width: 1024, height: 640 });
+  });
+
   it("refuses screenshots with populated protected fields and discards captures that overlap takeover", async () => {
     const { manager, views } = harness();
     await manager.navigate("bot-a", "https://example.com");

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -808,13 +808,10 @@ describe("browser surface manager", () => {
     ]);
 
     await manager.scroll("bot-a", "down", 600);
-    expect(cdpCalls(views[0]).findLast(([name, params]) =>
-      name === "Input.dispatchMouseEvent" && params.type === "mouseWheel")[1]).toMatchObject({
-      x: 400,
-      y: 250,
-      deltaX: 0,
-      deltaY: 600,
-    });
+    expect(cdpCalls(views[0]).filter(([name]) => name === "Input.dispatchMouseEvent").slice(-2).map(([, params]) => params)).toEqual([
+      { type: "mouseMoved", x: 400, y: 250 },
+      { type: "mouseWheel", x: 400, y: 250, deltaX: 0, deltaY: 600 },
+    ]);
   });
 
   it("emits a real double-click sequence instead of only a detail-2 pair", async () => {
@@ -1200,6 +1197,8 @@ describe("browser surface manager", () => {
     const enter = cdpCalls(views[0]).find(([name, params]) => name === "Input.dispatchKeyEvent" && params.key === "Enter" && params.type === "keyDown");
     expect(enter?.[1]).toMatchObject({ type: "keyDown", key: "Enter", code: "Enter", windowsVirtualKeyCode: 13, text: "\r" });
     await manager.scroll("bot-a", "down");
+    expect(cdpCalls(views[0]).findLast(([name, params]) => name === "Input.dispatchMouseEvent" && params.type === "mouseMoved")?.[1])
+      .toMatchObject({ x: 640, y: 400 });
     expect(cdpCalls(views[0]).find(([name, params]) => name === "Input.dispatchMouseEvent" && params.type === "mouseWheel")[1]).toMatchObject({ x: 640, y: 400, deltaX: 0, deltaY: 600 });
     await expect(manager.scroll("bot-a", "sideways")).rejects.toThrow(/direction/);
     const shot = await manager.screenshot("bot-a");

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -376,6 +376,22 @@ describe("browser surface manager", () => {
     expect(emulationCalls.at(-1)[1].scale).toBeCloseTo(0.25, 4);
   });
 
+  it("reapplies compact emulation after a main-frame navigation commits", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    const view = views[0];
+    expect(view.calls.filter(([name]) => name === "enableDeviceEmulation")).toHaveLength(1);
+
+    view.listeners.get("did-navigate")?.();
+
+    const emulationCalls = view.calls.filter(([name]) => name === "enableDeviceEmulation");
+    expect(emulationCalls).toHaveLength(2);
+    expect(emulationCalls.at(-1)[1]).toMatchObject({
+      viewSize: VIEWPORT,
+      screenSize: VIEWPORT,
+    });
+  });
+
   it("navigates only to web pages and answers with the page's elements plus a scroll hint", async () => {
     const { manager, views } = harness();
     await expect(manager.navigate("bot-a", "file:///etc/passwd")).rejects.toThrow(/http and https/);
@@ -516,6 +532,35 @@ describe("browser surface manager", () => {
     expect(manager.list().filter((entry) => entry.active).map((entry) => entry.botId).sort()).toEqual(["bot-a", "bot-b"]);
     expect(states.some((state) => state.botId === "bot-a" && state.profile === "work")).toBe(true);
     expect(views[1].calls.some(([name]) => name === "close")).toBe(false);
+  });
+
+  it("applies compact bounds when switching profiles after the old surface was hidden", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    manager.layout("bot-a", null, "", "compact");
+
+    manager.layout("bot-a", BOUNDS, "work", "compact");
+
+    expect(views).toHaveLength(2);
+    expect(views[1].bounds).toEqual(BOUNDS);
+    expect(views[1].visible).toBe(true);
+    expect(views[1].calls.find(([name]) => name === "enableDeviceEmulation")?.[1]).toMatchObject({
+      viewSize: VIEWPORT,
+      screenSize: VIEWPORT,
+    });
+  });
+
+  it("ignores a stale profile-scoped hide after another profile is active", () => {
+    const { manager, views } = harness();
+    manager.layout("bot-a", BOUNDS, "", "compact");
+    manager.layout("bot-a", BOUNDS, "work", "compact");
+
+    const state = manager.layout("bot-a", null, "", "compact");
+
+    expect(state).toMatchObject({ profile: "work", visible: true });
+    expect(views[1].visible).toBe(true);
+    manager.layout("bot-a", null, "work", "compact");
+    expect(views[1].visible).toBe(false);
   });
 
   it("reuses a cold own-profile view after the active shared profile is removed", async () => {

--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -85,6 +85,7 @@ async function run() {
   });
   try {
     manager.ensure("fixture-bot", "");
+    manager.layout("fixture-bot", { x: 20, y: 30, width: 400, height: 250 }, "", "compact");
     const html = `<!doctype html><html><body><closed-login></closed-login><script>
       customElements.define("closed-login", class extends HTMLElement {
         constructor() {
@@ -128,6 +129,14 @@ async function run() {
       });
     </script></body></html>`;
     await browserView.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
+    const viewport = await browserView.webContents.executeJavaScript(`({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    })`);
+    if (viewport.width !== 1280 || viewport.height !== 800) {
+      throw new Error(`compact browser viewport changed after navigation: ${JSON.stringify(viewport)}`);
+    }
+    process.stdout.write("compact-viewport-stable-after-navigation\n");
     const protectedValues = [
       "sk_closed_shadow_must_not_reach_pixels",
       "closed shadow mnemonic must stay private",

--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -387,8 +387,8 @@ async function run() {
     const lockedRootHtml = `<!doctype html><html style="overflow:hidden"><body style="margin:0;overflow:hidden">
       <div style="height:2400px">Locked page</div>
     </body></html>`;
-    manager.setHumanControl("fixture-bot", false, "");
     await browserView.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(lockedRootHtml)}`);
+    manager.setHumanControl("fixture-bot", false, "");
     await manager.scroll("fixture-bot", "down", 300, "");
     await new Promise((resolve) => setTimeout(resolve, 50));
     const lockedScrollTop = await browserView.webContents.executeJavaScript(`document.scrollingElement.scrollTop`);

--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -3,7 +3,7 @@
 process.stdout.write("fixture-entered\n");
 const { once } = require("node:events");
 const { join } = require("node:path");
-const { app, BrowserWindow, WebContentsView } = require("electron");
+const { app, BrowserWindow, WebContentsView, nativeImage } = require("electron");
 const { createBrowserSurfaceManager } = require("../browser-surface.cjs");
 process.stdout.write("fixture-modules-loaded\n");
 
@@ -252,15 +252,95 @@ async function run() {
     }
     process.stdout.write("rich-nested-name-source-redacted\n");
 
-    const actionHtml = `<!doctype html><html><body>
+    const actionHtml = `<!doctype html><html><head><style>
+      html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+      #scroller { width: 100vw; height: 100vh; overflow: auto; }
+      #scroll-content { min-height: 2400px; }
+    </style></head><body>
+      <main id="scroller"><div id="scroll-content"></div></main>
       <button id="reviewed" style="position:fixed;left:40px;top:40px;width:180px;height:60px">Publish draft</button>
       <input id="empty-password" type="password" aria-label="Password">
       <div id="empty-secret-editor" role="textbox" contenteditable="true" aria-label="Signing key"></div>
+      <script>
+        window.actionEvents = [];
+        const reviewed = document.getElementById("reviewed");
+        for (const type of ["click", "dblclick"]) reviewed.addEventListener(type, event => {
+          window.actionEvents.push({ type, detail: event.detail, x: event.clientX, y: event.clientY });
+        });
+      </script>
     </body></html>`;
     await browserView.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(actionHtml)}`);
     const actionSnapshot = await manager.snapshot("fixture-bot", "");
     const reviewedRef = String(actionSnapshot.yaml ?? "").match(/button[^\n]*\[ref=(e\d+)\]/)?.[1];
     if (!reviewedRef) throw new Error("real Electron fixture did not produce a rich browser ref");
+    manager.setHumanControl("fixture-bot", false, "");
+
+    // CDP DOM boxes are in the fixed 1280x800 page viewport, while Electron's
+    // native device-emulation scale expects pointer positions in the smaller
+    // WebContentsView. Exercise real compositor dispatch in both modes: this
+    // failed silently before page coordinates were converted for the current
+    // presentation scale.
+    const compactViewport = await browserView.webContents.executeJavaScript(`({ width: innerWidth, height: innerHeight })`);
+    if (compactViewport.width !== 1280 || compactViewport.height !== 800) {
+      throw new Error(`compact action viewport was not fixed: ${JSON.stringify(compactViewport)}`);
+    }
+    await manager.click("fixture-bot", reviewedRef, { profile: "" });
+    let actionEvents = await browserView.webContents.executeJavaScript(`window.actionEvents`);
+    if (JSON.stringify(actionEvents) !== JSON.stringify([{ type: "click", detail: 1, x: 130, y: 70 }])) {
+      throw new Error(`compact known-coordinate click missed its target: ${JSON.stringify(actionEvents)}`);
+    }
+    process.stdout.write("compact-known-coordinate-click\n");
+
+    await manager.scroll("fixture-bot", "down", 600, "");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const compactScrollTop = await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop`);
+    if (compactScrollTop !== 600) throw new Error(`compact nested scroll moved ${compactScrollTop}px instead of 600px`);
+    await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop = 0`);
+    process.stdout.write("compact-known-coordinate-scroll\n");
+
+    const compactShot = await manager.screenshot("fixture-bot", "");
+    const compactShotSize = nativeImage.createFromBuffer(Buffer.from(compactShot.png, "base64")).getSize();
+    if (compactShot.width !== 1024 || compactShot.height !== 640
+      || compactShotSize.width !== compactShot.width || compactShotSize.height !== compactShot.height) {
+      throw new Error(`compact screenshot pixels disagree with metadata: ${JSON.stringify({ metadata: [compactShot.width, compactShot.height], encoded: compactShotSize })}`);
+    }
+
+    manager.layout("fixture-bot", { x: 10, y: 20, width: 820, height: 600 }, "", "expanded");
+    const expandedViewport = await browserView.webContents.executeJavaScript(`({ width: innerWidth, height: innerHeight })`);
+    if (expandedViewport.width !== 1280 || expandedViewport.height !== 800) {
+      throw new Error(`expanded action viewport was not fixed: ${JSON.stringify(expandedViewport)}`);
+    }
+    const expandedSnapshot = await manager.snapshot("fixture-bot", "");
+    const expandedRef = String(expandedSnapshot.yaml ?? "").match(/button[^\n]*\[ref=(e\d+)\]/)?.[1];
+    if (!expandedRef) throw new Error("expanded Electron fixture did not produce a rich browser ref");
+    await manager.click("fixture-bot", expandedRef, { clickCount: 2, profile: "" });
+    actionEvents = await browserView.webContents.executeJavaScript(`window.actionEvents`);
+    const expectedEvents = [
+      { type: "click", detail: 1, x: 130, y: 70 },
+      { type: "click", detail: 1, x: 130, y: 70 },
+      { type: "click", detail: 2, x: 130, y: 70 },
+      { type: "dblclick", detail: 2, x: 130, y: 70 },
+    ];
+    if (JSON.stringify(actionEvents) !== JSON.stringify(expectedEvents)) {
+      throw new Error(`expanded double-click sequence was incorrect: ${JSON.stringify(actionEvents)}`);
+    }
+    process.stdout.write("expanded-known-coordinate-click\n");
+    process.stdout.write("real-double-click-sequence\n");
+
+    await manager.scroll("fixture-bot", "down", 300, "");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const expandedScrollTop = await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop`);
+    if (expandedScrollTop !== 300) throw new Error(`expanded nested scroll moved ${expandedScrollTop}px instead of 300px`);
+    process.stdout.write("expanded-known-coordinate-scroll\n");
+
+    const expandedShot = await manager.screenshot("fixture-bot", "");
+    const expandedShotSize = nativeImage.createFromBuffer(Buffer.from(expandedShot.png, "base64")).getSize();
+    if (expandedShot.width !== 1024 || expandedShot.height !== 640
+      || expandedShotSize.width !== expandedShot.width || expandedShotSize.height !== expandedShot.height) {
+      throw new Error(`expanded screenshot pixels disagree with metadata: ${JSON.stringify({ metadata: [expandedShot.width, expandedShot.height], encoded: expandedShotSize })}`);
+    }
+    process.stdout.write("fixed-screenshot-pixel-size\n");
+
     for (const [selector, key] of [["#empty-password", "Enter"], ["#empty-secret-editor", "Backspace"]]) {
       await browserView.webContents.executeJavaScript(`document.querySelector(${JSON.stringify(selector)}).focus()`);
       manager.setHumanControl("fixture-bot", false, "");

--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -383,6 +383,17 @@ async function run() {
     }
     if (!relabelRefused) throw new Error("relabelled ref was not invalidated");
     process.stdout.write("relabelled-ref-refused\n");
+
+    const lockedRootHtml = `<!doctype html><html style="overflow:hidden"><body style="margin:0;overflow:hidden">
+      <div style="height:2400px">Locked page</div>
+    </body></html>`;
+    manager.setHumanControl("fixture-bot", false, "");
+    await browserView.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(lockedRootHtml)}`);
+    await manager.scroll("fixture-bot", "down", 300, "");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const lockedScrollTop = await browserView.webContents.executeJavaScript(`document.scrollingElement.scrollTop`);
+    if (lockedScrollTop !== 0) throw new Error(`browser_scroll bypassed a root scroll lock by ${lockedScrollTop}px`);
+    process.stdout.write("root-scroll-lock-preserved\n");
   } finally {
     await closeFixture(manager, browserView, owner);
   }

--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -23,6 +23,17 @@ async function waitForLifecycleEvent(emitter, event, label, timeoutMs = 2_000) {
   }
 }
 
+async function waitForFixedViewport(browserView, label, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  let viewport = null;
+  do {
+    viewport = await browserView.webContents.executeJavaScript(`({ width: innerWidth, height: innerHeight })`);
+    if (viewport.width === 1280 && viewport.height === 800) return viewport;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } while (Date.now() < deadline);
+  throw new Error(`${label} viewport was not fixed: ${JSON.stringify(viewport)}`);
+}
+
 async function closeFixture(manager, browserView, owner) {
   const viewContents = browserView?.webContents;
   const viewDestroyed = viewContents && !viewContents.isDestroyed()
@@ -129,13 +140,7 @@ async function run() {
       });
     </script></body></html>`;
     await browserView.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-    const viewport = await browserView.webContents.executeJavaScript(`({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    })`);
-    if (viewport.width !== 1280 || viewport.height !== 800) {
-      throw new Error(`compact browser viewport changed after navigation: ${JSON.stringify(viewport)}`);
-    }
+    await waitForFixedViewport(browserView, "compact browser after navigation");
     process.stdout.write("compact-viewport-stable-after-navigation\n");
     const protectedValues = [
       "sk_closed_shadow_must_not_reach_pixels",
@@ -280,10 +285,7 @@ async function run() {
     // WebContentsView. Exercise real compositor dispatch in both modes: this
     // failed silently before page coordinates were converted for the current
     // presentation scale.
-    const compactViewport = await browserView.webContents.executeJavaScript(`({ width: innerWidth, height: innerHeight })`);
-    if (compactViewport.width !== 1280 || compactViewport.height !== 800) {
-      throw new Error(`compact action viewport was not fixed: ${JSON.stringify(compactViewport)}`);
-    }
+    await waitForFixedViewport(browserView, "compact action");
     await manager.click("fixture-bot", reviewedRef, { profile: "" });
     let actionEvents = await browserView.webContents.executeJavaScript(`window.actionEvents`);
     if (JSON.stringify(actionEvents) !== JSON.stringify([{ type: "click", detail: 1, x: 130, y: 70 }])) {
@@ -306,10 +308,7 @@ async function run() {
     }
 
     manager.layout("fixture-bot", { x: 10, y: 20, width: 820, height: 600 }, "", "expanded");
-    const expandedViewport = await browserView.webContents.executeJavaScript(`({ width: innerWidth, height: innerHeight })`);
-    if (expandedViewport.width !== 1280 || expandedViewport.height !== 800) {
-      throw new Error(`expanded action viewport was not fixed: ${JSON.stringify(expandedViewport)}`);
-    }
+    await waitForFixedViewport(browserView, "expanded action");
     const expandedSnapshot = await manager.snapshot("fixture-bot", "");
     const expandedRef = String(expandedSnapshot.yaml ?? "").match(/button[^\n]*\[ref=(e\d+)\]/)?.[1];
     if (!expandedRef) throw new Error("expanded Electron fixture did not produce a rich browser ref");

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1217,12 +1217,15 @@ function browserSurfaceForEvent(event) {
 
 ipcMain.handle("browser:available", () => Boolean(browserSurface && browserHost?.url));
 ipcMain.handle("browser:state", (event, botId) => browserSurfaceForEvent(event).state(botId));
-ipcMain.handle("browser:layout", (event, botId, bounds, profile, mode) =>
+ipcMain.handle("browser:layout", (event, botId, bounds, profile, mode, layoutOwner) =>
   browserSurfaceForEvent(event).layout(
     botId,
     bounds ?? null,
     Object.prototype.toString.call(profile) === "[object String]" ? profile : undefined,
     mode === "expanded" ? "expanded" : "compact",
+    Object.prototype.toString.call(layoutOwner) === "[object String]" && layoutOwner.length <= 128
+      ? layoutOwner
+      : undefined,
   ),
 );
 const browserProfileFromRenderer = (profile) =>
@@ -1230,6 +1233,10 @@ const browserProfileFromRenderer = (profile) =>
 
 ipcMain.handle("browser:forward", async (event, botId, profile) => {
   const result = await browserSurfaceForEvent(event).forward(botId, browserProfileFromRenderer(profile), { source: "user" });
+  return { url: result.url, title: result.title };
+});
+ipcMain.handle("browser:reload", async (event, botId, profile) => {
+  const result = await browserSurfaceForEvent(event).reload(botId, browserProfileFromRenderer(profile), { source: "user" });
   return { url: result.url, title: result.title };
 });
 ipcMain.handle("browser:navigate", async (event, botId, url, profile) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -163,10 +163,12 @@ contextBridge.exposeInMainWorld("ogb", {
   browser: browserSurfaceSupported ? {
     available: () => ipcRenderer.invoke("browser:available"),
     state: (botId) => ipcRenderer.invoke("browser:state", botId),
-    layout: (botId, bounds, profile, mode) => ipcRenderer.invoke("browser:layout", botId, bounds, profile, mode),
+    layout: (botId, bounds, profile, mode, layoutOwner) =>
+      ipcRenderer.invoke("browser:layout", botId, bounds, profile, mode, layoutOwner),
     navigate: (botId, url, profile) => ipcRenderer.invoke("browser:navigate", botId, url, profile),
     back: (botId, profile) => ipcRenderer.invoke("browser:back", botId, profile),
     forward: (botId, profile) => ipcRenderer.invoke("browser:forward", botId, profile),
+    reload: (botId, profile) => ipcRenderer.invoke("browser:reload", botId, profile),
     setHumanControl: (botId, held, profile) => ipcRenderer.invoke("browser:set-human-control", botId, held, profile),
     /** Wipe a named profile's logins, storage and cache after it is deleted. */
     forgetProfile: (partitionId) => ipcRenderer.invoke("browser:forget-profile", partitionId),

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3125,6 +3125,22 @@ describe("harness HTTP API", () => {
       await expect.poll(() => browserCapabilityCalls.slice(callOffset).some(
         (call) => call.operation === "register" && call.body.botId === activeBot.id,
       ), { timeout: 5_000 }).toBe(true);
+      // Registration happens before the provider's init frame is persisted.
+      // Wait for that final startup write before sabotaging the store;
+      // otherwise slower Windows runners can reset the next HTTP request when
+      // the resume-cursor save races the deliberately-invalid bots path.
+      await expect.poll(() => {
+        try {
+          const bots = z.array(z.object({
+            id: z.string().optional(),
+            resumeCursors: z.record(z.string(), z.string()).optional(),
+          }).passthrough()).parse(JSON.parse(readFileSync(botsFile, "utf8")));
+          const cursor = bots.find((bot) => bot.id === activeBot.id)?.resumeCursors?.claude;
+          return Boolean(cursor);
+        } catch {
+          return false;
+        }
+      }, { timeout: 5_000 }).toBe(true);
 
       // The hanging provider may bank one final activity write concurrently.
       // Win the replacement atomically by retrying until the path is a

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, Menu } from "lucide-react";
 import { StoreProvider, useStore } from "@/state/store";
 import { Onboarding } from "@/components/Onboarding";
@@ -126,14 +126,14 @@ function Shell() {
     dispatch({ type: "toggleComputer", open: false });
     setLocalVmWorkspaceBotId(botId);
   };
-  const openBrowserWorkspace = (botId: string) => {
+  const openBrowserWorkspace = useCallback((botId: string) => {
     dispatch({ type: "toggleComputer", open: false });
     setBrowserWorkspaceBotId(botId);
-  };
-  const closeBrowserWorkspace = () => {
+  }, [dispatch]);
+  const closeBrowserWorkspace = useCallback(() => {
     setBrowserWorkspaceBotId(null);
     dispatch({ type: "toggleComputer", open: true });
-  };
+  }, [dispatch]);
   useEffect(() => {
     if (browserWorkspaceBotId && (state.activeView !== "chat" || state.selectedId !== browserWorkspaceBotId)) {
       setBrowserWorkspaceBotId(null);
@@ -244,7 +244,12 @@ function Shell() {
       )}
       {state.settingsOpen && bot && <SettingsPanel bot={bot} />}
       {state.computerOpen && bot && (
-        <ComputerPanel bot={bot} onOpenVmWorkspace={openLocalVmWorkspace} onExpandBrowser={openBrowserWorkspace} />
+        <ComputerPanel
+          key={bot.id}
+          bot={bot}
+          onOpenVmWorkspace={openLocalVmWorkspace}
+          onExpandBrowser={openBrowserWorkspace}
+        />
       )}
       {state.inspectorOpen && bot && <InspectorPanel bot={bot} />}
       {state.appSettingsOpen && <SettingsModal />}

--- a/src/components/BrowserPanel.test.ts
+++ b/src/components/BrowserPanel.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  aspectFitBrowserBounds,
+  BrowserSurfacePlaceholder,
+  browserSurfaceForProfile,
+  browserSurfacePresentation,
   browserProfileChangesDisabled,
   editableUrl,
   profileIdFor,
+  shouldAcceptBrowserSurfaceState,
+  shouldClearBrowserSurfaceFailure,
   shouldRequestBrowserControl,
 } from "./BrowserPanel";
 import {
@@ -11,11 +19,47 @@ import {
   transitionBrowserControlLease,
 } from "@/lib/computer-control";
 
+const surface = (overrides: Partial<BrowserSurfaceState> = {}): BrowserSurfaceState => ({
+  botId: "bot-1",
+  open: true,
+  url: "about:blank",
+  title: "",
+  loading: false,
+  canGoBack: false,
+  canGoForward: false,
+  visible: false,
+  partition: "persist:profile-work",
+  profile: "profile-work",
+  mode: "compact",
+  ...overrides,
+});
+
 describe("browser panel address and profile helpers", () => {
   it("keeps the complete URL that will be submitted", () => {
     const url = "https://example.com/path/to/page?account=work&tab=2#details";
     expect(editableUrl(url)).toBe(url);
     expect(editableUrl("about:blank")).toBe("");
+  });
+
+  it("centers the 16:10 page inside wide and tall expanded workspaces", () => {
+    expect(aspectFitBrowserBounds({ x: 10, y: 20, width: 1_000, height: 500 })).toEqual({
+      x: 110,
+      y: 20,
+      width: 800,
+      height: 500,
+    });
+    expect(aspectFitBrowserBounds({ x: 10, y: 20, width: 800, height: 800 })).toEqual({
+      x: 10,
+      y: 170,
+      width: 800,
+      height: 500,
+    });
+    expect(aspectFitBrowserBounds({ x: 10, y: 20, width: 1_280, height: 800 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 1_280,
+      height: 800,
+    });
   });
 
   it("creates partition-safe, collision-free profile ids", () => {
@@ -49,6 +93,85 @@ describe("browser panel address and profile helpers", () => {
     expect(browserProfileChangesDisabled({ busy: false }, { controlTransition: true })).toBe(true);
     expect(browserProfileChangesDisabled({ busy: false })).toBe(false);
     expect(browserProfileChangesDisabled({})).toBe(false);
+  });
+
+  it("never leaks the old profile's page or address into a new selection", () => {
+    const work = surface({ url: "https://work.example/inbox" });
+    expect(browserSurfaceForProfile(work, "bot-1", "profile-work")).toBe(work);
+    expect(browserSurfaceForProfile(work, "bot-1", "profile-personal")).toBeNull();
+    expect(browserSurfaceForProfile(work, "bot-2", "profile-work")).toBeNull();
+    expect(browserSurfacePresentation({
+      surface: work,
+      botId: "bot-1",
+      profile: "profile-personal",
+    })).toBe("connecting");
+    expect(shouldAcceptBrowserSurfaceState(work, "bot-1", "profile-personal")).toBe(false);
+    expect(shouldAcceptBrowserSurfaceState(
+      surface({ profile: "profile-personal", url: "https://personal.example" }),
+      "bot-1",
+      "profile-personal",
+    )).toBe(true);
+    expect(shouldAcceptBrowserSurfaceState(
+      surface({ open: false, profile: null, code: "renderer-gone" }),
+      "bot-1",
+      "profile-personal",
+    )).toBe(true);
+  });
+
+  it("derives explicit connecting, empty, loading, ready, and failed page states", () => {
+    const common = { botId: "bot-1", profile: "profile-work" };
+    expect(browserSurfacePresentation({ surface: null, ...common })).toBe("connecting");
+    expect(browserSurfacePresentation({ surface: surface(), ...common })).toBe("empty");
+    expect(browserSurfacePresentation({ surface: surface({ loading: true }), ...common })).toBe("loading");
+    expect(browserSurfacePresentation({
+      surface: surface({ url: "https://example.com" }),
+      ...common,
+    })).toBe("ready");
+    expect(browserSurfacePresentation({
+      surface: surface({ url: "https://example.com" }),
+      actionPending: true,
+      ...common,
+    })).toBe("loading");
+    expect(browserSurfacePresentation({
+      surface: surface({ open: false, profile: null, code: "renderer-gone" }),
+      failureCode: "renderer-gone",
+      ...common,
+    })).toBe("failed");
+  });
+
+  it("renders useful empty, loading, and recoverable failure chrome", () => {
+    const empty = renderToStaticMarkup(createElement(BrowserSurfacePlaceholder, {
+      presentation: "empty",
+      botName: "Sprout",
+    }));
+    const loading = renderToStaticMarkup(createElement(BrowserSurfacePlaceholder, {
+      presentation: "loading",
+      botName: "Sprout",
+    }));
+    const failed = renderToStaticMarkup(createElement(BrowserSurfacePlaceholder, {
+      presentation: "failed",
+      botName: "Sprout",
+      failureCode: "renderer-gone",
+      onRetry: vi.fn(),
+    }));
+
+    expect(empty).toContain("Nothing open yet");
+    expect(empty).toContain("Sprout");
+    expect(loading).toContain('role="status"');
+    expect(loading).toContain("Opening page");
+    expect(failed).toContain('role="alert"');
+    expect(failed).toContain("Page unavailable");
+    expect(failed).toContain("Retry");
+  });
+
+  it("keeps a terminal failure visible until retry creates a replacement surface", () => {
+    const closed = surface({ open: false, profile: null, url: "" });
+    expect(shouldClearBrowserSurfaceFailure("failed", closed)).toBe(false);
+    expect(shouldClearBrowserSurfaceFailure("loading", closed)).toBe(true);
+    expect(shouldClearBrowserSurfaceFailure(
+      "loading",
+      surface({ open: false, profile: null, url: "", code: "renderer-gone" }),
+    )).toBe(false);
   });
 
   it("mirrors only positive authoritative control snapshots", () => {

--- a/src/components/BrowserPanel.test.ts
+++ b/src/components/BrowserPanel.test.ts
@@ -43,8 +43,10 @@ describe("browser panel address and profile helpers", () => {
     expect(shouldRequestBrowserControl({ ...first, eventBotId: "bot-2" })).toBe(false);
   });
 
-  it("locks browser profile changes while a bot turn is active", () => {
+  it("locks browser profile changes while a bot turn or local browser transition is active", () => {
     expect(browserProfileChangesDisabled({ busy: true })).toBe(true);
+    expect(browserProfileChangesDisabled({ busy: false }, { browserAction: true })).toBe(true);
+    expect(browserProfileChangesDisabled({ busy: false }, { controlTransition: true })).toBe(true);
     expect(browserProfileChangesDisabled({ busy: false })).toBe(false);
     expect(browserProfileChangesDisabled({})).toBe(false);
   });

--- a/src/components/BrowserPanel.test.ts
+++ b/src/components/BrowserPanel.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   aspectFitBrowserBounds,
   BrowserSurfacePlaceholder,
+  browserInteractionPlan,
   browserSurfaceForProfile,
   browserSurfacePresentation,
   browserProfileChangesDisabled,
@@ -12,7 +13,6 @@ import {
   profileIdFor,
   shouldAcceptBrowserSurfaceState,
   shouldClearBrowserSurfaceFailure,
-  shouldRequestBrowserControl,
 } from "./BrowserPanel";
 import {
   heldComputerControlBotIds,
@@ -72,19 +72,25 @@ describe("browser panel address and profile helpers", () => {
     expect(profileIdFor("Guest", profiles)).toBe("guest-2");
   });
 
-  it("coalesces native focus and input into one take-control request", () => {
+  it("coalesces native focus and input and still reopens a controlled compact page", () => {
     const first = {
       botId: "bot-1",
       eventBotId: "bot-1",
+      profile: "profile-work",
+      eventProfile: "profile-work",
+      compact: false,
       held: false,
       pending: false,
       takeInFlight: false,
     };
-    expect(shouldRequestBrowserControl(first)).toBe(true);
-    expect(shouldRequestBrowserControl({ ...first, takeInFlight: true })).toBe(false);
-    expect(shouldRequestBrowserControl({ ...first, pending: true })).toBe(false);
-    expect(shouldRequestBrowserControl({ ...first, held: true })).toBe(false);
-    expect(shouldRequestBrowserControl({ ...first, eventBotId: "bot-2" })).toBe(false);
+    expect(browserInteractionPlan(first)).toBe("take");
+    expect(browserInteractionPlan({ ...first, compact: true })).toBe("expand-and-take");
+    expect(browserInteractionPlan({ ...first, compact: true, held: true })).toBe("expand");
+    expect(browserInteractionPlan({ ...first, takeInFlight: true })).toBe("ignore");
+    expect(browserInteractionPlan({ ...first, pending: true })).toBe("ignore");
+    expect(browserInteractionPlan({ ...first, held: true })).toBe("ignore");
+    expect(browserInteractionPlan({ ...first, eventBotId: "bot-2" })).toBe("ignore");
+    expect(browserInteractionPlan({ ...first, eventProfile: "profile-personal" })).toBe("ignore");
   });
 
   it("locks browser profile changes while a bot turn or local browser transition is active", () => {
@@ -113,6 +119,11 @@ describe("browser panel address and profile helpers", () => {
     )).toBe(true);
     expect(shouldAcceptBrowserSurfaceState(
       surface({ open: false, profile: null, code: "renderer-gone" }),
+      "bot-1",
+      "profile-personal",
+    )).toBe(false);
+    expect(shouldAcceptBrowserSurfaceState(
+      surface({ open: false, profile: "profile-personal", code: "renderer-gone" }),
       "bot-1",
       "profile-personal",
     )).toBe(true);

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -4,22 +4,34 @@
 // told where its rectangle is. Anything the renderer draws is painted UNDER
 // the native view, so menus and dialogs that would overlap it hide it
 // instead. Compact in the panel; expanded when handed the main column.
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { ArrowLeft, ExternalLink, Globe, Hand, Loader2, Maximize2, Minimize2, Plus, UserRound } from "lucide-react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+  Globe,
+  Hand,
+  Loader2,
+  Maximize2,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  UserRound,
+} from "lucide-react";
 import { usePageVisible } from "@/lib/page-visible";
 import { cn } from "@/lib/cn";
 import { transitionBrowserControlLease } from "@/lib/computer-control";
 import { useStore, type Bot, type BotAnnouncement, type BrowserProfile } from "@/state/store";
 import { browserProfilePartitionId, browserProfilesForPatch } from "@/lib/browser-profiles";
+import { useNativeViewObscured } from "@/hooks/use-native-view-obscured";
 
 type ControlSnapshot = { held: boolean; helpReason: string | null };
 
-const NATIVE_VIEW_OVERLAY_SELECTOR = '[aria-modal="true"], [role="dialog"], [role="menu"], [popover], [data-native-view-overlay]';
 const OWN_PROFILE = "";
 const GUEST_PROFILE = "guest";
-// Deliberately outside the server's profile-id alphabet so no legacy or API
-// profile can collide with this select-only action.
-const NEW_PROFILE = ":new-profile";
+
+export type BrowserSurfacePresentation = "connecting" | "empty" | "loading" | "ready" | "failed";
 
 async function api(path: string, init?: RequestInit): Promise<any> {
   const res = await fetch(path, { headers: { "content-type": "application/json" }, ...init });
@@ -34,18 +46,26 @@ function elementBounds(element: HTMLElement | null): DesktopWorkspaceBounds | nu
   return { x: Math.round(rect.left), y: Math.round(rect.top), width: Math.round(rect.width), height: Math.round(rect.height) };
 }
 
-/** A visible dialog/menu intersecting the host rectangle would be painted
- * under the native view — hide the view while it is up. */
-function overlayIntersects(host: DesktopWorkspaceBounds): boolean {
-  for (const node of document.querySelectorAll<HTMLElement>(NATIVE_VIEW_OVERLAY_SELECTOR)) {
-    if (node.closest("[data-native-view-host]")) continue;
-    const rect = node.getBoundingClientRect();
-    if (rect.width < 1 || rect.height < 1) continue;
-    const overlaps =
-      rect.left < host.x + host.width && rect.right > host.x && rect.top < host.y + host.height && rect.bottom > host.y;
-    if (overlaps) return true;
+/** Center the fixed 1280×800 browser viewport inside an arbitrary workspace.
+ * Electron receives only this rectangle, leaving an even renderer-owned
+ * letterbox instead of anchoring the page to the top-left. */
+export function aspectFitBrowserBounds(bounds: DesktopWorkspaceBounds): DesktopWorkspaceBounds {
+  const widthFromHeight = Math.max(1, Math.floor(bounds.height * 1.6));
+  if (widthFromHeight <= bounds.width) {
+    return {
+      x: bounds.x + Math.floor((bounds.width - widthFromHeight) / 2),
+      y: bounds.y,
+      width: widthFromHeight,
+      height: bounds.height,
+    };
   }
-  return false;
+  const heightFromWidth = Math.max(1, Math.floor(bounds.width / 1.6));
+  return {
+    x: bounds.x,
+    y: bounds.y + Math.floor((bounds.height - heightFromWidth) / 2),
+    width: bounds.width,
+    height: heightFromWidth,
+  };
 }
 
 /** The editable address must retain the exact page URL. A shortened host/path
@@ -53,22 +73,6 @@ function overlayIntersects(host: DesktopWorkspaceBounds): boolean {
 export function editableUrl(url: string): string {
   if (!url || url === "about:blank") return "";
   return url;
-}
-
-function mutationAffectsOverlay(record: MutationRecord): boolean {
-  if (record.type === "attributes") {
-    return record.target instanceof Element && (
-      record.target.matches(NATIVE_VIEW_OVERLAY_SELECTOR) ||
-      Boolean(record.target.closest(NATIVE_VIEW_OVERLAY_SELECTOR)) ||
-      Boolean(record.target.querySelector(NATIVE_VIEW_OVERLAY_SELECTOR))
-    );
-  }
-  return [...record.addedNodes, ...record.removedNodes].some((node) =>
-    node instanceof Element && (
-      node.matches(NATIVE_VIEW_OVERLAY_SELECTOR) ||
-      Boolean(node.querySelector(NATIVE_VIEW_OVERLAY_SELECTOR))
-    ),
-  );
 }
 
 function sameSurfaceState(left: BrowserSurfaceState | null, right: BrowserSurfaceState): boolean {
@@ -86,6 +90,118 @@ function sameSurfaceState(left: BrowserSurfaceState | null, right: BrowserSurfac
       left.profile === right.profile &&
       left.mode === right.mode &&
       left.code === right.code,
+  );
+}
+
+/** Ignore a late event from the profile that was just switched away from. */
+export function browserSurfaceForProfile(
+  surface: BrowserSurfaceState | null,
+  botId: string,
+  profile: string,
+): BrowserSurfaceState | null {
+  return surface?.botId === botId && surface.profile === profile ? surface : null;
+}
+
+export function shouldAcceptBrowserSurfaceState(
+  next: BrowserSurfaceState,
+  botId: string,
+  profile: string,
+): boolean {
+  if (next.botId !== botId) return false;
+  // Terminal states intentionally omit profile/partition after the destroyed
+  // entry is removed. Ordinary updates must match the active profile exactly:
+  // an old hidden page may finish navigating after a profile switch.
+  return Boolean(next.code) || next.profile === profile;
+}
+
+export function browserSurfacePresentation(input: {
+  surface: BrowserSurfaceState | null;
+  botId: string;
+  profile: string;
+  failureCode?: BrowserSurfaceState["code"];
+  actionPending?: boolean;
+  retrying?: boolean;
+}): BrowserSurfacePresentation {
+  if (input.retrying || input.actionPending) return "loading";
+  if (input.failureCode) return "failed";
+  const active = browserSurfaceForProfile(input.surface, input.botId, input.profile);
+  if (!active) return "connecting";
+  if (active.loading) return "loading";
+  if (!active.url || active.url === "about:blank") return "empty";
+  return "ready";
+}
+
+export function shouldClearBrowserSurfaceFailure(
+  presentation: BrowserSurfacePresentation,
+  next: BrowserSurfaceState,
+): boolean {
+  return !next.code && presentation !== "failed";
+}
+
+function browserSurfaceFailureText(code: BrowserSurfaceState["code"]): string {
+  if (code === "renderer-gone") return "The page stopped unexpectedly.";
+  if (code === "evicted") return "This page was paused to free memory.";
+  return "The browser surface needs to be reopened.";
+}
+
+export function BrowserSurfacePlaceholder({
+  presentation,
+  botName,
+  failureCode,
+  onRetry,
+}: {
+  presentation: BrowserSurfacePresentation;
+  botName: string;
+  failureCode?: BrowserSurfaceState["code"];
+  onRetry?: () => void;
+}) {
+  if (presentation === "ready") return null;
+  if (presentation === "failed") {
+    return (
+      <div
+        className="absolute inset-0 flex flex-col items-center justify-center gap-2.5 px-6 text-center text-[13px] text-ink-secondary"
+        role="alert"
+      >
+        <AlertTriangle size={22} className="text-danger" aria-hidden="true" />
+        <div>
+          <div className="font-medium text-ink">Page unavailable</div>
+          <div className="mt-0.5">{browserSurfaceFailureText(failureCode)}</div>
+        </div>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRetry();
+            }}
+            className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-control px-3 py-1.5 font-medium text-ink outline-none hover:bg-raised-hover focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <RotateCcw size={13} aria-hidden="true" /> Retry
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+  if (presentation === "empty") {
+    return (
+      <div
+        className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-[13px] text-ink-secondary"
+        role="status"
+      >
+        <Globe size={22} className="opacity-60" aria-hidden="true" />
+        <span>Nothing open yet. Ask {botName} to look something up, or enter an address above.</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-[13px] text-ink-secondary"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 size={20} className="animate-spin text-accent" aria-hidden="true" />
+      <span>{presentation === "connecting" ? "Preparing browser…" : "Opening page…"}</span>
+    </div>
   );
 }
 
@@ -123,7 +239,6 @@ export function BrowserPanel({
   onControl,
   size = "compact",
   onExpand,
-  onCollapse,
 }: {
   bot: Bot;
   control: ControlSnapshot;
@@ -138,7 +253,9 @@ export function BrowserPanel({
   const { state, dispatch } = useStore();
   const bridge = window.ogb?.browser;
   const pageVisible = usePageVisible();
+  const layoutOwner = useId();
   const hostRef = useRef<HTMLDivElement>(null);
+  const nativeViewObscured = useNativeViewObscured(hostRef);
   const nativeTakePending = useRef(false);
   const botBusyRef = useRef(browserProfileChangesDisabled(bot));
   // Async profile creation must only observe committed bot state. Updating the
@@ -148,6 +265,10 @@ export function BrowserPanel({
     botBusyRef.current = browserProfileChangesDisabled(bot);
   }, [bot.busy]);
   const [surface, setSurface] = useState<BrowserSurfaceState | null>(null);
+  const [surfaceFailure, setSurfaceFailure] = useState<{
+    profile: string;
+    code: NonNullable<BrowserSurfaceState["code"]>;
+  } | null>(null);
   const [address, setAddress] = useState("");
   const [addressFocused, setAddressFocused] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -155,6 +276,7 @@ export function BrowserPanel({
   const [addingProfile, setAddingProfile] = useState(false);
   const [newProfileName, setNewProfileName] = useState("");
   const [profileBusy, setProfileBusy] = useState(false);
+  const [retrying, setRetrying] = useState(false);
   const acceptSurface = useCallback((next: BrowserSurfaceState) => {
     setSurface((current) => (sameSurfaceState(current, next) ? current : next));
   }, []);
@@ -171,6 +293,21 @@ export function BrowserPanel({
   const activePartition = activeProfile === OWN_PROFILE || activeProfile === GUEST_PROFILE
     ? activeProfile
     : browserProfilePartitionId(profiles, activeProfile);
+  const activeSurface = browserSurfaceForProfile(surface, botId, activePartition);
+  const currentUrl = activeSurface?.url && activeSurface.url !== "about:blank" ? activeSurface.url : null;
+  const activeFailureCode = surfaceFailure?.profile === activePartition ? surfaceFailure.code : undefined;
+  const presentation = browserSurfacePresentation({
+    surface,
+    botId,
+    profile: activePartition,
+    failureCode: activeFailureCode,
+    actionPending: busy,
+    retrying,
+  });
+  // A connecting surface must be laid out once so Electron can create (or
+  // restore) the selected profile. Empty/loading/failed states remain hidden
+  // so the renderer's useful status is not covered by about:blank.
+  const shouldPlaceNativeSurface = presentation === "connecting" || presentation === "ready" || retrying;
   // A profile switch changes the native session underneath this panel. Keep
   // that transition serialized with address-bar navigation, history changes,
   // and takeover handoff so an old page cannot finish in a hidden profile (or
@@ -194,15 +331,24 @@ export function BrowserPanel({
     let frame = 0;
     const send = () => {
       if (!alive) return;
-      const bounds = elementBounds(hostRef.current);
-      const target = bounds && pageVisible && !overlayIntersects(bounds) ? bounds : null;
+      const rawBounds = elementBounds(hostRef.current);
+      const bounds = rawBounds && size === "expanded" ? aspectFitBrowserBounds(rawBounds) : rawBounds;
+      const target = bounds && pageVisible && !nativeViewObscured && shouldPlaceNativeSurface ? bounds : null;
       bridge
-        .layout(botId, target, activePartition, size)
+        .layout(botId, target, activePartition, size, layoutOwner)
         .then((next) => {
-          if (alive) acceptSurface(next);
+          if (!alive) return;
+          acceptSurface(next);
+          // A terminal entry has already been removed, so a hide-only layout
+          // returns an ordinary closed state. Keep the failure visible until
+          // the person explicitly retries and creates a replacement entry.
+          if (shouldClearBrowserSurfaceFailure(presentation, next)) setSurfaceFailure(null);
+          if (retrying) setRetrying(false);
         })
         .catch((cause) => {
-          if (alive) setError(cause instanceof Error ? cause.message : String(cause));
+          if (!alive) return;
+          setRetrying(false);
+          setError(cause instanceof Error ? cause.message : String(cause));
         });
     };
     const schedule = () => {
@@ -215,39 +361,45 @@ export function BrowserPanel({
     send();
     const resize = new ResizeObserver(schedule);
     if (hostRef.current) resize.observe(hostRef.current);
-    // Portals may live anywhere under body, but normal app animation/style
-    // churn must not produce a layout IPC call every frame.
-    const mutation = new MutationObserver((records) => {
-      if (records.some(mutationAffectsOverlay)) schedule();
-    });
-    mutation.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["class", "style", "open", "aria-modal", "hidden"],
-    });
     window.addEventListener("resize", schedule);
     document.addEventListener("scroll", schedule, true);
     return () => {
       alive = false;
       if (frame) window.cancelAnimationFrame(frame);
       resize.disconnect();
-      mutation.disconnect();
       window.removeEventListener("resize", schedule);
       document.removeEventListener("scroll", schedule, true);
       // The tab is gone; the page stays alive (a bot mid-task keeps its tab)
       // but nothing may paint over the chat. Scope the hide to this profile:
       // cleanup from an old selection must not hide the newly selected one.
-      void bridge.layout(botId, null, activePartition, size).catch(() => {});
+      void bridge.layout(botId, null, activePartition, size, layoutOwner).catch(() => {});
     };
-  }, [bridge, botId, pageVisible, activePartition, size, acceptSurface]);
+  }, [
+    bridge,
+    botId,
+    pageVisible,
+    activePartition,
+    layoutOwner,
+    size,
+    acceptSurface,
+    nativeViewObscured,
+    presentation,
+    retrying,
+    shouldPlaceNativeSurface,
+  ]);
 
   useEffect(() => {
     if (!bridge) return;
     return bridge.onState((next) => {
-      if (next.botId === botId) acceptSurface(next);
+      if (!shouldAcceptBrowserSurfaceState(next, botId, activePartition)) return;
+      acceptSurface(next);
+      if (next.code) {
+        setSurfaceFailure({ profile: activePartition, code: next.code });
+      } else if (next.profile === activePartition) {
+        setSurfaceFailure(null);
+      }
     });
-  }, [bridge, botId, acceptSurface]);
+  }, [bridge, botId, activePartition, acceptSurface]);
 
   useEffect(() => {
     // Keep the synchronous guard set until React has folded the successful
@@ -322,8 +474,8 @@ export function BrowserPanel({
   }, [bridge, botId, changeControl, control.held, controlPending, onExpand, size]);
 
   useEffect(() => {
-    if (!addressFocused) setAddress(editableUrl(surface?.url ?? ""));
-  }, [surface?.url, addressFocused]);
+    if (!addressFocused) setAddress(editableUrl(activeSurface?.url ?? ""));
+  }, [activeSurface?.url, activePartition, addressFocused]);
 
   const navigate = useCallback(
     async (raw: string) => {
@@ -345,27 +497,39 @@ export function BrowserPanel({
     [activePartition, bridge, botId, busy, changeControl, profileBusy],
   );
 
-  const back = async () => {
+  const moveHistory = useCallback(async (direction: "back" | "forward") => {
     if (!bridge || busy || profileBusy) return;
     setBusy(true);
     setError(null);
     try {
       if (!(await changeControl("take"))) return;
-      await bridge.back(botId, activePartition);
+      if (direction === "back") await bridge.back(botId, activePartition);
+      else if (bridge.forward) await bridge.forward(botId, activePartition);
+      else throw new Error("Update OpenMausBot before using Forward.");
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
     }
-  };
+  }, [activePartition, botId, bridge, busy, changeControl, profileBusy]);
+
+  const reload = useCallback(async () => {
+    if (!bridge?.reload || busy || profileBusy || !currentUrl) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (!(await changeControl("take"))) return;
+      await bridge.reload(botId, activePartition);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }, [activePartition, botId, bridge, busy, changeControl, currentUrl, profileBusy]);
 
   const chooseProfile = async (value: string) => {
     if (profileBusy || profileChangesLocked) {
       setError(profileChangeLockMessage ?? "Wait for the current profile change to finish.");
-      return;
-    }
-    if (value === NEW_PROFILE) {
-      setAddingProfile(true);
       return;
     }
     setProfileBusy(true);
@@ -426,38 +590,32 @@ export function BrowserPanel({
     );
   }
 
-  const currentUrl = surface?.url && surface.url !== "about:blank" ? surface.url : null;
   const expanded = size === "expanded";
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="mb-1.5 mt-2 flex items-center justify-between text-[13px] text-ink-secondary">
-        <span className="flex items-center gap-2">
-          {bot.name}'s browser
-          {surface?.loading || busy ? <Loader2 size={13} className="animate-spin" /> : null}
-        </span>
-        {expanded && onCollapse ? (
-          <button
-            type="button"
-            onClick={onCollapse}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12px] hover:bg-control hover:text-ink"
-            title="Back to the small view"
-          >
-            <Minimize2 size={13} /> Shrink
-          </button>
-        ) : onExpand ? (
-          <button
-            type="button"
-            onClick={onExpand}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12px] hover:bg-control hover:text-ink"
-            title="Show the page large"
-          >
-            <Maximize2 size={13} /> Expand
-          </button>
-        ) : null}
-      </div>
+    <div className={cn("flex h-full min-h-0 flex-col", !expanded && "overflow-y-auto overscroll-contain pr-0.5")}>
+      {!expanded ? (
+        <div className="mb-2 mt-2 flex items-center justify-between text-[13px] text-ink-secondary">
+          <span className="flex items-center gap-2" aria-live="polite">
+            {bot.name}'s browser
+            {presentation === "loading" || presentation === "connecting" ? (
+              <Loader2 size={13} className="animate-spin" aria-label="Browser is loading" />
+            ) : null}
+          </span>
+          {onExpand ? (
+            <button
+              type="button"
+              onClick={onExpand}
+              className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12px] outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent"
+              title="Show the page large"
+            >
+              <Maximize2 size={13} aria-hidden="true" /> Expand
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       <form
-        className="mb-2 flex items-center gap-1.5"
+        className={cn("mb-2 flex items-center gap-1.5", expanded && "mt-3")}
         onSubmit={(event) => {
           event.preventDefault();
           void navigate(address);
@@ -465,16 +623,36 @@ export function BrowserPanel({
       >
         <button
           type="button"
-          onClick={() => void back()}
-          disabled={!surface?.canGoBack || busy || profileBusy}
-          className="rounded-md p-1.5 text-ink-secondary hover:bg-control hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={() => void moveHistory("back")}
+          disabled={!activeSurface?.canGoBack || busy || profileBusy}
+          className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
           title="Back"
           aria-label="Back"
         >
-          <ArrowLeft size={15} />
+          <ArrowLeft size={15} aria-hidden="true" />
         </button>
-        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg bg-inset px-2.5 py-1.5">
-          <Globe size={13} className="shrink-0 text-ink-secondary" />
+        <button
+          type="button"
+          onClick={() => void moveHistory("forward")}
+          disabled={!bridge.forward || !activeSurface?.canGoForward || busy || profileBusy}
+          className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
+          title="Forward"
+          aria-label="Forward"
+        >
+          <ArrowRight size={15} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          onClick={() => void reload()}
+          disabled={!bridge.reload || !currentUrl || busy || profileBusy}
+          className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
+          title="Reload"
+          aria-label="Reload"
+        >
+          <RefreshCw size={15} aria-hidden="true" />
+        </button>
+        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-transparent bg-inset px-2.5 py-1.5 focus-within:border-accent/50 focus-within:ring-2 focus-within:ring-accent/20">
+          <Globe size={13} className="shrink-0 text-ink-secondary" aria-hidden="true" />
           <input
             value={address}
             onChange={(event) => setAddress(event.target.value)}
@@ -489,49 +667,56 @@ export function BrowserPanel({
             aria-label="Web address"
           />
         </div>
+        <button
+          type="submit"
+          disabled={!address.trim() || busy || profileBusy}
+          className="rounded-lg bg-control px-2.5 py-1.5 text-[12px] font-medium text-ink outline-none hover:bg-raised-hover focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Go
+        </button>
         {currentUrl && (
           <button
             type="button"
             onClick={() => void window.ogb?.openExternal?.(currentUrl)}
-            className="rounded-md p-1.5 text-ink-secondary hover:bg-control hover:text-ink"
+            className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent"
             title="Open in your default browser"
             aria-label="Open in your default browser"
           >
-            <ExternalLink size={15} />
+            <ExternalLink size={15} aria-hidden="true" />
           </button>
         )}
       </form>
 
-      {/* The native view is positioned over this box by the main process. In
-          the panel it is a small preview — click it to expand. */}
+      {/* Keep a visible renderer frame around the rectangular native view.
+          Compact clicks are consumed by Electron: the first click expands and
+          takes control without also activating whatever is underneath it. */}
       <div
-        ref={hostRef}
-        data-native-view-host
         onClick={!expanded && onExpand ? onExpand : undefined}
-        role={!expanded && onExpand ? "button" : undefined}
-        tabIndex={!expanded && onExpand ? 0 : undefined}
-        onKeyDown={
-          !expanded && onExpand
-            ? (event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                onExpand();
-              }
-            : undefined
-        }
-        aria-label={!expanded && onExpand ? `Expand ${bot.name}'s browser` : undefined}
         title={!expanded && onExpand ? "Click to expand" : undefined}
+        data-browser-presentation={presentation}
         className={cn(
-          "relative overflow-hidden rounded-xl border border-hairline/40 bg-inset",
-          expanded ? "min-h-[320px] flex-1" : "aspect-[16/10] w-full shrink-0 cursor-zoom-in",
+          "relative overflow-hidden rounded-2xl border border-hairline/60 bg-card p-[3px] shadow-sm shadow-black/10",
+          expanded
+            ? "min-h-[320px] flex-1"
+            : "aspect-[16/10] w-full max-w-[720px] shrink-0 self-center cursor-zoom-in",
         )}
       >
-        {!currentUrl && !surface?.loading && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-[13px] text-ink-secondary">
-            <Globe size={22} className="opacity-60" />
-            <span>Nothing open yet. Ask {bot.name} to look something up, or enter an address above.</span>
-          </div>
-        )}
+        <div
+          ref={hostRef}
+          data-native-view-host
+          aria-busy={presentation === "connecting" || presentation === "loading"}
+          className="absolute inset-[3px] overflow-hidden rounded-[13px] bg-inset"
+        >
+          <BrowserSurfacePlaceholder
+            presentation={presentation}
+            botName={bot.name}
+            failureCode={activeFailureCode}
+            onRetry={() => {
+              setError(null);
+              setRetrying(true);
+            }}
+          />
+        </div>
       </div>
 
       <div className="mt-3 flex items-center justify-between gap-3">
@@ -541,30 +726,31 @@ export function BrowserPanel({
             : "Click into the page to take over any time; the bot pauses while you drive."}
         </div>
         <button
+          type="button"
           onClick={() => void changeControl(control.held ? "release" : "take")}
           disabled={controlPending || busy || profileBusy}
           className={cn(
-            "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium disabled:opacity-60",
+            "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-60",
             control.held ? "bg-accent text-accent-ink" : "bg-control text-ink hover:bg-raised-hover",
           )}
         >
-          <Hand size={14} />
+          <Hand size={14} aria-hidden="true" />
           {control.held ? "Hand back" : "Take control"}
         </button>
       </div>
 
       {/* Profile: which session (cookies, logins) this bot's tab uses. */}
-      <div className="mt-3 rounded-xl bg-card p-3">
+      <div className="mt-3 rounded-xl border border-hairline/30 bg-card p-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2 text-[13px] text-ink">
-            <UserRound size={14} className="shrink-0 text-ink-secondary" />
+            <UserRound size={14} className="shrink-0 text-ink-secondary" aria-hidden="true" />
             <span className="shrink-0">Profile</span>
             <select
               value={activeProfile}
               onChange={(event) => void chooseProfile(event.target.value)}
               disabled={profileBusy || profileChangesLocked}
               aria-label="Browser profile"
-              className="min-w-0 flex-1 rounded-md bg-inset px-2 py-1 text-[13px] text-ink outline-none"
+              className="min-w-0 flex-1 rounded-md bg-inset px-2 py-1 text-[13px] text-ink outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <option value={OWN_PROFILE}>{bot.name}'s own</option>
               {profiles.map((profile) => (
@@ -573,18 +759,18 @@ export function BrowserPanel({
                 </option>
               ))}
               <option value={GUEST_PROFILE}>Guest (forgets everything)</option>
-              <option value={NEW_PROFILE}>+ Add profile…</option>
             </select>
           </div>
           <button
             type="button"
             onClick={() => setAddingProfile((open) => !open)}
             disabled={profileBusy || profileChangesLocked}
-            className="rounded-md p-1.5 text-ink-secondary hover:bg-control hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
             title={profileChangeLockMessage ?? "Add a profile"}
             aria-label="Add a profile"
+            aria-expanded={addingProfile}
           >
-            <Plus size={15} />
+            <Plus size={15} aria-hidden="true" />
           </button>
         </div>
         {addingProfile && (
@@ -602,13 +788,13 @@ export function BrowserPanel({
               placeholder="Profile name, e.g. Work"
               maxLength={40}
               disabled={profileBusy || profileChangesLocked}
-              className="min-w-0 flex-1 rounded-md bg-inset px-2.5 py-1.5 text-[13px] text-ink outline-none placeholder:text-ink-secondary/70"
+              className="min-w-0 flex-1 rounded-md bg-inset px-2.5 py-1.5 text-[13px] text-ink outline-none placeholder:text-ink-secondary/70 focus-visible:ring-2 focus-visible:ring-accent"
               aria-label="New profile name"
             />
             <button
               type="submit"
               disabled={!newProfileName.trim() || profileBusy || profileChangesLocked}
-              className="rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-accent-ink disabled:opacity-50"
+              className="rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-accent-ink outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
             >
               Add
             </button>
@@ -618,7 +804,7 @@ export function BrowserPanel({
                 setAddingProfile(false);
                 setNewProfileName("");
               }}
-              className="rounded-md px-2 py-1.5 text-[13px] text-ink-secondary hover:text-ink"
+              className="rounded-md px-2 py-1.5 text-[13px] text-ink-secondary outline-none hover:text-ink focus-visible:ring-2 focus-visible:ring-accent"
             >
               Cancel
             </button>
@@ -629,10 +815,14 @@ export function BrowserPanel({
             ? bot.busy
               ? `Stop ${bot.name}'s current turn before changing profiles, so it cannot keep acting in a hidden session.`
               : profileChangeLockMessage
-            : `A profile is its own set of logins and cookies — sign in once and it stays. Bots pointed at the same profile share it; “${bot.name}'s own” is private to this bot; Guest is thrown away when you switch off it.`}
+            : `Profiles keep logins separate. “${bot.name}'s own” is private to this bot; Guest is cleared when you switch away.`}
         </div>
       </div>
-      {error && <div className="mt-2 text-[12px] text-danger">{error}</div>}
+      {error && (
+        <div role="alert" className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+          {error}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -109,8 +109,11 @@ export function shouldRequestBrowserControl(input: {
   return input.botId === input.eventBotId && !input.held && !input.pending && !input.takeInFlight;
 }
 
-export function browserProfileChangesDisabled(bot: Pick<Bot, "busy">): boolean {
-  return bot.busy === true;
+export function browserProfileChangesDisabled(
+  bot: Pick<Bot, "busy">,
+  pending: { browserAction?: boolean; controlTransition?: boolean } = {},
+): boolean {
+  return bot.busy === true || pending.browserAction === true || pending.controlTransition === true;
 }
 
 export function BrowserPanel({
@@ -168,6 +171,19 @@ export function BrowserPanel({
   const activePartition = activeProfile === OWN_PROFILE || activeProfile === GUEST_PROFILE
     ? activeProfile
     : browserProfilePartitionId(profiles, activeProfile);
+  // A profile switch changes the native session underneath this panel. Keep
+  // that transition serialized with address-bar navigation, history changes,
+  // and takeover handoff so an old page cannot finish in a hidden profile (or
+  // be destroyed mid-load when the old profile is Guest).
+  const profileChangesLocked = browserProfileChangesDisabled(bot, {
+    browserAction: busy,
+    controlTransition: controlPending,
+  });
+  const profileChangeLockMessage = bot.busy
+    ? `Stop ${bot.name}'s current turn before changing profiles.`
+    : profileChangesLocked
+      ? "Finish the current browser action before changing profiles."
+      : null;
 
   // Layout: tell main where the tab's rectangle is, on every change that can
   // move it (resize, scroll, sidebar toggles, dialogs). Coalesced per frame.
@@ -220,8 +236,9 @@ export function BrowserPanel({
       window.removeEventListener("resize", schedule);
       document.removeEventListener("scroll", schedule, true);
       // The tab is gone; the page stays alive (a bot mid-task keeps its tab)
-      // but nothing may paint over the chat.
-      void bridge.layout(botId, null).catch(() => {});
+      // but nothing may paint over the chat. Scope the hide to this profile:
+      // cleanup from an old selection must not hide the newly selected one.
+      void bridge.layout(botId, null, activePartition, size).catch(() => {});
     };
   }, [bridge, botId, pageVisible, activePartition, size, acceptSurface]);
 
@@ -310,31 +327,41 @@ export function BrowserPanel({
 
   const navigate = useCallback(
     async (raw: string) => {
-      if (!bridge) return;
+      if (!bridge || busy || profileBusy) return;
       const target = raw.trim();
       if (!target) return;
-      if (!(await changeControl("take"))) return;
       setBusy(true);
       setError(null);
-      bridge
-        .navigate(botId, target, activePartition)
-        .then(() => setAddressFocused(false))
-        .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
-        .finally(() => setBusy(false));
+      try {
+        if (!(await changeControl("take"))) return;
+        await bridge.navigate(botId, target, activePartition);
+        setAddressFocused(false);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        setBusy(false);
+      }
     },
-    [activePartition, bridge, botId, changeControl],
+    [activePartition, bridge, botId, busy, changeControl, profileBusy],
   );
 
   const back = async () => {
-    if (!bridge) return;
-    if (!(await changeControl("take"))) return;
+    if (!bridge || busy || profileBusy) return;
+    setBusy(true);
     setError(null);
-    await bridge.back(botId, activePartition).catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)));
+    try {
+      if (!(await changeControl("take"))) return;
+      await bridge.back(botId, activePartition);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
   };
 
   const chooseProfile = async (value: string) => {
-    if (browserProfileChangesDisabled(bot) || profileBusy) {
-      setError(`Stop ${bot.name}'s turn before changing its browser profile.`);
+    if (profileBusy || profileChangesLocked) {
+      setError(profileChangeLockMessage ?? "Wait for the current profile change to finish.");
       return;
     }
     if (value === NEW_PROFILE) {
@@ -361,7 +388,7 @@ export function BrowserPanel({
 
   const addProfile = async () => {
     const name = newProfileName.trim();
-    if (!name || profileBusy || botBusyRef.current) return;
+    if (!name || profileBusy || profileChangesLocked || botBusyRef.current) return;
     setProfileBusy(true);
     setError(null);
     try {
@@ -401,7 +428,6 @@ export function BrowserPanel({
 
   const currentUrl = surface?.url && surface.url !== "about:blank" ? surface.url : null;
   const expanded = size === "expanded";
-  const profileChangesLocked = browserProfileChangesDisabled(bot);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -440,7 +466,7 @@ export function BrowserPanel({
         <button
           type="button"
           onClick={() => void back()}
-          disabled={!surface?.canGoBack}
+          disabled={!surface?.canGoBack || busy || profileBusy}
           className="rounded-md p-1.5 text-ink-secondary hover:bg-control hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
           title="Back"
           aria-label="Back"
@@ -458,6 +484,7 @@ export function BrowserPanel({
             spellCheck={false}
             autoCapitalize="off"
             autoCorrect="off"
+            disabled={busy || profileBusy}
             className="min-w-0 flex-1 bg-transparent text-[13px] text-ink outline-none placeholder:text-ink-secondary/70"
             aria-label="Web address"
           />
@@ -515,7 +542,7 @@ export function BrowserPanel({
         </div>
         <button
           onClick={() => void changeControl(control.held ? "release" : "take")}
-          disabled={controlPending}
+          disabled={controlPending || busy || profileBusy}
           className={cn(
             "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium disabled:opacity-60",
             control.held ? "bg-accent text-accent-ink" : "bg-control text-ink hover:bg-raised-hover",
@@ -552,9 +579,9 @@ export function BrowserPanel({
           <button
             type="button"
             onClick={() => setAddingProfile((open) => !open)}
-            disabled={profileChangesLocked}
+            disabled={profileBusy || profileChangesLocked}
             className="rounded-md p-1.5 text-ink-secondary hover:bg-control hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
-            title={profileChangesLocked ? `Stop ${bot.name}'s turn before changing browser profiles` : "Add a profile"}
+            title={profileChangeLockMessage ?? "Add a profile"}
             aria-label="Add a profile"
           >
             <Plus size={15} />
@@ -574,7 +601,7 @@ export function BrowserPanel({
               onChange={(event) => setNewProfileName(event.target.value)}
               placeholder="Profile name, e.g. Work"
               maxLength={40}
-              disabled={profileChangesLocked}
+              disabled={profileBusy || profileChangesLocked}
               className="min-w-0 flex-1 rounded-md bg-inset px-2.5 py-1.5 text-[13px] text-ink outline-none placeholder:text-ink-secondary/70"
               aria-label="New profile name"
             />
@@ -599,7 +626,9 @@ export function BrowserPanel({
         )}
         <div className="mt-1.5 text-[11.5px] leading-relaxed text-ink-secondary">
           {profileChangesLocked
-            ? `Stop ${bot.name}'s current turn before changing profiles, so it cannot keep acting in a hidden session.`
+            ? bot.busy
+              ? `Stop ${bot.name}'s current turn before changing profiles, so it cannot keep acting in a hidden session.`
+              : profileChangeLockMessage
             : `A profile is its own set of logins and cookies — sign in once and it stays. Bots pointed at the same profile share it; “${bot.name}'s own” is private to this bot; Guest is thrown away when you switch off it.`}
         </div>
       </div>

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -25,6 +25,11 @@ import { transitionBrowserControlLease } from "@/lib/computer-control";
 import { useStore, type Bot, type BotAnnouncement, type BrowserProfile } from "@/state/store";
 import { browserProfilePartitionId, browserProfilesForPatch } from "@/lib/browser-profiles";
 import { useNativeViewObscured } from "@/hooks/use-native-view-obscured";
+import { aspectFitNativeViewBounds } from "@/lib/local-vm-workspace";
+import {
+  beginBrowserPanelOperation,
+  useBrowserPanelOperationPending,
+} from "@/lib/browser-panel-operation";
 
 type ControlSnapshot = { held: boolean; helpReason: string | null };
 
@@ -50,22 +55,7 @@ function elementBounds(element: HTMLElement | null): DesktopWorkspaceBounds | nu
  * Electron receives only this rectangle, leaving an even renderer-owned
  * letterbox instead of anchoring the page to the top-left. */
 export function aspectFitBrowserBounds(bounds: DesktopWorkspaceBounds): DesktopWorkspaceBounds {
-  const widthFromHeight = Math.max(1, Math.floor(bounds.height * 1.6));
-  if (widthFromHeight <= bounds.width) {
-    return {
-      x: bounds.x + Math.floor((bounds.width - widthFromHeight) / 2),
-      y: bounds.y,
-      width: widthFromHeight,
-      height: bounds.height,
-    };
-  }
-  const heightFromWidth = Math.max(1, Math.floor(bounds.width / 1.6));
-  return {
-    x: bounds.x,
-    y: bounds.y + Math.floor((bounds.height - heightFromWidth) / 2),
-    width: bounds.width,
-    height: heightFromWidth,
-  };
+  return aspectFitNativeViewBounds(bounds, 1.6);
 }
 
 /** The editable address must retain the exact page URL. A shortened host/path
@@ -107,11 +97,10 @@ export function shouldAcceptBrowserSurfaceState(
   botId: string,
   profile: string,
 ): boolean {
-  if (next.botId !== botId) return false;
-  // Terminal states intentionally omit profile/partition after the destroyed
-  // entry is removed. Ordinary updates must match the active profile exactly:
-  // an old hidden page may finish navigating after a profile switch.
-  return Boolean(next.code) || next.profile === profile;
+  // Every state, including terminal crash/eviction notices, carries the
+  // originating profile. An old hidden page may navigate or die after a
+  // switch and must never replace the selected profile's page or error state.
+  return next.botId === botId && next.profile === profile;
 }
 
 export function browserSurfacePresentation(input: {
@@ -215,14 +204,22 @@ export function profileIdFor(name: string, taken: BrowserProfile[]): string {
   return candidate;
 }
 
-export function shouldRequestBrowserControl(input: {
+export type BrowserInteractionPlan = "ignore" | "expand" | "take" | "expand-and-take";
+
+export function browserInteractionPlan(input: {
   botId: string;
   eventBotId: string;
+  profile: string;
+  eventProfile: string;
+  compact: boolean;
   held: boolean;
   pending: boolean;
   takeInFlight: boolean;
-}): boolean {
-  return input.botId === input.eventBotId && !input.held && !input.pending && !input.takeInFlight;
+}): BrowserInteractionPlan {
+  if (input.botId !== input.eventBotId || input.profile !== input.eventProfile) return "ignore";
+  if (input.held) return input.compact ? "expand" : "ignore";
+  if (input.pending || input.takeInFlight) return "ignore";
+  return input.compact ? "expand-and-take" : "take";
 }
 
 export function browserProfileChangesDisabled(
@@ -255,7 +252,8 @@ export function BrowserPanel({
   const pageVisible = usePageVisible();
   const layoutOwner = useId();
   const hostRef = useRef<HTMLDivElement>(null);
-  const nativeViewObscured = useNativeViewObscured(hostRef);
+  const nativeViewObscured = useNativeViewObscured(hostRef, size === "expanded" ? 1.6 : null);
+  const operationPending = useBrowserPanelOperationPending(bot.id);
   const nativeTakePending = useRef(false);
   const botBusyRef = useRef(browserProfileChangesDisabled(bot));
   // Async profile creation must only observe committed bot state. Updating the
@@ -313,7 +311,7 @@ export function BrowserPanel({
   // and takeover handoff so an old page cannot finish in a hidden profile (or
   // be destroyed mid-load when the old profile is Guest).
   const profileChangesLocked = browserProfileChangesDisabled(bot, {
-    browserAction: busy,
+    browserAction: busy || profileBusy || operationPending,
     controlTransition: controlPending,
   });
   const profileChangeLockMessage = bot.busy
@@ -410,68 +408,77 @@ export function BrowserPanel({
 
   const changeControl = useCallback(
     async (action: "take" | "release"): Promise<boolean> => {
-      if (action === "take") {
-        if (control.held) {
+      if (operationPending) return false;
+      const finishOperation = beginBrowserPanelOperation(botId);
+      try {
+        if (action === "take") {
+          if (control.held) {
+            try {
+              const applied = await bridge?.setHumanControl?.(botId, true, activePartition) === true;
+              if (!applied) setError("The browser tab is not ready for takeover yet.");
+              return applied;
+            } catch (cause) {
+              setError(cause instanceof Error ? cause.message : String(cause));
+              return false;
+            }
+          }
+          if (controlPending || nativeTakePending.current) return false;
+          nativeTakePending.current = true;
+        }
+        const setLocalControl = async (held: boolean): Promise<boolean> => {
           try {
-            const applied = await bridge?.setHumanControl?.(botId, true, activePartition) === true;
-            if (!applied) setError("The browser tab is not ready for takeover yet.");
-            return applied;
+            if (!bridge?.setHumanControl) throw new Error("Update OpenMausBot before using browser takeover.");
+            const applied = await bridge.setHumanControl(botId, held, activePartition);
+            if (!applied) throw new Error("The browser tab is not ready for takeover yet.");
+            return true;
           } catch (cause) {
             setError(cause instanceof Error ? cause.message : String(cause));
             return false;
           }
-        }
-        if (controlPending || nativeTakePending.current) return false;
-        nativeTakePending.current = true;
-      }
-      const setLocalControl = async (held: boolean): Promise<boolean> => {
-        try {
-          if (!bridge?.setHumanControl) throw new Error("Update OpenMausBot before using browser takeover.");
-          const applied = await bridge.setHumanControl(botId, held, activePartition);
-          if (!applied) throw new Error("The browser tab is not ready for takeover yet.");
-          return true;
-        } catch (cause) {
-          setError(cause instanceof Error ? cause.message : String(cause));
-          return false;
-        }
-      };
+        };
 
-      const result = await transitionBrowserControlLease({
-        action,
-        requestDurableControl: (requested) => onControl(requested).catch(() => false),
-        setNativeControl: setLocalControl,
-      });
-      if (result.ok) return true;
-      if (result.failed === "durable-take") {
-        // The person may already be typing into the native page. Keep the
-        // agent gated even though the durable lease endpoint failed; a
-        // subsequent Take control click retries the server transition.
-        setError("Browser control could not be confirmed. The bot remains paused here for safety — retry Take control.");
-      } else if (result.failed === "durable-release") {
-        setError("Control could not be handed back. The bot remains paused here for safety — retry Hand back.");
-      } else if (result.failed === "native-release") {
-        setError("The server released control, but this browser remains paused locally for safety. Reopen the Browser panel to retry.");
+        const result = await transitionBrowserControlLease({
+          action,
+          requestDurableControl: (requested) => onControl(requested).catch(() => false),
+          setNativeControl: setLocalControl,
+        });
+        if (result.ok) return true;
+        if (result.failed === "durable-take") {
+          // The person may already be typing into the native page. Keep the
+          // agent gated even though the durable lease endpoint failed; a
+          // subsequent Take control click retries the server transition.
+          setError("Browser control could not be confirmed. The bot remains paused here for safety — retry Take control.");
+        } else if (result.failed === "durable-release") {
+          setError("Control could not be handed back. The bot remains paused here for safety — retry Hand back.");
+        } else if (result.failed === "native-release") {
+          setError("The server released control, but this browser remains paused locally for safety. Reopen the Browser panel to retry.");
+        }
+        if (action === "take") nativeTakePending.current = false;
+        return false;
+      } finally {
+        finishOperation();
       }
-      if (action === "take") nativeTakePending.current = false;
-      return false;
     },
-    [activePartition, botId, bridge, control.held, controlPending, onControl],
+    [activePartition, botId, bridge, control.held, controlPending, onControl, operationPending],
   );
 
   useEffect(() => {
     if (!bridge?.onUserInteraction) return;
     return bridge.onUserInteraction((event) => {
-      if (!shouldRequestBrowserControl({
+      const plan = browserInteractionPlan({
         botId,
         eventBotId: event.botId,
+        profile: activePartition,
+        eventProfile: event.profile,
+        compact: size === "compact",
         held: control.held,
-        pending: controlPending,
+        pending: controlPending || operationPending,
         takeInFlight: nativeTakePending.current,
-      })) return;
-      if (size === "compact") onExpand?.();
-      void changeControl("take");
+      });
+      if (plan === "expand" || plan === "expand-and-take") onExpand?.();
+      if (plan === "take" || plan === "expand-and-take") void changeControl("take");
     });
-  }, [bridge, botId, changeControl, control.held, controlPending, onExpand, size]);
+  }, [activePartition, bridge, botId, changeControl, control.held, controlPending, onExpand, operationPending, size]);
 
   useEffect(() => {
     if (!addressFocused) setAddress(editableUrl(activeSurface?.url ?? ""));
@@ -479,9 +486,10 @@ export function BrowserPanel({
 
   const navigate = useCallback(
     async (raw: string) => {
-      if (!bridge || busy || profileBusy) return;
+      if (!bridge || busy || profileBusy || operationPending) return;
       const target = raw.trim();
       if (!target) return;
+      const finishOperation = beginBrowserPanelOperation(botId);
       setBusy(true);
       setError(null);
       try {
@@ -492,13 +500,15 @@ export function BrowserPanel({
         setError(cause instanceof Error ? cause.message : String(cause));
       } finally {
         setBusy(false);
+        finishOperation();
       }
     },
-    [activePartition, bridge, botId, busy, changeControl, profileBusy],
+    [activePartition, bridge, botId, busy, changeControl, operationPending, profileBusy],
   );
 
   const moveHistory = useCallback(async (direction: "back" | "forward") => {
-    if (!bridge || busy || profileBusy) return;
+    if (!bridge || busy || profileBusy || operationPending) return;
+    const finishOperation = beginBrowserPanelOperation(botId);
     setBusy(true);
     setError(null);
     try {
@@ -510,11 +520,13 @@ export function BrowserPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
+      finishOperation();
     }
-  }, [activePartition, botId, bridge, busy, changeControl, profileBusy]);
+  }, [activePartition, botId, bridge, busy, changeControl, operationPending, profileBusy]);
 
   const reload = useCallback(async () => {
-    if (!bridge?.reload || busy || profileBusy || !currentUrl) return;
+    if (!bridge?.reload || busy || profileBusy || operationPending || !currentUrl) return;
+    const finishOperation = beginBrowserPanelOperation(botId);
     setBusy(true);
     setError(null);
     try {
@@ -524,14 +536,16 @@ export function BrowserPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
+      finishOperation();
     }
-  }, [activePartition, botId, bridge, busy, changeControl, currentUrl, profileBusy]);
+  }, [activePartition, botId, bridge, busy, changeControl, currentUrl, operationPending, profileBusy]);
 
   const chooseProfile = async (value: string) => {
     if (profileBusy || profileChangesLocked) {
       setError(profileChangeLockMessage ?? "Wait for the current profile change to finish.");
       return;
     }
+    const finishOperation = beginBrowserPanelOperation(botId);
     setProfileBusy(true);
     setError(null);
     try {
@@ -547,12 +561,14 @@ export function BrowserPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setProfileBusy(false);
+      finishOperation();
     }
   };
 
   const addProfile = async () => {
     const name = newProfileName.trim();
     if (!name || profileBusy || profileChangesLocked || botBusyRef.current) return;
+    const finishOperation = beginBrowserPanelOperation(botId);
     setProfileBusy(true);
     setError(null);
     try {
@@ -579,6 +595,7 @@ export function BrowserPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setProfileBusy(false);
+      finishOperation();
     }
   };
 
@@ -624,7 +641,7 @@ export function BrowserPanel({
         <button
           type="button"
           onClick={() => void moveHistory("back")}
-          disabled={!activeSurface?.canGoBack || busy || profileBusy}
+          disabled={!activeSurface?.canGoBack || busy || profileBusy || operationPending}
           className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
           title="Back"
           aria-label="Back"
@@ -634,7 +651,7 @@ export function BrowserPanel({
         <button
           type="button"
           onClick={() => void moveHistory("forward")}
-          disabled={!bridge.forward || !activeSurface?.canGoForward || busy || profileBusy}
+          disabled={!bridge.forward || !activeSurface?.canGoForward || busy || profileBusy || operationPending}
           className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
           title="Forward"
           aria-label="Forward"
@@ -644,7 +661,7 @@ export function BrowserPanel({
         <button
           type="button"
           onClick={() => void reload()}
-          disabled={!bridge.reload || !currentUrl || busy || profileBusy}
+          disabled={!bridge.reload || !currentUrl || busy || profileBusy || operationPending}
           className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
           title="Reload"
           aria-label="Reload"
@@ -662,14 +679,14 @@ export function BrowserPanel({
             spellCheck={false}
             autoCapitalize="off"
             autoCorrect="off"
-            disabled={busy || profileBusy}
+            disabled={busy || profileBusy || operationPending}
             className="min-w-0 flex-1 bg-transparent text-[13px] text-ink outline-none placeholder:text-ink-secondary/70"
             aria-label="Web address"
           />
         </div>
         <button
           type="submit"
-          disabled={!address.trim() || busy || profileBusy}
+          disabled={!address.trim() || busy || profileBusy || operationPending}
           className="rounded-lg bg-control px-2.5 py-1.5 text-[12px] font-medium text-ink outline-none hover:bg-raised-hover focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
         >
           Go
@@ -728,7 +745,7 @@ export function BrowserPanel({
         <button
           type="button"
           onClick={() => void changeControl(control.held ? "release" : "take")}
-          disabled={controlPending || busy || profileBusy}
+          disabled={controlPending || busy || profileBusy || operationPending}
           className={cn(
             "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-60",
             control.held ? "bg-accent text-accent-ink" : "bg-control text-ink hover:bg-raised-hover",

--- a/src/components/BrowserWorkspace.tsx
+++ b/src/components/BrowserWorkspace.tsx
@@ -2,7 +2,7 @@
 // whole main column. Opened by clicking the small preview in the computer
 // panel; closing hands the tab back to the panel. Control (Take control /
 // Hand back) is the same lease the panel uses, so a hold survives the swap.
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Globe, X } from "lucide-react";
 import { z } from "zod";
 import { useStore, type Bot } from "@/state/store";
@@ -46,7 +46,7 @@ export function BrowserWorkspace({ bot, onClose }: { bot: Bot; onClose: () => vo
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bot.id]);
 
-  const controlAction = async (action: "take" | "release"): Promise<boolean> => {
+  const controlAction = useCallback(async (action: "take" | "release"): Promise<boolean> => {
     setControlPending(true);
     setError(null);
     try {
@@ -69,7 +69,7 @@ export function BrowserWorkspace({ bot, onClose }: { bot: Bot; onClose: () => vo
     } finally {
       setControlPending(false);
     }
-  };
+  }, [bot.id, dispatch]);
 
   return (
     <main className="flex h-full min-w-0 flex-1 flex-col bg-app">
@@ -86,14 +86,14 @@ export function BrowserWorkspace({ bot, onClose }: { bot: Bot; onClose: () => vo
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink"
+          className="rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           aria-label="Back to the small browser"
           title="Back to the panel"
         >
           <X size={18} />
         </button>
       </header>
-      {error && <div className="mx-5 mt-3 text-[12px] text-danger">{error}</div>}
+      {error && <div role="alert" className="mx-5 mt-3 text-[12px] text-danger">{error}</div>}
       <div className="flex min-h-0 flex-1 flex-col px-5 pb-4">
         <BrowserPanel
           bot={bot}

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -4,7 +4,7 @@
 // in-panel capture. Linux local mode is an automation readiness state and its
 // separate preview remains explicitly user-initiated. Auto never selects a
 // Linux user's desktop.
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import {
   CalendarClock,
@@ -46,6 +46,11 @@ import {
   localComputerSelectable,
 } from "@/lib/local-computer";
 import { vpsComputerNeedsReplacement, type VpsComputerStatus } from "@/lib/vps-computer";
+import {
+  readComputerPanelView,
+  writeComputerPanelView,
+  type ComputerPanelView,
+} from "@/lib/computer-panel-view";
 
 async function api(path: string, init?: RequestInit): Promise<any> {
   const res = await fetch(path, { headers: { "content-type": "application/json" }, ...init });
@@ -192,7 +197,7 @@ export function ComputerPanel({
   const [viewerOpen, setViewerOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [creatingRoutine, setCreatingRoutine] = useState(false);
-  const [panelView, setPanelView] = useState<"computer" | "android" | "browser">("computer");
+  const [panelView, setPanelView] = useState<ComputerPanelView>(() => readComputerPanelView(bot.id));
   const androidStatus = useAndroidUsbDevices();
   const androidConnected = androidStatus.devices.length > 0;
   // the built-in browser: a per-bot switch in Settings, and only the desktop app has one
@@ -203,6 +208,15 @@ export function ComputerPanel({
   const selectedInstance = state.instances.find(
     (instance) => instance.instanceId === bot.modelSelection.instanceId,
   );
+
+  const selectPanelView = (view: ComputerPanelView) => {
+    setPanelView(view);
+    writeComputerPanelView(bot.id, view);
+  };
+
+  useEffect(() => {
+    setPanelView(readComputerPanelView(bot.id));
+  }, [bot.id]);
 
   // Pause the screenshot poll while this bot's viewer is open; seed from the
   // live viewer so a remount/switch mid-session doesn't wrongly resume it.
@@ -227,9 +241,11 @@ export function ComputerPanel({
   }, [bot.id]);
 
   useEffect(() => {
-    if (!androidConnected && panelView === "android") setPanelView("computer");
-    if (!browserEnabled && panelView === "browser") setPanelView("computer");
-  }, [androidConnected, browserEnabled, panelView]);
+    if ((!androidConnected && panelView === "android") || (!browserEnabled && panelView === "browser")) {
+      setPanelView("computer");
+      writeComputerPanelView(bot.id, "computer");
+    }
+  }, [androidConnected, bot.id, browserEnabled, panelView]);
   useEffect(() => {
     vmReadinessAttempts.current = 0;
   }, [bot.id, bot.computer]);
@@ -270,6 +286,9 @@ export function ComputerPanel({
   // resolve the mode on open; box endpoints are only ever hit on the
   // cloud path, so local/off can never render a JSON error as an image
   useEffect(() => {
+    // Browser and Android own their own live surfaces. Do not provision a VM,
+    // wake a box, or churn preview state behind either tab.
+    if (panelView !== "computer") return;
     let alive = true;
     setPhase("checking");
     setPolledFrame(null);
@@ -467,6 +486,7 @@ export function ComputerPanel({
     cloudSupported,
     vpsSupported,
     state.config?.vps?.sshAlias,
+    panelView,
   ]);
 
   // cloud preview: SSE frames win while the bot works; otherwise poll.
@@ -477,7 +497,7 @@ export function ComputerPanel({
   const sseFlowing = Boolean(bot.busy && live);
   const inFlight = useRef(false);
   useEffect(() => {
-    if (phase !== "ready" || sseFlowing || viewerOpen || !pageVisible) return;
+    if (panelView !== "computer" || phase !== "ready" || sseFlowing || viewerOpen || !pageVisible) return;
     let alive = true;
     const shoot = async () => {
       if (inFlight.current) return;
@@ -497,13 +517,13 @@ export function ComputerPanel({
       alive = false;
       clearInterval(timer);
     };
-  }, [phase, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
+  }, [panelView, phase, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
 
   // Local VM preview comes directly from Cua Driver through the harness. It
   // does not use the password-protected noVNC viewer or cloud endpoints.
   const vmInFlight = useRef(false);
   useEffect(() => {
-    if (phase !== "vm" || viewerOpen || !pageVisible) return;
+    if (panelView !== "computer" || phase !== "vm" || viewerOpen || !pageVisible) return;
     let alive = true;
     const shoot = async () => {
       if (vmInFlight.current) return;
@@ -523,7 +543,7 @@ export function ComputerPanel({
       alive = false;
       window.clearInterval(timer);
     };
-  }, [phase, bot.id, viewerOpen, pageVisible, bot.busy]);
+  }, [panelView, phase, bot.id, viewerOpen, pageVisible, bot.busy]);
 
   // local preview: frames from the Electron main process. The FIRST capture
   // attempt is what makes macOS show the Screen Recording prompt (there is
@@ -531,7 +551,7 @@ export function ComputerPanel({
   // the user denied — surface the Settings repair path instead of spinning.
   const [localMisses, setLocalMisses] = useState(0);
   useEffect(() => {
-    if (phase !== "local" || !window.ogb || isLinux || !pageVisible) return;
+    if (panelView !== "computer" || phase !== "local" || !window.ogb || isLinux || !pageVisible) return;
     let alive = true;
     setLocalMisses(0);
     const shoot = async () => {
@@ -551,7 +571,7 @@ export function ComputerPanel({
       alive = false;
       clearInterval(timer);
     };
-  }, [phase, isLinux, pageVisible, bot.busy]);
+  }, [panelView, phase, isLinux, pageVisible, bot.busy, bot.id]);
 
   const lastScreenMessage = [...bot.messages].reverse().find((m) => m.kind === "screen" && m.png);
   const cloudFrame =
@@ -593,7 +613,7 @@ export function ComputerPanel({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bot.id]);
-  const requestControl = async (action: ComputerControlAction) => {
+  const requestControl = useCallback(async (action: ComputerControlAction) => {
     const snap = computerControlSnapshotSchema.parse(await api(`/api/bots/${bot.id}/computer/control`, {
       method: "POST",
       body: JSON.stringify({ action }),
@@ -605,16 +625,16 @@ export function ComputerPanel({
       helpReason: snap.helpReason,
     });
     return snap;
-  };
+  }, [bot.id, dispatch]);
 
-  const setNativeBrowserControl = async (held: boolean): Promise<boolean> => {
+  const setNativeBrowserControl = useCallback(async (held: boolean): Promise<boolean> => {
     const setter = window.ogb?.browser?.setHumanControl;
     if (!setter) return true;
     const profile = bot.browserProfile === "guest" ? "guest" : bot.browserProfile ?? "";
     return (await setter(bot.id, held, profile)) === true;
-  };
+  }, [bot.browserProfile, bot.id]);
 
-  const transitionControl = async (action: ComputerControlAction) => {
+  const transitionControl = useCallback(async (action: ComputerControlAction) => {
     // BrowserPanel performs the same two-phase transition itself. Every
     // other computer surface must also gate Electron's direct browser host:
     // the server hold is bot-wide, and a shell-capable agent can otherwise
@@ -625,9 +645,9 @@ export function ComputerPanel({
       requestControl,
       setNativeBrowserControl,
     });
-  };
+  }, [panelView, requestControl, setNativeBrowserControl]);
 
-  const controlAction = async (action: ComputerControlAction): Promise<boolean> => {
+  const controlAction = useCallback(async (action: ComputerControlAction): Promise<boolean> => {
     setControlPending(true);
     setError(null);
     try {
@@ -639,7 +659,11 @@ export function ComputerPanel({
     } finally {
       setControlPending(false);
     }
-  };
+  }, [transitionControl]);
+
+  const expandBrowser = useCallback(() => {
+    onExpandBrowser?.(bot.id);
+  }, [bot.id, onExpandBrowser]);
 
   const openDesktop = async () => {
     setPending("join");
@@ -829,7 +853,7 @@ export function ComputerPanel({
         {androidConnected || browserEnabled ? (
           <div className="flex overflow-hidden rounded-lg border border-hairline/40">
             <button
-              onClick={() => setPanelView("computer")}
+              onClick={() => selectPanelView("computer")}
               aria-pressed={panelView === "computer"}
               className={cn(
                 "flex items-center gap-1.5 px-2.5 py-1 text-[12.5px]",
@@ -840,7 +864,7 @@ export function ComputerPanel({
             </button>
             {androidConnected && (
             <button
-              onClick={() => setPanelView("android")}
+              onClick={() => selectPanelView("android")}
               aria-pressed={panelView === "android"}
               className={cn(
                 "flex items-center gap-1.5 border-l border-hairline/40 px-2.5 py-1 text-[12.5px]",
@@ -854,7 +878,7 @@ export function ComputerPanel({
             <button
               onClick={() => {
                 setError(null);
-                setPanelView("browser");
+                selectPanelView("browser");
               }}
               aria-pressed={panelView === "browser"}
               className={cn(
@@ -884,7 +908,7 @@ export function ComputerPanel({
             control={control}
             controlPending={controlPending}
             onControl={controlAction}
-            onExpand={onExpandBrowser ? () => onExpandBrowser(bot.id) : undefined}
+            onExpand={onExpandBrowser ? expandBrowser : undefined}
           />
           {error && (
             <div role="alert" className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1357,6 +1357,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   return (
     <aside
       aria-label="Bots and navigation"
+      data-native-view-overlay
       className={cn(
         "flex h-full shrink-0 flex-col border-r border-hairline/40 bg-panel transition-[width] duration-200",
         density === "icons" ? "w-[80px]" : density === "compact" ? "w-[272px]" : "w-[320px]",

--- a/src/hooks/use-native-view-obscured.test.ts
+++ b/src/hooks/use-native-view-obscured.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { syncNativeViewResizeTargets } from "./use-native-view-obscured";
+
+describe("native view resize targets", () => {
+  it("observes new overlays once and unobserves stale candidates", () => {
+    const observer = {
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+    };
+    const observed = new Set<{ name: string }>();
+    const body = { name: "body" };
+    const host = { name: "host" };
+    const firstOverlay = { name: "first overlay" };
+    const secondOverlay = { name: "second overlay" };
+
+    syncNativeViewResizeTargets(observer, observed, [body, host, firstOverlay]);
+    expect(observer.observe.mock.calls.map(([target]) => target)).toEqual([
+      body,
+      host,
+      firstOverlay,
+    ]);
+
+    syncNativeViewResizeTargets(observer, observed, [body, host, firstOverlay]);
+    expect(observer.observe).toHaveBeenCalledTimes(3);
+    expect(observer.unobserve).not.toHaveBeenCalled();
+
+    syncNativeViewResizeTargets(observer, observed, [body, host, secondOverlay]);
+    expect(observer.unobserve).toHaveBeenCalledWith(firstOverlay);
+    expect(observer.observe).toHaveBeenLastCalledWith(secondOverlay);
+    expect(observed).toEqual(new Set([body, host, secondOverlay]));
+  });
+});

--- a/src/hooks/use-native-view-obscured.ts
+++ b/src/hooks/use-native-view-obscured.ts
@@ -16,6 +16,26 @@ function isOverlayCandidate(target: EventTarget | null): target is Element {
   return target instanceof Element && Boolean(target.closest(POSITIONED_OVERLAY_SELECTOR));
 }
 
+export function syncNativeViewResizeTargets<T>(
+  observer: { observe(target: T): void; unobserve(target: T): void },
+  observedTargets: Set<T>,
+  nextTargets: Iterable<T>,
+): void {
+  const next = new Set(nextTargets);
+
+  for (const target of observedTargets) {
+    if (next.has(target)) continue;
+    observer.unobserve(target);
+    observedTargets.delete(target);
+  }
+
+  for (const target of next) {
+    if (observedTargets.has(target)) continue;
+    observer.observe(target);
+    observedTargets.add(target);
+  }
+}
+
 /**
  * Electron native views always paint above React. Hide a native view while a
  * renderer-owned dialog, menu, banner, or other raised layer crosses it so
@@ -31,11 +51,16 @@ export function useNativeViewObscured(
     let frame = 0;
     let activeMotion = 0;
     let motionDeadline = 0;
+    let resize: ResizeObserver | null = null;
+    const resizeTargets = new Set<Element>();
 
     const read = () => {
       frame = 0;
       const host = hostRef.current;
       if (!host) {
+        if (resize) {
+          syncNativeViewResizeTargets(resize, resizeTargets, [document.body]);
+        }
         setObscured(false);
       } else {
         const rawHostRect = host.getBoundingClientRect();
@@ -57,26 +82,34 @@ export function useNativeViewObscured(
               height: fittedHost.height,
             }
           : rawHostRect;
-        const candidates = [...document.querySelectorAll<HTMLElement>(POSITIONED_OVERLAY_SELECTOR)]
-          .filter(
-            (candidate) =>
-              candidate !== host &&
-              !candidate.contains(host) &&
-              !host.contains(candidate),
-          )
-          .map((candidate) => {
-            const style = window.getComputedStyle(candidate);
-            const zIndex = Number.parseInt(style.zIndex, 10);
-            return {
-              rect: candidate.getBoundingClientRect(),
-              explicit: candidate.matches(EXPLICIT_OVERLAY_SELECTOR),
-              visible:
-                style.display !== "none" &&
-                style.visibility !== "hidden" &&
-                Number(style.opacity) !== 0,
-              zIndex: Number.isFinite(zIndex) ? zIndex : null,
-            };
-          });
+        const candidateElements = [
+          ...document.querySelectorAll<HTMLElement>(POSITIONED_OVERLAY_SELECTOR),
+        ].filter(
+          (candidate) =>
+            candidate !== host &&
+            !candidate.contains(host) &&
+            !host.contains(candidate),
+        );
+        if (resize) {
+          syncNativeViewResizeTargets(resize, resizeTargets, [
+            document.body,
+            host,
+            ...candidateElements,
+          ]);
+        }
+        const candidates = candidateElements.map((candidate) => {
+          const style = window.getComputedStyle(candidate);
+          const zIndex = Number.parseInt(style.zIndex, 10);
+          return {
+            rect: candidate.getBoundingClientRect(),
+            explicit: candidate.matches(EXPLICIT_OVERLAY_SELECTOR),
+            visible:
+              style.display !== "none" &&
+              style.visibility !== "hidden" &&
+              Number(style.opacity) !== 0,
+            zIndex: Number.isFinite(zIndex) ? zIndex : null,
+          };
+        });
         setObscured(
           nativeViewOverlayIntersects(
             hostRect.width > 0 && hostRect.height > 0 ? [hostRect] : [],
@@ -111,7 +144,6 @@ export function useNativeViewObscured(
       scheduleRead();
     };
 
-    read();
     const mutation = new MutationObserver(scheduleRead);
     mutation.observe(document.body, {
       childList: true,
@@ -128,9 +160,8 @@ export function useNativeViewObscured(
         "popover",
       ],
     });
-    const resize = new ResizeObserver(scheduleRead);
-    resize.observe(document.body);
-    if (hostRef.current) resize.observe(hostRef.current);
+    resize = new ResizeObserver(scheduleRead);
+    read();
 
     for (const name of ["animationstart", "transitionstart"] as const) {
       document.addEventListener(name, startMotion, true);
@@ -145,7 +176,8 @@ export function useNativeViewObscured(
     return () => {
       if (frame) window.cancelAnimationFrame(frame);
       mutation.disconnect();
-      resize.disconnect();
+      resize?.disconnect();
+      resizeTargets.clear();
       for (const name of ["animationstart", "transitionstart"] as const) {
         document.removeEventListener(name, startMotion, true);
       }

--- a/src/hooks/use-native-view-obscured.ts
+++ b/src/hooks/use-native-view-obscured.ts
@@ -1,0 +1,134 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+import { nativeViewOverlayIntersects } from "@/lib/local-vm-workspace";
+
+const EXPLICIT_OVERLAY_SELECTOR =
+  '[aria-modal="true"], [role="dialog"], [role="menu"], [popover], [data-native-view-overlay]';
+const POSITIONED_OVERLAY_SELECTOR = `${EXPLICIT_OVERLAY_SELECTOR}, .fixed, .absolute`;
+
+function isOverlayCandidate(target: EventTarget | null): target is Element {
+  return target instanceof Element && Boolean(target.closest(POSITIONED_OVERLAY_SELECTOR));
+}
+
+/**
+ * Electron native views always paint above React. Hide a native view while a
+ * renderer-owned dialog, menu, banner, or other raised layer crosses it so
+ * controls never disappear behind the page.
+ */
+export function useNativeViewObscured(hostRef: RefObject<HTMLElement | null>): boolean {
+  const [obscured, setObscured] = useState(false);
+
+  useLayoutEffect(() => {
+    let frame = 0;
+    let activeMotion = 0;
+    let motionDeadline = 0;
+
+    const read = () => {
+      frame = 0;
+      const host = hostRef.current;
+      if (!host) {
+        setObscured(false);
+      } else {
+        const hostRect = host.getBoundingClientRect();
+        const candidates = [...document.querySelectorAll<HTMLElement>(POSITIONED_OVERLAY_SELECTOR)]
+          .filter(
+            (candidate) =>
+              candidate !== host &&
+              !candidate.contains(host) &&
+              !host.contains(candidate),
+          )
+          .map((candidate) => {
+            const style = window.getComputedStyle(candidate);
+            const zIndex = Number.parseInt(style.zIndex, 10);
+            return {
+              rect: candidate.getBoundingClientRect(),
+              explicit: candidate.matches(EXPLICIT_OVERLAY_SELECTOR),
+              visible:
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                Number(style.opacity) !== 0,
+              zIndex: Number.isFinite(zIndex) ? zIndex : null,
+            };
+          });
+        setObscured(
+          nativeViewOverlayIntersects(
+            hostRect.width > 0 && hostRect.height > 0 ? [hostRect] : [],
+            candidates,
+          ),
+        );
+      }
+      // ResizeObserver and DOM mutations do not report intermediate animation
+      // frames. Follow raised layers until their motion ends so a sliding
+      // dialog cannot cross a live native page for a few frames.
+      if (activeMotion > 0 && performance.now() < motionDeadline) {
+        frame = window.requestAnimationFrame(read);
+      } else if (activeMotion > 0) {
+        // A removed animated node may never dispatch its matching end event.
+        // Stop the safety sampling eventually instead of leaking a forever-rAF.
+        activeMotion = 0;
+      }
+    };
+
+    const scheduleRead = () => {
+      if (!frame) frame = window.requestAnimationFrame(read);
+    };
+    const startMotion = (event: Event) => {
+      if (!isOverlayCandidate(event.target)) return;
+      activeMotion += 1;
+      motionDeadline = Math.max(motionDeadline, performance.now() + 30_000);
+      scheduleRead();
+    };
+    const stopMotion = (event: Event) => {
+      if (!isOverlayCandidate(event.target)) return;
+      activeMotion = Math.max(0, activeMotion - 1);
+      scheduleRead();
+    };
+
+    read();
+    const mutation = new MutationObserver(scheduleRead);
+    mutation.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [
+        "class",
+        "style",
+        "open",
+        "hidden",
+        "aria-hidden",
+        "aria-modal",
+        "role",
+        "popover",
+      ],
+    });
+    const resize = new ResizeObserver(scheduleRead);
+    resize.observe(document.body);
+    if (hostRef.current) resize.observe(hostRef.current);
+
+    for (const name of ["animationstart", "transitionstart"] as const) {
+      document.addEventListener(name, startMotion, true);
+    }
+    for (const name of ["animationend", "animationcancel", "transitionend", "transitioncancel"] as const) {
+      document.addEventListener(name, stopMotion, true);
+    }
+    document.addEventListener("toggle", scheduleRead, true);
+    window.addEventListener("resize", scheduleRead);
+    window.addEventListener("scroll", scheduleRead, true);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      mutation.disconnect();
+      resize.disconnect();
+      for (const name of ["animationstart", "transitionstart"] as const) {
+        document.removeEventListener(name, startMotion, true);
+      }
+      for (const name of ["animationend", "animationcancel", "transitionend", "transitioncancel"] as const) {
+        document.removeEventListener(name, stopMotion, true);
+      }
+      document.removeEventListener("toggle", scheduleRead, true);
+      window.removeEventListener("resize", scheduleRead);
+      window.removeEventListener("scroll", scheduleRead, true);
+    };
+  }, [hostRef]);
+
+  return obscured;
+}

--- a/src/hooks/use-native-view-obscured.ts
+++ b/src/hooks/use-native-view-obscured.ts
@@ -1,9 +1,16 @@
 import { useLayoutEffect, useState, type RefObject } from "react";
-import { nativeViewOverlayIntersects } from "@/lib/local-vm-workspace";
+import {
+  aspectFitNativeViewBounds,
+  nativeViewOverlayIntersects,
+} from "@/lib/local-vm-workspace";
 
 const EXPLICIT_OVERLAY_SELECTOR =
   '[aria-modal="true"], [role="dialog"], [role="menu"], [popover], [data-native-view-overlay]';
-const POSITIONED_OVERLAY_SELECTOR = `${EXPLICIT_OVERLAY_SELECTOR}, .fixed, .absolute`;
+// Responsive utility variants such as `max-md:absolute` do not match
+// `.absolute`; a class substring gives us a bounded candidate set, and the
+// computed position/z-index below decides whether it is currently raised.
+const POSITIONED_OVERLAY_SELECTOR =
+  `${EXPLICIT_OVERLAY_SELECTOR}, [class*="fixed"], [class*="absolute"]`;
 
 function isOverlayCandidate(target: EventTarget | null): target is Element {
   return target instanceof Element && Boolean(target.closest(POSITIONED_OVERLAY_SELECTOR));
@@ -14,7 +21,10 @@ function isOverlayCandidate(target: EventTarget | null): target is Element {
  * renderer-owned dialog, menu, banner, or other raised layer crosses it so
  * controls never disappear behind the page.
  */
-export function useNativeViewObscured(hostRef: RefObject<HTMLElement | null>): boolean {
+export function useNativeViewObscured(
+  hostRef: RefObject<HTMLElement | null>,
+  aspectRatio: number | null = null,
+): boolean {
   const [obscured, setObscured] = useState(false);
 
   useLayoutEffect(() => {
@@ -28,7 +38,25 @@ export function useNativeViewObscured(hostRef: RefObject<HTMLElement | null>): b
       if (!host) {
         setObscured(false);
       } else {
-        const hostRect = host.getBoundingClientRect();
+        const rawHostRect = host.getBoundingClientRect();
+        const fittedHost = aspectRatio
+          ? aspectFitNativeViewBounds({
+              x: Math.round(rawHostRect.left),
+              y: Math.round(rawHostRect.top),
+              width: Math.round(rawHostRect.width),
+              height: Math.round(rawHostRect.height),
+            }, aspectRatio)
+          : null;
+        const hostRect = fittedHost
+          ? {
+              left: fittedHost.x,
+              right: fittedHost.x + fittedHost.width,
+              top: fittedHost.y,
+              bottom: fittedHost.y + fittedHost.height,
+              width: fittedHost.width,
+              height: fittedHost.height,
+            }
+          : rawHostRect;
         const candidates = [...document.querySelectorAll<HTMLElement>(POSITIONED_OVERLAY_SELECTOR)]
           .filter(
             (candidate) =>
@@ -128,7 +156,7 @@ export function useNativeViewObscured(hostRef: RefObject<HTMLElement | null>): b
       window.removeEventListener("resize", scheduleRead);
       window.removeEventListener("scroll", scheduleRead, true);
     };
-  }, [hostRef]);
+  }, [aspectRatio, hostRef]);
 
   return obscured;
 }

--- a/src/lib/browser-panel-operation.test.ts
+++ b/src/lib/browser-panel-operation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginBrowserPanelOperation,
+  browserPanelOperationPending,
+} from "./browser-panel-operation";
+
+describe("browser panel operation handoff", () => {
+  it("keeps a bot locked until every overlapping operation finishes", () => {
+    const finishFirst = beginBrowserPanelOperation("bot-a");
+    const finishSecond = beginBrowserPanelOperation("bot-a");
+
+    expect(browserPanelOperationPending("bot-a")).toBe(true);
+    expect(browserPanelOperationPending("bot-b")).toBe(false);
+    finishFirst();
+    expect(browserPanelOperationPending("bot-a")).toBe(true);
+    finishSecond();
+    expect(browserPanelOperationPending("bot-a")).toBe(false);
+  });
+
+  it("makes operation cleanup idempotent", () => {
+    const finish = beginBrowserPanelOperation("bot-a");
+    finish();
+    finish();
+    expect(browserPanelOperationPending("bot-a")).toBe(false);
+  });
+});

--- a/src/lib/browser-panel-operation.ts
+++ b/src/lib/browser-panel-operation.ts
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from "react";
+
+const operationCounts = new Map<string, number>();
+const listeners = new Set<() => void>();
+
+function notifyListeners() {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Keep browser mutations locked across the compact/expanded React handoff.
+ * Both panels are short-lived views over the same native page, so component
+ * state alone cannot represent an operation that outlives either panel.
+ */
+export function beginBrowserPanelOperation(botId: string): () => void {
+  operationCounts.set(botId, (operationCounts.get(botId) ?? 0) + 1);
+  notifyListeners();
+
+  let finished = false;
+  return () => {
+    if (finished) return;
+    finished = true;
+    const remaining = (operationCounts.get(botId) ?? 1) - 1;
+    if (remaining > 0) operationCounts.set(botId, remaining);
+    else operationCounts.delete(botId);
+    notifyListeners();
+  };
+}
+
+export function browserPanelOperationPending(botId: string): boolean {
+  return (operationCounts.get(botId) ?? 0) > 0;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useBrowserPanelOperationPending(botId: string): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => browserPanelOperationPending(botId),
+    () => false,
+  );
+}

--- a/src/lib/computer-panel-view.test.ts
+++ b/src/lib/computer-panel-view.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readComputerPanelView, writeComputerPanelView } from "./computer-panel-view";
+
+describe("computer panel view persistence", () => {
+  it("restores the browser for the same bot after the expanded workspace closes", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    writeComputerPanelView("sprout", "browser", storage);
+
+    expect(readComputerPanelView("sprout", storage)).toBe("browser");
+    expect(readComputerPanelView("another-bot", storage)).toBe("computer");
+  });
+
+  it("falls back safely for stale values or blocked storage", () => {
+    expect(readComputerPanelView("sprout", { getItem: () => "unknown" })).toBe("computer");
+    expect(readComputerPanelView("sprout", { getItem: () => { throw new Error("blocked"); } })).toBe("computer");
+
+    const setItem = vi.fn(() => { throw new Error("blocked"); });
+    expect(() => writeComputerPanelView("sprout", "browser", { setItem })).not.toThrow();
+  });
+});

--- a/src/lib/computer-panel-view.ts
+++ b/src/lib/computer-panel-view.ts
@@ -1,0 +1,32 @@
+export type ComputerPanelView = "computer" | "android" | "browser";
+
+const STORAGE_PREFIX = "omb-computer-panel-view";
+
+function storageKey(botId: string): string {
+  return `${STORAGE_PREFIX}:${botId}`;
+}
+
+export function readComputerPanelView(
+  botId: string,
+  storage: Pick<Storage, "getItem"> = localStorage,
+): ComputerPanelView {
+  try {
+    const value = storage.getItem(storageKey(botId));
+    if (value === "android" || value === "browser") return value;
+  } catch {
+    // Storage can be unavailable in hardened or private renderer sessions.
+  }
+  return "computer";
+}
+
+export function writeComputerPanelView(
+  botId: string,
+  view: ComputerPanelView,
+  storage: Pick<Storage, "setItem"> = localStorage,
+): void {
+  try {
+    storage.setItem(storageKey(botId), view);
+  } catch {
+    // The in-memory React state still preserves the choice for this mount.
+  }
+}

--- a/src/lib/local-vm-workspace.test.ts
+++ b/src/lib/local-vm-workspace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  aspectFitNativeViewBounds,
   initialLocalVmWorkspaceSlots,
   nativeViewOverlayIntersects,
   readyLocalVmViewerUrl,
@@ -28,6 +29,19 @@ const bots = [
 ];
 
 describe("Local VM native overlay shielding", () => {
+  it("checks overlays against the fitted native surface, not its letterbox", () => {
+    const fitted = aspectFitNativeViewBounds({ x: 0, y: 0, width: 1_000, height: 500 }, 1.6);
+    const hosts = [rect(fitted.x, fitted.y, fitted.width, fitted.height)];
+
+    expect(fitted).toEqual({ x: 100, y: 0, width: 800, height: 500 });
+    expect(nativeViewOverlayIntersects(hosts, [{
+      rect: rect(0, 0, 80, 500),
+      explicit: true,
+      visible: true,
+      zIndex: 40,
+    }])).toBe(false);
+  });
+
   it("hides panes only for visible intersecting overlays", () => {
     const hosts = [rect(100, 100, 400, 300)];
     expect(

--- a/src/lib/local-vm-workspace.ts
+++ b/src/lib/local-vm-workspace.ts
@@ -51,6 +51,36 @@ export interface NativeViewOverlayCandidate {
   zIndex: number | null;
 }
 
+export interface NativeViewBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Fit a fixed-aspect native surface inside renderer-owned bounds. */
+export function aspectFitNativeViewBounds(
+  bounds: NativeViewBounds,
+  aspectRatio: number,
+): NativeViewBounds {
+  const widthFromHeight = Math.max(1, Math.floor(bounds.height * aspectRatio));
+  if (widthFromHeight <= bounds.width) {
+    return {
+      x: bounds.x + Math.floor((bounds.width - widthFromHeight) / 2),
+      y: bounds.y,
+      width: widthFromHeight,
+      height: bounds.height,
+    };
+  }
+  const heightFromWidth = Math.max(1, Math.floor(bounds.width / aspectRatio));
+  return {
+    x: bounds.x,
+    y: bounds.y + Math.floor((bounds.height - heightFromWidth) / 2),
+    width: bounds.width,
+    height: heightFromWidth,
+  };
+}
+
 /** Native views paint above renderer content. Hide them only when a visible,
  * real overlay intersects a pane; ordinary positioned layout remains visible. */
 export function nativeViewOverlayIntersects(

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -215,10 +215,12 @@ type SkillRecordingPayload = {
           bounds: DesktopWorkspaceBounds | null,
           profile?: string,
           mode?: "compact" | "expanded",
+          layoutOwner?: string,
         ): Promise<BrowserSurfaceState>;
         navigate(botId: string, url: string, profile?: string): Promise<{ url: string; title: string }>;
         back(botId: string, profile?: string): Promise<{ url: string; title: string }>;
         forward?(botId: string, profile?: string): Promise<{ url: string; title: string }>;
+        reload?(botId: string, profile?: string): Promise<{ url: string; title: string }>;
         /** Immediately gates native browser mutations while the durable
          * server-side human-control snapshot catches up. */
         setHumanControl?(botId: string, held: boolean, profile?: string): Promise<boolean>;

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -113,7 +113,7 @@ type SkillRecordingPayload = {
     partition?: string | null;
     profile?: string | null;
     mode?: "compact" | "expanded" | null;
-    code?: "renderer-gone" | "profile-changed" | "evicted";
+    code?: "renderer-gone" | "profile-deleted" | "evicted";
   }
 
   interface DesktopWorkspaceState {
@@ -225,7 +225,7 @@ type SkillRecordingPayload = {
          * server-side human-control snapshot catches up. */
         setHumanControl?(botId: string, held: boolean, profile?: string): Promise<boolean>;
         /** Native page focus/input means the person has taken the wheel. */
-        onUserInteraction?(cb: (event: { botId: string }) => void): () => void;
+        onUserInteraction?(cb: (event: { botId: string; profile: string }) => void): () => void;
         forgetProfile?(partitionId: string): Promise<{ dropped: number }>;
         close(botId: string): Promise<boolean>;
         onState(cb: (state: BrowserSurfaceState) => void): () => void;


### PR DESCRIPTION
## Summary

- keep a fixed 1280×800 page viewport in compact and expanded surfaces, with exact scaled input and screenshot coordinates
- make the compact preview watch-only and race-safe across focus, clicks, wheel inertia, expand/shrink, reload, and profile switches
- add clear browser states, controls, a centered aspect-fit layout, overlay shielding, and per-bot tab restoration
- stop hidden computer polling and provisioning while Browser or Android owns the panel
- preserve exact profile identity on terminal events and serialize operations across panel remounts

## Validation

- `pnpm test` — 2,590 passed, 19 skipped; broker, updater, desktop viewer, package, server boot, and packaged smoke follow-ups passed
- `pnpm typecheck`
- `pnpm build`
- changed-file Oxlint
- real Electron pass: UI navigation, 1280×800 compact and expanded viewport, exact click targeting, nested scroll, reload, expand/shrink restoration, compact click shielding, and held-preview reopening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser back, forward, and reload controls.
  * Added profile creation and profile-aware browser views.
  * Preserved each bot’s selected Computer, Android, or Browser tab.
  * Added connection, loading, empty, and failure states with retry options.
  * Improved browser scaling, pointer interactions, multi-click actions, dragging, and screenshot sizing.

* **Bug Fixes**
  * Prevented overlays and compact-mode interactions from activating unintended page elements.
  * Improved scrolling, profile switching, navigation, reloading, and failure recovery.
  * Prevented conflicting browser actions during transitions.
  * Improved accessibility for error notifications and keyboard focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->