### PR TITLE
feat(ios): create sidebar sections with swipe selection

### DIFF
--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -63,6 +63,9 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
   // the fleet, and making a bot
   { method: "GET", path: /^\/api\/bots$/ },
   { method: "POST", path: /^\/api\/bots$/ },
+  // One narrow, atomic organizer write. This can only file visible bots;
+  // unlike the desktop's broad PATCH it cannot alter execution policy.
+  { method: "POST", path: /^\/api\/sidebar-sections$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/messages$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/interrupt$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/read$/ },

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -344,6 +344,33 @@ describe("the sidecar in front of an unmodified harness", () => {
     }
   });
 
+  it("files bots through only the narrow atomic organizer route", async () => {
+    const listed = await device("GET", "/api/bots");
+    const first = listed.body.bots[0];
+    const second = (await device("POST", "/api/bots")).body.bot;
+
+    const partial = await device("POST", "/api/sidebar-sections", {
+      body: { name: "Mobile", botIds: [first.id, "missing"] },
+    });
+    expect(partial.status).toBe(404);
+    const afterFailure = await device("GET", "/api/bots");
+    expect(afterFailure.body.bots.find((bot: { id: string }) => bot.id === first.id)?.section)
+      .toBe(first.section);
+
+    const filed = await device("POST", "/api/sidebar-sections", {
+      body: { name: "  Mobile  ", botIds: [first.id, second.id, first.id] },
+    });
+    expect(filed.status).toBe(200);
+    expect(filed.body.section).toBe("Mobile");
+    expect(filed.body.bots.map((bot: { id: string }) => bot.id)).toEqual([first.id, second.id]);
+    expect(filed.body.bots.every((bot: { section?: string }) => bot.section === "Mobile")).toBe(true);
+
+    const smuggled = await device("POST", "/api/sidebar-sections", {
+      body: { name: "Unsafe", botIds: [first.id], autoApprove: true },
+    });
+    expect(smuggled.status).toBe(400);
+  });
+
   it("only remembers an always-allow key carried by a pending card", async () => {
     const { body } = await device("GET", "/api/bots");
     const bot = body.bots[0];

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -42,6 +42,7 @@ describe("what the app may do", () => {
     ["GET", "/api/companion/endpoints"],
     ["GET", "/api/bots"],
     ["POST", "/api/bots"],
+    ["POST", "/api/sidebar-sections"],
     ["POST", "/api/bots/bot_123/messages"],
     ["POST", "/api/bots/bot_123/interrupt"],
     ["POST", "/api/bots/bot_123/read"],
@@ -165,6 +166,9 @@ describe("what it may not", () => {
     expect(allowed("GET", "/api/groups/room-1")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123/profile/execution-policy")).toBe(false);
+    expect(allowed("GET", "/api/sidebar-sections")).toBe(false);
+    expect(allowed("PATCH", "/api/sidebar-sections")).toBe(false);
+    expect(allowed("POST", "/api/sidebar-sections/extra")).toBe(false);
     expect(allowed("PUT", "/api/config")).toBe(false);
     expect(allowed("GET", "/api/attachments/../config.json")).toBe(false);
     expect(allowed("POST", "/api/routine-runs/run_1/cancel")).toBe(false);

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -1,11 +1,9 @@
 // The roster.
 //
-// Messages-shaped: a glass header, your groups across the top, every bot
-// below with the unread dot in the bot's own colour at the left edge, and a
-// glass bar floating at the bottom. The bar's pill is Updates — only the
-// bots that need you, are working, or have something you have not read —
-// beside round search and new-bot buttons. Everything scrolls under the
-// glass, which is the whole point of the glass.
+// Messages-shaped: a glass header, built-in and user-named sidebar sections,
+// channels as compact tiles, and bot conversations as rows. The floating bar
+// keeps Updates, search, organization and new-bot actions within one thumb's
+// reach while everything scrolls beneath the glass.
 import SwiftUI
 import CompanionCore
 
@@ -21,6 +19,7 @@ struct ChatListView: View {
     @State private var searchOpen = false
     @State private var showingUpdates = false
     @State private var showingNewGroup = false
+    @State private var showingNewSection = false
     @FocusState private var searchFocused: Bool
 
     /// Room for the floating bar, so the last row can scroll clear of it.
@@ -36,60 +35,49 @@ struct ChatListView: View {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         if query.isEmpty {
-                            groupsStrip
-                            sectionLabel("Bots")
-                                .padding(.top, 18)
-                                .padding(.bottom, 4)
-                        }
-
-                        if !query.isEmpty, !searchHits.isEmpty {
-                            HStack {
-                                sectionLabel("Messages")
-                                Spacer()
-                                if searching { ProgressView().controlSize(.small) }
-                            }
-                            .padding(.top, 10)
-                            .padding(.bottom, 4)
-
-                            ForEach(searchHits) { hit in
-                                Button {
-                                    Task {
-                                        if let chat = await session.open(hit) {
-                                            Haptics.selection()
-                                            path.append(chat)
-                                        }
-                                    }
-                                } label: {
-                                    SearchHitRow(hit: hit)
+                            rosterSections
+                        } else {
+                            if !searchHits.isEmpty {
+                                HStack {
+                                    sectionLabel("Messages")
+                                    Spacer()
+                                    if searching { ProgressView().controlSize(.small) }
                                 }
-                                .buttonStyle(.plain)
-                                .padding(.horizontal, 16)
-                            }
-                            sectionLabel("Chats")
-                                .padding(.top, 14)
+                                .padding(.top, 10)
                                 .padding(.bottom, 4)
-                        }
 
-                        let rows = chats
-                        ForEach(Array(rows.enumerated()), id: \.element.id) { index, summary in
-                            NavigationLink(value: summary.chat) {
-                                ChatRow(
-                                    chat: summary.chat,
-                                    preview: summary.preview,
-                                    at: summary.lastActivity,
-                                    state: MausState.forChat(summary.chat, in: session.state),
-                                    waiting: waitingChats.contains(summary.chat.id),
-                                    last: index == rows.count - 1
-                                )
+                                ForEach(searchHits) { hit in
+                                    Button {
+                                        Task {
+                                            if let chat = await session.open(hit) {
+                                                Haptics.selection()
+                                                path.append(chat)
+                                            }
+                                        }
+                                    } label: {
+                                        SearchHitRow(hit: hit)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .padding(.horizontal, 16)
+                                }
+                                sectionLabel("Chats")
+                                    .padding(.top, 14)
+                                    .padding(.bottom, 4)
+                            } else if searching {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.top, 24)
                             }
-                            .buttonStyle(.plain)
+
+                            botRows(chats)
                         }
                     }
                     .padding(.bottom, Self.barClearance)
                 }
                 .refreshable { await session.refresh() }
                 .overlay {
-                    if chats.isEmpty && searchHits.isEmpty {
+                    if rosterIsEmpty {
                         ContentUnavailableView(
                             query.isEmpty ? "No bots yet" : "Nothing matches",
                             systemImage: query.isEmpty ? "bubble.left.and.bubble.right" : "magnifyingglass",
@@ -127,10 +115,12 @@ struct ChatListView: View {
                 }
             }
 #if DEBUG
-            // `-store-preview -open-first`: land on the first chat, for the
-            // screenshot harness and for looking at the chat screen without
-            // a pairing.
+            // Preview-only routes let the screenshot harness reach screens
+            // that normally require a paired computer and a tap.
             .task {
+                if ProcessInfo.processInfo.arguments.contains("-open-new-section") {
+                    showingNewSection = true
+                }
                 if ProcessInfo.processInfo.arguments.contains("-open-first"),
                    path.isEmpty, let first = chats.first {
                     path.append(first.chat)
@@ -148,6 +138,9 @@ struct ChatListView: View {
                     showingNewGroup = false
                     path.append(Chat.room(room))
                 }
+            }
+            .sheet(isPresented: $showingNewSection) {
+                NewSectionSheet()
             }
             .task(id: query) {
                 let expected = query
@@ -221,19 +214,76 @@ struct ChatListView: View {
         }
     }
 
-    // MARK: - Groups
+    // MARK: - Sidebar sections
 
-    private var groupsStrip: some View {
+    @ViewBuilder
+    private var rosterSections: some View {
+        if let chief = session.state.unsectionedChief {
+            botRows(summaries(for: [chief]))
+        }
+
+        let pinned = summaries(for: session.state.pinnedBots)
+        if !pinned.isEmpty {
+            sectionLabel("Pinned")
+                .padding(.top, 2)
+                .padding(.bottom, 4)
+            botRows(pinned)
+        }
+
+        channelsStrip(
+            title: "Channels",
+            rooms: session.state.unsectionedChannels,
+            showsCreate: true
+        )
+
+        if !session.state.botChats.isEmpty {
+            channelsStrip(title: "Bot chats", rooms: session.state.botChats, showsCreate: false)
+        }
+
+        let unsectioned = summaries(for: session.state.unsectionedBots)
+        if !unsectioned.isEmpty {
+            sectionLabel("Bots")
+                .padding(.top, 18)
+                .padding(.bottom, 4)
+            botRows(unsectioned)
+        }
+
+        ForEach(session.state.sidebarSections) { section in
+            VStack(alignment: .leading, spacing: 0) {
+                sectionLabel(section.name)
+                    .padding(.top, 18)
+                    .padding(.bottom, section.chiefs.isEmpty && !section.channels.isEmpty ? 10 : 4)
+                if !section.chiefs.isEmpty {
+                    botRows(summaries(for: section.chiefs))
+                }
+                if !section.channels.isEmpty {
+                    channelTiles(section.channels, showsCreate: false)
+                        .padding(.top, section.chiefs.isEmpty ? 0 : 8)
+                        .padding(.bottom, section.bots.isEmpty ? 4 : 8)
+                }
+                botRows(summaries(for: section.bots))
+            }
+        }
+    }
+
+    private func channelsStrip(title: String, rooms: [Room], showsCreate: Bool) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            sectionLabel("Groups")
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(session.state.rooms) { room in
-                        NavigationLink(value: Chat.room(room)) {
-                            GroupTile(room: room)
-                        }
-                        .buttonStyle(.plain)
+            sectionLabel(title)
+            channelTiles(rooms, showsCreate: showsCreate)
+        }
+        .padding(.top, 2)
+    }
+
+    private func channelTiles(_ rooms: [Room], showsCreate: Bool) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(rooms) { room in
+                    NavigationLink(value: Chat.room(room)) {
+                        GroupTile(room: room)
                     }
+                    .buttonStyle(.plain)
+                }
+                if showsCreate {
                     Button {
                         Haptics.selection()
                         showingNewGroup = true
@@ -241,12 +291,28 @@ struct ChatListView: View {
                         GroupTile(room: nil)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("New group")
+                    .accessibilityLabel("New channel")
                 }
-                .padding(.horizontal, 16)
             }
+            .padding(.horizontal, 16)
         }
-        .padding(.top, 2)
+    }
+
+    @ViewBuilder
+    private func botRows(_ rows: [ChatSummary]) -> some View {
+        ForEach(Array(rows.enumerated()), id: \.element.id) { index, summary in
+            NavigationLink(value: summary.chat) {
+                ChatRow(
+                    chat: summary.chat,
+                    preview: summary.preview,
+                    at: summary.lastActivity,
+                    state: MausState.forChat(summary.chat, in: session.state),
+                    waiting: waitingChats.contains(summary.chat.id),
+                    last: index == rows.count - 1
+                )
+            }
+            .buttonStyle(.plain)
+        }
     }
 
     // MARK: - Bottom bar
@@ -288,34 +354,95 @@ struct ChatListView: View {
                     .frame(height: 52)
                     .glassCapsule()
                 } else {
-                    UpdatesPill(updates: session.state.updates) {
-                        Haptics.selection()
-                        showingUpdates = true
+                    ViewThatFits(in: .horizontal) {
+                        expandedBottomActions
+                        compactBottomActions
                     }
-                        .frame(height: 52)
-
-                    GlassButton(systemImage: "magnifyingglass", size: 48, weight: .semibold) {
-                        Haptics.selection()
-                        searchOpen = true
-                        searchFocused = true
-                    }
-                    .accessibilityLabel("Search")
-
-                    GlassButton(systemImage: "square.and.pencil", size: 48, weight: .medium) {
-                        Task {
-                            if let bot = await session.createBot() {
-                                Haptics.success()
-                                path.append(Chat.bot(bot))
-                            }
-                        }
-                    }
-                    .accessibilityLabel("New bot")
                 }
             }
         }
         .padding(.horizontal, 16)
         .padding(.bottom, 8)
         .animation(.snappy(duration: 0.25), value: searchOpen)
+    }
+
+    private var expandedBottomActions: some View {
+        HStack(spacing: 8) {
+            updatesButton
+                .frame(width: 180)
+            searchButton
+            sectionButton
+            newBotButton
+        }
+    }
+
+    private var compactBottomActions: some View {
+        HStack(spacing: 8) {
+            updatesButton
+                .frame(minWidth: 148)
+            searchButton
+            Menu {
+                Button("New section", systemImage: "folder.badge.plus", action: openNewSection)
+                    .disabled(!hasVisibleBots)
+                Button("New bot", systemImage: "square.and.pencil", action: createBot)
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(Color.primary)
+                    .frame(width: 48, height: 48)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .glassCapsule()
+            .accessibilityLabel("Create")
+        }
+    }
+
+    private var updatesButton: some View {
+        UpdatesPill(updates: session.state.updates) {
+            Haptics.selection()
+            showingUpdates = true
+        }
+        .frame(height: 52)
+    }
+
+    private var searchButton: some View {
+        GlassButton(systemImage: "magnifyingglass", size: 48, weight: .semibold) {
+            Haptics.selection()
+            searchOpen = true
+            searchFocused = true
+        }
+        .accessibilityLabel("Search")
+    }
+
+    private var sectionButton: some View {
+        GlassButton(systemImage: "folder.badge.plus", size: 48, weight: .medium, action: openNewSection)
+            .disabled(!hasVisibleBots)
+            .opacity(hasVisibleBots ? 1 : 0.45)
+            .accessibilityLabel("New section")
+    }
+
+    private var newBotButton: some View {
+        GlassButton(systemImage: "square.and.pencil", size: 48, weight: .medium, action: createBot)
+            .accessibilityLabel("New bot")
+    }
+
+    private var hasVisibleBots: Bool {
+        session.state.bots.contains { $0.hidden != true }
+    }
+
+    private func openNewSection() {
+        Haptics.selection()
+        showingNewSection = true
+    }
+
+    private func createBot() {
+        Task {
+            if let bot = await session.createBot() {
+                Haptics.success()
+                path.append(Chat.bot(bot))
+            }
+        }
     }
 
     // MARK: - Data
@@ -333,8 +460,23 @@ struct ChatListView: View {
         }
     }
 
+    private func summaries(for bots: [Bot]) -> [ChatSummary] {
+        let ids = Set(bots.map(\.id))
+        return session.state.chatSummaries.filter { summary in
+            if case let .bot(bot) = summary.chat { return ids.contains(bot.id) }
+            return false
+        }
+    }
+
     private var waitingChats: Set<String> {
         Set(session.state.pendingApprovals.compactMap { session.state.chat(forThread: $0.threadId)?.id })
+    }
+
+    private var rosterIsEmpty: Bool {
+        if query.isEmpty {
+            return session.state.bots.allSatisfy { $0.hidden == true } && session.state.rooms.isEmpty
+        }
+        return chats.isEmpty && searchHits.isEmpty && !searching
     }
 
     private func sectionLabel(_ text: String) -> some View {
@@ -389,7 +531,7 @@ struct GroupTile: View {
             }
             .frame(width: 64, height: 64)
 
-            Text(room?.name ?? "New group")
+            Text(room?.name ?? "New channel")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(room == nil ? Color.secondary : Color.primary)
                 .lineLimit(1)

--- a/ios/App/NewGroupSheet.swift
+++ b/ios/App/NewGroupSheet.swift
@@ -1,4 +1,4 @@
-// Make a room from the phone: a name, and which bots are in it.
+// Make a channel from the phone: a name, and which bots are in it.
 //
 // The harness names it after the first member if the name is left blank,
 // which is what the desktop's dialog does too — one rule, two screens.
@@ -19,7 +19,7 @@ struct NewGroupSheet: View {
         NavigationStack {
             List {
                 Section {
-                    TextField("Group name (optional)", text: $name)
+                    TextField("Channel name (optional)", text: $name)
                         .autocorrectionDisabled()
                 }
                 Section("Bots") {
@@ -46,7 +46,7 @@ struct NewGroupSheet: View {
                     }
                 }
             }
-            .navigationTitle("New group")
+            .navigationTitle("New channel")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/ios/App/NewSectionSheet.swift
+++ b/ios/App/NewSectionSheet.swift
@@ -1,0 +1,622 @@
+import SwiftUI
+import CompanionCore
+
+private let maximumBotsPerSection = 100
+
+/// A quick, phone-native way to file several bots under one sidebar heading.
+/// A normal tap always works; holding for a beat starts a trail that can be
+/// drawn through the grid without lifting a finger.
+struct NewSectionSheet: View {
+    @EnvironmentObject private var session: Session
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var step: Step = .bots
+    @State private var selection = SectionSelection(maximumCount: maximumBotsPerSection)
+    @State private var name = ""
+    @State private var saving = false
+    @State private var saveError: String?
+    @State private var lastCreatedName: String?
+    @State private var cellFrames: [String: CGRect] = [:]
+    @State private var fingerLocation: CGPoint?
+    @State private var dwellTask: Task<Void, Never>?
+    @State private var scheduledCandidate: SectionSelection.Candidate?
+    @FocusState private var nameFocused: Bool
+
+    private static let gridSpace = "new-section-grid"
+    private static let activationMilliseconds = 300
+    private static let dwellMilliseconds = 160
+
+    private enum Step {
+        case bots
+        case name
+    }
+
+    private var bots: [Bot] {
+        session.state.bots.filter { $0.hidden != true }
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var existingSections: Set<String> {
+        let botSections = bots.compactMap { normalizedSection($0.section) }
+        let roomSections = session.state.rooms.compactMap { normalizedSection($0.section) }
+        return Set(botSections + roomSections)
+    }
+
+    private var joinsExistingSection: Bool {
+        existingSections.contains(trimmedName)
+    }
+
+    private var selectedBots: [Bot] {
+        selection.selectedIDs.compactMap { id in bots.first { $0.id == id } }
+    }
+
+    /// Sections allow one coordinator. Moving two Chiefs together, or moving
+    /// one beside a different incumbent, must never silently remove a role.
+    private var hasChiefConflict: Bool {
+        let selectedChiefIDs = selectedBots
+            .filter { $0.chiefOfStaff == true }
+            .map(\.id)
+        let destinationChiefIDs = bots
+            .filter {
+                $0.chiefOfStaff == true && normalizedSection($0.section) == trimmedName
+            }
+            .map(\.id)
+        return Set(selectedChiefIDs + destinationChiefIDs).count > 1
+    }
+
+    private var hasPinnedSelection: Bool {
+        selectedBots.contains { $0.pinned == true && $0.chiefOfStaff != true }
+    }
+
+    private var canSave: Bool {
+        !saving
+            && !selection.selectedIDs.isEmpty
+            && (1...60).contains(trimmedName.utf16.count)
+            && !hasChiefConflict
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch step {
+                case .bots: botPicker
+                case .name: nameStep
+                }
+            }
+            .navigationTitle(step == .bots ? "New section" : "Name section")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(lastCreatedName == nil ? "Cancel" : "Done") { dismiss() }
+                        .disabled(saving)
+                }
+            }
+            .interactiveDismissDisabled(saving)
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+        .alert(
+            "Couldn’t create section",
+            isPresented: Binding(
+                get: { saveError != nil },
+                set: { if !$0 { saveError = nil } }
+            )
+        ) {
+            Button("OK") { saveError = nil }
+        } message: {
+            Text(saveError ?? "Try again.")
+        }
+        .onDisappear { endDrawing() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase != .active { endDrawing() }
+        }
+        .onChange(of: bots.map(\.id)) { _, ids in
+            if selection.isDragging { endDrawing() }
+            let available = Set(ids)
+            selection.selectAll(selection.selectedIDs.filter(available.contains))
+        }
+    }
+
+    // MARK: - Pick bots
+
+    private var botPicker: some View {
+        VStack(spacing: 0) {
+            if let lastCreatedName {
+                successBanner(name: lastCreatedName)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 10)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Swipe a section together")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                Text("Hold a bot, then glide. Pause on each bot until it clicks.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.top, 18)
+            .padding(.bottom, 14)
+
+            HStack {
+                Text(selection.selectedIDs.isEmpty ? "Choose bots" : "\(selection.selectedIDs.count) selected")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.secondary)
+                Spacer()
+                let selectableCount = min(bots.count, maximumBotsPerSection)
+                Button(selection.selectedIDs.count == selectableCount && selectableCount > 0 ? "Clear" : "Select all") {
+                    if selection.selectedIDs.count == selectableCount {
+                        selection.clear()
+                    } else {
+                        selection.selectAll(bots.map(\.id))
+                    }
+                    Haptics.selection()
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .disabled(bots.isEmpty || selection.isDragging)
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, bots.count > maximumBotsPerSection ? 4 : 10)
+
+            if bots.count > maximumBotsPerSection {
+                Text(
+                    selection.selectedIDs.count == maximumBotsPerSection
+                        ? "100 selected — that’s the section limit."
+                        : "Choose up to 100 bots for one section."
+                )
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Color.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 10)
+            }
+
+            if bots.isEmpty {
+                ContentUnavailableView(
+                    "No bots yet",
+                    systemImage: "square.grid.2x2",
+                    description: Text("Create a bot first, then come back to group it into a section.")
+                )
+                .frame(maxHeight: .infinity)
+            } else {
+                botGrid
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 8) {
+                if selection.selectedIDs.isEmpty {
+                    Text("Tap bots individually, or hold and swipe through the grid.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.secondary)
+                }
+                Button {
+                    endDrawing()
+                    step = .name
+                    nameFocused = true
+                } label: {
+                    Text("Continue with \(selection.selectedIDs.count) bot\(selection.selectedIDs.count == 1 ? "" : "s")")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                }
+                .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.capsule)
+                .disabled(selection.selectedIDs.isEmpty)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+            .background(.ultraThinMaterial)
+        }
+    }
+
+    private var botGrid: some View {
+        ScrollView {
+            ZStack(alignment: .topLeading) {
+                trail
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 108, maximum: 180), spacing: 12)],
+                    spacing: 12
+                ) {
+                    ForEach(bots) { bot in
+                        botCell(bot)
+                            .background {
+                                GeometryReader { proxy in
+                                    Color.clear.preference(
+                                        key: SectionCellFramePreference.self,
+                                        value: [bot.id: proxy.frame(in: .named(Self.gridSpace))]
+                                    )
+                                }
+                            }
+                    }
+                }
+            }
+            .coordinateSpace(name: Self.gridSpace)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+            .onPreferenceChange(SectionCellFramePreference.self) { cellFrames = $0 }
+        }
+        // A normal swipe scrolls. Holding a tile for the short dwell switches
+        // into drawing and freezes the scroll position; there is deliberately
+        // no surprising edge auto-scroll while a trail is active.
+        .scrollDisabled(selection.isDragging)
+    }
+
+    private func botCell(_ bot: Bot) -> some View {
+        let selected = selection.contains(bot.id)
+        let candidate = selection.candidate?.id == bot.id
+        let order = selection.selectedIDs.firstIndex(of: bot.id).map { $0 + 1 }
+        let tint = MausPalette.color(bot.color)
+
+        return Button {
+            if selection.toggle(bot.id) {
+                Haptics.selection()
+            } else {
+                Haptics.notification(.warning)
+            }
+        } label: {
+            VStack(spacing: 9) {
+                ZStack(alignment: .topTrailing) {
+                    BotAvatarView(bot: bot, size: 52, animated: false)
+                    if let order {
+                        Text("\(order)")
+                            .font(.system(size: 11, weight: .bold, design: .rounded))
+                            .foregroundStyle(Color.white)
+                            .frame(minWidth: 21, minHeight: 21)
+                            .background(tint, in: Circle())
+                            .overlay(Circle().stroke(Color(uiColor: .systemBackground), lineWidth: 2))
+                            .offset(x: 5, y: -5)
+                    }
+                }
+
+                VStack(spacing: 3) {
+                    Text(bot.name)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.primary)
+                        .lineLimit(1)
+                    Text(botContext(bot))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 116)
+            .background(
+                selected ? tint.opacity(0.13) : Color.secondary.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(
+                        candidate ? tint : (selected ? tint.opacity(0.75) : Color.secondary.opacity(0.12)),
+                        lineWidth: candidate ? 3 : 1
+                    )
+            }
+            .overlay(alignment: .bottom) {
+                if candidate {
+                    Capsule()
+                        .fill(tint)
+                        .frame(height: 4)
+                        .padding(.horizontal, 18)
+                        .padding(.bottom, 7)
+                        .transition(.opacity)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(bot.name), \(botContext(bot))")
+        .accessibilityValue(selected ? "Selected, number \(order ?? 1)" : "Not selected")
+        .accessibilityHint(selected ? "Double tap to remove this bot" : "Double tap to add this bot")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .highPriorityGesture(drawGesture(startingAt: bot.id))
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: selected)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.12), value: candidate)
+    }
+
+    private var trail: some View {
+        Canvas { context, _ in
+            guard selection.isDragging else { return }
+            var points = selection.gestureTrail.compactMap { cellFrames[$0]?.center }
+            if let fingerLocation { points.append(fingerLocation) }
+            guard let first = points.first else { return }
+
+            var path = Path()
+            path.move(to: first)
+            for point in points.dropFirst() { path.addLine(to: point) }
+            context.stroke(
+                path,
+                with: .color(Color.accentColor.opacity(0.72)),
+                style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round)
+            )
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func drawGesture(startingAt botID: String) -> some Gesture {
+        LongPressGesture(
+            minimumDuration: Double(Self.activationMilliseconds) / 1_000,
+            maximumDistance: 12
+        )
+        .sequenced(
+            before: DragGesture(minimumDistance: 0, coordinateSpace: .named(Self.gridSpace))
+        )
+        .onChanged { phase in
+            switch phase {
+            case .first(true):
+                guard !selection.isDragging else { return }
+                // The long press itself already supplied the first dwell.
+                if let candidate = selection.beginDrag(over: botID) {
+                    commit(candidate)
+                }
+            case let .second(true, drag):
+                guard let drag else { return }
+                fingerLocation = drag.location
+                let hit = SectionGridHitTesting.cellID(
+                    at: .init(x: drag.location.x, y: drag.location.y),
+                    in: hitFrames
+                )
+                schedule(selection.moveDrag(over: hit))
+            default:
+                break
+            }
+        }
+        .onEnded { _ in endDrawing() }
+    }
+
+    private var hitFrames: [SectionGridCellFrame] {
+        bots.compactMap { bot in
+            guard let frame = cellFrames[bot.id] else { return nil }
+            return SectionGridCellFrame(
+                id: bot.id,
+                minX: frame.minX,
+                minY: frame.minY,
+                maxX: frame.maxX,
+                maxY: frame.maxY
+            )
+        }
+    }
+
+    private func schedule(_ candidate: SectionSelection.Candidate?) {
+        guard scheduledCandidate != candidate else { return }
+        dwellTask?.cancel()
+        dwellTask = nil
+        scheduledCandidate = candidate
+        guard let candidate else { return }
+        dwellTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(Self.dwellMilliseconds))
+            guard !Task.isCancelled else { return }
+            commit(candidate)
+            if scheduledCandidate == candidate {
+                scheduledCandidate = nil
+                dwellTask = nil
+            }
+        }
+    }
+
+    private func commit(_ candidate: SectionSelection.Candidate) {
+        let result = selection.commit(candidate)
+        if case .limitReached = result {
+            Haptics.notification(.warning)
+        } else if result.givesFeedback {
+            Haptics.selection()
+        }
+    }
+
+    private func endDrawing() {
+        dwellTask?.cancel()
+        dwellTask = nil
+        scheduledCandidate = nil
+        selection.endDrag()
+        // A bot can disappear while the finger is down. Reconcile after the
+        // gesture ends so a stale ID cannot turn the eventual save into a 404.
+        let available = Set(bots.map(\.id))
+        selection.selectAll(selection.selectedIDs.filter(available.contains))
+        fingerLocation = nil
+    }
+
+    // MARK: - Name and save
+
+    private var nameStep: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                Button {
+                    nameFocused = false
+                    step = .bots
+                } label: {
+                    Label("Back to bots", systemImage: "chevron.left")
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .disabled(saving)
+
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("What should this section be called?")
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                    Text("It will appear on both your phone and computer.")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color.secondary)
+                }
+
+                TextField("For example, Research", text: $name)
+                    .font(.system(size: 19, weight: .medium))
+                    .textInputAutocapitalization(.words)
+                    .autocorrectionDisabled()
+                    .submitLabel(.done)
+                    .focused($nameFocused)
+                    .padding(.horizontal, 16)
+                    .frame(height: 56)
+                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+                    }
+                    .onSubmit { if canSave { save() } }
+
+                HStack {
+                    if joinsExistingSection {
+                        Label("Adds to existing section", systemImage: "arrow.triangle.merge")
+                            .foregroundStyle(Color.secondary)
+                    } else {
+                        Label("Creates a new section", systemImage: "square.stack.3d.up")
+                            .foregroundStyle(Color.secondary)
+                    }
+                    Spacer()
+                    Text("\(trimmedName.utf16.count)/60")
+                        .foregroundStyle(trimmedName.utf16.count > 60 ? Color.red : Color.secondary)
+                }
+                .font(.system(size: 13, weight: .medium))
+
+                if hasChiefConflict {
+                    Label(
+                        "A section can have one Chief. Go back and choose one Chief, or use a section without one.",
+                        systemImage: "person.crop.circle.badge.exclamationmark"
+                    )
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color.orange)
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 14))
+                }
+
+                if hasPinnedSelection {
+                    Label(
+                        "Pinned bots stay in Pinned until you unpin them.",
+                        systemImage: "pin.fill"
+                    )
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("\(selection.selectedIDs.count) bot\(selection.selectedIDs.count == 1 ? "" : "s")")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.secondary)
+                    selectedBotChips
+                }
+            }
+            .padding(20)
+        }
+        .safeAreaInset(edge: .bottom) {
+            Button(action: save) {
+                HStack(spacing: 8) {
+                    if saving { ProgressView().tint(.white) }
+                    Text(saving ? "Creating…" : (joinsExistingSection ? "Add to section" : "Create section"))
+                        .font(.system(size: 17, weight: .semibold))
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .disabled(!canSave)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+            .background(.ultraThinMaterial)
+        }
+        .onAppear { nameFocused = true }
+    }
+
+    private var selectedBotChips: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], spacing: 8) {
+            ForEach(Array(selection.selectedIDs.enumerated()), id: \.element) { index, id in
+                if let bot = bots.first(where: { $0.id == id }) {
+                    HStack(spacing: 7) {
+                        BotAvatarView(bot: bot, size: 26, animated: false)
+                        Text("\(index + 1). \(bot.name)")
+                            .font(.system(size: 13, weight: .semibold))
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 10)
+                    .frame(height: 40)
+                    .background(Color.secondary.opacity(0.08), in: Capsule())
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard canSave else { return }
+        let section = trimmedName
+        let botIDs = selection.selectedIDs
+        saving = true
+        saveError = nil
+        session.actionError = nil
+        nameFocused = false
+
+        Task {
+            let result = await session.assignSection(name: section, botIds: botIDs)
+            saving = false
+            guard result != nil else {
+                let message = session.actionError
+                    ?? "The section could not be saved. Your bot selection is still here."
+                session.actionError = nil
+                saveError = message
+                return
+            }
+
+            Haptics.success()
+            lastCreatedName = section
+            selection.clear()
+            name = ""
+            step = .bots
+        }
+    }
+
+    private func successBanner(name: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Color.green)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(name) is ready")
+                    .font(.system(size: 14, weight: .semibold))
+                Text("Swipe another section together, or tap Done.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(Color.green.opacity(0.1), in: RoundedRectangle(cornerRadius: 14))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func normalizedSection(_ section: String?) -> String? {
+        guard let value = section?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private func botContext(_ bot: Bot) -> String {
+        var parts: [String] = []
+        if bot.chiefOfStaff == true {
+            parts.append("Chief")
+        } else if bot.pinned == true {
+            parts.append("Pinned")
+        }
+        parts.append(normalizedSection(bot.section) ?? "Bots")
+        return parts.joined(separator: " · ")
+    }
+}
+
+private struct SectionCellFramePreference: PreferenceKey {
+    static var defaultValue: [String: CGRect] = [:]
+
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, next in next })
+    }
+}
+
+private extension CGRect {
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
+}

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -864,6 +864,22 @@ final class Session: ObservableObject {
         }
     }
 
