### PR TITLE
feat(channels): add bounded goal-driven team runs

### DIFF
--- a/server/group-goal-run.e2e.test.ts
+++ b/server/group-goal-run.e2e.test.ts
@@ -1,0 +1,227 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { freePortBlock } from "./testing/ports.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+
+let child: ChildProcess;
+let home = "";
+let base = "";
+let stderr = "";
+
+const completeReplies = [
+  [
+    "Scout should verify the draft.\n<openmaus-goal>{\"status\":\"continue\",",
+    "\"next\":\"Scout\",\"instruction\":\"Verify the draft and report evidence\",\"detail\":\"Draft prepared\"}</openmaus-goal>",
+  ],
+  "The draft is accurate and the cited evidence checks out.",
+  "The verified draft is ready to ship.\n<openmaus-goal>{\"status\":\"completed\",\"detail\":\"Draft produced and independently verified.\"}</openmaus-goal>",
+];
+
+const loopReplies = Array.from({ length: 13 }, (_, index) =>
+  index % 2 === 0
+    ? `More work is needed.\n<openmaus-goal>{"status":"continue","next":"Looper","instruction":"Try approach ${index / 2 + 1}","detail":"Still working"}</openmaus-goal>`
+    : `Approach ${Math.ceil(index / 2)} did not finish the task.`,
+);
+
+const api = async (method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> => {
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: response.status, body: await response.json() };
+};
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "omb-goal-run-"));
+  const data = join(home, ".openmausbot");
+  const staticDir = join(home, "static");
+  mkdirSync(data, { recursive: true });
+  mkdirSync(join(staticDir, "assets"), { recursive: true });
+  writeFileSync(join(staticDir, "index.html"), "<!doctype html><title>Goal run test</title>");
+  writeFileSync(join(staticDir, "assets", "smoke.css"), "body{}");
+  writeFileSync(join(data, "config.json"), JSON.stringify({
+    instances: {
+      complete: {
+        driver: "claudeAgent",
+        displayName: "Completing fixture",
+        environment: {
+          FAKE_CLAUDE_MODE: "happy",
+          FAKE_CLAUDE_REPLIES: JSON.stringify(completeReplies),
+          FAKE_CLAUDE_REPLY_STATE: join(home, "complete-replies.txt"),
+        },
+        config: { cli: FAKE_CLAUDE },
+      },
+      loop: {
+        driver: "claudeAgent",
+        displayName: "Looping fixture",
+        environment: {
+          FAKE_CLAUDE_MODE: "happy",
+          FAKE_CLAUDE_REPLIES: JSON.stringify(loopReplies),
+          FAKE_CLAUDE_REPLY_STATE: join(home, "loop-replies.txt"),
+        },
+        config: { cli: FAKE_CLAUDE },
+      },
+      crash: {
+        driver: "claudeAgent",
+        displayName: "Failing fixture",
+        environment: { FAKE_CLAUDE_MODE: "exit-early" },
+        config: { cli: FAKE_CLAUDE },
+      },
+    },
+  }));
+  const port = await freePortBlock([0, 1]);
+  base = `http://127.0.0.1:${port}`;
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(port),
+      OMB_WEBHOOK_PORT: String(port + 1),
+      OMB_STATIC_DIR: staticDir,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr!.on("data", (chunk) => (stderr += chunk));
+
+  const deadline = Date.now() + 20_000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}: ${stderr}`);
+    try {
+      if ((await fetch(`${base}/api/health`)).status === 200) break;
+    } catch {
+      // Still starting.
+    }
+    if (Date.now() >= deadline) throw new Error(`server never became healthy: ${stderr}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}, 30_000);
+
+afterAll(async () => {
+  if (child) await waitForExit(child, { signal: "SIGTERM" });
+  if (home) await removeTempDir(home);
+});
+
+describe("goal-driven channel runs", () => {
+  it("returns to the lead until the goal is completed and appends a clean receipt", async () => {
+    const lead = (await api("POST", "/api/bots", {
+      name: "Lead",
+      modelSelection: { instanceId: "complete", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    const scout = (await api("POST", "/api/bots", {
+      name: "Scout",
+      modelSelection: { instanceId: "complete", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Launch team",
+      memberIds: [lead.id, scout.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: lead.id } },
+    })).body.group;
+
+    const sent = await api("POST", `/api/groups/${room.id}/messages`, {
+      text: "Produce and verify the launch draft",
+      mode: "goal",
+      sendId: "goal_send_1234567890",
+    });
+    expect(sent.status).toBe(202);
+    expect(sent.body.message).toMatchObject({ channelMode: "goal" });
+
+    await expect.poll(async () => {
+      const state = (await api("GET", "/api/bots?messages=30")).body;
+      const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+      return current?.messages.find((message: { kind: string }) => message.kind === "goal.run")?.goalRun;
+    }, { timeout: 10_000 }).toMatchObject({
+      status: "completed",
+      coordinatorBotId: lead.id,
+      turnCount: 3,
+      detail: "Draft produced and independently verified.",
+    });
+
+    const state = (await api("GET", "/api/bots?messages=30")).body;
+    const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+    expect(current.messages.find((message: { kind: string }) => message.kind === "goal.run")?.text)
+      .toBe("Goal completed: Draft produced and independently verified.");
+    expect(current.working).toBe(false);
+    expect(current.messages.filter((message: { kind: string; role?: string }) => message.kind === "text" && message.role === "bot")
+      .map((message: { from?: { name?: string } }) => message.from?.name)).toEqual(["Lead", "Scout", "Lead"]);
+    expect(JSON.stringify(current.messages)).not.toContain("<openmaus-goal>");
+  });
+
+  it("pauses a non-converging team at the hard turn limit", async () => {
+    const looper = (await api("POST", "/api/bots", {
+      name: "Looper",
+      modelSelection: { instanceId: "loop", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Bounded team",
+      memberIds: [looper.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: looper.id } },
+    })).body.group;
+    expect((await api("POST", `/api/groups/${room.id}/messages`, {
+      text: "Keep trying forever",
+      mode: "goal",
+    })).status).toBe(202);
+
+    await expect.poll(async () => {
+      const state = (await api("GET", "/api/bots?messages=40")).body;
+      const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+      return current?.messages.find((message: { kind: string }) => message.kind === "goal.run")?.goalRun;
+    }, { timeout: 15_000 }).toMatchObject({ status: "limit-reached", turnCount: 13, maxTurns: 13 });
+  });
+
+  it("never treats a failed provider turn as a completed goal", async () => {
+    const lead = (await api("POST", "/api/bots", {
+      name: "Failing lead",
+      modelSelection: { instanceId: "crash", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Failure checks",
+      memberIds: [lead.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: lead.id } },
+    })).body.group;
+
+    expect((await api("POST", `/api/groups/${room.id}/messages`, {
+      text: "Do not claim this succeeded",
+      mode: "goal",
+    })).status).toBe(202);
+
+    await expect.poll(async () => {
+      const state = (await api("GET", "/api/bots?messages=20")).body;
+      const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+      return current?.messages.find((message: { kind: string }) => message.kind === "goal.run")?.goalRun;
+    }, { timeout: 10_000 }).toMatchObject({ status: "failed", turnCount: 1 });
+  });
+
+  it("validates mode and binds it to the send id", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Mode checks",
+      memberIds: [bot.id],
+      setup: { bulletin: "", defaultResponder: { kind: "mentions" } },
+    })).body.group;
+    expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "hello", mode: "forever" })).status).toBe(400);
+    const body = { text: "quiet note", mode: "chat", sendId: "mode_send_1234567890" };
+    expect((await api("POST", `/api/groups/${room.id}/messages`, body)).status).toBe(202);
+    expect((await api("POST", `/api/groups/${room.id}/messages`, { ...body, mode: "goal" })).status).toBe(409);
+
+    const dm = (await api("GET", "/api/bots?messages=0")).body.groups.find((group: { dm?: boolean }) => group.dm);
+    if (dm) expect((await api("POST", `/api/groups/${dm.id}/messages`, { text: "goal", mode: "goal" })).status).toBe(400);
+  });
+});

--- a/server/group-goal-run.test.ts
+++ b/server/group-goal-run.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  GROUP_GOAL_CONTROL_CLOSE,
+  GROUP_GOAL_CONTROL_OPEN,
+  GROUP_GOAL_MAX_TURNS,
+  groupGoalAssignmentKey,
+  parseGroupGoalDecision,
+  resolveGroupGoalMember,
+  selectGroupGoalCoordinator,
+} from "./group-goal-run.ts";
+
+const members = [
+  { id: "scout-id", name: "Scout" },
+  { id: "chief-id", name: "Miso", chiefOfStaff: true },
+  { id: "old-id", name: "Old", hidden: true },
+];
+
+describe("group goal runs", () => {
+  it("strips and validates a coordinator decision", () => {
+    const parsed = parseGroupGoalDecision(
+      `I am asking Scout to verify it.\n${GROUP_GOAL_CONTROL_OPEN}`
+      + `{"status":"continue","next":"@Scout","instruction":"Verify the release","detail":"Draft ready"}`
+      + GROUP_GOAL_CONTROL_CLOSE,
+    );
+    expect(parsed.visibleText).toBe("I am asking Scout to verify it.");
+    expect(parsed.decision).toEqual({
+      status: "continue",
+      next: "@Scout",
+      instruction: "Verify the release",
+      detail: "Draft ready",
+    });
+  });
+
+  it("fails closed on incomplete or malformed decisions", () => {
+    expect(parseGroupGoalDecision("ordinary reply")).toEqual({ visibleText: "ordinary reply", decision: null });
+    expect(parseGroupGoalDecision(
+      `${GROUP_GOAL_CONTROL_OPEN}{"status":"continue","next":"Scout"}${GROUP_GOAL_CONTROL_CLOSE}`,
+    ).decision).toBeNull();
+    expect(parseGroupGoalDecision(
+      `${GROUP_GOAL_CONTROL_OPEN}{not json}${GROUP_GOAL_CONTROL_CLOSE}`,
+    ).decision).toBeNull();
+    expect(parseGroupGoalDecision(
+      `Safe update\n${GROUP_GOAL_CONTROL_OPEN}{"status":"continue"}`,
+    )).toEqual({ visibleText: "Safe update", decision: null });
+  });
+
+  it("removes every private envelope while the last complete one controls", () => {
+    const parsed = parseGroupGoalDecision(
+      `First\n${GROUP_GOAL_CONTROL_OPEN}{"status":"blocked","detail":"old"}${GROUP_GOAL_CONTROL_CLOSE}`
+      + `\nFinal\n${GROUP_GOAL_CONTROL_OPEN}{"status":"completed","detail":"done"}${GROUP_GOAL_CONTROL_CLOSE}`,
+    );
+    expect(parsed.visibleText).toBe("First\n\nFinal");
+    expect(parsed.decision).toEqual({ status: "completed", detail: "done" });
+  });
+
+  it("honors an explicit active lead, then an in-room Chief", () => {
+    expect(selectGroupGoalCoordinator(members, { kind: "member", botId: "scout-id" })?.id).toBe("scout-id");
+    expect(selectGroupGoalCoordinator(members, { kind: "everyone" })?.id).toBe("chief-id");
+    expect(selectGroupGoalCoordinator(members, { kind: "member", botId: "old-id" })?.id).toBe("chief-id");
+  });
+
+  it("resolves only an exact active room member", () => {
+    expect(resolveGroupGoalMember("@SCOUT", members)?.id).toBe("scout-id");
+    expect(resolveGroupGoalMember("chief-id", members)?.name).toBe("Miso");
+    expect(resolveGroupGoalMember("Old", members)).toBeNull();
+    expect(resolveGroupGoalMember("Sco", members)).toBeNull();
+    expect(resolveGroupGoalMember("Scout", [
+      ...members,
+      { id: "other-scout", name: "Scout" },
+    ])).toBeNull();
+    expect(resolveGroupGoalMember("other-scout", [
+      ...members,
+      { id: "other-scout", name: "Scout" },
+    ])?.id).toBe("other-scout");
+  });
+
+  it("normalizes repeated assignments for no-progress detection", () => {
+    expect(groupGoalAssignmentKey("scout-id", "  Verify   THE release "))
+      .toBe(groupGoalAssignmentKey("scout-id", "verify the release"));
+  });
+
+  it("reserves the final bounded turn for coordinator evaluation", () => {
+    expect(GROUP_GOAL_MAX_TURNS % 2).toBe(1);
+  });
+});

