### PR TITLE
Import public Grok bot templates safely

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,20 @@
+!macro customInstall
+  WriteRegStr HKCU "Software\Classes\OpenMausBot.GrokBot" "" "OpenMausBot Grok Bot link"
+  WriteRegStr HKCU "Software\Classes\OpenMausBot.GrokBot" "URL Protocol" ""
+  WriteRegStr HKCU "Software\Classes\OpenMausBot.GrokBot\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
+  WriteRegStr HKCU "Software\Classes\OpenMausBot.GrokBot\shell\open\command" "" "$\"$INSTDIR\${APP_EXECUTABLE_FILENAME}$\" $\"%1$\""
+
+  WriteRegStr HKCU "Software\OpenMausBot\Capabilities" "ApplicationName" "OpenMausBot"
+  WriteRegStr HKCU "Software\OpenMausBot\Capabilities" "ApplicationDescription" "Open public Grok Bot links in OpenMausBot for review and import."
+  WriteRegStr HKCU "Software\OpenMausBot\Capabilities" "ApplicationIcon" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
+  WriteRegStr HKCU "Software\OpenMausBot\Capabilities\UrlAssociations" "grokbot" "OpenMausBot.GrokBot"
+  WriteRegStr HKCU "Software\RegisteredApplications" "OpenMausBot" "Software\OpenMausBot\Capabilities"
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+!macroend
+
+!macro customUnInstall
+  DeleteRegValue HKCU "Software\RegisteredApplications" "OpenMausBot"
+  DeleteRegKey HKCU "Software\OpenMausBot\Capabilities"
+  DeleteRegKey HKCU "Software\Classes\OpenMausBot.GrokBot"
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+!macroend

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -143,6 +143,7 @@ win:
 nsis:
   oneClick: true
   perMachine: false
+  include: build/installer.nsh
   shortcutName: OpenMausBot
   # Versioned, like the .dmg. The README's /latest/download/ button needs a
   # STABLE filename, so ship a second copy named OpenMausBot-setup.exe on the

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -28,6 +28,7 @@ import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace
 import { activateExistingWindow } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
+import { grokBotDefaultAppsSettingsUrl } from "./windows-default-apps.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
 import { defaultSaveName, withSavableFile } from "./save-file.mjs";
 import {
@@ -1685,6 +1686,13 @@ ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
     throw new Error("Only web links can be opened");
   }
   await shell.openExternal(url.toString());
+  return true;
+});
+
+ipcMain.handle("desktop:open-grok-default-apps", async () => {
+  const settingsUrl = grokBotDefaultAppsSettingsUrl();
+  if (!settingsUrl) return false;
+  await shell.openExternal(settingsUrl);
   return true;
 });
 

--- a/electron/package-link.mjs
+++ b/electron/package-link.mjs
@@ -1,4 +1,20 @@
 const ALLOWED_PACKAGE_HOSTS = new Set(["github.com", "www.github.com", "raw.githubusercontent.com"]);
