### PR TITLE
feat(sidebar): add persistent collapsible sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/comms-visibility.test.ts
+++ b/server/comms-visibility.test.ts
@@ -1,0 +1,46 @@
+import { rmSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DATA_DIR } from "./config.ts";
+import type { ModelSelection } from "./contracts.ts";
+import { getOrCreateChannel } from "./comms-visibility.ts";
+import { closeMessageDb } from "./message-db.ts";
+import { Store } from "./store.ts";
+
+const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
+
+describe("bot-to-bot channel context", () => {
+  beforeEach(() => {
+    closeMessageDb();
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    closeMessageDb();
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+
+  it("keeps a new DM in the sender's semantic section", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+
+    const channel = getOrCreateChannel(store, from, target);
+
+    expect(channel.dm).toBe(true);
+    expect(channel.section).toBe("Agents");
+  });
+
+  it("updates an existing DM's context without turning Bot Chats into a stored section", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const existing = store.createGroup("Forge ⇄ Quarry", [from.id, target.id], true, "Personal");
+
+    const channel = getOrCreateChannel(store, from, target);
+
+    expect(channel.id).toBe(existing.id);
+    expect(channel.section).toBe("Agents");
+    expect(channel.section).not.toBe("Bot Chats");
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { track } from "@/lib/analytics";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   Archive,
@@ -46,11 +46,37 @@ import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
 import { BotPickerList } from "./BotPickerList";
 import {
+  loadCollapsedSections,
+  loadSectionOrder,
   loadSidebarDensity,
+  saveCollapsedSections,
+  saveSectionOrder,
   saveSidebarDensity,
+  toggleCollapsedSection,
   type SidebarDensity,
 } from "@/lib/sidebar-preferences";
+import {
+  BOT_CHATS_SECTION_ID,
+  BOTS_SECTION_ID,
+  CHANNELS_SECTION_ID,
+  PINNED_SECTION_ID,
+  mergeSectionOrder,
+  moveSection,
+  orderedSidebarSections,
+  partitionSidebarBots,
+  partitionSidebarGroups,
+  placeSection,
+  sameSectionOrder,
+  sidebarLayoutInteractive,
+  sidebarSectionCollapsed,
+  sidebarSectionLabel,
+  userSectionId,
+  userSectionName,
+  type SectionDropPlace,
+} from "@/lib/sidebar-layout";
+import { sidebarSectionAttention } from "@/lib/sidebar-attention";
 import { phoneSettingsAction, SidebarPhoneButton } from "./SidebarPhoneButton";
+import { SidebarSectionHeader } from "./SidebarSectionHeader";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
 function profileInitials(profile?: { name?: string; email?: string }): string {
@@ -290,6 +316,7 @@ function RoomContextMenu({
   }, [onClose]);
 
   if (!group) return null;
+  const isBotChat = Boolean(group.dm);
   const saveRename = () => {
     const name = nextRename(group.name, draft);
     if (name) dispatch({ type: "patchGroup", groupId: group.id, patch: { name } });
@@ -327,7 +354,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={saveRename}
-            aria-label="Save channel name"
+            aria-label={isBotChat ? "Save chat name" : "Save channel name"}
             title="Save"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -336,7 +363,7 @@ function RoomContextMenu({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Cancel channel rename"
+            aria-label={isBotChat ? "Cancel chat rename" : "Cancel channel rename"}
             title="Cancel"
             className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
           >
@@ -352,19 +379,21 @@ function RoomContextMenu({
           className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
         >
           <Pencil size={16} className="text-ink-secondary" />
-          Rename Channel
+          {isBotChat ? "Rename chat" : "Rename Channel"}
         </button>
       )}
-      <button
-        onClick={() => {
-          onClose();
-          onMoveToSection(group.id);
-        }}
-        className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
-      >
-        <FolderPlus size={16} className="text-ink-secondary" />
-        Move to context
-      </button>
+      {!isBotChat && (
+        <button
+          onClick={() => {
+            onClose();
+            onMoveToSection(group.id);
+          }}
+          className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
+        >
+          <FolderPlus size={16} className="text-ink-secondary" />
+          Move to context
+        </button>
+      )}
       <button
         onClick={() => {
           void navigator.clipboard?.writeText(group.threadId);
@@ -383,7 +412,7 @@ function RoomContextMenu({
         className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-danger hover:bg-raised/70"
       >
         <Trash2 size={16} />
-        Delete Channel
+        {isBotChat ? "Delete chat" : "Delete Channel"}
       </button>
     </div>,
     document.body,
@@ -460,19 +489,6 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
           Create Channel{picked.size ? ` · ${picked.size} ${picked.size === 1 ? "bot" : "bots"}` : ""}
         </button>
       </div>
-    </div>
-  );
-}
-
-/** Labeled divider between sidebar sections. Same typographic register as
- * EngineGroupLabel so the sidebar reads as one system. */
-function SectionDivider({ name }: { name: string }) {
-  return (
-    <div className="flex items-center gap-2 px-3 pb-1 pt-3 first:pt-0" data-section={name}>
-      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
-        {name}
-      </span>
-      <span className="h-px flex-1 bg-hairline/40" />
     </div>
   );
 }
@@ -1035,6 +1051,15 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     return saved === "icons" ? "comfortable" : saved;
   });
   const [densityOpen, setDensityOpen] = useState(false);
+  const [collapsedSections, setCollapsedSections] = useState<string[]>(() => loadCollapsedSections());
+  const [sectionOrder, setSectionOrder] = useState<string[]>(() => loadSectionOrder());
+  const [draggingSectionId, setDraggingSectionId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: string; place: SectionDropPlace } | null>(null);
+  const [reorderAnnouncement, setReorderAnnouncement] = useState("");
+  const sectionDragRef = useRef<{
+    from: string | null;
+    over: { id: string; place: SectionDropPlace } | null;
+  }>({ from: null, over: null });
 
   const setDensity = (next: SidebarDensity) => {
     setDensityState(next);
@@ -1227,19 +1252,18 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         (b.title ?? "").toLowerCase().includes(q) ||
         preview(b).toLowerCase().includes(q),
     );
-  const unsectionedChief = matchingBots.find((bot) => bot.chiefOfStaff && !bot.section);
-  const sectionChiefs = matchingBots.filter((bot) => bot.chiefOfStaff && bot.section);
-  const sectionedBots = matchingBots
-    .filter((bot) => !bot.chiefOfStaff && bot.section)
-    .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
-  const visibleBots = matchingBots
-    .filter((bot) => !bot.chiefOfStaff && !bot.section)
-    .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
   const visibleGroups = state.groups.filter((g) => !q || g.name.toLowerCase().includes(q));
-  const sectionedGroups = visibleGroups.filter((g) => g.section);
-  const unsectionedGroups = visibleGroups.filter((g) => !g.section);
-  // sections keep first-appearance order within the current list; a section
-  // whose members all moved away (or fell out of the filter) simply vanishes
+  const {
+    unsectionedChief,
+    pinnedBots,
+    sectionChiefs,
+    sectionedBots,
+    unsectionedBots,
+  } = partitionSidebarBots(matchingBots);
+  const { botChats, sectionedRooms, unsectionedRooms } = partitionSidebarGroups(visibleGroups);
+
+  // User sections keep first-appearance order. The saved layout keeps an
+  // empty section's former slot so it returns there when content comes back.
   const sectionNames: string[] = [];
   for (const bot of sectionedBots) {
     if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
@@ -1247,9 +1271,84 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   for (const bot of sectionChiefs) {
     if (!sectionNames.includes(bot.section!)) sectionNames.push(bot.section!);
   }
-  for (const group of sectionedGroups) {
+  for (const group of sectionedRooms) {
     if (!sectionNames.includes(group.section!)) sectionNames.push(group.section!);
   }
+  const naturalSectionIds = [
+    ...(pinnedBots.length > 0 ? [PINNED_SECTION_ID] : []),
+    ...(unsectionedRooms.length > 0 ? [CHANNELS_SECTION_ID] : []),
+    ...(botChats.length > 0 ? [BOT_CHATS_SECTION_ID] : []),
+    ...(unsectionedBots.length > 0 ? [BOTS_SECTION_ID] : []),
+    ...sectionNames.map(userSectionId),
+  ];
+  const sectionIds = orderedSidebarSections(naturalSectionIds, sectionOrder);
+  const layoutInteractive = sidebarLayoutInteractive(density, q);
+  const sectionCollapsed = (id: string) =>
+    sidebarSectionCollapsed(id, collapsedSections, density, q);
+
+  const toggleSection = (id: string) => {
+    if (!layoutInteractive) return;
+    const next = toggleCollapsedSection(collapsedSections, id);
+    setCollapsedSections(next);
+    saveCollapsedSections(next);
+  };
+
+  const commitSectionOrder = (visibleOrder: string[]) => {
+    if (!layoutInteractive) return;
+    const next = mergeSectionOrder(sectionOrder, visibleOrder);
+    if (sameSectionOrder(next, sectionOrder)) return;
+    setSectionOrder(next);
+    saveSectionOrder(next);
+  };
+
+  const announceSectionPosition = (id: string, visibleOrder: string[]) => {
+    const position = visibleOrder.indexOf(id);
+    if (position < 0) return;
+    setReorderAnnouncement(
+      `${sidebarSectionLabel(id)} moved to position ${position + 1} of ${visibleOrder.length}`,
+    );
+  };
+
+  const moveSidebarSection = (id: string, direction: -1 | 1) => {
+    const next = moveSection(sectionIds, id, direction);
+    if (sameSectionOrder(next, sectionIds)) return;
+    commitSectionOrder(next);
+    announceSectionPosition(id, next);
+  };
+
+  const resetSectionDrag = () => {
+    sectionDragRef.current = { from: null, over: null };
+    setDraggingSectionId(null);
+    setDropTarget(null);
+  };
+
+  const updateSectionDropTarget = (event: React.DragEvent<HTMLDivElement>, id: string) => {
+    if (!layoutInteractive || !sectionDragRef.current.from) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const place: SectionDropPlace = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    const next = { id, place };
+    sectionDragRef.current.over = next;
+    setDropTarget(next);
+  };
+
+  const dropSection = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const from =
+      event.dataTransfer.getData("application/x-openmausbot-sidebar-section") ||
+      event.dataTransfer.getData("text/plain") ||
+      sectionDragRef.current.from;
+    const over = sectionDragRef.current.over;
+    if (from && over) {
+      const next = placeSection(sectionIds, from, over.id, over.place);
+      if (!sameSectionOrder(next, sectionIds)) {
+        commitSectionOrder(next);
+        announceSectionPosition(from, next);
+      }
+    }
+    resetSectionDrag();
+  };
   const activeBotCount = state.bots.filter((bot) => !bot.hidden).length;
   const archivedBots = state.bots.filter((bot) => bot.hidden);
   const pendingTeamUndo = teamFeedback?.undo;
@@ -1435,7 +1534,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       {/* Bot list */}
       <div className="flex-1 overflow-y-auto px-2">
         <div className="flex flex-col gap-0.5">
-          {!unsectionedChief && sectionChiefs.length === 0 && visibleBots.length === 0 && sectionedBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
+          {matchingBots.length === 0 && visibleGroups.length === 0 && q && q.length < MIN_QUERY && (
             <div className="px-3 py-6 text-center text-[13px] text-ink-secondary">Nothing matches “{query}”</div>
           )}
           {unsectionedChief && (
@@ -1449,58 +1548,111 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
               />
             </div>
           )}
-          {unsectionedGroups.length > 0 && density !== "icons" && <SectionDivider name="Channels" />}
-          {unsectionedGroups.map((g) => (
-            <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
-          ))}
-          {visibleBots.length > 0 && density !== "icons" && <SectionDivider name="Bots" />}
-          {visibleBots.map((b) => (
-            <BotListItem
-              key={b.id}
-              bot={b}
-              density={density}
-              onMenu={setMenu}
-              onArchive={(bot) => void archiveBot(bot)}
-              archiveDisabled={activeBotCount <= 1}
-            />
-          ))}
-          {sectionNames.map((name) => (
-            <Fragment key={name}>
-              {density !== "icons" && <SectionDivider name={name} />}
-              {sectionChiefs
-                .filter((bot) => bot.section === name)
-                .map((bot) => (
-                  <BotListItem
-                    key={bot.id}
-                    bot={bot}
-                    density={density}
-                    onMenu={setMenu}
-                    onArchive={(candidate) => void archiveBot(candidate)}
-                    archiveDisabled
+          {sectionIds.map((id, index) => {
+            const sectionName = userSectionName(id);
+            const sectionChiefItems = sectionName
+              ? sectionChiefs.filter((bot) => bot.section === sectionName)
+              : [];
+            const sectionGroupItems =
+              id === CHANNELS_SECTION_ID
+                ? unsectionedRooms
+                : id === BOT_CHATS_SECTION_ID
+                  ? botChats
+                  : sectionName
+                    ? sectionedRooms.filter((group) => group.section === sectionName)
+                    : [];
+            const sectionBotItems =
+              id === PINNED_SECTION_ID
+                ? pinnedBots
+                : id === BOTS_SECTION_ID
+                  ? unsectionedBots
+                  : sectionName
+                    ? sectionedBots.filter((bot) => bot.section === sectionName)
+                    : [];
+            const collapsed = sectionCollapsed(id);
+            const attention = collapsed
+              ? sidebarSectionAttention(
+                  [...sectionChiefItems, ...sectionBotItems],
+                  sectionGroupItems,
+                )
+              : undefined;
+            return (
+              <div
+                key={id}
+                data-sidebar-section-id={id}
+                className={cn(
+                  "flex flex-col gap-0.5",
+                  density !== "icons" && index > 0 && "pt-3",
+                )}
+              >
+                {dropTarget?.id === id && dropTarget.place === "before" && draggingSectionId !== id && (
+                  <div className="mx-2 h-0.5 rounded-full bg-accent" />
+                )}
+                {density !== "icons" && (
+                  <SidebarSectionHeader
+                    name={sidebarSectionLabel(id)}
+                    collapsed={collapsed}
+                    attention={attention}
+                    onToggle={layoutInteractive ? () => toggleSection(id) : undefined}
+                    reorderable={layoutInteractive && sectionIds.length > 1}
+                    dragging={draggingSectionId === id}
+                    onDragStart={(event) => {
+                      event.dataTransfer.effectAllowed = "move";
+                      event.dataTransfer.setData("application/x-openmausbot-sidebar-section", id);
+                      event.dataTransfer.setData("text/plain", id);
+                      sectionDragRef.current = { from: id, over: null };
+                      setDraggingSectionId(id);
+                    }}
+                    onDragEnd={resetSectionDrag}
+                    onDragOver={(event) => updateSectionDropTarget(event, id)}
+                    onDrop={dropSection}
+                    onMove={(direction) => moveSidebarSection(id, direction)}
                   />
-                ))}
-              {sectionedGroups
-                .filter((g) => g.section === name)
-                .map((g) => (
-                  <GroupListItem key={g.id} group={g} density={density} onMenu={setRoomMenu} />
-                ))}
-              {sectionedBots
-                .filter((b) => b.section === name)
-                .map((b) => (
-                  <BotListItem
-                    key={b.id}
-                    bot={b}
-                    density={density}
-                    onMenu={setMenu}
-                    onArchive={(bot) => void archiveBot(bot)}
-                    archiveDisabled={activeBotCount <= 1}
-                  />
-                ))}
-            </Fragment>
-          ))}
+                )}
+                {!collapsed && (
+                  <>
+                    {sectionChiefItems.map((bot) => (
+                      <BotListItem
+                        key={bot.id}
+                        bot={bot}
+                        density={density}
+                        onMenu={setMenu}
+                        onArchive={(candidate) => void archiveBot(candidate)}
+                        archiveDisabled
+                      />
+                    ))}
+                    {sectionGroupItems.map((group) => (
+                      <GroupListItem
+                        key={group.id}
+                        group={group}
+                        density={density}
+                        onMenu={setRoomMenu}
+                      />
+                    ))}
+                    {sectionBotItems.map((bot) => (
+                      <BotListItem
+                        key={bot.id}
+                        bot={bot}
+                        density={density}
+                        onMenu={setMenu}
+                        onArchive={(candidate) => void archiveBot(candidate)}
+                        archiveDisabled={activeBotCount <= 1}
+                      />
+                    ))}
+                  </>
+                )}
+                {dropTarget?.id === id && dropTarget.place === "after" && draggingSectionId !== id && (
+                  <div className="mx-2 h-0.5 rounded-full bg-accent" />
+                )}
+              </div>
+            );
+          })}
           <SearchResults query={query} onLanded={() => setQuery("")} />
         </div>
       </div>
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {reorderAnnouncement}
+      </p>
 
       {/* Footer */}
       <div className={cn("pb-3 pt-2", density === "icons" ? "px-2" : "px-3")}>

--- a/src/components/SidebarSectionHeader.test.ts
+++ b/src/components/SidebarSectionHeader.test.ts
@@ -1,0 +1,43 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SidebarSectionHeader } from "./SidebarSectionHeader";
+
+describe("SidebarSectionHeader", () => {
+  it("exposes collapse and keyboard reorder semantics without a fake grip button", () => {
+    const html = renderToStaticMarkup(
+      createElement(SidebarSectionHeader, {
+        name: "Work",
+        collapsed: false,
+        onToggle: () => {},
+        reorderable: true,
+        dragging: false,
+      }),
+    );
+
+    expect(html).toContain("<button");
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain('role="button"');
+  });
+
+  it("renders collapsed attention signals in the heading", () => {
+    const html = renderToStaticMarkup(
+      createElement(SidebarSectionHeader, {
+        name: "Bot Chats",
+        collapsed: true,
+        attention: { waiting: 1, unread: 2, working: 1 },
+        onToggle: () => {},
+        reorderable: false,
+        dragging: false,
+      }),
+    );
+
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain("1 waiting for you");
+    expect(html).toContain("2 unread");
+    expect(html).toContain("1 working");
+  });
+});

--- a/src/components/SidebarSectionHeader.tsx
+++ b/src/components/SidebarSectionHeader.tsx
@@ -1,0 +1,125 @@
+import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
+import type { DragEvent, KeyboardEvent } from "react";
+
+import { cn } from "@/lib/cn";
+import {
+  sidebarAttentionLabel,
+  type SidebarSectionAttention,
+} from "@/lib/sidebar-attention";
+
+export function SidebarSectionHeader({
+  name,
+  collapsed,
+  attention,
+  onToggle,
+  reorderable,
+  dragging,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+  onMove,
+}: {
+  name: string;
+  collapsed: boolean;
+  attention?: SidebarSectionAttention;
+  onToggle?: () => void;
+  reorderable: boolean;
+  dragging: boolean;
+  onDragStart?: (event: DragEvent<HTMLSpanElement>) => void;
+  onDragEnd?: () => void;
+  onDragOver?: (event: DragEvent<HTMLDivElement>) => void;
+  onDrop?: (event: DragEvent<HTMLDivElement>) => void;
+  onMove?: (direction: -1 | 1) => void;
+}) {
+  const Chevron = collapsed ? ChevronRight : ChevronDown;
+  const attentionLabel = attention ? sidebarAttentionLabel(attention) : "";
+  const onHeaderKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (!reorderable || !event.altKey) return;
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      onMove?.(-1);
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      onMove?.(1);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 px-2 pb-1"
+      data-section={name}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {onToggle ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          onKeyDown={onHeaderKeyDown}
+          aria-expanded={!collapsed}
+          aria-keyshortcuts={reorderable ? "Alt+ArrowUp Alt+ArrowDown" : undefined}
+          title={
+            reorderable
+              ? `${collapsed ? "Expand" : "Collapse"} ${name}. Alt+Up/Down reorders it.`
+              : `${collapsed ? "Expand" : "Collapse"} ${name}`
+          }
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1 py-0.5 text-left hover:bg-raised/50"
+        >
+          <Chevron size={12} className="shrink-0 text-ink-secondary" />
+          <span className="truncate text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+            {name}
+          </span>
+          {attention && attention.waiting > 0 && (
+            <span
+              aria-hidden="true"
+              className="min-w-4 rounded-full bg-warning/15 px-1 text-center text-[9px] font-semibold leading-4 text-warning"
+            >
+              {attention.waiting}
+            </span>
+          )}
+          {attention && attention.unread > 0 && (
+            <span
+              aria-hidden="true"
+              className="min-w-4 rounded-full bg-accent/15 px-1 text-center text-[9px] font-semibold leading-4 text-accent"
+            >
+              {attention.unread}
+            </span>
+          )}
+          {attention && attention.working > 0 && (
+            <span
+              aria-hidden="true"
+              className="flex size-4 items-center justify-center"
+            >
+              <span className="size-1.5 animate-pulse rounded-full bg-success" />
+            </span>
+          )}
+          <span className="h-px flex-1 bg-hairline/40" />
+          {attentionLabel && <span className="sr-only">{attentionLabel}</span>}
+        </button>
+      ) : (
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 px-1 py-0.5">
+          <span className="truncate text-[10px] font-medium uppercase tracking-[0.08em] text-ink-secondary">
+            {name}
+          </span>
+          <span className="h-px flex-1 bg-hairline/40" />
+        </div>
+      )}
+      {reorderable && (
+        <span
+          aria-hidden="true"
+          draggable
+          title="Drag to reorder"
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          className={cn(
+            "flex size-6 shrink-0 cursor-grab items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink",
+            dragging && "opacity-40",
+          )}
+        >
+          <GripVertical size={13} />
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/sidebar-attention.test.ts
+++ b/src/lib/sidebar-attention.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { sidebarAttentionLabel, sidebarSectionAttention } from "./sidebar-attention";
+
+describe("collapsed sidebar attention", () => {
+  it("keeps unread chats and approval waits visible at the section level", () => {
+    const attention = sidebarSectionAttention(
+      [
+        { unread: true, activity: "waiting-on-you" },
+        { busy: true, activity: "working" },
+      ],
+      [{ unread: true }, { busyBotId: "writer" }],
+    );
+
+    expect(attention).toEqual({ unread: 2, waiting: 1, working: 2 });
+    expect(sidebarAttentionLabel(attention)).toBe(
+      "1 waiting for you, 2 unread, 2 working",
+    );
+  });
+
+  it("does not count a waiting bot twice as working", () => {
+    expect(
+      sidebarSectionAttention([{ busy: true, activity: "waiting-on-you" }], []),
+    ).toEqual({ unread: 0, waiting: 1, working: 0 });
+  });
+});

--- a/src/lib/sidebar-attention.ts
+++ b/src/lib/sidebar-attention.ts
@@ -1,0 +1,49 @@
+export type SidebarAttentionBot = {
+  unread?: boolean;
+  busy?: boolean;
+  activity?: "working" | "waiting-on-you" | "idle" | "no-signal" | "dead";
+};
+
+export type SidebarAttentionGroup = {
+  unread?: boolean;
+  busyBotId?: string | null;
+};
+
+export type SidebarSectionAttention = {
+  unread: number;
+  waiting: number;
+  working: number;
+};
+
+/** Summarize signals that would otherwise disappear when a section closes. */
+export function sidebarSectionAttention(
+  bots: SidebarAttentionBot[],
+  groups: SidebarAttentionGroup[],
+): SidebarSectionAttention {
+  return {
+    unread:
+      bots.filter((bot) => Boolean(bot.unread)).length +
+      groups.filter((group) => Boolean(group.unread)).length,
+    waiting: bots.filter((bot) => bot.activity === "waiting-on-you").length,
+    working:
+      bots.filter(
+        (bot) =>
+          bot.activity === "working" ||
+          (Boolean(bot.busy) && bot.activity !== "waiting-on-you"),
+      ).length + groups.filter((group) => Boolean(group.busyBotId)).length,
+  };
+}
+
+export function sidebarAttentionLabel(attention: SidebarSectionAttention): string {
+  const parts: string[] = [];
+  if (attention.waiting > 0) {
+    parts.push(`${attention.waiting} waiting for you`);
+  }
+  if (attention.unread > 0) {
+    parts.push(`${attention.unread} unread`);
+  }
+  if (attention.working > 0) {
+    parts.push(`${attention.working} working`);
+  }
+  return parts.join(", ");
+}

--- a/src/lib/sidebar-layout.test.ts
+++ b/src/lib/sidebar-layout.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BOT_CHATS_SECTION_ID,
+  BOTS_SECTION_ID,
+  CHANNELS_SECTION_ID,
+  PINNED_SECTION_ID,
+  mergeSectionOrder,
+  moveSection,
+  orderedSidebarSections,
+  partitionSidebarBots,
+  partitionSidebarGroups,
+  placeSection,
+  sidebarLayoutInteractive,
+  sidebarSectionCollapsed,
+  sidebarSectionLabel,
+  userSectionId,
+  userSectionName,
+} from "./sidebar-layout";
+
+describe("sidebar virtual sections", () => {
+  it("keeps reserved labels separate from identically named user sections", () => {
+    for (const name of ["Pinned", "pinned", "channels", "bots", "bot-chats", "Bot Chats"]) {
+      const id = userSectionId(name);
+      expect([PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOT_CHATS_SECTION_ID, BOTS_SECTION_ID]).not.toContain(id);
+      expect(userSectionName(id)).toBe(name);
+      expect(sidebarSectionLabel(id)).toBe(name);
+    }
+    expect(sidebarSectionLabel(CHANNELS_SECTION_ID)).toBe("Channels");
+  });
+
+  it("round-trips every valid section name without URI encoding", () => {
+    const maxLengthEmojiName = "🧠".repeat(30);
+    expect(maxLengthEmojiName).toHaveLength(60);
+
+    for (const name of ["Design / Research", "100%", "\ud800", maxLengthEmojiName]) {
+      const id = userSectionId(name);
+      expect(id).toBe(`section:${name}`);
+      expect(userSectionName(id)).toBe(name);
+      expect(sidebarSectionLabel(id)).toBe(name);
+    }
+  });
+
+  it("shows pinned bots once without erasing their saved context", () => {
+    const bot = { id: "writer", section: "Work", pinned: true };
+    const parts = partitionSidebarBots([
+      { id: "chief", chiefOfStaff: true },
+      bot,
+      { id: "plain" },
+      { id: "hidden", hidden: true, pinned: true },
+    ]);
+    expect(parts.unsectionedChief?.id).toBe("chief");
+    expect(parts.pinnedBots).toEqual([bot]);
+    expect(parts.sectionedBots).toEqual([]);
+    expect(parts.unsectionedBots.map((candidate) => candidate.id)).toEqual(["plain"]);
+    expect(bot.section).toBe("Work");
+  });
+
+  it("shows DMs in Bot Chats without rewriting their comms context", () => {
+    const dm = { id: "dm", dm: true, section: "Work" };
+    const namedBotChats = { id: "named", section: "Bot Chats" };
+    const parts = partitionSidebarGroups([
+      dm,
+      { id: "project", section: "Work" },
+      namedBotChats,
+      { id: "general" },
+    ]);
+    expect(parts.botChats).toEqual([dm]);
+    expect(parts.sectionedRooms.map((room) => room.id)).toEqual(["project", "named"]);
+    expect(parts.unsectionedRooms.map((room) => room.id)).toEqual(["general"]);
+    expect(dm.section).toBe("Work");
+    expect(namedBotChats.section).toBe("Bot Chats");
+  });
+
+  it("keeps section Chiefs in their actual section", () => {
+    const chief = { id: "chief", chiefOfStaff: true, section: "Work", pinned: true };
+    const parts = partitionSidebarBots([chief]);
+    expect(parts.sectionChiefs).toEqual([chief]);
+    expect(parts.pinnedBots).toEqual([]);
+  });
+
+  it("forces filtered and icon-only views open and non-reorderable", () => {
+    expect(sidebarLayoutInteractive("comfortable", "")).toBe(true);
+    expect(sidebarLayoutInteractive("comfortable", "writer")).toBe(false);
+    expect(sidebarLayoutInteractive("icons", "")).toBe(false);
+    expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "compact", "")).toBe(true);
+    expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "compact", "writer")).toBe(false);
+    expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "icons", "")).toBe(false);
+  });
+});
+
+describe("sidebar section ordering", () => {
+  const natural = [
+    PINNED_SECTION_ID,
+    CHANNELS_SECTION_ID,
+    BOT_CHATS_SECTION_ID,
+    BOTS_SECTION_ID,
+    userSectionId("Work"),
+  ];
+
+  it("uses natural order when no preference exists", () => {
+    expect(orderedSidebarSections(natural, [])).toEqual(natural);
+  });
+
+  it("preserves a user move and inserts a newly visible bucket naturally", () => {
+    const withoutBotChats = natural.filter((id) => id !== BOT_CHATS_SECTION_ID);
+    const saved = [userSectionId("Work"), PINNED_SECTION_ID, CHANNELS_SECTION_ID, BOTS_SECTION_ID];
+    expect(orderedSidebarSections(withoutBotChats, saved)).toEqual(saved);
+    expect(orderedSidebarSections(natural, saved)).toEqual([
+      userSectionId("Work"),
+      PINNED_SECTION_ID,
+      CHANNELS_SECTION_ID,
+      BOT_CHATS_SECTION_ID,
+      BOTS_SECTION_ID,
+    ]);
+  });
+
+  it("moves and drops sections without wrapping", () => {
+    expect(moveSection(natural, CHANNELS_SECTION_ID, -1)).toEqual([
+      CHANNELS_SECTION_ID,
+      PINNED_SECTION_ID,
+      BOT_CHATS_SECTION_ID,
+      BOTS_SECTION_ID,
+      userSectionId("Work"),
+    ]);
+    expect(moveSection(natural, PINNED_SECTION_ID, -1)).toBe(natural);
+    expect(placeSection(natural, BOTS_SECTION_ID, PINNED_SECTION_ID, "before")).toEqual([
+      BOTS_SECTION_ID,
+      PINNED_SECTION_ID,
+      CHANNELS_SECTION_ID,
+      BOT_CHATS_SECTION_ID,
+      userSectionId("Work"),
+    ]);
+  });
+
+  it("retains empty sections in their saved slot", () => {
+    const visible = natural.filter((id) => id !== CHANNELS_SECTION_ID);
+    expect(mergeSectionOrder(natural, visible)).toEqual(natural);
+  });
+
+  it("retains leading empty sections before their next visible successor", () => {
+    const work = userSectionId("Work");
+    const personal = userSectionId("Personal");
+    const saved = [work, personal, PINNED_SECTION_ID, CHANNELS_SECTION_ID];
+
+    expect(mergeSectionOrder(saved, [PINNED_SECTION_ID, CHANNELS_SECTION_ID])).toEqual(saved);
+  });
+
+  it("preserves a leading empty section when visible sections were reordered", () => {
+    const work = userSectionId("Work");
+    const saved = [work, PINNED_SECTION_ID, CHANNELS_SECTION_ID];
+
+    expect(mergeSectionOrder(saved, [CHANNELS_SECTION_ID, PINNED_SECTION_ID])).toEqual([
+      CHANNELS_SECTION_ID,
+      work,
+      PINNED_SECTION_ID,
+    ]);
+  });
+});

--- a/src/lib/sidebar-layout.ts
+++ b/src/lib/sidebar-layout.ts
@@ -1,0 +1,187 @@
+export const PINNED_SECTION_ID = "builtin:pinned";
+export const CHANNELS_SECTION_ID = "builtin:channels";
+export const BOT_CHATS_SECTION_ID = "builtin:bot-chats";
+export const BOTS_SECTION_ID = "builtin:bots";
+
+const USER_SECTION_PREFIX = "section:";
+
+export type SidebarSectionId = string;
+export type SectionDropPlace = "before" | "after";
+export type SidebarDensityMode = "comfortable" | "compact" | "icons";
+
+export type SidebarBot = {
+  id: string;
+  chiefOfStaff?: boolean;
+  section?: string;
+  pinned?: boolean;
+  hidden?: boolean;
+};
+
+export type SidebarGroup = {
+  id: string;
+  section?: string;
+  dm?: boolean;
+};
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function userSectionId(name: string): SidebarSectionId {
+  return `${USER_SECTION_PREFIX}${name}`;
+}
+
+export function userSectionName(id: SidebarSectionId): string | null {
+  if (!id.startsWith(USER_SECTION_PREFIX)) return null;
+  return id.slice(USER_SECTION_PREFIX.length);
+}
+
+export function sidebarSectionLabel(id: SidebarSectionId): string {
+  if (id === PINNED_SECTION_ID) return "Pinned";
+  if (id === CHANNELS_SECTION_ID) return "Channels";
+  if (id === BOT_CHATS_SECTION_ID) return "Bot Chats";
+  if (id === BOTS_SECTION_ID) return "Bots";
+  return userSectionName(id) ?? id;
+}
+
+export function sidebarLayoutInteractive(density: SidebarDensityMode, query: string): boolean {
+  return density !== "icons" && query.trim().length === 0;
+}
+
+export function sidebarSectionCollapsed(
+  id: SidebarSectionId,
+  collapsedIds: SidebarSectionId[],
+  density: SidebarDensityMode,
+  query: string,
+): boolean {
+  return sidebarLayoutInteractive(density, query) && collapsedIds.includes(id);
+}
+
+/** Pinned bots are a virtual view. Their saved section is left untouched so
+ * unpinning returns them to the context they came from. */
+export function partitionSidebarBots<T extends SidebarBot>(bots: T[]) {
+  const visible = bots.filter((bot) => !bot.hidden);
+  const unsectionedChief = visible.find((bot) => bot.chiefOfStaff && !bot.section) ?? null;
+  const pinnedBots = visible.filter((bot) => !bot.chiefOfStaff && Boolean(bot.pinned));
+  const pinnedIds = new Set(pinnedBots.map((bot) => bot.id));
+  const sectionChiefs = visible.filter((bot) => bot.chiefOfStaff && Boolean(bot.section));
+  const sectionedBots = visible.filter(
+    (bot) => !bot.chiefOfStaff && Boolean(bot.section) && !pinnedIds.has(bot.id),
+  );
+  const unsectionedBots = visible.filter(
+    (bot) => !bot.chiefOfStaff && !bot.section && !pinnedIds.has(bot.id),
+  );
+  return { unsectionedChief, pinnedBots, sectionChiefs, sectionedBots, unsectionedBots };
+}
+
+/** Bot-to-bot DMs are also a virtual view. We do not rewrite their persisted
+ * context, because that context still participates in comms visibility. */
+export function partitionSidebarGroups<T extends SidebarGroup>(groups: T[]) {
+  const botChats = groups.filter((group) => Boolean(group.dm));
+  const rooms = groups.filter((group) => !group.dm);
+  const sectionedRooms = rooms.filter((group) => Boolean(group.section));
+  const unsectionedRooms = rooms.filter((group) => !group.section);
+  return { botChats, sectionedRooms, unsectionedRooms };
+}
+
+/** Restore saved positions while inserting newly visible buckets at their
+ * natural position instead of always appending them. */
+export function orderedSidebarSections(
+  present: SidebarSectionId[],
+  savedOrder: SidebarSectionId[],
+): SidebarSectionId[] {
+  const visible = unique(present);
+  const visibleSet = new Set(visible);
+  const result = unique(savedOrder).filter((id) => visibleSet.has(id));
+  if (result.length === 0) return visible;
+
+  for (const id of visible) {
+    if (result.includes(id)) continue;
+    const naturalIndex = visible.indexOf(id);
+    const naturalPredecessors = visible.slice(0, naturalIndex).reverse();
+    const naturalSuccessors = visible.slice(naturalIndex + 1);
+    const predecessor = naturalPredecessors.find((candidate) => result.includes(candidate));
+    const successor = naturalSuccessors.find((candidate) => result.includes(candidate));
+    const predecessorIndex = predecessor ? result.indexOf(predecessor) : -1;
+    const successorIndex = successor ? result.indexOf(successor) : -1;
+
+    if (predecessorIndex >= 0 && (successorIndex < 0 || predecessorIndex < successorIndex)) {
+      result.splice(predecessorIndex + 1, 0, id);
+    } else if (successorIndex >= 0) {
+      result.splice(successorIndex, 0, id);
+    } else {
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+export function moveSection(
+  ids: SidebarSectionId[],
+  id: SidebarSectionId,
+  direction: -1 | 1,
+): SidebarSectionId[] {
+  const index = ids.indexOf(id);
+  const destination = index + direction;
+  if (index < 0 || destination < 0 || destination >= ids.length) return ids;
+  const result = [...ids];
+  const [moved] = result.splice(index, 1);
+  result.splice(destination, 0, moved!);
+  return result;
+}
+
+export function placeSection(
+  ids: SidebarSectionId[],
+  fromId: SidebarSectionId,
+  targetId: SidebarSectionId,
+  place: SectionDropPlace,
+): SidebarSectionId[] {
+  if (fromId === targetId || !ids.includes(fromId) || !ids.includes(targetId)) return ids;
+  const result = ids.filter((id) => id !== fromId);
+  let destination = result.indexOf(targetId);
+  if (place === "after") destination += 1;
+  result.splice(destination, 0, fromId);
+  return result;
+}
+
+/** Preserve temporarily empty sections in the saved order so their position
+ * returns when a bot or channel is later assigned to them again. */
+export function mergeSectionOrder(
+  savedOrder: SidebarSectionId[],
+  visibleOrder: SidebarSectionId[],
+): SidebarSectionId[] {
+  const saved = unique(savedOrder);
+  const result = unique(visibleOrder);
+  const included = new Set(result);
+
+  for (let savedIndex = 0; savedIndex < saved.length; savedIndex += 1) {
+    const id = saved[savedIndex]!;
+    if (included.has(id)) continue;
+    let destination = result.length;
+    let foundPredecessor = false;
+    for (let previous = savedIndex - 1; previous >= 0; previous -= 1) {
+      const previousPosition = result.indexOf(saved[previous]!);
+      if (previousPosition >= 0) {
+        destination = previousPosition + 1;
+        foundPredecessor = true;
+        break;
+      }
+    }
+    if (!foundPredecessor) {
+      for (let next = savedIndex + 1; next < saved.length; next += 1) {
+        const nextPosition = result.indexOf(saved[next]!);
+        if (nextPosition >= 0) {
+          destination = nextPosition;
+          break;
+        }
+      }
+    }
+    result.splice(destination, 0, id);
+    included.add(id);
+  }
+  return result;
+}
+
+export function sameSectionOrder(a: SidebarSectionId[], b: SidebarSectionId[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}

--- a/src/lib/sidebar-preferences.test.ts
+++ b/src/lib/sidebar-preferences.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  SIDEBAR_COLLAPSED_SECTIONS_KEY,
   SIDEBAR_DENSITY_KEY,
+  SIDEBAR_SECTION_ORDER_KEY,
+  loadCollapsedSections,
+  loadSectionOrder,
   loadSidebarDensity,
   parseSidebarDensity,
+  saveCollapsedSections,
+  saveSectionOrder,
   saveSidebarDensity,
+  toggleCollapsedSection,
 } from "./sidebar-preferences";
+import { userSectionId } from "./sidebar-layout";
 
 describe("sidebar density preferences", () => {
   it("accepts the three supported layouts and rejects stale values", () => {
@@ -22,5 +30,68 @@ describe("sidebar density preferences", () => {
     expect(setItem).toHaveBeenCalledWith(SIDEBAR_DENSITY_KEY, "icons");
     expect(loadSidebarDensity({ getItem: () => "compact" })).toBe("compact");
     expect(loadSidebarDensity({ getItem: () => { throw new Error("blocked"); } })).toBe("comfortable");
+  });
+});
+
+describe("sidebar section preferences", () => {
+  it("round-trips unique collapsed and ordered section ids", () => {
+    const collapsedSet = vi.fn();
+    saveCollapsedSections(["builtin:pinned", "builtin:pinned", "section:Work"], {
+      setItem: collapsedSet,
+    });
+    expect(collapsedSet).toHaveBeenCalledWith(
+      SIDEBAR_COLLAPSED_SECTIONS_KEY,
+      JSON.stringify(["builtin:pinned", "section:Work"]),
+    );
+    expect(
+      loadCollapsedSections({
+        getItem: () => JSON.stringify(["builtin:pinned", "section:Work"]),
+      }),
+    ).toEqual(["builtin:pinned", "section:Work"]);
+
+    const orderSet = vi.fn();
+    saveSectionOrder(["section:Work", "builtin:bots"], { setItem: orderSet });
+    expect(orderSet).toHaveBeenCalledWith(
+      SIDEBAR_SECTION_ORDER_KEY,
+      JSON.stringify(["section:Work", "builtin:bots"]),
+    );
+    expect(loadSectionOrder({ getItem: () => JSON.stringify(["section:Work", "builtin:bots"]) })).toEqual([
+      "section:Work",
+      "builtin:bots",
+    ]);
+  });
+
+  it("ignores malformed storage and toggles ids without mutating the source", () => {
+    expect(loadCollapsedSections({ getItem: () => "not-json" })).toEqual([]);
+    expect(loadSectionOrder({ getItem: () => JSON.stringify({ nope: true }) })).toEqual([]);
+    const current = ["section:Work"];
+    expect(toggleCollapsedSection(current, "builtin:bots")).toEqual([
+      "section:Work",
+      "builtin:bots",
+    ]);
+    expect(toggleCollapsedSection(current, "section:Work")).toEqual([]);
+    expect(current).toEqual(["section:Work"]);
+  });
+
+  it("supports newlines, caps untrusted arrays, and tolerates blocked storage", () => {
+    const withNewline = "section:Line\nBreak";
+    expect(loadSectionOrder({ getItem: () => JSON.stringify([withNewline]) })).toEqual([withNewline]);
+
+    const oversized = Array.from({ length: 105 }, (_, index) => `section:${index}`);
+    expect(loadSectionOrder({ getItem: () => JSON.stringify(oversized) })).toHaveLength(100);
+    expect(loadSectionOrder({ getItem: () => { throw new Error("blocked"); } })).toEqual([]);
+    expect(() => saveSectionOrder(["section:Work"], { setItem: () => { throw new Error("blocked"); } })).not.toThrow();
+  });
+
+  it("persists raw section ids with lone surrogates and max-length emoji names", () => {
+    const ids = [userSectionId("\ud800"), userSectionId("🧠".repeat(30))];
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    saveSectionOrder(ids, storage);
+    expect(loadSectionOrder(storage)).toEqual(ids);
   });
 });

--- a/src/lib/sidebar-preferences.ts
+++ b/src/lib/sidebar-preferences.ts
@@ -1,6 +1,10 @@
+import { z } from "zod";
+
 export type SidebarDensity = "comfortable" | "compact" | "icons";
 
 export const SIDEBAR_DENSITY_KEY = "openmausbot.sidebarDensity";
+export const SIDEBAR_COLLAPSED_SECTIONS_KEY = "openmausbot.sidebarCollapsedSections.v1";
+export const SIDEBAR_SECTION_ORDER_KEY = "openmausbot.sidebarSectionOrder.v1";
 
 export function parseSidebarDensity(value: string | null): SidebarDensity {
   switch (value) {
@@ -33,4 +37,72 @@ export function saveSidebarDensity(
     // Private browsing and locked-down webviews may reject localStorage.
     // The in-memory React state still makes the control useful this session.
   }
+}
+
+const stringListSchema = z.array(z.string().min(1).max(240));
+
+function parseStringList(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const result = stringListSchema.safeParse(parsed);
+    return result.success ? [...new Set(result.data)].slice(0, 100) : [];
+  } catch {
+    return [];
+  }
+}
+
+function loadStringList(
+  key: string,
+  storage?: Pick<Storage, "getItem"> | null,
+): string[] {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    return parseStringList(target?.getItem(key) ?? null);
+  } catch {
+    return [];
+  }
+}
+
+function saveStringList(
+  key: string,
+  values: string[],
+  storage?: Pick<Storage, "setItem"> | null,
+): void {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    const safe = [
+      ...new Set(values.filter((value) => value.length > 0 && value.length <= 240)),
+    ].slice(0, 100);
+    target?.setItem(key, JSON.stringify(safe));
+  } catch {
+    // Private browsing and locked-down webviews may reject localStorage.
+    // In-memory React state still keeps the interaction useful this session.
+  }
+}
+
+export function loadCollapsedSections(storage?: Pick<Storage, "getItem"> | null): string[] {
+  return loadStringList(SIDEBAR_COLLAPSED_SECTIONS_KEY, storage);
+}
+
+export function saveCollapsedSections(
+  ids: string[],
+  storage?: Pick<Storage, "setItem"> | null,
+): void {
+  saveStringList(SIDEBAR_COLLAPSED_SECTIONS_KEY, ids, storage);
+}
+
+export function toggleCollapsedSection(ids: string[], id: string): string[] {
+  return ids.includes(id) ? ids.filter((candidate) => candidate !== id) : [...ids, id];
+}
+
+export function loadSectionOrder(storage?: Pick<Storage, "getItem"> | null): string[] {
+  return loadStringList(SIDEBAR_SECTION_ORDER_KEY, storage);
+}
+
+export function saveSectionOrder(
+  ids: string[],
+  storage?: Pick<Storage, "setItem"> | null,
+): void {
+  saveStringList(SIDEBAR_SECTION_ORDER_KEY, ids, storage);
 }


### PR DESCRIPTION
## Summary

- add persistent collapsible and drag/keyboard-reorderable sidebar sections
- add UI-only Pinned and Bot Chats buckets without rewriting bots' or channels' semantic context
- preserve unread, approval, and working signals when a section is collapsed
- use chat-specific actions for bot-to-bot conversations
- bump the desktop version to 0.1.42

## Why this rewrite

This extracts and credits the valuable sidebar ideas from #549 by @matt5115 while leaving out its unrelated live-stream, Vite exposure, clipboard, Codex Micro, and partial terminology changes. The live-delivery work was already superseded by #555.

## Validation

- 66 test files / 414 tests passed
- `pnpm build`
- focused Oxlint and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible sidebar sections with drag-and-drop and keyboard reordering.
  * Sidebar section order and collapsed states are now remembered between sessions.
  * Added attention indicators for unread items, pending responses, and active work.
  * Improved organization of pinned items, channels, bot chats, bots, and custom sections.

* **Bug Fixes**
  * Bot-to-bot direct-message channels now retain the sender’s section and reuse existing conversations correctly.
  * Context-menu labels now distinguish bot chats from channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->