### PR TITLE
Add portable OpenMausBot diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "clean": "node scripts/clean.mjs",
+    "doctor": "node scripts/openmaus-doctor.mjs",
     "lint": "oxlint .",
     "check:contrast": "node scripts/check-skin-contrast.mjs",
     "i18n:check": "node scripts/generate-locale.mjs --check",

--- a/scripts/openmaus-doctor.mjs
+++ b/scripts/openmaus-doctor.mjs
@@ -1,0 +1,267 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_ENDPOINT = "http://127.0.0.1:8799";
+const STATUS_PATHS = ["/api/status-capsule", "/api/status", "/api/capsule"];
+const DIGEST = /^(?:sha256:)?[a-f0-9]{64}$/i;
+
+/**
+ * Creates one normalized doctor check result.
+ * @param {string} level Check severity.
+ * @param {string} name Check name.
+ * @param {string} message Human-readable check message.
+ * @param {Record<string, unknown>} [details] Additional structured fields.
+ * @returns {Record<string, unknown>} The normalized check result.
+ */
+function check(level, name, message, details = {}) {
+  return { level, name, message, ...details };
+}
+
+/**
+ * Validates and normalizes a local HTTP endpoint.
+ * @param {string} value Endpoint URL to validate.
+ * @returns {URL} The normalized loopback URL.
+ * @throws {TypeError} If the value is not an HTTP loopback URL.
+ */
+function localEndpoint(value) {
+  const url = new URL(value);
+  const hostname = url.hostname.startsWith("[") && url.hostname.endsWith("]") ? url.hostname.slice(1, -1) : url.hostname;
+  if (
+    url.protocol !== "http:" ||
+    url.username ||
+    url.password ||
+    !["localhost", "127.0.0.1", "::1"].includes(hostname)
+  ) {
+    throw new Error("endpoint must be an HTTP localhost URL");
+  }
+  url.pathname = url.pathname.replace(/\/$/, "");
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+/**
+ * Reads and parses a fetch response body without exposing read or parse errors.
+ * @param {Response} response Fetch response to read.
+ * @returns {Promise<{value?: unknown, state?: string}>} Parsed body or a bounded error state.
+ */
+async function readResponse(response) {
+  let text;
+  try {
+    text = await response.text();
+  } catch {
+    return { value: undefined, state: "response_error" };
+  }
+  try {
+    return { value: JSON.parse(text) };
+  } catch {
+    return { value: undefined };
+  }
+}
+
+/**
+ * Fetches and parses JSON with a bounded abort timeout.
+ * @param {typeof fetch} fetcher Fetch implementation to call.
+ * @param {string} url Request URL.
+ * @param {number} timeoutMs Abort timeout in milliseconds.
+ * @returns {Promise<Record<string, unknown>>} Fetch outcome and parsed response data.
+ */
+async function fetchJson(fetcher, url, timeoutMs) {
+  let response;
+  try {
+    response = await fetcher(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: "error",
+    });
+  } catch {
+    return { kind: "unreachable" };
+  }
+  const body = await readResponse(response);
+  return { kind: "response", response, ...body };
+}
+
+/**
+ * Collects and validates digest fields from a status payload.
+ * @param {Record<string, unknown> | null | undefined} value Status payload.
+ * @param {string[]} names Accepted digest field names.
+ * @returns {{invalid: boolean} | {values: string[]}} Digest validation result.
+ */
+function digestPair(value, names) {
+  const values = names.map((name) => value?.[name]).filter((item) => item !== undefined && item !== null);
+  if (values.some((item) => typeof item !== "string" || !DIGEST.test(item))) return { invalid: true };
+  if (new Set(values.map((item) => item.toLowerCase())).size > 1) return { invalid: true };
+  return { values };
+}
+
+/**
+ * Validates the identity, readiness, and digest relationships in a status payload.
+ * @param {unknown} value Status payload to inspect.
+ * @returns {string | null} Failure reason, or null when the payload is valid.
+ */
+function inspectStatus(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "invalid JSON object";
+  const app = value.app ?? value.identity?.app;
+  if (app !== undefined && app !== "openmausbot") return "wrong app identity";
+  if (value.ready !== undefined && value.ready !== true) return "ready=false";
+  if (value.identity?.ready !== undefined && value.identity.ready !== true) return "ready=false";
+  const source = digestPair(value, ["sourceSha256", "source_sha256"]);
+  const build = digestPair(value, ["buildSha256", "build_sha256", "dualViewSha256", "dual_view_sha256"]);
+  if (source.invalid || build.invalid) return "invalid source/build digest";
+  if (source.values.length && build.values.length && source.values[0].toLowerCase() !== build.values[0].toLowerCase()) {
+    return "source/build digest mismatch";
+  }
+  return null;
+}
+
+/**
+ * Hashes a watched regular file and returns a doctor check.
+ * @param {string} file File path to hash.
+ * @param {string} label Display label for the check.
+ * @returns {Promise<Record<string, unknown>>} File integrity check result.
+ */
+async function watchFileWithDigest(file, label) {
+  const path = resolve(file);
+  try {
+    const stat = await lstat(path);
+    if (!stat.isFile()) return check("FAIL", "watch", `${label}: not a regular file`);
+    const hash = createHash("sha256");
+    await new Promise((resolvePromise, reject) => {
+      const stream = createReadStream(path);
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("error", reject);
+      stream.on("end", resolvePromise);
+    });
+    const sha256 = hash.digest("hex");
+    return check("PASS", "watch", `${label} sha256=${sha256}`, { sha256 });
+  } catch {
+    return check("FAIL", "watch", `${label}: unreadable`);
+  }
+}
+
+/**
+ * Runs the local endpoint and optional file-integrity diagnostics.
+ * @param {object} [options] Doctor options.
+ * @param {string} [options.endpoint] Local endpoint URL.
+ * @param {string[]} [options.watches] Files to hash.
+ * @param {typeof fetch} [options.fetcher] Fetch implementation to use.
+ * @param {number} [options.timeoutMs] Request timeout in milliseconds.
+ * @returns {Promise<{endpoint: string | null, checks: Record<string, unknown>[], exitCode: number}>} Doctor report.
+ */
+export async function runDoctor({ endpoint = DEFAULT_ENDPOINT, watches = [], fetcher = fetch, timeoutMs = 2_000 } = {}) {
+  const checks = [];
+  let base;
+  try {
+    base = localEndpoint(endpoint);
+    checks.push(check("PASS", "endpoint", `local endpoint ${base.origin}`));
+  } catch {
+    checks.push(check("FAIL", "endpoint", "endpoint must be an HTTP localhost URL"));
+    return { endpoint: null, checks, exitCode: 2 };
+  }
+
+  const health = await fetchJson(fetcher, `${base.origin}/api/health`, timeoutMs);
+  if (health.kind === "unreachable") {
+    checks.push(check("FAIL", "health", "unreachable endpoint", { state: "unreachable" }));
+  } else if (!health.response.ok) {
+    checks.push(check("FAIL", "health", `HTTP ${health.response.status}`, { state: "http_error", status: health.response.status }));
+  } else if (health.state === "response_error") {
+    checks.push(check("FAIL", "health", "response body unreadable", { state: "response_error" }));
+  } else if (health.value === undefined) {
+    checks.push(check("FAIL", "health", "invalid JSON", { state: "invalid_json" }));
+  } else if (!health.value || typeof health.value !== "object" || Array.isArray(health.value)) {
+    checks.push(check("FAIL", "health", "invalid JSON object", { state: "invalid_shape" }));
+  } else if (health.value.app !== "openmausbot") {
+    checks.push(check("FAIL", "health", "wrong app identity", { state: "wrong_identity" }));
+  } else if (health.value.ready === false) {
+    checks.push(check("WARN", "health", "app identity is valid but ready=false", { state: "degraded", pid: health.value.pid ?? null }));
+  } else {
+    checks.push(check("PASS", "health", "OpenMausBot identity confirmed", { state: "ready", pid: health.value.pid ?? null }));
+  }
+
+  let statusSeen = false;
+  for (const path of STATUS_PATHS) {
+    const result = await fetchJson(fetcher, `${base.origin}${path}`, timeoutMs);
+    if (result.kind === "unreachable") continue;
+    if (result.response.status === 404) continue;
+    statusSeen = true;
+    if (!result.response.ok) checks.push(check("FAIL", "status", `${path}: HTTP ${result.response.status}`, { path, state: "http_error", status: result.response.status }));
+    else if (result.state === "response_error") checks.push(check("FAIL", "status", `${path}: response body unreadable`, { path, state: "response_error" }));
+    else if (result.value === undefined) checks.push(check("FAIL", "status", `${path}: invalid JSON`, { path, state: "invalid_json" }));
+    else {
+      const problem = inspectStatus(result.value);
+      checks.push(problem ? check("FAIL", "status", `${path}: ${problem}`, { path, state: "invalid_effect" }) : check("PASS", "status", `${path}: identity/readiness/digests valid`, { path, state: "valid" }));
+    }
+    break;
+  }
+  if (!statusSeen) checks.push(check("INFO", "status", "status/capsule endpoint unavailable", { state: "unknown" }));
+  for (const [index, file] of watches.entries()) checks.push(await watchFileWithDigest(file, `watch #${index + 1}`));
+
+  const exitCode = checks.some((item) => item.level === "FAIL") ? 2 : checks.some((item) => item.level === "WARN") ? 1 : 0;
+  return { endpoint: base.origin, checks, exitCode };
+}
+
+/**
+ * Parses command-line options for the doctor CLI.
+ * @param {string[]} argv Command-line arguments.
+ * @returns {{endpoint: string, watches: string[], json: boolean, quiet: boolean}} Parsed options.
+ * @throws {Error} If an argument is unknown or output modes conflict.
+ */
+export function parseArgs(argv) {
+  const options = { endpoint: DEFAULT_ENDPOINT, watches: [], json: false, quiet: false };
+  const nextValue = (index, flag) => {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    return value;
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--endpoint") {
+      options.endpoint = nextValue(i, arg);
+      i += 1;
+    } else if (arg === "--watch") {
+      options.watches.push(nextValue(i, arg));
+      i += 1;
+    }
+    else if (arg === "--json") options.json = true;
+    else if (arg === "--quiet") options.quiet = true;
+    else throw new Error("unknown argument");
+  }
+  if (options.json && options.quiet) throw new Error("--json and --quiet cannot be combined");
+  return options;
+}
+
+/**
+ * Renders a doctor report as JSON or human-readable text.
+ * @param {{checks: Array<{level: string, name: string, message: string}>}} report Doctor report.
+ * @param {object} [options] Output options.
+ * @param {boolean} [options.json] Render machine-readable JSON.
+ * @param {boolean} [options.quiet] Hide passing and informational checks.
+ * @returns {string} Rendered report.
+ */
+export function renderReport(report, { json = false, quiet = false } = {}) {
+  if (json) return JSON.stringify(report);
+  const rows = report.checks.filter((item) => !quiet || item.level === "FAIL" || item.level === "WARN");
+  return rows.length ? rows.map((item) => `${item.level} ${item.name}: ${item.message}`).join("\n") : "OK";
+}
+
+/**
+ * Runs the command-line doctor entry point.
+ * @returns {Promise<void>} Resolves after setting the process exit code.
+ */
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`FAIL args: ${error instanceof Error ? error.message : "invalid arguments"}`);
+    process.exitCode = 2;
+    return;
+  }
+  const report = await runDoctor(options);
+  console.log(renderReport(report, options));
+  process.exitCode = report.exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) await main();

