### PR TITLE
feat(calendar): add focused workspace mode

### DIFF
--- a/server/calendar-calls.test.ts
+++ b/server/calendar-calls.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CalendarCallManager, type CalendarCallInput } from "./calendar-calls.ts";
 
@@ -62,6 +62,81 @@ describe("CalendarCallManager", () => {
       durationMinutes: 45,
       attachments: [{ path: "/safe/local/Launch brief.pdf", kind: "file" }],
     });
+  });
+
+  it("fires a due call once and persists the occurrence cursor", async () => {
+    const file = tempFile();
+    let now = 1_000;
+    const due: Array<{ id: string; scheduledFor: number }> = [];
+    const calls = new CalendarCallManager({
+      file,
+      now: () => now,
+      botExists: () => true,
+      onDue: (call, scheduledFor) => {
+        due.push({ id: call.id, scheduledFor });
+      },
+    });
+    const created = calls.create(input({ schedule: { type: "once", at: 2_000 } }));
+
+    await calls.tick();
+    expect(due).toEqual([]);
+    now = 2_000;
+    await calls.tick();
+    await calls.tick();
+
+    expect(due).toEqual([{ id: created.id, scheduledFor: 2_000 }]);
+    expect(calls.get(created.id)?.nextRunAt).toBeNull();
+    expect(manager(file, now).get(created.id)?.nextRunAt).toBeNull();
+  });
+
+  it("retries a failed kickoff while the event is current and skips stale events", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    let now = 2_000;
+    let attempts = 0;
+    const calls = new CalendarCallManager({
+      file: tempFile(),
+      now: () => now,
+      botExists: () => true,
+      onDue: () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("temporary failure");
+      },
+    });
+    const current = calls.create(input({ schedule: { type: "once", at: 2_000 }, durationMinutes: 15 }));
+
+    await calls.tick();
+    expect(attempts).toBe(1);
+    expect(calls.get(current.id)?.nextRunAt).toBe(2_000);
+    await calls.tick();
+    expect(attempts).toBe(2);
+    expect(calls.get(current.id)?.nextRunAt).toBeNull();
+
+    const stale = calls.create(input({ schedule: { type: "once", at: 3_000 }, durationMinutes: 15 }));
+    now = 3_000 + 15 * 60_000;
+    await calls.tick();
+    expect(attempts).toBe(2);
+    expect(calls.get(stale.id)?.nextRunAt).toBeNull();
+    error.mockRestore();
+  });
+
+  it("links a room until the event roster changes", () => {
+    const calls = manager();
+    const created = calls.create(input());
+    expect(calls.linkRoom(created.id, "room-1").roomId).toBe("room-1");
+    expect(calls.update(created.id, { name: "Renamed" }).roomId).toBe("room-1");
+    expect(calls.update(created.id, { botIds: ["chief"] }).roomId).toBeUndefined();
+  });
+
+  it("persists the first schedule cursor when migrating old reminder files", () => {
+    const file = tempFile();
+    const created = manager(file, 100).create(input({ schedule: { type: "once", at: 2_000 } }));
+    const persisted = JSON.parse(readFileSync(file, "utf8")) as { calls: Array<{ nextRunAt?: number | null }> };
+    delete persisted.calls[0]!.nextRunAt;
+    writeFileSync(file, JSON.stringify(persisted));
+
+    expect(manager(file, 1_000).get(created.id)?.nextRunAt).toBe(2_000);
+    expect(JSON.parse(readFileSync(file, "utf8")).calls[0].nextRunAt).toBe(2_000);
+    expect(manager(file, 2_100).get(created.id)?.nextRunAt).toBe(2_000);
   });
 
   it("validates participants, schedules, duration, and attachments", () => {

--- a/server/calendar-calls.ts
+++ b/server/calendar-calls.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { writeFileAtomic } from "./atomic.ts";
 import { DATA_DIR } from "./config.ts";
+import { nextOccurrence } from "./routines.ts";
 
 export type CalendarCallSchedule =
   | { type: "once"; at: number }
@@ -29,6 +30,8 @@ export interface CalendarCall {
   schedule: CalendarCallSchedule;
   durationMinutes: number;
   attachments: CalendarCallAttachment[];
+  roomId?: string;
+  nextRunAt: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -48,6 +51,7 @@ export interface CalendarCallManagerOptions {
   file?: string;
   now?: () => number;
   botExists: (botId: string) => boolean;
+  onDue?: (call: CalendarCall, scheduledFor: number) => void | Promise<void>;
 }
 
 interface CalendarCallFile {
@@ -81,6 +85,8 @@ const callSchema = z.object({
   schedule: scheduleSchema,
   durationMinutes: z.number().int().min(15).max(240),
   attachments: z.array(attachmentSchema).max(MAX_ATTACHMENTS),
+  roomId: z.string().min(1).optional(),
+  nextRunAt: z.number().finite().nonnegative().nullable().optional(),
   createdAt: z.number().finite().nonnegative(),
   updatedAt: z.number().finite().nonnegative(),
 });
@@ -93,6 +99,12 @@ function cloneSchedule(schedule: CalendarCallSchedule): CalendarCallSchedule {
   return schedule.type === "once"
     ? { type: "once", at: schedule.at }
     : { type: "daily", time: schedule.time, weekdays: [...schedule.weekdays] };
+}
+
+function sameRoster(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const wanted = new Set(left);
+  return right.every((id) => wanted.has(id));
 }
 
 function cloneCall(call: CalendarCall): CalendarCall {
@@ -133,7 +145,7 @@ function cleanAttachments(value: CalendarCallAttachment[] | undefined): Calendar
 function cleanInput(
   input: CalendarCallInput,
   botExists: CalendarCallManagerOptions["botExists"],
-): Omit<CalendarCall, "id" | "createdAt" | "updatedAt"> {
+): Omit<CalendarCall, "id" | "roomId" | "nextRunAt" | "createdAt" | "updatedAt"> {
   const name = String(input.name ?? "").trim().slice(0, 120);
   const description = String(input.description ?? "").trim().slice(0, 20_000);
   if (!name) throw new Error("Give the call a title");
@@ -163,27 +175,49 @@ export class CalendarCallManager {
   private readonly file: string;
   private readonly now: () => number;
   private readonly botExists: CalendarCallManagerOptions["botExists"];
+  private readonly onDue: CalendarCallManagerOptions["onDue"];
   private calls: CalendarCall[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private ticking = false;
 
   constructor(options: CalendarCallManagerOptions) {
     this.file = options.file ?? join(DATA_DIR, "calendar-calls.json");
     this.now = options.now ?? Date.now;
     this.botExists = options.botExists;
+    this.onDue = options.onDue;
+    let migrated = false;
     try {
       const parsed = fileSchema.safeParse(JSON.parse(readFileSync(this.file, "utf8")));
       this.calls = parsed.success
         ? parsed.data.calls.flatMap((candidate) => {
             const call = callSchema.safeParse(candidate);
-            return call.success ? [cloneCall(call.data)] : [];
+            if (!call.success) return [];
+            if (call.data.nextRunAt === undefined) migrated = true;
+            const nextRunAt = call.data.nextRunAt === undefined
+              ? this.loadedOccurrence(call.data.schedule)
+              : call.data.nextRunAt;
+            return [cloneCall({ ...call.data, nextRunAt })];
           })
         : [];
     } catch {
       this.calls = [];
     }
+    if (migrated) {
+      try {
+        this.save();
+      } catch (error) {
+        console.error("calendar calls: could not persist schedule migration", error);
+      }
+    }
   }
 
   list(): CalendarCall[] {
     return this.calls.map(cloneCall);
+  }
+
+  get(id: string): CalendarCall | null {
+    const call = this.calls.find((candidate) => candidate.id === id);
+    return call ? cloneCall(call) : null;
   }
 
   create(input: CalendarCallInput): CalendarCall {
@@ -192,10 +226,12 @@ export class CalendarCallManager {
     const call: CalendarCall = {
       id: randomUUID(),
       ...clean,
+      nextRunAt: this.initialOccurrence(clean.schedule, timestamp),
       createdAt: timestamp,
       updatedAt: timestamp,
     };
     this.commit(() => this.calls.push(call));
+    if (this.timer) queueMicrotask(() => void this.tick());
     return cloneCall(call);
   }
 
@@ -214,13 +250,26 @@ export class CalendarCallManager {
     const updated: CalendarCall = {
       id: previous.id,
       ...clean,
+      roomId: patch.botIds && !sameRoster(clean.botIds, previous.botIds) ? undefined : previous.roomId,
+      nextRunAt: this.initialOccurrence(clean.schedule, this.now()),
       createdAt: previous.createdAt,
       updatedAt: this.now(),
     };
     this.commit(() => {
       this.calls[index] = updated;
     });
+    if (this.timer) queueMicrotask(() => void this.tick());
     return cloneCall(updated);
+  }
+
+  linkRoom(id: string, roomId: string): CalendarCall {
+    const call = this.calls.find((candidate) => candidate.id === id);
+    if (!call) throw new Error("Call not found");
+    if (call.roomId === roomId) return cloneCall(call);
+    this.commit(() => {
+      call.roomId = roomId;
+    });
+    return cloneCall(call);
   }
 
   remove(id: string): boolean {
@@ -245,6 +294,56 @@ export class CalendarCallManager {
       });
     });
     return affected;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), 10_000);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<void> {
+    if (this.ticking) return;
+    this.ticking = true;
+    try {
+      const now = this.now();
+      for (const call of this.calls) {
+        if (call.nextRunAt == null || call.nextRunAt > now) continue;
+        const scheduledFor = call.nextRunAt;
+        if (now - scheduledFor < call.durationMinutes * 60_000) {
+          try {
+            await this.onDue?.(cloneCall(call), scheduledFor);
+          } catch (error) {
+            console.error(`calendar call ${call.id}: scheduled room kickoff failed`, error);
+            continue;
+          }
+        }
+        call.nextRunAt = call.schedule.type === "once"
+          ? null
+          : nextOccurrence(call.schedule, Math.max(now, scheduledFor));
+        this.save();
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+
+  private initialOccurrence(schedule: CalendarCallSchedule, now: number): number | null {
+    return schedule.type === "once" ? schedule.at : nextOccurrence(schedule, now);
+  }
+
+  /** Old calendar calls were reminders only. Start recurring reminders from
+   * the next future slot and never replay an already-past one-time reminder. */
+  private loadedOccurrence(schedule: CalendarCallSchedule): number | null {
+    const now = this.now();
+    if (schedule.type === "once") return schedule.at > now ? schedule.at : null;
+    return nextOccurrence(schedule, now);
   }
 
   private commit(mutate: () => void): void {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2647,6 +2647,79 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("opens one calendar room and posts the scheduled seed to everyone", async () => {
+    const modelSelection = { instanceId: "ghost", model: "ghost-1" };
+    const first = (await api("POST", "/api/bots", { name: "Calendar researcher", modelSelection })).body.bot;
+    const second = (await api("POST", "/api/bots", { name: "Calendar writer", modelSelection })).body.bot;
+    let callId = "";
+    let roomId = "";
+    try {
+      const created = await api("POST", "/api/calendar-calls", {
+        name: "Launch room",
+        description: "Review the launch plan.",
+        botIds: [first.id, second.id],
+        schedule: { type: "once", at: Date.now() - 100 },
+        durationMinutes: 30,
+        attachments: [{
+          id: "launch-brief",
+          name: "Launch brief.txt",
+          path: "/tmp/a\"&<>.txt",
+          size: 12,
+          kind: "file",
+        }],
+      });
+      expect(created.status).toBe(201);
+      callId = created.body.call.id;
+
+      await expect.poll(async () => {
+        const snapshot = await api("GET", "/api/bots?messages=50");
+        const room = snapshot.body.groups.find((candidate: { memberIds: string[] }) =>
+          candidate.memberIds.length === 2 &&
+          candidate.memberIds.includes(first.id) &&
+          candidate.memberIds.includes(second.id)
+        );
+        return room?.messages.find((message: { sendId?: string }) =>
+          message.sendId?.startsWith(`calendar_${callId}_`)
+        )?.text;
+      }, { timeout: 5_000 }).toBe(
+        '@everyone Review the launch plan.\n\n<attached-file path="/tmp/a&quot;&amp;&lt;&gt;.txt" />',
+      );
+
+      const snapshot = await api("GET", "/api/bots?messages=50");
+      const room = snapshot.body.groups.find((candidate: { memberIds: string[] }) =>
+        candidate.memberIds.length === 2 &&
+        candidate.memberIds.includes(first.id) &&
+        candidate.memberIds.includes(second.id)
+      );
+      expect(room).toMatchObject({ defaultResponder: { kind: "everyone" } });
+      roomId = room.id;
+
+      await expect.poll(async () => {
+        const refreshed = await api("GET", "/api/bots?messages=50");
+        const current = refreshed.body.groups.find((candidate: { id: string }) => candidate.id === roomId);
+        return current?.messages
+          .filter((message: { from?: { botId?: string } }) => message.from?.botId)
+          .map((message: { from: { botId: string } }) => message.from.botId)
+          .sort();
+      }, { timeout: 5_000 }).toEqual([first.id, second.id].sort());
+
+      const joined = await api("POST", `/api/calendar-calls/${callId}/room`, {});
+      expect(joined.status).toBe(200);
+      expect(joined.body.group.id).toBe(roomId);
+      expect(room.messages.filter((message: { sendId?: string }) =>
+        message.sendId?.startsWith(`calendar_${callId}_`)
+      )).toHaveLength(1);
+    } finally {
+      if (callId) await api("DELETE", `/api/calendar-calls/${callId}`).catch(() => undefined);
+      if (roomId) {
+        await api("POST", `/api/groups/${roomId}/interrupt`, {}).catch(() => undefined);
+        await api("DELETE", `/api/groups/${roomId}`).catch(() => undefined);
+      }
+      await api("DELETE", `/api/bots/${first.id}`).catch(() => undefined);
+      await api("DELETE", `/api/bots/${second.id}`).catch(() => undefined);
+    }
+  });
+
   it("refuses to delete a bot while one of its routines is active", async () => {
     const bot = (await api("POST", "/api/bots", {
       modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { extname, join } from "node:path";
 
 import { z } from "zod";
 import { botAvatarUrlFromStoredPath } from "../shared/bot-avatar.ts";
+import { escapeAttribute } from "../src/lib/composer-attachments.ts";
 import {
   CREDENTIAL_TARGETS,
   credentialResumeOutcome,
@@ -170,7 +171,7 @@ import { RepeatDetector, callKey } from "./repeat-detector.ts";
 import { redactSecretsInText } from "./redact.ts";
 import * as vps from "./vps-computer.ts";
 import { RoutineManager, type RoutineRun, type RoutineRunOn, type RoutineRunTrigger } from "./routines.ts";
-import { CalendarCallManager } from "./calendar-calls.ts";
+import { CalendarCallManager, type CalendarCall } from "./calendar-calls.ts";
 import {
   BUILT_IN_BROWSER_SYSTEM_PROMPT,
   applyDesktopBrowserConnectionMessage,
@@ -2908,6 +2909,7 @@ routines = new RoutineManager({
 });
 calendarCalls = new CalendarCallManager({
   botExists: (botId) => Boolean(store.bot(botId)),
+  onDue: deliverCalendarCall,
 });
 const recoveryOwners = routines.routineRequestReceiptOwners();
 if (recoveryOwners.length > 0) {
@@ -3606,6 +3608,44 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
   const tracked = next.finally(() => finishGroupTurnOperation(groupId, operation));
   groupQueues.set(groupId, tracked.catch(() => {}));
   return message;
+}
+
+function sameCalendarRoster(group: GroupRecord, botIds: readonly string[]): boolean {
+  if (group.dm || group.memberIds.length !== botIds.length) return false;
+  const wanted = new Set(botIds);
+  return group.memberIds.every((id) => wanted.has(id));
+}
+
+function ensureCalendarCallRoom(call: CalendarCall): GroupRecord {
+  const linked = call.roomId ? store.group(call.roomId) : undefined;
+  let group = linked && sameCalendarRoster(linked, call.botIds) && !roomSetupPending(linked)
+    ? linked
+    : undefined;
+  group ??= store.createGroup(call.name, call.botIds, false, undefined, {
+    bulletin: "",
+    defaultResponder: { kind: "everyone" },
+    completed: true,
+  });
+  if (call.roomId !== group.id) calendarCalls!.linkRoom(call.id, group.id);
+  return group;
+}
+
+function deliverCalendarCall(call: CalendarCall, scheduledFor: number): void {
+  // A one-bot calendar entry remains a reminder that opens that bot's chat.
+  // Multi-bot entries are rooms and begin with the shared event prompt.
+  if (call.botIds.length < 2) return;
+  const group = ensureCalendarCallRoom(call);
+  const text = [
+    `@everyone ${call.description.trim() || call.name}`,
+    ...call.attachments.map((attachment) =>
+      `<${attachment.kind === "image" ? "attached-image" : "attached-file"} path="${escapeAttribute(attachment.path)}" />`
+    ),
+  ].join("\n\n");
+  const sendId = `calendar_${call.id}_${scheduledFor}`;
+  const threadIds = new Set([group.threadId, ...(group.tasks ?? []).map((task) => task.threadId)]);
+  const messages = [...threadIds].flatMap((threadId) => store.messagesFor(threadId));
+  if (messages.some((message) => message.sendId === sendId)) return;
+  startGroupTurn(group.id, text, undefined, sendId);
 }
 
 function roomSetupPending(group: GroupRecord): boolean {
@@ -5017,9 +5057,7 @@ const server = createServer(async (req, res) => {
       return run ? json(res, 200, { run }) : json(res, 404, { error: "no such active run" });
     }
 
-    // ── scheduled calls ────────────────────────────────────────────────
-    // Calls are calendar plans, not unattended jobs. The renderer opens the
-    // existing live call UI only after the user clicks Join.
+    // ── scheduled room sessions ────────────────────────────────────────
     if (path === "/api/calendar-calls" && method === "GET") {
       return json(res, 200, { calls: calendarCalls!.list() });
     }
@@ -5030,10 +5068,19 @@ const server = createServer(async (req, res) => {
         throw Object.assign(error instanceof Error ? error : new Error(String(error)), { status: 400 });
       }
     }
+    const calendarCallRoomMatch = path.match(/^\/api\/calendar-calls\/([\w-]+)\/room$/);
+    if (calendarCallRoomMatch && method === "POST") {
+      const call = calendarCalls!.get(calendarCallRoomMatch[1]);
+      if (!call) return json(res, 404, { error: "no such scheduled call" });
+      if (call.botIds.length < 2) {
+        return json(res, 400, { error: "single-bot events open that bot's chat directly" });
+      }
+      const group = ensureCalendarCallRoom(call);
+      return json(res, 200, { group: { ...publicGroupState(group), messages: store.messagesFor(group.threadId) } });
+    }
     const calendarCallMatch = path.match(/^\/api\/calendar-calls\/([\w-]+)$/);
     if (calendarCallMatch && method === "PATCH") {
-      const exists = calendarCalls!.list().some((call) => call.id === calendarCallMatch[1]);
-      if (!exists) return json(res, 404, { error: "no such scheduled call" });
+      if (!calendarCalls!.get(calendarCallMatch[1])) return json(res, 404, { error: "no such scheduled call" });
       try {
         return json(res, 200, { call: calendarCalls!.update(calendarCallMatch[1], await readBody(req)) });
       } catch (error) {
@@ -7850,6 +7897,8 @@ const server = createServer(async (req, res) => {
   }
 });
 
+calendarCalls.start();
+
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);
 });
@@ -7861,6 +7910,7 @@ const gracefulShutdown = createGracefulShutdown({
       vps.closeAllVpsDesktopTunnels();
       watchdog.stop();
       routines?.stop();
+      calendarCalls?.stop();
       webhookIngress?.server.close();
     },
     () => releaseAllBrowserCapabilities(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { BrowserWorkspace } from "@/components/BrowserWorkspace";
 import { SkillRecorderPage } from "@/components/SkillRecorderPage";
 import { TeamMapPage } from "@/components/TeamMapPage";
 import { heldComputerControlBotIds } from "@/lib/computer-control";
+import { skillRecorderEnabled } from "@/lib/feature-flags";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -39,8 +40,11 @@ function Shell() {
   // the panel hands off to this and back)
   const [browserWorkspaceBotId, setBrowserWorkspaceBotId] = useState<string | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const previousViewRef = useRef(state.activeView);
+  const calendarOriginRef = useRef<"chat" | "team-map" | "skill-recorder">("chat");
   const group = state.groups.find((g) => g.id === state.selectedId);
   const bot = group ? undefined : (state.bots.find((b) => b.id === state.selectedId) ?? state.bots[0]);
+  const calendarFocus = state.activeView === "routines";
 
   // Nothing on this machine can run a bot. A missing cloud login does not
   // count — that CLI can still host a local model. Wait for the first
@@ -115,6 +119,13 @@ function Shell() {
   }, [state.selectedId, state.activeView, state.pluginsOpen, state.settingsOpen]);
 
   useEffect(() => {
+    if (state.activeView === "routines" && previousViewRef.current !== "routines") {
+      calendarOriginRef.current = previousViewRef.current;
+    }
+    previousViewRef.current = state.activeView;
+  }, [state.activeView]);
+
+  useEffect(() => {
     if (
       localVmWorkspaceBotId &&
       (state.activeView !== "chat" || state.selectedId !== localVmWorkspaceBotId)
@@ -146,6 +157,18 @@ function Shell() {
     dispatch({ type: "select", id: botId });
     dispatch({ type: "toggleComputer", open: true });
   };
+
+  const closeCalendar = useCallback(() => {
+    if (calendarOriginRef.current === "team-map") {
+      dispatch({ type: "showTeamMap" });
+      return;
+    }
+    if (calendarOriginRef.current === "skill-recorder" && skillRecorderEnabled(state.config)) {
+      dispatch({ type: "showSkillRecorder" });
+      return;
+    }
+    dispatch({ type: "select", id: state.selectedId });
+  }, [dispatch, state.config, state.selectedId]);
 
   const nativeViewOverlayOpen =
     drawerOpen ||
@@ -185,7 +208,7 @@ function Shell() {
       {/* fixed-position popup, bottom-left — outside the layout flow */}
       <UpdateBanner />
       <div className="relative flex min-h-0 flex-1">
-      <button
+      {!calendarFocus && <button
         type="button"
         ref={menuButtonRef}
         aria-label="Open bot list"
@@ -194,25 +217,25 @@ function Shell() {
         className="absolute left-3 top-3 z-30 rounded-md p-1.5 text-ink-secondary hover:bg-raised hover:text-ink md:hidden"
       >
         <Menu size={18} />
-      </button>
-      {drawerOpen && (
+      </button>}
+      {drawerOpen && !calendarFocus && (
         <div
           aria-hidden
           onMouseDown={(e) => e.target === e.currentTarget && setDrawerOpen(false)}
           className="absolute inset-0 z-30 bg-black/50 md:hidden"
         />
       )}
-      <Sidebar
+      {!calendarFocus && <Sidebar
         open={drawerOpen}
         onClose={() => {
           setDrawerOpen(false);
           menuButtonRef.current?.focus();
         }}
-      />
+      />}
       {state.activeView === "team-map" ? (
         <TeamMapPage />
       ) : state.activeView === "routines" ? (
-        <RoutinesPage />
+        <RoutinesPage onBack={closeCalendar} />
       ) : state.activeView === "skill-recorder" ? (
         <SkillRecorderPage />
       ) : browserWorkspaceBotId && bot && bot.id === browserWorkspaceBotId ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,9 @@ function Shell() {
     }
     dispatch({ type: "select", id: state.selectedId });
   }, [dispatch, state.config, state.selectedId]);
+  const openCalendarRoom = useCallback((id: string) => {
+    dispatch({ type: "select", id });
+  }, [dispatch]);
 
   const nativeViewOverlayOpen =
     drawerOpen ||
@@ -235,7 +238,7 @@ function Shell() {
       {state.activeView === "team-map" ? (
         <TeamMapPage />
       ) : state.activeView === "routines" ? (
-        <RoutinesPage onBack={closeCalendar} />
+        <RoutinesPage onBack={closeCalendar} onOpenRoom={openCalendarRoom} />
       ) : state.activeView === "skill-recorder" ? (
         <SkillRecorderPage />
       ) : browserWorkspaceBotId && bot && bot.id === browserWorkspaceBotId ? (

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -7,8 +7,10 @@ import {
   useState,
   type DragEvent as ReactDragEvent,
   type PointerEvent as ReactPointerEvent,
+  type CSSProperties,
 } from "react";
 import {
+  ArrowLeft,
   CalendarDays,
   CheckCircle2,
   ChevronLeft,
@@ -38,6 +40,7 @@ import { BotAvatar } from "@/components/Avatar";
 import { CallTargetButton } from "@/components/CallView";
 import { pathForFile } from "@/components/ComposerAttachments";
 import { CalendarSidebar } from "@/components/routines/CalendarSidebar";
+import { useDesktopCapabilities } from "@/components/DesktopCapabilities";
 import { WebhooksPanel } from "@/components/WebhooksPanel";
 import type { CalendarCall, CalendarCallAttachment, CalendarCallInput } from "@/lib/calendar-calls";
 import { startCall } from "@/lib/call";
@@ -999,8 +1002,10 @@ export function RoutineEditor({
   return <EventEditor seed={{ kind: "routine", at, durationMinutes: routine?.durationMinutes ?? 30, botIds: lockedBotId ? [lockedBotId] : routine ? [routine.botId] : [], routine }} bots={bots} lockedBotId={lockedBotId} defaultRunOn={defaultRunOn} onClose={onClose} onSavedCall={() => {}} />;
 }
 
-export function RoutinesPage() {
+export function RoutinesPage({ onBack }: { onBack: () => void }) {
   const { state, dispatch } = useStore();
+  const { capabilities } = useDesktopCapabilities();
+  const backButtonRef = useRef<HTMLButtonElement>(null);
   const [section, setSection] = useState<"calendar" | "webhooks">("calendar");
   const [viewDays, setViewDays] = useState<1 | 3 | 7>(7);
   const [anchor, setAnchor] = useState(() => startOfDay(Date.now()));
@@ -1024,6 +1029,7 @@ export function RoutinesPage() {
     }
   }, []);
   useEffect(() => { void loadCalls(); }, [loadCalls]);
+  useEffect(() => { backButtonRef.current?.focus({ preventScroll: true }); }, []);
 
   const items = useMemo<CalendarEventItem[]>(() => {
     const routineItems = projectedRoutineItems(state.routines, state.routineRuns, rangeStart, rangeEnd).map((item) => ({ ...item, kind: "routine" as const }));
@@ -1045,6 +1051,13 @@ export function RoutinesPage() {
   const paused = state.routines.filter((routine) => !routine.enabled && (routine.schedule.type === "daily" || routine.schedule.at > Date.now()));
   const running = state.routineRuns.filter((run) => ["queued", "running", "waiting"].includes(run.status)).length;
   const unseenFailures = state.routineRuns.filter((run) => ["failed", "missed"].includes(run.status) && !run.seenAt).length;
+  const macInset = capabilities.windowChrome === "mac-inset";
+  const windowDragStyle = macInset
+    ? ({ WebkitAppRegion: "drag" } as CSSProperties)
+    : undefined;
+  const windowNoDragStyle = macInset
+    ? ({ WebkitAppRegion: "no-drag" } as CSSProperties)
+    : undefined;
 
   const setView = (days: 1 | 3 | 7) => {
     setViewDays(days);
@@ -1109,16 +1122,30 @@ export function RoutinesPage() {
 
   return (
     <main className="flex h-full min-w-0 flex-1 flex-col bg-app">
-      <header className="shrink-0 border-b border-hairline/35 bg-app px-4 py-3 pl-11 md:pl-4">
+      <header
+        className={cn("shrink-0 border-b border-hairline/35 bg-app py-3 pr-4", macInset ? "pl-[86px]" : "pl-4")}
+        style={windowDragStyle}
+      >
         <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            ref={backButtonRef}
+            onClick={onBack}
+            aria-label="Back"
+            title="Back"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
+            style={windowNoDragStyle}
+          >
+            <ArrowLeft size={18} />
+          </button>
           <div className="mr-3 flex items-center gap-2"><CalendarDays size={21} className="text-accent" /><h1 className="text-[18px] font-semibold tracking-tight text-ink">Calendar</h1></div>
-          <div className="flex items-center rounded-lg border border-hairline/50 bg-panel p-0.5">
+          <div className="flex items-center rounded-lg border border-hairline/50 bg-panel p-0.5" style={windowNoDragStyle}>
             <button onClick={() => setAnchor((current) => addDays(current, -viewDays))} className="rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Previous dates"><ChevronLeft size={16} /></button>
             <button onClick={goToday} className="rounded-md px-3 py-1.5 text-[12px] font-medium text-ink hover:bg-raised">Today</button>
             <button onClick={() => setAnchor((current) => addDays(current, viewDays))} className="rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Next dates"><ChevronRight size={16} /></button>
           </div>
           <div className="min-w-[220px] px-2 text-[15px] font-medium text-ink">{calendarRangeLabel(rangeStart, viewDays)}</div>
-          <div className="ml-auto flex items-center gap-2">
+          <div className="ml-auto flex items-center gap-2" style={windowNoDragStyle}>
             {running > 0 && <span className="hidden items-center gap-1.5 rounded-full bg-accent/10 px-2.5 py-1.5 text-[10.5px] text-accent sm:flex"><Loader2 size={11} className="animate-spin" />{running} active</span>}
             {unseenFailures > 0 && <span className="hidden items-center gap-1.5 rounded-full bg-danger/10 px-2.5 py-1.5 text-[10.5px] text-danger sm:flex"><CircleAlert size={11} />{unseenFailures}</span>}
             {paused.length > 0 && <button onClick={() => setPausedOpen(true)} className="hidden items-center gap-1.5 rounded-full border border-hairline/50 px-2.5 py-1.5 text-[10.5px] text-ink-secondary hover:bg-raised sm:flex"><Pause size={11} />{paused.length}</button>}
@@ -1126,7 +1153,7 @@ export function RoutinesPage() {
             <select value={viewDays} onChange={(event) => setView(Number(event.target.value) as 1 | 3 | 7)} className="rounded-lg border border-hairline/50 bg-panel px-2.5 py-2 text-[11.5px] text-ink outline-none focus:border-accent"><option value={1}>Day</option><option value={3}>3 days</option><option value={7}>Week</option></select>
           </div>
         </div>
-        <div className="mt-2 flex items-center gap-1">
+        <div className="mt-2 flex items-center gap-1" style={windowNoDragStyle}>
           <button onClick={() => setSection("calendar")} className={cn("rounded-lg px-3 py-1.5 text-[11.5px] font-medium", section === "calendar" ? "bg-accent/12 text-accent" : "text-ink-secondary hover:bg-raised hover:text-ink")}>Routines &amp; calls</button>
           <button onClick={() => setSection("webhooks")} className={cn("flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11.5px] font-medium", section === "webhooks" ? "bg-accent/12 text-accent" : "text-ink-secondary hover:bg-raised hover:text-ink")}><Webhook size={12} />Webhooks{state.webhooks.length > 0 && <span className="rounded-full bg-accent/15 px-1.5 text-[9px]">{state.webhooks.length}</span>}</button>
           {error && <button onClick={() => setError("")} className="ml-auto flex items-center gap-1.5 rounded-lg bg-danger/10 px-2.5 py-1.5 text-[10.5px] text-danger"><CircleAlert size={11} />{error}<X size={11} /></button>}

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -1006,6 +1006,8 @@ export function RoutinesPage({ onBack }: { onBack: () => void }) {
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const backButtonRef = useRef<HTMLButtonElement>(null);
+  const [leaving, setLeaving] = useState(false);
+  const exitTimerRef = useRef<number | null>(null);
   const [section, setSection] = useState<"calendar" | "webhooks">("calendar");
   const [viewDays, setViewDays] = useState<1 | 3 | 7>(7);
   const [anchor, setAnchor] = useState(() => startOfDay(Date.now()));
@@ -1068,6 +1070,25 @@ export function RoutinesPage({ onBack }: { onBack: () => void }) {
     setSelected(null);
     setQuick({ kind: "routine", at: nextHour(), durationMinutes: 30, botIds: [], ...seed });
   }, []);
+  const finishClose = useCallback(() => {
+    if (exitTimerRef.current === null) return;
+    window.clearTimeout(exitTimerRef.current);
+    exitTimerRef.current = null;
+    onBack();
+  }, [onBack]);
+  const close = () => {
+    if (leaving) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      onBack();
+      return;
+    }
+    setLeaving(true);
+    exitTimerRef.current = window.setTimeout(finishClose, 220);
+  };
+
+  useEffect(() => () => {
+    if (exitTimerRef.current !== null) window.clearTimeout(exitTimerRef.current);
+  }, []);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -1121,7 +1142,12 @@ export function RoutinesPage({ onBack }: { onBack: () => void }) {
   };
 
   return (
-    <main className="flex h-full min-w-0 flex-1 flex-col bg-app">
+    <main
+      className={cn("flex h-full min-w-0 flex-1 flex-col bg-app", leaving ? "pointer-events-none animate-workspace-out" : "animate-workspace-in")}
+      onAnimationEnd={(event) => {
+        if (leaving && event.target === event.currentTarget) finishClose();
+      }}
+    >
       <header
         className={cn("shrink-0 border-b border-hairline/35 bg-app py-3 pr-4", macInset ? "pl-[86px]" : "pl-4")}
         style={windowDragStyle}
@@ -1130,7 +1156,7 @@ export function RoutinesPage({ onBack }: { onBack: () => void }) {
           <button
             type="button"
             ref={backButtonRef}
-            onClick={onBack}
+            onClick={close}
             aria-label="Back"
             title="Back"
             className="flex size-9 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -24,7 +24,6 @@ import {
   Loader2,
   Paperclip,
   Pause,
-  Phone,
   Play,
   Plus,
   Repeat2,
@@ -37,13 +36,11 @@ import {
 } from "lucide-react";
 
 import { BotAvatar } from "@/components/Avatar";
-import { CallTargetButton } from "@/components/CallView";
 import { pathForFile } from "@/components/ComposerAttachments";
 import { CalendarSidebar } from "@/components/routines/CalendarSidebar";
 import { useDesktopCapabilities } from "@/components/DesktopCapabilities";
 import { WebhooksPanel } from "@/components/WebhooksPanel";
 import type { CalendarCall, CalendarCallAttachment, CalendarCallInput } from "@/lib/calendar-calls";
-import { startCall } from "@/lib/call";
 import { cn } from "@/lib/cn";
 import {
   imageAttachmentFromFile,
@@ -841,6 +838,7 @@ function EventDetails({
   onClose,
   onEdit,
   onCallChanged,
+  onOpenRoom,
 }: {
   item: CalendarEventItem;
   bots: Bot[];
@@ -848,6 +846,7 @@ function EventDetails({
   onClose: () => void;
   onEdit: () => void;
   onCallChanged: (id: string | null) => void;
+  onOpenRoom: (id: string) => void;
 }) {
   const { dispatch } = useStore();
   const [working, setWorking] = useState(false);
@@ -863,6 +862,7 @@ function EventDetails({
   const description = call?.description ?? routine?.prompt ?? run?.prompt ?? "";
   const attachments = call?.attachments ?? routine?.attachments ?? run?.attachments ?? [];
   const group = call && call.botIds.length > 1 ? groups.find((candidate) => sameMembers(candidate, call.botIds)) : undefined;
+  const roomId = call?.botIds.length === 1 ? primary?.id : group?.id;
 
   const invoke = async (path: string, method = "POST") => {
     setWorking(true);
@@ -888,13 +888,11 @@ function EventDetails({
         body: JSON.stringify({
           name: call.name,
           memberIds: call.botIds,
-          setup: { bulletin: call.description, defaultResponder: { kind: "mentions" } },
+          setup: { bulletin: call.description, defaultResponder: { kind: "everyone" } },
         }),
       });
       dispatch({ type: "groupPatched", group: created });
-      dispatch({ type: "select", id: created.id });
-      setTimeout(() => startCall(created.id), 0);
-      onClose();
+      onOpenRoom(created.id);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -945,13 +943,8 @@ function EventDetails({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 border-t border-hairline/40 px-4 py-3">
-          {call && call.botIds.length === 1 && primary && (
-            <div className="flex items-center gap-2 rounded-lg bg-accent/10 pl-2 pr-1 text-[12px] font-medium text-accent"><span>Join call</span><CallTargetButton targetId={primary.id} targetName={primary.name} voices={[primary.voice]} setupBotId={primary.id} requireExplicitVoices={false} onStart={() => { dispatch({ type: "select", id: primary.id }); onClose(); }} /></div>
-          )}
-          {call && call.botIds.length > 1 && group && (
-            <div className="flex items-center gap-2 rounded-lg bg-accent/10 pl-2 pr-1 text-[12px] font-medium text-accent"><span>Join call</span><CallTargetButton targetId={group.id} targetName={group.name} voices={invited.map((bot) => bot.voice)} setupBotId={invited.find((bot) => !bot.voice)?.id ?? invited[0]?.id} requireExplicitVoices onStart={() => { dispatch({ type: "select", id: group.id }); onClose(); }} /></div>
-          )}
-          {call && call.botIds.length > 1 && !group && <button onClick={createRoomAndJoin} disabled={working} className="flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><Phone size={14} />Create room &amp; join</button>}
+          {roomId && <button onClick={() => onOpenRoom(roomId)} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110"><ExternalLink size={13} />Join room</button>}
+          {call && call.botIds.length > 1 && !group && <button onClick={createRoomAndJoin} disabled={working} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><ExternalLink size={13} />Create room &amp; join</button>}
           {routine && <button onClick={() => void invoke(`/api/routines/${routine.id}/run`)} disabled={working} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><Play size={13} />Run now</button>}
           {run?.threadId && primary && <button onClick={() => { dispatch({ type: "select", id: primary.id }); dispatch({ type: "switchTask", botId: primary.id, threadId: run.threadId! }); onClose(); }} className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink"><ExternalLink size={13} />Open task</button>}
           {run && ["queued", "running", "waiting"].includes(run.status) && <button onClick={() => void invoke(`/api/routine-runs/${run.id}/cancel`)} disabled={working} className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40"><X size={13} />Cancel run</button>}
@@ -1002,7 +995,7 @@ export function RoutineEditor({
   return <EventEditor seed={{ kind: "routine", at, durationMinutes: routine?.durationMinutes ?? 30, botIds: lockedBotId ? [lockedBotId] : routine ? [routine.botId] : [], routine }} bots={bots} lockedBotId={lockedBotId} defaultRunOn={defaultRunOn} onClose={onClose} onSavedCall={() => {}} />;
 }
 
-export function RoutinesPage({ onBack }: { onBack: () => void }) {
+export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpenRoom: (id: string) => void }) {
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const backButtonRef = useRef<HTMLButtonElement>(null);
@@ -1196,7 +1189,7 @@ export function RoutinesPage({ onBack }: { onBack: () => void }) {
 
       {quick && <><div className="fixed inset-0 z-40 bg-black/25" onMouseDown={() => setQuick(null)} /><QuickComposer seed={quick} bots={visibleBots} onClose={() => setQuick(null)} onMore={(seed) => { setQuick(null); setEditor(seed); }} onSavedRoutine={(routine) => dispatch({ type: "routinePatched", routine })} onSavedCall={upsertCall} /></>}
       {editor && <EventEditor seed={editor} bots={visibleBots} onClose={() => setEditor(null)} onSavedCall={upsertCall} />}
-      {liveSelected && <EventDetails item={liveSelected} bots={state.bots} groups={state.groups} onClose={() => setSelected(null)} onEdit={() => { const seed: EventSeed = liveSelected.kind === "call" ? { kind: "call", at: liveSelected.at, durationMinutes: liveSelected.call.durationMinutes, botIds: liveSelected.call.botIds, call: liveSelected.call } : { kind: "routine", at: liveSelected.at, durationMinutes: liveSelected.routine?.durationMinutes ?? liveSelected.run?.durationMinutes ?? 30, botIds: [liveSelected.routine?.botId ?? liveSelected.run?.botId ?? ""].filter(Boolean), routine: liveSelected.routine ?? undefined }; setSelected(null); setEditor(seed); }} onCallChanged={(id) => { if (id) setCalls((current) => current.filter((call) => call.id !== id)); else void loadCalls(); }} />}
+      {liveSelected && <EventDetails item={liveSelected} bots={state.bots} groups={state.groups} onClose={() => setSelected(null)} onEdit={() => { const seed: EventSeed = liveSelected.kind === "call" ? { kind: "call", at: liveSelected.at, durationMinutes: liveSelected.call.durationMinutes, botIds: liveSelected.call.botIds, call: liveSelected.call } : { kind: "routine", at: liveSelected.at, durationMinutes: liveSelected.routine?.durationMinutes ?? liveSelected.run?.durationMinutes ?? 30, botIds: [liveSelected.routine?.botId ?? liveSelected.run?.botId ?? ""].filter(Boolean), routine: liveSelected.routine ?? undefined }; setSelected(null); setEditor(seed); }} onCallChanged={(id) => { if (id) setCalls((current) => current.filter((call) => call.id !== id)); else void loadCalls(); }} onOpenRoom={onOpenRoom} />}
       {pausedOpen && <PausedList routines={paused} bots={state.bots} onClose={() => setPausedOpen(false)} onEdit={(routine) => { setPausedOpen(false); const at = routine.schedule.type === "once" ? routine.schedule.at : atLocalTime(Date.now(), routine.schedule.time); setEditor({ kind: "routine", at, durationMinutes: routine.durationMinutes, botIds: [routine.botId], routine }); }} />}
     </main>
   );

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -72,7 +72,7 @@ import type {
   RoutineRunStatus,
   RoutineSchedule,
 } from "@/lib/routines";
-import { api, useStore, type Bot, type Group } from "@/state/store";
+import { api, useStore, type Bot } from "@/state/store";
 
 const HOUR_HEIGHT = 64;
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -181,12 +181,6 @@ function statusState(status: RoutineRunStatus): MausState {
   if (status === "failed" || status === "missed") return "sad";
   if (status === "cancelled") return "sleeping";
   return "drowsy";
-}
-
-function sameMembers(group: Group, botIds: string[]): boolean {
-  if (group.dm || group.memberIds.length !== botIds.length) return false;
-  const wanted = new Set(botIds);
-  return group.memberIds.every((id) => wanted.has(id));
 }
 
 function AttachmentChips({
@@ -459,7 +453,9 @@ function EventEditor({
               <div className="text-[11px] leading-relaxed text-ink-secondary">
                 {kind === "routine"
                   ? "Attachments are passed to each local routine run and excluded from shared team files."
-                  : "References remain on this calendar event. Share them in chat when the call starts."}
+                  : selectedBots.length > 1
+                    ? "References will be shared in the room when the event starts."
+                    : "References stay with the event and are available when you join the room."}
               </div>
               {attachmentNotice && <div className="text-[11.5px] text-warning">{attachmentNotice}</div>}
             </div>
@@ -834,7 +830,6 @@ function CalendarGrid({
 function EventDetails({
   item,
   bots,
-  groups,
   onClose,
   onEdit,
   onCallChanged,
@@ -842,7 +837,6 @@ function EventDetails({
 }: {
   item: CalendarEventItem;
   bots: Bot[];
-  groups: Group[];
   onClose: () => void;
   onEdit: () => void;
   onCallChanged: (id: string | null) => void;
@@ -861,8 +855,7 @@ function EventDetails({
   const title = call?.name ?? routine?.name ?? run?.routineName ?? "Routine";
   const description = call?.description ?? routine?.prompt ?? run?.prompt ?? "";
   const attachments = call?.attachments ?? routine?.attachments ?? run?.attachments ?? [];
-  const group = call && call.botIds.length > 1 ? groups.find((candidate) => sameMembers(candidate, call.botIds)) : undefined;
-  const roomId = call?.botIds.length === 1 ? primary?.id : group?.id;
+  const roomId = call?.botIds.length === 1 ? primary?.id : undefined;
 
   const invoke = async (path: string, method = "POST") => {
     setWorking(true);
@@ -878,19 +871,12 @@ function EventDetails({
     }
   };
 
-  const createRoomAndJoin = async () => {
+  const joinRoom = async () => {
     if (!call) return;
     setWorking(true);
     setError("");
     try {
-      const { group: created } = await api("/api/groups", {
-        method: "POST",
-        body: JSON.stringify({
-          name: call.name,
-          memberIds: call.botIds,
-          setup: { bulletin: call.description, defaultResponder: { kind: "everyone" } },
-        }),
-      });
+      const { group: created } = await api(`/api/calendar-calls/${call.id}/room`, { method: "POST" });
       dispatch({ type: "groupPatched", group: created });
       onOpenRoom(created.id);
     } catch (cause) {
@@ -935,7 +921,7 @@ function EventDetails({
             </div>
           </div>
           {description && <div className="flex items-start gap-3"><FileText size={17} className="mt-1 shrink-0 text-ink-secondary" /><div className="whitespace-pre-wrap text-[12.5px] leading-relaxed text-ink">{description}</div></div>}
-          {attachments.length > 0 && <div className="flex items-start gap-3"><Paperclip size={17} className="mt-1 shrink-0 text-ink-secondary" /><div className="min-w-0 flex-1 space-y-2"><AttachmentChips attachments={attachments} />{call && <div className="text-[11px] leading-relaxed text-ink-secondary">These references stay on the calendar event. Share them in chat when the call starts.</div>}</div></div>}
+          {attachments.length > 0 && <div className="flex items-start gap-3"><Paperclip size={17} className="mt-1 shrink-0 text-ink-secondary" /><div className="min-w-0 flex-1 space-y-2"><AttachmentChips attachments={attachments} />{call && <div className="text-[11px] leading-relaxed text-ink-secondary">{call.botIds.length > 1 ? "These references will be shared in the room when the event starts." : "These references stay with the event and are available when you join the room."}</div>}</div></div>}
           {run && <div className="rounded-xl border border-hairline/40 bg-inset p-3"><div className="flex items-center gap-2 text-[12px] font-medium capitalize text-ink">{run.status === "running" && <Loader2 size={13} className="animate-spin text-accent" />}{run.status.replace("waiting", "needs you")}</div>{run.output && <div className="mt-2 whitespace-pre-wrap text-[11.5px] leading-relaxed text-ink-secondary">{run.output}</div>}{run.error && <div className="mt-2 text-[11.5px] text-danger">{run.error}</div>}</div>}
           {run?.attention && <div className="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2.5 text-warning"><CircleAlert size={15} className="mt-0.5 shrink-0" /><div className="min-w-0"><div className="text-[11.5px] font-semibold">Needs your attention</div><div className="mt-1 whitespace-pre-wrap text-[11.5px] leading-relaxed">{run.attention}</div></div></div>}
           {run?.status === "waiting" && !run.attention && <div className="rounded-xl border border-warning/30 bg-warning/10 px-3 py-2.5 text-[11.5px] text-warning">This bot needs your answer. Open its task to continue the run.</div>}
@@ -944,7 +930,7 @@ function EventDetails({
 
         <div className="flex flex-wrap items-center gap-2 border-t border-hairline/40 px-4 py-3">
           {roomId && <button onClick={() => onOpenRoom(roomId)} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110"><ExternalLink size={13} />Join room</button>}
-          {call && call.botIds.length > 1 && !group && <button onClick={createRoomAndJoin} disabled={working} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><ExternalLink size={13} />Create room &amp; join</button>}
+          {call && call.botIds.length > 1 && <button onClick={joinRoom} disabled={working} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><ExternalLink size={13} />Join room</button>}
           {routine && <button onClick={() => void invoke(`/api/routines/${routine.id}/run`)} disabled={working} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-50"><Play size={13} />Run now</button>}
           {run?.threadId && primary && <button onClick={() => { dispatch({ type: "select", id: primary.id }); dispatch({ type: "switchTask", botId: primary.id, threadId: run.threadId! }); onClose(); }} className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink"><ExternalLink size={13} />Open task</button>}
           {run && ["queued", "running", "waiting"].includes(run.status) && <button onClick={() => void invoke(`/api/routine-runs/${run.id}/cancel`)} disabled={working} className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40"><X size={13} />Cancel run</button>}
@@ -999,8 +985,6 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const backButtonRef = useRef<HTMLButtonElement>(null);
-  const [leaving, setLeaving] = useState(false);
-  const exitTimerRef = useRef<number | null>(null);
   const [section, setSection] = useState<"calendar" | "webhooks">("calendar");
   const [viewDays, setViewDays] = useState<1 | 3 | 7>(7);
   const [anchor, setAnchor] = useState(() => startOfDay(Date.now()));
@@ -1063,25 +1047,6 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
     setSelected(null);
     setQuick({ kind: "routine", at: nextHour(), durationMinutes: 30, botIds: [], ...seed });
   }, []);
-  const finishClose = useCallback(() => {
-    if (exitTimerRef.current === null) return;
-    window.clearTimeout(exitTimerRef.current);
-    exitTimerRef.current = null;
-    onBack();
-  }, [onBack]);
-  const close = () => {
-    if (leaving) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      onBack();
-      return;
-    }
-    setLeaving(true);
-    exitTimerRef.current = window.setTimeout(finishClose, 220);
-  };
-
-  useEffect(() => () => {
-    if (exitTimerRef.current !== null) window.clearTimeout(exitTimerRef.current);
-  }, []);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -1135,12 +1100,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
   };
 
   return (
-    <main
-      className={cn("flex h-full min-w-0 flex-1 flex-col bg-app", leaving ? "pointer-events-none animate-workspace-out" : "animate-workspace-in")}
-      onAnimationEnd={(event) => {
-        if (leaving && event.target === event.currentTarget) finishClose();
-      }}
-    >
+    <main className="flex h-full min-w-0 flex-1 flex-col bg-app animate-workspace-in">
       <header
         className={cn("shrink-0 border-b border-hairline/35 bg-app py-3 pr-4", macInset ? "pl-[86px]" : "pl-4")}
         style={windowDragStyle}
@@ -1149,7 +1109,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
           <button
             type="button"
             ref={backButtonRef}
-            onClick={close}
+            onClick={onBack}
             aria-label="Back"
             title="Back"
             className="flex size-9 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
@@ -1189,7 +1149,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
 
       {quick && <><div className="fixed inset-0 z-40 bg-black/25" onMouseDown={() => setQuick(null)} /><QuickComposer seed={quick} bots={visibleBots} onClose={() => setQuick(null)} onMore={(seed) => { setQuick(null); setEditor(seed); }} onSavedRoutine={(routine) => dispatch({ type: "routinePatched", routine })} onSavedCall={upsertCall} /></>}
       {editor && <EventEditor seed={editor} bots={visibleBots} onClose={() => setEditor(null)} onSavedCall={upsertCall} />}
-      {liveSelected && <EventDetails item={liveSelected} bots={state.bots} groups={state.groups} onClose={() => setSelected(null)} onEdit={() => { const seed: EventSeed = liveSelected.kind === "call" ? { kind: "call", at: liveSelected.at, durationMinutes: liveSelected.call.durationMinutes, botIds: liveSelected.call.botIds, call: liveSelected.call } : { kind: "routine", at: liveSelected.at, durationMinutes: liveSelected.routine?.durationMinutes ?? liveSelected.run?.durationMinutes ?? 30, botIds: [liveSelected.routine?.botId ?? liveSelected.run?.botId ?? ""].filter(Boolean), routine: liveSelected.routine ?? undefined }; setSelected(null); setEditor(seed); }} onCallChanged={(id) => { if (id) setCalls((current) => current.filter((call) => call.id !== id)); else void loadCalls(); }} onOpenRoom={onOpenRoom} />}
+      {liveSelected && <EventDetails item={liveSelected} bots={state.bots} onClose={() => setSelected(null)} onEdit={() => { const seed: EventSeed = liveSelected.kind === "call" ? { kind: "call", at: liveSelected.at, durationMinutes: liveSelected.call.durationMinutes, botIds: liveSelected.call.botIds, call: liveSelected.call } : { kind: "routine", at: liveSelected.at, durationMinutes: liveSelected.routine?.durationMinutes ?? liveSelected.run?.durationMinutes ?? 30, botIds: [liveSelected.routine?.botId ?? liveSelected.run?.botId ?? ""].filter(Boolean), routine: liveSelected.routine ?? undefined }; setSelected(null); setEditor(seed); }} onCallChanged={(id) => { if (id) setCalls((current) => current.filter((call) => call.id !== id)); else void loadCalls(); }} onOpenRoom={onOpenRoom} />}
       {pausedOpen && <PausedList routines={paused} bots={state.bots} onClose={() => setPausedOpen(false)} onEdit={(routine) => { setPausedOpen(false); const at = routine.schedule.type === "once" ? routine.schedule.at : atLocalTime(Date.now(), routine.schedule.time); setEditor({ kind: "routine", at, durationMinutes: routine.durationMinutes, botIds: [routine.botId], routine }); }} />}
     </main>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1687,8 +1687,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         )}
         <button
           onClick={() => dispatch({ type: "showRoutines" })}
-          aria-label={density === "icons" ? "Tasks and routines" : undefined}
-          title={density === "icons" ? "Tasks and routines" : undefined}
+          aria-label={density === "icons" ? "Calendar" : undefined}
+          title={density === "icons" ? "Calendar" : undefined}
           className={cn(
             "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
             density === "icons" ? "justify-center px-2" : "gap-3 px-3",
@@ -1696,7 +1696,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           )}
         >
           <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Tasks &amp; routines</span>
+          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Calendar</span>
           {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
             <span className="size-2 rounded-full bg-danger" />
           )}

--- a/src/components/routines/CalendarSidebar.tsx
+++ b/src/components/routines/CalendarSidebar.tsx
@@ -32,7 +32,7 @@ export function CalendarSidebar({ bots, anchor, onSelectDate, onCreate }: Calend
   return (
     <aside
       aria-label="Calendar sidebar"
-      className="flex h-full w-[238px] shrink-0 flex-col overflow-hidden border-r border-hairline/40 bg-panel/55"
+      className="flex h-full w-[320px] shrink-0 flex-col overflow-hidden border-r border-hairline/40 bg-panel"
     >
       <div className="px-4 pb-2 pt-4">
         <button

--- a/src/lib/calendar-calls.ts
+++ b/src/lib/calendar-calls.ts
@@ -1,5 +1,5 @@
-/** A calendar call is a reminder to join a live bot call. It is never run by
- * the routine scheduler automatically. */
+/** A calendar call opens a shared bot room and posts its seed prompt at the
+ * scheduled time. Joining the room never starts audio automatically. */
 export type CalendarCallSchedule =
   | { type: "once"; at: number }
   | { type: "daily"; time: string; weekdays: number[] };
@@ -23,6 +23,8 @@ export interface CalendarCall {
   schedule: CalendarCallSchedule;
   durationMinutes: number;
   attachments: CalendarCallAttachment[];
+  roomId?: string;
+  nextRunAt: number | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,6 @@
 @theme {
   --animate-panel-in: panel-in 0.24s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-workspace-in: workspace-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
-  --animate-workspace-out: workspace-out 0.14s cubic-bezier(0.4, 0, 1, 1) both;
   --animate-pop-in: pop-in 0.2s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-caret: caret-blink 1s step-end infinite;
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
@@ -328,10 +327,6 @@ body {
 @keyframes workspace-in {
   from { opacity: 0.92; }
   to { opacity: 1; }
-}
-@keyframes workspace-out {
-  from { opacity: 1; }
-  to { opacity: 0; }
 }
 @keyframes pop-in {
   from { transform: scale(0.96) translateY(6px); opacity: 0; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,8 @@
    ───────────────────────────────────────────────────────────────────────── */
 @theme {
   --animate-panel-in: panel-in 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+  --animate-workspace-in: workspace-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  --animate-workspace-out: workspace-out 0.14s cubic-bezier(0.4, 0, 1, 1) both;
   --animate-pop-in: pop-in 0.2s cubic-bezier(0.22, 1, 0.36, 1);
   --animate-caret: caret-blink 1s step-end infinite;
   --animate-msg-in: msg-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
@@ -322,6 +324,14 @@ body {
 @keyframes panel-in {
   from { transform: translateX(28px); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
+}
+@keyframes workspace-in {
+  from { opacity: 0.92; }
+  to { opacity: 1; }
+}
+@keyframes workspace-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 @keyframes pop-in {
   from { transform: scale(0.96) translateY(6px); opacity: 0; }


### PR DESCRIPTION
## Summary
- open Calendar as a focused full-width workspace
- keep the calendar rail while hiding the global bot sidebar and mobile drawer
- add an accessible Back action that returns to the originating screen
- rename the global entry to Calendar and preserve macOS window controls and dragging

## Verification
- pnpm typecheck
- pnpm build
- focused Oxlint and diff checks
- live browser smoke: chat and Team Map → Calendar → Back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a back button to the Calendar view, returning you to the previous screen.
  * Calendar events can now open shared rooms for multi-bot sessions.
  * Scheduled events now automatically deliver prompts at their scheduled times.
  * Improved desktop window interactions and keyboard focus in the Calendar header.

* **Updates**
  * Renamed “Tasks & routines” to “Calendar.”
  * Expanded and clarified the Calendar sidebar layout.
  * Simplified Calendar view by hiding navigation menus and sidebars while open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->