--- a/server/group-goal-run.ts
+++ b/server/group-goal-run.ts
@@ -1,0 +1,151 @@
+import type { GroupDefaultResponder } from "./store.ts";
+
+// Odd by design: coordinator/worker alternation must always leave the final
+// bounded turn to the coordinator for an honest completion decision.
+export const GROUP_GOAL_MAX_TURNS = 13;
+export const GROUP_GOAL_CONTROL_OPEN = "<openmaus-goal>";
+export const GROUP_GOAL_CONTROL_CLOSE = "</openmaus-goal>";
+
+export type GroupGoalDecision =
+  | { status: "continue"; next: string; instruction: string; detail?: string }
+  | { status: "completed" | "needs-input" | "blocked"; detail: string };
+
+export interface GoalRunMember {
+  id: string;
+  name: string;
+  hidden?: boolean;
+  chiefOfStaff?: boolean;
+}
+
+export interface ParsedGroupGoalDecision {
+  visibleText: string;
+  decision: GroupGoalDecision | null;
+}
+
+const bounded = (value: unknown, max: number): string =>
+  typeof value === "string" ? value.trim().slice(0, max) : "";
+
+function visibleCoordinatorText(text: string): string {
+  let visible = text;
+  for (;;) {
+    const closeAt = visible.indexOf(GROUP_GOAL_CONTROL_CLOSE);
+    if (closeAt < 0) break;
+    const openAt = visible.lastIndexOf(GROUP_GOAL_CONTROL_OPEN, closeAt);
+    if (openAt < 0) {
+      visible = `${visible.slice(0, closeAt)}${visible.slice(closeAt + GROUP_GOAL_CONTROL_CLOSE.length)}`;
+      continue;
+    }
+    visible = `${visible.slice(0, openAt)}${visible.slice(closeAt + GROUP_GOAL_CONTROL_CLOSE.length)}`;
+  }
+  // A truncated final envelope is private protocol too. Keep the prose that
+  // preceded it, but never expose a half-written marker or JSON fragment.
+  const danglingOpen = visible.indexOf(GROUP_GOAL_CONTROL_OPEN);
+  if (danglingOpen >= 0) visible = visible.slice(0, danglingOpen);
+  return visible.replaceAll(GROUP_GOAL_CONTROL_CLOSE, "").trim();
+}
+
+/** Keep the orchestration envelope out of the human transcript while still
+ * accepting ordinary prose before it. The last complete envelope wins: a
+ * quoted example earlier in the reply cannot accidentally steer the run. */
+export function parseGroupGoalDecision(text: string): ParsedGroupGoalDecision {
+  const closeAt = text.lastIndexOf(GROUP_GOAL_CONTROL_CLOSE);
+  const openAt = closeAt < 0 ? -1 : text.lastIndexOf(GROUP_GOAL_CONTROL_OPEN, closeAt);
+  if (openAt < 0 || closeAt < 0) return { visibleText: visibleCoordinatorText(text), decision: null };
+
+  const visibleText = visibleCoordinatorText(text);
+  const payload = text.slice(openAt + GROUP_GOAL_CONTROL_OPEN.length, closeAt).trim();
+  try {
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const status = raw.status;
+    const detail = bounded(raw.detail, 500);
+    if (status === "continue") {
+      const next = bounded(raw.next, 100);
+      const instruction = bounded(raw.instruction, 2_000);
+      if (!next || !instruction) return { visibleText, decision: null };
+      return {
+        visibleText,
+        decision: { status, next, instruction, ...(detail ? { detail } : {}) },
+      };
+    }
+    if (status === "completed" || status === "needs-input" || status === "blocked") {
+      if (!detail) return { visibleText, decision: null };
+      return { visibleText, decision: { status, detail } };
+    }
+  } catch {
+    // A malformed control envelope is a safe pause, never permission to keep
+    // an autonomous loop running on a guess.
+  }
+  return { visibleText, decision: null };
+}
+
+/** Explicit room lead wins. Otherwise prefer an in-room Chief, then the
+ * first active member. A goal run never recruits somebody outside the room. */
+export function selectGroupGoalCoordinator<Member extends GoalRunMember>(
+  members: Member[],
+  responder: GroupDefaultResponder,
+): Member | null {
+  const active = members.filter((member) => !member.hidden);
+  if (responder.kind === "member") {
+    const explicit = active.find((member) => member.id === responder.botId);
+    if (explicit) return explicit;
+  }
+  return active.find((member) => member.chiefOfStaff) ?? active[0] ?? null;
+}
+
+/** Resolve a model-selected teammate without letting fuzzy or duplicate
+ * names choose the wrong person. IDs always work; names work only if unique. */
+export function resolveGroupGoalMember(reference: string, members: GoalRunMember[]): GoalRunMember | null {
+  const wanted = reference.trim().replace(/^@/, "").toLocaleLowerCase();
+  if (!wanted) return null;
+  const active = members.filter((member) => !member.hidden);
+  const idMatch = active.find((member) => member.id.toLocaleLowerCase() === wanted);
+  if (idMatch) return idMatch;
+  const nameMatches = active.filter((member) => member.name.toLocaleLowerCase() === wanted);
+  return nameMatches.length === 1 ? nameMatches[0]! : null;
+}
+
+export function groupGoalCoordinatorInstructions(args: {
+  goal: string;
+  members: GoalRunMember[];
+  turn: number;
+  maxTurns: number;
+  remainingTurns: number;
+}): string {
+  const roster = args.members
+    .filter((member) => !member.hidden)
+    .map((member) => `${member.name} (${member.id})`)
+    .join(", ");
+  return [
+    "You are the lead coordinator for a bounded team goal run.",
+    `Goal: ${args.goal}`,
+    `Available room members: ${roster}.`,
+    `This is team turn ${args.turn} of ${args.maxTurns}; ${args.remainingTurns} turn(s) remain after this one.`,
+    "Use the conversation as the progress ledger. Decide whether the goal is genuinely complete, needs the human, is blocked, or needs one named teammate next.",
+    "Do not continue merely to generate discussion. Do not claim completion unless the requested deliverable or answer is present in the conversation.",
+    "Write a brief human-facing update or final answer, then end with exactly one private control envelope on its own line.",
+    `${GROUP_GOAL_CONTROL_OPEN}{"status":"continue","next":"Exact member id from the roster","instruction":"Concrete next assignment","detail":"Short progress note"}${GROUP_GOAL_CONTROL_CLOSE}`,
+    `Or use status "completed", "needs-input", or "blocked" with a non-empty "detail" and omit next/instruction.`,
+    "Never mention, quote, or explain the control envelope in your human-facing text.",
+  ].join("\n");
+}
+
+export function groupGoalWorkerInstructions(args: {
+  goal: string;
+  coordinatorName: string;
+  assignment: string;
+  turn: number;
+  maxTurns: number;
+}): string {
+  return [
+    `You are a specialist contributing to a bounded team goal run led by ${args.coordinatorName}.`,
+    `Goal: ${args.goal}`,
+    `Your assignment: ${args.assignment}`,
+    `This is team turn ${args.turn} of ${args.maxTurns}.`,
+    "Do the assigned work now and put concrete results, evidence, or a clear blocker in your reply.",
+    `Address your result to ${args.coordinatorName}. Do not invent a new orchestration protocol or emit an openmaus-goal control envelope.`,
+  ].join("\n");
+}
+
+export function groupGoalAssignmentKey(memberId: string, instruction: string): string {
+  return `${memberId}:${instruction.trim().toLocaleLowerCase().replace(/\s+/g, " ")}`;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -104,6 +104,17 @@ import {
   newId,
 } from "./contracts.ts";
 import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
+import {
+  GROUP_GOAL_MAX_TURNS,
+  groupGoalAssignmentKey,
+  groupGoalCoordinatorInstructions,
+  groupGoalWorkerInstructions,
+  parseGroupGoalDecision,
+  resolveGroupGoalMember,
+  selectGroupGoalCoordinator,
+  type GoalRunMember,
+} from "./group-goal-run.ts";
+import type { GroupGoalRunCardData, GroupGoalRunStatus } from "../shared/group-goal-run.ts";
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
@@ -832,6 +843,16 @@ type GroupTurnOperation = {
   botIds: Set<string>;
   cancelled: boolean;
   providerHandshakePending: boolean;
+  goalRun?: {
+    runId: string;
+    goal: string;
+    coordinatorBotId: string;
+    coordinatorName: string;
+    turnCount: number;
+    maxTurns: number;
+    startedAt: number;
+    finished: boolean;
+  };
 };
 
 // busyBotId names only the speaker that currently owns the provider process.
@@ -839,6 +860,81 @@ type GroupTurnOperation = {
 // queued behind that speaker. Keep that operation visible for its whole
 // lifetime so polling clients cannot mistake a handoff for completion.
 const groupTurnOperations = new Map<string, Set<GroupTurnOperation>>();
+
+/** The central runtime fold uses this to hide a coordinator's private
+ * decision envelope from both streaming UI and the durable transcript. */
+type GroupGoalCoordinatorTurn = {
+  token: symbol;
+  turnId?: string;
+  assistantItems: string[];
+  /** A timed-out provider may still emit after the goal operation returns.
+   * Keep swallowing that abandoned turn until its real completion arrives. */
+  discard: boolean;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+};
+const groupGoalCoordinatorTurns = new Map<string, Set<GroupGoalCoordinatorTurn>>();
+const GROUP_GOAL_COORDINATOR_GUARD_MS = 5 * 60_000;
+
+function addGroupGoalCoordinatorTurn(threadId: string, turn: GroupGoalCoordinatorTurn): void {
+  const turns = groupGoalCoordinatorTurns.get(threadId) ?? new Set<GroupGoalCoordinatorTurn>();
+  turns.add(turn);
+  groupGoalCoordinatorTurns.set(threadId, turns);
+}
+
+function removeGroupGoalCoordinatorTurn(threadId: string, turn: GroupGoalCoordinatorTurn): void {
+  if (turn.cleanupTimer) clearTimeout(turn.cleanupTimer);
+  const turns = groupGoalCoordinatorTurns.get(threadId);
+  turns?.delete(turn);
+  if (turns?.size === 0) groupGoalCoordinatorTurns.delete(threadId);
+}
+
+function hasUnboundDiscardedGroupGoalTurn(threadId: string): boolean {
+  return [...(groupGoalCoordinatorTurns.get(threadId) ?? [])]
+    .some((turn) => turn.discard && !turn.turnId);
+}
+
+/** Match private coordinator output to one provider turn, never merely to a
+ * reusable room thread. Most adapters emit turn.started before sendTurn
+ * resolves, so the first stable event may bind an otherwise pending guard. */
+function groupGoalCoordinatorTurnForEvent(event: RuntimeEvent): GroupGoalCoordinatorTurn | undefined {
+  const turns = groupGoalCoordinatorTurns.get(event.threadId);
+  if (!turns?.size) return undefined;
+  const candidates = [...turns];
+  if (event.turnId) {
+    const exact = candidates.find((turn) => turn.turnId === event.turnId);
+    if (exact) return exact;
+    // Until an interrupted handshake returns its own id, no new id can be
+    // attributed safely. The stall fallback keeps this thread unavailable in
+    // that narrow window; private text is suppressed below until sendTurn's
+    // result binds the old guard or its bounded expiry releases ownership.
+    const unboundDiscarded = candidates.filter((turn) => turn.discard && !turn.turnId);
+    if (unboundDiscarded.length > 0) {
+      // The ownership fallback below keeps a lone abandoned handshake's
+      // thread closed, so its first eventual id can safely bind here. More
+      // than one unbound candidate is genuinely ambiguous and stays gated.
+      if (candidates.length === 1) {
+        unboundDiscarded[0]!.turnId = event.turnId;
+        // This event is the first stable identity for an already-abandoned
+        // provider turn. Tombstone it immediately so this event and every
+        // later completion/request cannot settle a replacement on the same
+        // room thread.
+        retireProviderTurn(event.turnId);
+        return unboundDiscarded[0];
+      }
+      return undefined;
+    }
+    const pending = candidates.findLast((turn) => !turn.turnId && !turn.discard);
+    if (pending && !pending.turnId) {
+      pending.turnId = event.turnId;
+      return pending;
+    }
+    return undefined;
+  }
+  // Turn-scoped events normally carry an id. If an adapter omits it, fail
+  // closed for private text; with multiple overlapping guards there is no
+  // safe way to attribute a completion, so leave cleanup to the bounded timer.
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
 
 function groupIsWorking(group: GroupRecord): boolean {
   return Boolean(group.busyBotId) || Boolean(groupTurnOperations.get(group.id)?.size);
@@ -869,6 +965,9 @@ function beginGroupTurnOperation(
 }
 
 function finishGroupTurnOperation(groupId: string, operation: GroupTurnOperation) {
+  if (operation.goalRun && !operation.goalRun.finished) {
+    finishGroupGoalRun(groupId, operation, "failed", "The team run ended before the lead reported an outcome.");
+  }
   clearCancelledProviderHandshake(operation.threadId, `group:${operation.id}`);
   const operations = groupTurnOperations.get(groupId);
   operations?.delete(operation);
@@ -877,10 +976,57 @@ function finishGroupTurnOperation(groupId: string, operation: GroupTurnOperation
   if (group) broadcast({ kind: "group", group: publicGroupState(group) });
 }
 
+function finishGroupGoalRun(
+  groupId: string,
+  operation: GroupTurnOperation,
+  status: Exclude<GroupGoalRunStatus, "working">,
+  detail: string,
+): void {
+  const run = operation.goalRun;
+  if (!run || run.finished) return;
+  run.finished = true;
+  const finishedAt = Date.now();
+  const card: GroupGoalRunCardData = {
+    runId: run.runId,
+    goal: run.goal,
+    status,
+    coordinatorBotId: run.coordinatorBotId,
+    coordinatorName: run.coordinatorName,
+    turnCount: run.turnCount,
+    maxTurns: run.maxTurns,
+    detail: detail.trim().slice(0, 500),
+    startedAt: run.startedAt,
+    finishedAt,
+  };
+  const group = store.group(groupId);
+  const coordinator = store.bot(run.coordinatorBotId);
+  const ownsThread = group?.dm
+    ? group.threadId === operation.threadId
+    : Boolean(group && store.groupTaskByThread(group.id, operation.threadId));
+  if (!ownsThread) return;
+  const fallbackState = status === "completed"
+    ? "completed"
+    : status === "needs-input"
+      ? "needs your input"
+      : status === "limit-reached"
+        ? "reached its turn limit"
+        : status;
+  store.appendMessage(operation.threadId, {
+    role: "bot",
+    kind: "goal.run",
+    text: `Goal ${fallbackState}: ${card.detail ?? card.goal}`,
+    from: coordinator
+      ? { botId: coordinator.id, name: coordinator.name, color: coordinator.color }
+      : undefined,
+    goalRun: card,
+  });
+}
+
 function cancelGroupTurnOperations(groupId: string, threadId: string) {
   for (const operation of groupTurnOperations.get(groupId) ?? []) {
     if (operation.threadId !== threadId) continue;
     operation.cancelled = true;
+    finishGroupGoalRun(groupId, operation, "stopped", "Stopped by you.");
     if (operation.providerHandshakePending) {
       markCancelledProviderHandshake(operation.threadId, `group:${operation.id}`);
     }
@@ -1229,7 +1375,16 @@ const watchdog = new TurnWatchdog({
     // sooner. Keep ownership during that grace period so another turn cannot
     // overlap the process we are stopping. The normal turn.completed fold
     // clears it first when the adapter responds.
-    const release = setTimeout(() => {
+    const releaseOwnership = () => {
+      // A goal coordinator can stall before sendTurn reveals its provider
+      // turn id. Reusing the room during that ambiguous pre-id window would
+      // make old and replacement events indistinguishable. Keep ownership
+      // until the guard binds or reaches its bounded expiry.
+      if (hasUnboundDiscardedGroupGoalTurn(turn.threadId)) {
+        const retry = setTimeout(releaseOwnership, 1_000);
+        retry.unref?.();
+        return;
+      }
       const group = store.groupByThread(turn.threadId);
       const speaker = groupSpeakers.get(turn.threadId);
       if (group && group.busyBotId === turn.botId && speaker?.botId === turn.botId) {
@@ -1249,7 +1404,8 @@ const watchdog = new TurnWatchdog({
         drainConnectorResumes();
         drainSecretResumes();
       }
-    }, 6_000);
+    };
+    const release = setTimeout(releaseOwnership, 6_000);
     release.unref?.();
   },
 });
@@ -1461,6 +1617,45 @@ bus.subscribe((event: RuntimeEvent) => {
   if (event.type === "turn.completed") {
     releaseLocalVmThread(event.threadId);
   }
+  const coordinatorTurnsForThread = groupGoalCoordinatorTurns.get(event.threadId);
+  const ambiguousCoordinatorText = !event.turnId && (coordinatorTurnsForThread?.size ?? 0) > 1;
+  const goalCoordinatorTurn = groupGoalCoordinatorTurnForEvent(event);
+  if (goalCoordinatorTurn?.discard && retiredProviderTurns.has(event.turnId)) {
+    removeGroupGoalCoordinatorTurn(event.threadId, goalCoordinatorTurn);
+    return;
+  }
+  // Buffer every coordinator text item for the whole provider turn. A model
+  // can split the private envelope across assistant items (or emit multiple
+  // envelopes), so sanitizing item-by-item can leak protocol into the chat.
+  if (
+    event.type === "item.completed" &&
+    event.itemType === "assistant_text" &&
+    (goalCoordinatorTurn || ambiguousCoordinatorText)
+  ) {
+    if (goalCoordinatorTurn && !goalCoordinatorTurn.discard) goalCoordinatorTurn.assistantItems.push(event.text);
+    return;
+  }
+  if (
+    event.type === "content.delta" &&
+    event.streamKind === "assistant_text" &&
+    (goalCoordinatorTurn || ambiguousCoordinatorText)
+  ) return;
+  const coordinatorVisibleText = goalCoordinatorTurn && !goalCoordinatorTurn.discard && event.type === "turn.completed"
+    ? parseGroupGoalDecision(goalCoordinatorTurn.assistantItems.join("\n")).visibleText
+    : "";
+  if (goalCoordinatorTurn && event.type === "turn.completed") {
+    removeGroupGoalCoordinatorTurn(event.threadId, goalCoordinatorTurn);
+  }
+  if (coordinatorVisibleText) {
+    const publicAssistantEvent: RuntimeEvent = {
+      ...event,
+      eventId: `${event.eventId}-goal-text`,
+      type: "item.completed",
+      itemType: "assistant_text",
+      text: coordinatorVisibleText,
+    };
+    broadcast({ kind: "runtime", event: publicAssistantEvent });
+  }
   broadcast({ kind: "runtime", event });
   const routineRun = routines?.handleRuntimeEvent(event) ?? null;
   const bot = store.botByThread(event.threadId);
@@ -1473,6 +1668,11 @@ bus.subscribe((event: RuntimeEvent) => {
     return message;
   };
 
+  if (coordinatorVisibleText) {
+    pushMessage({ role: "bot", kind: "text", text: coordinatorVisibleText });
+    lastReply.set(event.threadId, coordinatorVisibleText);
+  }
+
   switch (event.type) {
     case "session.started":
       if (bot && event.sessionId && event.providerInstanceId) {
@@ -1481,10 +1681,11 @@ bus.subscribe((event: RuntimeEvent) => {
       break;
     case "item.completed":
       if (event.itemType === "assistant_text") {
-        pushMessage({ role: "bot", kind: "text", text: event.text });
+        const text = event.text;
+        pushMessage({ role: "bot", kind: "text", text });
         // kept so "finished" can say what it finished with, rather than
         // just that something ended
-        lastReply.set(event.threadId, event.text);
+        lastReply.set(event.threadId, text);
       } else if (event.itemType === "tool" && event.itemId) {
         const itemKey = `${event.threadId}:${event.itemId}`;
         const messageId = toolMessageByItem.get(itemKey);
@@ -3125,6 +3326,14 @@ const groupQueues = new Map<string, Promise<void>>();
 const GROUP_CONTEXT_MESSAGES = 30;
 const MAX_GROUP_HOPS = 1;
 
+type GroupMemberTurnOutcome = "settled" | "provider_failed" | "dispatch_failed" | "stalled" | "timed_out" | "cancelled";
+type GroupTurnOrchestration = {
+  systemInstructions: string;
+  followMentions: boolean;
+  result: { replyText?: string; outcome?: GroupMemberTurnOutcome; stopReason?: string | null };
+  onTurnStarted?: (turnId: string) => void;
+};
+
 function serializeRoomContext(threadId: string, userName: string): string {
   const messages = store.messagesFor(threadId);
   const messagesById = new Map(messages.map((message) => [message.id, message]));
@@ -3179,6 +3388,7 @@ async function runGroupMemberTurn(
   onProviderHandshakeStarted?: () => void,
   onProviderHandshakeSettled?: () => void,
   skillAuthoringClaim: { claimed: boolean } = { claimed: false },
+  orchestration?: GroupTurnOrchestration,
 ): Promise<boolean> {
   if (isCancelled?.()) return false;
   const group = store.group(groupId);
@@ -3334,6 +3544,7 @@ async function runGroupMemberTurn(
       "If the user explicitly asks to list or review, schedule, run, or change routines, use list_routines and propose_routine or propose_routine_action. A proposal is not applied until the user confirms its in-app card, so never claim the action completed before that confirmation.",
     skillAuthoring &&
       "If the user sends /learn or asks you to save a reusable procedure from this work, use skills_list and skill_manage. Only create new skills, include the URL, folder, or conversation as source provenance, and wait for the user to review and enable the staged SKILL.md.",
+    orchestration?.systemInstructions,
   ]
     .filter(Boolean)
     .join("\n");
@@ -3369,13 +3580,44 @@ async function runGroupMemberTurn(
   // connector-failed first responder must not silently consume /learn for the
   // next eligible room member.
   if (skillAuthoring) skillAuthoringClaim.claimed = true;
+  // A stopped room handshake may not have revealed its provider turn id yet.
+  // Do not launch a replacement into that ambiguous window; once the old id
+  // is known it is retired and this bounded gate clears immediately.
+  await pendingCancelledProviderHandshakes.waitForClear(threadId);
+  if (
+    isCancelled?.() ||
+    store.group(group.id)?.busyBotId !== bot.id ||
+    store.bot(bot.id)?.busy !== true
+  ) {
+    await releaseBrowserCapabilityForThread(threadId);
+    if (store.group(group.id)?.busyBotId === bot.id) {
+      groupSpeakers.delete(threadId);
+      store.patchGroup(group.id, { busyBotId: null, unread: true });
+    }
+    if (store.bot(bot.id)?.busy) {
+      store.setActivity(bot.id, "idle");
+      retryDelegationsWaitingOn(bot.id);
+    }
+    return false;
+  }
   let replyText = "";
+  let providerTurnId: string | undefined;
+  let abandoned = false;
+  const retirementOwner = `room-abandoned:${randomUUID()}`;
+  const abandonProviderTurn = () => {
+    if (abandoned) return;
+    abandoned = true;
+    watchdog.settle(threadId);
+    if (providerTurnId) retireProviderTurn(providerTurnId);
+    else markCancelledProviderHandshake(threadId, retirementOwner);
+  };
   const timeoutMinutes = roomTurnTimeoutMinutes(cfg);
-  const outcome = await new Promise<"settled" | "dispatch_failed" | "stalled" | "timed_out" | "cancelled">((resolve) => {
+  const outcome = await new Promise<GroupMemberTurnOutcome>((resolve) => {
     let done = false;
     let unsub = () => {};
     let unregisterStall = () => {};
     const deadline = new RoomTurnDeadline(timeoutMinutes, () => {
+      abandonProviderTurn();
       void releaseBrowserCapabilityForThread(threadId);
       void instance.adapter.interruptTurn(threadId).catch(() => {});
       store.appendMessage(threadId, {
@@ -3386,7 +3628,7 @@ async function runGroupMemberTurn(
       });
       finish("timed_out");
     });
-    const finish = (value: "settled" | "dispatch_failed" | "stalled" | "timed_out" | "cancelled") => {
+    const finish = (value: GroupMemberTurnOutcome) => {
       if (done) return;
       done = true;
       deadline.stop();
@@ -3397,8 +3639,16 @@ async function runGroupMemberTurn(
     unsub = bus.subscribe((e: RuntimeEvent) => {
       if (shouldIgnoreProviderEvent(e)) return;
       if (e.threadId !== threadId) return;
+      if (providerTurnId && e.turnId && e.turnId !== providerTurnId) return;
       if (e.type === "item.completed" && e.itemType === "assistant_text") replyText += `\n${e.text}`;
-      else if (e.type === "turn.completed") finish("settled");
+      else if (e.type === "turn.completed") {
+        if (orchestration && !e.ok) {
+          orchestration.result.stopReason = e.stopReason ?? null;
+          finish("provider_failed");
+        } else {
+          finish("settled");
+        }
+      }
       // Waiting on a person is not turn work: hold the ceiling while an
       // approval or question card is open, so deciding slowly does not
       // stop the turn underneath the card. Everything else keeps burning it.
@@ -3406,7 +3656,10 @@ async function runGroupMemberTurn(
       else if (e.type === "request.resolved") deadline.setWaitingOnHuman(false);
     });
     deadline.start();
-    unregisterStall = roomStallCompletions.register(threadId, () => finish("stalled"));
+    unregisterStall = roomStallCompletions.register(threadId, () => {
+      abandonProviderTurn();
+      finish("stalled");
+    });
     watchdog.watch(threadId, bot.id);
     onProviderHandshakeStarted?.();
     guardTurnDispatch(instance.adapter.sendTurn({
@@ -3416,7 +3669,7 @@ async function runGroupMemberTurn(
         cwd,
         integrations,
         ...memberTurnSelection(bot.modelSelection),
-      }), () => Boolean(isCancelled?.()), async () => {
+      }), () => abandoned || Boolean(isCancelled?.()), async () => {
         // Stop may have landed while the adapter was authenticating, before
         // it had an active process for the first interrupt to reach. Now that
         // sendTurn completed setup, revoke again and interrupt the real turn.
@@ -3424,6 +3677,12 @@ async function runGroupMemberTurn(
         await instance.adapter.interruptTurn(threadId).catch(() => {});
       })
       .then((dispatch) => {
+        providerTurnId = dispatch.value.turnId;
+        orchestration?.onTurnStarted?.(dispatch.value.turnId);
+        if (abandoned) {
+          retireProviderTurn(dispatch.value.turnId);
+          clearCancelledProviderHandshake(threadId, retirementOwner);
+        }
         if (dispatch.cancelled) {
           retireProviderTurn(dispatch.value.turnId);
           onProviderHandshakeSettled?.();
@@ -3434,6 +3693,8 @@ async function runGroupMemberTurn(
       })
       .catch((err) => {
         onProviderHandshakeSettled?.();
+        clearCancelledProviderHandshake(threadId, retirementOwner);
+        if (abandoned) return;
         const message = err instanceof Error ? err.message : "turn failed";
         store.appendMessage(threadId, {
           role: "bot",
@@ -3446,6 +3707,10 @@ async function runGroupMemberTurn(
         finish("dispatch_failed");
       });
   });
+  if (orchestration) {
+    orchestration.result.replyText = replyText.trim();
+    orchestration.result.outcome = outcome;
+  }
   // A timed-out provider still owns the room thread until its interrupt
   // produces turn.completed (or the stall watchdog's grace fallback runs).
   // Do not clear busy or start the next member on that same thread early.
@@ -3470,7 +3735,37 @@ async function runGroupMemberTurn(
     drainSecretResumes();
     return false;
   }
-  if (outcome === "stalled" || outcome === "timed_out") return false;
+  if (outcome === "timed_out") {
+    // turn.completed is intentionally retired above, so it cannot release
+    // room ownership for us. Give interrupt a short grace period, then do the
+    // same bounded cleanup as the stall watchdog. An unbound goal handshake
+    // keeps the room closed until attribution becomes safe.
+    const releaseOwnership = () => {
+      if (hasUnboundDiscardedGroupGoalTurn(threadId)) {
+        const retry = setTimeout(releaseOwnership, 1_000);
+        retry.unref?.();
+        return;
+      }
+      const currentGroup = store.group(group.id);
+      const speaker = groupSpeakers.get(threadId);
+      if (currentGroup?.busyBotId === bot.id && speaker?.botId === bot.id) {
+        groupSpeakers.delete(threadId);
+        store.patchGroup(group.id, { busyBotId: null, unread: true });
+      }
+      const currentBot = store.bot(bot.id);
+      if (currentBot?.busy) {
+        store.setActivity(bot.id, "idle");
+        retryDelegationsWaitingOn(bot.id);
+        drainQueuedSends();
+        drainConnectorResumes();
+        drainSecretResumes();
+      }
+    };
+    const release = setTimeout(releaseOwnership, 6_000);
+    release.unref?.();
+    return false;
+  }
+  if (outcome === "stalled") return false;
   // turn.completed normally performs this cleanup. Only use the fallback
   // when this invocation still owns the room; otherwise it would emit a
   // duplicate group frame or clear a newer speaker's state.
@@ -3491,9 +3786,18 @@ async function runGroupMemberTurn(
     drainConnectorResumes();
     drainSecretResumes();
   }
+  if (outcome === "provider_failed") {
+    if (skillAuthoring) skillAuthoringClaim.claimed = false;
+    return false;
+  }
 
   // chained mentions: a member's reply can summon teammates — one hop only
-  if (!isCancelled?.() && hop < MAX_GROUP_HOPS && replyText.trim()) {
+  if (
+    (orchestration?.followMentions ?? true) &&
+    !isCancelled?.() &&
+    hop < MAX_GROUP_HOPS &&
+    replyText.trim()
+  ) {
     const members = group.memberIds
       .map((id) => store.bot(id))
       .filter((b): b is NonNullable<typeof b> => Boolean(b) && b!.id !== bot.id);
@@ -3520,7 +3824,210 @@ async function runGroupMemberTurn(
   return true;
 }
 
-function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId?: string) {
+async function runGroupGoalStep(args: {
+  groupId: string;
+  threadId: string;
+  bot: BotRecord;
+  operation: GroupTurnOperation;
+  skillAuthoringClaim: { claimed: boolean };
+  coordinator: boolean;
+  instructions: string;
+}): Promise<{ ran: boolean; replyText: string; outcome?: GroupMemberTurnOutcome; stopReason?: string | null }> {
+  const run = args.operation.goalRun;
+  if (!run || args.operation.cancelled || run.turnCount >= run.maxTurns) {
+    return { ran: false, replyText: "" };
+  }
+  run.turnCount += 1;
+  args.operation.botIds.add(args.bot.id);
+  const result: GroupTurnOrchestration["result"] = {};
+  const token = Symbol("goal-coordinator-turn");
+  const coordinatorTurn: GroupGoalCoordinatorTurn | undefined = args.coordinator
+    ? { token, assistantItems: [], discard: false }
+    : undefined;
+  if (coordinatorTurn) addGroupGoalCoordinatorTurn(args.threadId, coordinatorTurn);
+  try {
+    const ran = await runGroupMemberTurn(
+      args.groupId,
+      args.threadId,
+      args.bot.id,
+      run.turnCount === 1 ? 0 : 1,
+      new Set(),
+      undefined,
+      undefined,
+      () => args.operation.cancelled,
+      () => groupProviderHandshakeStarted(args.operation),
+      () => groupProviderHandshakeSettled(args.operation),
+      args.skillAuthoringClaim,
+      {
+        systemInstructions: args.instructions,
+        followMentions: false,
+        result,
+        onTurnStarted: (turnId) => {
+          if (coordinatorTurn && !coordinatorTurn.turnId) coordinatorTurn.turnId = turnId;
+        },
+      },
+    );
+    return {
+      ran,
+      replyText: result.replyText ?? "",
+      outcome: result.outcome,
+      stopReason: result.stopReason,
+    };
+  } finally {
+    if (coordinatorTurn && groupGoalCoordinatorTurns.get(args.threadId)?.has(coordinatorTurn)) {
+      if (result.outcome === "timed_out" || result.outcome === "stalled") {
+        // interruptTurn is asynchronous: the orchestration can stop before
+        // the provider emits its final text/completion. Retain a discard-only
+        // guard so a late private decision envelope never reaches the room.
+        // Broken providers get a bounded fallback; the token check keeps an
+        // old timer from deleting a newer goal turn on the same thread.
+        coordinatorTurn.discard = true;
+        coordinatorTurn.assistantItems = [];
+        const cleanupTimer = setTimeout(() => {
+          removeGroupGoalCoordinatorTurn(args.threadId, coordinatorTurn);
+        }, GROUP_GOAL_COORDINATOR_GUARD_MS);
+        cleanupTimer.unref?.();
+        coordinatorTurn.cleanupTimer = cleanupTimer;
+      } else {
+        removeGroupGoalCoordinatorTurn(args.threadId, coordinatorTurn);
+      }
+    }
+  }
+}
+
+async function runGroupGoalOperation(args: {
+  groupId: string;
+  threadId: string;
+  coordinator: BotRecord;
+  members: BotRecord[];
+  operation: GroupTurnOperation;
+}): Promise<void> {
+  const run = args.operation.goalRun;
+  if (!run) return;
+  const skillAuthoringClaim = { claimed: false };
+  const assignmentCounts = new Map<string, number>();
+  const goalMembers: GoalRunMember[] = args.members.map((member) => ({
+    id: member.id,
+    name: member.name,
+    hidden: member.hidden,
+    chiefOfStaff: member.chiefOfStaff,
+  }));
+
+  while (!args.operation.cancelled && run.turnCount < run.maxTurns) {
+    const coordinatorTurn = run.turnCount + 1;
+    const coordinatorResult = await runGroupGoalStep({
+      ...args,
+      bot: args.coordinator,
+      skillAuthoringClaim,
+      coordinator: true,
+      instructions: groupGoalCoordinatorInstructions({
+        goal: run.goal,
+        members: goalMembers,
+        turn: coordinatorTurn,
+        maxTurns: run.maxTurns,
+        remainingTurns: run.maxTurns - coordinatorTurn,
+      }),
+    });
+    if (args.operation.cancelled) return;
+    if (!coordinatorResult.ran || coordinatorResult.outcome !== "settled") {
+      const reason = coordinatorResult.stopReason?.trim().slice(0, 120);
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "failed",
+        `${args.coordinator.name} could not complete the coordination step${reason ? ` — ${reason}` : ""}.`,
+      );
+      return;
+    }
+
+    const decision = parseGroupGoalDecision(coordinatorResult.replyText).decision;
+    if (!decision) {
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "blocked",
+        `${args.coordinator.name} did not provide a valid next-step decision.`,
+      );
+      return;
+    }
+    if (decision.status !== "continue") {
+      finishGroupGoalRun(args.groupId, args.operation, decision.status, decision.detail);
+      return;
+    }
+    if (run.turnCount >= run.maxTurns) break;
+
+    const worker = resolveGroupGoalMember(decision.next, goalMembers);
+    if (!worker) {
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "blocked",
+        `${args.coordinator.name} selected a teammate who is not an active member of this channel.`,
+      );
+      return;
+    }
+    const workerBot = store.bot(worker.id);
+    if (!workerBot || workerBot.hidden) {
+      finishGroupGoalRun(args.groupId, args.operation, "blocked", `${worker.name} is not available.`);
+      return;
+    }
+    const assignmentKey = groupGoalAssignmentKey(worker.id, decision.instruction);
+    const repeated = (assignmentCounts.get(assignmentKey) ?? 0) + 1;
+    assignmentCounts.set(assignmentKey, repeated);
+    if (repeated >= 3) {
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "blocked",
+        `The team repeated the same assignment three times without resolving the goal.`,
+      );
+      return;
+    }
+
+    const workerTurn = run.turnCount + 1;
+    const workerResult = await runGroupGoalStep({
+      ...args,
+      bot: workerBot,
+      skillAuthoringClaim,
+      coordinator: false,
+      instructions: groupGoalWorkerInstructions({
+        goal: run.goal,
+        coordinatorName: args.coordinator.name,
+        assignment: decision.instruction,
+        turn: workerTurn,
+        maxTurns: run.maxTurns,
+      }),
+    });
+    if (args.operation.cancelled) return;
+    if (!workerResult.ran || workerResult.outcome !== "settled" || !workerResult.replyText.trim()) {
+      const reason = workerResult.stopReason?.trim().slice(0, 120);
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "failed",
+        `${workerBot.name} could not return a result to ${args.coordinator.name}${reason ? ` — ${reason}` : ""}.`,
+      );
+      return;
+    }
+  }
+
+  if (!args.operation.cancelled && !run.finished) {
+    finishGroupGoalRun(
+      args.groupId,
+      args.operation,
+      "limit-reached",
+      `Paused at the ${run.maxTurns}-turn safety limit. Send the goal again to continue with a fresh bounded run.`,
+    );
+  }
+}
+
+function startGroupTurn(
+  groupId: string,
+  text: string,
+  replyTo?: Message,
+  sendId?: string,
+  channelMode: "chat" | "goal" = "chat",
+) {
   const group = store.group(groupId);
   if (!group) throw Object.assign(new Error("no such group"), { status: 404 });
   if (roomSetupPending(group)) {
@@ -3535,6 +4042,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
     text,
     replyToId: replyTo?.id,
     sendId,
+    channelMode,
   });
   if (!group.dm) store.titleGroupTaskFromFirstMessage(group.id, text, threadId);
 
@@ -3555,6 +4063,10 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
     });
   }
   let responders = roomResponders(text, members, group.defaultResponder);
+  const explicitlyMentionedLead = roomResponders(text, availableMembers, { kind: "mentions" })[0];
+  const goalCoordinator = channelMode === "goal"
+    ? explicitlyMentionedLead ?? selectGroupGoalCoordinator(availableMembers, group.defaultResponder)
+    : null;
   // bot⇄bot channels: chipping in without a tag addresses the last speaker
   if (!responders.length && group.dm) {
     const lastSpeakerId = [...store.messagesFor(threadId)]
@@ -3563,7 +4075,7 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
     const last = availableMembers.find((b) => b.id === lastSpeakerId) ?? availableMembers[0];
     responders = last ? [last] : [];
   }
-  if (!responders.length) {
+  if (!responders.length && !goalCoordinator) {
     const defaultArchivedId = group.defaultResponder.kind === "member" ? group.defaultResponder.botId : undefined;
     const defaultArchived = archived.find((member) => member.id === defaultArchivedId);
     let unavailableMessage: string | undefined;
@@ -3582,7 +4094,23 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
     return message;
   }
 
-  const operation = beginGroupTurnOperation(groupId, threadId, responders.map((responder) => responder.id));
+  const operation = beginGroupTurnOperation(
+    groupId,
+    threadId,
+    goalCoordinator ? [goalCoordinator.id] : responders.map((responder) => responder.id),
+  );
+  if (goalCoordinator) {
+    operation.goalRun = {
+      runId: `goal-${Date.now().toString(36)}-${randomUUID()}`,
+      goal: text,
+      coordinatorBotId: goalCoordinator.id,
+      coordinatorName: goalCoordinator.name,
+      turnCount: 0,
+      maxTurns: GROUP_GOAL_MAX_TURNS,
+      startedAt: Date.now(),
+      finished: false,
+    };
+  }
   const prev = groupQueues.get(groupId) ?? Promise.resolve();
   const next = prev.then(async () => {
     if (operation.cancelled) return;
@@ -3596,24 +4124,28 @@ function startGroupTurn(groupId: string, text: string, replyTo?: Message, sendId
       });
       return;
     }
-    const spoken = new Set<string>();
-    const skillAuthoringClaim = { claimed: false };
-    for (const responder of responders) {
-      if (operation.cancelled) break;
-      if (spoken.has(responder.id)) continue;
-      if (!(await runGroupMemberTurn(
-        groupId,
-        threadId,
-        responder.id,
-        0,
-        spoken,
-        undefined,
-        undefined,
-        () => operation.cancelled,
-        () => groupProviderHandshakeStarted(operation),
-        () => groupProviderHandshakeSettled(operation),
-        skillAuthoringClaim,
-      ))) break;
+    if (goalCoordinator) {
+      await runGroupGoalOperation({ groupId, threadId, coordinator: goalCoordinator, members, operation });
+    } else {
+      const spoken = new Set<string>();
+      const skillAuthoringClaim = { claimed: false };
+      for (const responder of responders) {
+        if (operation.cancelled) break;
+        if (spoken.has(responder.id)) continue;
+        if (!(await runGroupMemberTurn(
+          groupId,
+          threadId,
+          responder.id,
+          0,
+          spoken,
+          undefined,
+          undefined,
+          () => operation.cancelled,
+          () => groupProviderHandshakeStarted(operation),
+          () => groupProviderHandshakeSettled(operation),
+          skillAuthoringClaim,
+        ))) break;
+      }
     }
   });
   const tracked = next.finally(() => finishGroupTurnOperation(groupId, operation));
@@ -6066,6 +6598,13 @@ const server = createServer(async (req, res) => {
       if (!text) return json(res, 400, { error: "text required" });
       const group = store.group(m[1]);
       if (!group) return json(res, 404, { error: "no such group" });
+      if (body.mode !== undefined && body.mode !== "chat" && body.mode !== "goal") {
+        return json(res, 400, { error: "mode must be chat or goal" });
+      }
+      const channelMode: "chat" | "goal" = body.mode === "goal" ? "goal" : "chat";
+      if (group.dm && channelMode === "goal") {
+        return json(res, 400, { error: "goal mode is available in team channels, not bot-to-bot channels" });
+      }
       if (body.threadId !== undefined && (typeof body.threadId !== "string" || !/^[\w-]+$/.test(body.threadId))) {
         return json(res, 400, { error: "threadId must be a task id" });
       }
@@ -6080,10 +6619,10 @@ const server = createServer(async (req, res) => {
       const replyTo = resolveReplyTarget(threadId, body.replyToId);
       const receipt = await sendSequencer.run(
         sendId ? `group:${group.id}:${threadId}:${sendId}` : undefined,
-        sendFingerprint(text, replyTo?.id),
+        sendFingerprint(text, replyTo?.id, channelMode),
         async () => {
           if (sendId) {
-            const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id);
+            const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id, channelMode);
             if (accepted.kind === "conflict") {
               throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
             }
@@ -6098,7 +6637,7 @@ const server = createServer(async (req, res) => {
               status: 409,
             });
           }
-          const message = startGroupTurn(current.id, text, replyTo, sendId);
+          const message = startGroupTurn(current.id, text, replyTo, sendId, channelMode);
           return { ok: true as const, threadId, message };
         },
       );

--- a/server/send-idempotency.test.ts
+++ b/server/send-idempotency.test.ts
@@ -38,6 +38,26 @@ describe("send idempotency", () => {
     });
   });
 
+  it("does not let one send id change channel execution mode", () => {
+    const sendId = "send_1234567890123456";
+    const message = userMessage({ channelMode: "goal" });
+    expect(acceptedSendMatch([message], sendId, "ship it", undefined, "goal")).toEqual({
+      kind: "match",
+      message,
+    });
+    expect(acceptedSendMatch([message], sendId, "ship it", undefined, "chat")).toEqual({ kind: "conflict" });
+    expect(sendFingerprint("ship it", undefined, "goal")).not.toBe(sendFingerprint("ship it", undefined, "chat"));
+  });
+
+  it("treats a legacy missing channel mode as ordinary chat", () => {
+    const sendId = "send_1234567890123456";
+    const message = userMessage();
+    expect(acceptedSendMatch([message], sendId, "ship it", undefined, "chat")).toEqual({
+      kind: "match",
+      message,
+    });
+  });
+
   it("coalesces simultaneous retries onto one operation", async () => {
     const sequencer = new SendSequencer();
     let releaseFirst = () => {};

--- a/server/send-idempotency.ts
+++ b/server/send-idempotency.ts
@@ -23,6 +23,7 @@ export function acceptedSendMatch(
   sendId: string,
   text: string,
   replyToId?: string,
+  channelMode?: "chat" | "goal",
 ): AcceptedSendMatch {
   const message = messages.find((candidate) => candidate.sendId === sendId);
   if (!message) return { kind: "none" };
@@ -30,7 +31,8 @@ export function acceptedSendMatch(
     message.role !== "user" ||
     message.kind !== "text" ||
     message.text !== text ||
-    message.replyToId !== replyToId
+    message.replyToId !== replyToId ||
+    (message.channelMode ?? "chat") !== (channelMode ?? "chat")
   ) {
     return { kind: "conflict" };
   }
@@ -67,6 +69,6 @@ export class SendSequencer {
   }
 }
 
-export function sendFingerprint(text: string, replyToId?: string): string {
-  return JSON.stringify([text, replyToId ?? null]);
+export function sendFingerprint(text: string, replyToId?: string, channelMode?: "chat" | "goal"): string {
+  return JSON.stringify([text, replyToId ?? null, channelMode ?? null]);
 }

--- a/server/store.ts
+++ b/server/store.ts
@@ -18,6 +18,7 @@ import { botAvatarProfile, type BotAvatarCrop } from "../shared/bot-avatar.ts";
 import type { RoutineRequestCardData } from "../shared/routine-request.ts";
 import type { RoutineRunCardData } from "../shared/routine-run.ts";
 import type { SkillRequestCardData } from "../shared/skill-request.ts";
+import type { GroupGoalRunCardData } from "../shared/group-goal-run.ts";
 
 export type MausColor =
   | "green"
@@ -93,7 +94,7 @@ export interface SecretRequestCardData {
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run";
+  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run" | "goal.run";
   text?: string;
   card?: OptionCardData;
   connector?: ConnectorCardData;
@@ -101,6 +102,8 @@ export interface Message {
   /** One idempotently updated status card in the conversation that created a
    * routine. The actual provider turn remains in its isolated task. */
   routineRun?: RoutineRunCardData;
+  /** Terminal receipt for a bounded multi-bot channel goal. */
+  goalRun?: GroupGoalRunCardData;
   /** activity messages: tool name + outcome. `spoken` is the same chip as
    * a phrase a voice can read ("reading a file") — computed once here so
    * call mode never has to re-derive it from the raw tool name, and absent
@@ -124,6 +127,8 @@ export interface Message {
   replyToId?: string;
   /** Stable client identity for at-most-once chat POST retries. */
   sendId?: string;
+  /** Per-send channel behavior. Absent is legacy quick chat. */
+  channelMode?: "chat" | "goal";
   /** group threads: which member said this (sender attribution). */
   from?: { botId: string; name: string; color: string };
   /** emoji reactions; by = "user" or a member botId. */
@@ -257,6 +262,14 @@ function redactBotAuthored<T extends Omit<Message, "id" | "at"> & { at?: number 
     if (routineRun.summary) routineRun.summary = redactSecretsInText(routineRun.summary);
     if (routineRun.error) routineRun.error = redactSecretsInText(routineRun.error);
     out.routineRun = routineRun;
+  }
+  if (out.goalRun) {
+    out.goalRun = {
+      ...out.goalRun,
+      goal: redactSecretsInText(out.goalRun.goal),
+      coordinatorName: redactSecretsInText(out.goalRun.coordinatorName),
+      detail: out.goalRun.detail ? redactSecretsInText(out.goalRun.detail) : undefined,
+    };
   }
   if (out.card) {
     const card = { ...out.card } as OptionCardData & { summary?: string };

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -13,6 +13,11 @@
 //                      way the real CLI reads it — the driver writes it to a
 //                      private temp file and deletes it when the turn settles,
 //                      so a test cannot open it after the fact.
+//   FAKE_CLAUDE_REPLIES JSON array of strings (or string arrays for multiple
+//                      assistant items) used in order across turns. This makes
+//                      bounded multi-turn orchestration deterministic.
+//   FAKE_CLAUDE_REPLY_STATE Optional counter file shared by fresh CLI
+//                      processes so scripted replies keep their order.
 //   FAKE_CLAUDE_AUTH   in (default) | out | unsupported | malformed |
 //                      inherited-api-key — what `auth status` reports
 //
@@ -20,6 +25,32 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CLAUDE_MODE ?? "happy";
+const scriptedReplies = (() => {
+  try {
+    const parsed = JSON.parse(process.env.FAKE_CLAUDE_REPLIES ?? "[]");
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string | string[] =>
+      typeof value === "string" || (Array.isArray(value) && value.every((part) => typeof part === "string"))
+    );
+  } catch {
+    return [];
+  }
+})();
+let scriptedReplyIndex = 0;
+const nextScriptedReply = (): string[] => {
+  const stateFile = process.env.FAKE_CLAUDE_REPLY_STATE;
+  let index = scriptedReplyIndex;
+  if (stateFile) {
+    try {
+      index = Number(readFileSync(stateFile, "utf8")) || 0;
+    } catch {}
+    writeFileSync(stateFile, String(index + 1));
+  } else {
+    scriptedReplyIndex += 1;
+  }
+  const reply = scriptedReplies[index] ?? "hello from fake claude";
+  return Array.isArray(reply) ? reply : [reply];
+};
 
 const argv = process.argv.slice(2);
 const argAfter = (flag: string): string | null => {
@@ -184,15 +215,19 @@ const playTurn = (prompt: JsonValue) => {
     });
   }
 
-  out({
-    type: "assistant",
-    message: {
-      content: [
-        { type: "text", text: "hello from fake claude" },
-        { type: "tool_use", id: "tu-1", name: "Bash" },
-      ],
-      usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 },
-    },
+  const replyParts = nextScriptedReply();
+  replyParts.forEach((text, index) => {
+    const content: Array<
+      { type: "text"; text: string } | { type: "tool_use"; id: string; name: string }
+    > = [{ type: "text", text }];
+    if (index === replyParts.length - 1) content.push({ type: "tool_use", id: "tu-1", name: "Bash" });
+    out({
+      type: "assistant",
+      message: {
+        content,
+        usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 },
+      },
+    });
   });
   out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu-1", is_error: false }] } });
 

--- a/shared/group-goal-run.ts
+++ b/shared/group-goal-run.ts
@@ -1,0 +1,22 @@
+/** Durable progress receipt for one goal-driven channel run. */
+export type GroupGoalRunStatus =
+  | "working"
+  | "completed"
+  | "needs-input"
+  | "blocked"
+  | "limit-reached"
+  | "stopped"
+  | "failed";
+
+export interface GroupGoalRunCardData {
+  runId: string;
+  goal: string;
+  status: GroupGoalRunStatus;
+  coordinatorBotId: string;
+  coordinatorName: string;
+  turnCount: number;
+  maxTurns: number;
+  detail?: string;
+  startedAt: number;
+  finishedAt?: number;
+}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { track } from "@/lib/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
-import { ArrowUp, Check, Clock, Hand, Mic, Paperclip, ShieldCheck, Square, Users, X } from "lucide-react";
+import { ArrowUp, Check, Clock, Hand, Mic, Paperclip, ShieldCheck, Square, Target, Users, X } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group, type Message } from "@/state/store";
 import { cn } from "@/lib/cn";
 import {
@@ -30,7 +30,7 @@ import {
   type PasteAttachment,
 } from "@/lib/composer-attachments";
 import { normalizeState } from "@/lib/mascot";
-import { groupComposerHint, roomRespondersForComposer } from "@/lib/group-routing";
+import { goalCoordinatorForComposer, groupComposerHint, roomRespondersForComposer } from "@/lib/group-routing";
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { ReplyQuote } from "./ReplyQuote";
@@ -56,6 +56,7 @@ interface ComposerDraftSnapshot extends ComposerSendSnapshot {
 interface QueuedGroupSend {
   text: string;
   replyToId?: string;
+  mode: "chat" | "goal";
   draft: ComposerDraftSnapshot;
 }
 
@@ -183,7 +184,7 @@ export function Composer({
   // Unified target: a 1:1 bot thread or a room. In a room the @ picker
   // offers members plus @everyone; explicit mentions override the room's
   // configured default responder.
-  const busy = group ? Boolean(group.busyBotId) : Boolean(bot?.busy);
+  const busy = group ? Boolean(group.working || group.busyBotId) : Boolean(bot?.busy);
   // an engine with a live session takes a message INTO the running turn;
   // for those the composer never locks — the server steers instead of 409
   const canSteer =
@@ -199,7 +200,7 @@ export function Composer({
       members?.find((member) => member.id === group.busyBotId)
     : bot;
   const busyName = group
-    ? (members?.find((b) => b.id === group.busyBotId)?.name ?? "A bot")
+    ? (members?.find((b) => b.id === group.busyBotId)?.name ?? (group.working ? "The team" : "A bot"))
     : (bot?.name ?? "The bot");
   // Per-thread draft: switching bots unmounts this component, so both the
   // text and its attachment chips have to outlive it (see lib/drafts).
@@ -211,6 +212,9 @@ export function Composer({
     !group && bot ? `bot:${bot.id}` : undefined,
   );
   const failedSends = useFailedComposerSends(draftId);
+  // Goal mode is opt-in and one-shot so the next ordinary channel message
+  // cannot accidentally start another multi-turn team run.
+  const [channelMode, setChannelMode] = useState<"chat" | "goal">("chat");
   const editText = useCallback(
     (next: string) => {
       markDraftEdited(draftId);
@@ -229,8 +233,9 @@ export function Composer({
     (sent: ComposerDraftSnapshot) => {
       // Shared recovery reaches a newly mounted view after navigation and
       // falls back to a separate retry item when a newer draft already exists.
-      if (recoverFailedComposerSend(sent) === "restored" && sent.reply) {
-        onRestoreReply?.(sent.reply, sent.threadId);
+      if (recoverFailedComposerSend(sent) === "restored") {
+        setChannelMode(sent.channelMode ?? "chat");
+        if (sent.reply) onRestoreReply?.(sent.reply, sent.threadId);
       }
     },
     [onRestoreReply],
@@ -277,12 +282,15 @@ export function Composer({
       candidate &&
         state.instances.find((i) => i.instanceId === candidate.modelSelection.instanceId)?.capabilities?.images,
     );
-  const imageTargetsSupport = (message: string) => {
+  const imageTargetsSupport = (message: string, mode: "chat" | "goal") => {
     if (!group) return botSupportsImages(bot);
+    if (mode === "goal") {
+      return botSupportsImages(goalCoordinatorForComposer(message, members ?? [], group) ?? undefined);
+    }
     const responders = roomRespondersForComposer(message, members ?? [], group);
     return responders.length > 0 && responders.every(botSupportsImages);
   };
-  const engineSupportsImages = imageTargetsSupport(text);
+  const engineSupportsImages = imageTargetsSupport(text, channelMode);
 
   // ── @mention picker (tag another bot; the agent reaches it via ask_bot) ──
   const mention = mentionQueryAt(text, caret);
@@ -385,7 +393,8 @@ export function Composer({
 
   const hasContent = Boolean(text.trim()) || attachments.length > 0;
   const retryFailedSend = (failed: FailedComposerSend) => {
-    if (failed.requestText.includes("<attached-image ") && !imageTargetsSupport(failed.requestText)) {
+    const failedMode = failed.channelMode ?? "chat";
+    if (failed.requestText.includes("<attached-image ") && !imageTargetsSupport(failed.requestText, failedMode)) {
       dispatch({ type: "error", message: "The selected responder does not support image attachments." });
       return;
     }
@@ -402,11 +411,12 @@ export function Composer({
           requestText: failed.requestText,
           replyToId: failed.replyToId,
           threadId: failed.threadId,
+          channelMode: failed.channelMode,
         });
       },
     };
     if (group) {
-      dispatch({ type: "sendGroup", groupId: group.id, ...retry });
+      dispatch({ type: "sendGroup", groupId: group.id, mode: failedMode, ...retry });
     } else if (bot) {
       dispatch({ type: "send", botId: bot.id, ...retry });
     }
@@ -416,7 +426,7 @@ export function Composer({
     // as an editable draft until that send is dispatched; replacing the slot
     // here would silently lose the first message.
     if (locked || (group && queued)) return;
-    if (attachments.some((attachment) => attachment.kind === "image") && !imageTargetsSupport(text)) {
+    if (attachments.some((attachment) => attachment.kind === "image") && !imageTargetsSupport(text, channelMode)) {
       dispatch({ type: "error", message: "The selected responder does not support image attachments." });
       return;
     }
@@ -432,14 +442,16 @@ export function Composer({
       reply: replyTo ?? null,
       replyToId: replyTo?.id,
       threadId,
+      channelMode: group ? channelMode : undefined,
     };
     if (busy && group) {
-      const pending = { text: t, replyToId: replyTo?.id, draft: sentDraft };
+      const pending = { text: t, replyToId: replyTo?.id, mode: channelMode, draft: sentDraft };
       queuedRef.current = pending;
       setQueued(pending);
       setText("");
       setAttachments([]);
       onConsumeReply?.();
+      setChannelMode("chat");
       return;
     }
     if (group) {
@@ -450,9 +462,10 @@ export function Composer({
         sendId: sentDraft.sendId,
         replyToId: replyTo?.id,
         threadId,
+        mode: channelMode,
         onError: () => restoreDraft(sentDraft),
       });
-      track("message_sent", { room: true });
+      track("message_sent", { room: true, mode: channelMode });
     } else if (bot) {
       dispatch({
         type: "send",
@@ -468,11 +481,12 @@ export function Composer({
     setText("");
     setAttachments([]);
     onConsumeReply?.();
+    if (group) setChannelMode("chat");
   };
   useEffect(() => {
     if (busy || !queued) return;
     if (group) {
-      if (queued.text.includes("<attached-image ") && !imageTargetsSupport(queued.text)) {
+      if (queued.text.includes("<attached-image ") && !imageTargetsSupport(queued.text, queued.mode)) {
         dispatch({ type: "error", message: "The selected responder does not support image attachments." });
         clearQueued();
         restoreDraft(queued.draft);
@@ -486,9 +500,10 @@ export function Composer({
         sendId: queued.draft.sendId,
         replyToId: queued.replyToId,
         threadId: queued.draft.threadId,
+        mode: queued.mode,
         onError: () => restoreDraft(queued.draft),
       });
-      track("message_sent", { room: true, queued: true });
+      track("message_sent", { room: true, queued: true, mode: queued.mode });
     }
   }, [busy, queued, group, members, state.instances, dispatch, clearQueued, restoreDraft]);
 
@@ -688,6 +703,27 @@ export function Composer({
               >
                 <Paperclip size={17} />
               </button>
+              {group && !group.dm && (
+                <button
+                  type="button"
+                  aria-pressed={channelMode === "goal"}
+                  aria-label="Finish together"
+                  title="Finish together — the team keeps working until the goal is complete"
+                  onClick={() => {
+                    markDraftEdited(draftId);
+                    setChannelMode((current) => current === "goal" ? "chat" : "goal");
+                  }}
+                  className={cn(
+                    "flex h-8 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 text-[13px] transition-colors",
+                    channelMode === "goal"
+                      ? "border-accent/35 bg-accent/10 text-accent"
+                      : "border-hairline/20 bg-transparent text-ink-secondary hover:bg-raised hover:text-ink",
+                  )}
+                >
+                  <Target size={14} aria-hidden="true" />
+                  Goal
+                </button>
+              )}
               {autoBot && <PermissionModeSelector bot={autoBot} onSetAuto={setAuto} />}
             </div>
           )}
@@ -785,7 +821,9 @@ export function Composer({
                   ? `${busyName} is working — Enter queues your message`
                   : `${busyName} is working — sends when this turn finishes`
                 : group
-                  ? `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`
+                  ? channelMode === "goal"
+                    ? `Describe what ${group.name} should finish together`
+                    : `Message ${group.name} — ${groupComposerHint(group, members ?? [])}`
                   : `Message ${bot?.name ?? ""}`
           }
           aria-label={`Message ${group ? group.name : (bot?.name ?? "")}`}

--- a/src/components/GoalRunCard.test.ts
+++ b/src/components/GoalRunCard.test.ts
@@ -1,0 +1,66 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { GroupGoalRunCardData } from "../../shared/group-goal-run";
+import type { Message } from "@/state/store";
+import { GoalRunCard } from "./GoalRunCard";
+
+function message(status: GroupGoalRunCardData["status"], detail?: string): Message {
+  return {
+    id: "goal-run-card",
+    role: "bot",
+    kind: "goal.run",
+    at: 1,
+    goalRun: {
+      runId: "run-1",
+      goal: "Write and polish the launch announcement",
+      status,
+      coordinatorBotId: "bot-1",
+      coordinatorName: "Sprout",
+      turnCount: status === "working" ? 2 : 5,
+      maxTurns: 12,
+      detail,
+      startedAt: 1,
+    },
+  };
+}
+
+describe("GoalRunCard", () => {
+  it("shows live goal progress without expanding into a run log", () => {
+    const markup = renderToStaticMarkup(createElement(GoalRunCard, {
+      message: message("working", "Luna is reviewing the second draft."),
+    }));
+
+    expect(markup).toContain("Write and polish the launch announcement");
+    expect(markup).toContain("Working");
+    expect(markup).toContain("Luna is reviewing the second draft.");
+    expect(markup).toContain("Sprout coordinating · Turn 3 of 12");
+    expect(markup).toContain('aria-label="Goal run: Working"');
+  });
+
+  it.each([
+    ["completed", "Completed"],
+    ["needs-input", "Needs your input"],
+    ["blocked", "Blocked"],
+    ["limit-reached", "Turn limit reached"],
+    ["stopped", "Stopped"],
+    ["failed", "Failed"],
+  ] as const)("renders the %s terminal status", (status, label) => {
+    const markup = renderToStaticMarkup(createElement(GoalRunCard, { message: message(status) }));
+    expect(markup).toContain(label);
+    expect(markup).toContain("Sprout coordinating · 5 turns");
+  });
+
+  it("keeps an incomplete payload readable", () => {
+    const legacy: Message = {
+      id: "goal-run-fallback",
+      role: "bot",
+      kind: "goal.run",
+      at: 1,
+      text: "The channel goal is complete.",
+    };
+    expect(renderToStaticMarkup(createElement(GoalRunCard, { message: legacy })))
+      .toContain("The channel goal is complete.");
+  });
+});

--- a/src/components/GoalRunCard.tsx
+++ b/src/components/GoalRunCard.tsx
@@ -1,0 +1,96 @@
+import {
+  CheckCircle2,
+  CircleAlert,
+  Hand,
+  Loader2,
+  Square,
+  XCircle,
+} from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import type { Message } from "@/state/store";
+import type { GroupGoalRunCardData } from "../../shared/group-goal-run";
+
+const DETAIL_LIMIT = 280;
+
+const COPY = {
+  working: { label: "Working", tone: "text-accent", border: "border-accent/30" },
+  completed: { label: "Completed", tone: "text-success", border: "border-success/30" },
+  "needs-input": { label: "Needs your input", tone: "text-warning", border: "border-warning/35" },
+  blocked: { label: "Blocked", tone: "text-warning", border: "border-warning/35" },
+  "limit-reached": { label: "Turn limit reached", tone: "text-warning", border: "border-warning/35" },
+  stopped: { label: "Stopped", tone: "text-ink-secondary", border: "border-hairline/45" },
+  failed: { label: "Failed", tone: "text-danger", border: "border-danger/35" },
+} satisfies Record<
+  GroupGoalRunCardData["status"],
+  { label: string; tone: string; border: string }
+>;
+
+function compact(value: string | undefined, limit: number): string {
+  const clean = value?.replace(/\s+/g, " ").trim() ?? "";
+  return clean.length > limit ? `${clean.slice(0, limit - 1).trimEnd()}…` : clean;
+}
+
+function StatusIcon({ status }: { status: GroupGoalRunCardData["status"] }) {
+  const className = "size-4 shrink-0";
+  switch (status) {
+    case "working":
+      return <Loader2 aria-hidden="true" className={cn(className, "animate-spin text-accent")} />;
+    case "completed":
+      return <CheckCircle2 aria-hidden="true" className={cn(className, "text-success")} />;
+    case "needs-input":
+      return <Hand aria-hidden="true" className={cn(className, "text-warning")} />;
+    case "blocked":
+    case "limit-reached":
+      return <CircleAlert aria-hidden="true" className={cn(className, "text-warning")} />;
+    case "stopped":
+      return <Square aria-hidden="true" className={cn(className, "text-ink-secondary")} />;
+    case "failed":
+      return <XCircle aria-hidden="true" className={cn(className, "text-danger")} />;
+  }
+}
+
+/** One durable terminal receipt for a goal-driven channel run. */
+export function GoalRunCard({ message }: { message: Message }) {
+  const run = message.goalRun;
+  if (!run) {
+    const fallback = compact(message.text, DETAIL_LIMIT);
+    return fallback ? (
+      <div className="w-fit max-w-[min(42rem,88%)] rounded-2xl bg-card px-4 py-2.5 text-[14px] leading-relaxed text-ink">
+        {fallback}
+      </div>
+    ) : null;
+  }
+
+  const copy = COPY[run.status];
+  const goal = compact(run.goal, 180);
+  const detail = compact(run.detail, DETAIL_LIMIT);
+  const turns = run.status === "working"
+    ? `Turn ${Math.min(run.turnCount + 1, run.maxTurns)} of ${run.maxTurns}`
+    : `${run.turnCount} ${run.turnCount === 1 ? "turn" : "turns"}`;
+
+  return (
+    <section
+      aria-label={`Goal run: ${copy.label}`}
+      className={cn("w-full max-w-[680px] rounded-2xl border bg-card px-3.5 py-3 shadow-sm", copy.border)}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl bg-inset">
+          <StatusIcon status={run.status} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <h3 className="truncate text-[13.5px] font-semibold text-ink">{goal || "Channel goal"}</h3>
+            <span aria-live="polite" className={cn("text-[11.5px] font-medium", copy.tone)}>
+              {copy.label}
+            </span>
+          </div>
+          {detail && <p className="mt-1 line-clamp-2 text-[12.5px] leading-relaxed text-ink-secondary">{detail}</p>}
+          <p className="mt-1 text-[11.5px] text-ink-secondary/80">
+            {run.coordinatorName} coordinating · {turns}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/GroupCallView.tsx
+++ b/src/components/GroupCallView.tsx
@@ -59,7 +59,7 @@ function questionIn(messages: Message[]): Message | undefined {
 function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
   const { dispatch } = useStore();
   const speech = useSpeech();
-  const initialPhase: Phase = group.busyBotId ? "working" : "listening";
+  const initialPhase: Phase = group.working || group.busyBotId ? "working" : "listening";
   const [phase, setPhase] = useState<Phase>(initialPhase);
   const [heard, setHeard] = useState("");
   const [note, setNote] = useState<string | null>(null);
@@ -72,10 +72,10 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
   const approval = pendingApprovals(messages)[0];
   const question = questionIn(messages);
   const membersRef = useRef(members);
-  const busyRef = useRef(Boolean(group.busyBotId));
+  const busyRef = useRef(Boolean(group.working || group.busyBotId));
   const defaultResponderRef = useRef(group.defaultResponder);
   membersRef.current = members;
-  busyRef.current = Boolean(group.busyBotId);
+  busyRef.current = Boolean(group.working || group.busyBotId);
   defaultResponderRef.current = group.defaultResponder;
 
   const spokenIds = useRef<Set<string>>(new Set());
@@ -315,7 +315,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
       }
       if (phaseRef.current === "listening") listen();
     });
-    if (group.busyBotId && !approval && !question) move("working");
+    if ((group.working || group.busyBotId) && !approval && !question) move("working");
     else listen();
     return () => {
       offTranscript();
@@ -336,7 +336,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
       askedQuestion.current = null;
     }
 
-    if (resumeAfterRoutine && !approval && !question && !group.busyBotId) {
+    if (resumeAfterRoutine && !approval && !question && !group.working && !group.busyBotId) {
       scheduleListen(true);
       return;
     }
@@ -394,10 +394,10 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
         enqueueSpeech(chip.tool.spoken, member);
       }
     }
-  }, [approval, enqueueSpeech, group.busyBotId, members, messages, question, scheduleListen]);
+  }, [approval, enqueueSpeech, group.busyBotId, group.working, members, messages, question, scheduleListen]);
 
   useEffect(() => {
-    const busy = Boolean(group.busyBotId);
+    const busy = Boolean(group.working || group.busyBotId);
     busyRef.current = busy;
     if (busy) {
       if (
@@ -419,7 +419,7 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
     ) {
       scheduleListen();
     }
-  }, [group.busyBotId, hush, move, scheduleListen]);
+  }, [group.busyBotId, group.working, hush, move, scheduleListen]);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -28,6 +28,7 @@ import { ReplyQuote } from "./ReplyQuote";
 import { ConnectorCard } from "./ConnectorCard";
 import { SecretRequestCard } from "./SecretRequestCard";
 import { hasRoutineExecutionTask, RoutineRunCard } from "./RoutineRunCard";
+import { GoalRunCard } from "./GoalRunCard";
 import { AttachedFileChips, AttachedImageGallery } from "./AttachmentPreview";
 import { GroupCallButton, GroupCallOverlay } from "./GroupCallView";
 
@@ -199,6 +200,10 @@ const Transcript = memo(function Transcript({
           ) : m.kind === "options" && m.card?.requestId && m.card.tool ? (
             <div className="flex justify-start">
               <ApprovalCard bot={memberOf(m.from?.botId)} message={m} />
+            </div>
+          ) : m.kind === "goal.run" ? (
+            <div className="flex justify-start">
+              <GoalRunCard message={m} />
             </div>
           ) : m.kind === "routine.run" ? (
             <div className="flex justify-start">
@@ -957,7 +962,7 @@ export function GroupView({ group }: { group: Group }) {
     if (!el || !followRef.current) return;
     el.scrollTo({ top: el.scrollHeight });
     previousScrollTop.current = el.scrollTop;
-  }, [group.id, group.messages.length, streaming, group.busyBotId, composerDock.pad]);
+  }, [group.id, group.messages.length, streaming, group.busyBotId, group.working, composerDock.pad]);
 
   // Expanding prepends rows: capture the height first, then after the commit
   // shift scrollTop by the growth so the message under the cursor stays put

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -67,6 +67,7 @@ import {
   partitionSidebarGroups,
   placeSection,
   sameSectionOrder,
+  sidebarGoalRunPreview,
   sidebarLayoutInteractive,
   sidebarSectionCollapsed,
   sidebarSectionLabel,
@@ -191,9 +192,14 @@ function groupPreview(group: Group, bots: Bot[]): string {
   if (group.busyBotId) {
     return `${bots.find((b) => b.id === group.busyBotId)?.name ?? "A bot"} is working…`;
   }
+  if (group.working) return "The team is working…";
   const last = group.messages.at(-1);
   if (!last) return "No messages yet";
-  const text = last.kind === "activity" && last.tool ? last.tool.name : (last.text ?? "");
+  const text = last.kind === "activity" && last.tool
+    ? last.tool.name
+    : last.kind === "goal.run" && last.goalRun
+      ? sidebarGoalRunPreview(last.goalRun)
+      : (last.text ?? "");
   if (last.role === "user") return `You: ${text}`;
   return last.from ? `${last.from.name}: ${text}` : text;
 }
@@ -1581,6 +1587,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
               <div
                 key={id}
                 data-sidebar-section-id={id}
+                onDragOver={(event) => updateSectionDropTarget(event, id)}
+                onDrop={dropSection}
                 className={cn(
                   "flex flex-col gap-0.5",
                   density !== "icons" && index > 0 && "pt-3",
@@ -1605,8 +1613,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                       setDraggingSectionId(id);
                     }}
                     onDragEnd={resetSectionDrag}
-                    onDragOver={(event) => updateSectionDropTarget(event, id)}
-                    onDrop={dropSection}
                     onMove={(direction) => moveSidebarSection(id, direction)}
                   />
                 )}

--- a/src/components/SidebarSectionHeader.tsx
+++ b/src/components/SidebarSectionHeader.tsx
@@ -16,8 +16,6 @@ export function SidebarSectionHeader({
   dragging,
   onDragStart,
   onDragEnd,
-  onDragOver,
-  onDrop,
   onMove,
 }: {
   name: string;
@@ -28,8 +26,6 @@ export function SidebarSectionHeader({
   dragging: boolean;
   onDragStart?: (event: DragEvent<HTMLSpanElement>) => void;
   onDragEnd?: () => void;
-  onDragOver?: (event: DragEvent<HTMLDivElement>) => void;
-  onDrop?: (event: DragEvent<HTMLDivElement>) => void;
   onMove?: (direction: -1 | 1) => void;
 }) {
   const Chevron = collapsed ? ChevronRight : ChevronDown;
@@ -46,12 +42,7 @@ export function SidebarSectionHeader({
   };
 
   return (
-    <div
-      className="flex items-center gap-1 px-2 pb-1"
-      data-section={name}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-    >
+    <div className="flex items-center gap-1 px-2 pb-1" data-section={name}>
       {onToggle ? (
         <button
           type="button"

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -390,7 +390,7 @@ export function GroupTaskPicker({ group }: { group: Group }) {
     <ConversationTaskPicker
       threadId={group.threadId}
       tasks={group.tasks ?? []}
-      busy={Boolean(group.busyBotId)}
+      busy={Boolean(group.working || group.busyBotId)}
       onNew={() => dispatch({ type: "newGroupTask", groupId: group.id })}
       onSwitch={(threadId) => dispatch({ type: "switchGroupTask", groupId: group.id, threadId })}
       onRename={(threadId, title) => dispatch({ type: "renameGroupTask", groupId: group.id, threadId, title })}

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -25,6 +25,8 @@ export interface FailedComposerSend {
   requestText: string;
   replyToId?: string;
   threadId: string;
+  /** Channel delivery mode; absent for 1:1 messages and legacy retries. */
+  channelMode?: "chat" | "goal";
 }
 type FailedComposerSendInput = Omit<FailedComposerSend, "id">;
 export interface ComposerSendSnapshot extends FailedComposerSendInput {
@@ -245,6 +247,7 @@ export function recoverFailedComposerSend(sent: ComposerSendSnapshot): "restored
       requestText: sent.requestText,
       replyToId: sent.replyToId,
       threadId: sent.threadId,
+      channelMode: sent.channelMode,
     });
     return "outbox";
   }

--- a/src/lib/group-routing.test.ts
+++ b/src/lib/group-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { roomRespondersForComposer } from "./group-routing";
+import { goalCoordinatorForComposer, roomRespondersForComposer } from "./group-routing";
 
 describe("roomRespondersForComposer", () => {
   const members = [
@@ -29,3 +29,26 @@ describe("roomRespondersForComposer", () => {
   });
 });
 
+describe("goalCoordinatorForComposer", () => {
+  const members = [
+    { id: "first", name: "First" },
+    { id: "chief", name: "Chief", chiefOfStaff: true },
+    { id: "writer", name: "Writer" },
+  ];
+
+  it("uses an explicit mention before the configured lead", () => {
+    expect(goalCoordinatorForComposer(
+      "@Writer finish this",
+      members,
+      { defaultResponder: { kind: "member", botId: "first" } },
+    )?.id).toBe("writer");
+  });
+
+  it("falls back to the in-room Chief for mentions-only goal channels", () => {
+    expect(goalCoordinatorForComposer(
+      "finish this",
+      members,
+      { defaultResponder: { kind: "mentions" } },
+    )?.id).toBe("chief");
+  });
+});

--- a/src/lib/group-routing.ts
+++ b/src/lib/group-routing.ts
@@ -56,6 +56,31 @@ export function roomRespondersForComposer<T extends { id: string; name: string; 
   return [];
 }
 
+/** Goal mode always starts with one coordinator: an explicit mention, the
+ * configured lead, an in-room Chief, or the first active member. Keep this
+ * aligned with the server's selectGroupGoalCoordinator path. */
+export function goalCoordinatorForComposer<
+  T extends { id: string; name: string; hidden?: boolean; chiefOfStaff?: boolean },
+>(
+  text: string,
+  members: T[],
+  group: Pick<Group, "defaultResponder">,
+): T | null {
+  const available = members.filter((member) => !member.hidden);
+  const explicitlyMentioned = roomRespondersForComposer(
+    text,
+    available,
+    { defaultResponder: { kind: "mentions" } },
+  )[0];
+  if (explicitlyMentioned) return explicitlyMentioned;
+  const configuredResponder = group.defaultResponder;
+  if (configuredResponder?.kind === "member") {
+    const configured = available.find((member) => member.id === configuredResponder.botId);
+    if (configured) return configured;
+  }
+  return available.find((member) => member.chiefOfStaff) ?? available[0] ?? null;
+}
+
 function mentionedMembers<T extends { name: string; hidden?: boolean }>(text: string, peers: T[]): T[] {
   const candidates = peers
     .filter((p) => !p.hidden && p.name.trim())

--- a/src/lib/sidebar-layout.test.ts
+++ b/src/lib/sidebar-layout.test.ts
@@ -12,6 +12,7 @@ import {
   partitionSidebarGroups,
   placeSection,
   sidebarLayoutInteractive,
+  sidebarGoalRunPreview,
   sidebarSectionCollapsed,
   sidebarSectionLabel,
   userSectionId,
@@ -86,6 +87,21 @@ describe("sidebar virtual sections", () => {
     expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "compact", "")).toBe(true);
     expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "compact", "writer")).toBe(false);
     expect(sidebarSectionCollapsed(PINNED_SECTION_ID, [PINNED_SECTION_ID], "icons", "")).toBe(false);
+  });
+
+  it("keeps a terminal channel goal meaningful in the sidebar", () => {
+    expect(sidebarGoalRunPreview({
+      runId: "run-1",
+      goal: "Ship the launch post",
+      status: "completed",
+      coordinatorBotId: "lead",
+      coordinatorName: "Lead",
+      turnCount: 3,
+      maxTurns: 13,
+      detail: "Drafted and verified.",
+      startedAt: 1,
+      finishedAt: 2,
+    })).toBe("Completed: Drafted and verified.");
   });
 });
 

--- a/src/lib/sidebar-layout.ts
+++ b/src/lib/sidebar-layout.ts
@@ -1,3 +1,5 @@
+import type { GroupGoalRunCardData } from "../../shared/group-goal-run";
+
 export const PINNED_SECTION_ID = "builtin:pinned";
 export const CHANNELS_SECTION_ID = "builtin:channels";
 export const BOT_CHATS_SECTION_ID = "builtin:bot-chats";
@@ -8,6 +10,16 @@ const USER_SECTION_PREFIX = "section:";
 export type SidebarSectionId = string;
 export type SectionDropPlace = "before" | "after";
 export type SidebarDensityMode = "comfortable" | "compact" | "icons";
+
+const GOAL_RUN_PREVIEW_LABEL = {
+  working: "Working",
+  completed: "Completed",
+  "needs-input": "Needs your input",
+  blocked: "Blocked",
+  "limit-reached": "Turn limit reached",
+  stopped: "Stopped",
+  failed: "Failed",
+} satisfies Record<GroupGoalRunCardData["status"], string>;
 
 export type SidebarBot = {
   id: string;
@@ -42,6 +54,14 @@ export function sidebarSectionLabel(id: SidebarSectionId): string {
   if (id === BOT_CHATS_SECTION_ID) return "Bot Chats";
   if (id === BOTS_SECTION_ID) return "Bots";
   return userSectionName(id) ?? id;
+}
+
+export function sidebarGoalRunPreview(run: GroupGoalRunCardData): string {
+  const detail = run.detail?.replace(/\s+/g, " ").trim();
+  const goal = run.goal.replace(/\s+/g, " ").trim();
+  const summary = detail || goal;
+  const label = GOAL_RUN_PREVIEW_LABEL[run.status];
+  return summary ? `${label}: ${summary}` : label;
 }
 
 export function sidebarLayoutInteractive(density: SidebarDensityMode, query: string): boolean {

--- a/src/lib/taskTimeline.ts
+++ b/src/lib/taskTimeline.ts
@@ -3,7 +3,7 @@
 export interface TimelineMessage {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run";
+  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run" | "goal.run";
   text?: string;
   tool?: { name: string; ok?: boolean };
   png?: string;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -18,6 +18,7 @@ import type { MausColor, MausMotion } from "@/lib/mascot";
 import type { BotAvatarCrop } from "../../shared/bot-avatar";
 import type { RoutineRequestCardData } from "../../shared/routine-request";
 import type { RoutineRunCardData } from "../../shared/routine-run";
+import type { GroupGoalRunCardData } from "../../shared/group-goal-run";
 import { reviewedSkillSha256, type SkillRequestCardData } from "../../shared/skill-request";
 import type { Routine, RoutineInput, RoutineRun } from "@/lib/routines";
 import type { WebhookAttempt, WebhookIngressStatus, WebhookTrigger } from "@/lib/webhooks";
@@ -79,13 +80,17 @@ export interface SecretRequestCardData {
 export interface Message {
   id: string;
   role: "bot" | "user";
-  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run";
+  kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run" | "goal.run";
   text?: string;
   card?: OptionCardData;
   connector?: ConnectorCardData;
   secret?: SecretRequestCardData;
   /** Lifecycle mirror for a routine whose real work lives in a fresh task. */
   routineRun?: RoutineRunCardData;
+  /** Durable lifecycle receipt for a goal-driven channel run. */
+  goalRun?: GroupGoalRunCardData;
+  /** How a channel user message should be handled. Absent means ordinary chat. */
+  channelMode?: "chat" | "goal";
   /** activity messages: tool name + outcome. `spoken` is the server's
    * narration of the same chip ("reading a file"), used by call mode. */
   /** `setup` marks an error fixed by installing something, not by retrying. */
@@ -136,6 +141,8 @@ export interface Group {
   /** auto-created bot⇄bot channel (ask_bot exchanges mirror here) */
   dm?: boolean;
   busyBotId?: string | null;
+  /** True for the whole orchestrated run, including hand-offs between members. */
+  working?: boolean;
   /** the room's shared desk — where member turns run their shell tools,
    * overriding each member's own folder; absent = each member's own */
   cwd?: string;
@@ -529,6 +536,7 @@ export type Action =
       sendId?: string;
       replyToId?: string;
       threadId?: string;
+      mode?: "chat" | "goal";
       onError?: () => void;
     }
   | {
@@ -1658,7 +1666,13 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           const sendId = action.sendId ?? crypto.randomUUID();
           api(`/api/groups/${action.groupId}/messages`, {
             method: "POST",
-            body: JSON.stringify({ text: action.text, replyToId: action.replyToId, threadId, sendId }),
+            body: JSON.stringify({
+              text: action.text,
+              replyToId: action.replyToId,
+              threadId,
+              sendId,
+              mode: action.mode ?? "chat",
+            }),
           })
             .then((body) => {
               if (body?.message && typeof body.threadId === "string") {


### PR DESCRIPTION
## Summary

- Add a one-shot Goal mode for team channels so a coordinator and specialists keep working until the requested outcome is complete, blocked, needs input, or reaches a 13-turn safety limit.
- Add durable goal receipts, accurate working state, retry/idempotency support, image capability routing, and privacy-safe coordinator control handling.
- Retire abandoned provider turns safely so late output cannot leak internal control data or settle a replacement turn.
- Make sidebar section drag-and-drop work across the full expanded section instead of only its small header.

Calendar-triggered rooms remain ordinary chat and the calendar behavior already on main is preserved.

## Validation

- Full Vitest suite: 241 files passed, 1 skipped; 2,678 tests passed, 19 skipped
- TypeScript checks passed
- Production build passed
- Focused lifecycle, goal-run, idempotency, routing, and sidebar tests passed
- Final independent concurrency review found no remaining actionable race

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Goal mode for group channels, enabling coordinated multi-turn work by team bots.
  * Added a Goal toggle in the composer, with progress and status updates shown in the conversation and sidebar.
  * Added clear outcomes for completed, blocked, input-needed, stopped, failed, and turn-limit runs.
* **Bug Fixes**
  * Prevented private orchestration details from appearing in transcripts.
  * Improved busy-state handling while group goals are running.
  * Prevented send IDs from being reused across different channel modes.
* **Tests**
  * Added comprehensive coverage for goal execution, validation, failure handling, and progress displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->