+    /// Create a sidebar section by assigning its complete starting set in one
+    /// request. The server commits the batch before returning, then these
+    /// folds make the roster move immediately instead of waiting for SSE.
+    @discardableResult
+    func assignSection(name: String, botIds: [String]) async -> [Bot]? {
+        guard let client else { return nil }
+        do {
+            let bots = try await client.assignSection(name: name, botIds: botIds)
+            for bot in bots { state.apply(.bot(bot)) }
+            return bots
+        } catch {
+            actionError = error.localizedDescription
+            return nil
+        }
+    }
+
     func interrupt(bot: Bot) async {
         await perform { try await $0.interrupt(botId: bot.id) }
     }

--- a/ios/App/StorePreview.json
+++ b/ios/App/StorePreview.json
@@ -8,6 +8,8 @@
       "description": "Finds the facts and brings back sources.",
       "notifications": true,
       "color": "cyan",
+      "section": "Launch",
+      "chiefOfStaff": true,
       "unread": true,
       "modelSelection": { "instanceId": "preview", "model": "preview" },
       "createdAt": 1787000000000,
@@ -43,6 +45,8 @@
       "description": "Shapes polished product experiences.",
       "notifications": true,
       "color": "purple",
+      "section": "Launch",
+      "pinned": true,
       "unread": false,
       "modelSelection": { "instanceId": "preview", "model": "preview" },
       "createdAt": 1786900000000,
