### PR TITLE
Enforce bounded runtime policies and delegated-turn receipts

### DIFF
--- a/server/bot-runtime-policy.test.ts
+++ b/server/bot-runtime-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultBotRuntimePolicy,
+  effectiveTaskRuntimePolicy,
+  runtimePolicyFingerprint,
+  runtimePolicyOverrideFingerprint,
+  validateRuntimePolicyPatch,
+} from "./bot-runtime-policy.ts";
+
+describe("runtime policy evidence", () => {
+  it("is stable for equivalent effective policy snapshots", () => {
+    const policy = defaultBotRuntimePolicy();
+    expect(runtimePolicyFingerprint(policy)).toBe(runtimePolicyFingerprint(structuredClone(policy)));
+  });
+
+  it("changes when a validated override changes", () => {
+    const override = validateRuntimePolicyPatch({ maxToolAgentSteps: 12 });
+    expect(override).toEqual({ maxToolAgentSteps: 12 });
+    expect(runtimePolicyOverrideFingerprint(override!)).not.toBe(
+      runtimePolicyOverrideFingerprint({ maxToolAgentSteps: 24 }),
+    );
+    expect(runtimePolicyFingerprint(effectiveTaskRuntimePolicy(undefined, override!))).not.toBe(
+      runtimePolicyFingerprint(defaultBotRuntimePolicy()),
+    );
+  });
+
+  it("rejects malformed overrides instead of fingerprinting them", () => {
+    expect(() => validateRuntimePolicyPatch({ unknown: true })).toThrow(/unknown key/);
+    expect(() => validateRuntimePolicyPatch({ retryCap: 2 })).toThrow(/retryCap/);
+    expect(validateRuntimePolicyPatch(null)).toBeNull();
+  });
+});

--- a/server/bot-runtime-policy.ts
+++ b/server/bot-runtime-policy.ts
@@ -1,0 +1,274 @@
+/**
+ * Small, persisted runtime-policy shape used only to identify an admission
+ * snapshot. Enforcement remains owned by the runtime that admits a turn.
+ * Raw policy values never cross the delegation receipt boundary.
+ */
+
+import { createHash } from "node:crypto";
+
+export type CumulativeTokenPolicyMode = "disabled" | "soft" | "hard";
+
+export interface CumulativeTokenPolicy {
+  mode: CumulativeTokenPolicyMode;
+  limit: number;
+}
+
+export interface BotRuntimePolicy {
+  wallClockTimeoutMinutes: number;
+  idleTimeoutMinutes: number;
+  cancellationGraceSeconds: number;
+  maxToolAgentSteps: number;
+  delegationConcurrency: number;
+  cumulativeTokenPolicy: CumulativeTokenPolicy;
+}
+
+export interface RuntimePolicyOverrides {
+  wallClockTimeoutMinutes?: number;
+  idleTimeoutMinutes?: number;
+  cancellationGraceSeconds?: number;
+  maxToolAgentSteps?: number;
+  delegationConcurrency?: number;
+  cumulativeTokenPolicy?: {
+    mode?: CumulativeTokenPolicyMode;
+    limit?: number;
+  };
+}
+
+export type RuntimePolicyPatch = RuntimePolicyOverrides | null;
+
+export const DEFAULT_CUMULATIVE_TOKEN_LIMIT = 1_000_000;
+
+/** Read a legacy millisecond environment value, using the supplied fallback when it is absent or falsy. */
+function legacyNumber(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return value || fallback;
+}
+
+/** Clamp a finite duration to the supported positive integer range. */
+function boundedCeil(value: number, maximum: number): number {
+  if (!Number.isFinite(value)) return maximum;
+  return Math.max(1, Math.min(maximum, Math.ceil(value)));
+}
+
+/** Build effective defaults while preserving legacy environment timing values. */
+export function defaultBotRuntimePolicy(): BotRuntimePolicy {
+  return {
+    wallClockTimeoutMinutes: 0,
+    idleTimeoutMinutes: boundedCeil(legacyNumber("OMB_TURN_STALL_MS", 20 * 60_000) / 60_000, 1_440),
+    cancellationGraceSeconds: boundedCeil(legacyNumber("OMB_TURN_STOP_GRACE_MS", 5_000) / 1_000, 120),
+    maxToolAgentSteps: 0,
+    delegationConcurrency: 4,
+    cumulativeTokenPolicy: {
+      mode: "disabled",
+      limit: DEFAULT_CUMULATIVE_TOKEN_LIMIT,
+    },
+  };
+}
+
+/** Narrow an unknown value to a non-array object record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Test whether an object owns a field, including fields with undefined values. */
+function has(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/** Validate a required integer policy field against an inclusive range. */
+function integerInRange(value: unknown, field: string, min: number, max: number): number {
+  if (!Number.isInteger(value) || (value as number) < min || (value as number) > max) {
+    throw new Error(`${field} must be an integer between ${min} and ${max}`);
+  }
+  return value as number;
+}
+
+/** Validate a policy field that permits zero as its disabled value. */
+function zeroOrRange(value: unknown, field: string, max: number): number {
+  if (!Number.isInteger(value) || (value as number) < 0 || (value as number) > max) {
+    throw new Error(`${field} must be 0 or an integer between 1 and ${max}`);
+  }
+  return value as number;
+}
+
+/** Validate and normalize the user-supplied runtime-policy override object. */
+function validateOverrides(value: unknown): RuntimePolicyOverrides {
+  if (!isRecord(value)) throw new Error("runtimePolicyOverride must be an object or null");
+  const allowed = new Set([
+    "wallClockTimeoutMinutes",
+    "idleTimeoutMinutes",
+    "cancellationGraceSeconds",
+    "maxToolAgentSteps",
+    "delegationConcurrency",
+    "cumulativeTokenPolicy",
+  ]);
+  const unknown = Object.keys(value).find((key) => !allowed.has(key));
+  if (unknown) throw new Error(`runtimePolicyOverride contains unknown key "${unknown}"`);
+
+  const patch: RuntimePolicyOverrides = {};
+  if (has(value, "wallClockTimeoutMinutes")) {
+    patch.wallClockTimeoutMinutes = zeroOrRange(value.wallClockTimeoutMinutes, "wallClockTimeoutMinutes", 1_440);
+  }
+  if (has(value, "idleTimeoutMinutes")) {
+    patch.idleTimeoutMinutes = integerInRange(value.idleTimeoutMinutes, "idleTimeoutMinutes", 1, 1_440);
+  }
+  if (has(value, "cancellationGraceSeconds")) {
+    patch.cancellationGraceSeconds = integerInRange(value.cancellationGraceSeconds, "cancellationGraceSeconds", 1, 120);
+  }
+  if (has(value, "maxToolAgentSteps")) patch.maxToolAgentSteps = zeroOrRange(value.maxToolAgentSteps, "maxToolAgentSteps", 1_000);
+  if (has(value, "delegationConcurrency")) {
+    patch.delegationConcurrency = integerInRange(value.delegationConcurrency, "delegationConcurrency", 1, 4);
+  }
+  if (has(value, "cumulativeTokenPolicy")) {
+    const cumulativePolicy = value.cumulativeTokenPolicy;
+    if (!isRecord(cumulativePolicy)) throw new Error("cumulativeTokenPolicy must be an object");
+    const tokenUnknown = Object.keys(cumulativePolicy).find((key) => key !== "mode" && key !== "limit");
+    if (tokenUnknown) throw new Error(`cumulativeTokenPolicy contains unknown key "${tokenUnknown}"`);
+    const tokenPatch: NonNullable<RuntimePolicyOverrides["cumulativeTokenPolicy"]> = {};
+    if (has(cumulativePolicy, "mode")) {
+      if (cumulativePolicy.mode !== "disabled" && cumulativePolicy.mode !== "soft" && cumulativePolicy.mode !== "hard") {
+        throw new Error("cumulativeTokenPolicy.mode must be disabled, soft, or hard");
+      }
+      tokenPatch.mode = cumulativePolicy.mode;
+    }
+    if (has(cumulativePolicy, "limit")) tokenPatch.limit = integerInRange(cumulativePolicy.limit, "cumulativeTokenPolicy.limit", 1_000, 10_000_000);
+    patch.cumulativeTokenPolicy = tokenPatch;
+  }
+  return patch;
+}
+
+/** undefined means the field was absent; malformed values throw. */
+export function validateRuntimePolicyPatch(value: unknown): RuntimePolicyPatch | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return validateOverrides(value);
+}
+
+/** Check whether an override number is an allowed integer, including optional zero. */
+function validOverrideNumber(value: unknown, min: number, max: number, allowZero: boolean): value is number {
+  return Number.isInteger(value)
+    && (allowZero ? (value as number) === 0 || (value as number) >= min : (value as number) >= min)
+    && (value as number) <= max;
+}
+
+/** Copy only well-formed override fields so persisted data cannot widen the policy shape. */
+function copyOverrides(value: RuntimePolicyOverrides | undefined): RuntimePolicyOverrides {
+  const out: RuntimePolicyOverrides = {};
+  if (value && validOverrideNumber(value.wallClockTimeoutMinutes, 1, 1_440, true)) {
+    out.wallClockTimeoutMinutes = value.wallClockTimeoutMinutes;
+  }
+  if (value && validOverrideNumber(value.idleTimeoutMinutes, 1, 1_440, false)) {
+    out.idleTimeoutMinutes = value.idleTimeoutMinutes;
+  }
+  if (value && validOverrideNumber(value.cancellationGraceSeconds, 1, 120, false)) {
+    out.cancellationGraceSeconds = value.cancellationGraceSeconds;
+  }
+  if (value && validOverrideNumber(value.maxToolAgentSteps, 1, 1_000, true)) {
+    out.maxToolAgentSteps = value.maxToolAgentSteps;
+  }
+  if (value && validOverrideNumber(value.delegationConcurrency, 1, 4, false)) {
+    out.delegationConcurrency = value.delegationConcurrency;
+  }
+  if (value?.cumulativeTokenPolicy) {
+    const cumulativePolicy: NonNullable<RuntimePolicyOverrides["cumulativeTokenPolicy"]> = {};
+    if (value.cumulativeTokenPolicy.mode === "disabled" || value.cumulativeTokenPolicy.mode === "soft" || value.cumulativeTokenPolicy.mode === "hard") {
+      cumulativePolicy.mode = value.cumulativeTokenPolicy.mode;
+    }
+    if (validOverrideNumber(value.cumulativeTokenPolicy.limit, 1_000, 10_000_000, false)) {
+      cumulativePolicy.limit = value.cumulativeTokenPolicy.limit;
+    }
+    if (cumulativePolicy.mode !== undefined || cumulativePolicy.limit !== undefined) out.cumulativeTokenPolicy = cumulativePolicy;
+  }
+  return out;
+}
+
+/** Merge a task patch over bot overrides while retaining nested token-policy fields. */
+function mergeRuntimePolicy(previous: RuntimePolicyOverrides | undefined, patch: RuntimePolicyPatch | undefined): RuntimePolicyOverrides | undefined {
+  if (patch === undefined) {
+    const copied = copyOverrides(previous);
+    return Object.keys(copied).length ? copied : undefined;
+  }
+  if (patch === null) return undefined;
+  const prior = copyOverrides(previous);
+  return {
+    ...prior,
+    ...patch,
+    ...(prior.cumulativeTokenPolicy || patch.cumulativeTokenPolicy
+      ? { cumulativeTokenPolicy: { ...prior.cumulativeTokenPolicy, ...patch.cumulativeTokenPolicy } }
+      : {}),
+  };
+}
+
+/** Resolve explicit overrides onto the current effective runtime defaults. */
+export function effectiveBotRuntimePolicy(overrides?: RuntimePolicyOverrides): BotRuntimePolicy {
+  const defaults = defaultBotRuntimePolicy();
+  const explicit = copyOverrides(overrides);
+  return {
+    wallClockTimeoutMinutes: explicit.wallClockTimeoutMinutes ?? defaults.wallClockTimeoutMinutes,
+    idleTimeoutMinutes: explicit.idleTimeoutMinutes ?? defaults.idleTimeoutMinutes,
+    cancellationGraceSeconds: explicit.cancellationGraceSeconds ?? defaults.cancellationGraceSeconds,
+    maxToolAgentSteps: explicit.maxToolAgentSteps ?? defaults.maxToolAgentSteps,
+    delegationConcurrency: explicit.delegationConcurrency ?? defaults.delegationConcurrency,
+    cumulativeTokenPolicy: {
+      mode: explicit.cumulativeTokenPolicy?.mode ?? defaults.cumulativeTokenPolicy.mode,
+      limit: explicit.cumulativeTokenPolicy?.limit ?? defaults.cumulativeTokenPolicy.limit,
+    },
+  };
+}
+
+/** Resolve bot and one-task overrides into the immutable policy admitted for a turn. */
+export function effectiveTaskRuntimePolicy(
+  botOverrides: RuntimePolicyOverrides | undefined,
+  taskOverride: RuntimePolicyOverrides | undefined,
+): BotRuntimePolicy {
+  return effectiveBotRuntimePolicy(mergeRuntimePolicy(botOverrides, taskOverride));
+}
+
+/** Runtime admission snapshots cross async boundaries; keep them detached from
+ * mutable bot/task records so queue-time evidence and dispatch-time limits
+ * cannot silently diverge. */
+export function cloneRuntimePolicy(policy: BotRuntimePolicy): BotRuntimePolicy {
+  return { ...policy, cumulativeTokenPolicy: { ...policy.cumulativeTokenPolicy } };
+}
+
+/** Check that an unknown value is a complete effective runtime-policy snapshot. */
+export function isBotRuntimePolicy(value: unknown): value is BotRuntimePolicy {
+  if (!isRecord(value) || !isRecord(value.cumulativeTokenPolicy)) return false;
+  return validOverrideNumber(value.wallClockTimeoutMinutes, 1, 1_440, true)
+    && validOverrideNumber(value.idleTimeoutMinutes, 1, 1_440, false)
+    && validOverrideNumber(value.cancellationGraceSeconds, 1, 120, false)
+    && validOverrideNumber(value.maxToolAgentSteps, 1, 1_000, true)
+    && validOverrideNumber(value.delegationConcurrency, 1, 4, false)
+    && (value.cumulativeTokenPolicy.mode === "disabled"
+      || value.cumulativeTokenPolicy.mode === "soft"
+      || value.cumulativeTokenPolicy.mode === "hard")
+    && validOverrideNumber(value.cumulativeTokenPolicy.limit, 1_000, 10_000_000, false);
+}
+
+/** Project a policy or override into the ordered, secret-free fingerprint input vector. */
+function fingerprintVector(value: BotRuntimePolicy | RuntimePolicyOverrides): unknown[] {
+  return [
+    value.wallClockTimeoutMinutes,
+    value.idleTimeoutMinutes,
+    value.cancellationGraceSeconds,
+    value.maxToolAgentSteps,
+    value.delegationConcurrency,
+    value.cumulativeTokenPolicy?.mode,
+    value.cumulativeTokenPolicy?.limit,
+  ];
+}
+
+/** Hash the canonical policy vector into its stable evidence string. */
+function fingerprint(value: unknown[]): string {
+  return createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex");
+}
+
+/** Stable, secret-free evidence for the effective admission snapshot. */
+export function runtimePolicyFingerprint(policy: BotRuntimePolicy): string {
+  return fingerprint(fingerprintVector(policy));
+}
+
+/** Stable evidence for the explicit override, without retaining raw values. */
+export function runtimePolicyOverrideFingerprint(overrides?: RuntimePolicyOverrides): string | undefined {
+  return overrides ? fingerprint(fingerprintVector(overrides)) : undefined;
+}

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -4,6 +4,7 @@
 // assert what would have been dispatched to the harness. The harness itself
 // stays out of these — the integration happens in comms.test.ts (the full
 // e2e through the agents proxy + fake ACP CLI).
