### PR TITLE
Add an isolated Codex permission reviewer

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -5,18 +5,70 @@
 //
 // The fake is a shebang script — the same constraint codex.cmd itself
 // hits on Windows. resolveCliSpawn covers both, so these run everywhere.
-import { chmodSync, mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ProviderInstance } from "../contracts.ts";
+import { parseReviewVerdict } from "../auto-review.ts";
+import { PROVIDER_CREDENTIAL_ENV } from "../config.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { CodexDriver } from "./codex.ts";
+import { CODEX_REVIEW_TIMEOUT_MS, CodexDriver, runCodexPermissionReview } from "./codex.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
+
+/** Create a local app-server fake with controllable review lifecycle output. */
+function writeReviewFake(scratch: string, mode = "valid", dumpPath = ""): string {
+  const cli = join(scratch, "codex-review-fake.mjs");
+  writeFileSync(cli, `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+const argv = process.argv.slice(2);
+const mode = ${JSON.stringify(mode)};
+const dumpPath = ${JSON.stringify(dumpPath)};
+const calls = [];
+const dump = () => {
+  if (dumpPath) {
+    writeFileSync(dumpPath, JSON.stringify({ argv, env: process.env, calls }, null, 2));
+  }
+};
+const out = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+if (argv[0] === "--version") { process.stdout.write("codex-review-fake 1\\n"); process.exit(0); }
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (message.method) calls.push({ method: message.method, params: message.params ?? null });
+    if (message.method === "initialize") out({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
+    else if (message.method === "model/list") out({ jsonrpc: "2.0", id: message.id, result: { data: [], nextCursor: null } });
+    else if (message.method === "thread/start") out({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "review-thread" } } });
+    else if (message.method === "turn/start") {
+      dump();
+      if (mode === "hang") continue;
+      out({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
+      const text = mode === "oversize"
+        ? "x".repeat(1_000_001)
+        : mode === "malformed"
+          ? "not json"
+          : mode === "extra"
+            ? '{"allow":true,"reason":"safe"}\\ntrailing'
+            : '{"allow":true,"reason":"safe"}';
+      out({ jsonrpc: "2.0", method: "item/completed", params: { item: { type: "agentMessage", text } } });
+      out({ jsonrpc: "2.0", method: "turn/completed", params: { turn: { status: "completed" } } });
+    }
+  }
+});
+setInterval(() => {}, 1000);
+`);
+  chmodSync(cli, 0o755);
+  return cli;
+}
 
 describe("CodexDriver.decodeConfig", () => {
   it("defaults to the codex binary with fullAuto off", () => {
@@ -60,11 +112,117 @@ describe("CodexDriver turns (fake app-server)", () => {
     delete process.env.FAKE_CODEX_STATE;
     delete process.env.FAKE_CODEX_RETRY_SCALE;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.NVIDIA_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
     delete process.env.BOX_TOKEN;
     delete process.env.OMB_TTS_KEY;
     recorder?.stop();
     await instance?.dispose();
     await removeTempDir(scratch);
+  });
+
+  it("reviews through a fresh ephemeral app-server over stdin with no MCP or dynamic tool scope", async () => {
+    const dump = join(scratch, "review.json");
+    const prompt = "review secret command: rm -rf /very-sensitive-path";
+    const reviewCli = writeReviewFake(scratch, "valid", dump);
+    const reviewEnvironment = Object.fromEntries(
+      PROVIDER_CREDENTIAL_ENV.map((key) => [key, "redacted-test-value"]),
+    );
+    const unlistedSecrets = {
+      UNSLOTH_STUDIO_AUTH_TOKEN: "unsloth-review-sentinel",
+      ARBITRARY_REVIEW_SECRET: "arbitrary-review-sentinel",
+    };
+    const codexHome = join(scratch, "review-codex-home");
+    instance = await CodexDriver.create({
+      instanceId: "codex-review",
+      displayName: "Codex Review",
+      environment: { ...reviewEnvironment, ...unlistedSecrets, CODEX_HOME: codexHome },
+      enabled: true,
+      config: { cli: reviewCli, fullAuto: false },
+    });
+
+    const raw = await instance.reviewPermission!(prompt);
+    expect(parseReviewVerdict(raw)).toEqual({ allow: true, reason: "safe" });
+
+    const seen = JSON.parse(readFileSync(dump, "utf8")) as {
+      argv: string[];
+      env: Record<string, string | undefined>;
+      calls: Array<{ method: string; params: any }>;
+    };
+    expect(seen.argv).toContain("mcp_servers={}");
+    expect(seen.argv.some((value) => value.includes(prompt))).toBe(false);
+    expect(seen.argv).not.toContain("--print");
+    expect(seen.argv.some((value) => value.startsWith("mcp_servers.") && value !== "mcp_servers={}")).toBe(false);
+    for (const key of PROVIDER_CREDENTIAL_ENV) expect(seen.env[key]).toBeUndefined();
+    expect(seen.env.BOX_TOKEN).toBeUndefined();
+    for (const [key, value] of Object.entries(unlistedSecrets)) {
+      expect(seen.env[key]).toBeUndefined();
+      expect(JSON.stringify(seen.env)).not.toContain(value);
+    }
+    expect(seen.env.CODEX_HOME).toBe(codexHome);
+    expect(seen.env.NPM_CONFIG_LOGLEVEL).toBe("error");
+    const start = seen.calls.find((call) => call.method === "thread/start")!;
+    expect(start.params).toMatchObject({
+      sandbox: "read-only",
+      approvalPolicy: "never",
+      ephemeral: true,
+      dynamicTools: [],
+    });
+    expect(start.params.developerInstructions).toContain("Do not call tools");
+    expect(start.params.cwd).toContain("omb-codex-review-");
+    const turn = seen.calls.find((call) => call.method === "turn/start")!;
+    expect(turn.params.input[0].text).toBe(prompt);
+    expect(turn.params.outputSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: ["allow", "reason"],
+    });
+  });
+
+  it("leaves malformed and extra review output to the strict parser, which refuses both", async () => {
+    for (const mode of ["malformed", "extra"]) {
+      const reviewCli = writeReviewFake(scratch, mode);
+      instance = await CodexDriver.create({
+        instanceId: `codex-review-shape-${mode}`,
+        displayName: "Codex Review Shape",
+        environment: {},
+        enabled: true,
+        config: { cli: reviewCli, fullAuto: false },
+      });
+      const raw = await instance.reviewPermission!("return a verdict");
+      expect(parseReviewVerdict(raw)).toBeNull();
+      await instance.dispose();
+    }
+  });
+
+  it("cancels and reaps a wedged review child", async () => {
+    const reviewCli = writeReviewFake(scratch, "hang");
+    instance = await CodexDriver.create({
+      instanceId: "codex-review-cancel",
+      displayName: "Codex Review Cancel",
+      environment: {},
+      enabled: true,
+      config: { cli: reviewCli, fullAuto: false },
+    });
+    const controller = new AbortController();
+    const pending = instance.reviewPermission!("cancel this review", controller.signal);
+    setTimeout(() => controller.abort(), 25);
+    await expect(pending).rejects.toThrow("Codex review aborted");
+  });
+
+  it("enforces the bounded review timeout", async () => {
+    const reviewCli = writeReviewFake(scratch, "hang");
+    await expect(
+      runCodexPermissionReview(reviewCli, {}, "timeout this review", undefined, 25),
+    ).rejects.toThrow("Codex review timed out after 25ms");
+    expect(CODEX_REVIEW_TIMEOUT_MS).toBe(60_000);
+  });
+
+  it("rejects review output before retaining more than the configured bound", async () => {
+    const reviewCli = writeReviewFake(scratch, "oversize");
+    await expect(
+      runCodexPermissionReview(reviewCli, {}, "oversized review", undefined, 1_000),
+    ).rejects.toThrow("Codex review output exceeded 1 MB");
   });
 
   it("runs the handshake and normalizes a full turn", async () => {

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -51,6 +51,8 @@ process.stdin.on("data", (chunk) => {
     else if (message.method === "turn/start") {
       dump();
       if (mode === "hang") continue;
+      if (mode === "null-line") process.stdout.write("null\\n");
+      if (mode === "server-request") out({ jsonrpc: "2.0", id: "srv-1", method: "item/tool/requestUserInput", params: {} });
       out({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
       const text = mode === "oversize"
         ? "x".repeat(1_000_001)
@@ -223,6 +225,18 @@ describe("CodexDriver turns (fake app-server)", () => {
     await expect(
       runCodexPermissionReview(reviewCli, {}, "oversized review", undefined, 1_000),
     ).rejects.toThrow("Codex review output exceeded 1 MB");
+  });
+
+  it("safely ignores null or scalar JSON-RPC output lines during review", async () => {
+    const reviewCli = writeReviewFake(scratch, "null-line");
+    const raw = await runCodexPermissionReview(reviewCli, {}, "allow test command");
+    expect(parseReviewVerdict(raw)).toEqual({ allow: true, reason: "safe" });
+  });
+
+  it("declines server-initiated JSON-RPC requests without hanging", async () => {
+    const reviewCli = writeReviewFake(scratch, "server-request");
+    const raw = await runCodexPermissionReview(reviewCli, {}, "allow test command");
+    expect(parseReviewVerdict(raw)).toEqual({ allow: true, reason: "safe" });
   });
 
   it("runs the handshake and normalizes a full turn", async () => {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -226,6 +226,17 @@ export function runCodexPermissionReview(
         } catch {
           continue;
         }
+        if (!message || typeof message !== "object" || Array.isArray(message)) {
+          continue;
+        }
+        if (message.id !== undefined && typeof message.method === "string") {
+          try {
+            send({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "Method not allowed during permission review" } });
+          } catch {
+            // child stdin closed
+          }
+          continue;
+        }
         if (message.id !== undefined && (message.result !== undefined || message.error !== undefined)) {
           const waiting = pending.get(message.id);
           if (!waiting) continue;

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -9,7 +9,9 @@
 //
 // resumeCursor is the codex thread id; a later turn tries thread/resume
 // and falls back to a fresh thread/start.
-import { homedir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { stripWorkspaceCredentialEnv } from "../config.ts";
 import { computerProxyEnv } from "../container-computer.ts";
@@ -41,6 +43,7 @@ export interface CodexConfig {
   fullAuto: boolean;
 }
 
+/** Decode persisted Codex settings while keeping full-auto opt-in strict. */
 function decodeConfig(raw: unknown): CodexConfig {
   const o = (raw ?? {}) as Record<string, unknown>;
   return {
@@ -78,6 +81,224 @@ function mountMcpServer(
   }
 }
 
+/** The review child is intentionally independent from normal turn routing. */
+export const CODEX_REVIEW_TIMEOUT_MS = 60_000;
+const CODEX_REVIEW_MAX_OUTPUT_BYTES = 1_000_000;
+const CODEX_REVIEW_INSTRUCTIONS =
+  "Review only the supplied permission request. Do not call tools, inspect files, or access the network. Return only the requested JSON verdict.";
+const CODEX_REVIEW_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["allow", "reason"],
+  properties: {
+    allow: { type: "boolean" },
+    reason: { type: "string", minLength: 1, maxLength: 200 },
+  },
+} as const;
+const CODEX_REVIEW_ENV_KEYS = [
+  "PATH",
+  "CODEX_HOME",
+  "HOME",
+  "USERPROFILE",
+  "SystemRoot",
+  "ComSpec",
+  "PATHEXT",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "NPM_CONFIG_LOGLEVEL",
+] as const;
+
+/** Keep only non-secret runtime context needed by the isolated reviewer. */
+function codexReviewEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  const reviewEnv: Record<string, string | undefined> = {};
+  for (const key of CODEX_REVIEW_ENV_KEYS) {
+    if (env[key] !== undefined) reviewEnv[key] = env[key];
+  }
+  return reviewEnv;
+}
+
+/**
+ * Run one permission review through a fresh app-server process. The prompt is
+ * only present in the JSON-RPC turn/start message on child stdin. The child
+ * gets a disposable cwd, read-only/never-approval session settings, and an
+ * empty MCP table; it never receives a normal turn's integrations or cursor.
+ *
+ * The raw assistant text is returned so auto-review's existing strict parser
+ * remains the security boundary for malformed or extra output.
+ */
+export function runCodexPermissionReview(
+  cli: string,
+  env: Record<string, string | undefined>,
+  prompt: string,
+  signal?: AbortSignal,
+  timeoutMs = CODEX_REVIEW_TIMEOUT_MS,
+): Promise<string> {
+  if (signal?.aborted) return Promise.reject(new Error("Codex review aborted"));
+
+  const reviewCwd = mkdtempSync(join(tmpdir(), "omb-codex-review-"));
+  const args = [
+    "app-server",
+    // Do not inherit MCP servers from the user's Codex config. Normal turns
+    // add their own named entries explicitly; this review has none.
+    "-c", "mcp_servers={}",
+    // Do not let the app-server inject project instructions from the temp cwd.
+    "-c", "project_doc_max_bytes=0",
+  ];
+  const reviewEnv = codexReviewEnv(env);
+  let child: ReturnType<typeof spawnCli> | undefined;
+  let settled = false;
+  let outputBytes = 0;
+  let stderr = "";
+  let buffer = "";
+  let answer: string | undefined;
+  let nextId = 1;
+  const pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
+  let timer: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
+
+  return new Promise((resolve, reject) => {
+    const removeTempCwd = () => {
+      try {
+        rmSync(reviewCwd, { recursive: true, force: true });
+      } catch {
+        // The cwd is disposable; a later process cleanup must not turn a
+        // completed review into an apparently failed approval.
+      }
+    };
+    const finish = (error?: Error, value?: string) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (onAbort) signal?.removeEventListener("abort", onAbort);
+      for (const request of pending.values()) request.reject(error ?? new Error("Codex review settled"));
+      pending.clear();
+      if (child && child.exitCode === null && child.signalCode === null) killCliTree(child);
+      if (child) child.once("close", removeTempCwd);
+      else removeTempCwd();
+      if (error) reject(error);
+      else resolve(value ?? "");
+    };
+    const send = (message: unknown) => {
+      if (!child?.stdin?.writable) throw new Error("Codex review stdin is unavailable");
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    };
+    const request = (method: string, params: unknown): Promise<any> =>
+      new Promise((resolveRequest, rejectRequest) => {
+        const id = nextId++;
+        pending.set(id, { resolve: resolveRequest, reject: rejectRequest });
+        try {
+          send({ jsonrpc: "2.0", id, method, params });
+        } catch (error) {
+          pending.delete(id);
+          rejectRequest(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+
+    try {
+      child = spawnCli(cli, args, {
+        cwd: reviewCwd,
+        env: reviewEnv,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      const chunkBytes = Buffer.byteLength(chunk, "utf8");
+      if (outputBytes + chunkBytes > CODEX_REVIEW_MAX_OUTPUT_BYTES) {
+        finish(new Error("Codex review output exceeded 1 MB"));
+        return;
+      }
+      outputBytes += chunkBytes;
+      buffer += chunk;
+      let newline: number;
+      while ((newline = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line.trim()) continue;
+        let message: any;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id !== undefined && (message.result !== undefined || message.error !== undefined)) {
+          const waiting = pending.get(message.id);
+          if (!waiting) continue;
+          pending.delete(message.id);
+          if (message.error) waiting.reject(new Error(message.error.message ?? JSON.stringify(message.error)));
+          else waiting.resolve(message.result);
+          continue;
+        }
+        if (message.method === "item/completed" && message.params?.item?.type === "agentMessage") {
+          const text = message.params.item.text;
+          if (typeof text === "string") {
+            if (answer !== undefined) {
+              finish(new Error("Codex review returned multiple assistant messages"));
+              return;
+            }
+            answer = text;
+          }
+          continue;
+        }
+        if (message.method === "turn/completed") {
+          const status = message.params?.turn?.status;
+          if (status !== "completed") {
+            finish(new Error(`Codex review turn failed: ${String(status ?? "unknown")}`));
+          } else if (answer === undefined) {
+            finish(new Error("Codex review returned no assistant message"));
+          } else {
+            finish(undefined, answer.trim());
+          }
+        }
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr = (stderr + chunk).slice(-8_192);
+    });
+    child.on("error", (error) => finish(error));
+    child.on("close", (code, signalCode) => {
+      removeTempCwd();
+      if (!settled) finish(new Error(stderr.trim() || `Codex review exited ${code ?? signalCode ?? "before result"}`));
+    });
+
+    onAbort = () => finish(new Error("Codex review aborted"));
+    timer = setTimeout(() => finish(new Error(`Codex review timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+    if (signal?.aborted) onAbort();
+    else signal?.addEventListener("abort", onAbort, { once: true });
+
+    void (async () => {
+      try {
+        await request("initialize", { clientInfo: { name: "openmausbot-review", version: "1" } });
+        send({ jsonrpc: "2.0", method: "initialized", params: {} });
+        const started = await request("thread/start", {
+          cwd: reviewCwd,
+          sandbox: "read-only",
+          approvalPolicy: "never",
+          ephemeral: true,
+          dynamicTools: [],
+          developerInstructions: CODEX_REVIEW_INSTRUCTIONS,
+        });
+        const threadId = started?.thread?.id;
+        if (typeof threadId !== "string" || !threadId) throw new Error("Codex review returned no ephemeral thread id");
+        await request("turn/start", {
+          threadId,
+          input: [{ type: "text", text: prompt }],
+          outputSchema: CODEX_REVIEW_OUTPUT_SCHEMA,
+        });
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    })();
+  });
+}
+
 export const CodexDriver: ProviderDriver<CodexConfig> = {
   driverKind: DRIVER_KIND,
   metadata: { displayName: "Codex", supportsMultipleInstances: true },
@@ -95,6 +316,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
   decodeConfig,
   defaultConfig: () => decodeConfig({}),
 
+  /** Create a Codex provider instance and its runtime adapter. */
   async create(input: DriverCreateInput<CodexConfig>): Promise<ProviderInstance> {
     const { instanceId, config } = input;
     const childEnv = (): Record<string, string | undefined> => {
@@ -665,6 +887,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         return () => listeners.delete(listener);
       },
     },
+    reviewPermission: (prompt, signal) => runCodexPermissionReview(config.cli, childEnv(), prompt, signal),
     dispose: async () => {
       for (const { stop } of active.values()) stop();
       listeners.clear();


### PR DESCRIPTION
## What changed

Adds a dedicated Codex permission-review path instead of reusing a normal bot turn.

The reviewer now:

- starts a fresh ephemeral `codex app-server` process for each review;
- receives the review prompt over stdin, never through argv;
- runs from a disposable empty working directory;
- uses `sandbox: "read-only"` and `approvalPolicy: "never"`;
- disables inherited MCP servers and passes no dynamic tools;
- receives explicit developer instructions not to call tools or inspect files;
- constrains the final answer with the existing strict `{ allow, reason }` JSON contract;
- inherits only the small runtime environment allowlist required to launch Codex;
- enforces abort handling, a 60-second process bound, and a 1 MB output bound.

Malformed, multiple, oversized, missing, aborted, or timed-out responses fail closed and leave the human approval card open.

## Why

Permission-review prompts may contain untrusted command and tool text. They must not run inside the original bot session with its integrations, working directory, provider credentials, or conversation state.

## Verification

Validated after rebasing onto current official `main`:

- `server/drivers/codex.test.ts`
- `server/auto-review.test.ts`
- 42 focused tests passed
- server TypeScript check passed
- `git diff --check` passed
- staged additions were checked for private emails and common secret-token formats

## Scope

- 1 commit
- 2 files changed
- no UI changes
- no dependency or lockfile changes
- no credentials or private account data included

Current head: `9153c82db1d1d48f31861d166f07ee901df6ed98`.