@@ -61,6 +65,7 @@
       "description": "Builds and verifies releases.",
       "notifications": true,
       "color": "orange",
+      "section": "Engineering",
       "unread": false,
       "busy": true,
       "modelSelection": { "instanceId": "preview", "model": "preview" },
@@ -73,5 +78,31 @@
       ]
     }
   ],
-  "groups": []
+  "groups": [
+    {
+      "id": "preview-launch-channel",
+      "threadId": "preview-thread-launch-channel",
+      "name": "Launch room",
+      "memberIds": ["preview-scout", "preview-pixel"],
+      "defaultResponder": { "kind": "mentions" },
+      "bulletin": "Coordinate the mobile launch.",
+      "unread": false,
+      "createdAt": 1787000001000,
+      "section": "Launch",
+      "tasks": [{ "threadId": "preview-thread-launch-channel", "title": "Launch plan", "createdAt": 1787000001000 }],
+      "messages": []
+    },
+    {
+      "id": "preview-general-channel",
+      "threadId": "preview-thread-general-channel",
+      "name": "General",
+      "memberIds": ["preview-scout", "preview-pixel", "preview-forge"],
+      "defaultResponder": { "kind": "mentions" },
+      "bulletin": "",
+      "unread": false,
+      "createdAt": 1787000002000,
+      "tasks": [{ "threadId": "preview-thread-general-channel", "title": "New task", "createdAt": 1787000002000 }],
+      "messages": []
+    }
+  ]
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -12,7 +12,7 @@ same harness the desktop app talks to, through the restricted sidecar described 
 
 Built and verified against a real harness on both a simulator and an iPhone:
 QR handoff, Bonjour discovery, manual LAN and Tailscale pairing, the roster, paged chat,
