### PR TITLE
fix: harden shared chat streams for v0.1.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/drivers/grok.test.ts
+++ b/server/drivers/grok.test.ts
@@ -2,8 +2,12 @@
 // fake is a stubbed globalThis.fetch that scripts HTTP failures and SSE
 // bodies. Covers the auto-retry policy: transient (429/5xx) retried with
 // backoff, terminal (401/400) never, partial streamed output never.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { ensureDirs, NATIVE_DIR } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { GrokDriver } from "./grok.ts";
@@ -38,6 +42,7 @@ describe("GrokDriver turns (fake fetch)", () => {
   };
 
   beforeEach(() => {
+    ensureDirs();
     process.env.FAKE_GROK_RETRY_SCALE = "0.001";
     previousFetch = globalThis.fetch;
     calls = 0;
@@ -76,6 +81,20 @@ describe("GrokDriver turns (fake fetch)", () => {
       itemType: "assistant_text",
       text: "done from fake grok",
     });
+  });
+
+  it("records the resolved default model in native diagnostics", async () => {
+    script = [];
+    await create();
+    const threadId = "t-default-model-log";
+    await instance.adapter.sendTurn({ threadId, text: "hi" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const entries = readFileSync(join(NATIVE_DIR, `${threadId}.ndjson`), "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { dir: string; msg: { model?: string } });
+    expect(entries.find((entry) => entry.dir === "out")?.msg.model).toBe("grok-4");
   });
 
   it("auto-retries transient 429/5xx responses, then completes once", async () => {

--- a/server/drivers/grok.ts
+++ b/server/drivers/grok.ts
@@ -52,7 +52,7 @@ export const GrokDriver: ProviderDriver<GrokConfig> = {
       generateModel: () => "grok-3-mini",
       nativeLog: {
         source: "xai.chat.completions",
-        outgoing: (turn, messages) => ({ model: turn.model, messages }),
+        outgoing: (_turn, messages, model) => ({ model, messages }),
         incoming: ({ text, usage }) => ({ text, usage }),
       },
     });

--- a/server/drivers/minimax.ts
+++ b/server/drivers/minimax.ts
@@ -115,7 +115,6 @@ export const MinimaxDriver: ProviderDriver<MinimaxConfig> = {
       missingKeyError: `no MiniMax key — set ${API_KEY_ENV} or run mmx auth login --api-key …`,
       unavailableReason: `no MiniMax API key — run mmx auth login --api-key … or set ${API_KEY_ENV}`,
       timeoutMs: 180_000,
-      timeoutStreaming: true,
       billing: "metered",
       includeUsageInCompleted: true,
       noBodyError: "MiniMax returned no response body",

--- a/server/drivers/openai-chat.ts
+++ b/server/drivers/openai-chat.ts
@@ -59,7 +59,6 @@ interface RuntimeOptions<Config> {
   includeUsageInCompleted?: boolean;
   noBodyError?: string;
   retryScale?: number;
-  timeoutStreaming?: boolean;
 }
 
 const usageFrom = (usage: CompletionJson["usage"]): Usage | null =>
@@ -99,7 +98,7 @@ export function createOpenAIChatRuntime<Config>(options: RuntimeOptions<Config>)
       method: "POST",
       headers: { authorization: `Bearer ${options.apiKey}`, "content-type": "application/json" },
       body: JSON.stringify(options.requestBody(model, messages, stream)),
-      signal: signal && options.timeoutStreaming ? AbortSignal.any([signal, timeout]) : signal ?? timeout,
+      signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
     });
     if (!response.ok) {
       const body = await response.text().catch(() => "");

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -91,7 +91,7 @@ describe("OpenAICompatDriver", () => {
     await inst.dispose();
   });
 
-  it("includes streamed token totals in turn.completed", async () => {
+  it("includes streamed token totals and bounds the cancellable stream", async () => {
     const anySignal = vi.spyOn(AbortSignal, "any");
     vi.stubGlobal(
       "fetch",
@@ -119,7 +119,7 @@ describe("OpenAICompatDriver", () => {
     const completed = await recorder.until((event) => event.type === "turn.completed");
 
     expect(completed).toMatchObject({ ok: true, usage: { input: 12, output: 3 } });
-    expect(anySignal).not.toHaveBeenCalled();
+    expect(anySignal).toHaveBeenCalledTimes(1);
     recorder.stop();
     await inst.dispose();
   });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -93,6 +93,19 @@ const api = async (method: string, path: string, body?: unknown): Promise<{ stat
   return { status: res.status, body: await res.json() };
 };
 
+const readJsonFileWhenReady = async <T = unknown>(file: string, timeout = 5_000): Promise<T> => {
+  let parsed: unknown;
+  await expect.poll(() => {
+    try {
+      parsed = JSON.parse(readFileSync(file, "utf8"));
+      return true;
+    } catch {
+      return false;
+    }
+  }, { timeout }).toBe(true);
+  return parsed as T;
+};
+
 const storedMessageCount = (threadId: string): number => {
   const db = new DatabaseSync(join(home, ".openmausbot", "messages.db"), { readOnly: true });
   try {
@@ -867,14 +880,13 @@ describe("harness HTTP API", () => {
 
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${chief.id}/messages`, { text: "prepare the team" })).status).toBe(202);
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
       const dump = z.object({
         mcpConfig: z.object({
           mcpServers: z.object({
             agents: z.object({ env: z.object({ OMB_COMMS_TOKEN: z.string() }) }),
           }),
         }),
-      }).parse(JSON.parse(readFileSync(fakeClaudeDump, "utf8")));
+      }).parse(await readJsonFileWhenReady(fakeClaudeDump));
       const internalHeaders = {
         authorization: `Bearer ${dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN}`,
         "content-type": "application/json",
@@ -2602,7 +2614,6 @@ describe("harness HTTP API", () => {
 
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "Check the website" })).status).toBe(202);
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
       const dump = z.object({
         argv: z.array(z.string()),
         env: z.record(z.string(), z.string()),
@@ -2617,7 +2628,7 @@ describe("harness HTTP API", () => {
             }),
           }),
         }),
-      }).parse(JSON.parse(readFileSync(fakeClaudeDump, "utf8")));
+      }).parse(await readJsonFileWhenReady(fakeClaudeDump));
       const browserEnv = dump.mcpConfig.mcpServers.browser.env;
       expect(browserEnv).toMatchObject({ OMB_BOT_ID: bot.id, OMB_BROWSER_PROFILE: "work" });
       const registration = browserCapabilityCalls.find(
@@ -2731,8 +2742,7 @@ describe("harness HTTP API", () => {
       expect(replacementTooSoon.body.queued).toBe(true);
       expect(existsSync(fakeClaudeDump)).toBe(false);
 
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
-      expect(JSON.stringify(JSON.parse(readFileSync(fakeClaudeDump, "utf8")))).toContain("replacement");
+      expect(JSON.stringify(await readJsonFileWhenReady(fakeClaudeDump))).toContain("replacement");
     } finally {
       browserRegisterDelayMs = 0;
       await api("POST", `/api/bots/${bot.id}/interrupt`, {}).catch(() => undefined);
@@ -3527,11 +3537,10 @@ describe("harness HTTP API", () => {
 
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "start the lead" })).status).toBe(202);
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
-      const firstDump = JSON.parse(readFileSync(fakeClaudeDump, "utf8")) as {
+      const firstDump = await readJsonFileWhenReady<{
         pid: number;
         mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
-      };
+      }>(fakeClaudeDump);
       const token = firstDump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
 
@@ -3600,8 +3609,9 @@ describe("harness HTTP API", () => {
 
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "prepare a routine" })).status).toBe(202);
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
-      const dump = JSON.parse(readFileSync(fakeClaudeDump, "utf8"));
+      const dump = await readJsonFileWhenReady<{
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+      }>(fakeClaudeDump);
       const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
       expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
@@ -3952,8 +3962,9 @@ describe("harness HTTP API", () => {
 
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "prepare a skill" })).status).toBe(202);
-      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
-      const dump = JSON.parse(readFileSync(fakeClaudeDump, "utf8"));
+      const dump = await readJsonFileWhenReady<{
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+      }>(fakeClaudeDump);
       const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
       const internalHeaders = {


### PR DESCRIPTION
## Summary
- combine user cancellation with provider timeouts for every OpenAI-compatible streaming turn
- record Grok’s resolved default model in native diagnostics
- bump the desktop app to 0.1.43

## Verification
- pnpm typecheck
- 30 targeted provider tests
- tracked-source lint
- contrast check
- full suite: 2,595 passed; one unrelated Claude steering timing test passed immediately on isolated rerun
- PR #604 CI green on macOS, Windows, Ubuntu, packaged Ubuntu, control plane, and iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation and timeout handling for streaming requests.
  - Streaming requests can now be cancelled reliably while respecting configured timeouts.
  - Improved model reporting in diagnostics, including accurate default model details.
  - Updated MiniMax streaming behavior for more consistent request handling.

- **Chores**
  - Updated the package version to 0.1.43.
  - Improved reliability of automated streaming and request-handling checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->