+import { createHash } from "node:crypto";
 import { rmSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -30,6 +31,7 @@ import {
   _pendingCount,
 } from "./delegations.ts";
 import { peerAllowKey, resolvePeerComms } from "./peer-approval.ts";
+import { effectiveTaskRuntimePolicy, runtimePolicyFingerprint } from "./bot-runtime-policy.ts";
 import { Store, type BotRecord } from "./store.ts";
 
 const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
@@ -179,6 +181,50 @@ describe("queueDelegation", () => {
       store.messagesFor(from.threadId).some((m) => m.tool?.name === "Delegated to @Helper"),
     ).toBe(false);
   });
+
+  it("records hash-only policy evidence and fails closed on malformed overrides", () => {
+    store.setChiefOfStaff(from.id);
+    const queued = queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "bounded work",
+      runtimePolicyOverride: { maxToolAgentSteps: 12 },
+      depth: 0,
+    }, 1);
+    expect(queued.result).toBe("ok");
+    expect(queued.evidence).toMatchObject({
+      evidenceKey: expect.stringMatching(/^[a-f0-9]{64}$/),
+      runtimePolicyFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      runtimePolicyOverrideFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(JSON.stringify(queued.evidence)).not.toContain("maxToolAgentSteps");
+
+    const invalid = queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "bad policy",
+      runtimePolicyOverride: { idleTimeoutMinutes: 0 },
+      depth: 0,
+    }, 1);
+    expect(invalid.result).toBe("invalid_runtime_policy");
+
+    store.setChiefOfStaff(null);
+    const unauthorized = queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "unauthorized policy",
+      runtimePolicyOverride: { maxToolAgentSteps: 12 },
+      depth: 0,
+    }, 1);
+    expect(unauthorized.result).toBe("runtime_policy_chief_only");
+  });
+
+  it("uses locale-independent canonicalization for evidence keys", () => {
+    const queued = queueDelegation(commsBus, from, { toBotId: target.id, message: "I", depth: 0 }, 1);
+    expect(queued.result).toBe("ok");
+    const policyFingerprint = runtimePolicyFingerprint(effectiveTaskRuntimePolicy(target.runtimePolicy, undefined));
+    const expected = createHash("sha256")
+      .update(["i", "", policyFingerprint, "none"].join("\n\u241f\n"), "utf8")
+      .digest("hex");
+    expect(queued.evidence?.evidenceKey).toBe(expected);
+  });
 });
 
 describe("drainDelegations", () => {
@@ -248,6 +294,44 @@ describe("drainDelegations", () => {
     });
     await waitFor(() => runTargetCalls.length === 1);
     expect(runTargetCalls[0]!.message).toContain("[Reason: next step]");
+  });
+
+  it("passes runtime policy evidence to the target runner and task record", async () => {
+    store.patchBot(from.id, { chiefOfStaff: true });
+    const queued = queueDelegation(
+      commsBus,
+      from,
+      {
+        toBotId: target.id,
+        message: "run with bounded policy",
+        runtimePolicyOverride: { maxToolAgentSteps: 12 },
+        depth: 0,
+      },
+      1,
+    );
+    expect(queued.result).toBe("ok");
+    if (queued.result !== "ok") return;
+
+    let receivedEvidence: unknown;
+    drainDelegations(
+      commsBus,
+      approvalBus,
+      from.threadId,
+      (toBotId, message, commsDepth, sourceThreadId, channel, taskId, evidence) => {
+        receivedEvidence = evidence;
+        runTargetCalls.push({ toBotId, message, commsDepth, sourceThreadId });
+        void channel;
+        void taskId;
+      },
+    );
+
+    await waitFor(() => receivedEvidence !== undefined);
+    expect(receivedEvidence).toEqual(queued.evidence);
+    const task = store.taskByThread(target.id, target.threadId);
+    expect(task?.runtimePolicyFingerprint).toBe(queued.evidence?.runtimePolicyFingerprint);
+    expect(task?.runtimePolicyOverrideFingerprint).toBe(
+      queued.evidence?.runtimePolicyOverrideFingerprint,
+    );
   });
 
   it("drains and mirrors a detached routine delegation on its source thread", async () => {
@@ -638,6 +722,46 @@ describe("busy retries and receipts", () => {
 
   const chipCount = (needle: string) =>
     store.messagesFor(from.threadId).filter((m) => m.kind === "activity" && m.tool?.name?.includes(needle)).length;
+
+  it("leaves a terminal evidence receipt when Chief authority is revoked", async () => {
+    store.setChiefOfStaff(from.id);
+    const queued = queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "bounded work",
+      runtimePolicyOverride: { maxToolAgentSteps: 1 },
+      depth: 0,
+    }, 1);
+    expect(queued.result).toBe("ok");
+    store.setChiefOfStaff(null);
+    const runTarget = vi.fn();
+    drainDelegations(commsBus, approvalBus, from.threadId, runTarget);
+    await waitFor(() => _pendingCount(from.threadId) === 0);
+    expect(runTarget).not.toHaveBeenCalled();
+    expect(findDelegationReceipt(queued.id!)).toMatchObject({
+      status: "denied",
+      result: "only a Chief of Staff may set a runtime policy override",
+      evidence: queued.evidence,
+    });
+  });
+
+  it("reuses the queue-time policy snapshot for evidence, task, and dispatch", async () => {
+    store.setChiefOfStaff(from.id);
+    const queued = queueDelegation(commsBus, from, {
+      toBotId: target.id,
+      message: "snapshot this",
+      runtimePolicyOverride: { maxToolAgentSteps: 2 },
+      depth: 0,
+    }, 1);
+    expect(queued.result).toBe("ok");
+    store.patchBot(target.id, { runtimePolicy: { maxToolAgentSteps: 99 } });
+    const dispatched: unknown[][] = [];
+    drainDelegations(commsBus, approvalBus, from.threadId, (...args: unknown[]) => void dispatched.push(args));
+    await waitFor(() => dispatched.length === 1 && _pendingCount(from.threadId) === 0);
+    const policy = dispatched[0]![7] as Parameters<typeof runtimePolicyFingerprint>[0];
+    expect(policy.maxToolAgentSteps).toBe(2);
+    expect(runtimePolicyFingerprint(policy)).toBe(queued.evidence?.runtimePolicyFingerprint);
+    expect(store.taskByThread(target.id, target.threadId)?.runtimePolicySnapshot?.maxToolAgentSteps).toBe(2);
+  });
 
   it("keeps a handoff queued while the target is busy and dispatches on the retry drain", async () => {
     store.patchBot(target.id, { busy: true });

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -11,6 +11,7 @@
 // time, never at queue time, because the user might have just turned
 // approvePeerComms on between queueing and draining.
 
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -18,6 +19,16 @@ import { writeFileAtomic } from "./atomic.ts";
 import { getOrCreateChannel, mirrorExchange, type CommsBus } from "./comms-visibility.ts";
 import { DATA_DIR } from "./config.ts";
 import { newId } from "./contracts.ts";
+import {
+  cloneRuntimePolicy,
+  effectiveTaskRuntimePolicy,
+  isBotRuntimePolicy,
+  runtimePolicyFingerprint,
+  runtimePolicyOverrideFingerprint,
+  validateRuntimePolicyPatch,
+  type BotRuntimePolicy,
+  type RuntimePolicyOverrides,
+} from "./bot-runtime-policy.ts";
 import { requestPeerApproval, type ApprovalBus } from "./peer-approval.ts";
 import { sectionKey, type BotRecord, type GroupRecord } from "./store.ts";
 
@@ -25,6 +36,8 @@ export interface DelegationItem {
   toBotId: string;
   message: string;
   reason?: string;
+  /** Optional one-task policy override. It is validated before queueing. */
+  runtimePolicyOverride?: RuntimePolicyOverrides;
   /** The user already approved this exact peer message while it was still
    * an ask_bot request. If that peer became busy before dispatch, the
    * fallback handoff must not ask them to approve the same action twice. */
@@ -48,6 +61,14 @@ interface PendingDelegationItem extends DelegationItem {
    * queue activity must not count that same period again; the target's idle
    * transition clears this marker before the next retry. */
   waitingOnBusy?: boolean;
+  evidence?: DelegationEvidence;
+  runtimePolicySnapshot?: import("./bot-runtime-policy.ts").BotRuntimePolicy;
+}
+
+export interface DelegationEvidence {
+  evidenceKey: string;
+  runtimePolicyFingerprint: string;
+  runtimePolicyOverrideFingerprint?: string;
 }
 
 export type DelegationOutcome = "done" | "failed" | "denied" | "busy_gave_up" | "dropped" | "error";
@@ -64,15 +85,18 @@ export interface DelegationReceipt {
   /** the peer's reply on success; the failure name otherwise (bounded) */
   result?: string;
   finishedAt: number;
+  /** Hash-only evidence for reproducing the admission decision. */
+  evidence?: DelegationEvidence;
 }
 
-export type QueueResult = "ok" | "no_target" | "self" | "too_deep" | "too_many";
+export type QueueResult = "ok" | "no_target" | "self" | "too_deep" | "too_many" | "invalid_runtime_policy" | "runtime_policy_chief_only";
 
 /** What queueDelegation hands back: the verdict, and on success the task id
  * the delegating bot can later read back with check/wait_delegation. */
 export interface QueuedDelegation {
   result: QueueResult;
   id?: string;
+  evidence?: DelegationEvidence;
 }
 
 /** Per source-thread queue. Persisted to delegations.json on every change
@@ -95,6 +119,42 @@ export const MAX_BUSY_ATTEMPTS = 3;
 
 let receipts: DelegationReceipt[] = [];
 
+/** Hash normalized delegation evidence parts without retaining their raw values. */
+function digest(parts: string[]): string {
+  return createHash("sha256").update(parts.join("\n\u241f\n"), "utf8").digest("hex");
+}
+
+/** Normalize user-controlled evidence text for deterministic hashing. */
+function normalized(value: string | undefined): string {
+  return (value ?? "").trim().normalize("NFKC").replaceAll("\\", "/").replace(/\s+/gu, " ").toLowerCase();
+}
+
+/** Build hash-only evidence for a queued delegation and its policy snapshot. */
+function delegationEvidence(
+  message: string,
+  reason: string | undefined,
+  policy: BotRuntimePolicy,
+  runtimePolicyOverride: RuntimePolicyOverrides | undefined,
+): DelegationEvidence {
+  const effectiveFingerprint = runtimePolicyFingerprint(policy);
+  const overrideFingerprint = runtimePolicyOverrideFingerprint(runtimePolicyOverride);
+  return {
+    evidenceKey: digest([
+      normalized(message),
+      normalized(reason),
+      effectiveFingerprint,
+      overrideFingerprint ?? "none",
+    ]),
+    runtimePolicyFingerprint: effectiveFingerprint,
+    ...(overrideFingerprint ? { runtimePolicyOverrideFingerprint: overrideFingerprint } : {}),
+  };
+}
+
+/** Return the optional evidence field for durable queue and receipt records. */
+function evidenceFields(item: PendingDelegationItem): { evidence?: DelegationEvidence } {
+  return item.evidence ? { evidence: item.evidence } : {};
+}
+
 function saveReceipts(): void {
   try {
     writeFileAtomic(RECEIPTS_FILE, JSON.stringify(receipts, null, 2), { mode: 0o600 });
@@ -116,21 +176,23 @@ export function recordDelegationReceipt(receipt: Omit<DelegationReceipt, "finish
     finishedAt: receipt.finishedAt ?? now,
   };
   if (receipt.result !== undefined) bounded.result = receipt.result.slice(0, RESULT_MAX_CHARS);
+  if (receipt.evidence) bounded.evidence = receipt.evidence;
   receipts = [bounded, ...receipts.filter((existing) => existing.id !== bounded.id)]
     .filter((existing) => now - existing.finishedAt <= RECEIPT_MAX_AGE_MS)
     .slice(0, MAX_RECEIPTS);
   saveReceipts();
 }
 
+/** Find one bounded terminal delegation receipt by its stable task id. */
 export function findDelegationReceipt(id: string): DelegationReceipt | null {
   return receipts.find((receipt) => receipt.id === id) ?? null;
 }
 
 /** A still-queued task's routing info, or null once it dispatched/settled. */
-export function pendingDelegationInfo(id: string): { sourceThreadId: string; toBotId: string; attempts: number } | null {
+export function pendingDelegationInfo(id: string): { sourceThreadId: string; toBotId: string; attempts: number; evidence?: DelegationEvidence } | null {
   for (const [sourceThreadId, items] of pendingDelegations) {
     const item = items.find((candidate) => candidate.id === id);
-    if (item) return { sourceThreadId, toBotId: item.toBotId, attempts: item.attempts };
+    if (item) return { sourceThreadId, toBotId: item.toBotId, attempts: item.attempts, ...evidenceFields(item) };
   }
   return null;
 }
@@ -182,16 +244,47 @@ export function _loadPending(): void {
           typeof item.message !== "string" ||
           !Number.isFinite(item.depth)
         ) return [];
+        let runtimePolicyOverride: RuntimePolicyOverrides | undefined;
+        if (item.runtimePolicyOverride !== undefined) {
+          try {
+            const validated = validateRuntimePolicyPatch(item.runtimePolicyOverride);
+            if (!validated || typeof validated !== "object") return [];
+            runtimePolicyOverride = validated;
+          } catch {
+            return [];
+          }
+        }
         const loaded: PendingDelegationItem = {
           id: typeof item.id === "string" && item.id ? item.id : newId(),
           toBotId: item.toBotId,
           message: item.message,
           ...(typeof item.reason === "string" ? { reason: item.reason } : {}),
+          ...(runtimePolicyOverride ? { runtimePolicyOverride } : {}),
           depth: Math.max(0, Math.trunc(item.depth!)),
           attempts: Number.isFinite(item.attempts) ? Math.max(0, Math.trunc(item.attempts!)) : 0,
         };
         if (item.approvalAlreadyGranted === true) loaded.approvalAlreadyGranted = true;
         if (item.waitingOnBusy === true) loaded.waitingOnBusy = true;
+        if (item.evidence && typeof item.evidence === "object" && !Array.isArray(item.evidence)) {
+          const evidence = item.evidence as Partial<DelegationEvidence>;
+          if (typeof evidence.evidenceKey === "string" && typeof evidence.runtimePolicyFingerprint === "string") {
+            loaded.evidence = {
+              evidenceKey: evidence.evidenceKey,
+              runtimePolicyFingerprint: evidence.runtimePolicyFingerprint,
+              ...(typeof evidence.runtimePolicyOverrideFingerprint === "string"
+                ? { runtimePolicyOverrideFingerprint: evidence.runtimePolicyOverrideFingerprint }
+                : {}),
+            };
+          }
+        }
+        if (isBotRuntimePolicy(item.runtimePolicySnapshot)) {
+          loaded.runtimePolicySnapshot = cloneRuntimePolicy(item.runtimePolicySnapshot);
+        } else {
+          // Old queue records have no recoverable effective policy identity;
+          // recompute both policy and evidence together at dispatch rather
+          // than retaining a fingerprint for a different snapshot.
+          delete loaded.evidence;
+        }
         return [loaded];
       });
       if (items.length) pendingDelegations.set(threadId, items);
@@ -218,6 +311,18 @@ export function _loadPending(): void {
         if (!Number.isFinite(finishedAt) || now - finishedAt! > RECEIPT_MAX_AGE_MS) continue;
         const receipt: DelegationReceipt = { id, sourceThreadId, toBotId, toBotName, status, finishedAt: finishedAt! };
         if (typeof result === "string") receipt.result = result;
+        if (candidate.evidence && typeof candidate.evidence === "object" && !Array.isArray(candidate.evidence)) {
+          const evidence = candidate.evidence as Partial<DelegationEvidence>;
+          if (typeof evidence.evidenceKey === "string" && typeof evidence.runtimePolicyFingerprint === "string") {
+            receipt.evidence = {
+              evidenceKey: evidence.evidenceKey,
+              runtimePolicyFingerprint: evidence.runtimePolicyFingerprint,
+              ...(typeof evidence.runtimePolicyOverrideFingerprint === "string"
+                ? { runtimePolicyOverrideFingerprint: evidence.runtimePolicyOverrideFingerprint }
+                : {}),
+            };
+          }
+        }
         loaded.push(receipt);
       }
       receipts = loaded.slice(0, MAX_RECEIPTS);
@@ -265,13 +370,33 @@ export function queueDelegation(
   if (item.depth >= maxDepth) return { result: "too_deep" };
   const target = bus.store.bot(item.toBotId);
   if (!target) return { result: "no_target" };
+  let runtimePolicyOverride: RuntimePolicyOverrides | undefined;
+  if (item.runtimePolicyOverride !== undefined) {
+    try {
+      const validated = validateRuntimePolicyPatch(item.runtimePolicyOverride);
+      if (!validated || typeof validated !== "object") return { result: "invalid_runtime_policy" };
+      runtimePolicyOverride = validated;
+    } catch {
+      return { result: "invalid_runtime_policy" };
+    }
+    if (!from.chiefOfStaff) return { result: "runtime_policy_chief_only" };
+  }
+  const runtimePolicySnapshot = effectiveTaskRuntimePolicy(target.runtimePolicy, runtimePolicyOverride);
+  const evidence = delegationEvidence(item.message, item.reason, runtimePolicySnapshot, runtimePolicyOverride);
   const list = pendingDelegations.get(sourceThreadId) ?? [];
   // Async handoff removes the backpressure that ask_bot got for free by
   // making the caller wait. Without a cap, one turn can queue unboundedly
   // and fan out into as many real turns on the next settle.
   if (list.length >= MAX_QUEUED_PER_THREAD) return { result: "too_many" };
   const id = newId();
-  list.push({ ...item, id, attempts: 0 });
+  list.push({
+    ...item,
+    ...(runtimePolicyOverride ? { runtimePolicyOverride } : {}),
+    id,
+    attempts: 0,
+    evidence,
+    runtimePolicySnapshot: cloneRuntimePolicy(runtimePolicySnapshot),
+  });
   pendingDelegations.set(sourceThreadId, list);
   savePending();
   const label = `Delegated to @${target.name}${item.reason ? `: ${item.reason}` : ""}`;
@@ -280,7 +405,7 @@ export function queueDelegation(
     kind: "activity",
     tool: { name: label },
   });
-  return { result: "ok", id };
+  return { result: "ok", id, evidence };
 }
 
 /** Drain queued delegations for a source thread (called on its
@@ -300,6 +425,9 @@ export function drainDelegations(
     sourceThreadId: string,
     channel: GroupRecord | undefined,
     taskId: string,
+    evidence: DelegationEvidence,
+    runtimePolicySnapshot: BotRuntimePolicy,
+    runtimePolicyOverride: RuntimePolicyOverrides | undefined,
   ) => void | Promise<void>,
 ): void {
   if (drainingThreads.has(threadId)) {
@@ -330,6 +458,7 @@ export function drainDelegations(
           toBotName: bus.store.bot(item.toBotId)?.name ?? item.toBotId,
           status: "error",
           result: why.slice(0, 200),
+          ...evidenceFields(item),
         });
         try {
           bus.store.appendMessage(threadId, {
@@ -386,6 +515,7 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
       toBotName: bus.store.bot(item.toBotId)?.name ?? item.toBotId,
       status: "dropped",
       result: "the delegating turn did not finish",
+      ...evidenceFields(item),
     });
   }
   const from = bus.store.botByThread(threadId);
@@ -397,6 +527,7 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
   });
 }
 
+/** Process one queued delegation through admission, provider execution, and durable receipt settlement. */
 async function processOne(
   bus: CommsBus,
   approvalBus: ApprovalBus,
@@ -410,6 +541,9 @@ async function processOne(
     sourceThreadId: string,
     channel: GroupRecord | undefined,
     taskId: string,
+    evidence: DelegationEvidence,
+    runtimePolicySnapshot: BotRuntimePolicy,
+    runtimePolicyOverride: RuntimePolicyOverrides | undefined,
   ) => void | Promise<void>,
 ): Promise<"settled" | "requeued"> {
   let sender = from;
@@ -422,11 +556,29 @@ async function processOne(
       toBotName: item.toBotId,
       status: "error",
       result: "no such bot",
+      ...evidenceFields(item),
     });
     bus.store.appendMessage(sourceThreadId, {
       role: "bot",
       kind: "activity",
       tool: { name: `error: delegation to ${item.toBotId} failed — no such bot`, ok: false },
+    });
+    return "settled";
+  }
+  if (item.runtimePolicyOverride && !sender.chiefOfStaff) {
+    recordDelegationReceipt({
+      id: item.id,
+      sourceThreadId,
+      toBotId: target.id,
+      toBotName: target.name,
+      status: "denied",
+      result: "only a Chief of Staff may set a runtime policy override",
+      ...evidenceFields(item),
+    });
+    bus.store.appendMessage(sourceThreadId, {
+      role: "bot",
+      kind: "activity",
+      tool: { name: `Delegation to @${target.name} canceled — only a Chief of Staff may set a runtime policy override`, ok: false },
     });
     return "settled";
   }
@@ -453,6 +605,7 @@ async function processOne(
       toBotName: target.name,
       status: "busy_gave_up",
       result: `@${target.name} stayed busy through ${MAX_BUSY_ATTEMPTS} retries`,
+      ...evidenceFields(item),
     });
     bus.store.appendMessage(sourceThreadId, {
       role: "bot",
@@ -482,6 +635,7 @@ async function processOne(
         toBotName: target.name,
         status: "denied",
         result: "the user denied this handoff",
+        ...evidenceFields(item),
       });
       bus.store.appendMessage(sourceThreadId, {
         role: "bot",
@@ -496,7 +650,35 @@ async function processOne(
     // and mirror a "Messaged @X" chip for an exchange that never happens.
     const current = bus.store.bot(item.toBotId);
     const currentSender = bus.store.bot(from.id);
-    if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return "settled";
+    if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) {
+      recordDelegationReceipt({
+        id: item.id,
+        sourceThreadId,
+        toBotId: current?.id ?? item.toBotId,
+        toBotName: current?.name ?? item.toBotId,
+        status: "error",
+        result: "the sender or source conversation disappeared while approval was pending",
+        ...evidenceFields(item),
+      });
+      return "settled";
+    }
+    if (item.runtimePolicyOverride && !currentSender.chiefOfStaff) {
+      recordDelegationReceipt({
+        id: item.id,
+        sourceThreadId,
+        toBotId: current.id,
+        toBotName: current.name,
+        status: "denied",
+        result: "only a Chief of Staff may set a runtime policy override",
+        ...evidenceFields(item),
+      });
+      bus.store.appendMessage(sourceThreadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name: `Delegation to @${current.name} canceled — Chief of Staff authority was revoked`, ok: false },
+      });
+      return "settled";
+    }
     if (dropIfSectionsChanged(bus, currentSender, current, sourceThreadId, item)) {
       return "settled";
     }
@@ -520,6 +702,7 @@ async function processOne(
         toBotName: current.name,
         status: "busy_gave_up",
         result: `@${current.name} stayed busy through ${MAX_BUSY_ATTEMPTS} retries`,
+        ...evidenceFields(item),
       });
       bus.store.appendMessage(sourceThreadId, {
         role: "bot",
@@ -531,11 +714,19 @@ async function processOne(
     sender = currentSender;
     target = current;
   }
+  const runtimePolicySnapshot = item.runtimePolicySnapshot
+    ? cloneRuntimePolicy(item.runtimePolicySnapshot)
+    : effectiveTaskRuntimePolicy(target.runtimePolicy, item.runtimePolicyOverride);
+  const evidence = item.evidence ?? delegationEvidence(item.message, item.reason, runtimePolicySnapshot, item.runtimePolicyOverride);
+  item.evidence = evidence;
+  item.runtimePolicySnapshot = runtimePolicySnapshot;
+  savePending();
+  bus.store.recordTaskRuntimePolicy(target.id, target.threadId, runtimePolicySnapshot, item.runtimePolicyOverride);
   const channel = getOrCreateChannel(bus.store, sender, target);
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id);
+  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id, evidence, runtimePolicySnapshot, item.runtimePolicyOverride);
   return "settled";
 }
 
@@ -559,6 +750,7 @@ function dropIfSectionsChanged(
     toBotName: target.name,
     status: "dropped",
     result,
+    ...evidenceFields(item),
   });
   bus.store.appendMessage(sourceThreadId, {
     role: "bot",

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -16,6 +16,7 @@ const TOKEN = "test-comms-token";
 let stub: Server;
 let stubPort = 0;
 let lastAuth: string | undefined;
+let lastCapability: { botId?: string; threadId?: string; value?: string } = {};
 let lastAskBody: any = null;
 /** What the stub harness returns from /api/internal/ask-bot. */
 type StubAskResponse = { botName?: string; text?: string; busy?: boolean; timeout?: boolean; waitedMs?: number; taskId?: string; toBotName?: string; error?: string };
@@ -63,6 +64,10 @@ let skillsResponse: unknown = {
   staged: [{ name: "pending-skill", action: "create", gist: "UNREVIEWED GIST", source: "UNREVIEWED SOURCE" }],
 };
 let skillStageResponse: unknown = { name: "file-expense", action: "create", gist: "Files an expense.", warnings: [] };
+let redirectAgents = false;
+let redirectSink: Server;
+let redirectSinkPort = 0;
+let leakedRedirectCapability: string | undefined;
 
 let child: ChildProcess;
 const pending = new Map<number, (msg: any) => void>();
@@ -81,13 +86,28 @@ function rpc(method: string, params?: unknown): Promise<any> {
 const callTool = (name: string, args: unknown) => rpc("tools/call", { name, arguments: args });
 
 beforeAll(async () => {
+  redirectSink = createServer((req, res) => {
+    leakedRedirectCapability = req.headers["x-omb-capability"] as string | undefined;
+    res.end("redirect sink");
+  });
+  await new Promise<void>((r) => redirectSink.listen(0, "127.0.0.1", r));
+  redirectSinkPort = (redirectSink.address() as { port: number }).port;
   stub = createServer((req, res) => {
     lastAuth = req.headers.authorization;
+    lastCapability = {
+      botId: req.headers["x-omb-bot-id"] as string | undefined,
+      threadId: req.headers["x-omb-thread-id"] as string | undefined,
+      value: req.headers["x-omb-capability"] as string | undefined,
+    };
     if (req.headers.authorization !== `Bearer ${TOKEN}`) {
       res.writeHead(401, { "content-type": "application/json" });
       return res.end(JSON.stringify({ error: "unauthorized" }));
     }
     if (req.method === "GET" && req.url?.startsWith("/api/internal/agents")) {
+      if (redirectAgents) {
+        res.writeHead(302, { location: "http://127.0.0.1:" + redirectSinkPort + "/sink" });
+        return res.end();
+      }
       res.writeHead(200, { "content-type": "application/json" });
       return res.end(
         JSON.stringify({
@@ -184,6 +204,7 @@ beforeAll(async () => {
       OMB_BOT_ID: "bot-asker",
       OMB_THREAD_ID: "thread-asker-routine",
       OMB_COMMS_TOKEN: TOKEN,
+      OMB_COMMS_CAPABILITY: "scoped-capability",
       OMB_TURN_DEPTH: "0",
       OMB_SKILL_AUTHORING_ENABLED: "1",
     },
@@ -207,6 +228,7 @@ beforeAll(async () => {
 afterAll(async () => {
   child?.kill();
   await new Promise<void>((r) => stub.close(() => r()));
+  await new Promise<void>((r) => redirectSink.close(() => r()));
 });
 
 describe("agents-proxy MCP surface", () => {
@@ -275,6 +297,20 @@ describe("agents-proxy MCP surface", () => {
     expect(text).toContain("Assign work with delegate_bot");
     expect(text).toContain("Use ask_bot only for a short answer");
     expect(lastAuth).toBe(`Bearer ${TOKEN}`);
+    expect(lastCapability).toEqual({ botId: "bot-asker", threadId: "thread-asker-routine", value: "scoped-capability" });
+  });
+
+  it("rejects redirects before forwarding the sender capability", async () => {
+    redirectAgents = true;
+    leakedRedirectCapability = undefined;
+    try {
+      const response = await callTool("list_bots", {});
+      expect(response.result.isError).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(leakedRedirectCapability).toBeUndefined();
+    } finally {
+      redirectAgents = false;
+    }
   });
 
   it("ask_bot forwards sender + depth and returns the reply", async () => {

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -23,6 +23,8 @@
 //   OMB_HARNESS_URL  base URL of the harness (http://127.0.0.1:8799)
 //   OMB_BOT_ID       the calling bot's id (excluded from list_bots; sender)
 //   OMB_COMMS_TOKEN  shared secret for the localhost-only internal endpoints
+//   OMB_COMMS_CAPABILITY scoped bot capability minted by the harness; the
+//                         injected thread id is checked at the existing route boundary
 //   OMB_TURN_DEPTH   this turn's comms depth (the harness refuses recursion)
 import readline from "node:readline";
 
@@ -32,6 +34,7 @@ const HARNESS = process.env.OMB_HARNESS_URL ?? "http://127.0.0.1:8799";
 const BOT_ID = process.env.OMB_BOT_ID ?? "";
 const THREAD_ID = process.env.OMB_THREAD_ID ?? "";
 const TOKEN = process.env.OMB_COMMS_TOKEN ?? "";
+const CAPABILITY = process.env.OMB_COMMS_CAPABILITY ?? "";
 const DEPTH = Number(process.env.OMB_TURN_DEPTH ?? "0") || 0;
 const SKILL_AUTHORING_ENABLED = process.env.OMB_SKILL_AUTHORING_ENABLED === "1";
 const MAX_CREATED_PER_TURN = 4;
@@ -248,6 +251,7 @@ const TOOLS = [
         bot_id: { type: "string", description: "The target bot's id (from list_bots)." },
         message: { type: "string", description: "What the peer should do / answer." },
         reason: { type: "string", description: "Optional one-line reason for the delegation (shown to the user as a chip)." },
+        runtimePolicyOverride: { type: "object", description: "Optional one-task runtime policy override; validated and accepted only when the caller is authorized." },
       },
       required: ["bot_id", "message"],
     },
@@ -415,10 +419,19 @@ const rpcErr = (id: unknown, code: number, message: string) => send({ jsonrpc: "
 const textResult = (id: unknown, text: string, isError = false) =>
   ok(id, { content: [{ type: "text", text }], isError });
 
+/** Call the local agents-proxy HTTP surface and decode its JSON response. */
 async function api(path: string, init?: RequestInit): Promise<Json> {
   const res = await fetch(HARNESS + path, {
     ...init,
-    headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}`, ...init?.headers },
+    redirect: "error",
+    headers: {
+      ...init?.headers,
+      "content-type": "application/json",
+      authorization: `Bearer ${TOKEN}`,
+      "x-omb-bot-id": BOT_ID,
+      "x-omb-thread-id": THREAD_ID,
+      "x-omb-capability": CAPABILITY,
+    },
   });
   const body = (await res.json().catch(() => ({}))) as Json;
   if (!res.ok) throw new Error(String(body.error ?? `HTTP ${res.status}`));
@@ -460,6 +473,7 @@ function confirmationResult(r: Json, fallback: string): { text: string } {
   };
 }
 
+/** Dispatch one approved agents-proxy tool request to the local server surface. */
 async function callTool(name: string, args: Json): Promise<{ text: string; isError?: boolean }> {
   if (name === "list_bots") {
     const r = await api(`/api/internal/agents?self=${encodeURIComponent(BOT_ID)}`);
@@ -520,6 +534,9 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       depth: DEPTH,
     };
     if (reason) body.reason = reason;
+    if (Object.prototype.hasOwnProperty.call(args, "runtimePolicyOverride")) {
+      body.runtimePolicyOverride = args.runtimePolicyOverride;
+    }
     const r = await api(`/api/internal/delegate-bot`, { method: "POST", body: JSON.stringify(body) });
     if (r.error) return { text: `Couldn't queue the delegation: ${r.error}`, isError: true };
     // Fire-and-forget by contract: the harness returns immediately, the

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -584,6 +584,39 @@ describe("harness HTTP API", () => {
     expect(body.bots[0].messages.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("serializes and persists runtime controls, while enforcing the Chief lock", async () => {
+    const created = await api("POST", "/api/bots");
+    const bot = created.body.bot;
+    try {
+      expect(bot.runtimePolicy).toMatchObject({
+        wallClockTimeoutMinutes: 0,
+        delegationConcurrency: 4,
+        cumulativeTokenPolicy: { mode: "disabled" },
+      });
+      const values = {
+        wallClockTimeoutMinutes: 8,
+        idleTimeoutMinutes: 4,
+        cancellationGraceSeconds: 12,
+        delegationConcurrency: 2,
+        cumulativeTokenPolicy: { mode: "hard", limit: 20_000 },
+      };
+      const saved = await api("PATCH", `/api/bots/${bot.id}`, { runtimePolicy: values });
+      expect(saved.status).toBe(200);
+      expect(saved.body.bot.runtimePolicy).toMatchObject(values);
+      const roundTrip = await api("GET", "/api/bots?messages=0");
+      expect(roundTrip.body.bots.find((candidate: { id: string }) => candidate.id === bot.id).runtimePolicy).toMatchObject(values);
+
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { chiefRuntimePolicyLocked: true })).status).toBe(200);
+      const blocked = await api("PATCH", `/api/bots/${bot.id}`, { runtimePolicy: { delegationConcurrency: 1 } });
+      expect(blocked.status).toBe(409);
+      expect(blocked.body.error).toMatch(/locked/i);
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { chiefRuntimePolicyLocked: false })).status).toBe(200);
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { runtimePolicy: { delegationConcurrency: 1 } })).status).toBe(200);
+    } finally {
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("projects privacy-safe live team-map metadata", async () => {
     const response = await api("GET", "/api/team-map");
     expect(response.status).toBe(200);
@@ -1085,20 +1118,70 @@ describe("harness HTTP API", () => {
       const dump = z.object({
         mcpConfig: z.object({
           mcpServers: z.object({
-            agents: z.object({ env: z.object({ OMB_COMMS_TOKEN: z.string() }) }),
+            agents: z.object({ env: z.object({ OMB_COMMS_TOKEN: z.string(), OMB_COMMS_CAPABILITY: z.string() }) }),
           }),
         }),
       }).parse(await readJsonFileWhenReady(fakeClaudeDump));
       const internalHeaders = {
         authorization: `Bearer ${dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN}`,
+        "x-omb-bot-id": chief.id,
+        "x-omb-thread-id": chief.threadId,
+        "x-omb-capability": dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_CAPABILITY,
         "content-type": "application/json",
       };
+      const captureThreadHeaders = async (threadId: string) => {
+        rmSync(fakeClaudeDump, { force: true });
+        expect((await api("POST", `/api/groups/${channel.id}/messages`, { text: `capture ${threadId}` })).status).toBe(202);
+        const threadDump = await readJsonFileWhenReady<{
+          mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_CAPABILITY: string } } } };
+        }>(fakeClaudeDump);
+        await api("POST", `/api/groups/${channel.id}/interrupt`, { threadId });
+        await expect.poll(async () => {
+          const state = (await api("GET", "/api/bots?messages=0")).body;
+          return state.groups.find((candidate: { id: string }) => candidate.id === channel.id)?.working;
+        }, { timeout: 5_000 }).toBe(false);
+        return {
+          ...internalHeaders,
+          "x-omb-thread-id": threadId,
+          "x-omb-capability": threadDump.mcpConfig.mcpServers.agents.env.OMB_COMMS_CAPABILITY,
+        };
+      };
+      const spoofed = await fetch(`${BASE}/api/internal/create-bot`, {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({
+          fromBotId: outsider.id,
+          fromThreadId: outsider.threadId,
+          name: "Spoofed operator",
+          role: "Research operator",
+          instructions: "Must not be created.",
+        }),
+      });
+      expect(spoofed.status).toBe(403);
+      expect((await spoofed.json() as { error?: string }).error).toMatch(/capability/i);
+      const spoofedDelegation = await fetch(`${BASE}/api/internal/delegate-bot`, {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({
+          fromBotId: outsider.id,
+          fromThreadId: outsider.threadId,
+          toBotId: chief.id,
+          message: "must not queue",
+          runtimePolicyOverride: { maxToolAgentSteps: 1 },
+        }),
+      });
+      expect(spoofedDelegation.status).toBe(403);
+      expect((await spoofedDelegation.json() as { error?: string }).error).toMatch(/capability/i);
       expect((await api("POST", `/api/bots/${chief.id}/interrupt`)).status).toBe(200);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((candidate: { id: string }) => candidate.id === chief.id)?.busy;
+      }, { timeout: 5_000 }).toBe(false);
 
-      const createOperator = async (fromThreadId: string, name: string, fromBotId = chief.id) => {
+      const createOperator = async (fromThreadId: string, name: string, fromBotId = chief.id, headers = internalHeaders) => {
         const response = await fetch(`${BASE}/api/internal/create-bot`, {
           method: "POST",
-          headers: internalHeaders,
+          headers,
           body: JSON.stringify({
             fromBotId,
             fromThreadId,
@@ -1122,14 +1205,16 @@ describe("harness HTTP API", () => {
       channel = (await api("POST", "/api/groups", {
         name: "Chief member channel",
         memberIds: [chief.id],
-        setup: { bulletin: "", defaultResponder: { kind: "member", botId: chief.id } },
+        setup: { bulletin: "", defaultResponder: { kind: "member", botId: chief.id }, completed: true },
       })).body.group;
       const rootThreadId = channel.threadId;
+      const rootHeaders = await captureThreadHeaders(rootThreadId);
       const channelTask = await api("POST", `/api/groups/${channel.id}/tasks`, { title: "Research task" });
       expect(channelTask.status).toBe(201);
-      const rootTask = await createOperator(rootThreadId, "Channel Root Operator");
+      const taskHeaders = await captureThreadHeaders(channelTask.body.task.threadId);
+      const rootTask = await createOperator(rootThreadId, "Channel Root Operator", chief.id, rootHeaders);
       expect(rootTask.status).toBe(201);
-      const nestedTask = await createOperator(channelTask.body.task.threadId, "Channel Task Operator");
+      const nestedTask = await createOperator(channelTask.body.task.threadId, "Channel Task Operator", chief.id, taskHeaders);
       expect(nestedTask.status).toBe(201);
 
       outsiderChannel = (await api("POST", "/api/groups", {
@@ -1140,12 +1225,12 @@ describe("harness HTTP API", () => {
       const nonChief = await createOperator(outsiderChannel.threadId, "Non-Chief Operator", outsider.id);
       expect(nonChief).toEqual({
         status: 403,
-        body: { error: "only a section's Chief of Staff can create operator bots" },
+        body: { error: "sender capability does not match proxy identity" },
       });
       const denied = await createOperator(outsiderChannel.threadId, "Forbidden Operator");
       expect(denied).toEqual({
         status: 403,
-        body: { error: "source conversation does not belong to sender" },
+        body: { error: "sender capability does not match proxy identity" },
       });
       const state = (await api("GET", "/api/bots?messages=0")).body;
       expect(state.bots.some((bot: { name: string }) => bot.name === "Forbidden Operator")).toBe(false);
@@ -4556,7 +4641,7 @@ describe("harness HTTP API", () => {
       expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "start the lead" })).status).toBe(202);
       const firstDump = await readJsonFileWhenReady<{
         pid: number;
-        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string; OMB_COMMS_CAPABILITY: string } } } };
       }>(fakeClaudeDump);
       const token = firstDump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
@@ -4565,6 +4650,9 @@ describe("harness HTTP API", () => {
         method: "POST",
         headers: {
           authorization: `Bearer ${token}`,
+          "x-omb-bot-id": first.id,
+          "x-omb-thread-id": room.threadId,
+          "x-omb-capability": firstDump.mcpConfig.mcpServers.agents.env.OMB_COMMS_CAPABILITY,
           "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -4627,7 +4715,7 @@ describe("harness HTTP API", () => {
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "prepare a routine" })).status).toBe(202);
       const dump = await readJsonFileWhenReady<{
-        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string; OMB_COMMS_CAPABILITY: string } } } };
       }>(fakeClaudeDump);
       const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
@@ -4638,6 +4726,9 @@ describe("harness HTTP API", () => {
       }, { timeout: 5_000 }).toBe(false);
       const internalHeaders = {
         authorization: `Bearer ${token}`,
+        "x-omb-bot-id": bot.id,
+        "x-omb-thread-id": bot.threadId,
+        "x-omb-capability": dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_CAPABILITY,
         "content-type": "application/json",
       };
 
@@ -4980,12 +5071,15 @@ describe("harness HTTP API", () => {
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "prepare a skill" })).status).toBe(202);
       const dump = await readJsonFileWhenReady<{
-        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string; OMB_COMMS_CAPABILITY: string } } } };
       }>(fakeClaudeDump);
       const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
       expect(token).toMatch(/^[a-f0-9]{48}$/);
       const internalHeaders = {
         authorization: `Bearer ${token}`,
+        "x-omb-bot-id": bot.id,
+        "x-omb-thread-id": bot.threadId,
+        "x-omb-capability": dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_CAPABILITY,
         "content-type": "application/json",
       };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 // OpenMausBot server — the harness host. Clients hold no transports
 // (upstream rule): the React app dispatches typed commands over HTTP and
 // folds one SSE event stream; every provider process runs here.
-import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { extname, join } from "node:path";
@@ -122,6 +122,14 @@ import {
 } from "./mcp-registry.ts";
 import { probeMcpServer } from "./mcp-probe.ts";
 import {
+  cloneRuntimePolicy,
+  effectiveBotRuntimePolicy,
+  effectiveTaskRuntimePolicy,
+  validateRuntimePolicyPatch,
+  type BotRuntimePolicy,
+  type RuntimePolicyOverrides,
+} from "./bot-runtime-policy.ts";
+import {
   GROUP_GOAL_MAX_TURNS,
   groupGoalAssignmentKey,
   groupGoalCompletionTurnId,
@@ -138,7 +146,7 @@ import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
-import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, summarizeDelegatedActivity, type QueueResult } from "./delegations.ts";
+import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, summarizeDelegatedActivity, type DelegationEvidence, type QueueResult } from "./delegations.ts";
 import {
   cancelSteeredMessage,
   drainSteeredMessages,
@@ -175,6 +183,8 @@ import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
 import { buildTurnContext, engineIsFresh } from "./turn-context.ts";
 import { TurnWatchdog } from "./turn-watchdog.ts";
+import { TurnSupervision, type UnknownTurn } from "./turn-supervision.ts";
+import { TurnRuntimeLimits, type TurnRuntimeLimitEvent } from "./turn-runtime-limits.ts";
 import {
   ensureWorkspace,
   listMemoryTopics,
@@ -350,6 +360,7 @@ bus.attach(registry.instances());
 // A shared secret guards the localhost-only /api/internal endpoints the
 // agents-proxy calls; regenerated each boot (the proxy gets it via env).
 const COMMS_TOKEN = randomBytes(24).toString("hex");
+const COMMS_CAPABILITY_SECRET = randomBytes(32);
 
 /** Constant-time bearer check for the internal comms endpoints. The token
  * is high-entropy and loopback-only, so a timing oracle is a long shot —
@@ -357,6 +368,27 @@ const COMMS_TOKEN = randomBytes(24).toString("hex");
 function authorizedComms(header: string | string[] | undefined): boolean {
   const expected = Buffer.from(`Bearer ${COMMS_TOKEN}`);
   const got = Buffer.from(Array.isArray(header) ? "" : (header ?? ""));
+  return got.length === expected.length && timingSafeEqual(got, expected);
+}
+
+/** Derive the per-bot, per-thread capability used by the local agents proxy. */
+function agentCapability(botId: string, threadId: string): string {
+  return createHmac("sha256", COMMS_CAPABILITY_SECRET).update(`${botId}\n${threadId}`, "utf8").digest("hex");
+}
+
+/** The bearer proves the request came from this boot. The scoped capability
+ * additionally proves which injected bot proxy is speaking. The requested
+ * thread is still checked against that bot by every existing route boundary,
+ * so a process holding the shared bearer cannot rewrite fromBotId. */
+function authorizedAgentProxy(req: IncomingMessage, botId: string, threadId?: string): boolean {
+  const header = (value: string | string[] | undefined): string => Array.isArray(value) ? "" : value ?? "";
+  const claimedBotId = header(req.headers["x-omb-bot-id"]);
+  const claimedThreadId = header(req.headers["x-omb-thread-id"]);
+  const claimedCapability = header(req.headers["x-omb-capability"]);
+  const effectiveThreadId = threadId ?? claimedThreadId;
+  if (!claimedBotId || !claimedThreadId || claimedBotId !== botId || !effectiveThreadId || claimedThreadId !== effectiveThreadId) return false;
+  const expected = Buffer.from(agentCapability(botId, effectiveThreadId), "utf8");
+  const got = Buffer.from(claimedCapability, "utf8");
   return got.length === expected.length && timingSafeEqual(got, expected);
 }
 // Cap message chains: depth 0 = a user-initiated turn (may ask a peer);
@@ -377,6 +409,7 @@ const phoneProxyPath = SPAWNED_PROXIES.phone;
 // in the packaged app process.execPath is Electron — run the proxy as node
 const AGENTS_NODE_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
 
+/** Build the isolated agents-proxy launch configuration for a bot thread. */
 function agentsIntegration(botId: string, threadId: string, depth: number, skillAuthoring: boolean) {
   return {
     command: process.execPath,
@@ -387,6 +420,7 @@ function agentsIntegration(botId: string, threadId: string, depth: number, skill
       OMB_BOT_ID: botId,
       OMB_THREAD_ID: threadId,
       OMB_COMMS_TOKEN: COMMS_TOKEN,
+      OMB_COMMS_CAPABILITY: agentCapability(botId, threadId),
       OMB_TURN_DEPTH: String(depth),
       OMB_SKILL_AUTHORING_ENABLED: skillAuthoring ? "1" : "0",
     },
@@ -551,6 +585,15 @@ function shouldIgnoreProviderEvent(event: RuntimeEvent): boolean {
   // narrow pre-id window and tombstone any id it reveals; the broad gate is
   // time-bounded so a broken promise cannot suppress a later turn forever.
   if (isTurnEventQuarantined(pendingCancelledProviderHandshakes, retiredProviderTurns, event)) return true;
+  if (event.turnId) {
+    const owner = store.botByThread(event.threadId) ??
+      (groupSpeakers.get(event.threadId) ? store.bot(groupSpeakers.get(event.threadId)!.botId) : null);
+    if (owner && !turnSupervision.wasJustAccepted(owner.id, event.threadId, event.turnId)) {
+      if (turnSupervision.isLate(owner.id, event.threadId, event.turnId)) return true;
+      if (turnSupervision.has(owner.id, event.threadId)
+        && !turnSupervision.isCurrent(owner.id, event.threadId, event.turnId)) return true;
+    }
+  }
   if (event.type !== "session.exited" || event.turnId !== undefined) return false;
   return store.botByThread(event.threadId)?.busy === true || Boolean(store.groupByThread(event.threadId)?.busyBotId);
 }
@@ -897,12 +940,33 @@ if (browserCleanupReferencesReconciled) browserCleanup.startPending();
  * paired phone has even less business holding provider session identifiers
  * than the desktop window did. Stripped here rather than at each call site
  * so a new broadcast cannot forget. */
-const wireTask = ({ resumeCursors: _resumeCursors, lastInstanceId: _lastInstanceId, ...task }: TaskRecord) => task;
+const wireTask = ({ resumeCursors: _resumeCursors, lastInstanceId: _lastInstanceId, runtimePolicySnapshot: _runtimePolicySnapshot, ...task }: TaskRecord) => task;
 
 const wireBot = (bot: NonNullable<ReturnType<typeof store.bot>>) => {
   const { resumeCursors: _resumeCursors, tasks, ...rest } = bot;
-  return { ...rest, avatarUrl: rest.avatarUrl ?? null, ...(tasks ? { tasks: tasks.map(wireTask) } : {}) };
+  return {
+    ...rest,
+    avatarUrl: rest.avatarUrl ?? null,
+    runtimePolicy: effectiveBotRuntimePolicy(rest.runtimePolicy),
+    chiefRuntimePolicyLocked: rest.chiefRuntimePolicyLocked === true,
+    ...(tasks ? { tasks: tasks.map(wireTask) } : {}),
+  };
 };
+
+function mergeRuntimePolicyOverrides(
+  previous: RuntimePolicyOverrides | undefined,
+  patch: ReturnType<typeof validateRuntimePolicyPatch>,
+): RuntimePolicyOverrides | undefined {
+  if (patch === undefined) return previous;
+  if (patch === null) return undefined;
+  return {
+    ...previous,
+    ...patch,
+    ...(previous?.cumulativeTokenPolicy || patch.cumulativeTokenPolicy
+      ? { cumulativeTokenPolicy: { ...previous?.cumulativeTokenPolicy, ...patch.cumulativeTokenPolicy } }
+      : {}),
+  };
+}
 
 /** Profile URLs are app-owned references, not merely strings with a trusted
  * prefix. Resolve them before persistence so every accepted avatar can be
@@ -1619,6 +1683,57 @@ const groupSpeakers = new Map<string, { botId: string; name: string; color: stri
 // Providers report cumulative-within-turn numbers; the final value is folded
 // into the task's tally when the turn settles.
 const turnUsage = new Map<string, { input: number; output: number; cachedInput?: number }>();
+const runtimeLimits = new TurnRuntimeLimits();
+const turnSupervision = new TurnSupervision({
+  graceMs: Math.max(1, Number(process.env.OMB_TURN_STOP_GRACE_MS) || 5_000),
+  onUnknown: (turn: UnknownTurn) => {
+    runtimeLimits.settle(turn.threadId);
+    repeats.settle(turn.threadId);
+    watchdog.settle(turn.threadId);
+    turnUsage.delete(turn.threadId);
+    void releaseBrowserCapabilityForThread(turn.threadId);
+    const direct = store.bot(turn.botId);
+    const group = store.groupByThread(turn.threadId);
+    const groupOwned = group?.busyBotId === turn.botId;
+    const groupSpeaker = groupSpeakers.get(turn.threadId);
+    if (groupOwned) {
+      groupSpeakers.delete(turn.threadId);
+      store.patchGroup(group.id, { busyBotId: null, unread: true });
+    }
+    if (direct?.busy || groupOwned) {
+      if (direct?.busy) {
+        stopScreenPoller(direct.id);
+        if (activeVpsThreads.get(direct.id) === turn.threadId) activeVpsThreads.delete(direct.id);
+        store.setActivity(direct.id, "idle");
+        retryDelegationsWaitingOn(direct.id);
+      } else {
+        if (groupSpeaker) {
+          const member = store.bot(groupSpeaker.botId);
+          if (member?.busy) {
+            store.setActivity(member.id, "idle");
+            retryDelegationsWaitingOn(member.id);
+          }
+        }
+      }
+    }
+    const receipt = finalizeDelegationWatch(
+      turn.threadId,
+      false,
+      "",
+      `Delegated turn ended without a terminal receipt — ${turn.reason}`,
+    );
+    if (!receipt) {
+      store.appendMessage(turn.threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name: `error: ${turn.reason}`, ok: false },
+      });
+    }
+    drainQueuedSends();
+    drainConnectorResumes();
+    drainSecretResumes();
+  },
+});
 
 // Bounded per active turn. OpenHands uses a bounded recent-event scan for
 // the same class of stuck-loop detection; retaining an unlimited set of
@@ -1649,12 +1764,19 @@ const watchdog = new TurnWatchdog({
   stallMs: TURN_STALL_MS,
   checkMs: 60_000,
   onStall: (turn) => {
+    const admittedPolicy = runtimeLimits.snapshot(turn.threadId);
     void releaseBrowserCapabilityForThread(turn.threadId);
     repeats.settle(turn.threadId);
+    runtimeLimits.settle(turn.threadId);
     const bot = store.bot(turn.botId);
     const instance = bot ? registry.get(bot.modelSelection.instanceId) : null;
-    void instance?.adapter.interruptTurn(turn.threadId).catch(() => {});
-    const minutes = Math.round(TURN_STALL_MS / 60_000);
+    void turnSupervision.requestStop(
+      turn.botId,
+      turn.threadId,
+      "timeout",
+      () => instance?.adapter.interruptTurn(turn.threadId),
+    );
+    const minutes = Math.round(turn.idleMs / 60_000);
     store.appendMessage(turn.threadId, {
       role: "bot",
       kind: "activity",
@@ -1697,7 +1819,7 @@ const watchdog = new TurnWatchdog({
         drainSecretResumes();
       }
     };
-    const release = setTimeout(releaseOwnership, 6_000);
+    const release = setTimeout(releaseOwnership, (admittedPolicy?.cancellationGraceSeconds ?? 6) * 1_000);
     release.unref?.();
   },
 });
@@ -1778,10 +1900,29 @@ async function reviewPermissionCard(args: {
 
 bus.subscribe((event: RuntimeEvent) => {
   if (shouldIgnoreProviderEvent(event)) return;
+  const speaker = groupSpeakers.get(event.threadId);
+  const owner = store.botByThread(event.threadId) ?? (speaker ? store.bot(speaker.botId) : null);
+  if (owner && event.type === "turn.started" && event.turnId) {
+    turnSupervision.bind(owner.id, event.threadId, event.turnId);
+  }
+  if (owner && event.type === "turn.completed") {
+    turnSupervision.observeTerminal(owner.id, event.threadId, event.turnId);
+  } else if (owner && event.type === "session.exited" && turnSupervision.has(owner.id, event.threadId)) {
+    void turnSupervision.requestStop(owner.id, event.threadId, "provider-exit", () => {
+      const instance = registry.get(owner.modelSelection.instanceId);
+      return instance?.adapter.interruptTurn(event.threadId);
+    });
+  }
+  if (event.type === "item.started" && event.itemType === "tool") {
+    runtimeLimits.recordToolStarted(event.threadId, event.itemId ?? event.title ?? "tool");
+  } else if (event.type === "thread.token-usage.updated") {
+    runtimeLimits.recordTokenSample(event.threadId, event.input, event.output);
+  }
   if (event.type === "request.opened") watchdog.setWaitingOnHuman(event.threadId, true);
   else if (event.type === "request.resolved") watchdog.setWaitingOnHuman(event.threadId, false);
   else if (event.type === "turn.completed") {
     watchdog.settle(event.threadId);
+    runtimeLimits.settle(event.threadId);
     void releaseBrowserCapabilityForThread(event.threadId);
   } else if (event.type === "session.exited") {
     // A retained provider session can exit after a newer turn reused the same
@@ -2415,6 +2556,7 @@ const delegationWatch = new Map<string, {
   sourceThreadId?: string;
   /** when the delegated turn was dispatched — elapsed time for status checks */
   startedAtMs?: number;
+  evidence?: DelegationEvidence;
 }>();
 
 // Peer wake: when a delegated reply lands, resume the source bot so it can
@@ -2521,6 +2663,7 @@ function finalizeDelegationWatch(
       toBotName: store.bot(watched.toBotId)?.name ?? watched.toBotId,
       status: ok ? "done" : "failed",
       result: ok ? reply : failureName,
+      ...(watched.evidence ? { evidence: watched.evidence } : {}),
     });
   }
   const target = store.bot(watched.toBotId);
@@ -2603,7 +2746,7 @@ bus.subscribe((event: RuntimeEvent) => {
 /** How a drained delegation becomes a real turn on the target. Shared by
  * the settle-time drain and the boot-time drain of what a previous process
  * left queued. */
-const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text, commsDepth, sourceThreadId, channel, taskId) => {
+const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text, commsDepth, sourceThreadId, channel, taskId, evidence, runtimePolicySnapshot, runtimePolicyOverride) => {
     // startTurn REJECTS on an ordinary condition — busy target, deleted bot,
     // unavailable provider. Unhandled, that rejection is fatal to the
     // harness (Node's default), which in the packaged app kills the server
@@ -2618,6 +2761,7 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
         taskId,
         sourceThreadId,
         startedAtMs: Date.now(),
+        evidence,
       });
     }
     let failureReported = false;
@@ -2645,6 +2789,8 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
     };
     return startTurn(toBotId, text, {
       commsDepth,
+      runtimePolicySnapshot,
+      runtimePolicyOverride,
       unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
       // startTurn schedules provider/integration setup after marking the bot
       // busy. Those asynchronous setup failures do not emit turn.completed,
@@ -2868,6 +3014,7 @@ async function finalScreenFrame(botId: string, threadId: string): Promise<Frame 
 }
 
 // ── turn dispatch (upstream ProviderCommandReactor, miniature) ──────────
+/** Admit and execute one turn with its immutable runtime-policy snapshot. */
 async function startTurn(
   botId: string,
   text: string,
@@ -2895,6 +3042,10 @@ async function startTurn(
     /** Stable identity supplied by the composer so a network retry cannot
      * dispatch the same user action twice. */
     sendId?: string;
+    /** Immutable policy captured at delegation queue time. */
+    runtimePolicySnapshot?: BotRuntimePolicy;
+    /** Explicit override retained in task evidence for delegated turns. */
+    runtimePolicyOverride?: RuntimePolicyOverrides;
     onDispatchError?: (message: string) => void;
   },
 ) {
@@ -2916,6 +3067,10 @@ async function startTurn(
   }
   const task = store.taskByThread(bot.id, threadId);
   if (!task) throw Object.assign(new Error("no such task"), { status: 404 });
+  const runtimePolicy = cloneRuntimePolicy(
+    opts?.runtimePolicySnapshot ?? effectiveTaskRuntimePolicy(bot.runtimePolicy, opts?.runtimePolicyOverride),
+  );
+  store.recordTaskRuntimePolicy(bot.id, threadId, runtimePolicy, opts?.runtimePolicyOverride);
   const commsDepth = opts?.commsDepth ?? 0;
   // a task takes its name from the first thing you asked it to do
   if (text.trim() && !opts?.cardContinuation) store.titleTaskFromFirstMessage(bot.id, text, threadId);
@@ -3027,6 +3182,29 @@ async function startTurn(
   // in the background — box provisioning can take ~90s and must never
   // hang the HTTP request
   const dispatchClaimId = randomUUID();
+  if (!runtimeLimits.begin(threadId, runtimePolicy, {
+    onHardStop: (event: TurnRuntimeLimitEvent) => {
+      store.appendMessage(threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name: `error: runtime ${event.kind} limit reached (${event.observed}/${event.limit})`, ok: false },
+      });
+      void turnSupervision.requestStop(bot.id, threadId, "timeout", () => instance.adapter.interruptTurn(threadId));
+    },
+    onSoftTokenWarning: (event: TurnRuntimeLimitEvent) => {
+      store.appendMessage(threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: { name: `runtime token budget reached (${event.observed}/${event.limit})`, ok: false },
+      });
+    },
+  })) {
+    throw Object.assign(new Error("the thread already has an active runtime policy"), { status: 409 });
+  }
+  if (!turnSupervision.begin(bot.id, threadId, runtimePolicy.cancellationGraceSeconds * 1_000)) {
+    runtimeLimits.settle(threadId);
+    throw Object.assign(new Error("the thread already has an active supervised turn"), { status: 409 });
+  }
   directTurnGenerationByBot.set(bot.id, dispatchClaimId);
   directTurnDispatchClaims.set(bot.id, { id: dispatchClaimId, threadId, phase: "setup" });
   store.setActivity(bot.id, "working");
@@ -3358,7 +3536,7 @@ async function startTurn(
       if (!markDirectTurnDispatching(bot.id, dispatchClaimId, threadId)) {
         throw new DirectTurnSetupCancelled("turn stopped before dispatch");
       }
-      watchdog.watch(threadId, bot.id);
+      watchdog.watch(threadId, bot.id, runtimePolicy.idleTimeoutMinutes * 60_000);
       const dispatch = await guardTurnDispatch(instance.adapter.sendTurn({
         threadId,
         text: turnText,
@@ -3447,6 +3625,8 @@ async function startTurn(
         releaseLocalVmThread(threadId);
         if (activeVpsThreads.get(bot.id) === threadId) activeVpsThreads.delete(bot.id);
         watchdog.settle(threadId);
+        runtimeLimits.settle(threadId);
+        turnSupervision.finishWithoutProvider(bot.id, threadId);
         turnUsage.delete(threadId);
       }
       if (e instanceof DirectTurnSetupCancelled) {
@@ -3976,6 +4156,7 @@ _loadPending();
   for (const threadId of leftover) drainDelegations(commsBus, approvalBus, threadId, runDelegatedTurn);
 }
 
+/** Execute one group member turn while preserving group-level lifecycle state. */
 async function runGroupMemberTurn(
   groupId: string,
   threadId: string,
@@ -4004,6 +4185,7 @@ async function runGroupMemberTurn(
   if (!group || !bot || !ownsThread) return false;
   spoken.add(botId);
   const instance = registry.get(bot.modelSelection.instanceId);
+  const runtimePolicy = effectiveBotRuntimePolicy(bot.runtimePolicy);
   const userName = cfg.profile?.name?.trim() || "User";
   if (!instance) {
     const message = `${bot.name}'s model is unavailable`;
@@ -4235,6 +4417,12 @@ async function runGroupMemberTurn(
     }
     return false;
   }
+  if (!turnSupervision.begin(bot.id, threadId, runtimePolicy.cancellationGraceSeconds * 1_000)) {
+    groupSpeakers.delete(threadId);
+    store.patchGroup(group.id, { busyBotId: null, unread: true });
+    store.setActivity(bot.id, "idle");
+    return false;
+  }
   let replyText = "";
   let providerTurnId: string | undefined;
   let abandoned = false;
@@ -4246,7 +4434,10 @@ async function runGroupMemberTurn(
     if (providerTurnId) retireProviderTurn(providerTurnId);
     else markCancelledProviderHandshake(threadId, retirementOwner);
   };
-  const timeoutMinutes = roomTurnTimeoutMinutes(cfg);
+  const configuredTimeoutMinutes = roomTurnTimeoutMinutes(cfg);
+  const timeoutMinutes = runtimePolicy.wallClockTimeoutMinutes > 0
+    ? Math.min(configuredTimeoutMinutes, runtimePolicy.wallClockTimeoutMinutes)
+    : configuredTimeoutMinutes;
   const outcome = await new Promise<GroupMemberTurnOutcome>((resolve) => {
     let done = false;
     let unsub = () => {};
@@ -4254,7 +4445,7 @@ async function runGroupMemberTurn(
     const deadline = new RoomTurnDeadline(timeoutMinutes, () => {
       abandonProviderTurn();
       void releaseBrowserCapabilityForThread(threadId);
-      void instance.adapter.interruptTurn(threadId).catch(() => {});
+      void turnSupervision.requestStop(bot.id, threadId, "timeout", () => instance.adapter.interruptTurn(threadId));
       store.appendMessage(threadId, {
         role: "bot",
         kind: "activity",
@@ -4295,7 +4486,31 @@ async function runGroupMemberTurn(
       abandonProviderTurn();
       finish("stalled");
     });
-    watchdog.watch(threadId, bot.id);
+    if (!runtimeLimits.begin(threadId, runtimePolicy, {
+      onHardStop: (event) => {
+        store.appendMessage(threadId, {
+          role: "bot",
+          kind: "activity",
+          from: { botId: bot.id, name: bot.name, color: bot.color },
+          tool: { name: `error: runtime ${event.kind} limit reached (${event.observed}/${event.limit})`, ok: false },
+        });
+        void turnSupervision.requestStop(bot.id, threadId, "timeout", () => instance.adapter.interruptTurn(threadId));
+        finish("timed_out");
+      },
+      onSoftTokenWarning: (event) => {
+        store.appendMessage(threadId, {
+          role: "bot",
+          kind: "activity",
+          from: { botId: bot.id, name: bot.name, color: bot.color },
+          tool: { name: `runtime token budget reached (${event.observed}/${event.limit})`, ok: false },
+        });
+      },
+    })) {
+      turnSupervision.finishWithoutProvider(bot.id, threadId);
+      finish("dispatch_failed");
+      return;
+    }
+    watchdog.watch(threadId, bot.id, runtimePolicy.idleTimeoutMinutes * 60_000);
     onProviderHandshakeStarted?.();
     guardTurnDispatch(instance.adapter.sendTurn({
         threadId,
@@ -4329,6 +4544,8 @@ async function runGroupMemberTurn(
       .catch((err) => {
         onProviderHandshakeSettled?.();
         clearCancelledProviderHandshake(threadId, retirementOwner);
+        runtimeLimits.settle(threadId);
+        turnSupervision.finishWithoutProvider(bot.id, threadId);
         if (abandoned) return;
         const message = err instanceof Error ? err.message : "turn failed";
         store.appendMessage(threadId, {
@@ -4396,7 +4613,7 @@ async function runGroupMemberTurn(
         drainSecretResumes();
       }
     };
-    const release = setTimeout(releaseOwnership, 6_000);
+    const release = setTimeout(releaseOwnership, runtimePolicy.cancellationGraceSeconds * 1_000);
     release.unref?.();
     return false;
   }
@@ -5140,10 +5357,12 @@ function stagedSkillCleanupsForThread(threadId: string): Array<{ botId: string; 
   return cleanups;
 }
 
+/** Reject staged skill writes left behind when their source thread is deleted. */
 function rejectDeletedThreadSkillStages(cleanups: Array<{ botId: string; stagedId: string }>): void {
   for (const cleanup of cleanups) rejectStagedSkillWrite(cleanup.botId, cleanup.stagedId);
 }
 
+/** Convert staged skill metadata into the user-facing approval-card copy. */
 function skillCardCopy(staged: { action: "create" | "update"; name: string; gist: string; warnings: string[] }): {
   title: string;
   subtitle: string;
@@ -5159,6 +5378,7 @@ function skillCardCopy(staged: { action: "create" | "update"; name: string; gist
   };
 }
 
+/** Append a staged skill request card to the target thread's message stream. */
 function appendSkillRequestCard(args: {
   botId: string;
   threadId: string;
@@ -5210,6 +5430,7 @@ function appendSkillRequestCard(args: {
   };
 }
 
+/** Resolve a reviewed skill request and apply only the approved lifecycle action. */
 function resolveSkillRequest(args: {
   botId: string;
   botName?: string;
@@ -5755,11 +5976,39 @@ function persistMcpServers(next: Record<string, unknown>): void {
 /** Rebuild the provider fleet after a config change so new keys take
  * effect without a server restart (kills any in-flight turns). */
 async function reloadProviders() {
+  // Dispose/reload is a provider lifecycle boundary. Reconcile every active
+  // generation before the old fleet disappears so a replacement turn is not
+  // rejected by a stale in-memory supervisor entry.
+  const supervised = new Set<string>();
+  for (const bot of store.bots.filter((candidate) => candidate.busy)) {
+    const threadId = bot.threadId;
+    runtimeLimits.settle(threadId);
+    watchdog.settle(threadId);
+    repeats.settle(threadId);
+    turnUsage.delete(threadId);
+    if (turnSupervision.has(bot.id, threadId)) {
+      supervised.add(`${bot.id}\u0000${threadId}`);
+      // The reload reconciliation below owns the user-visible failure chip
+      // and delegated terminal receipt for this deliberate provider restart.
+      turnSupervision.finishWithoutProvider(bot.id, threadId);
+    }
+  }
+  for (const [threadId, speaker] of groupSpeakers) {
+    runtimeLimits.settle(threadId);
+    watchdog.settle(threadId);
+    repeats.settle(threadId);
+    turnUsage.delete(threadId);
+    if (supervised.has(`${speaker.botId}\u0000${threadId}`)) continue;
+    if (turnSupervision.has(speaker.botId, threadId)) {
+      turnSupervision.finishWithoutProvider(speaker.botId, threadId);
+    }
+  }
   await releaseAllBrowserCapabilities();
   bus.detachAll();
   await registry.disposeAll();
   await registry.load(instanceConfigs(cfg));
   bus.attach(registry.instances());
+  turnSupervision.resetProviderLifecycle();
   // A killed turn's terminal events can die with the old fleet (dispose is
   // async under the hood), stranding the bot busy — and its screen poller —
   // forever. Settle anything still marked busy.
@@ -5986,6 +6235,7 @@ const server = createServer(async (req, res) => {
         const self = url.searchParams.get("self");
         const sender = self ? store.bot(self) : null;
         if (!sender) return json(res, 403, { error: "unknown sender" });
+        if (!authorizedAgentProxy(req, sender.id)) return json(res, 403, { error: "sender capability does not match proxy identity" });
         // title/description included so a "chief of staff"-style bot can
         // judge the team (who does what, who has no job description yet)
         const bots = store.bots
@@ -6179,10 +6429,11 @@ const server = createServer(async (req, res) => {
         // hard refusal — every peer turn has an accountable sender.
         const from = store.bot(fromBotId);
         if (!from) return json(res, 403, { error: "unknown sender" });
+        const fromThreadId = String(body.fromThreadId ?? from.threadId);
+        if (!authorizedAgentProxy(req, from.id, fromThreadId)) return json(res, 403, { error: "sender capability does not match proxy identity" });
         if (sectionKey(from.section) !== sectionKey(target.section)) {
           return json(res, 403, { error: "that bot belongs to a different section" });
         }
-        const fromThreadId = String(body.fromThreadId ?? from.threadId);
         if (!store.taskByThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
         }
@@ -6296,6 +6547,7 @@ const server = createServer(async (req, res) => {
         const fromThreadId = String(url.searchParams.get("fromThreadId") ?? "");
         const from = store.bot(fromBotId);
         if (!from || !store.taskByThread(from.id, fromThreadId)) return json(res, 403, { error: "unknown sender" });
+        if (!authorizedAgentProxy(req, from.id, fromThreadId)) return json(res, 403, { error: "sender capability does not match proxy identity" });
         const waitMs = Math.min(Math.max(Number(url.searchParams.get("wait_ms")) || 0, 0), 240_000);
         const deadline = Date.now() + waitMs;
         // Bounded long-poll: the delegating bot parks ONE cheap HTTP request
@@ -6306,7 +6558,12 @@ const server = createServer(async (req, res) => {
             if (receipt.sourceThreadId !== fromThreadId) {
               return json(res, 403, { error: "that task belongs to a different conversation" });
             }
-            return json(res, 200, { status: receipt.status, toBotName: receipt.toBotName, result: receipt.result ?? "" });
+            return json(res, 200, {
+              status: receipt.status,
+              toBotName: receipt.toBotName,
+              result: receipt.result ?? "",
+              ...(receipt.evidence ? { evidence: receipt.evidence } : {}),
+            });
           }
           const stillQueued = pendingDelegationInfo(taskId);
           const runningEntry = [...delegationWatch.entries()].find(([, watch]) => watch.taskId === taskId);
@@ -6331,6 +6588,7 @@ const server = createServer(async (req, res) => {
             return json(res, 200, {
               status: "queued",
               toBotName: store.bot(toBotId)?.name ?? toBotId,
+              ...(stillQueued?.evidence ?? running?.evidence ? { evidence: stillQueued?.evidence ?? running?.evidence } : {}),
             });
           }
           await new Promise((wake) => setTimeout(wake, 500));
@@ -6343,22 +6601,41 @@ const server = createServer(async (req, res) => {
         const message = String(body.message ?? "").trim();
         const reason = typeof body.reason === "string" && body.reason.trim() ? body.reason.trim() : undefined;
         const depth = Number(body.depth ?? 0) || 0;
+        let runtimePolicyOverride: RuntimePolicyOverrides | undefined;
+        if (Object.prototype.hasOwnProperty.call(body, "runtimePolicyOverride")) {
+          try {
+            const checked = validateRuntimePolicyPatch(body.runtimePolicyOverride);
+            runtimePolicyOverride = checked === null ? undefined : checked;
+          } catch (error) {
+            return json(res, 200, { error: `runtimePolicyOverride was rejected by the server-owned validator: ${error instanceof Error ? error.message : String(error)}` });
+          }
+        }
         if (!toBotId || !message) return json(res, 400, { error: "toBotId and message required" });
         const from = store.bot(fromBotId);
         if (!from) return json(res, 404, { error: "no such bot" });
+        const fromThreadId = String(body.fromThreadId ?? from.threadId);
+        if (!authorizedAgentProxy(req, from.id, fromThreadId)) return json(res, 403, { error: "sender capability does not match proxy identity" });
         const target = store.bot(toBotId);
         if (!target) return json(res, 404, { error: "no such bot" });
+        if (runtimePolicyOverride !== undefined && target.chiefRuntimePolicyLocked === true) {
+          return json(res, 200, { error: "the target bot's Chief runtime policy control is locked by the user" });
+        }
         if (sectionKey(from.section) !== sectionKey(target.section)) {
           return json(res, 403, { error: "that bot belongs to a different section" });
         }
-        const fromThreadId = String(body.fromThreadId ?? from.threadId);
         if (!store.taskByThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
+        }
+        const sourcePolicy = runtimeLimits.snapshot(fromThreadId) ?? effectiveBotRuntimePolicy(from.runtimePolicy);
+        const sourceDelegations = pendingDelegationSnapshot().filter((item) => item.sourceThreadId === fromThreadId).length
+          + [...delegationWatch.values()].filter((watch) => watch.sourceThreadId === fromThreadId).length;
+        if (sourceDelegations >= sourcePolicy.delegationConcurrency) {
+          return json(res, 200, { error: "source turn reached its delegation concurrency limit" });
         }
         const queued = queueDelegation(
           commsBus,
           from,
-          { toBotId, message, reason, depth },
+          { toBotId, message, reason, depth, ...(runtimePolicyOverride !== undefined ? { runtimePolicyOverride } : {}) },
           MAX_COMMS_DEPTH,
           fromThreadId,
         );
@@ -6370,6 +6647,8 @@ const server = createServer(async (req, res) => {
             too_deep: "delegation chains are limited to one hop — do this one yourself",
             no_target: "no such bot",
             too_many: "too many delegations queued on this turn — finish some first",
+            invalid_runtime_policy: "runtimePolicyOverride was rejected by the server-owned validator",
+            runtime_policy_chief_only: "only a Chief of Staff may set a runtime policy override",
           };
           return json(res, 200, { error: said[queued.result === "ok" ? "no_target" : queued.result] });
         }
@@ -6377,6 +6656,7 @@ const server = createServer(async (req, res) => {
         return json(res, 200, {
           queued: true,
           taskId: queued.id,
+          ...(queued.evidence ? { evidence: queued.evidence } : {}),
           message: from.approvePeerComms
             ? `Queued for review — @${targetName} will only pick it up if the user approves after your turn finishes.`
             : `Delegation queued — @${targetName} will pick it up after your current turn finishes.`,
@@ -6388,6 +6668,7 @@ const server = createServer(async (req, res) => {
         const chief = store.bot(fromBotId);
         if (!chief) return json(res, 403, { error: "unknown sender" });
         const fromThreadId = String(body.fromThreadId ?? chief.threadId);
+        if (!authorizedAgentProxy(req, chief.id, fromThreadId)) return json(res, 403, { error: "sender capability does not match proxy identity" });
         if (!connectorThread(chief.id, fromThreadId)) {
           return json(res, 403, { error: "source conversation does not belong to sender" });
         }
@@ -8071,6 +8352,22 @@ const server = createServer(async (req, res) => {
         return json(res, 400, { error: "body must be a JSON object" });
       }
       const existingBot = store.bot(m[1]);
+      let runtimePolicyPatch: ReturnType<typeof validateRuntimePolicyPatch>;
+      try {
+        runtimePolicyPatch = validateRuntimePolicyPatch(body.runtimePolicy);
+      } catch (error) {
+        return json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+      }
+      if (body.chiefRuntimePolicyLocked !== undefined && typeof body.chiefRuntimePolicyLocked !== "boolean") {
+        return json(res, 400, { error: "chiefRuntimePolicyLocked must be true or false" });
+      }
+      if (
+        runtimePolicyPatch !== undefined &&
+        existingBot?.chiefRuntimePolicyLocked === true &&
+        body.chiefRuntimePolicyLocked !== false
+      ) {
+        return json(res, 409, { error: "Chief runtime policy control is locked by the user" });
+      }
       if (body.requireAvailableModel !== undefined && typeof body.requireAvailableModel !== "boolean") {
         return json(res, 400, { error: "requireAvailableModel must be true or false" });
       }
@@ -8109,6 +8406,12 @@ const server = createServer(async (req, res) => {
       }
       const patch: Record<string, unknown> = {};
       Object.assign(patch, profile.patch);
+      if (runtimePolicyPatch !== undefined) {
+        patch.runtimePolicy = mergeRuntimePolicyOverrides(existingBot?.runtimePolicy, runtimePolicyPatch);
+      }
+      if (body.chiefRuntimePolicyLocked !== undefined) {
+        patch.chiefRuntimePolicyLocked = body.chiefRuntimePolicyLocked;
+      }
       let section: string | undefined | null;
       if (body.section !== undefined) {
         if (body.section === null) section = null;
@@ -8870,7 +9173,13 @@ const server = createServer(async (req, res) => {
         }
         cancelGroupTurnOperations(busyGroup.group.id, busyGroup.threadId);
         await releaseBrowserCapabilityForThread(busyGroup.threadId);
-        await instance?.adapter.interruptTurn(busyGroup.threadId).catch(() => {});
+        const supervised = await turnSupervision.requestStop(
+          bot.id,
+          busyGroup.threadId,
+          "cancel",
+          () => instance?.adapter.interruptTurn(busyGroup.threadId),
+        );
+        if (!supervised) await instance?.adapter.interruptTurn(busyGroup.threadId).catch(() => {});
         closeOpenApprovals(busyGroup.threadId);
         return json(res, 200, { ok: true });
       }
@@ -8885,7 +9194,13 @@ const server = createServer(async (req, res) => {
       const cancelledDirect = cancelDirectTurnDispatch(bot.id, expectedThreadId);
       const directThreadId = cancelledDirect?.threadId ?? bot.threadId;
       await releaseBrowserCapabilityForThread(directThreadId);
-      await instance?.adapter.interruptTurn(directThreadId).catch(() => {});
+      const supervised = await turnSupervision.requestStop(
+        bot.id,
+        directThreadId,
+        "cancel",
+        () => instance?.adapter.interruptTurn(directThreadId),
+      );
+      if (!supervised) await instance?.adapter.interruptTurn(directThreadId).catch(() => {});
       closeOpenApprovals(directThreadId);
       return json(res, 200, { ok: true });
     }

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
 import * as mdb from "./message-db.ts";
+import { effectiveTaskRuntimePolicy } from "./bot-runtime-policy.ts";
 import { peerAllowKey } from "./peer-approval-key.ts";
 import { Store, type BotRecord } from "./store.ts";
 
@@ -1031,6 +1032,57 @@ describe("Store task usage", () => {
     const store = new Store(selection);
     const bot = store.createBot();
     expect(store.addTaskUsage(bot.id, "nope", { input: 1, output: 1, costUsd: null })).toBeNull();
+  });
+});
+
+describe("Store task runtime policy evidence", () => {
+  beforeEach(() => {
+    rmSync(DATA_DIR, { recursive: true, force: true });
+  });
+
+  it("persists effective and explicit override fingerprints with the task", () => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    store.patchBot(bot.id, { runtimePolicy: { maxToolAgentSteps: 12 } });
+    const override = { idleTimeoutMinutes: 5 } as const;
+    const task = store.recordTaskRuntimePolicy(
+      bot.id,
+      bot.threadId,
+      effectiveTaskRuntimePolicy(bot.runtimePolicy, override),
+      override,
+    );
+    expect(task?.runtimePolicyOverride).toEqual({ idleTimeoutMinutes: 5 });
+    expect(task?.runtimePolicyFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(task?.runtimePolicyOverrideFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(task?.runtimePolicySnapshot?.idleTimeoutMinutes).toBe(5);
+
+    const reloaded = new Store(selection).taskByThread(bot.id, bot.threadId);
+    expect(reloaded?.runtimePolicyFingerprint).toBe(task?.runtimePolicyFingerprint);
+    expect(reloaded?.runtimePolicyOverrideFingerprint).toBe(task?.runtimePolicyOverrideFingerprint);
+  });
+
+  it("round-trips runtime controls and the Chief lock", () => {
+    const store = new Store(selection);
+    const bot = store.createBot({}, { seedMessages: false });
+    store.patchBot(bot.id, {
+      runtimePolicy: {
+        wallClockTimeoutMinutes: 7,
+        idleTimeoutMinutes: 3,
+        cancellationGraceSeconds: 9,
+        delegationConcurrency: 2,
+        cumulativeTokenPolicy: { mode: "hard", limit: 25_000 },
+      },
+      chiefRuntimePolicyLocked: true,
+    });
+    const reloaded = new Store(selection).bot(bot.id);
+    expect(reloaded?.runtimePolicy).toEqual(expect.objectContaining({
+      wallClockTimeoutMinutes: 7,
+      idleTimeoutMinutes: 3,
+      cancellationGraceSeconds: 9,
+      delegationConcurrency: 2,
+      cumulativeTokenPolicy: { mode: "hard", limit: 25_000 },
+    }));
+    expect(reloaded?.chiefRuntimePolicyLocked).toBe(true);
   });
 });
 

--- a/server/store.ts
+++ b/server/store.ts
@@ -14,6 +14,13 @@ import { workspaceDir } from "./workspace.ts";
 import { newId, type CloudBackend, type ModelSelection, type ThreadId } from "./contracts.ts";
 import { pickBotName } from "./names.ts";
 import { redactSecretsInText } from "./redact.ts";
+import {
+  cloneRuntimePolicy,
+  runtimePolicyFingerprint,
+  runtimePolicyOverrideFingerprint,
+  type BotRuntimePolicy,
+  type RuntimePolicyOverrides,
+} from "./bot-runtime-policy.ts";
 import { botAvatarProfile, type BotAvatarCrop } from "../shared/bot-avatar.ts";
 import type { MascotBodyId } from "../shared/mascot-bodies.ts";
 import type { RoutineRequestCardData } from "../shared/routine-request.ts";
@@ -241,6 +248,11 @@ export interface TaskRecord {
    * a folder that moved under a live session would break resume. `null`
    * = pinned to the default (home); absent = not pinned yet. */
   cwd?: string | null;
+  /** Secret-free admission evidence for a delegated task. */
+  runtimePolicyOverride?: RuntimePolicyOverrides;
+  runtimePolicySnapshot?: BotRuntimePolicy;
+  runtimePolicyFingerprint?: string;
+  runtimePolicyOverrideFingerprint?: string;
 }
 
 export interface TaskUsage {
@@ -435,6 +447,8 @@ export interface BotRecord {
   /** where NEW tasks run their shell tools; each task pins its own copy
    * on its first turn (TaskRecord.cwd). Absent = the home folder. */
   cwd?: string;
+  /** Optional persisted policy inputs used when recording admission evidence. */
+  runtimePolicy?: RuntimePolicyOverrides;
   /** Auto mode: the bot approves its own tool permissions and keeps
    * working instead of stopping to ask. Questions it asks YOU still come
    * through, and a short list of destructive commands still stops it. */
@@ -466,6 +480,8 @@ export interface BotRecord {
   /** The coordinator for this bot's sidebar section. The store enforces
    * at most one Chief per section (including the unsectioned area). */
   chiefOfStaff?: boolean;
+  /** User-owned guard for persistent Chief runtime policy changes. */
+  chiefRuntimePolicyLocked?: boolean;
   /** Pause for human approval before this bot talks to a peer (ask_bot,
    * delegate_bot). Off by default: a chief-of-staff-style bot is most
    * useful when it can coordinate without nagging. */
@@ -1421,6 +1437,26 @@ export class Store {
     if (!task || task.lastInstanceId === instanceId) return;
     task.lastInstanceId = instanceId;
     this.saveBots();
+  }
+
+  /** Persist only the policy snapshot identity used by this task. Raw policy
+   * values are retained only when they are an explicit task override. */
+  recordTaskRuntimePolicy(
+    botId: string,
+    threadId: string,
+    policySnapshot: BotRuntimePolicy,
+    taskOverride?: RuntimePolicyOverrides,
+  ): TaskRecord | null {
+    const bot = this.bot(botId);
+    const task = bot ? this.taskByThread(botId, threadId) : undefined;
+    if (!bot || !task) return null;
+    task.runtimePolicyOverride = taskOverride ? structuredClone(taskOverride) : undefined;
+    task.runtimePolicySnapshot = cloneRuntimePolicy(policySnapshot);
+    task.runtimePolicyFingerprint = runtimePolicyFingerprint(policySnapshot);
+    task.runtimePolicyOverrideFingerprint = runtimePolicyOverrideFingerprint(taskOverride);
+    this.saveBots();
+    this.emit({ type: "bot", botId });
+    return task;
   }
 
   /** Bank one settled turn onto its task. Called once per turn.completed;

--- a/server/turn-runtime-limits.test.ts
+++ b/server/turn-runtime-limits.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { defaultBotRuntimePolicy } from "./bot-runtime-policy.ts";
+import { TurnRuntimeLimits } from "./turn-runtime-limits.ts";
+
+describe("TurnRuntimeLimits", () => {
+  it("enforces a delegated max-tool override against actual tool starts", () => {
+    const limits = new TurnRuntimeLimits();
+    const stopped = vi.fn();
+    const policy = { ...defaultBotRuntimePolicy(), maxToolAgentSteps: 1 };
+    expect(limits.begin("thread", policy, { onHardStop: stopped, onSoftTokenWarning: vi.fn() })).toBe(true);
+
+    limits.recordToolStarted("thread", "tool-1");
+    expect(stopped).not.toHaveBeenCalled();
+    limits.recordToolStarted("thread", "tool-2");
+    expect(stopped).toHaveBeenCalledWith(expect.objectContaining({ kind: "tool-steps", limit: 1, observed: 2 }));
+  });
+
+  it("retains one immutable policy snapshot until settlement", () => {
+    const limits = new TurnRuntimeLimits();
+    const policy = { ...defaultBotRuntimePolicy(), cumulativeTokenPolicy: { mode: "hard" as const, limit: 2_000 } };
+    limits.begin("thread", policy, { onHardStop: vi.fn(), onSoftTokenWarning: vi.fn() });
+    policy.maxToolAgentSteps = 99;
+    expect(limits.snapshot("thread")?.maxToolAgentSteps).toBe(0);
+    limits.settle("thread");
+    expect(limits.snapshot("thread")).toBeNull();
+  });
+});

--- a/server/turn-runtime-limits.ts
+++ b/server/turn-runtime-limits.ts
@@ -1,0 +1,116 @@
+import type { BotRuntimePolicy } from "./bot-runtime-policy.ts";
+
+export type TurnRuntimeLimitEvent = {
+  threadId: string;
+  kind: "wall-clock" | "tool-steps" | "cumulative-tokens";
+  limit: number;
+  observed: number;
+};
+
+type ActiveTurn = {
+  policy: BotRuntimePolicy;
+  toolIds: Set<string>;
+  tokenTotal: number;
+  softWarned: boolean;
+  hardStopped: boolean;
+  timer?: ReturnType<typeof setTimeout>;
+  onHardStop: (event: TurnRuntimeLimitEvent) => void;
+  onSoftTokenWarning: (event: TurnRuntimeLimitEvent) => void;
+};
+
+/** Runtime-owned enforcement for the limits that can be observed at the
+ * harness boundary. Each entry retains the immutable admission snapshot used
+ * by the turn; later bot policy edits cannot change an active turn. */
+export class TurnRuntimeLimits {
+  private readonly active = new Map<string, ActiveTurn>();
+
+  /** Admit a turn with a detached policy snapshot and arm its wall-clock limit. */
+  begin(
+    threadId: string,
+    policy: BotRuntimePolicy,
+    callbacks: Pick<ActiveTurn, "onHardStop" | "onSoftTokenWarning">,
+  ): boolean {
+    if (this.active.has(threadId)) return false;
+    const entry: ActiveTurn = {
+      policy: { ...policy, cumulativeTokenPolicy: { ...policy.cumulativeTokenPolicy } },
+      toolIds: new Set(),
+      tokenTotal: 0,
+      softWarned: false,
+      hardStopped: false,
+      ...callbacks,
+    };
+    if (entry.policy.wallClockTimeoutMinutes > 0) {
+      entry.timer = setTimeout(() => {
+        const current = this.active.get(threadId);
+        if (!current || current.hardStopped) return;
+        this.stop(current, {
+          threadId,
+          kind: "wall-clock",
+          limit: current.policy.wallClockTimeoutMinutes * 60_000,
+          observed: current.policy.wallClockTimeoutMinutes * 60_000,
+        });
+      }, entry.policy.wallClockTimeoutMinutes * 60_000);
+      entry.timer.unref?.();
+    }
+    this.active.set(threadId, entry);
+    return true;
+  }
+
+  /** Record a distinct tool step and stop the turn when its step cap is exceeded. */
+  recordToolStarted(threadId: string, itemId: string): void {
+    const entry = this.active.get(threadId);
+    if (!entry || entry.hardStopped || entry.policy.maxToolAgentSteps <= 0) return;
+    entry.toolIds.add(itemId);
+    if (entry.toolIds.size > entry.policy.maxToolAgentSteps) {
+      this.stop(entry, {
+        threadId,
+        kind: "tool-steps",
+        limit: entry.policy.maxToolAgentSteps,
+        observed: entry.toolIds.size,
+      });
+    }
+  }
+
+  /** Update cumulative token usage and emit the configured soft or hard limit event. */
+  recordTokenSample(threadId: string, input: number, output: number): void {
+    const entry = this.active.get(threadId);
+    if (!entry || entry.hardStopped) return;
+    const inputTokens = Number.isFinite(input) && input >= 0 ? input : 0;
+    const outputTokens = Number.isFinite(output) && output >= 0 ? output : 0;
+    entry.tokenTotal = Math.max(entry.tokenTotal, inputTokens + outputTokens);
+    const tokenPolicy = entry.policy.cumulativeTokenPolicy;
+    if (tokenPolicy.mode === "soft" && !entry.softWarned && entry.tokenTotal >= tokenPolicy.limit) {
+      entry.softWarned = true;
+      entry.onSoftTokenWarning({
+        threadId,
+        kind: "cumulative-tokens",
+        limit: tokenPolicy.limit,
+        observed: entry.tokenTotal,
+      });
+    }
+    if (tokenPolicy.mode === "hard" && entry.tokenTotal >= tokenPolicy.limit) {
+      this.stop(entry, { threadId, kind: "cumulative-tokens", limit: tokenPolicy.limit, observed: entry.tokenTotal });
+    }
+  }
+
+  /** Settle a turn and release its active state and wall-clock timer. */
+  settle(threadId: string): void {
+    const entry = this.active.get(threadId);
+    if (!entry) return;
+    if (entry.timer) clearTimeout(entry.timer);
+    this.active.delete(threadId);
+  }
+
+  /** Return a detached copy of the active turn's admitted policy, if present. */
+  snapshot(threadId: string): BotRuntimePolicy | null {
+    const entry = this.active.get(threadId);
+    return entry ? { ...entry.policy, cumulativeTokenPolicy: { ...entry.policy.cumulativeTokenPolicy } } : null;
+  }
+
+  /** Mark an active turn stopped once and notify its hard-limit consumer. */
+  private stop(entry: ActiveTurn, event: TurnRuntimeLimitEvent): void {
+    if (entry.hardStopped) return;
+    entry.hardStopped = true;
+    entry.onHardStop(event);
+  }
+}

--- a/server/turn-supervision.test.ts
+++ b/server/turn-supervision.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { TurnSupervision } from "./turn-supervision.ts";
+
+describe("TurnSupervision", () => {
+  it("accepts the matching terminal event and rejects a late provider id", () => {
+    const unknown = vi.fn();
+    const guard = new TurnSupervision({ graceMs: 20, onUnknown: unknown });
+    expect(guard.begin("bot", "thread")).toBe(true);
+    expect(guard.bind("bot", "thread", "turn-1")).toBe(true);
+    expect(guard.observeTerminal("bot", "thread", "turn-1")).toMatchObject({ accepted: true, turnId: "turn-1" });
+    expect(guard.isLate("bot", "thread", "turn-1")).toBe(true);
+    expect(guard.begin("bot", "thread")).toBe(true);
+    expect(guard.isCurrent("bot", "thread", "turn-1")).toBe(false);
+    expect(unknown).not.toHaveBeenCalled();
+  });
+
+  it("emits exactly one unknown receipt after bounded cancellation grace", async () => {
+    const unknown = vi.fn();
+    const guard = new TurnSupervision({ graceMs: 5, onUnknown: unknown });
+    guard.begin("bot", "thread");
+    await guard.requestStop("bot", "thread", "cancel", () => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(unknown).toHaveBeenCalledTimes(1);
+    expect(unknown.mock.calls[0]?.[0]).toMatchObject({ intent: "cancel", threadId: "thread" });
+    expect(guard.has("bot", "thread")).toBe(false);
+  });
+});

--- a/server/turn-supervision.ts
+++ b/server/turn-supervision.ts
@@ -1,0 +1,184 @@
+/** Owns one provider turn's process lifetime across interrupt and terminal races. */
+export type TurnStopIntent = "cancel" | "timeout" | "restart" | "provider-exit";
+
+export interface UnknownTurn {
+  botId: string;
+  threadId: string;
+  turnId?: string;
+  intent: TurnStopIntent;
+  eventId: string;
+  reason: string;
+}
+
+export interface TerminalObservation {
+  accepted: boolean;
+  intent?: TurnStopIntent;
+  turnId?: string;
+}
+
+interface ActiveTurn {
+  key: string;
+  botId: string;
+  threadId: string;
+  generation: number;
+  providerTurnId?: string;
+  intent?: TurnStopIntent;
+  graceMs: number;
+  stopTimer?: ReturnType<typeof setTimeout>;
+  interruptIssued: boolean;
+}
+
+interface TurnSupervisionOptions {
+  graceMs: number;
+  onUnknown: (turn: UnknownTurn) => void;
+}
+
+const keyFor = (botId: string, threadId: string): string => `${botId}\u0000${threadId}`;
+
+export class TurnSupervision {
+  private readonly active = new Map<string, ActiveTurn>();
+  private readonly remembered = new Map<string, Set<string>>();
+  private readonly justAccepted = new Map<string, string>();
+  private generation = 0;
+  private readonly graceMs: number;
+  private readonly onUnknown: (turn: UnknownTurn) => void;
+
+  constructor(options: TurnSupervisionOptions) {
+    this.graceMs = Math.max(1, Math.trunc(options.graceMs));
+    this.onUnknown = options.onUnknown;
+  }
+
+  begin(botId: string, threadId: string, graceMs = this.graceMs): boolean {
+    const key = keyFor(botId, threadId);
+    if (this.active.has(key)) return false;
+    this.justAccepted.delete(key);
+    this.active.set(key, {
+      key,
+      botId,
+      threadId,
+      generation: ++this.generation,
+      graceMs: Math.max(1, Math.trunc(graceMs)),
+      interruptIssued: false,
+    });
+    return true;
+  }
+
+  bind(botId: string, threadId: string, turnId: string): boolean {
+    const normalized = turnId.trim();
+    if (!normalized) return false;
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry || this.wasRemembered(entry.key, normalized)) return false;
+    if (entry.providerTurnId && entry.providerTurnId !== normalized) return false;
+    entry.providerTurnId = normalized;
+    return true;
+  }
+
+  isCurrent(botId: string, threadId: string, turnId?: string): boolean {
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry) return false;
+    if (turnId && this.wasRemembered(entry.key, turnId)) return false;
+    if (!turnId || !entry.providerTurnId) return true;
+    return entry.providerTurnId === turnId;
+  }
+
+  isLate(botId: string, threadId: string, turnId?: string): boolean {
+    if (!turnId) return false;
+    const key = keyFor(botId, threadId);
+    return !this.active.has(key) && this.wasRemembered(key, turnId);
+  }
+
+  wasJustAccepted(botId: string, threadId: string, turnId?: string): boolean {
+    return Boolean(turnId && this.justAccepted.get(keyFor(botId, threadId)) === turnId);
+  }
+
+  async requestStop(
+    botId: string,
+    threadId: string,
+    intent: Exclude<TurnStopIntent, "restart">,
+    interrupt: () => Promise<void> | void,
+  ): Promise<boolean> {
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry) return false;
+    if (!entry.intent || intent === "cancel") entry.intent = intent;
+    if (!entry.interruptIssued) {
+      entry.interruptIssued = true;
+      try { void Promise.resolve(interrupt()).catch(() => {}); } catch { /* grace timer remains authoritative */ }
+    }
+    if (!entry.stopTimer && this.active.get(entry.key) === entry) {
+      entry.stopTimer = setTimeout(() => {
+        this.expire(entry, entry.intent ?? intent, this.defaultUnknownReason(entry.intent ?? intent));
+      }, entry.graceMs);
+      entry.stopTimer.unref?.();
+    }
+    return true;
+  }
+
+  observeTerminal(botId: string, threadId: string, turnId?: string): TerminalObservation {
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry || !this.matches(entry, turnId)) return { accepted: false, turnId };
+    const settledTurnId = turnId ?? entry.providerTurnId;
+    this.remove(entry, settledTurnId);
+    if (settledTurnId) {
+      const key = entry.key;
+      this.justAccepted.set(key, settledTurnId);
+      queueMicrotask(() => {
+        if (this.justAccepted.get(key) === settledTurnId) this.justAccepted.delete(key);
+      });
+    }
+    return { accepted: true, intent: entry.intent, turnId: settledTurnId };
+  }
+
+  finishWithoutProvider(botId: string, threadId: string): boolean {
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry) return false;
+    this.remove(entry, entry.providerTurnId);
+    return true;
+  }
+
+  forceUnknown(botId: string, threadId: string, reason: string, intent: TurnStopIntent = "restart"): boolean {
+    const entry = this.active.get(keyFor(botId, threadId));
+    if (!entry) return false;
+    this.expire(entry, intent, reason);
+    return true;
+  }
+
+  resetProviderLifecycle(): void {
+    this.remembered.clear();
+    this.justAccepted.clear();
+  }
+
+  has(botId: string, threadId: string): boolean { return this.active.has(keyFor(botId, threadId)); }
+
+  private matches(entry: ActiveTurn, turnId?: string): boolean {
+    if (!turnId) return true;
+    if (this.wasRemembered(entry.key, turnId)) return false;
+    return !entry.providerTurnId || entry.providerTurnId === turnId;
+  }
+
+  private expire(entry: ActiveTurn, intent: TurnStopIntent, reason: string): void {
+    if (this.active.get(entry.key) !== entry) return;
+    const turnId = entry.providerTurnId;
+    this.remove(entry, turnId);
+    this.onUnknown({ botId: entry.botId, threadId: entry.threadId, ...(turnId ? { turnId } : {}), intent, eventId: `supervision:${entry.generation}:${intent}`, reason });
+  }
+
+  private remove(entry: ActiveTurn, turnId?: string): void {
+    if (entry.stopTimer) clearTimeout(entry.stopTimer);
+    entry.stopTimer = undefined;
+    this.active.delete(entry.key);
+    if (turnId) {
+      const ids = this.remembered.get(entry.key) ?? new Set<string>();
+      ids.add(turnId);
+      this.remembered.set(entry.key, ids);
+    }
+  }
+
+  private wasRemembered(key: string, turnId: string): boolean { return this.remembered.get(key)?.has(turnId) ?? false; }
+
+  private defaultUnknownReason(intent: TurnStopIntent): string {
+    if (intent === "timeout") return "provider did not confirm timeout cancellation before supervision grace expired";
+    if (intent === "cancel") return "provider did not confirm explicit cancellation before supervision grace expired";
+    if (intent === "provider-exit") return "provider process exited before a terminal completion was observed";
+    return "provider supervision ended during server restart before a terminal event was observed";
+  }
+}

--- a/server/turn-watchdog.test.ts
+++ b/server/turn-watchdog.test.ts
@@ -82,4 +82,12 @@ describe("TurnWatchdog", () => {
     dog.sweep();
     expect(stalls).toEqual([expect.objectContaining({ botId: "bot2" })]);
   });
+
+  it("uses the admitted per-turn idle timeout", () => {
+    const { dog, stalls, tick } = rig();
+    dog.watch("short", "bot1", 2_000);
+    tick(2_001);
+    dog.sweep();
+    expect(stalls).toEqual([expect.objectContaining({ threadId: "short", idleMs: 2_000 })]);
+  });
 });

--- a/server/turn-watchdog.ts
+++ b/server/turn-watchdog.ts
@@ -15,6 +15,7 @@ export interface WatchedTurn {
   startedAt: number;
   lastEventAt: number;
   waitingOnHuman: boolean;
+  idleMs: number;
 }
 
 export interface TurnWatchdogOptions {
@@ -54,9 +55,16 @@ export class TurnWatchdog {
   }
 
   /** A turn was dispatched on this thread. */
-  watch(threadId: string, botId: string): void {
+  watch(threadId: string, botId: string, idleMs = this.opts.stallMs): void {
     const at = this.now();
-    this.turns.set(threadId, { threadId, botId, startedAt: at, lastEventAt: at, waitingOnHuman: false });
+    this.turns.set(threadId, {
+      threadId,
+      botId,
+      startedAt: at,
+      lastEventAt: at,
+      waitingOnHuman: false,
+      idleMs: Math.max(1, Math.floor(idleMs)),
+    });
   }
 
   /** Any provider event for the thread proves the turn is alive. */
@@ -88,7 +96,7 @@ export class TurnWatchdog {
     const at = this.now();
     for (const turn of this.turns.values()) {
       if (turn.waitingOnHuman) continue;
-      if (at - turn.lastEventAt < this.opts.stallMs) continue;
+      if (at - turn.lastEventAt < turn.idleMs) continue;
       this.turns.delete(turn.threadId);
       this.opts.onStall(turn);
     }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,6 @@
-import { BookOpen, CalendarClock, ChevronDown, ChevronLeft, Crown, FolderOpen, Plus, Trash2, X } from "lucide-react";
+import { BookOpen, CalendarClock, ChevronDown, ChevronLeft, Crown, FolderOpen, Lock, Plus, RotateCcw, Trash2, Unlock, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { api, useStore, type Bot } from "@/state/store";
+import { api, useStore, type Bot, type RuntimePolicy } from "@/state/store";
 import { stateForBot } from "@/lib/mascot";
 import { CloudBackendPicker } from "./CloudBackendPicker";
 import { ModelPicker } from "./ModelPicker";
@@ -30,6 +30,187 @@ function Field({
       <div className="mb-1.5 text-[13px] text-ink-secondary">{label}</div>
       {children}
     </label>
+  );
+}
+
+const FALLBACK_RUNTIME_POLICY: RuntimePolicy = {
+  wallClockTimeoutMinutes: 0,
+  idleTimeoutMinutes: 20,
+  cancellationGraceSeconds: 5,
+  maxToolAgentSteps: 0,
+  delegationConcurrency: 4,
+  cumulativeTokenPolicy: { mode: "disabled", limit: 1_000_000 },
+};
+
+const RUNTIME_NUMBER_FIELDS = [
+  ["wallClockTimeoutMinutes", "Wall-clock turn limit", "0 = off", 0, 1_440],
+  ["idleTimeoutMinutes", "Idle timeout", "Minutes without provider activity", 1, 1_440],
+  ["cancellationGraceSeconds", "Cancel grace", "Seconds to let the provider settle", 1, 120],
+  ["delegationConcurrency", "Delegate concurrency", "Simultaneous delegated tasks", 1, 4],
+  ["maxToolAgentSteps", "Tool step limit", "0 = off", 0, 1_000],
+] as const;
+
+function RuntimeControlsCard({ bot }: { bot: Bot }) {
+  const { dispatch } = useStore();
+  const [draft, setDraft] = useState<RuntimePolicy>(bot.runtimePolicy ?? FALLBACK_RUNTIME_POLICY);
+  const [savedSignature, setSavedSignature] = useState(() => JSON.stringify(bot.runtimePolicy ?? FALLBACK_RUNTIME_POLICY));
+  const [status, setStatus] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const locked = bot.chiefRuntimePolicyLocked === true;
+
+  useEffect(() => {
+    const next = bot.runtimePolicy ?? FALLBACK_RUNTIME_POLICY;
+    setDraft(next);
+    setSavedSignature(JSON.stringify(next));
+    setStatus(null);
+  }, [bot.id, bot.runtimePolicy]);
+
+  const dirty = JSON.stringify(draft) !== savedSignature;
+  const updateNumber = (key: typeof RUNTIME_NUMBER_FIELDS[number][0], value: string, min: number, max: number) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return;
+    setDraft((current) => ({ ...current, [key]: Math.max(min, Math.min(max, Math.floor(parsed))) }));
+  };
+  const save = async () => {
+    setSaving(true);
+    setStatus(null);
+    try {
+      const result = await api(`/api/bots/${bot.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ runtimePolicy: draft }),
+      }) as { bot: Bot };
+      dispatch({ type: "botPatched", bot: result.bot });
+      setSavedSignature(JSON.stringify(result.bot.runtimePolicy ?? draft));
+      setStatus("Saved");
+    } catch (error) {
+      setStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+  const reset = async () => {
+    setSaving(true);
+    setStatus(null);
+    try {
+      const result = await api(`/api/bots/${bot.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ runtimePolicy: null }),
+      }) as { bot: Bot };
+      dispatch({ type: "botPatched", bot: result.bot });
+      setStatus("Defaults restored");
+    } catch (error) {
+      setStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+  const toggleLock = async () => {
+    setStatus(null);
+    try {
+      const result = await api(`/api/bots/${bot.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ chiefRuntimePolicyLocked: !locked }),
+      }) as { bot: Bot };
+      dispatch({ type: "botPatched", bot: result.bot });
+      setStatus(!locked ? "Chief control locked" : "Chief control unlocked");
+    } catch (error) {
+      setStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[15px] font-medium text-ink">Runtime controls</div>
+          <div className="mt-0.5 text-[13px] leading-relaxed text-ink-secondary">
+            Persisted server-side and applied when the next turn is admitted.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => void toggleLock()}
+          aria-label={locked ? "Unlock Chief runtime controls" : "Lock Chief runtime controls"}
+          title={locked ? "Unlock Chief runtime controls" : "Lock Chief runtime controls"}
+          className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-control text-ink-secondary hover:text-ink"
+        >
+          {locked ? <Lock size={15} /> : <Unlock size={15} />}
+        </button>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {RUNTIME_NUMBER_FIELDS.map(([key, label, hint, min, max]) => (
+          <label key={key} className="min-w-0">
+            <span className="block truncate text-[11.5px] text-ink-secondary" title={hint}>{label}</span>
+            <input
+              aria-label={label}
+              type="number"
+              min={min}
+              max={max}
+              value={draft[key]}
+              disabled={locked || saving}
+              onChange={(event) => updateNumber(key, event.target.value, min, max)}
+              className={cn(inputCls, "mt-1 h-8 px-2 text-[12px]")}
+            />
+          </label>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[12px] text-ink-secondary">Token budget</div>
+          <div className="mt-1 flex items-center gap-2">
+            <select
+              value={draft.cumulativeTokenPolicy.mode}
+              aria-label="Token budget mode"
+              disabled={locked || saving}
+              onChange={(event) => setDraft((current) => ({
+                ...current,
+                cumulativeTokenPolicy: {
+                  ...current.cumulativeTokenPolicy,
+                  mode: event.target.value as RuntimePolicy["cumulativeTokenPolicy"]["mode"],
+                },
+              }))}
+              className="h-8 rounded-lg border border-hairline/40 bg-control px-2 text-[12px] text-ink"
+            >
+              <option value="disabled">Off</option>
+              <option value="soft">Warn</option>
+              <option value="hard">Stop</option>
+            </select>
+            <input
+              aria-label="Token budget limit"
+              type="number"
+              min={1000}
+              max={10_000_000}
+              value={draft.cumulativeTokenPolicy.limit}
+              disabled={locked || saving}
+              onChange={(event) => {
+                const limit = Number(event.target.value);
+                if (Number.isFinite(limit)) setDraft((current) => ({
+                  ...current,
+                  cumulativeTokenPolicy: {
+                    ...current.cumulativeTokenPolicy,
+                    limit: Math.max(1_000, Math.min(10_000_000, Math.floor(limit))),
+                  },
+                }));
+              }}
+              className={cn(inputCls, "h-8 w-24 px-2 text-[12px]")}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <span className={cn("text-[12px]", status?.startsWith("Error:") ? "text-danger" : "text-ink-secondary")}>
+          {status ?? (locked ? "Locked by the user" : dirty ? "Unsaved changes" : "")}
+        </span>
+        <div className="flex gap-2">
+          <button type="button" disabled={locked || saving} onClick={() => void reset()} className="flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] text-ink-secondary hover:bg-control disabled:opacity-40">
+            <RotateCcw size={13} /> Reset
+          </button>
+          <button type="button" disabled={locked || saving || !dirty} onClick={() => void save()} className="rounded-lg bg-accent px-3 py-1.5 text-[12px] font-medium text-white disabled:opacity-40">
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -853,6 +1034,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               </div>
             </div>
           )}
+
+          <RuntimeControlsCard key={`runtime-${bot.id}`} bot={bot} />
 
           <div className="rounded-xl bg-card p-4">
             <div className="text-[15px] font-medium text-ink">Works on</div>

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -208,6 +208,20 @@ export interface ModelSelection {
   effort?: EffortLevel;
 }
 
+export type RuntimeTokenPolicyMode = "disabled" | "soft" | "hard";
+
+export interface RuntimePolicy {
+  wallClockTimeoutMinutes: number;
+  idleTimeoutMinutes: number;
+  cancellationGraceSeconds: number;
+  maxToolAgentSteps: number;
+  delegationConcurrency: number;
+  cumulativeTokenPolicy: {
+    mode: RuntimeTokenPolicyMode;
+    limit: number;
+  };
+}
+
 /** One of a bot's separate contexts: its own thread, transcript and
  * provider session. The bot's threadId points at the active one. */
 export interface Task {
@@ -282,6 +296,10 @@ export interface Bot {
   pinnedMessageId?: string;
   /** This sidebar section's primary coordinator. */
   chiefOfStaff?: boolean;
+  /** User-owned guard for persistent Chief runtime policy changes. */
+  chiefRuntimePolicyLocked?: boolean;
+  /** Effective server-owned runtime controls for this bot. */
+  runtimePolicy?: RuntimePolicy;
   /** When this bot wants to talk to another bot (ask_bot/delegate_bot),
    * pause and ask the user first. Off by default. */
   approvePeerComms?: boolean;


### PR DESCRIPTION
## What changed

Adds persisted, server-validated runtime policies that are snapshotted when a turn is admitted and fingerprinted in delegation evidence.

Enforced controls:

- wall-clock turn limit
- idle timeout
- cancellation grace period
- distinct tool-step limit
- source delegation concurrency
- cumulative token warning or hard stop

The admitted policy is detached from later bot edits, recorded on task/delegation receipts as a hash, and used by direct and room turns. Provider interruption is supervised so late or missing terminal events cannot release a newer turn.

Internal agents receive a thread-scoped capability in addition to the existing local shared secret. One-task overrides are accepted only from the current Chief of Staff and can be locked by the user on the target bot.

## Corrections made during review

The previous branch exposed `retryCap`, `freshSessionEnforcement`, and `handoffByteCap` even though no runtime path enforced them. Those fields were removed instead of publishing no-op settings. The remaining numeric controls now clamp to the same bounds enforced by the server.

Unrelated effort-picker refactoring and documentation-only changes were also removed.

## Verification

- 279 targeted tests passed, 1 existing test skipped.
- 39 policy/delegation tests passed again after the final scope reduction.
- Client and server TypeScript checks passed.
- Production UI build passed.
- Staged secret scanner passed across 1,788 added lines.
- `git diff --check` passed.
- Rebased as one commit on official `main` at `cb0d376`.
- Current head: `12fdb106e46e37081fe3c2b109327ff26d0561fe`.

## Screenshots

This adds a Runtime controls card in bot settings. No fresh before/after screenshot is attached, so no visual acceptance is claimed.