### PR TITLE
Add bounded managed BotMRR share links

### DIFF
--- a/cloudflare/control-plane/migrations/0006_bot_shares.sql
+++ b/cloudflare/control-plane/migrations/0006_bot_shares.sql
@@ -1,0 +1,79 @@
+-- Shared bots remain portable BotMRR Markdown. D1 stores ownership, discovery
+-- state, and immutable snapshots; it is not a second bot registry.
+CREATE TABLE bot_shares (
+  id TEXT PRIMARY KEY CHECK (length(id) = 21 AND id NOT GLOB '*[^A-Za-z0-9_-]*'),
+  owner_user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  visibility TEXT NOT NULL CHECK (visibility IN ('unlisted', 'private')),
+  active_version INTEGER NOT NULL CHECK (active_version >= 1),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER
+);
+
+CREATE INDEX bot_shares_owner_active_idx
+  ON bot_shares(owner_user_id, deleted_at, updated_at DESC);
+
+-- Quotas live in D1 triggers rather than a read-then-write application check,
+-- so concurrent publish requests cannot race past the same limit.
+CREATE TRIGGER bot_shares_owner_limit_before_insert
+BEFORE INSERT ON bot_shares
+WHEN (
+  SELECT COUNT(*)
+    FROM bot_shares
+   WHERE owner_user_id = NEW.owner_user_id
+     AND deleted_at IS NULL
+) >= 100
+BEGIN
+  SELECT RAISE(ABORT, 'bot_share_owner_limit');
+END;
+
+CREATE TABLE bot_share_versions (
+  share_id TEXT NOT NULL REFERENCES bot_shares(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL CHECK (version >= 1),
+  name TEXT NOT NULL CHECK (length(name) BETWEEN 1 AND 100),
+  summary TEXT NOT NULL CHECK (length(summary) BETWEEN 1 AND 2000),
+  package_markdown TEXT NOT NULL,
+  package_sha256 TEXT NOT NULL CHECK (length(package_sha256) = 64),
+  package_bytes INTEGER NOT NULL CHECK (package_bytes BETWEEN 1 AND 1000000),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (share_id, version)
+);
+
+CREATE TRIGGER bot_share_versions_limit_before_insert
+BEFORE INSERT ON bot_share_versions
+WHEN (
+  SELECT COUNT(*)
+    FROM bot_share_versions
+   WHERE share_id = NEW.share_id
+) >= 50
+BEGIN
+  SELECT RAISE(ABORT, 'bot_share_version_limit');
+END;
+
+-- A version insert and the active pointer advance happen in one D1 statement.
+-- Concurrent writers that started from the same expected version cannot both
+-- succeed, and no version can be inserted behind the active pointer.
+CREATE TRIGGER bot_share_versions_expected_active_before_insert
+BEFORE INSERT ON bot_share_versions
+WHEN NEW.version > 1 AND NOT EXISTS (
+  SELECT 1
+    FROM bot_shares
+   WHERE id = NEW.share_id
+     AND deleted_at IS NULL
+     AND active_version = NEW.version - 1
+)
+BEGIN
+  SELECT RAISE(ABORT, 'bot_share_version_conflict');
+END;
+
+CREATE TRIGGER bot_share_versions_advance_after_insert
+AFTER INSERT ON bot_share_versions
+WHEN NEW.version > 1
+BEGIN
+  UPDATE bot_shares
+     SET active_version = NEW.version,
+         updated_at = NEW.created_at
+   WHERE id = NEW.share_id
+     AND deleted_at IS NULL
+     AND active_version = NEW.version - 1;
+END;

--- a/cloudflare/control-plane/src/bot-shares.ts
+++ b/cloudflare/control-plane/src/bot-shares.ts
@@ -1,0 +1,382 @@
+import { z } from "zod";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+import type { ControlPlaneAuth } from "./auth";
+import { accountSession } from "./auth";
+import { HTTPError, json, readBoundedJSONWithLimit } from "./http";
+
+export const BOT_SHARE_PACKAGE_MAX_BYTES = 1_000_000;
+export const BOT_SHARE_MAX_PER_OWNER = 100;
+export const BOT_SHARE_MAX_VERSIONS = 50;
+// JSON.stringify can turn one UTF-8 input byte containing a JSON control
+// character into a six-byte `\u00XX` escape. Keep the canonical package cap
+// unchanged, but leave enough transport budget for the worst legal JSON
+// representation plus the fixed envelope and optional visibility field.
+const BOT_SHARE_JSON_ESCAPE_MAX_BYTES_PER_INPUT_BYTE = 6;
+const BOT_SHARE_PUBLISH_BODY_FIXED_BYTES = new TextEncoder().encode(
+  JSON.stringify({ packageMarkdown: "", visibility: "private" }),
+).byteLength;
+export const BOT_SHARE_PUBLISH_BODY_MAX_BYTES =
+  BOT_SHARE_PACKAGE_MAX_BYTES * BOT_SHARE_JSON_ESCAPE_MAX_BYTES_PER_INPUT_BYTE +
+  BOT_SHARE_PUBLISH_BODY_FIXED_BYTES;
+
+const COLORS = ["green", "blue", "red", "orange", "purple", "cyan", "pink", "yellow", "teal", "coral"] as const;
+
+const requiredText = (max: number) => z.string().trim().min(1).max(max);
+const optionalText = (max: number) => z.union([z.string(), z.null(), z.undefined()])
+  .transform((value) => value?.trim() || undefined)
+  .refine((value) => value === undefined || value.length <= max)
+  .optional();
+const key = requiredText(64).regex(/^[a-z0-9][a-z0-9_-]*$/);
+const packageDefinitionSchema = z.object({
+  id: requiredText(80).regex(/^[a-z0-9][a-z0-9-]*$/),
+  release: requiredText(30).regex(/^\d+\.\d+\.\d+$/),
+  name: requiredText(100),
+  tagline: requiredText(160),
+  summary: requiredText(2_000),
+  category: requiredText(80),
+  author: z.object({ name: requiredText(100), url: optionalText(500) }),
+  license: requiredText(80),
+  featured: z.boolean().optional(),
+  tags: z.array(requiredText(80)).max(30).optional(),
+  outcomes: z.array(requiredText(240)).min(1).max(12),
+  setupMinutes: z.number().int().min(1).max(240),
+  requirements: z.object({
+    apps: z.array(z.object({
+      slug: key,
+      label: requiredText(100),
+      reason: requiredText(240),
+      optional: z.boolean().optional(),
+    })).max(30),
+    capabilities: z.array(requiredText(80)).max(20),
+    platforms: z.array(requiredText(80)).max(10).optional(),
+  }),
+  agents: z.array(z.object({
+    key,
+    name: requiredText(100),
+    title: optionalText(200),
+    description: optionalText(4_000),
+    appearance: z.object({
+      color: z.enum(COLORS),
+      mascotExpression: optionalText(80),
+      mascotBody: optionalText(40),
+    }),
+    playbooks: z.array(key).max(40).optional(),
+  })).min(1).max(200),
+  chiefOfStaff: key.optional(),
+  rooms: z.array(z.object({
+    key,
+    name: requiredText(100),
+    members: z.array(key).min(1).max(200),
+    bulletin: optionalText(12_000),
+    defaultResponder: z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("agent"), agent: key }),
+      z.object({ kind: z.literal("everyone") }),
+      z.object({ kind: z.literal("mentions") }),
+    ]),
+  })).max(30).optional(),
+  routines: z.array(z.object({
+    key,
+    name: requiredText(80),
+    agent: key,
+    prompt: requiredText(20_000),
+    runOn: z.enum(["maus", "cloud"]),
+    schedule: z.discriminatedUnion("type", [
+      z.object({ type: z.literal("once"), at: z.number().int() }),
+      z.object({
+        type: z.literal("daily"),
+        time: requiredText(5).regex(/^([01]\d|2[0-3]):[0-5]\d$/),
+        weekdays: z.array(z.number().int().min(0).max(6)).min(1).max(7),
+      }),
+    ]),
+    durationMinutes: z.number().int().min(15).max(240),
+    enabledAfterInstall: z.literal(false),
+  })).max(50).optional(),
+  playbooks: z.array(z.object({
+    key,
+    name: requiredText(100),
+    summary: requiredText(300),
+    triggers: z.array(requiredText(100)).min(1).max(30),
+    instructions: requiredText(24_000),
+  })).max(80).optional(),
+  examples: z.array(z.object({
+    title: requiredText(120),
+    input: requiredText(4_000),
+    output: requiredText(8_000),
+  })).max(12).optional(),
+});
+type PackageDefinition = z.infer<typeof packageDefinitionSchema>;
+const packageFrontmatterSchema = packageDefinitionSchema.extend({ botmrr: z.literal(1) });
+
+function unique(values: string[]): Set<string> {
+  const result = new Set(values);
+  if (result.size !== values.length) throw new Error("duplicate package key");
+  return result;
+}
+
+function parsePackageMarkdown(markdown: string): PackageDefinition {
+  const frontmatter = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatter) throw new Error("missing frontmatter");
+  const metadata: unknown = parseYaml(frontmatter[1]);
+  for (const heading of ["Activation", "Mission", "Outcomes", "Connections", "Team", "Chief of Staff", "Completion rule"]) {
+    if (!markdown.includes(`## ${heading}`)) throw new Error("missing required section");
+  }
+  const parsedFrontmatter = packageFrontmatterSchema.parse(metadata);
+  const pkg = packageDefinitionSchema.parse(parsedFrontmatter);
+  const agents = unique(pkg.agents.map((agent) => agent.key));
+  const playbooks = unique((pkg.playbooks ?? []).map((playbook) => playbook.key));
+  unique((pkg.rooms ?? []).map((room) => room.key));
+  unique((pkg.routines ?? []).map((routine) => routine.key));
+  if (pkg.chiefOfStaff && !agents.has(pkg.chiefOfStaff)) throw new Error("unknown chief of staff");
+  for (const agent of pkg.agents) {
+    for (const playbook of agent.playbooks ?? []) if (!playbooks.has(playbook)) throw new Error("unknown playbook");
+  }
+  for (const room of pkg.rooms ?? []) {
+    const members = unique(room.members);
+    for (const member of members) if (!agents.has(member)) throw new Error("unknown room member");
+    if (room.defaultResponder.kind === "agent" && !members.has(room.defaultResponder.agent)) {
+      throw new Error("unknown default responder");
+    }
+  }
+  for (const routine of pkg.routines ?? []) if (!agents.has(routine.agent)) throw new Error("unknown routine agent");
+  return pkg;
+}
+
+const list = (values: string[]) => values.map((value) => `- ${value}`).join("\n");
+
+function renderPackageMarkdown(pkg: PackageDefinition): string {
+  const frontmatter = stringifyYaml({ botmrr: 1, ...pkg }, { lineWidth: 0 }).trim();
+  const agents = pkg.agents.map((agent) => [
+    `### ${agent.name} — ${agent.title || "Specialist"}`,
+    `**Role key:** \`${agent.key}\``,
+    agent.playbooks?.length ? `**Use these playbooks:** ${agent.playbooks.map((value) => `\`${value}\``).join(", ")}` : "",
+    "",
+    agent.description,
+  ].filter(Boolean).join("\n\n")).join("\n\n");
+  const rooms = (pkg.rooms ?? []).map((room) => [
+    `### ${room.name}`,
+    `**Members:** ${room.members.map((value) => `\`${value}\``).join(", ")}`,
+    `**Default responder:** ${room.defaultResponder.kind === "agent" ? `\`${room.defaultResponder.agent}\`` : room.defaultResponder.kind}`,
+    "",
+    room.bulletin,
+  ].join("\n\n")).join("\n\n");
+  const routines = (pkg.routines ?? []).map((routine) => [
+    `### ${routine.name}`,
+    `**Owner:** \`${routine.agent}\`  `,
+    `**Schedule:** ${routine.schedule.type === "daily" ? `${routine.schedule.time} on weekdays ${routine.schedule.weekdays.join(", ")}` : `once at ${routine.schedule.at}`}  `,
+    "**Initial state:** paused — the user must enable it",
+    "",
+    routine.prompt,
+  ].join("\n")).join("\n\n");
+  const playbooks = (pkg.playbooks ?? []).map((playbook) => [
+    `### ${playbook.name}`,
+    `**Playbook key:** \`${playbook.key}\`  `,
+    `**Use when:** ${playbook.triggers.join(", ")}`,
+    "",
+    playbook.summary,
+    "",
+    playbook.instructions,
+  ].join("\n")).join("\n\n");
+  const examples = (pkg.examples ?? []).map((example) => [
+    `### ${example.title}`,
+    "**Ask**",
+    "",
+    example.input,
+    "",
+    "**Expected result**",
+    "",
+    example.output,
+  ].join("\n")).join("\n\n");
+  const connections = pkg.requirements.apps.length
+    ? pkg.requirements.apps.map((app) => `- **${app.label}${app.optional ? " (optional)" : ""}:** ${app.reason}`).join("\n")
+    : "- No connected apps are required.";
+  return `---\n${frontmatter}\n---\n\n# ${pkg.name}\n\n${pkg.tagline}\n\n> **Give this file to your Chief of Staff.** It is the complete team blueprint. Any agent system can run it; OpenMausBot can also install it directly.\n\n## Activation\n\nYou are the Chief of Staff for this blueprint. Read the whole document before acting. Confirm the user's goal and any missing inputs, then create or delegate to the specialist roles below. Preserve their names, ownership, boundaries, shared-room rules, and playbooks. If your platform cannot literally spawn agents, perform the roles one at a time and keep their outputs clearly separated.\n\nNever request pasted passwords or secret keys. Use the platform's normal connection flow. Do not send messages, publish content, spend money, delete data, or enable a schedule without the user's explicit approval. All routines start paused.\n\n## Mission\n\n${pkg.summary}\n\n## Outcomes\n\n${list(pkg.outcomes)}\n\n## Connections\n\n${connections}\n\n## Team\n\n${agents}\n\n## Chief of Staff\n\nThe Chief of Staff role is \`${pkg.chiefOfStaff ?? pkg.agents[0].key}\`. This role owns delegation, synthesis, conflict resolution, and the final answer to the user.\n${rooms ? `\n## Shared rooms\n\n${rooms}\n` : ""}${routines ? `\n## Suggested routines\n\n${routines}\n` : ""}${playbooks ? `\n## Playbooks\n\n${playbooks}\n` : ""}${examples ? `\n## Example job\n\n${examples}\n` : ""}\n## Completion rule\n\nReturn one clear result to the user, distinguish evidence from inference, cite source links when the work uses external material, and state what still needs human approval or a connected app.\n`;
+}
+
+const SHARE_ID = /^[A-Za-z0-9_-]{21}$/;
+const visibilitySchema = z.enum(["unlisted", "private"]);
+const publishSchema = z.strictObject({ packageMarkdown: z.string().min(1), visibility: visibilitySchema.optional() });
+const updateSchema = z.strictObject({ packageMarkdown: z.string().min(1), expectedActiveVersion: z.number().int().min(1) });
+const visibilityPatchSchema = z.strictObject({ visibility: visibilitySchema });
+
+interface ShareRow {
+  id: string;
+  visibility: "unlisted" | "private";
+  active_version: number;
+  created_at: number;
+  updated_at: number;
+  name: string;
+  summary: string;
+  package_sha256: string;
+  package_bytes: number;
+  version_created_at: number;
+}
+
+interface PublicShareRow extends ShareRow { package_markdown: string; }
+
+function base64URL(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function newShareId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return base64URL(bytes).slice(0, 21);
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function packageSnapshot(markdown: string) {
+  if (new TextEncoder().encode(markdown).byteLength > BOT_SHARE_PACKAGE_MAX_BYTES) throw new HTTPError(413, "package_too_large");
+  let parsed: PackageDefinition;
+  try { parsed = parsePackageMarkdown(markdown); } catch { throw new HTTPError(400, "invalid_package"); }
+  const canonicalMarkdown = renderPackageMarkdown(parsed);
+  const packageBytes = new TextEncoder().encode(canonicalMarkdown).byteLength;
+  if (packageBytes > BOT_SHARE_PACKAGE_MAX_BYTES) throw new HTTPError(413, "package_too_large");
+  return {
+    markdown: canonicalMarkdown,
+    name: parsed.name,
+    summary: parsed.summary,
+    bytes: packageBytes,
+    sha256: hex(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonicalMarkdown))),
+  };
+}
+
+async function requireAccount(request: Request, auth: ControlPlaneAuth) {
+  const session = await accountSession(request, auth);
+  if (!session) throw new HTTPError(401, "unauthorized");
+  return session;
+}
+
+function shareJSON(row: ShareRow, baseURL: string) {
+  return {
+    id: row.id, visibility: row.visibility, activeVersion: row.active_version,
+    name: row.name, summary: row.summary, sha256: row.package_sha256,
+    byteSize: row.package_bytes, createdAt: row.created_at, updatedAt: row.updated_at,
+    versionCreatedAt: row.version_created_at, shareUrl: `${baseURL}/s/${row.id}`,
+    packageUrl: `${baseURL}/v1/bot-shares/${row.id}/package`,
+  };
+}
+
+const activeShareSelect = `
+  SELECT s.id, s.visibility, s.active_version, s.created_at, s.updated_at,
+         v.name, v.summary, v.package_sha256, v.package_bytes,
+         v.created_at AS version_created_at
+    FROM bot_shares s
+    JOIN bot_share_versions v ON v.share_id = s.id AND v.version = s.active_version`;
+
+async function ownedShare(shareId: string, ownerUserId: string, env: Env): Promise<ShareRow | null> {
+  if (!SHARE_ID.test(shareId)) return null;
+  return env.DB.prepare(`${activeShareSelect} WHERE s.id = ? AND s.owner_user_id = ? AND s.deleted_at IS NULL`)
+    .bind(shareId, ownerUserId).first<ShareRow>();
+}
+
+export async function listBotShares(request: Request, env: Env, auth: ControlPlaneAuth, baseURL: string): Promise<Response> {
+  const session = await requireAccount(request, auth);
+  const result = await env.DB.prepare(`${activeShareSelect} WHERE s.owner_user_id = ? AND s.deleted_at IS NULL ORDER BY s.updated_at DESC, s.id ASC LIMIT 100`)
+    .bind(session.user.id).all<ShareRow>();
+  return json({ shares: result.results.map((row) => shareJSON(row, baseURL)) });
+}
+
+export async function createBotShare(request: Request, env: Env, auth: ControlPlaneAuth, baseURL: string): Promise<Response> {
+  const session = await requireAccount(request, auth);
+  const parsed = publishSchema.safeParse(await readBoundedJSONWithLimit(request, BOT_SHARE_PUBLISH_BODY_MAX_BYTES));
+  if (!parsed.success) throw new HTTPError(400, "invalid_request");
+  const snapshot = await packageSnapshot(parsed.data.packageMarkdown);
+  const shareId = newShareId();
+  const now = Date.now();
+  try {
+    await env.DB.batch([
+      env.DB.prepare(`INSERT INTO bot_shares (id, owner_user_id, visibility, active_version, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)`)
+        .bind(shareId, session.user.id, parsed.data.visibility ?? "unlisted", now, now),
+      env.DB.prepare(`INSERT INTO bot_share_versions (share_id, version, name, summary, package_markdown, package_sha256, package_bytes, created_at) VALUES (?, 1, ?, ?, ?, ?, ?, ?)`)
+        .bind(shareId, snapshot.name, snapshot.summary, snapshot.markdown, snapshot.sha256, snapshot.bytes, now),
+    ]);
+  } catch (error) {
+    if (error instanceof Error && /bot_share_owner_limit/i.test(error.message)) throw new HTTPError(409, "share_limit_reached");
+    if (error instanceof Error && /UNIQUE constraint failed/i.test(error.message)) throw new HTTPError(409, "share_id_conflict");
+    throw error;
+  }
+  const row = await ownedShare(shareId, session.user.id, env);
+  if (!row) throw new Error("created bot share is missing");
+  return json({ share: shareJSON(row, baseURL) }, 201);
+}
+
+export async function updateBotShare(request: Request, shareId: string, env: Env, auth: ControlPlaneAuth, baseURL: string): Promise<Response> {
+  const session = await requireAccount(request, auth);
+  const parsed = updateSchema.safeParse(await readBoundedJSONWithLimit(request, BOT_SHARE_PUBLISH_BODY_MAX_BYTES));
+  if (!parsed.success) throw new HTTPError(400, "invalid_request");
+  const current = await ownedShare(shareId, session.user.id, env);
+  if (!current) throw new HTTPError(404, "not_found");
+  if (current.active_version !== parsed.data.expectedActiveVersion) throw new HTTPError(409, "version_conflict");
+  const snapshot = await packageSnapshot(parsed.data.packageMarkdown);
+  try {
+    await env.DB.prepare(`INSERT INTO bot_share_versions (share_id, version, name, summary, package_markdown, package_sha256, package_bytes, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .bind(shareId, parsed.data.expectedActiveVersion + 1, snapshot.name, snapshot.summary, snapshot.markdown, snapshot.sha256, snapshot.bytes, Date.now()).run();
+  } catch (error) {
+    if (error instanceof Error && /bot_share_version_limit/i.test(error.message)) throw new HTTPError(409, "version_limit_reached");
+    if (error instanceof Error && /bot_share_version_conflict|UNIQUE constraint failed/i.test(error.message)) throw new HTTPError(409, "version_conflict");
+    throw error;
+  }
+  const row = await ownedShare(shareId, session.user.id, env);
+  if (!row) throw new Error("updated bot share is missing");
+  return json({ share: shareJSON(row, baseURL) });
+}
+
+export async function updateBotShareVisibility(request: Request, shareId: string, env: Env, auth: ControlPlaneAuth, baseURL: string): Promise<Response> {
+  const session = await requireAccount(request, auth);
+  const parsed = visibilityPatchSchema.safeParse(await readBoundedJSONWithLimit(request, 16 * 1024));
+  if (!parsed.success) throw new HTTPError(400, "invalid_request");
+  if (!SHARE_ID.test(shareId)) throw new HTTPError(404, "not_found");
+  const result = await env.DB.prepare("UPDATE bot_shares SET visibility = ?, updated_at = ? WHERE id = ? AND owner_user_id = ? AND deleted_at IS NULL")
+    .bind(parsed.data.visibility, Date.now(), shareId, session.user.id).run();
+  if (result.meta.changes === 0) throw new HTTPError(404, "not_found");
+  const row = await ownedShare(shareId, session.user.id, env);
+  if (!row) throw new Error("updated bot share is missing");
+  return json({ share: shareJSON(row, baseURL) });
+}
+
+export async function deleteBotShare(request: Request, shareId: string, env: Env, auth: ControlPlaneAuth): Promise<Response> {
+  const session = await requireAccount(request, auth);
+  if (!SHARE_ID.test(shareId)) throw new HTTPError(404, "not_found");
+  const now = Date.now();
+  const result = await env.DB.prepare("UPDATE bot_shares SET deleted_at = ?, updated_at = ? WHERE id = ? AND owner_user_id = ? AND deleted_at IS NULL")
+    .bind(now, now, shareId, session.user.id).run();
+  if (result.meta.changes === 0) throw new HTTPError(404, "not_found");
+  return new Response(null, { status: 204, headers: { "cache-control": "no-store" } });
+}
+
+async function publicShare(shareId: string, env: Env): Promise<PublicShareRow | null> {
+  if (!SHARE_ID.test(shareId)) return null;
+  return env.DB.prepare(`SELECT s.id, s.visibility, s.active_version, s.created_at, s.updated_at, v.name, v.summary, v.package_sha256, v.package_bytes, v.created_at AS version_created_at, v.package_markdown FROM bot_shares s JOIN bot_share_versions v ON v.share_id = s.id AND v.version = s.active_version WHERE s.id = ? AND s.visibility = 'unlisted' AND s.deleted_at IS NULL`)
+    .bind(shareId).first<PublicShareRow>();
+}
+
+export async function publicBotSharePackage(shareId: string, env: Env): Promise<Response> {
+  const row = await publicShare(shareId, env);
+  if (!row) throw new HTTPError(404, "not_found");
+  return new Response(row.package_markdown, { headers: {
+    "content-type": "text/markdown; charset=utf-8",
+    "content-disposition": `inline; filename="openmaus-${shareId}-v${row.active_version}.md"`,
+    "x-content-sha256": row.package_sha256,
+  }});
+}
+
+function escapeHTML(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+
+export async function publicBotShareLanding(shareId: string, env: Env, baseURL: string): Promise<Response> {
+  const row = await publicShare(shareId, env);
+  if (!row) throw new HTTPError(404, "not_found");
+  const packageURL = `${baseURL}/v1/bot-shares/${row.id}/package`;
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHTML(row.name)} · OpenMausBot</title></head><body><main><h1>${escapeHTML(row.name)}</h1><p>${escapeHTML(row.summary)}</p><p>Version ${row.active_version}</p><p><a href="${escapeHTML(packageURL)}">Download BotMRR package</a></p><p>Import the downloaded package from Teams in OpenMausBot.</p></main></body></html>`;
+  return new Response(html, { headers: {
+    "content-type": "text/html; charset=utf-8",
+    "content-security-policy": "default-src 'none'; style-src 'none'; img-src 'none'; script-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+  }});
+}

--- a/cloudflare/control-plane/src/http.ts
+++ b/cloudflare/control-plane/src/http.ts
@@ -10,7 +10,7 @@ export const JSON_HEADERS = {
 const jsonValueSchema = z.json();
 export type JSONValue = z.infer<typeof jsonValueSchema>;
 
-const MAX_API_BODY_BYTES = 16 * 1024;
+export const MAX_API_BODY_BYTES = 16 * 1024;
 const BODYLESS_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const ALLOWED_CORS_METHODS = new Set(["GET", "POST", "DELETE"]);
 const ALLOWED_CORS_HEADERS = new Set(["authorization", "content-type"]);
@@ -32,17 +32,17 @@ export function errorResponse(status: number, code: string): Response {
   return json({ error: code }, status);
 }
 
-function validateDeclaredBodyLength(request: Request) {
+function validateDeclaredBodyLength(request: Request, maxBytes: number) {
   const contentLength = request.headers.get("content-length");
   if (contentLength !== null) {
     const declared = Number(contentLength);
     if (!Number.isSafeInteger(declared) || declared < 0) throw new HTTPError(400, "invalid_request");
-    if (declared > MAX_API_BODY_BYTES) throw new HTTPError(413, "request_too_large");
+    if (declared > maxBytes) throw new HTTPError(413, "request_too_large");
   }
 }
 
-async function readBoundedBody(request: Request): Promise<Uint8Array<ArrayBuffer>> {
-  validateDeclaredBodyLength(request);
+async function readBoundedBody(request: Request, maxBytes = MAX_API_BODY_BYTES): Promise<Uint8Array<ArrayBuffer>> {
+  validateDeclaredBodyLength(request, maxBytes);
   if (!request.body) return new Uint8Array();
 
   const reader = request.body.getReader();
@@ -53,7 +53,7 @@ async function readBoundedBody(request: Request): Promise<Uint8Array<ArrayBuffer
       const { done, value } = await reader.read();
       if (done) break;
       length += value.byteLength;
-      if (length > MAX_API_BODY_BYTES) {
+      if (length > maxBytes) {
         await reader.cancel();
         throw new HTTPError(413, "request_too_large");
       }
@@ -72,9 +72,9 @@ async function readBoundedBody(request: Request): Promise<Uint8Array<ArrayBuffer
   return bytes;
 }
 
-export async function withBoundedRequestBody(request: Request): Promise<Request> {
+export async function withBoundedRequestBody(request: Request, maxBytes = MAX_API_BODY_BYTES): Promise<Request> {
   if (BODYLESS_METHODS.has(request.method.toUpperCase())) return request;
-  const bytes = await readBoundedBody(request);
+  const bytes = await readBoundedBody(request, maxBytes);
   if (!request.body) return request;
 
   const headers = new Headers(request.headers);
@@ -85,11 +85,15 @@ export async function withBoundedRequestBody(request: Request): Promise<Request>
 }
 
 export async function readBoundedJSON(request: Request): Promise<JSONValue> {
+  return readBoundedJSONWithLimit(request, MAX_API_BODY_BYTES);
+}
+
+export async function readBoundedJSONWithLimit(request: Request, maxBytes: number): Promise<JSONValue> {
   const mediaType = request.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
   if (mediaType !== "application/json") throw new HTTPError(415, "unsupported_media_type");
   if (!request.body) throw new HTTPError(400, "invalid_request");
 
-  const bytes = await readBoundedBody(request);
+  const bytes = await readBoundedBody(request, maxBytes);
   try {
     return jsonValueSchema.parse(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
   } catch {

--- a/cloudflare/control-plane/src/index.ts
+++ b/cloudflare/control-plane/src/index.ts
@@ -19,9 +19,24 @@ import {
   revokeInstallation,
   rotateInstallationCredential,
 } from "./installations";
+import {
+  BOT_SHARE_PUBLISH_BODY_MAX_BYTES,
+  createBotShare,
+  deleteBotShare,
+  listBotShares,
+  publicBotShareLanding,
+  publicBotSharePackage,
+  updateBotShare,
+  updateBotShareVisibility,
+} from "./bot-shares";
 
 const ROTATE_ROUTE = /^\/v1\/installations\/([^/]+)\/credentials\/rotate$/;
 const INSTALLATION_ROUTE = /^\/v1\/installations\/([^/]+)$/;
+const BOT_SHARE_ROUTE = /^\/v1\/bot-shares\/([^/]+)$/;
+const BOT_SHARE_VERSION_ROUTE = /^\/v1\/bot-shares\/([^/]+)\/versions$/;
+const BOT_SHARE_VISIBILITY_ROUTE = /^\/v1\/bot-shares\/([^/]+)\/visibility$/;
+const BOT_SHARE_PACKAGE_ROUTE = /^\/v1\/bot-shares\/([^/]+)\/package$/;
+const BOT_SHARE_LANDING_ROUTE = /^\/s\/([^/]+)$/;
 
 const BETTER_AUTH_ERROR_CODES = new Map([
   ["INVALID_EMAIL", "invalid_email"],
@@ -79,6 +94,19 @@ async function route(
   }
 
   const auth = createAuth(env, ctx, config, requestId);
+  const baseURL = new URL(config.authBaseURL).origin;
+  if (request.method === "GET" && url.pathname === "/v1/bot-shares") return listBotShares(request, env, auth, baseURL);
+  if (request.method === "POST" && url.pathname === "/v1/bot-shares") return createBotShare(request, env, auth, baseURL);
+  const shareVersion = url.pathname.match(BOT_SHARE_VERSION_ROUTE);
+  if (request.method === "POST" && shareVersion) return updateBotShare(request, shareVersion[1], env, auth, baseURL);
+  const shareVisibility = url.pathname.match(BOT_SHARE_VISIBILITY_ROUTE);
+  if (request.method === "POST" && shareVisibility) return updateBotShareVisibility(request, shareVisibility[1], env, auth, baseURL);
+  const sharePackage = url.pathname.match(BOT_SHARE_PACKAGE_ROUTE);
+  if (request.method === "GET" && sharePackage) return publicBotSharePackage(sharePackage[1], env);
+  const shareLanding = url.pathname.match(BOT_SHARE_LANDING_ROUTE);
+  if (request.method === "GET" && shareLanding) return publicBotShareLanding(shareLanding[1], env, baseURL);
+  const share = url.pathname.match(BOT_SHARE_ROUTE);
+  if (request.method === "DELETE" && share) return deleteBotShare(request, share[1], env, auth);
   if (request.method === "GET" && url.pathname === "/v1/me") {
     const session = await accountSession(request, auth);
     if (!session) throw new HTTPError(401, "unauthorized");
@@ -156,7 +184,13 @@ export function createWorker(cloudflareFetch: CloudflareFetch = fetch) {
         if (origin && !config.allowedOrigins.has(origin)) {
           return secureResponse(errorResponse(403, "origin_not_allowed"), request, config, requestId);
         }
-        const boundedRequest = await withBoundedRequestBody(request);
+        const publishBody = request.method === "POST" && (
+          url.pathname === "/v1/bot-shares" || BOT_SHARE_VERSION_ROUTE.test(url.pathname)
+        );
+        const boundedRequest = await withBoundedRequestBody(
+          request,
+          publishBody ? BOT_SHARE_PUBLISH_BODY_MAX_BYTES : undefined,
+        );
         return secureResponse(
           await route(boundedRequest, env, ctx, config, requestId, cloudflareFetch),
           request,

--- a/cloudflare/control-plane/test/bot-shares.test.ts
+++ b/cloudflare/control-plane/test/bot-shares.test.ts
@@ -1,0 +1,196 @@
+import { env } from "cloudflare:workers";
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { stringify as stringifyYaml } from "yaml";
+
+import { createAuth } from "../src/auth";
+import {
+  BOT_SHARE_MAX_PER_OWNER,
+  BOT_SHARE_MAX_VERSIONS,
+  BOT_SHARE_PACKAGE_MAX_BYTES,
+} from "../src/bot-shares";
+import { readConfig } from "../src/config";
+import worker from "../src/index";
+
+const BASE_URL = "https://auth.openmausbot.test";
+
+async function call(path: string, options: { method?: string; bearer?: string; body?: unknown } = {}) {
+  const headers = new Headers();
+  if (options.bearer) headers.set("authorization", `Bearer ${options.bearer}`);
+  let body: string | undefined;
+  if (options.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(options.body);
+  }
+  const request = new Request(`${BASE_URL}${path}`, { method: options.method ?? "GET", headers, body });
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function signIn(email: string) {
+  const ctx = createExecutionContext();
+  const auth = createAuth(env, ctx, readConfig(env), crypto.randomUUID());
+  const otp = await auth.api.createVerificationOTP({ body: { email, type: "sign-in" } });
+  await waitOnExecutionContext(ctx);
+  const response = await call("/api/auth/sign-in/email-otp", {
+    method: "POST",
+    body: { email, otp, name: email.split("@", 1)[0] },
+  });
+  expect(response.status).toBe(200);
+  const bearer = response.headers.get("set-auth-token");
+  if (!bearer) throw new Error("missing account bearer");
+  return bearer;
+}
+
+function packageMarkdown(name = "Research Team", summary = "A safe portable team.") {
+  const frontmatter = stringifyYaml({
+    botmrr: 1,
+    id: "research-team",
+    release: "1.0.0",
+    name,
+    tagline: "Research with a small focused team.",
+    summary,
+    category: "Research",
+    author: { name: "OpenMausBot user" },
+    license: "Unspecified",
+    outcomes: ["Produce a reviewed brief."],
+    setupMinutes: 3,
+    requirements: { apps: [], capabilities: [] },
+    agents: [{
+      key: "researcher",
+      name: "Researcher",
+      title: "Research lead",
+      description: "Find and synthesize evidence.",
+      appearance: { color: "blue", mascotBody: "star" },
+    }],
+    chiefOfStaff: "researcher",
+  }, { lineWidth: 0 }).trim();
+  return `---\n${frontmatter}\n---\n\n## Activation\n\nActivate.\n\n## Mission\n\n${summary}\n\n## Outcomes\n\n- Brief\n\n## Connections\n\n- None\n\n## Team\n\nResearcher\n\n## Chief of Staff\n\nresearcher\n\n## Completion rule\n\nReturn a brief.\n`;
+}
+
+async function createShare(bearer: string, markdown = packageMarkdown()) {
+  const response = await call("/v1/bot-shares", {
+    method: "POST",
+    bearer,
+    body: { packageMarkdown: markdown },
+  });
+  expect(response.status).toBe(201);
+  return response.json<{ share: { id: string; activeVersion: number; sha256: string; packageUrl: string } }>();
+}
+
+describe("managed bot shares", () => {
+  it("requires account ownership and keeps local package metadata canonical", async () => {
+    const owner = await signIn("share-owner@example.com");
+    const other = await signIn("share-other@example.com");
+    expect((await call("/v1/bot-shares", { method: "POST", body: { packageMarkdown: packageMarkdown() } })).status).toBe(401);
+
+    const { share } = await createShare(owner, packageMarkdown("UTF-8 мышь"));
+    expect(share.id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    expect(share.activeVersion).toBe(1);
+    expect(share.packageUrl).toBe(`https://accounts.openmausbot.com/v1/bot-shares/${share.id}/package`);
+    expect((await call("/v1/bot-shares", { bearer: other }).then((response) => response.json<{ shares: unknown[] }>())))
+      .toEqual({ shares: [] });
+
+    const smuggled = packageMarkdown().replace("botmrr: 1", "botmrr: 1\naccountToken: secret-value") + "\n<!-- private runtime memory -->"; // secret-scan: allow-test-fixture
+    const sanitized = await createShare(owner, smuggled);
+    const stored = await call(`/v1/bot-shares/${sanitized.share.id}/package`);
+    const storedMarkdown = await stored.text();
+    expect(storedMarkdown).not.toContain("accountToken");
+    expect(storedMarkdown).toContain("mascotBody: star");
+    expect(await call(`/v1/bot-shares/${share.id}/visibility`, { method: "POST", bearer: other, body: { visibility: "private" } })).toMatchObject({ status: 404 });
+  });
+
+  it("uses immutable versions with compare-and-swap conflict handling and tombstone delete", async () => {
+    const bearer = await signIn("share-lifecycle@example.com");
+    const { share: created } = await createShare(bearer, packageMarkdown("First"));
+    const updated = await call(`/v1/bot-shares/${created.id}/versions`, {
+      method: "POST", bearer,
+      body: { packageMarkdown: packageMarkdown("Second"), expectedActiveVersion: 1 },
+    });
+    expect(updated.status).toBe(200);
+    await expect(updated.json()).resolves.toMatchObject({ share: { activeVersion: 2, name: "Second" } });
+
+    const stale = await call(`/v1/bot-shares/${created.id}/versions`, {
+      method: "POST", bearer,
+      body: { packageMarkdown: packageMarkdown("Lost update"), expectedActiveVersion: 1 },
+    });
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({ error: "version_conflict" });
+
+    expect((await call(`/v1/bot-shares/${created.id}`, { method: "DELETE", bearer })).status).toBe(204);
+    expect((await call(`/v1/bot-shares/${created.id}/package`)).status).toBe(404);
+    const versions = await env.DB.prepare("SELECT version FROM bot_share_versions WHERE share_id = ? ORDER BY version")
+      .bind(created.id).all<{ version: number }>();
+    expect(versions.results.map((row) => row.version)).toEqual([1, 2]);
+  });
+
+  it("serves only public active packages and escapes the landing page", async () => {
+    const bearer = await signIn("share-public@example.com");
+    const { share } = await createShare(bearer, packageMarkdown("<Unsafe & Bot>", "<img src=x onerror=alert(1)>"));
+    const pkg = await call(`/v1/bot-shares/${share.id}/package`);
+    expect(pkg.status).toBe(200);
+    expect(pkg.headers.get("content-type")).toContain("text/markdown");
+    expect(pkg.headers.get("x-content-sha256")).toBe(share.sha256);
+    const landing = await call(`/s/${share.id}`);
+    expect(landing.status).toBe(200);
+    const html = await landing.text();
+    expect(html).toContain("&lt;Unsafe &amp; Bot&gt;");
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(html).not.toContain("<script");
+    expect(html).toContain("Download BotMRR package");
+    expect(html).not.toContain("openmausbot://");
+    expect(pkg.headers.get("cache-control")).toBe("no-store");
+    expect(landing.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("enforces per-account share and immutable-version quotas in D1", async () => {
+    const ownerEmail = "share-quota@example.com";
+    const bearer = await signIn(ownerEmail);
+    const owner = await env.DB.prepare('SELECT id FROM "user" WHERE email = ?')
+      .bind(ownerEmail).first<{ id: string }>();
+    if (!owner) throw new Error("missing quota owner");
+    const now = Date.now();
+    await env.DB.batch(Array.from({ length: BOT_SHARE_MAX_PER_OWNER }, (_, index) => {
+      const id = `quota-${String(index).padStart(15, "0")}`;
+      return env.DB.prepare("INSERT INTO bot_shares (id, owner_user_id, visibility, active_version, created_at, updated_at) VALUES (?, ?, 'private', 1, ?, ?)")
+        .bind(id, owner.id, now, now);
+    }));
+    const shareLimit = await call("/v1/bot-shares", {
+      method: "POST", bearer, body: { packageMarkdown: packageMarkdown() },
+    });
+    expect(shareLimit.status).toBe(409);
+    await expect(shareLimit.json()).resolves.toEqual({ error: "share_limit_reached" });
+
+    const versionToken = await signIn("version-quota@example.com");
+    const { share } = await createShare(versionToken);
+    await env.DB.batch(Array.from({ length: BOT_SHARE_MAX_VERSIONS - 1 }, (_, index) => {
+      const version = index + 2;
+      return env.DB.prepare("INSERT INTO bot_share_versions (share_id, version, name, summary, package_markdown, package_sha256, package_bytes, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)")
+        .bind(share.id, version, `Version ${version}`, "Quota fixture", packageMarkdown(), "0".repeat(64), 1, now + version);
+    }));
+    const versionLimit = await call(`/v1/bot-shares/${share.id}/versions`, {
+      method: "POST", bearer: versionToken,
+      body: { packageMarkdown: packageMarkdown("Too many"), expectedActiveVersion: BOT_SHARE_MAX_VERSIONS },
+    });
+    expect(versionLimit.status).toBe(409);
+    await expect(versionLimit.json()).resolves.toEqual({ error: "version_limit_reached" });
+  });
+
+  it("allows worst-case JSON escaping within the transport budget", async () => {
+    const bearer = await signIn("share-json-budget@example.com");
+    const response = await call("/v1/bot-shares", {
+      method: "POST",
+      bearer,
+      body: {
+        packageMarkdown: "\u0000".repeat(BOT_SHARE_PACKAGE_MAX_BYTES),
+        visibility: "private",
+      },
+    });
+    // The package itself is invalid, but it must reach package validation
+    // rather than being rejected by the transport envelope first.
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_package" });
+  });
+});

--- a/electron/companion-account-service.mjs
+++ b/electron/companion-account-service.mjs
@@ -137,6 +137,11 @@ const FRIENDLY_MESSAGES = Object.freeze({
   credential_rotation_rate_limited: "This computer was reconnected too often. Wait a little, then try again.",
   installation_limit_reached: "This account has reached its computer limit. Remove an old computer and try again.",
   installation_exists: "This computer is already connected. Try again to recover it.",
+  version_conflict: "This shared bot changed before the new version was published. Review the latest version and try again.",
+  invalid_package: "The BotMRR package could not be validated. Export a fresh preview and try again.",
+  package_too_large: "The BotMRR package is larger than 1 MB.",
+  share_limit_reached: "This account already has 100 active shared links. Delete one before publishing another.",
+  version_limit_reached: "This shared link already has 50 versions. Publish a new link instead.",
   endpoint_busy: "The secure connection is still being prepared. Try again in a moment.",
   endpoint_unavailable: "The secure connection service could not finish setup. Local pairing still works; try again shortly.",
   endpoint_cleanup_pending: "The secure connection is still being removed. Try signing out again shortly.",
@@ -615,6 +620,22 @@ export function createCompanionAccountService({
     return settledState();
   });
 
+  const shareAccount = () => {
+    if (!configured) throw new Error(FRIENDLY_MESSAGES.control_plane_unavailable);
+    const account = storedAccount(credentials());
+    if (!account?.accountToken) throw new Error("Sign in to publish and manage shared bots.");
+    return account;
+  };
+
+  const shareAction = async (action) => {
+    const account = shareAccount();
+    try {
+      return await action(account.accountToken);
+    } catch (error) {
+      throw new Error(friendlyCompanionAccountError(error));
+    }
+  };
+
   return Object.freeze({
     state: async () => {
       await probeControlPlane();
@@ -625,5 +646,10 @@ export function createCompanionAccountService({
     retry,
     signOut,
     restore,
+    listBotShares: () => shareAction((accountToken) => client.listBotShares(accountToken)),
+    createBotShare: (input) => serialize(() => shareAction((accountToken) => client.createBotShare(accountToken, input))),
+    updateBotShare: (shareId, input) => serialize(() => shareAction((accountToken) => client.updateBotShare(accountToken, shareId, input))),
+    setBotShareVisibility: (shareId, visibility) => serialize(() => shareAction((accountToken) => client.setBotShareVisibility(accountToken, shareId, visibility))),
+    deleteBotShare: (shareId) => serialize(() => shareAction((accountToken) => client.deleteBotShare(accountToken, shareId))),
   });
 }

--- a/electron/companion-account-service.test.mjs
+++ b/electron/companion-account-service.test.mjs
@@ -64,6 +64,11 @@ function readyClient(overrides = {}) {
       connectorToken: CONNECTOR_TOKEN,
     })),
     listInstallations: vi.fn(async () => []),
+    listBotShares: vi.fn(async () => []),
+    createBotShare: vi.fn(async (_token, input) => ({ id: "Abcdefghijklmnopqrstu", ...input })),
+    updateBotShare: vi.fn(async (_token, shareId, input) => ({ id: shareId, ...input })),
+    setBotShareVisibility: vi.fn(async (_token, shareId, visibility) => ({ id: shareId, visibility })),
+    deleteBotShare: vi.fn(async () => {}),
     deleteEndpoint: vi.fn(async () => {}),
     revokeInstallation: vi.fn(async () => {}),
     signOut: vi.fn(async () => {}),
@@ -104,6 +109,49 @@ function signedCredentials(overrides = {}) {
 }
 
 describe("Companion account service", () => {
+  it("uses the stored account bearer for share actions without persisting or exposing it", async () => {
+    const share = { id: "Abcdefghijklmnopqrstu", visibility: "unlisted" };
+    const client = readyClient({
+      listBotShares: vi.fn(async () => [share]),
+      createBotShare: vi.fn(async () => share),
+    });
+    const { service, store } = serviceFixture({ initial: signedCredentials(), client });
+
+    await expect(service.listBotShares()).resolves.toEqual([share]);
+    await expect(service.createBotShare({ packageMarkdown: "# safe" })).resolves.toEqual(share);
+    expect(client.listBotShares).toHaveBeenCalledWith(ACCOUNT_TOKEN);
+    expect(client.createBotShare).toHaveBeenCalledWith(ACCOUNT_TOKEN, { packageMarkdown: "# safe" });
+    expect(store.writes).toHaveLength(0);
+  });
+
+  it("keeps the local-ready account state usable when remote share listing fails", async () => {
+    const client = readyClient({
+      listBotShares: vi.fn(async () => {
+        throw new ControlPlaneError("not_found", 404);
+      }),
+    });
+    const { service, store } = serviceFixture({ initial: signedCredentials(), client });
+
+    await expect(service.listBotShares()).rejects.toThrow("The secure connection request could not be completed");
+    await expect(service.state()).resolves.toMatchObject({
+      available: true,
+      status: "ready",
+      email: "ada@example.com",
+      endpoint: ENDPOINT,
+    });
+    expect(store.writes).toHaveLength(0);
+  });
+
+  it("fails share actions closed while signed out", async () => {
+    const client = readyClient();
+    const { service } = serviceFixture({
+      initial: { [COMPANION_INSTALLATION_CREDENTIAL_FIELD]: INSTALLATION_CREDENTIAL },
+      client,
+    });
+    await expect(service.listBotShares()).rejects.toThrow("Sign in to publish");
+    expect(client.listBotShares).not.toHaveBeenCalled();
+  });
+
   it("uses the packaged hosted default and only explicit safe development origins", () => {
     expect(resolveCompanionControlPlaneURL({ isPackaged: true, environment: {} })).toBe(
       "https://accounts.openmausbot.com",

--- a/electron/control-plane-client.mjs
+++ b/electron/control-plane-client.mjs
@@ -4,6 +4,9 @@ const INSTALLATION_ID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const CLIENT_INSTANCE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const REQUEST_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const BOT_SHARE_ID = /^[A-Za-z0-9_-]{21}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const BOT_PACKAGE_MAX_BYTES = 1_000_000;
 
 const stringValue = (value) => (typeof value === "string" ? value : null);
 
@@ -164,6 +167,49 @@ function validatedEndpoint(value) {
   return { url: url.origin };
 }
 
+function safeInteger(value, minimum = 0) {
+  return Number.isSafeInteger(value) && value >= minimum ? value : null;
+}
+
+function boundedText(value, maximum) {
+  const input = stringValue(value);
+  return input !== null && input.length >= 1 && input.length <= maximum ? input : null;
+}
+
+function validatedBotShare(value, origin) {
+  const share = plainObject(value);
+  const id = stringValue(share?.id);
+  const visibility = share?.visibility;
+  const activeVersion = safeInteger(share?.activeVersion, 1);
+  const name = boundedText(share?.name, 100);
+  const summary = boundedText(share?.summary, 2_000);
+  const sha256 = stringValue(share?.sha256);
+  const byteSize = safeInteger(share?.byteSize, 1);
+  const createdAt = safeInteger(share?.createdAt);
+  const updatedAt = safeInteger(share?.updatedAt);
+  const versionCreatedAt = safeInteger(share?.versionCreatedAt);
+  if (
+    id === null || !BOT_SHARE_ID.test(id) ||
+    !["unlisted", "private"].includes(visibility) ||
+    activeVersion === null || !name || !summary ||
+    sha256 === null || !SHA256.test(sha256) ||
+    byteSize === null || byteSize > BOT_PACKAGE_MAX_BYTES ||
+    createdAt === null || updatedAt === null || versionCreatedAt === null ||
+    share?.shareUrl !== `${origin}/s/${id}` ||
+    share?.packageUrl !== `${origin}/v1/bot-shares/${id}/package`
+  ) return null;
+  return {
+    id, visibility, activeVersion, name, summary, sha256, byteSize,
+    createdAt, updatedAt, versionCreatedAt,
+    shareUrl: share.shareUrl, packageUrl: share.packageUrl,
+  };
+}
+
+function validatedPackageMarkdown(value) {
+  if (typeof value !== "string" || !value) return null;
+  return new TextEncoder().encode(value).byteLength <= BOT_PACKAGE_MAX_BYTES ? value : null;
+}
+
 export function createControlPlaneClient({
   baseURL,
   fetchImpl = globalThis.fetch,
@@ -176,10 +222,10 @@ export function createControlPlaneClient({
 
   const request = async (
     path,
-    { method = "GET", token, body, allowEmpty = false, deadlineMs = timeoutMs } = {},
+    { method = "GET", bearer, body, allowEmpty = false, deadlineMs = timeoutMs } = {},
   ) => {
     const headers = new Headers({ accept: "application/json" });
-    if (token) headers.set("authorization", `Bearer ${token}`);
+    if (bearer) headers.set("authorization", `Bearer ${bearer}`);
     // Node's fetch sends `Sec-Fetch-Mode: cors` even though Electron is a
     // native client. Better Auth 1.7 treats that Fetch Metadata as a
     // browser-shaped request and requires a trusted Origin. Our exact,
@@ -226,7 +272,7 @@ export function createControlPlaneClient({
 
   const accountInstallations = async (accountToken) => {
     if (!boundedSecret(accountToken)) throw new ControlPlaneError("signed_out", 401);
-    const { payload } = await request("/v1/installations", { token: accountToken });
+    const { payload } = await request("/v1/installations", { bearer: accountToken });
     if (!Array.isArray(payload.installations)) {
       throw new ControlPlaneError("invalid_response");
     }
@@ -235,6 +281,18 @@ export function createControlPlaneClient({
       throw new ControlPlaneError("invalid_response");
     }
     return installations;
+  };
+
+  const accountTokenOrThrow = (accountToken) => {
+    const bearer = boundedSecret(accountToken);
+    if (!bearer || INSTALLATION_CREDENTIAL.test(bearer)) throw new ControlPlaneError("signed_out", 401);
+    return bearer;
+  };
+
+  const shareFromPayload = (payload) => {
+    const share = validatedBotShare(payload.share, origin);
+    if (!share) throw new ControlPlaneError("invalid_response");
+    return share;
   };
 
   return {
@@ -290,7 +348,7 @@ export function createControlPlaneClient({
 
     async me(accountToken) {
       if (!boundedSecret(accountToken)) throw new ControlPlaneError("signed_out", 401);
-      const { payload } = await request("/v1/me", { token: accountToken });
+      const { payload } = await request("/v1/me", { bearer: accountToken });
       const user = validatedUser(payload.user);
       if (!user) throw new ControlPlaneError("invalid_response");
       return user;
@@ -298,6 +356,55 @@ export function createControlPlaneClient({
 
     async listInstallations(accountToken) {
       return accountInstallations(accountToken);
+    },
+
+    async listBotShares(accountToken) {
+      const { payload } = await request("/v1/bot-shares", { bearer: accountTokenOrThrow(accountToken) });
+      if (!Array.isArray(payload.shares)) throw new ControlPlaneError("invalid_response");
+      const shares = payload.shares.map((share) => validatedBotShare(share, origin));
+      if (shares.some((share) => !share)) throw new ControlPlaneError("invalid_response");
+      return shares;
+    },
+
+    async createBotShare(accountToken, { packageMarkdown, visibility = "unlisted" } = {}) {
+      const markdown = validatedPackageMarkdown(packageMarkdown);
+      if (!markdown || !["unlisted", "private"].includes(visibility)) {
+        throw new ControlPlaneError("invalid_request", 400);
+      }
+      const { payload } = await request("/v1/bot-shares", {
+        method: "POST", bearer: accountTokenOrThrow(accountToken),
+        body: { packageMarkdown: markdown, visibility },
+      });
+      return shareFromPayload(payload);
+    },
+
+    async updateBotShare(accountToken, shareId, { packageMarkdown, expectedActiveVersion } = {}) {
+      const markdown = validatedPackageMarkdown(packageMarkdown);
+      if (!BOT_SHARE_ID.test(String(shareId)) || !markdown || !Number.isSafeInteger(expectedActiveVersion) || expectedActiveVersion < 1) {
+        throw new ControlPlaneError("invalid_request", 400);
+      }
+      const { payload } = await request(`/v1/bot-shares/${shareId}/versions`, {
+        method: "POST", bearer: accountTokenOrThrow(accountToken),
+        body: { packageMarkdown: markdown, expectedActiveVersion },
+      });
+      return shareFromPayload(payload);
+    },
+
+    async setBotShareVisibility(accountToken, shareId, visibility) {
+      if (!BOT_SHARE_ID.test(String(shareId)) || !["unlisted", "private"].includes(visibility)) {
+        throw new ControlPlaneError("invalid_request", 400);
+      }
+      const { payload } = await request(`/v1/bot-shares/${shareId}/visibility`, {
+        method: "POST", bearer: accountTokenOrThrow(accountToken), body: { visibility },
+      });
+      return shareFromPayload(payload);
+    },
+
+    async deleteBotShare(accountToken, shareId) {
+      if (!BOT_SHARE_ID.test(String(shareId))) throw new ControlPlaneError("invalid_request", 400);
+      await request(`/v1/bot-shares/${shareId}`, {
+        method: "DELETE", bearer: accountTokenOrThrow(accountToken), allowEmpty: true,
+      });
     },
 
     async ensureInstallation({ accountToken, currentCredential, clientInstanceId, name, platform, appVersion }) {
@@ -312,7 +419,7 @@ export function createControlPlaneClient({
         INSTALLATION_CREDENTIAL.test(currentCredential)
       ) {
         try {
-          const { payload } = await request("/v1/installations/self", { token: currentCredential });
+          const { payload } = await request("/v1/installations/self", { bearer: currentCredential });
           const installation = validatedInstallation(payload.installation);
           if (installation?.clientInstanceId === clientInstanceId) {
             return {
@@ -335,11 +442,11 @@ export function createControlPlaneClient({
       const result = existing
         ? await request(`/v1/installations/${encodeURIComponent(existing.id)}/credentials/rotate`, {
             method: "POST",
-            token: accountToken,
+            bearer: accountToken,
           })
         : await request("/v1/installations", {
             method: "POST",
-            token: accountToken,
+            bearer: accountToken,
             body: { clientInstanceId, name, platform, appVersion },
           });
       const installation = existing ?? validatedInstallation(result.payload.installation);
@@ -366,7 +473,7 @@ export function createControlPlaneClient({
       }
       const { payload } = await request("/v1/installations/self/endpoint", {
         method: "POST",
-        token: installationCredential,
+        bearer: installationCredential,
       });
       const endpoint = validatedEndpoint(payload.endpoint);
       const connectorToken = boundedSecret(payload.connectorToken, 16_384);
@@ -383,7 +490,7 @@ export function createControlPlaneClient({
       }
       await request("/v1/installations/self/endpoint", {
         method: "DELETE",
-        token: installationCredential,
+        bearer: installationCredential,
         allowEmpty: true,
       });
     },
@@ -398,7 +505,7 @@ export function createControlPlaneClient({
       }
       await request(`/v1/installations/${encodeURIComponent(installationId)}`, {
         method: "DELETE",
-        token: accountToken,
+        bearer: accountToken,
         allowEmpty: true,
       });
     },
@@ -407,7 +514,7 @@ export function createControlPlaneClient({
       if (!boundedSecret(accountToken)) return;
       await request("/api/auth/sign-out", {
         method: "POST",
-        token: accountToken,
+        bearer: accountToken,
       });
     },
   };

--- a/electron/control-plane-client.test.mjs
+++ b/electron/control-plane-client.test.mjs
@@ -236,6 +236,38 @@ describe("control-plane desktop client", () => {
     });
   });
 
+  it("keeps account credentials in headers while validating managed share metadata", async () => {
+    const id = "Abcdefghijklmnopqrstu";
+    const share = {
+      id,
+      visibility: "unlisted",
+      activeVersion: 1,
+      name: "Research Team",
+      summary: "A portable team.",
+      sha256: "a".repeat(64),
+      byteSize: 120,
+      createdAt: 1,
+      updatedAt: 1,
+      versionCreatedAt: 1,
+      shareUrl: `https://accounts.openmausbot.com/s/${id}`,
+      packageUrl: `https://accounts.openmausbot.com/v1/bot-shares/${id}/package`,
+    };
+    const fetchImpl = vi.fn(async (url, init) => {
+      expect(init.headers.get("authorization")).toBe(`Bearer ${ACCOUNT}`);
+      expect(String(url)).not.toContain(ACCOUNT);
+      if (init.method === "DELETE") return new Response(null, { status: 204 });
+      return jsonResponse(String(url).endsWith("/v1/bot-shares") && init.method === "GET"
+        ? { shares: [share] }
+        : { share });
+    });
+    const client = createControlPlaneClient({ baseURL: "https://accounts.openmausbot.com", fetchImpl });
+
+    await expect(client.listBotShares(ACCOUNT)).resolves.toEqual([share]);
+    await expect(client.createBotShare(ACCOUNT, { packageMarkdown: "# safe" })).resolves.toEqual(share);
+    await expect(client.deleteBotShare(ACCOUNT, id)).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   it("validates endpoint material without leaking the connector token into the URL", async () => {
     const connectorToken = `eyJ${"x".repeat(80)}`;
     const fetchImpl = vi.fn(async (url, init) => {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -2004,17 +2004,57 @@ ipcMain.handle("companion:revoke", localOnly("companion:revoke", (_event, device
   companionRevoke(deviceId).then(() => desktopCompanionState()),
 ));
 
-// Auth and connector credentials never cross this boundary. Every handler
-// returns the same deliberately tiny, secret-free public account state.
-ipcMain.handle("companion-account:state", localOnly("companion-account:state", () => ensureCompanionAccountService().state()));
-ipcMain.handle("companion-account:request-code", localOnly("companion-account:request-code", (_event, email) =>
-  ensureCompanionAccountService().requestCode(email),
-));
-ipcMain.handle("companion-account:verify-code", localOnly("companion-account:verify-code", (_event, email, code) =>
-  ensureCompanionAccountService().verifyCode(email, code),
-));
-ipcMain.handle("companion-account:retry", localOnly("companion-account:retry", () => ensureCompanionAccountService().retry()));
-ipcMain.handle("companion-account:sign-out", localOnly("companion-account:sign-out", () => ensureCompanionAccountService().signOut()));
+// returns the same deliberately tiny, secret-free public account state. Keep
+// account-backed calls on the main app renderer: a child BrowserWindow must
+// not get to reuse the process-owned account bearer or share mutations.
+function mainWindowForAccountEvent(event) {
+  const owner = mainWindow;
+  if (!owner || owner.isDestroyed() || event.sender !== owner.webContents) {
+    throw new Error("Account actions are available only to the main app window");
+  }
+  return owner;
+}
+
+ipcMain.handle("companion-account:state", localOnly("companion-account:state", (event) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().state();
+}));
+ipcMain.handle("companion-account:request-code", localOnly("companion-account:request-code", (event, email) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().requestCode(email);
+}));
+ipcMain.handle("companion-account:verify-code", localOnly("companion-account:verify-code", (event, email, code) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().verifyCode(email, code);
+}));
+ipcMain.handle("companion-account:retry", localOnly("companion-account:retry", (event) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().retry();
+}));
+ipcMain.handle("companion-account:sign-out", localOnly("companion-account:sign-out", (event) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().signOut();
+}));
+ipcMain.handle("bot-shares:list", localOnly("bot-shares:list", (event) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().listBotShares();
+}));
+ipcMain.handle("bot-shares:create", localOnly("bot-shares:create", (event, input) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().createBotShare(input);
+}));
+ipcMain.handle("bot-shares:update", localOnly("bot-shares:update", (event, shareId, input) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().updateBotShare(shareId, input);
+}));
+ipcMain.handle("bot-shares:visibility", localOnly("bot-shares:visibility", (event, shareId, visibility) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().setBotShareVisibility(shareId, visibility);
+}));
+ipcMain.handle("bot-shares:delete", localOnly("bot-shares:delete", (event, shareId) => {
+  mainWindowForAccountEvent(event);
+  return ensureCompanionAccountService().deleteBotShare(shareId);
+}));
 
 ipcMain.handle("environments:state", (event) => ({
   localOrigin: rendererOrigin(),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -55,6 +55,15 @@ const bridge = {
     retry: () => ipcRenderer.invoke("companion-account:retry"),
     signOut: () => ipcRenderer.invoke("companion-account:sign-out"),
   },
+  /** Account-owned bot shares. The bearer stays in main; only validated
+   * metadata and user-authored package Markdown cross this bridge. */
+  botShares: {
+    list: () => ipcRenderer.invoke("bot-shares:list"),
+    create: (input) => ipcRenderer.invoke("bot-shares:create", input),
+    update: (shareId, input) => ipcRenderer.invoke("bot-shares:update", shareId, input),
+    setVisibility: (shareId, visibility) => ipcRenderer.invoke("bot-shares:visibility", shareId, visibility),
+    delete: (shareId) => ipcRenderer.invoke("bot-shares:delete", shareId),
+  },
   localControl: {
     status: () => ipcRenderer.invoke("cua:linux-status"),
     enable: () => ipcRenderer.invoke("cua:linux-enable"),

--- a/server/index.ts
+++ b/server/index.ts
@@ -236,7 +236,7 @@ import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./scree
 import { RoutineRequestService } from "./routine-requests.ts";
 import { fetchBotDirectory, matchDirectoryBots, type MatchedDirectoryBot } from "./bot-directory.ts";
 import { scoutProject, suggestTeam } from "./project-scout.ts";
-import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
+import { fetchGithubTeam, fetchLibraryTeam, fetchSharedBotPackage, fetchTeamCatalog } from "./team-library.ts";
 import { isBotPackage, packageAgentAsMember, parseBotPackage, renderBotPackageMarkdown } from "./bot-package.ts";
 import { createTeamManifest, importedMemberProfile, parseTeamManifest } from "./team-manifest.ts";
 import { readThreadEvents } from "./thread-events.ts";
@@ -7232,6 +7232,18 @@ const server = createServer(async (req, res) => {
       } catch (error) {
         const status = (error as { status?: number }).status === 404 ? 404 : 400;
         return json(res, status, { error: error instanceof Error ? error.message : "The GitHub team could not be loaded" });
+      }
+    }
+    if (method === "POST" && path === "/api/team-library/shared") {
+      const body = await readBody(req);
+      if (!body || typeof body.url !== "string" || !body.url.trim()) {
+        return json(res, 400, { error: "An OpenMausBot shared package URL is required" });
+      }
+      try {
+        return json(res, 200, await fetchSharedBotPackage(body.url));
+      } catch (error) {
+        const status = (error as { status?: number }).status === 404 ? 404 : 400;
+        return json(res, status, { error: error instanceof Error ? error.message : "The shared bot could not be loaded" });
       }
     }
     if (method === "GET" && path === "/api/teams/scout") {

--- a/server/team-library.test.ts
+++ b/server/team-library.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  BOT_SHARE_ORIGIN,
   TEAM_LIBRARY_CATALOG_URL,
   TEAM_LIBRARY_RAW_ROOT,
   fetchGithubTeam,
   fetchLibraryTeam,
+  fetchSharedBotPackage,
   githubManifestUrls,
   parseTeamCatalog,
+  sharedPackageUrl,
 } from "./team-library.ts";
+import { renderBotPackageMarkdown, type ParsedBotPackage } from "./bot-package.ts";
 
 const manifest = {
   format: "openmaus.team",
@@ -106,5 +110,49 @@ describe("team library", () => {
     if (loaded.format !== "openmaus.team") throw new Error("expected a legacy team");
     expect(loaded.team.members[0]?.name).toBe("Ada");
     expect(fetcher).toHaveBeenCalledTimes(6);
+  });
+
+  it("fetches, validates, and parses only exact OpenMausBot shared package links", async () => {
+    const shareId = "Abcdefghijklmnopqrstu";
+    const url = `${BOT_SHARE_ORIGIN}/v1/bot-shares/${shareId}/package`;
+    const document: ParsedBotPackage = {
+      format: "openmaus.package",
+      version: 1,
+      package: {
+        id: "shared-researcher",
+        release: "1.0.0",
+        name: "Shared Researcher",
+        tagline: "Research a focused question.",
+        summary: "A portable shared bot.",
+        category: "Research",
+        author: { name: "OpenMausBot user" },
+        license: "Unspecified",
+        outcomes: ["Produce a concise brief."],
+        setupMinutes: 2,
+        requirements: { apps: [], capabilities: [] },
+        agents: [{ key: "researcher", name: "Shared Researcher", appearance: { color: "blue" } }],
+        chiefOfStaff: "researcher",
+      },
+    };
+    const markdown = renderBotPackageMarkdown(document);
+    const fetcher = vi.fn(async (target: string | URL | Request) => {
+      expect(String(target)).toBe(url);
+      return new Response(markdown, { headers: { "content-type": "text/markdown" } });
+    }) as unknown as typeof fetch;
+
+    expect(sharedPackageUrl(url)).toBe(url);
+    expect(sharedPackageUrl(`${BOT_SHARE_ORIGIN}/s/${shareId}`)).toBe(url);
+    const loaded = await fetchSharedBotPackage(url, fetcher);
+    expect(loaded).toEqual(document);
+    expect(fetcher).toHaveBeenCalledOnce();
+    for (const unsafe of [
+      `${url}?version=1`,
+      `${BOT_SHARE_ORIGIN}:443/v1/bot-shares/${shareId}/package`,
+      `${BOT_SHARE_ORIGIN}/v1/bot-shares/short/package`,
+      `https://accounts.openmausbot.com.evil.example/v1/bot-shares/${shareId}/package`,
+      `${BOT_SHARE_ORIGIN}/share/${shareId}`,
+    ]) {
+      expect(() => sharedPackageUrl(unsafe)).toThrow("exact OpenMausBot");
+    }
   });
 });

--- a/server/team-library.ts
+++ b/server/team-library.ts
@@ -5,6 +5,7 @@ import { parseTeamManifest, type ParsedTeamManifest } from "./team-manifest.ts";
 export const TEAM_LIBRARY_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
 export const TEAM_LIBRARY_RAW_ROOT = "https://raw.githubusercontent.com/milind-soni/openmausbot-teams/main";
 export const TEAM_LIBRARY_CATALOG_URL = `${TEAM_LIBRARY_RAW_ROOT}/catalog.json`;
+export const BOT_SHARE_ORIGIN = "https://accounts.openmausbot.com";
 
 const MAX_CATALOG_BYTES = 256_000;
 const MAX_MANIFEST_BYTES = 1_000_000;
@@ -235,4 +236,56 @@ export async function fetchGithubTeam(input: string, fetcher: Fetcher = fetch): 
     }
   }
   throw lastError ?? new Error("No botmrr.md, team.md, or legacy team file was found in that repository");
+}
+
+export function sharedPackageUrl(input: string): string {
+  const raw = input.trim();
+  // URL normalisation erases the explicit default port, so reject it from
+  // the raw authority before constructing URL. The share contract uses one
+  // exact HTTPS origin and does not need an explicit :443 spelling.
+  if (/^https:\/\/[^/?#]*:443(?:[/?#]|$)/i.test(raw)) {
+    throw new Error("Only exact OpenMausBot shared links are supported");
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("Enter a valid OpenMausBot shared package URL");
+  }
+  const packageMatch = url.pathname.match(/^\/v1\/bot-shares\/([A-Za-z0-9_-]{21})\/package$/);
+  const landingMatch = url.pathname.match(/^\/s\/([A-Za-z0-9_-]{21})$/);
+  if (
+    url.origin !== BOT_SHARE_ORIGIN ||
+    url.username ||
+    url.password ||
+    url.port ||
+    url.search ||
+    url.hash ||
+    (!packageMatch && !landingMatch)
+  ) {
+    throw new Error("Only exact OpenMausBot shared links are supported");
+  }
+  const shareId = packageMatch?.[1] ?? landingMatch?.[1];
+  return `${BOT_SHARE_ORIGIN}/v1/bot-shares/${shareId}/package`;
+}
+
+/** Fetch one public, active, unlisted package. Private, deleted, and unknown
+ * shares all arrive as the same upstream failure and never reach preview. */
+export async function fetchSharedBotPackage(input: string, fetcher: Fetcher = fetch): Promise<ParsedBotPackage> {
+  const url = sharedPackageUrl(input);
+  const response = await fetcher(url, {
+    headers: { accept: "text/markdown" },
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw Object.assign(new Error("That shared bot is unavailable"), { status: response.status });
+  }
+  const announced = Number(response.headers.get("content-length") ?? 0);
+  if (announced > MAX_MANIFEST_BYTES) throw new Error("The shared bot package is too large");
+  const markdown = await response.text();
+  if (Buffer.byteLength(markdown, "utf8") > MAX_MANIFEST_BYTES) {
+    throw new Error("The shared bot package is too large");
+  }
+  return parseBotPackage(markdown);
 }

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -3,20 +3,25 @@ import { cn } from "@/lib/cn";
 import { teamImportPreview, type PendingTeamImport } from "@/lib/team-import";
 import type { Routine } from "@/lib/routines";
 import { api, useStore, type Bot, type Group } from "@/state/store";
+import type { BotShare, BotShareVisibility, CompanionAccountState } from "@/types/ogb";
 import {
   ArrowLeft,
   BookOpen,
   CalendarClock,
   Check,
   Compass,
+  Copy,
   Crown,
   ExternalLink,
   FolderOpen,
   Github,
+  Lock,
   Loader2,
   MessageSquare,
   Plug,
   Search,
+  Share2,
+  Trash2,
   UploadCloud,
   Users,
   X,
@@ -62,9 +67,15 @@ export interface TeamImportResult {
   archived: ArchivedTeamBot[];
 }
 
-type ImportSource = "library" | "file" | "github";
-type TeamTab = "explore" | "import" | "scout";
+type ImportSource = "library" | "file" | "github" | "shared";
+type TeamTab = "export" | "explore" | "import" | "scout";
 type ImportMode = "replace" | "add";
+
+interface PublishDraft {
+  name: string;
+  members: number;
+  markdown: string;
+}
 
 /** the scout endpoint's answer, as far as this panel renders it — the
  * manifest itself stays opaque and goes back to the server verbatim */
@@ -108,6 +119,18 @@ async function openExternal(url: string): Promise<void> {
   if (opened) opened.opener = null;
 }
 
+function downloadExportPackage(draft: PublishDraft): void {
+  const slug = draft.name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "botmrr-team";
+  const url = URL.createObjectURL(new Blob([draft.markdown], { type: "text/markdown;charset=utf-8" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${slug}.md`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
 function TeamGlyph({ index }: { index: number }) {
   return (
     <div className={cn("flex size-11 shrink-0 items-center justify-center rounded-xl", TEAM_GLYPHS[index % TEAM_GLYPHS.length])}>
@@ -130,7 +153,7 @@ export function TeamLibraryPanel({
   const { state, dispatch } = useStore();
   const dialogRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [tab, setTab] = useState<TeamTab>("explore");
+  const [tab, setTab] = useState<TeamTab>("export");
   const [catalog, setCatalog] = useState<TeamCatalog | null>(null);
   const [catalogLoading, setCatalogLoading] = useState(true);
   const [catalogError, setCatalogError] = useState("");
@@ -155,6 +178,13 @@ export function TeamLibraryPanel({
   const [pickedDirectory, setPickedDirectory] = useState<Set<string>>(new Set());
   const [roomName, setRoomName] = useState("");
   const [creating, setCreating] = useState(false);
+  const [accountState, setAccountState] = useState<CompanionAccountState | null>(null);
+  const [shares, setShares] = useState<BotShare[]>([]);
+  const [sharesLoading, setSharesLoading] = useState(false);
+  const [shareListError, setShareListError] = useState("");
+  const [shareBusy, setShareBusy] = useState("");
+  const [publishDraft, setPublishDraft] = useState<PublishDraft | null>(null);
+  const [publishVisibility, setPublishVisibility] = useState<BotShareVisibility>("unlisted");
   // monotonically increasing scout token: a late response from an older
   // scout (including its lazy directory call) must never overwrite state
   // that belongs to a newer one
@@ -178,6 +208,46 @@ export function TeamLibraryPanel({
   useEffect(() => {
     void loadCatalog();
   }, [loadCatalog]);
+
+  const loadShareAccount = useCallback(async () => {
+    const bridge = window.ogb;
+    setShareListError("");
+    if (!bridge?.companionAccount || !bridge.botShares) {
+      setAccountState(null);
+      setShares([]);
+      return;
+    }
+    try {
+      const account = await bridge.companionAccount.state();
+      setAccountState(account);
+      if (!account.email) {
+        setShares([]);
+        return;
+      }
+      setSharesLoading(true);
+      try {
+        setShares(await bridge.botShares.list());
+      } catch {
+        setShares([]);
+        setShareListError("Shared links are temporarily unavailable. Local export still works.");
+      } finally {
+        setSharesLoading(false);
+      }
+    } catch {
+      setAccountState({
+        available: false,
+        status: "error",
+        message: "The account could not be checked. Local export still works.",
+      });
+      setShares([]);
+      setSharesLoading(false);
+      setError("");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === "export") void loadShareAccount();
+  }, [loadShareAccount, tab]);
 
   useEffect(() => {
     dialogRef.current?.focus();
@@ -253,16 +323,29 @@ export function TeamLibraryPanel({
     await loadGithubUrl(githubUrl);
   };
 
+  const isSharedPackageLink = (value: string): boolean => {
+    try {
+      const url = new URL(value.trim());
+      return url.origin === "https://accounts.openmausbot.com" &&
+        (/^\/v1\/bot-shares\/[A-Za-z0-9_-]{21}\/package$/.test(url.pathname) ||
+          /^\/s\/[A-Za-z0-9_-]{21}$/.test(url.pathname)) &&
+        !url.username && !url.password && !url.port && !url.search && !url.hash;
+    } catch {
+      return false;
+    }
+  };
+
   const loadGithubUrl = async (requestedUrl: string) => {
     if (!requestedUrl.trim()) return;
     setGithubLoading(true);
     setError("");
     try {
-      const manifest = await api("/api/team-library/github", {
+      const shared = isSharedPackageLink(requestedUrl);
+      const manifest = await api(shared ? "/api/team-library/shared" : "/api/team-library/github", {
         method: "POST",
         body: JSON.stringify({ url: requestedUrl.trim() }),
       });
-      previewManifest(teamImportPreview(manifest), "github");
+      previewManifest(teamImportPreview(manifest), shared ? "shared" : "github");
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -409,6 +492,102 @@ export function TeamLibraryPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setCreating(false);
+    }
+  };
+
+  const createExportDraft = async (download: boolean): Promise<PublishDraft> => {
+    setShareBusy(download ? "export" : "publish");
+    setError("");
+    try {
+      const exported = (await api("/api/teams/export", {
+        method: "POST",
+        body: JSON.stringify({ format: "package" }),
+      })) as PublishDraft;
+      teamImportPreview(exported.markdown);
+      setPublishDraft(exported);
+      if (download) downloadExportPackage(exported);
+      return exported;
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setError(message);
+      throw cause;
+    } finally {
+      setShareBusy("");
+    }
+  };
+
+  const publishNewShare = async () => {
+    const botShares = window.ogb?.botShares;
+    if (!botShares) return;
+    setShareBusy("new");
+    setError("");
+    try {
+      const draft = publishDraft ?? await createExportDraft(false);
+      const created = await botShares.create({ packageMarkdown: draft.markdown, visibility: publishVisibility });
+      setShares((current) => [created, ...current.filter((share) => share.id !== created.id)]);
+      track("team_shared", { version: created.activeVersion, visibility: created.visibility });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setShareBusy("");
+    }
+  };
+
+  const publishShareVersion = async (share: BotShare) => {
+    const botShares = window.ogb?.botShares;
+    if (!botShares || !publishDraft) return;
+    setShareBusy(`version:${share.id}`);
+    setError("");
+    try {
+      const updated = await botShares.update(share.id, {
+        packageMarkdown: publishDraft.markdown,
+        expectedActiveVersion: share.activeVersion,
+      });
+      setShares((current) => current.map((item) => item.id === updated.id ? updated : item));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      await loadShareAccount();
+    } finally {
+      setShareBusy("");
+    }
+  };
+
+  const changeShareVisibility = async (share: BotShare) => {
+    const botShares = window.ogb?.botShares;
+    if (!botShares) return;
+    const visibility: BotShareVisibility = share.visibility === "unlisted" ? "private" : "unlisted";
+    setShareBusy(`visibility:${share.id}`);
+    setError("");
+    try {
+      const updated = await botShares.setVisibility(share.id, visibility);
+      setShares((current) => current.map((item) => item.id === updated.id ? updated : item));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setShareBusy("");
+    }
+  };
+
+  const deleteShare = async (share: BotShare) => {
+    const botShares = window.ogb?.botShares;
+    if (!botShares || !window.confirm(`Delete the shared link for “${share.name}”?`)) return;
+    setShareBusy(`delete:${share.id}`);
+    setError("");
+    try {
+      await botShares.delete(share.id);
+      setShares((current) => current.filter((item) => item.id !== share.id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setShareBusy("");
+    }
+  };
+
+  const copyShareLink = async (share: BotShare) => {
+    try {
+      await navigator.clipboard.writeText(share.shareUrl);
+    } catch {
+      setError("The share link could not be copied.");
     }
   };
 
@@ -563,7 +742,21 @@ export function TeamLibraryPanel({
         ) : (
           <>
             <div className="flex flex-col gap-3 px-6 pb-4 pt-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
-              <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Team source">
+            <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Team source">
+                <button
+                  role="tab"
+                  aria-selected={tab === "export"}
+                  onClick={() => {
+                    setTab("export");
+                    setError("");
+                  }}
+                  className={cn(
+                    "rounded-lg px-4 py-2 text-[13.5px] transition-colors",
+                    tab === "export" ? "bg-card text-ink shadow-sm" : "text-ink-secondary hover:text-ink",
+                  )}
+                >
+                  Export &amp; share
+                </button>
                 <button
                   role="tab"
                   aria-selected={tab === "explore"}
@@ -622,6 +815,72 @@ export function TeamLibraryPanel({
             </div>
 
             <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-7 pt-5 sm:px-8">
+              {tab === "export" && (
+                <section>
+                  <div className="mb-3">
+                    <h3 className="text-[16px] font-semibold text-ink">Export &amp; share</h3>
+                    <p className="mt-1 max-w-2xl text-[12.5px] leading-relaxed text-ink-secondary">
+                      Export the active team as the official BotMRR Markdown package. Local export works without an account.
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-raised/25 px-5 py-5">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                      <div>
+                        <div className="text-[14px] font-medium text-ink">Current team</div>
+                        <p className="mt-1 text-[12.5px] text-ink-secondary">
+                          {currentBotCount} active {currentBotCount === 1 ? "bot" : "bots"} · validated package format
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          onClick={() => void createExportDraft(true).catch(() => undefined)}
+                          disabled={currentBotCount === 0 || shareBusy !== ""}
+                          className="flex items-center justify-center gap-2 rounded-full bg-accent px-5 py-2.5 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-40"
+                        >
+                          {shareBusy === "export" && <Loader2 size={15} className="animate-spin" />}
+                          Export package
+                        </button>
+                        <button
+                          onClick={() => void createExportDraft(false).catch(() => undefined)}
+                          disabled={currentBotCount === 0 || shareBusy !== ""}
+                          className="rounded-full bg-card px-5 py-2.5 text-[13.5px] font-medium text-ink ring-1 ring-inset ring-hairline/50 hover:bg-raised disabled:opacity-40"
+                        >
+                          Prepare package
+                        </button>
+                      </div>
+                    </div>
+                    {publishDraft && <div className="mt-3 text-[11.5px] text-ink-secondary">Preview validated: {publishDraft.members} bots · ready to publish.</div>}
+                  </div>
+
+                  <div className="mt-5 rounded-2xl bg-raised/25 px-5 py-5">
+                    <div className="flex items-center gap-2 text-[15px] font-semibold text-ink"><Share2 size={17} /> Publish link</div>
+                    {!window.ogb?.botShares && <p className="mt-2 text-[12.5px] leading-relaxed text-ink-secondary">Publishing is available in the desktop app. Local package export remains available here.</p>}
+                    {window.ogb?.botShares && accountState === null && <div className="mt-3 flex items-center gap-2 text-[13px] text-ink-secondary"><Loader2 size={15} className="animate-spin" /> Checking account…</div>}
+                    {window.ogb?.botShares && accountState?.status === "error" && !accountState.email && <p className="mt-3 flex items-start gap-2 text-[12.5px] leading-relaxed text-ink-secondary"><Lock size={16} className="mt-0.5 shrink-0" /> {accountState.message ?? "The account could not be checked. Local export still works."}</p>}
+                    {window.ogb?.botShares && accountState !== null && accountState.status !== "error" && !accountState.email && <p className="mt-3 flex items-start gap-2 text-[12.5px] leading-relaxed text-ink-secondary"><Lock size={16} className="mt-0.5 shrink-0" /> Sign in from Settings to publish or manage links. This does not affect local export.</p>}
+                    {window.ogb?.botShares && accountState?.email && <>
+                      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex rounded-xl bg-raised/70 p-1" aria-label="Share visibility">
+                          {(["unlisted", "private"] as const).map((visibility) => (
+                            <button key={visibility} onClick={() => setPublishVisibility(visibility)} className={cn("rounded-lg px-3 py-1.5 text-[12px] capitalize", publishVisibility === visibility ? "bg-card text-ink shadow-sm" : "text-ink-secondary hover:text-ink")}>{visibility}</button>
+                          ))}
+                        </div>
+                        <button onClick={() => void publishNewShare()} disabled={!publishDraft || sharesLoading || shareBusy !== ""} className="flex items-center justify-center gap-1.5 rounded-full bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:bg-accent/90 disabled:opacity-40">
+                          {shareBusy === "new" && <Loader2 size={14} className="animate-spin" />} Publish new link
+                        </button>
+                      </div>
+                      <p className="mt-2 text-[11.5px] text-ink-secondary">The link uses the validated draft above. Unlisted is the default.</p>
+                      <div className="mt-6 flex items-center justify-between"><div className="text-[12px] font-medium text-ink-secondary">Your shared bots</div><div className="text-[11.5px] text-ink-secondary">{accountState.email}</div></div>
+                      {shareListError && <div role="status" className="mt-2 rounded-xl bg-raised/55 px-3.5 py-3 text-[12px] text-ink-secondary">{shareListError}</div>}
+                      {sharesLoading && <div className="flex items-center gap-2 py-8 text-[13px] text-ink-secondary"><Loader2 size={15} className="animate-spin" /> Loading links…</div>}
+                      {!sharesLoading && !shareListError && shares.length === 0 && <div className="mt-2 rounded-2xl border border-dashed border-hairline/60 px-5 py-8 text-center text-[12.5px] text-ink-secondary">No shared links yet.</div>}
+                      {!sharesLoading && shares.length > 0 && <div className="mt-2 divide-y divide-hairline/35 rounded-2xl bg-raised/20 px-4">{shares.map((share) => <div key={share.id} className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center"><div className="min-w-0 flex-1"><div className="flex items-center gap-2"><span className="truncate text-[14px] font-medium text-ink">{share.name}</span><span className="shrink-0 rounded-full bg-raised px-2 py-0.5 text-[10.5px] text-ink-secondary">v{share.activeVersion} · {share.visibility}</span></div><p className="mt-1 truncate text-[12px] text-ink-secondary">{share.summary}</p></div><div className="flex shrink-0 flex-wrap items-center gap-1"><button onClick={() => void copyShareLink(share)} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label={`Copy link for ${share.name}`} title="Copy link"><Copy size={14} /></button><button onClick={() => void openExternal(share.shareUrl)} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label={`Open ${share.name}`} title="Open link"><ExternalLink size={14} /></button><button onClick={() => void changeShareVisibility(share)} disabled={shareBusy !== ""} className="rounded-full bg-raised px-3 py-2 text-[11.5px] text-ink hover:bg-raised-hover disabled:opacity-40">{share.visibility === "unlisted" ? "Make private" : "Make unlisted"}</button><button onClick={() => void publishShareVersion(share)} disabled={!publishDraft || sharesLoading || shareBusy !== ""} className="rounded-full bg-raised px-3 py-2 text-[11.5px] text-ink hover:bg-raised-hover disabled:opacity-40">{shareBusy === `version:${share.id}` ? "Publishing…" : "Publish new version"}</button><button onClick={() => void deleteShare(share)} disabled={shareBusy !== ""} className="rounded-lg p-2 text-ink-secondary hover:bg-danger/10 hover:text-danger disabled:opacity-40" aria-label={`Delete ${share.name}`} title="Delete link"><Trash2 size={14} /></button></div></div>)}</div>}
+                    </>}
+                  </div>
+                  {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+                </section>
+              )}
+
               {tab === "explore" && (
                 <div>
                   <div className="mb-3 text-[12px] font-medium text-ink-secondary">
@@ -715,15 +974,15 @@ export function TeamLibraryPanel({
 
                     <div className="flex min-h-56 flex-col justify-center rounded-2xl bg-raised/25 px-6">
                       <Github size={25} className="text-ink-secondary" />
-                      <h3 className="mt-3 text-[14px] font-medium text-ink">Load from GitHub</h3>
-                      <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">Paste a public repo or a direct team JSON link.</p>
+                      <h3 className="mt-3 text-[14px] font-medium text-ink">Load from a link</h3>
+                      <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">Paste an OpenMausBot shared package or public GitHub team link.</p>
                       <div className="mt-4 flex gap-2">
                         <input
                           value={githubUrl}
                           onChange={(event) => setGithubUrl(event.target.value)}
                           onKeyDown={(event) => event.key === "Enter" && void loadGithubTeam()}
-                          placeholder="github.com/owner/repo"
-                          aria-label="GitHub team URL"
+                          placeholder="accounts.openmausbot.com or github.com/owner/repo"
+                          aria-label="Shared bot or GitHub team URL"
                           className="min-w-0 flex-1 rounded-xl bg-raised/80 px-3 py-2.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
                         />
                         <button

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -149,6 +149,13 @@ type SkillRecordingPayload = {
         retry(): Promise<CompanionAccountState>;
         signOut(): Promise<CompanionAccountState>;
       };
+      botShares?: {
+        list(): Promise<BotShare[]>;
+        create(input: { packageMarkdown: string; visibility?: BotShareVisibility }): Promise<BotShare>;
+        update(shareId: string, input: { packageMarkdown: string; expectedActiveVersion: number }): Promise<BotShare>;
+        setVisibility(shareId: string, visibility: BotShareVisibility): Promise<BotShare>;
+        delete(shareId: string): Promise<void>;
+      };
       localControl: {
         status(): Promise<LinuxLocalControlStatus>;
         enable(): Promise<LinuxLocalControlStatus>;
@@ -331,6 +338,23 @@ export interface CompanionAccountState {
   email?: string;
   endpoint?: string;
   message?: string;
+}
+
+export type BotShareVisibility = "unlisted" | "private";
+
+export interface BotShare {
+  id: string;
+  visibility: BotShareVisibility;
+  activeVersion: number;
+  name: string;
+  summary: string;
+  sha256: string;
+  byteSize: number;
+  createdAt: number;
+  updatedAt: number;
+  versionCreatedAt: number;
+  shareUrl: string;
+  packageUrl: string;
 }
 
 export type AndroidUsbDevice = {


### PR DESCRIPTION
## What changed

Adds account-owned BotMRR share links with immutable versions, private/unlisted visibility, exact-origin importing, and a Team Library export/share surface.

The final slice is rebased on current upstream and deliberately excludes the duplicate routine/package implementation that belongs to #606.

## Safety boundaries

- Account credentials remain in Electron main and never cross into the renderer.
- Publishing accepts a validated, canonical BotMRR package up to 1 MB.
- Imports accept only exact `https://accounts.openmausbot.com` landing/package URLs, reject credentials, ports, query/hash data, lookalike hosts, and redirects.
- Public responses are `no-store`; private, deleted, and unknown shares return the same unavailable result.
- D1 enforces 100 active links per account and 50 immutable versions per link with race-safe triggers.
- Current `mascotBody` appearance data is preserved.
- The unsupported `openmausbot://` launch link was removed. The landing page downloads a package for explicit import instead.

## Verification

- Cloudflare control-plane: 47 tests passed.
- Focused desktop/server/package tests: 54 passed; final affected rerun: 49 passed.
- TypeScript checks passed.
- Production renderer build passed.
- Electron syntax check: 90 modules.
- Added-line secret scan: 1,396 lines passed.
- Targeted lint passed with one unrelated pre-existing warning in `server/index.ts`.

## UI evidence

Before/after screenshots of the Team Library share surface are still required. No visual acceptance is claimed.

## Maintainer follow-up

The D1 migration and control-plane deployment require maintainer infrastructure approval. Vercel authorization was not attempted, and no CodeRabbit command was triggered.

Accepted head: `955218443591d1e692fe0bcd465d4c404d2cd7d0`.