+const GROK_BOT_ID = /^[A-Za-z0-9_-]{21}$/;
+
+function grokBotUrlFromDeepLink(link) {
+  if (
+    link.protocol !== "grokbot:" ||
+    link.hostname !== "app" ||
+    link.username ||
+    link.password ||
+    link.port ||
+    link.pathname !== "/v1/bot-template" ||
+    link.hash
+  ) return null;
+  const id = link.searchParams.get("id");
+  if (!id || !GROK_BOT_ID.test(id) || link.search !== `?id=${id}`) return null;
+  return `https://x.ai/bot/${id}`;
+}
 
 export function packageUrlFromDeepLink(rawValue) {
   let link;
@@ -7,6 +23,8 @@ export function packageUrlFromDeepLink(rawValue) {
   } catch {
     return null;
   }
+  const grokBotUrl = grokBotUrlFromDeepLink(link);
+  if (grokBotUrl) return grokBotUrl;
   if (link.protocol !== "openmausbot:" || link.hostname !== "install") return null;
   const rawPackage = link.searchParams.get("url");
   if (!rawPackage) return null;

--- a/electron/package-link.node-test.mjs
+++ b/electron/package-link.node-test.mjs
@@ -10,6 +10,22 @@ describe("BotMRR package deep links", () => {
     assert.equal(packageUrlFromCommandLine(["OpenMausBot", "--flag", `openmausbot://install?url=${encodeURIComponent(target)}`]), target);
   });
 
+  it("converts an exact Grok Bot app link into the public importer URL", () => {
+    const id = "KZ9xav0Qad1U5QigEn7rh";
+    const deepLink = `grokbot://app/v1/bot-template?id=${id}`;
+    assert.equal(packageUrlFromDeepLink(deepLink), `https://x.ai/bot/${id}`);
+    assert.equal(packageUrlFromCommandLine(["OpenMausBot.exe", deepLink]), `https://x.ai/bot/${id}`);
+  });
+
+  it("rejects malformed or expanded Grok Bot app links", () => {
+    const id = "KZ9xav0Qad1U5QigEn7rh";
+    assert.equal(packageUrlFromDeepLink(`grokbot://other/v1/bot-template?id=${id}`), null);
+    assert.equal(packageUrlFromDeepLink(`grokbot://app/v2/bot-template?id=${id}`), null);
+    assert.equal(packageUrlFromDeepLink(`grokbot://app/v1/bot-template?id=${id}&next=https://evil.example`), null);
+    assert.equal(packageUrlFromDeepLink(`grokbot://app/v1/bot-template?id=short`), null);
+    assert.equal(packageUrlFromDeepLink(`grokbot://app/v1/bot-template?id=${id}#fragment`), null);
+  });
+
   it("rejects other commands, hosts, protocols, credentials, and unsupported file types", () => {
     assert.equal(packageUrlFromDeepLink("openmausbot://settings"), null);
     assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://evil.example/bot.json"), null);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -124,6 +124,8 @@ contextBridge.exposeInMainWorld("ogb", {
   /** Open a web link in the default browser. Unlike renderer window.open,
    * this remains reliable after an asynchronous API request. */
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
+  /** Opens Windows Default Apps so the person can choose a Grok Bot link handler. */
+  openGrokDefaultApps: () => ipcRenderer.invoke("desktop:open-grok-default-apps"),
   /** Tell the window which skin the page wears, so the native chrome the
    * renderer cannot paint (the Windows caption-button overlay) matches. */
   applySkin: (skin) => ipcRenderer.invoke("desktop:skin", skin),

--- a/electron/windows-default-apps.mjs
+++ b/electron/windows-default-apps.mjs
@@ -1,0 +1,7 @@
+export const OPENMAUS_REGISTERED_APP_NAME = "OpenMausBot";
+
+/** Return the Windows-owned UI where a person can choose the Grok Bot link handler. */
+export function grokBotDefaultAppsSettingsUrl(platform = process.platform) {
+  if (platform !== "win32") return null;
+  return `ms-settings:defaultapps?registeredAppUser=${OPENMAUS_REGISTERED_APP_NAME}`;
+}

--- a/electron/windows-default-apps.node-test.mjs
+++ b/electron/windows-default-apps.node-test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { grokBotDefaultAppsSettingsUrl } from "./windows-default-apps.mjs";
+
+describe("Windows Grok Bot default-app handoff", () => {
+  it("opens only the Windows-owned app-specific settings page", () => {
+    assert.equal(
+      grokBotDefaultAppsSettingsUrl("win32"),
+      "ms-settings:defaultapps?registeredAppUser=OpenMausBot",
+    );
+    assert.equal(grokBotDefaultAppsSettingsUrl("darwin"), null);
+    assert.equal(grokBotDefaultAppsSettingsUrl("linux"), null);
+  });
+
+  it("registers a candidate ProgID and removes only OpenMausBot-owned keys", () => {
+    const installer = readFileSync(join(process.cwd(), "build", "installer.nsh"), "utf8");
+    assert.match(installer, /Software\\Classes\\OpenMausBot\.GrokBot/);
+    assert.match(installer, /Software\\OpenMausBot\\Capabilities/);
+    assert.match(installer, /Software\\RegisteredApplications/);
+    assert.match(installer, /Capabilities\\UrlAssociations" "grokbot" "OpenMausBot\.GrokBot"/);
+    assert.doesNotMatch(installer, /UserChoice/);
+    assert.doesNotMatch(installer, /grokbot\\shell\\open\\command/);
+  });
+});

--- a/server/bot-package.ts
+++ b/server/bot-package.ts
@@ -3,7 +3,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import { schemaIssue, type JsonValue } from "./schema.ts";
 import type { MausColor } from "./store.ts";
-import type { TeamManifestMember } from "./team-manifest.ts";
+import { BOT_INSTRUCTIONS_MAX_CHARS, type TeamManifestMember } from "./team-manifest.ts";
 
 export const BOT_PACKAGE_FORMAT = "openmaus.package" as const;
 export const BOT_PACKAGE_VERSION = 1 as const;
@@ -66,7 +66,7 @@ const packageSchema = z.object({
       key,
       name: requiredText(100),
       title: optionalText(200),
-      description: optionalText(4_000),
+      description: optionalText(BOT_INSTRUCTIONS_MAX_CHARS),
       appearance: z.object({
         color: z.enum(COLORS, { error: "is not supported" }),
         mascotExpression: optionalText(80),

--- a/server/grok-bot-template.test.ts
+++ b/server/grok-bot-template.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  fetchGrokBotPackage,
+  fetchGrokBotTemplate,
+  GROK_BOT_INSTRUCTION_MAX_CHARS,
+  GROK_BOT_RESPONSE_MAX_BYTES,
+  GROK_BOT_TEMPLATE_ENDPOINT,
+  GROK_BOT_TIMEOUT_MS,
+  parseGrokBotUrl,
+} from "./grok-bot-template.ts";
+
+const shareId = "a".repeat(21);
+
+function varint(value: number): number[] {
+  const result: number[] = [];
+  do {
+    const byte = value % 128;
+    value = Math.floor(value / 128);
+    result.push(value ? byte | 0x80 : byte);
+  } while (value);
+  return result;
+}
+
+function fieldKey(field: number, wireType: number): number[] {
+  return varint(field * 8 + wireType);
+}
+
+function fieldBytes(field: number, value: number[]): number[] {
+  return [...fieldKey(field, 2), ...varint(value.length), ...value];
+}
+
+function text(field: number, value: string): number[] {
+  return fieldBytes(field, [...new TextEncoder().encode(value)]);
+}
+
+function message(field: number, value: number[]): number[] {
+  return fieldBytes(field, value);
+}
+
+function templateBytes(description = "Public instructions.", id = shareId, published = 1): number[] {
+  return [
+    ...text(1, id),
+    ...text(2, "Public Grok Bot"),
+    ...text(3, "orb"),
+    ...text(4, "blue"),
+    ...fieldKey(10, 0), ...varint(published),
+    ...text(12, description),
+  ];
+}
+
+function responseBytes(description = "Public instructions.", id = shareId, published = 1): Uint8Array {
+  return new Uint8Array([
+    ...message(1, templateBytes(description, id, published)),
+    ...text(2, "Public owner"),
+  ]);
+}
+
+function okResponse(bytes = responseBytes()): Response {
+  return new Response(bytes, { status: 200, headers: { "content-type": "application/proto" } });
+}
+
+describe("public Grok Bot importer", () => {
+  it("accepts only an exact public x.ai bot URL", () => {
+    expect(parseGrokBotUrl(`https://x.ai/bot/${shareId}`)).toEqual({ id: shareId });
+    const rejected = [
+      `http://x.ai/bot/${shareId}`,
+      `https://www.x.ai/bot/${shareId}`,
+      `https://x.ai:443/bot/${shareId}`,
+      `https://user:secret@x.ai/bot/${shareId}`,
+      `https://x.ai/bot/${shareId}/`,
+      `https://x.ai/bot/${shareId}?extra=1`,
+      `https://x.ai/bot/${shareId}#fragment`,
+      `https://x.ai/not-a-bot/${shareId}`,
+      `https://x.ai/bot/${shareId.slice(0, -1)}`,
+      `https://x.ai/bot/${shareId}/../private`,
+    ];
+    for (const value of rejected) expect(() => parseGrokBotUrl(value)).toThrow();
+
+    try {
+      parseGrokBotUrl("https://example.com/not-a-grok-bot");
+      throw new Error("expected URL validation to fail");
+    } catch (error) {
+      expect(error).toMatchObject({ status: 400, message: "Only exact public x.ai Grok Bot links are supported" });
+    }
+  });
+
+  it("uses one anonymous protobuf request and maps the public profile to a package", async () => {
+    let target = "";
+    let init: RequestInit | undefined;
+    const fetcher = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {
+      target = String(url);
+      init = options;
+      return okResponse();
+    }) as unknown as typeof fetch;
+
+    const loaded = await fetchGrokBotPackage(`https://x.ai/bot/${shareId}`, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(target).toBe(GROK_BOT_TEMPLATE_ENDPOINT);
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "content-type": "application/proto", "connect-protocol-version": "1" });
+    expect(init?.redirect).toBe("error");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(GROK_BOT_TIMEOUT_MS).toBeLessThanOrEqual(15_000);
+    expect(new Uint8Array(init?.body as ArrayBuffer)).toEqual(new Uint8Array([0x0a, 21, ...new TextEncoder().encode(shareId)]));
+    expect(init?.headers).not.toHaveProperty("authorization");
+    expect(init?.headers).not.toHaveProperty("cookie");
+    expect(init?.headers).not.toHaveProperty("user-agent");
+
+    expect(loaded.package.agents).toHaveLength(1);
+    expect(loaded.package.agents[0]).toMatchObject({
+      name: "Public Grok Bot",
+      title: "Grok Bot",
+      description: "Public instructions.",
+      appearance: { color: "blue" },
+    });
+    expect(loaded.package.author.name).toBe("Public owner");
+    expect(loaded.package.requirements).toEqual({ apps: [], capabilities: [] });
+  });
+
+  it("rejects malformed, truncated, duplicate, and oversized protobuf data", async () => {
+    const unknown = [
+      ...fieldKey(90, 0), ...varint(42),
+      ...fieldKey(91, 1), 1, 2, 3, 4, 5, 6, 7, 8,
+      ...fieldKey(92, 2), ...varint(3), 9, 8, 7,
+      ...fieldKey(94, 3), ...fieldKey(1, 0), ...varint(1), ...fieldKey(94, 4),
+    ];
+    await expect(fetchGrokBotTemplate(`https://x.ai/bot/${shareId}`, async () =>
+      okResponse(new Uint8Array([...message(1, [...unknown, ...templateBytes()]), ...text(2, "owner")])),
+    )).resolves.toMatchObject({ template: { shareId, published: true } });
+
+    const malformed = [
+      new Uint8Array([0x0a, 0x80]),
+      new Uint8Array([...message(1, templateBytes()).slice(0, -1), ...text(2, "owner")]),
+      new Uint8Array([...message(1, [...fieldKey(1, 0), ...varint(1), ...templateBytes()]), ...text(2, "owner")]),
+      new Uint8Array([...message(1, [...text(1, shareId), ...text(1, shareId), ...text(2, "name"), ...text(12, "instructions"), ...fieldKey(10, 0), 1]), ...text(2, "owner")]),
+    ];
+    for (const bytes of malformed) {
+      await expect(fetchGrokBotTemplate(`https://x.ai/bot/${shareId}`, async () => okResponse(bytes))).rejects.toThrow("response is invalid");
+    }
+
+    const tooLarge = new Uint8Array(GROK_BOT_RESPONSE_MAX_BYTES + 1);
+    await expect(fetchGrokBotTemplate(`https://x.ai/bot/${shareId}`, async () => okResponse(tooLarge))).rejects.toThrow("response is too large");
+    await expect(fetchGrokBotTemplate(`https://x.ai/bot/${shareId}`, async () => new Response(new Uint8Array(), {
+      status: 200,
+      headers: { "content-length": String(GROK_BOT_RESPONSE_MAX_BYTES + 1) },
+    }))).rejects.toThrow("response is too large");
+  });
+
+  it("bounds public instruction text and rejects unpublished or mismatched profiles", async () => {
+    const url = `https://x.ai/bot/${shareId}`;
+    const longDescription = "A".repeat(6_219);
+    const loaded = await fetchGrokBotPackage(url, async () => okResponse(responseBytes(longDescription)));
+    expect(loaded.package.agents[0]?.description).toBe(longDescription);
+    expect(GROK_BOT_INSTRUCTION_MAX_CHARS).toBe(24_000);
+    const threeByteDescription = "€".repeat(GROK_BOT_INSTRUCTION_MAX_CHARS);
+    const threeByteLoaded = await fetchGrokBotPackage(url, async () => okResponse(responseBytes(threeByteDescription)));
+    expect(threeByteLoaded.package.agents[0]?.description).toBe(threeByteDescription);
+    const fourByteDescription = "😀".repeat(GROK_BOT_INSTRUCTION_MAX_CHARS / 2);
+    const fourByteLoaded = await fetchGrokBotPackage(url, async () => okResponse(responseBytes(fourByteDescription)));
+    expect(fourByteLoaded.package.agents[0]?.description).toBe(fourByteDescription);
+    await expect(fetchGrokBotPackage(url, async () => okResponse(responseBytes("x", "other-share-id-12345")))).rejects.toThrow("response is invalid");
+    await expect(fetchGrokBotPackage(url, async () => okResponse(responseBytes("instructions", shareId, 0)))).rejects.toThrow("profile is unpublished");
+    await expect(fetchGrokBotPackage(url, async () => okResponse(responseBytes("   ")))).rejects.toThrow("instructions are empty");
+    await expect(fetchGrokBotPackage(url, async () => okResponse(responseBytes("x".repeat(GROK_BOT_INSTRUCTION_MAX_CHARS + 1))))).rejects.toThrow("instructions are too large");
+  });
+
+  it("turns transport, redirect, and non-2xx failures into generic errors", async () => {
+    const url = `https://x.ai/bot/${shareId}`;
+    await expect(fetchGrokBotTemplate(url, async () => { throw new Error("redirect"); })).rejects.toThrow("request failed");
+    await expect(fetchGrokBotTemplate(url, async () => new Response(null, { status: 503 }))).rejects.toThrow("request failed");
+  });
+});

--- a/server/grok-bot-template.ts
+++ b/server/grok-bot-template.ts
@@ -1,0 +1,379 @@
+import { parseBotPackage, type ParsedBotPackage } from "./bot-package.ts";
+import { BOT_INSTRUCTIONS_MAX_CHARS } from "./team-manifest.ts";
+
+/** Reverse-engineered anonymous public-profile transport; the upstream API is undocumented. */
+export const GROK_BOT_TEMPLATE_ENDPOINT =
+  "https://api2.cursor.sh/aiserver.v1.GrokBotService/GetPublicGrokBotTemplate";
+export const GROK_BOT_RESPONSE_MAX_BYTES = 128 * 1024;
+export const GROK_BOT_INSTRUCTION_MAX_CHARS = BOT_INSTRUCTIONS_MAX_CHARS;
+export const GROK_BOT_TIMEOUT_MS = 10_000;
+const GROK_BOT_MAX_FIELDS_PER_MESSAGE = 256;
+const GROK_BOT_MAX_TEXT_BYTES = GROK_BOT_INSTRUCTION_MAX_CHARS * 4;
+const GROK_BOT_MAX_SHORT_TEXT_BYTES = 1_024;
+const GROK_BOT_MAX_NESTING = 16;
+
+export interface ParsedGrokBotUrl {
+  id: string;
+}
+
+export interface GrokBotTemplate {
+  shareId: string;
+  name: string;
+  avatarShape?: string;
+  avatarColor?: string;
+  published: boolean;
+  activeVersion?: string;
+  description: string;
+}
+
+export interface GrokBotTemplateResponse {
+  template: GrokBotTemplate;
+  ownerDisplayName?: string;
+}
+
+/** Create the stable client error used for invalid public Grok Bot URLs. */
+function throwGrokBotUrlError(message: string): never {
+  throw Object.assign(new Error(message), { status: 400 });
+}
+
+/** Accept only the exact public HTTPS URL supported by this importer. */
+export function parseGrokBotUrl(input: string): ParsedGrokBotUrl {
+  if (typeof input !== "string") throwGrokBotUrlError("Enter a public Grok Bot link");
+  const raw = input.trim();
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throwGrokBotUrlError("Enter a public Grok Bot link");
+  }
+
+  const authority = raw.match(/^https:\/\/([^/?#]*)/i)?.[1] ?? "";
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "x.ai" ||
+    authority.includes(":") ||
+    url.username ||
+    url.password ||
+    url.port ||
+    url.search ||
+    url.hash
+  ) {
+    throwGrokBotUrlError("Only exact public x.ai Grok Bot links are supported");
+  }
+
+  const match = url.pathname.match(/^\/bot\/([A-Za-z0-9_-]{21})$/);
+  if (!match) throwGrokBotUrlError("The x.ai link must point to a public Grok Bot");
+  return { id: match[1]! };
+}
+
+/** Read the bounded protobuf wire values returned by the public profile endpoint. */
+class ProtoReader {
+  private offset = 0;
+  private readonly bytes: Uint8Array;
+
+  constructor(bytes: Uint8Array) {
+    this.bytes = bytes;
+  }
+
+  /** Report whether the reader has consumed the complete input buffer. */
+  get done(): boolean {
+    return this.offset === this.bytes.length;
+  }
+
+  /** Read a protobuf varint and reject truncated or unsafe numeric values. */
+  readVarint(): number {
+    let value = 0;
+    for (let index = 0; index < 10; index += 1) {
+      if (this.offset >= this.bytes.length) throw new Error("truncated protobuf");
+      const byte = this.bytes[this.offset++]!;
+      if (index === 9 && byte > 1) throw new Error("invalid protobuf varint");
+      value += (byte & 0x7f) * 2 ** (7 * index);
+      if ((byte & 0x80) === 0) {
+        if (!Number.isSafeInteger(value)) throw new Error("invalid protobuf varint");
+        return value;
+      }
+    }
+    throw new Error("invalid protobuf varint");
+  }
+
+  /** Read one length-delimited field without exceeding its byte budget. */
+  readBytes(maxBytes = GROK_BOT_RESPONSE_MAX_BYTES): Uint8Array {
+    const length = this.readVarint();
+    if (!Number.isSafeInteger(length) || length > maxBytes) throw new Error("protobuf field is too large");
+    const end = this.offset + length;
+    if (end > this.bytes.length) throw new Error("truncated protobuf");
+    const value = this.bytes.slice(this.offset, end);
+    this.offset = end;
+    return value;
+  }
+
+  /** Decode one bounded length-delimited field as strict UTF-8 text. */
+  readString(maxBytes = GROK_BOT_MAX_TEXT_BYTES): string {
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(this.readBytes(maxBytes));
+    } catch {
+      throw new Error("invalid protobuf text");
+    }
+  }
+
+  /** Advance over a fixed-width protobuf field after checking its bounds. */
+  readFixed(length: 4 | 8): void {
+    if (this.offset + length > this.bytes.length) throw new Error("truncated protobuf");
+    this.offset += length;
+  }
+
+  /** Read a protobuf field number together with its wire type. */
+  readKey(): { field: number; wireType: number } {
+    const key = this.readVarint();
+    const field = Math.floor(key / 8);
+    const wireType = key % 8;
+    if (!Number.isSafeInteger(field) || field < 1) throw new Error("invalid protobuf field key");
+    return { field, wireType };
+  }
+}
+
+/** Skip an unknown protobuf field while enforcing supported wire and nesting limits. */
+function skipField(reader: ProtoReader, field: number, wireType: number, depth = 0): void {
+  if (depth > GROK_BOT_MAX_NESTING) throw new Error("protobuf nesting is too deep");
+  if (wireType === 0) {
+    reader.readVarint();
+    return;
+  }
+  if (wireType === 1) {
+    reader.readFixed(8);
+    return;
+  }
+  if (wireType === 2) {
+    reader.readBytes();
+    return;
+  }
+  if (wireType === 3) {
+    for (;;) {
+      if (reader.done) throw new Error("truncated protobuf group");
+      const nested = reader.readKey();
+      if (nested.wireType === 4) {
+        if (nested.field !== field) throw new Error("invalid protobuf group");
+        return;
+      }
+      skipField(reader, nested.field, nested.wireType, depth + 1);
+    }
+  }
+  if (wireType === 4) throw new Error("unexpected protobuf group end");
+  if (wireType === 5) {
+    reader.readFixed(4);
+    return;
+  }
+  throw new Error("unsupported protobuf wire type");
+}
+
+/** Enforce the maximum number of fields accepted in one protobuf message. */
+function assertFieldBudget(count: number): void {
+  if (count > GROK_BOT_MAX_FIELDS_PER_MESSAGE) throw new Error("protobuf has too many fields");
+}
+
+/** Decode the nested public-profile template message. */
+function decodeTemplate(bytes: Uint8Array): GrokBotTemplate {
+  const reader = new ProtoReader(bytes);
+  let shareId: string | undefined;
+  let name: string | undefined;
+  let avatarShape: string | undefined;
+  let avatarColor: string | undefined;
+  let published: boolean | undefined;
+  let activeVersion: string | undefined;
+  let description: string | undefined;
+  const seen = new Set<number>();
+  let fieldCount = 0;
+
+  while (!reader.done) {
+    assertFieldBudget(++fieldCount);
+    const { field, wireType } = reader.readKey();
+    if (field === 1 || field === 2 || field === 3 || field === 4 || field === 12) {
+      if (wireType !== 2 || seen.has(field)) throw new Error("invalid Grok Bot text field");
+      seen.add(field);
+      const value = reader.readString(field === 12 ? GROK_BOT_MAX_TEXT_BYTES : GROK_BOT_MAX_SHORT_TEXT_BYTES);
+      if (field === 1) shareId = value;
+      else if (field === 2) name = value;
+      else if (field === 3) avatarShape = value;
+      else if (field === 4) avatarColor = value;
+      else description = value;
+      continue;
+    }
+    if (field === 10) {
+      if (wireType !== 0 || seen.has(field)) throw new Error("invalid Grok Bot published field");
+      seen.add(field);
+      const value = reader.readVarint();
+      if (value !== 0 && value !== 1) throw new Error("invalid Grok Bot published value");
+      published = value === 1;
+      continue;
+    }
+    if (field === 11) {
+      if (seen.has(field)) throw new Error("duplicate Grok Bot field");
+      seen.add(field);
+      if (wireType === 2) activeVersion = reader.readString(GROK_BOT_MAX_SHORT_TEXT_BYTES);
+      else skipField(reader, field, wireType);
+      continue;
+    }
+    skipField(reader, field, wireType);
+  }
+
+  if (shareId === undefined || name === undefined || published === undefined || description === undefined) {
+    throw new Error("Grok Bot response is missing required fields");
+  }
+  return { shareId, name, avatarShape, avatarColor, published, activeVersion, description };
+}
+
+/** Decode the top-level public Grok Bot response message. */
+function decodeResponse(bytes: Uint8Array): GrokBotTemplateResponse {
+  const reader = new ProtoReader(bytes);
+  let template: GrokBotTemplate | undefined;
+  let ownerDisplayName: string | undefined;
+  const seen = new Set<number>();
+  let fieldCount = 0;
+  while (!reader.done) {
+    assertFieldBudget(++fieldCount);
+    const { field, wireType } = reader.readKey();
+    if (field === 1) {
+      if (wireType !== 2 || seen.has(field)) throw new Error("invalid Grok Bot template field");
+      seen.add(field);
+      template = decodeTemplate(reader.readBytes());
+    } else if (field === 2) {
+      if (wireType !== 2 || seen.has(field)) throw new Error("invalid Grok Bot owner field");
+      seen.add(field);
+      ownerDisplayName = reader.readString(GROK_BOT_MAX_SHORT_TEXT_BYTES);
+    } else {
+      skipField(reader, field, wireType);
+    }
+  }
+  if (!template) throw new Error("Grok Bot response has no template");
+  return { template, ownerDisplayName };
+}
+
+/** Encode the requested share ID as the endpoint's protobuf request body. */
+function encodeShareId(shareId: string): Uint8Array {
+  const value = new TextEncoder().encode(shareId);
+  const result = new Uint8Array(2 + value.length);
+  result[0] = 0x0a;
+  result[1] = value.length;
+  result.set(value, 2);
+  return result;
+}
+
+/** Read the response body with both announced and actual byte limits enforced. */
+async function readResponseBytes(response: Response): Promise<Uint8Array> {
+  const announced = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(announced) && announced > GROK_BOT_RESPONSE_MAX_BYTES) {
+    throw new Error("Grok Bot response is too large");
+  }
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      const chunk = next.value;
+      total += chunk.byteLength;
+      if (total > GROK_BOT_RESPONSE_MAX_BYTES) throw new Error("Grok Bot response is too large");
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+/** Fetch and decode one public Grok Bot template without authentication. */
+export async function fetchGrokBotTemplate(input: string, fetcher: typeof fetch = fetch): Promise<GrokBotTemplateResponse> {
+  const { id } = parseGrokBotUrl(input);
+  let response: Response;
+  try {
+    response = await fetcher(GROK_BOT_TEMPLATE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "content-type": "application/proto",
+        "connect-protocol-version": "1",
+      },
+      body: encodeShareId(id),
+      redirect: "error",
+      signal: AbortSignal.timeout(GROK_BOT_TIMEOUT_MS),
+    });
+  } catch {
+    throw new Error("Grok Bot request failed");
+  }
+  if (!response.ok) throw new Error("Grok Bot request failed");
+  try {
+    return decodeResponse(await readResponseBytes(response));
+  } catch (error) {
+    if (error instanceof Error && error.message === "Grok Bot response is too large") throw error;
+    throw new Error("Grok Bot response is invalid");
+  }
+}
+
+/** Validate the fetched profile identity and normalize its public text fields. */
+function publicTemplate(response: GrokBotTemplateResponse, expectedShareId: string): GrokBotTemplate {
+  const template = response.template;
+  if (template.shareId !== expectedShareId) throw new Error("Grok Bot response is invalid");
+  const name = template.name.trim();
+  const description = template.description.trim();
+  if (!template.published) throw new Error("Grok Bot profile is unpublished");
+  if (!description) throw new Error("Grok Bot public instructions are empty");
+  if (template.description.length > GROK_BOT_INSTRUCTION_MAX_CHARS || description.length > GROK_BOT_INSTRUCTION_MAX_CHARS) {
+    throw new Error("Grok Bot public instructions are too large");
+  }
+  if (!name || name.length > 100) throw new Error("Grok Bot response is invalid");
+  return { ...template, name, description };
+}
+
+const MAUS_COLORS = ["green", "blue", "red", "orange", "purple", "cyan", "pink", "yellow", "teal", "coral"] as const;
+
+/** Convert a validated public Grok Bot profile into an OpenMaus package. */
+export function grokBotTemplateToPackage(
+  template: GrokBotTemplate,
+  expectedShareId = template.shareId,
+  ownerDisplayName?: string,
+): ParsedBotPackage {
+  const publicProfile = publicTemplate({ template, ownerDisplayName }, expectedShareId);
+  const publicColor = publicProfile.avatarColor?.trim().toLowerCase();
+  const importedColor = MAUS_COLORS.find((color) => color === publicColor) ?? "blue";
+  const author = ownerDisplayName?.trim();
+  return parseBotPackage({
+    format: "openmaus.package",
+    version: 1,
+    package: {
+      id: `grok-${publicProfile.shareId.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+      release: "1.0.0",
+      name: publicProfile.name,
+      tagline: "Public Grok Bot profile instructions",
+      summary: "Imported from the public Grok Bot profile.",
+      category: "Grok Bot",
+      author: { name: author && author.length <= 100 ? author : "Grok" },
+      license: "Public profile",
+      outcomes: ["Follow the public profile instructions."],
+      setupMinutes: 1,
+      requirements: { apps: [], capabilities: [] },
+      agents: [{
+        key: "grok-bot",
+        name: publicProfile.name,
+        title: "Grok Bot",
+        description: publicProfile.description,
+        appearance: {
+          color: importedColor,
+        },
+      }],
+    },
+  });
+}
+
+/** Fetch a public Grok Bot profile and return its importable OpenMaus package. */
+export async function fetchGrokBotPackage(input: string, fetcher: typeof fetch = fetch): Promise<ParsedBotPackage> {
+  const { id } = parseGrokBotUrl(input);
+  const response = await fetchGrokBotTemplate(input, fetcher);
+  return grokBotTemplateToPackage(response.template, id, response.ownerDisplayName);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -222,6 +222,7 @@ import { RoutineRequestService } from "./routine-requests.ts";
 import { fetchBotDirectory, matchDirectoryBots, type MatchedDirectoryBot } from "./bot-directory.ts";
 import { scoutProject, suggestTeam } from "./project-scout.ts";
 import { fetchGithubTeam, fetchLibraryTeam, fetchTeamCatalog } from "./team-library.ts";
+import { fetchGrokBotPackage } from "./grok-bot-template.ts";
 import { isBotPackage, packageAgentAsMember, parseBotPackage, renderBotPackageMarkdown } from "./bot-package.ts";
 import { createTeamManifest, importedMemberProfile, parseTeamManifest } from "./team-manifest.ts";
 import { readThreadEvents } from "./thread-events.ts";
@@ -6365,6 +6366,25 @@ const server = createServer(async (req, res) => {
       } catch (error) {
         const status = (error as { status?: number }).status === 404 ? 404 : 400;
         return json(res, status, { error: error instanceof Error ? error.message : "The GitHub team could not be loaded" });
+      }
+    }
+    if (method === "POST" && path === "/api/team-library/grok") {
+      const body = await readBody(req);
+      if (
+        !body ||
+        typeof body !== "object" ||
+        Array.isArray(body) ||
+        typeof body.url !== "string" ||
+        !body.url.trim() ||
+        body.url.length > 300
+      ) {
+        return json(res, 400, { error: "A public Grok Bot URL is required" });
+      }
+      try {
+        return json(res, 200, await fetchGrokBotPackage(body.url));
+      } catch (error) {
+        const status = (error as { status?: unknown }).status === 400 ? 400 : 502;
+        return json(res, status, { error: error instanceof Error ? error.message : "The Grok Bot could not be loaded" });
       }
     }
     if (method === "GET" && path === "/api/teams/scout") {

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -8,6 +8,8 @@ export const TEAM_MANIFEST_FORMAT = "openmaus.team" as const;
 export const TEAM_MANIFEST_VERSION = 2 as const;
 export const LEGACY_TEAM_MANIFEST_VERSION = 1 as const;
 export const MAX_TEAM_MEMBERS = 200;
+/** Keep imported member instructions bounded independently from package size. */
+export const BOT_INSTRUCTIONS_MAX_CHARS = 24_000;
 
 const COLORS = [
   "green",
@@ -44,7 +46,7 @@ const memberSchema = z.object({
   }),
   name: requiredText(100),
   title: optionalText(200),
-  description: optionalText(4_000),
+  description: optionalText(BOT_INSTRUCTIONS_MAX_CHARS),
   appearance: z.object({
     color: z.enum(COLORS, { error: "is not supported" }),
     mascotExpression: optionalText(80),

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -728,6 +728,15 @@ export function TeamLibraryPanel({
                       <h3 className="mt-3 text-[14px] font-medium text-ink">Load from GitHub or Grok</h3>
                       <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">Paste a public repo, team JSON link, or exact public Grok Bot URL.</p>
                       <p className="mt-2 text-[11.5px] leading-relaxed text-ink-secondary">Experimental Grok import uses an undocumented endpoint. No Grok login or credentials are sent.</p>
+                      {window.ogb?.platform === "win32" && window.ogb.openGrokDefaultApps ? (
+                        <button
+                          type="button"
+                          onClick={() => void window.ogb?.openGrokDefaultApps?.()}
+                          className="mt-2 self-start text-[11.5px] font-medium text-accent hover:underline"
+                        >
+                          Choose app for Grok Bot links in Windows
+                        </button>
+                      ) : null}
                       <div className="mt-4 flex gap-2">
                         <input
                           value={githubUrl}

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -27,6 +27,15 @@ import { createPortal } from "react-dom";
 const MAX_TEAM_FILE_BYTES = 1_000_000;
 const COMMUNITY_TEAMS_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
 
+function isGrokBotUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "https:" && url.hostname === "x.ai";
+  } catch {
+    return false;
+  }
+}
+
 interface TeamCatalogEntry {
   slug: string;
   name: string;
@@ -62,7 +71,7 @@ export interface TeamImportResult {
   archived: ArchivedTeamBot[];
 }
 
-type ImportSource = "library" | "file" | "github";
+type ImportSource = "library" | "file" | "github" | "grok";
 type TeamTab = "explore" | "import" | "scout";
 type ImportMode = "replace" | "add";
 
@@ -258,11 +267,12 @@ export function TeamLibraryPanel({
     setGithubLoading(true);
     setError("");
     try {
-      const manifest = await api("/api/team-library/github", {
+      const grok = isGrokBotUrl(requestedUrl);
+      const manifest = await api(grok ? "/api/team-library/grok" : "/api/team-library/github", {
         method: "POST",
         body: JSON.stringify({ url: requestedUrl.trim() }),
       });
-      previewManifest(teamImportPreview(manifest), "github");
+      previewManifest(teamImportPreview(manifest), grok ? "grok" : "github");
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -715,15 +725,16 @@ export function TeamLibraryPanel({
 
                     <div className="flex min-h-56 flex-col justify-center rounded-2xl bg-raised/25 px-6">
                       <Github size={25} className="text-ink-secondary" />
-                      <h3 className="mt-3 text-[14px] font-medium text-ink">Load from GitHub</h3>
-                      <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">Paste a public repo or a direct team JSON link.</p>
+                      <h3 className="mt-3 text-[14px] font-medium text-ink">Load from GitHub or Grok</h3>
+                      <p className="mt-1 text-[12.5px] leading-relaxed text-ink-secondary">Paste a public repo, team JSON link, or exact public Grok Bot URL.</p>
+                      <p className="mt-2 text-[11.5px] leading-relaxed text-ink-secondary">Experimental Grok import uses an undocumented endpoint. No Grok login or credentials are sent.</p>
                       <div className="mt-4 flex gap-2">
                         <input
                           value={githubUrl}
                           onChange={(event) => setGithubUrl(event.target.value)}
                           onKeyDown={(event) => event.key === "Enter" && void loadGithubTeam()}
-                          placeholder="github.com/owner/repo"
-                          aria-label="GitHub team URL"
+                          placeholder="github.com/owner/repo or https://x.ai/bot/…"
+                          aria-label="GitHub team or public Grok Bot URL"
                           className="min-w-0 flex-1 rounded-xl bg-raised/80 px-3 py-2.5 text-[13px] text-ink placeholder:text-ink-secondary focus:outline-none"
                         />
                         <button

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -189,9 +189,11 @@ type SkillRecordingPayload = {
       openInstallTerminal?(command: string): Promise<boolean>;
       /** Opens an http(s) link in the user's default browser. */
       openExternal?(url: string): Promise<boolean>;
+      /** Opens Windows Default Apps for the registered Grok Bot link candidate. */
+      openGrokDefaultApps?(): Promise<boolean>;
       /** Recolor the native window chrome for a skin; absent on older builds. */
       applySkin?(skin: string): Promise<boolean>;
-      /** Receives a GitHub package URL opened through openmausbot://install. */
+      /** Receives a public package URL opened through an approved desktop deep link. */
       onPackageInstall?(cb: (url: string) => void): () => void;
       /** Updates the native Dock/taskbar unread indicator. */
       setUnreadCount?(count: number): void;


### PR DESCRIPTION
## What changed

Adds an explicit importer for exact public `https://x.ai/bot/<id>` links.

- Fetches the anonymous public profile from the undocumented protobuf endpoint.
- Imports public instructions and supported avatar color into a normal OpenMaus package.
- Does not send Grok cookies, tokens, credentials, or authorization headers.
- Rejects non-exact links, redirects, unpublished profiles, mismatched IDs, malformed protobuf, invalid UTF-8, oversized responses, and instructions over the package limit.
- Keeps OS-level protocol-handler behavior out of scope; that unsafe approach was closed in #652.

## Why

The existing GitHub import box accepted only repositories and team JSON. This gives users an explicit, reviewable path for public Grok profiles without registering a global URL handler or claiming access to private memories, skills, routines, or integrations.

## Verification

- 16 focused Grok/package/manifest tests passed.
- Client and server TypeScript checks passed.
- Production client build passed.
- Electron syntax check passed for 90 modules.
- Live anonymous import smoke passed for a public profile: one agent, 6,219 instruction characters, zero apps and zero capabilities.
- Staged diff and secret-pattern checks passed.
- Rebased as one commit on official `main` at `cb0d376`.
- Current head: `72bbc1c4a1a90fd63d1b24c9ef9ea65abed3be12`.

## Screenshots

This changes the import copy and routing, but no fresh before/after screenshot is attached. No visual acceptance is claimed.

## Notes

The endpoint is undocumented and may change upstream. Transport failures are surfaced as a generic import error; no credentials are requested or persisted.