-streaming replies, the computer view, and — the one that matters — an approval
+streaming replies, shared sidebar sections, the computer view, and — the one that matters — an approval
 raised by a bot on the Mac, answered on the phone, with the bot carrying on.
 
 The event stream deliberately reads raw bytes rather than
@@ -44,6 +44,7 @@ ios/
     SSE.swift                    line parser + URLSession event stream
     Client.swift                 every call the phone is allowed to make
     Store.swift                  the fold: frames → state
+    SectionSelection.swift       pure swipe/dwell selection state + grid hit testing
     Dictation.swift              composer text + transcript join
   Tests/CompanionCoreTests/
     Fixtures/                    captured from a real server — do not hand-edit
@@ -61,10 +62,11 @@ ios/
     PairingScanner.swift         native QR camera, permission and recovery UI
     Glass.swift                  the one material the chrome is made of (Liquid Glass on 26+)
     SpeechBubble.swift           the bubble shape; the tail is the reference vector, scaled
-    ChatListView.swift           roster: glass header, groups strip, bots, the Updates bar
+    ChatListView.swift           roster: channels and shared desktop/mobile sections
     Updates.swift                what the Updates pill shows — only bots doing something
     UpdatesSheet.swift           the pill opened: needs you / working / to review
-    NewGroupSheet.swift          make a room from the phone
+    NewGroupSheet.swift          make a channel from the phone
+    NewSectionSheet.swift        tap or swipe bots together into a section
     ChatView.swift               transcript, tailed bubbles, approval cards, composer
     SpeechDictation.swift        on-device speech recognition, press-to-stop
     ComputerView.swift           opt-in live view of a bot's computer
@@ -126,11 +128,13 @@ here by simply not having the methods:
 | Send messages, make a bot or a room | Manage pairing or revoke devices |
 | **Answer approvals and questions** | Drive the Local VM or this computer |
 | Interrupt a bot, mark chats read | Reach `/api/internal/*` |
+| File visible bots into one sidebar section | Use general bot or room `PATCH` routes |
 | Fetch screen images on demand | Load the packaged desktop UI |
 | Open an explicitly enabled cloud desktop | Provision, sleep or run shell commands on cloud computers |
 
 Marking a chat read and remembering an approval use purpose-built server
-verbs. The sidecar does not expose the general bot or room `PATCH` routes,
+verbs. Section creation likewise uses one strict atomic batch route. The
+sidecar does not expose the general bot or room `PATCH` routes,
 because those can also change execution policy, computers, connected apps, and
 working directories.
 

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -824,6 +824,21 @@ public struct CompanionClient: Sendable {
         return try await send(try makeRequest("POST", "/api/groups", body: body), as: CreatedRoom.self).group
     }
 