--- a/scripts/openmaus-doctor.test.mjs
+++ b/scripts/openmaus-doctor.test.mjs
@@ -1,0 +1,148 @@
+import { createServer } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+import { parseArgs, renderReport, runDoctor } from "./openmaus-doctor.mjs";
+
+const health = (body) => new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+const fake = (routes) => async (url) => routes[new URL(url).pathname] ?? new Response("not found", { status: 404 });
+
+test("clean health is green and human report is concise", async () => {
+  const report = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot", pid: 7 }) }) });
+  expect(report.exitCode).toBe(0);
+  expect(renderReport(report)).toMatch(/PASS health/);
+  expect(renderReport(report)).toMatch(/INFO status/);
+});
+
+test("accepts bracketed IPv6 loopback endpoints", async () => {
+  const report = await runDoctor({
+    endpoint: "http://[::1]:8799",
+    fetcher: fake({ "/api/health": health({ app: "openmausbot" }) }),
+  });
+  expect(report.endpoint).toBe("http://[::1]:8799");
+  expect(report.exitCode).toBe(0);
+});
+
+test("keeps requests local, rejects credentials, and never follows redirects", async () => {
+  let options;
+  const report = await runDoctor({
+    fetcher: async (_url, input) => {
+      options = input;
+      return health({ app: "openmausbot" });
+    },
+  });
+  expect(report.exitCode).toBe(0);
+  expect(options.redirect).toBe("error");
+  expect((await runDoctor({ endpoint: "http://user:secret@localhost:8799" })).exitCode).toBe(2);
+});
+
+test("turns a response.text rejection into a deterministic failure", async () => {
+  const unreadable = { ok: true, status: 200, text: async () => { throw new Error("body unavailable"); } };
+  const report = await runDoctor({ fetcher: fake({ "/api/health": unreadable }) });
+  const healthCheck = report.checks.find((item) => item.name === "health");
+  expect(report.exitCode).toBe(2);
+  expect(healthCheck).toMatchObject({ level: "FAIL", state: "response_error" });
+});
+
+test("rejects null and array health JSON before reading app", async () => {
+  for (const body of [null, [{ app: "openmausbot" }]]) {
+    const report = await runDoctor({ fetcher: fake({ "/api/health": health(body) }) });
+    const healthCheck = report.checks.find((item) => item.name === "health");
+    expect(report.exitCode).toBe(2);
+    expect(healthCheck).toMatchObject({ level: "FAIL", state: "invalid_shape" });
+  }
+});
+
+test("wrong identity, invalid JSON, and unreachable are failures", async () => {
+  for (const response of [health({ app: "other" }), new Response("{", { status: 200 })]) {
+    const report = await runDoctor({ fetcher: fake({ "/api/health": response }) });
+    expect(report.exitCode).toBe(2);
+    expect(report.checks.find((item) => item.name === "health").level).toBe("FAIL");
+  }
+  const report = await runDoctor({ endpoint: "http://127.0.0.1:1", timeoutMs: 50 });
+  expect(report.exitCode).toBe(2);
+  expect(report.checks.find((item) => item.name === "health").state).toBe("unreachable");
+});
+
+test("status/capsule validates effect and source/build digest agreement", async () => {
+  const mismatch = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }), "/api/status": health({ app: "openmausbot", ready: true, sourceSha256: "a".repeat(64), buildSha256: "b".repeat(64) }) }) });
+  expect(mismatch.exitCode).toBe(2);
+  expect(mismatch.checks.find((item) => item.name === "status").message).toMatch(/mismatch/);
+  const clean = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }), "/api/status": health({ app: "openmausbot", ready: true, sourceSha256: "a".repeat(64), buildSha256: "a".repeat(64) }) }) });
+  expect(clean.exitCode).toBe(0);
+  const conflictingAliases = await runDoctor({ fetcher: fake({
+    "/api/health": health({ app: "openmausbot" }),
+    "/api/status": health({
+      app: "openmausbot",
+      ready: true,
+      sourceSha256: "a".repeat(64),
+      source_sha256: "b".repeat(64),
+    }),
+  }) });
+  expect(conflictingAliases.exitCode).toBe(2);
+});
+
+test("watch is opt-in, hashes without baseline, and detects missing file", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openmaus-doctor-"));
+  const file = join(root, "watched.txt");
+  await writeFile(file, "hello");
+  try {
+    const report = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }), "/api/status": health({ app: "openmausbot", ready: true }) }), watches: [file] });
+    expect(report.exitCode).toBe(0);
+    const before = report.checks.find((item) => item.name === "watch").sha256;
+    expect(before).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    await writeFile(file, "changed");
+    const after = (await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }), "/api/status": health({ app: "openmausbot", ready: true }) }), watches: [file] })).checks.find((item) => item.name === "watch").sha256;
+    expect(after).not.toBe(before);
+    const missing = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }) }), watches: [join(root, "missing")] });
+    expect(missing.exitCode).toBe(2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("json and quiet semantics expose machine data or only warnings/failures", async () => {
+  const report = await runDoctor({ fetcher: fake({ "/api/health": health({ app: "openmausbot" }) }) });
+  const json = renderReport(report, { json: true });
+  expect(JSON.parse(json).exitCode).toBe(0);
+  expect(renderReport(report, { quiet: true })).toBe("OK");
+  expect(renderReport(report, { quiet: true })).not.toMatch(/PASS health/);
+  expect((await runDoctor({ fetcher: fake({ "/api/health": health({ app: "wrong" }) }) })).exitCode).toBe(2);
+});
+
+test("argument parsing rejects missing values and conflicting output modes", () => {
+  expect(() => parseArgs(["--endpoint", "--json"])).toThrow("--endpoint requires a value");
+  expect(() => parseArgs(["--watch"])).toThrow("--watch requires a value");
+  expect(() => parseArgs(["--json", "--quiet"])).toThrow("cannot be combined");
+});
+
+test("local HTTP negative control proves response effect, not TCP only", async () => {
+  const server = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ app: "not-openmausbot", ready: true }));
+  });
+  await new Promise((resolvePromise) => server.listen(0, "127.0.0.1", resolvePromise));
+  try {
+    const address = server.address();
+    const report = await runDoctor({ endpoint: `http://127.0.0.1:${address.port}` });
+    expect(report.exitCode).toBe(2);
+  } finally {
+    await new Promise((resolvePromise) => server.close(resolvePromise));
+  }
+});
+
+test("invalid endpoint and watch failures never echo supplied secret-shaped values", async () => {
+  const probeValue = ["sk-", "proj-", "doctor-secret-value"].join("");
+  const queryKey = ["to", "ken"].join("");
+  const invalid = await runDoctor({ endpoint: `https://localhost/?${queryKey}=${probeValue}` });
+  expect(invalid.exitCode).toBe(2);
+  expect(JSON.stringify(invalid)).not.toContain(probeValue);
+  const failedWatch = await runDoctor({
+    fetcher: fake({ "/api/health": health({ app: "openmausbot" }) }),
+    watches: [`C:\\missing\\${["api", "-", "key"].join("")}=${probeValue}`],
+  });
+  expect(failedWatch.exitCode).toBe(2);
+  expect(JSON.stringify(failedWatch)).not.toContain(probeValue);
+});