+    /// File several bots under one shared desktop/mobile sidebar heading.
+    /// This uses a narrow batch route instead of the desktop's general bot
+    /// PATCH, so a paired phone can change organization without gaining any
+    /// execution-policy controls and without leaving a half-created section.
+    public func assignSection(name: String, botIds: [String]) async throws -> [Bot] {
+        try await send(
+            try makeRequest(
+                "POST",
+                "/api/sidebar-sections",
+                body: ["name": name, "botIds": botIds]
+            ),
+            as: SidebarSectionResponse.self
+        ).bots
+    }
+
     public func send(text: String, toBot botId: String) async throws {
         try await send(try makeRequest("POST", "/api/bots/\(botId)/messages", body: ["text": text]))
     }

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -213,6 +213,8 @@ public struct Bot: Codable, Hashable, Identifiable, Sendable {
     public var busy: Bool?
     public var pinned: Bool?
     public var hidden: Bool?
+    /// Desktop sidebar section. Missing or blank means the built-in Bots area.
+    public var section: String?
     public var chiefOfStaff: Bool?
     public var autoApprove: Bool?
     public var alwaysAllow: [String]?
@@ -263,6 +265,8 @@ public struct Room: Codable, Hashable, Identifiable, Sendable {
     public var unread: Bool
     public var createdAt: Double
     public var dm: Bool?
+    /// Desktop sidebar section. Missing or blank means the built-in Channels area.
+    public var section: String?
     public var busyBotId: String?
     /// Independent user conversations in this channel. Bot-to-bot rooms
     /// omit tasks because their transcript is the canonical private chat.
@@ -882,6 +886,10 @@ struct ActiveBranchResponse: Codable, Sendable {
 
 struct BotResponse: Codable, Sendable {
     var bot: Bot
+}
+struct SidebarSectionResponse: Codable, Sendable {
+    var section: String
+    var bots: [Bot]
 }
 struct RoomResponse: Codable, Sendable {
     var group: Room

--- a/ios/Sources/CompanionCore/SectionSelection.swift
+++ b/ios/Sources/CompanionCore/SectionSelection.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Pure state for the section creator's draw-through gesture.
+///
+/// The view owns the 160 ms timer. Every hovered cell gets a unique candidate
+/// token, so a timer that finishes after the finger has moved cannot commit a
+/// stale bot. Keeping this independent of SwiftUI makes the fiddly gesture
+/// rules deterministic and cheap to test.
+public struct SectionSelection: Equatable, Sendable {
+    public struct Candidate: Equatable, Sendable {
+        public let id: String
+        fileprivate let generation: UInt
+    }
+
+    public enum Commit: Equatable, Sendable {
+        case added(String)
+        case visited(String)
+        case backtracked(removed: [String])
+        case limitReached(String)
+        case unchanged
+
+        public var givesFeedback: Bool {
+            switch self {
+            case .added, .visited, .backtracked: true
+            case .limitReached, .unchanged: false
+            }
+        }
+    }
+
+    public private(set) var selectedIDs: [String]
+    public let maximumCount: Int
+    public private(set) var candidate: Candidate?
+    public private(set) var gestureTrail: [String] = []
+    public private(set) var isDragging = false
+
+    private var gestureBase: [String] = []
+    private var settledID: String?
+    private var generation: UInt = 0
+
+    public init(selectedIDs: [String] = [], maximumCount: Int = .max) {
+        self.maximumCount = max(0, maximumCount)
+        self.selectedIDs = Array(Self.unique(selectedIDs).prefix(self.maximumCount))
+    }
+
+    public func contains(_ id: String) -> Bool {
+        selectedIDs.contains(id)
+    }
+
+    /// Accessible tap fallback. Buttons and VoiceOver use exactly the same
+    /// ordered selection as the drawing gesture.
+    @discardableResult
+    public mutating func toggle(_ id: String) -> Bool {
+        guard !isDragging else { return false }
+        if let index = selectedIDs.firstIndex(of: id) {
+            selectedIDs.remove(at: index)
+            return true
+        } else {
+            guard selectedIDs.count < maximumCount else { return false }
+            selectedIDs.append(id)
+            return true
+        }
+    }
+
+    public mutating func selectAll(_ ids: [String]) {
+        guard !isDragging else { return }
+        selectedIDs = Array(Self.unique(ids).prefix(maximumCount))
+    }
+
+    public mutating func clear() {
+        cancelGesture()
+        selectedIDs = []
+    }
+
+    /// Starts a new trail without disturbing selections made by accessible
+    /// taps or an earlier gesture.
+    @discardableResult
+    public mutating func beginDrag(over id: String?) -> Candidate? {
+        cancelCandidate()
+        isDragging = true
+        gestureBase = selectedIDs
+        gestureTrail = []
+        settledID = nil
+        return moveDrag(over: id)
+    }
+
+    /// Changes the dwell target. Passing `nil` means the finger is in a grid
+    /// gap and invalidates any outstanding timer.
+    @discardableResult
+    public mutating func moveDrag(over id: String?) -> Candidate? {
+        guard isDragging else { return nil }
+
+        if id == settledID {
+            cancelCandidate()
+            return nil
+        }
+        if candidate?.id == id {
+            return candidate
+        }
+
+        cancelCandidate()
+        guard let id else {
+            settledID = nil
+            return nil
+        }
+        settledID = nil
+        let next = Candidate(id: id, generation: generation)
+        candidate = next
+        return next
+    }
+
+    /// Commits only the candidate that is still under the finger. Revisiting
+    /// an earlier trail cell removes the tail; preselected bots remain in the
+    /// base selection even when the drawn tail is shortened.
+    @discardableResult
+    public mutating func commit(_ expected: Candidate) -> Commit {
+        guard isDragging, candidate == expected else { return .unchanged }
+        candidate = nil
+        settledID = expected.id
+
+        if let index = gestureTrail.firstIndex(of: expected.id) {
+            guard index < gestureTrail.index(before: gestureTrail.endIndex) else {
+                return .unchanged
+            }
+            let removed = Array(gestureTrail[gestureTrail.index(after: index)...])
+            gestureTrail.removeSubrange(gestureTrail.index(after: index)...)
+            rebuildSelection()
+            return .backtracked(removed: removed)
+        }
+
+        if !gestureBase.contains(expected.id), selectedIDs.count >= maximumCount {
+            return .limitReached(expected.id)
+        }
+        gestureTrail.append(expected.id)
+        let wasPreselected = gestureBase.contains(expected.id)
+        rebuildSelection()
+        return wasPreselected ? .visited(expected.id) : .added(expected.id)
+    }
+
+    public mutating func endDrag() {
+        cancelCandidate()
+        isDragging = false
+        settledID = nil
+        gestureBase = []
+        gestureTrail = []
+    }
+
+    private mutating func cancelGesture() {
+        cancelCandidate()
+        isDragging = false
+        settledID = nil
+        gestureBase = []
+        gestureTrail = []
+    }
+
+    private mutating func cancelCandidate() {
+        generation &+= 1
+        candidate = nil
+    }
+
+    private mutating func rebuildSelection() {
+        selectedIDs = Self.unique(gestureBase + gestureTrail)
+    }
+
+    private static func unique(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return ids.filter { seen.insert($0).inserted }
+    }
+}
+
+/// Small geometry values keep hit testing usable from CompanionCore without
+/// importing SwiftUI or leaking a particular grid implementation into it.
+public struct SectionGridPoint: Equatable, Sendable {
+    public var x: Double
+    public var y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct SectionGridCellFrame: Equatable, Sendable {
+    public var id: String
+    public var minX: Double
+    public var minY: Double
+    public var maxX: Double
+    public var maxY: Double
+
+    public init(id: String, minX: Double, minY: Double, maxX: Double, maxY: Double) {
+        self.id = id
+        self.minX = minX
+        self.minY = minY
+        self.maxX = maxX
+        self.maxY = maxY
+    }
+
+    public func contains(_ point: SectionGridPoint) -> Bool {
+        guard maxX > minX, maxY > minY else { return false }
+        // Half-open bounds make a shared edge deterministic.
+        return point.x >= minX && point.x < maxX && point.y >= minY && point.y < maxY
+    }
+}
+
+public enum SectionGridHitTesting {
+    public static func cellID(
+        at point: SectionGridPoint,
+        in frames: [SectionGridCellFrame]
+    ) -> String? {
+        frames.first(where: { $0.contains(point) })?.id
+    }
+}

--- a/ios/Sources/CompanionCore/Store.swift
+++ b/ios/Sources/CompanionCore/Store.swift
@@ -10,6 +10,15 @@
 // a phone client is a weekend of work rather than a rewrite.
 import Foundation
 
+public struct SidebarSection: Identifiable, Hashable, Sendable {
+    public var name: String
+    public var chiefs: [Bot]
+    public var bots: [Bot]
+    public var channels: [Room]
+
+    public var id: String { name }
+}
+
 public struct CompanionState: Sendable {
     public var bots: [Bot] = []
     public var rooms: [Room] = []
@@ -74,6 +83,78 @@ public struct CompanionState: Sendable {
 
     public func room(forThread threadId: String) -> Room? {
         rooms.first { $0.threadId == threadId }
+    }
+
+    /// User-named sidebar sections in the same natural order as the desktop:
+    /// first appearance among bots, then channels. Section ordering is not a
+    /// server record yet, so neither client can synchronize its local manual
+    /// reordering with the other one.
+    public var sidebarSections: [SidebarSection] {
+        let visibleBots = bots.filter { $0.hidden != true }
+        let visibleChannels = rooms.filter { $0.dm != true }
+        let sectionChiefs = visibleBots.filter {
+            $0.chiefOfStaff == true && Self.sectionName($0.section) != nil
+        }
+        let sectionBots = visibleBots.filter {
+            $0.chiefOfStaff != true && !Self.isSidebarPinned($0) && Self.sectionName($0.section) != nil
+        }
+        var names: [String] = []
+        // Match the desktop's natural order: ordinary bots, Chiefs, then
+        // channels. Manual desktop-only ordering remains local by design.
+        for raw in sectionBots.map(\.section) + sectionChiefs.map(\.section) + visibleChannels.map(\.section) {
+            guard let name = Self.sectionName(raw), !names.contains(name) else { continue }
+            names.append(name)
+        }
+        return names.map { name in
+            SidebarSection(
+                name: name,
+                chiefs: sectionChiefs.filter { Self.sectionName($0.section) == name },
+                bots: sectionBots.filter { Self.sectionName($0.section) == name },
+                channels: visibleChannels.filter { Self.sectionName($0.section) == name }
+            )
+        }
+    }
+
+    public var unsectionedChief: Bot? {
+        bots.first {
+            $0.hidden != true
+                && $0.chiefOfStaff == true
+                && Self.sectionName($0.section) == nil
+        }
+    }
+
+    public var unsectionedBots: [Bot] {
+        bots.filter {
+            $0.hidden != true
+                && $0.chiefOfStaff != true
+                && !Self.isSidebarPinned($0)
+                && Self.sectionName($0.section) == nil
+        }
+    }
+
+    /// Pinned is a virtual desktop/mobile bucket. A bot keeps its saved
+    /// section underneath so unpinning returns it to the same context.
+    public var pinnedBots: [Bot] {
+        bots.filter { $0.hidden != true && Self.isSidebarPinned($0) }
+    }
+
+    public var unsectionedChannels: [Room] {
+        rooms.filter { $0.dm != true && Self.sectionName($0.section) == nil }
+    }
+
+    public var botChats: [Room] {
+        rooms.filter { $0.dm == true }
+    }
+
+    private static func sectionName(_ raw: String?) -> String? {
+        guard let name = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+            return nil
+        }
+        return name
+    }
+
+    private static func isSidebarPinned(_ bot: Bot) -> Bool {
+        bot.pinned == true && bot.chiefOfStaff != true
     }
 
     /// Every unanswered approval or question, newest first. This is the

--- a/ios/TESTING.md
+++ b/ios/TESTING.md
@@ -209,23 +209,30 @@ On the phone, in order:
      same SSID and neither discovery nor a typed address gets through, the
      network is isolating its clients and there is nothing to fix on either
      machine.
-2. **The roster loads**, matching what the desktop shows.
-3. **Send a message** from the phone. It should appear on the desktop too — same
+2. **The roster loads**, matching what the desktop shows. Named sections contain
+   both their channels and bots; unfiled channels and bots stay in their built-in
+   areas.
+3. **Make a section.** Tap the folder-plus button, tap one bot normally, then
+   hold another and glide through the grid. Pausing on each tile should select
+   it with one haptic; moving back through the path should remove only its tail.
+   Name and save the section, then confirm the same bots move together on the
+   desktop. A failed save must leave the selection intact.
+4. **Send a message** from the phone. It should appear on the desktop too — same
    harness, two clients.
-4. **The approval.** This is the whole product. Ask a bot to do something that
+5. **The approval.** This is the whole product. Ask a bot to do something that
    needs permission (`run \`ls\` in my home directory` is enough for most
    engines). The card should reach the phone; answering it there should
    unblock the bot on the laptop.
-5. **Reconnect.** Background the app for a minute while the bot keeps working,
+6. **Reconnect.** Background the app for a minute while the bot keeps working,
    then come back. The transcript should catch up *without* a visible reload —
    that is the resumable stream doing its job. Watch the harness log to confirm
    it replayed rather than re-hydrated.
-6. **Dictate.** Open a chat, tap the mic, speak, and tap it again. Partial
+7. **Dictate.** Open a chat, tap the mic, speak, and tap it again. Partial
    words should replace each other in the composer rather than duplicate,
    and the result should remain editable before sending. The first attempt
    requests Microphone and Speech Recognition access. Locking or
    backgrounding the phone mid-sentence must release the mic.
-7. **Revoke.** Remove the device in Settings → Companion on the computer. The
+8. **Revoke.** Remove the device in Settings → Companion on the computer. The
    phone should land on "This phone was unpaired" rather than silently failing.
 
 ---

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -56,6 +56,18 @@ final class DecodingTests: XCTestCase {
         XCTAssertNil(fleet.bots.first?.hasMore)
     }
 
+    func testStorePreviewRemainsADecodableFleet() throws {
+        let iosDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let data = try Data(contentsOf: iosDirectory.appendingPathComponent("App/StorePreview.json"))
+        let fleet = try JSONDecoder().decode(Fleet.self, from: data)
+
+        XCTAssertFalse(fleet.bots.isEmpty)
+        XCTAssertFalse(fleet.groups.isEmpty)
+    }
+
     func testOldAndNewAvatarProfilesDecodeTogether() throws {
         let oldBot = try XCTUnwrap(decode(Fleet.self, "bots-full").bots.first)
         XCTAssertNil(oldBot.avatarUrl)
@@ -129,6 +141,33 @@ final class DecodingTests: XCTestCase {
         let fleet = try JSONDecoder().decode(Fleet.self, from: Data(json.utf8))
         XCTAssertEqual(fleet.bots.first?.cloudBackend, "vps")
         XCTAssertNil(fleet.bots.last?.cloudBackend)
+    }
+
+    func testDecodesSidebarSectionsOnBotsAndChannels() throws {
+        let json = """
+        {
+          "bots": [
+            {
+              "id":"b1","threadId":"t1","name":"Scout","title":"","description":"",
+              "notifications":true,"color":"green","unread":false,"section":"Research",
+              "modelSelection":{"instanceId":"i1","model":"m1"},"createdAt":1
+            }
+          ],
+          "groups": [
+            {
+              "id":"g1","threadId":"gt1","name":"Launch","memberIds":["b1"],
+              "defaultResponder":{"kind":"mentions"},"bulletin":"","unread":false,
+              "createdAt":2,"section":"Research"
+            }
+          ]
+        }
+        """
+        let fleet = try JSONDecoder().decode(Fleet.self, from: Data(json.utf8))
+
+        XCTAssertEqual(fleet.bots.first?.section, "Research")
+        XCTAssertEqual(fleet.groups.first?.section, "Research")
+        XCTAssertNil(try decode(Fleet.self, "bots-full").bots.first?.section,
+                     "older computers that omit sections remain compatible")
     }
 
     func testDecodesMultipleConnectedAccountsAndNoAuthToolkit() throws {

--- a/ios/Tests/CompanionCoreTests/SectionSelectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/SectionSelectionTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import CompanionCore
+
+final class SectionSelectionTests: XCTestCase {
+    func testStaleDwellCannotCommitAfterCandidateChanges() {
+        var selection = SectionSelection()
+        let stale = selection.beginDrag(over: "a")!
+        let current = selection.moveDrag(over: "b")!
+
+        XCTAssertEqual(selection.commit(stale), .unchanged)
+        XCTAssertEqual(selection.commit(current), .added("b"))
+        XCTAssertEqual(selection.selectedIDs, ["b"])
+    }
+
+    func testStableCellCommitsOnlyOnceUntilFingerLeaves() {
+        var selection = SectionSelection()
+        let candidate = selection.beginDrag(over: "a")!
+
+        XCTAssertEqual(selection.commit(candidate), .added("a"))
+        XCTAssertNil(selection.moveDrag(over: "a"))
+        XCTAssertEqual(selection.commit(candidate), .unchanged)
+        XCTAssertEqual(selection.selectedIDs, ["a"])
+    }
+
+    func testGapAndEndCancelOutstandingDwell() {
+        var selection = SectionSelection()
+        let gapStale = selection.beginDrag(over: "a")!
+        XCTAssertNil(selection.moveDrag(over: nil))
+        XCTAssertEqual(selection.commit(gapStale), .unchanged)
+
+        let endStale = selection.moveDrag(over: "b")!
+        selection.endDrag()
+        XCTAssertEqual(selection.commit(endStale), .unchanged)
+        XCTAssertTrue(selection.selectedIDs.isEmpty)
+        XCTAssertTrue(selection.gestureTrail.isEmpty)
+    }
+
+    func testReturningToEarlierCellBacktracksOnlyTheGestureTail() {
+        var selection = SectionSelection()
+        commit("a", into: &selection, beginning: true)
+        commit("b", into: &selection)
+        commit("c", into: &selection)
+
+        _ = selection.moveDrag(over: nil)
+        let backtrack = selection.moveDrag(over: "a")!
+        XCTAssertEqual(selection.commit(backtrack), .backtracked(removed: ["b", "c"]))
+        XCTAssertEqual(selection.selectedIDs, ["a"])
+        XCTAssertEqual(selection.gestureTrail, ["a"])
+    }
+
+    func testPreselectedBotsAreNotDuplicatedOrRemovedByBacktracking() {
+        var selection = SectionSelection(selectedIDs: ["kept", "also-kept", "kept"])
+        let kept = selection.beginDrag(over: "kept")!
+        XCTAssertEqual(selection.commit(kept), .visited("kept"))
+        commit("new-1", into: &selection)
+        commit("new-2", into: &selection)
+
+        _ = selection.moveDrag(over: nil)
+        let backtrack = selection.moveDrag(over: "kept")!
+        XCTAssertEqual(selection.commit(backtrack), .backtracked(removed: ["new-1", "new-2"]))
+        XCTAssertEqual(selection.selectedIDs, ["kept", "also-kept"])
+    }
+
+    func testTapFallbackSelectAllAndClearKeepStableOrder() {
+        var selection = SectionSelection()
+        selection.toggle("b")
+        selection.toggle("a")
+        selection.toggle("b")
+        XCTAssertEqual(selection.selectedIDs, ["a"])
+
+        selection.selectAll(["c", "a", "c", "b"])
+        XCTAssertEqual(selection.selectedIDs, ["c", "a", "b"])
+        selection.clear()
+        XCTAssertTrue(selection.selectedIDs.isEmpty)
+    }
+
+    func testSelectionLimitAppliesToInitialTapSelectAllAndDragPaths() {
+        var selection = SectionSelection(selectedIDs: ["a", "b", "c"], maximumCount: 2)
+        XCTAssertEqual(selection.selectedIDs, ["a", "b"])
+        XCTAssertFalse(selection.toggle("c"))
+
+        XCTAssertTrue(selection.toggle("a"))
+        XCTAssertTrue(selection.toggle("c"))
+        selection.selectAll(["d", "e", "f"])
+        XCTAssertEqual(selection.selectedIDs, ["d", "e"])
+
+        let candidate = selection.beginDrag(over: "f")!
+        XCTAssertEqual(selection.commit(candidate), .limitReached("f"))
+        XCTAssertEqual(selection.selectedIDs, ["d", "e"])
+    }
+
+    func testHitTestingFindsCellsAndLeavesGridGapsEmpty() {
+        let frames = [
+            SectionGridCellFrame(id: "left", minX: 0, minY: 0, maxX: 40, maxY: 40),
+            SectionGridCellFrame(id: "right", minX: 50, minY: 0, maxX: 90, maxY: 40),
+        ]
+
+        XCTAssertEqual(SectionGridHitTesting.cellID(at: .init(x: 20, y: 20), in: frames), "left")
+        XCTAssertNil(SectionGridHitTesting.cellID(at: .init(x: 45, y: 20), in: frames))
+        XCTAssertEqual(SectionGridHitTesting.cellID(at: .init(x: 50, y: 20), in: frames), "right")
+        XCTAssertNil(SectionGridHitTesting.cellID(at: .init(x: 90, y: 20), in: frames))
+    }
+
+    func testHitTestingIgnoresEmptyFramesAndUsesFirstOverlap() {
+        let frames = [
+            SectionGridCellFrame(id: "empty", minX: 10, minY: 10, maxX: 10, maxY: 30),
+            SectionGridCellFrame(id: "front", minX: 0, minY: 0, maxX: 30, maxY: 30),
+            SectionGridCellFrame(id: "back", minX: 0, minY: 0, maxX: 30, maxY: 30),
+        ]
+        XCTAssertEqual(SectionGridHitTesting.cellID(at: .init(x: 12, y: 12), in: frames), "front")
+    }
+
+    private func commit(
+        _ id: String,
+        into selection: inout SectionSelection,
+        beginning: Bool = false
+    ) {
+        let candidate = beginning
+            ? selection.beginDrag(over: id)!
+            : selection.moveDrag(over: id)!
+        XCTAssertTrue(selection.commit(candidate).givesFeedback)
+    }
+}

--- a/ios/Tests/CompanionCoreTests/SidebarSectionsClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/SidebarSectionsClientTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class SidebarSectionRequestStub: URLProtocol {
+    static var capturedRequest: URLRequest?
+    static var capturedBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequest = request
+        Self.capturedBody = Self.readBody(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        let body = Data(Self.response.utf8)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    private static let response = #"""
+    {
+      "section":"Research",
+      "bots":[{
+        "id":"b1","threadId":"t1","name":"Scout","title":"Researcher","description":"",
+        "notifications":true,"color":"green","unread":false,"section":"Research",
+        "modelSelection":{"instanceId":"i1","model":"m1"},"createdAt":1
+      }]
+    }
+    """#
+}
+
+final class SidebarSectionsClientTests: XCTestCase {
+    private var session: URLSession!
+    private var client: CompanionClient!
+
+    override func setUp() {
+        super.setUp()
+        SidebarSectionRequestStub.capturedRequest = nil
+        SidebarSectionRequestStub.capturedBody = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SidebarSectionRequestStub.self]
+        session = URLSession(configuration: configuration)
+        client = CompanionClient(
+            connection: Connection(name: "Mac", host: "127.0.0.1", port: 8810),
+            token: "paired-token",
+            session: session
+        )
+    }
+
+    override func tearDown() {
+        session.invalidateAndCancel()
+        session = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testAssignSectionUsesTheNarrowAtomicRoute() async throws {
+        let bots = try await client.assignSection(name: "Research", botIds: ["b2", "b1"])
+
+        let request = try XCTUnwrap(SidebarSectionRequestStub.capturedRequest)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/api/sidebar-sections")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer paired-token")
+
+        let data = try XCTUnwrap(SidebarSectionRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(body["name"] as? String, "Research")
+        XCTAssertEqual(body["botIds"] as? [String], ["b2", "b1"], "gesture order reaches the server unchanged")
+        XCTAssertEqual(bots.map(\.id), ["b1"])
+        XCTAssertEqual(bots.first?.section, "Research")
+    }
+}

--- a/ios/Tests/CompanionCoreTests/StoreTests.swift
+++ b/ios/Tests/CompanionCoreTests/StoreTests.swift
@@ -38,6 +38,71 @@ final class StoreTests: XCTestCase {
         }
     }
 
+    func testSidebarSectionsGroupBotsAndChannelsInNaturalOrder() throws {
+        let source = try fleet()
+        var researchBot = try XCTUnwrap(source.bots.first)
+        researchBot.id = "research-1"
+        researchBot.section = "Research"
+
+        var personalBot = researchBot
+        personalBot.id = "personal-1"
+        personalBot.section = "Personal"
+
+        var secondResearchBot = researchBot
+        secondResearchBot.id = "research-2"
+        secondResearchBot.pinned = true
+
+        var researchChief = researchBot
+        researchChief.id = "research-chief"
+        researchChief.chiefOfStaff = true
+        researchChief.pinned = true
+
+        var unsectionedChief = researchBot
+        unsectionedChief.id = "default-chief"
+        unsectionedChief.section = nil
+        unsectionedChief.chiefOfStaff = true
+
+        var pinnedOnlyBot = researchBot
+        pinnedOnlyBot.id = "pinned-only"
+        pinnedOnlyBot.section = "Pinned only"
+        pinnedOnlyBot.pinned = true
+
+        var hiddenBot = researchBot
+        hiddenBot.id = "hidden"
+        hiddenBot.section = "Secret"
+        hiddenBot.hidden = true
+
+        var researchChannel = try XCTUnwrap(source.groups.first)
+        researchChannel.id = "research-channel"
+        researchChannel.section = "Research"
+
+        var generalChannel = researchChannel
+        generalChannel.id = "general-channel"
+        generalChannel.section = "  "
+
+        var directChat = researchChannel
+        directChat.id = "direct-chat"
+        directChat.dm = true
+
+        var state = CompanionState()
+        state.bots = [
+            researchChief, researchBot, personalBot, secondResearchBot,
+            pinnedOnlyBot, unsectionedChief, hiddenBot,
+        ]
+        state.rooms = [generalChannel, researchChannel, directChat]
+
+        XCTAssertEqual(state.sidebarSections.map(\.name), ["Research", "Personal"])
+        XCTAssertEqual(state.sidebarSections[0].chiefs.map(\.id), ["research-chief"])
+        XCTAssertEqual(state.sidebarSections[0].bots.map(\.id), ["research-1"])
+        XCTAssertEqual(state.sidebarSections[0].channels.map(\.id), ["research-channel"])
+        XCTAssertTrue(state.sidebarSections[1].channels.isEmpty)
+        XCTAssertEqual(state.unsectionedChief?.id, "default-chief")
+        XCTAssertTrue(state.unsectionedBots.isEmpty)
+        XCTAssertEqual(state.pinnedBots.map(\.id), ["research-2", "pinned-only"])
+        XCTAssertEqual(state.unsectionedChannels.map(\.id), ["general-channel"])
+        XCTAssertEqual(state.botChats.map(\.id), ["direct-chat"])
+    }
+
     // MARK: - Messages
 
     func testAppendsAndPatchesInPlace() throws {

--- a/scripts/capture-companion-fixtures.mjs
+++ b/scripts/capture-companion-fixtures.mjs
@@ -190,6 +190,12 @@ async function main() {
   const created = await json(`${SIDECAR}/api/bots`, asDevice({ method: "POST" }));
   const bot = created.body.bot;
   if (!bot) throw new Error(`could not create a bot: ${JSON.stringify(created.body)}`);
+  const filed = await json(`${SIDECAR}/api/sidebar-sections`, asDevice({
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "Fixtures", botIds: [bot.id] }),
+  }));
+  if (filed.status !== 200) throw new Error(`could not file fixture bot: ${JSON.stringify(filed.body)}`);
 
   console.log("capturing frames");
   const frames = await captureFrames(4, async () => {
@@ -210,18 +216,17 @@ async function main() {
 
   // ── a room, so the paged fleet has a group in it ───────────────────────
   //
-  // Created directly on the harness: room creation is deliberately not on
-  // the sidecar's allowlist, so this is setup the phone cannot perform —
-  // like the harness boot itself. Everything after it goes back through the
-  // sidecar. Five messages, so a capture capped at three below has a page
-  // boundary to show: the decoding test pins messages == 3 and
+  // Created directly on the harness so the fixture can also exercise the
+  // desktop-owned section field on a channel. Everything after it goes back
+  // through the sidecar. Five messages, so a capture capped at three below
+  // has a page boundary to show: the decoding test pins messages == 3 and
   // hasMore == true, and this is what makes those numbers deterministic
   // rather than an accident of whichever harness the fixtures were last
   // captured against.
   const madeRoom = await json(`${HARNESS}/api/groups`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ name: "Fixtures", memberIds: [bot.id] }),
+    body: JSON.stringify({ name: "Fixtures", memberIds: [bot.id], section: "Fixtures" }),
   });
   const room = madeRoom.body.group;
   if (!room) throw new Error(`could not create a room: ${JSON.stringify(madeRoom.body)}`);

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -328,6 +328,31 @@ describe("drainDelegations", () => {
     expect(runTargetCalls).toEqual([]);
   });
 
+  it("drops a queued handoff when section assignment separates the bots before dispatch", async () => {
+    const queued = queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "do this", depth: 0 },
+      1,
+    );
+    expect(store.setBotsSection([target.id], "Elsewhere").ok).toBe(true);
+
+    drainDelegations(commsBus, approvalBus, from.threadId, (toBotId, message, commsDepth) => {
+      runTargetCalls.push({ toBotId, message, commsDepth });
+    });
+
+    await waitFor(() => findDelegationReceipt(queued.id!) && _pendingCount(from.threadId) === 0);
+    expect(findDelegationReceipt(queued.id!)).toMatchObject({
+      status: "dropped",
+      result: expect.stringContaining("different sections"),
+    });
+    expect(runTargetCalls).toEqual([]);
+    expect(
+      store.messagesFor(from.threadId).some((message) =>
+        message.tool?.name.includes("bots now belong to different sections")),
+    ).toBe(true);
+  });
+
   it("keeps the handoff queued with a 'waiting' chip when the target is currently busy", async () => {
     store.patchBot(target.id, { busy: true });
     queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1);
@@ -366,6 +391,29 @@ describe("drainDelegations", () => {
     await waitFor(() => runTargetCalls.length === 1);
     expect(runTargetCalls[0]!.toBotId).toBe(target.id);
     expect(runTargetCalls[0]!.commsDepth).toBe(1);
+  });
+
+  it("rechecks sections after a pending human approval before dispatch", async () => {
+    store.patchBot(from.id, { approvePeerComms: true });
+    const queued = queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "do this", depth: 0 },
+      1,
+    );
+    drainDelegations(commsBus, approvalBus, from.threadId, (toBotId, message, commsDepth) => {
+      runTargetCalls.push({ toBotId, message, commsDepth });
+    });
+
+    const card = await waitFor(() =>
+      store.messagesFor(from.threadId).find((message) => message.card?.requestId),
+    );
+    expect(store.setBotsSection([target.id], "Elsewhere").ok).toBe(true);
+    resolvePeerComms(approvalBus, card.card!.requestId!, "allow");
+
+    await waitFor(() => findDelegationReceipt(queued.id!) && _pendingCount(from.threadId) === 0);
+    expect(findDelegationReceipt(queued.id!)).toMatchObject({ status: "dropped" });
+    expect(runTargetCalls).toEqual([]);
   });
 
   it("does not ask twice when this exact fallback was already approved as ask_bot", async () => {

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -19,7 +19,7 @@ import { getOrCreateChannel, mirrorExchange, type CommsBus } from "./comms-visib
 import { DATA_DIR } from "./config.ts";
 import { newId } from "./contracts.ts";
 import { requestPeerApproval, type ApprovalBus } from "./peer-approval.ts";
-import type { BotRecord, GroupRecord } from "./store.ts";
+import { sectionKey, type BotRecord, type GroupRecord } from "./store.ts";
 
 export interface DelegationItem {
   toBotId: string;
@@ -430,6 +430,9 @@ async function processOne(
     });
     return "settled";
   }
+  if (dropIfSectionsChanged(bus, sender, target, sourceThreadId, item)) {
+    return "settled";
+  }
   if (target.busy) {
     if (item.waitingOnBusy) return "requeued";
     item.attempts += 1;
@@ -494,6 +497,9 @@ async function processOne(
     const current = bus.store.bot(item.toBotId);
     const currentSender = bus.store.bot(from.id);
     if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return "settled";
+    if (dropIfSectionsChanged(bus, currentSender, current, sourceThreadId, item)) {
+      return "settled";
+    }
     if (current.busy) {
       if (item.waitingOnBusy) return "requeued";
       item.attempts += 1;
@@ -531,6 +537,35 @@ async function processOne(
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
   await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id);
   return "settled";
+}
+
+/** Section membership is an execution boundary, not just sidebar styling.
+ * A queued handoff may wait through a turn, a busy target, or human approval,
+ * so the permission granted when it was queued must be checked again at the
+ * final dispatch edge. */
+function dropIfSectionsChanged(
+  bus: CommsBus,
+  sender: BotRecord,
+  target: BotRecord,
+  sourceThreadId: string,
+  item: PendingDelegationItem,
+): boolean {
+  if (sectionKey(sender.section) === sectionKey(target.section)) return false;
+  const result = `@${sender.name} and @${target.name} now belong to different sections`;
+  recordDelegationReceipt({
+    id: item.id,
+    sourceThreadId,
+    toBotId: target.id,
+    toBotName: target.name,
+    status: "dropped",
+    result,
+  });
+  bus.store.appendMessage(sourceThreadId, {
+    role: "bot",
+    kind: "activity",
+    tool: { name: `Delegation to @${target.name} canceled — bots now belong to different sections`, ok: false },
+  });
+  return true;
 }
 
 /** Test helper: how many items remain queued for a thread. */

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1252,6 +1252,118 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("files a sidebar section atomically, trims and dedupes, and preserves its Chief", async () => {
+    const incumbent = (await api("POST", "/api/bots")).body.bot;
+    const incoming = (await api("POST", "/api/bots")).body.bot;
+    const teammate = (await api("POST", "/api/bots")).body.bot;
+    try {
+      await api("PATCH", `/api/bots/${incumbent.id}`, { section: "Launch", chiefOfStaff: true });
+      await api("PATCH", `/api/bots/${incoming.id}`, { section: "Research" });
+      await api("PATCH", `/api/bots/${teammate.id}`, { section: "Personal" });
+
+      const stream = await openSse(`${BASE}/api/events`);
+      try {
+        await stream.until((frame) => frame.kind === "hello");
+        const created = await api("POST", "/api/sidebar-sections", {
+          name: "  Launch  ",
+          botIds: [incoming.id, teammate.id, incoming.id],
+        });
+        expect(created.status).toBe(200);
+        expect(created.body.section).toBe("Launch");
+        expect(created.body.bots.map((bot: { id: string }) => bot.id)).toEqual([
+          incoming.id,
+          teammate.id,
+        ]);
+        expect(created.body.bots.find((bot: { id: string }) => bot.id === incoming.id))
+          .toMatchObject({ section: "Launch" });
+        expect(Boolean(created.body.bots.find((bot: { id: string }) => bot.id === incoming.id)?.chiefOfStaff))
+          .toBe(false);
+
+        for (const id of [incoming.id, teammate.id]) {
+          const frame = await stream.until(
+            (candidate) => candidate.kind === "bot" && candidate.bot?.id === id,
+          );
+          expect(frame.bot.section).toBe("Launch");
+        }
+
+        const bots = (await api("GET", "/api/bots")).body.bots;
+        expect(bots.find((bot: { id: string }) => bot.id === incumbent.id))
+          .toMatchObject({ section: "Launch", chiefOfStaff: true });
+      } finally {
+        stream.close();
+      }
+    } finally {
+      for (const bot of [incumbent, incoming, teammate]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("rejects a sidebar section Chief collision without changing any bot", async () => {
+    const incumbent = (await api("POST", "/api/bots")).body.bot;
+    const incoming = (await api("POST", "/api/bots")).body.bot;
+    const teammate = (await api("POST", "/api/bots")).body.bot;
+    try {
+      await api("PATCH", `/api/bots/${incumbent.id}`, { section: "Launch", chiefOfStaff: true });
+      await api("PATCH", `/api/bots/${incoming.id}`, { section: "Research", chiefOfStaff: true });
+      await api("PATCH", `/api/bots/${teammate.id}`, { section: "Personal" });
+
+      const response = await api("POST", "/api/sidebar-sections", {
+        name: "Launch",
+        botIds: [incoming.id, teammate.id],
+      });
+      expect(response).toEqual({
+        status: 409,
+        body: {
+          error: "A section can have only one Chief of Staff. Choose one Chief or use a section without one.",
+        },
+      });
+
+      const bots = (await api("GET", "/api/bots")).body.bots;
+      expect(bots.find((bot: { id: string }) => bot.id === incumbent.id))
+        .toMatchObject({ section: "Launch", chiefOfStaff: true });
+      expect(bots.find((bot: { id: string }) => bot.id === incoming.id))
+        .toMatchObject({ section: "Research", chiefOfStaff: true });
+      expect(bots.find((bot: { id: string }) => bot.id === teammate.id))
+        .toMatchObject({ section: "Personal" });
+      expect(Boolean(bots.find((bot: { id: string }) => bot.id === teammate.id)?.chiefOfStaff))
+        .toBe(false);
+    } finally {
+      for (const bot of [incumbent, incoming, teammate]) await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("rejects malformed or unavailable sidebar section targets without partially filing bots", async () => {
+    const visible = (await api("POST", "/api/bots")).body.bot;
+    const hidden = (await api("POST", "/api/bots")).body.bot;
+    try {
+      await api("PATCH", `/api/bots/${visible.id}`, { section: "Original" });
+      await api("PATCH", `/api/bots/${hidden.id}`, { hidden: true, chiefOfStaff: false });
+
+      for (const body of [
+        { name: "   ", botIds: [visible.id] },
+        { name: "S".repeat(61), botIds: [visible.id] },
+        { name: "Work", botIds: [] },
+        { name: "Work", botIds: ["not/an/id"] },
+        { name: "Work", botIds: [visible.id], extra: true },
+      ]) {
+        expect((await api("POST", "/api/sidebar-sections", body)).status).toBe(400);
+      }
+      expect((await api("POST", "/api/sidebar-sections", {
+        name: "Work",
+        botIds: [visible.id, "missing"],
+      })).status).toBe(404);
+      expect((await api("POST", "/api/sidebar-sections", {
+        name: "Work",
+        botIds: [visible.id, hidden.id],
+      })).status).toBe(404);
+
+      const bots = (await api("GET", "/api/bots")).body.bots;
+      expect(bots.find((bot: { id: string }) => bot.id === visible.id)?.section).toBe("Original");
+    } finally {
+      await api("DELETE", `/api/bots/${visible.id}`);
+      await api("DELETE", `/api/bots/${hidden.id}`);
+    }
+  });
+
   it("explains when archived room members cannot respond", async () => {
     const archived = (await api("POST", "/api/bots")).body.bot;
     const active = (await api("POST", "/api/bots")).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -287,6 +287,10 @@ function authorizedComms(header: string | string[] | undefined): boolean {
 // A→B is allowed but B→C (and A→B→A loops) never start.
 const MAX_COMMS_DEPTH = 1;
 const MAX_WORKSPACE_BOTS = 100;
+const createSidebarSectionSchema = z.object({
+  name: z.string(),
+  botIds: z.array(z.string().regex(/^[\w-]+$/)).min(1).max(MAX_WORKSPACE_BOTS),
+}).strict();
 const createGroupTaskRequestSchema = z.object({ title: z.string().optional() });
 // Resolved from the server root — see server/proxy-paths.ts. This descending
 // path happened to survive bundling, but it goes through the same anchor so
@@ -5975,6 +5979,30 @@ const server = createServer(async (req, res) => {
       const patched = store.toggleReaction(m[1], m[2], emoji, typeof body.by === "string" ? body.by : "user");
       if (!patched) return json(res, 404, { error: "no such message" });
       return json(res, 200, { message: patched });
+    }
+    if (method === "POST" && path === "/api/sidebar-sections") {
+      const parsed = createSidebarSectionSchema.safeParse(await readBody(req));
+      if (!parsed.success) {
+        return json(res, 400, { error: "name and one to 100 valid botIds are required" });
+      }
+      const name = parsed.data.name.trim();
+      if (!name) return json(res, 400, { error: "name is required" });
+      if (name.length > 60) {
+        return json(res, 400, { error: "name must be at most 60 characters" });
+      }
+      const botIds = [...new Set(parsed.data.botIds)];
+      const result = store.setBotsSection(botIds, name);
+      if (!result.ok) {
+        if (result.reason === "chief-conflict") {
+          return json(res, 409, {
+            error: "A section can have only one Chief of Staff. Choose one Chief or use a section without one.",
+          });
+        }
+        return json(res, 404, { error: "one or more bots are unavailable" });
+      }
+      // This files bots under a derived label; it does not create a durable
+      // section resource, and an identical retry is an ordinary no-op.
+      return json(res, 200, { section: name, bots: result.bots.map(wireBot) });
     }
     if (method === "POST" && path === "/api/bots") {
       const body = await readBody(req);

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -380,6 +380,80 @@ describe("Store", () => {
     expect(reloaded.bot(second.id)?.chiefOfStaff).toBe(false);
   });
 
+  it("files visible bots atomically without changing Chief roles", () => {
+    const store = new Store(selection);
+    const incumbent = store.createBot({ section: "Launch" });
+    const incoming = store.createBot({ section: "Research" });
+    const teammate = store.createBot({ section: "Personal" });
+    store.setChiefOfStaff(incumbent.id);
+
+    const result = store.setBotsSection([incoming.id, teammate.id, incoming.id], "Launch");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`unexpected section assignment failure: ${result.reason}`);
+    expect(result.bots.map((bot) => bot.id)).toEqual([incoming.id, teammate.id]);
+    expect(store.bot(incumbent.id)).toMatchObject({ section: "Launch", chiefOfStaff: true });
+    expect(store.bot(incoming.id)?.section).toBe("Launch");
+    expect(Boolean(store.bot(incoming.id)?.chiefOfStaff)).toBe(false);
+    expect(store.bot(teammate.id)?.section).toBe("Launch");
+    expect(store.bots.filter((bot) => bot.section === "Launch" && bot.chiefOfStaff)).toHaveLength(1);
+
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(incumbent.id)).toMatchObject({ section: "Launch", chiefOfStaff: true });
+    expect(reloaded.bot(incoming.id)?.section).toBe("Launch");
+    expect(Boolean(reloaded.bot(incoming.id)?.chiefOfStaff)).toBe(false);
+    expect(reloaded.bot(teammate.id)?.section).toBe("Launch");
+    expect(reloaded.bots.filter((bot) => bot.section === "Launch" && bot.chiefOfStaff).map((bot) => bot.id))
+      .toEqual([incumbent.id]);
+  });
+
+  it("rejects unavailable or Chief-conflicting section assignments without changing bots", () => {
+    const store = new Store(selection);
+    const incumbent = store.createBot({ section: "Launch" });
+    const incoming = store.createBot({ section: "Research" });
+    const teammate = store.createBot({ section: "Personal" });
+    const hidden = store.createBot({ section: "Private" });
+    store.setChiefOfStaff(incumbent.id);
+    store.setChiefOfStaff(incoming.id);
+    store.patchBot(hidden.id, { hidden: true });
+
+    const snapshot = () => store.bots.map((bot) => ({
+      id: bot.id,
+      section: bot.section,
+      chief: bot.chiefOfStaff,
+    }));
+    const before = snapshot();
+
+    expect(store.setBotsSection([teammate.id, "missing"], "Launch"))
+      .toEqual({ ok: false, reason: "unavailable" });
+    expect(store.setBotsSection([teammate.id, hidden.id], "Launch"))
+      .toEqual({ ok: false, reason: "unavailable" });
+    expect(store.setBotsSection([incoming.id, teammate.id], "Launch"))
+      .toEqual({ ok: false, reason: "chief-conflict" });
+    expect(snapshot()).toEqual(before);
+
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(incumbent.id)).toMatchObject({ section: "Launch", chiefOfStaff: true });
+    expect(reloaded.bot(incoming.id)).toMatchObject({ section: "Research", chiefOfStaff: true });
+    expect(reloaded.bot(teammate.id)?.section).toBe("Personal");
+    expect(Boolean(reloaded.bot(teammate.id)?.chiefOfStaff)).toBe(false);
+  });
+
+  it("does not change memory or emit section updates when the atomic write fails", () => {
+    const store = new Store(selection);
+    const bot = store.createBot({ section: "Original" });
+    const changes: string[] = [];
+    store.onChange((change) => {
+      if (change.type === "bot") changes.push(change.botId);
+    });
+    (store as unknown as { saveBots: (bots?: BotRecord[]) => void }).saveBots = () => {
+      throw new Error("disk unavailable");
+    };
+
+    expect(() => store.setBotsSection([bot.id], "Research")).toThrow("disk unavailable");
+    expect(store.bot(bot.id)?.section).toBe("Original");
+    expect(changes).toEqual([]);
+  });
+
   it("patchMessage merges card patches and returns null for unknown ids", () => {
     const store = new Store(selection);
     const bot = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -744,8 +744,8 @@ export class Store {
     }
   }
 
-  private saveBots() {
-    writeFileAtomic(BOTS_FILE, JSON.stringify(this.bots, null, 2));
+  private saveBots(bots: BotRecord[] = this.bots) {
+    writeFileAtomic(BOTS_FILE, JSON.stringify(bots, null, 2));
   }
 
   private saveGroups() {
@@ -1213,6 +1213,54 @@ export class Store {
     this.saveBots();
     this.emit({ type: "bot", botId: id });
     return bot;
+  }
+
+  /** File visible bots into one sidebar section as a single durable write.
+   *
+   * This deliberately stages the complete next file before touching the
+   * live records. A missing/hidden target therefore changes nothing, and a
+   * failed atomic write cannot leave memory ahead of disk. A Chief collision
+   * is refused rather than silently removing somebody's coordinator role. */
+  setBotsSection(
+    botIds: string[],
+    section: string,
+  ): { ok: true; bots: BotRecord[] } | { ok: false; reason: "unavailable" | "chief-conflict" } {
+    const ids = [...new Set(botIds)];
+    const targets = ids.map((id) => this.bot(id));
+    if (targets.some((bot) => !bot || bot.hidden)) return { ok: false, reason: "unavailable" };
+
+    const targetSection = sectionKey(section);
+    const selected = targets as BotRecord[];
+    const destinationChiefIds = new Set([
+      ...selected.filter((bot) => bot.chiefOfStaff).map((bot) => bot.id),
+      ...this.bots
+        .filter((bot) => bot.chiefOfStaff && sectionKey(bot.section) === targetSection)
+        .map((bot) => bot.id),
+    ]);
+    if (destinationChiefIds.size > 1) return { ok: false, reason: "chief-conflict" };
+
+    const patches = new Map<string, Partial<BotRecord>>();
+    for (const bot of selected) {
+      patches.set(bot.id, { section: targetSection || undefined });
+    }
+
+    const changedIds = new Set<string>();
+    const nextBots = this.bots.map((bot) => {
+      const patch = patches.get(bot.id);
+      if (!patch) return bot;
+      const next = { ...bot, ...patch };
+      if (JSON.stringify(next) !== JSON.stringify(bot)) changedIds.add(bot.id);
+      return next;
+    });
+    if (changedIds.size) {
+      this.saveBots(nextBots);
+      for (const bot of this.bots) {
+        const patch = patches.get(bot.id);
+        if (patch) Object.assign(bot, patch);
+      }
+      for (const botId of changedIds) this.emit({ type: "bot", botId });
+    }
+    return { ok: true, bots: ids.map((id) => this.bot(id)!) };
   }
 
   /** The one way runtime state changes. Sets `activity` and derives `busy`


### PR DESCRIPTION
## Summary

- mirror the desktop sidebar on iPhone: Chief, Pinned, Channels, Bot chats, Bots, and named sections containing both bots and channels
- add a fast section creator with tap selection plus hold, glide, dwell, haptic feedback, trail backtracking, compact-phone layout, VoiceOver support, and a 100-bot safety limit
- let people create another section immediately without dismissing the sheet
- add one strict atomic paired-device endpoint instead of exposing general bot mutation; missing or hidden bots and Chief conflicts cannot partially change the fleet
- recheck the section communication boundary before queued bot delegations dispatch

## Validation

- pnpm test: 236 test files passed, 2,606 tests passed; broker, Electron, and packaged-server suites passed
- pnpm typecheck
- pnpm lint (existing repository warnings only)
- Swift package: 231 tests passed
- full OpenMausCompanion iOS simulator target build passed
- visually checked the roster and creator on iPhone 17 Pro and compact iPhone SE simulator layouts

## Manual follow-up

- verify the final dwell timing and haptic feel on a physical iPhone; the attached device was unavailable to the phone harness during this pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sidebar sections for organizing bots and channels.
  - Added section creation with multi-select bot assignment, validation, and success/error feedback.
  - Added support for filing multiple bots into a section atomically.
  - Added pinned, unsectioned, chief, channel, and bot-chat areas to the roster.
- **Bug Fixes**
  - Prevented handoffs between bots in different sections.
  - Added safeguards against partial updates, duplicate assignments, invalid entries, and chief conflicts.
- **Documentation**
  - Updated iOS setup and testing guidance for sidebar sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->