### PR DESCRIPTION
## What changed

Adds a portable `pnpm doctor` command for checking a local OpenMausBot instance without reading user configuration or credentials.

It reports:

- loopback endpoint validation;
- `/api/health` reachability, app identity, readiness, and PID;
- optional status/capsule identity and source/build digest agreement;
- opt-in SHA-256 hashes for explicitly supplied regular files;
- human-readable, `--json`, and `--quiet` output;
- deterministic exit codes: 0 healthy, 1 warning, 2 failure.

## Safety boundaries

- accepts only HTTP loopback hosts;
- rejects URL credentials;
- never follows redirects;
- uses bounded request timeouts;
- rejects conflicting digest aliases;
- does not print supplied watch paths when they fail;
- does not read `~/.openmausbot`, tokens, or account data;
- validates missing CLI argument values instead of consuming the next flag.

## Verification

Validated after rebasing onto current official `main`:

- 12 focused tests passed
- real smoke check against a running packaged OpenMausBot instance passed
- missing-argument negative control returned exit code 2
- `git diff --check` passed
- staged additions were checked for private emails and common secret-token formats

## Scope

- 1 commit
- 3 files changed
- no UI changes
- no dependency or lockfile changes
- no credentials or private account data included

Current head: `86be30484814d7af3c929e9bbf04ce85b8ab44af`.