### PR TITLE
Permission broker survives a held Windows pipe instead of silently denying the turn

### DIFF
--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -6,8 +6,8 @@
 // These used to be POSIX-only: the fake CLI is a shebang script Windows
 // cannot exec, and the broker is a unix socket. Both now go through
 // resolveCliSpawn / permissionSocketPath, so they run everywhere.
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { connect, type Socket } from "node:net";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { connect, createServer as createNetServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { ClaudeDriver, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
+import { brokerSocketCandidates, ClaudeDriver, createPermissionBroker, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-claude-cli.ts");
@@ -150,6 +150,64 @@ describe("ClaudeDriver.decodeConfig", () => {
     const paths = COLLISION_THREAD_IDS.map(permissionSocketPath);
     expect(new Set(paths).size).toBe(COLLISION_THREAD_IDS.length);
   });
+
+  it("keeps the deterministic path as the first broker candidate", () => {
+    const candidates = brokerSocketCandidates("t-candidates");
+    expect(candidates[0]).toBe(permissionSocketPath("t-candidates"));
+    if (process.platform === "win32") {
+      // pipes are never unlinkable, so a held name needs fresh fallbacks
+      expect(candidates.length).toBeGreaterThan(1);
+      expect(new Set(candidates).size).toBe(candidates.length);
+    } else {
+      // unlink-then-listen always wins on POSIX; one candidate suffices
+      expect(candidates).toEqual([permissionSocketPath("t-candidates")]);
+    }
+  });
+
+  // Windows can't listen on filesystem socket paths at all (EACCES), so the
+  // unbindable-first-candidate unit runs on POSIX; the fake-CLI e2e below
+  // covers the real pipe fallback on Windows CI.
+  it.skipIf(process.platform === "win32")(
+    "binds the next candidate when the first is unbindable, and asks round-trip on it",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "omb-broker-fallback-"));
+      const held = join(dir, "held.sock");
+      // a directory squats the path the way a hung child holds a pipe:
+      // unlink fails, listen fails — the broker must move on, not go dark
+      mkdirSync(held);
+      const free = join(dir, "free.sock");
+      const asks: Array<{ id: string }> = [];
+      const broker = await createPermissionBroker({
+        socketPaths: [held, free],
+        onAsk: (ask) => asks.push(ask),
+        onResolve: () => {},
+      });
+      try {
+        expect(broker.socketPath).toBe(free);
+        const conn = connect(free);
+        await new Promise<void>((resolve, reject) => {
+          conn.on("connect", resolve);
+          conn.on("error", reject);
+        });
+        const answered = new Promise<{ behavior: string }>((resolve) => {
+          let buf = "";
+          conn.on("data", (c) => {
+            buf += c;
+            const nl = buf.indexOf("\n");
+            if (nl !== -1) resolve(JSON.parse(buf.slice(0, nl)));
+          });
+        });
+        conn.write(JSON.stringify({ t: "ask", id: "ask-fb", tool: "Bash", input: { command: "echo hi" } }) + "\n");
+        await expect.poll(() => asks.length).toBe(1);
+        expect(broker.answer("ask-fb", "allow")).toBe(true);
+        expect(await answered).toMatchObject({ behavior: "allow" });
+        conn.end();
+      } finally {
+        broker.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("ClaudeDriver turns (fake CLI)", () => {
@@ -809,6 +867,54 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     conn.end();
     await instance.adapter.interruptTurn("t-perm-abc");
     await recorder.until((e) => e.type === "turn.completed");
+  });
+
+  it("binds a fallback pipe when the thread's broker path is already held", async () => {
+    await create("hang");
+    const dump = join(scratch, "dump.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const basePath = permissionSocketPath("t-perm-squat");
+    // squat the deterministic path the way a hung child from an earlier
+    // process does. On POSIX the driver steals the socket file (unlink) and
+    // still binds the base; on Windows the name is unstealable and the
+    // driver must bind a fallback — either way the ask flow must work.
+    const squatter = createNetServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      squatter.once("listening", () => resolve());
+      squatter.once("error", reject);
+      squatter.listen(basePath);
+    });
+    try {
+      await instance.adapter.sendTurn({ threadId: "t-perm-squat", text: "go" });
+      await recorder.until((e) => e.type === "session.started");
+      await expect.poll(() => existsSync(dump), { timeout: 5_000 }).toBe(true);
+      const seen = JSON.parse(readFileSync(dump, "utf8"));
+      const mcpPath = seen.argv[seen.argv.indexOf("--mcp-config") + 1];
+      const actual = JSON.parse(readFileSync(mcpPath, "utf8")).mcpServers.ogb.args[1];
+      if (process.platform === "win32") expect(actual).not.toBe(basePath);
+      const conn = connect(actual);
+      await new Promise<void>((resolve, reject) => {
+        conn.on("connect", resolve);
+        conn.on("error", reject);
+      });
+      const answered = new Promise<{ behavior: string }>((resolve) => {
+        let buf = "";
+        conn.on("data", (c) => {
+          buf += c;
+          const nl = buf.indexOf("\n");
+          if (nl !== -1) resolve(JSON.parse(buf.slice(0, nl)));
+        });
+      });
+      conn.write(JSON.stringify({ t: "ask", id: "ask-squat", tool: "Bash", input: { command: "echo hi" } }) + "\n");
+      await recorder.until((e) => e.type === "request.opened" && e.requestId === "ask-squat");
+      await expect(instance.adapter.respondToRequest("t-perm-squat", "ask-squat", { behavior: "allow" })).resolves.toBe("allowed-once");
+      expect(await answered).toMatchObject({ behavior: "allow" });
+      conn.end();
+      await instance.adapter.interruptTurn("t-perm-squat");
+      await recorder.until((e) => e.type === "turn.completed");
+    } finally {
+      squatter.close();
+    }
   });
 
   it("answers to unknown or already-resolved asks resolve `unavailable` — typed, never a throw", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -8,7 +8,7 @@
 //   - Composio Sessions (connected apps → tools) over streamable HTTP
 //   - the bot's cloud computer (box.ascii.dev) via server/computer-proxy.ts
 //     — screenshot/exec/open_url, the CUA-on-the-box bridge
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { homedir, tmpdir } from "node:os";
@@ -244,8 +244,28 @@ export function permissionSocketPath(threadId: string) {
   return brokerSocketPath(DATA_DIR, `${prefix}${digest}`);
 }
 
-function createPermissionBroker(opts: {
-  socketPath: string;
+/** Paths the broker may bind, tried in order. POSIX needs only the
+ * deterministic path — unlink-then-listen always wins there. Windows named
+ * pipes are never unlinkable, and a hung CLI child from an earlier server
+ * process can hold the name open for MINUTES after its turn: the next turn's
+ * listen then fails EADDRINUSE and every permission ask fail-closes into a
+ * deny nobody can explain (seen live in a user's diagnostics). Fresh
+ * suffixed fallbacks let the new broker bind immediately; the proxy child
+ * learns the real path from its argv, so nothing else needs the name. Pipe
+ * names have no sun_path length limit, so the longer tag is safe there. */
+export function brokerSocketCandidates(threadId: string): string[] {
+  const base = permissionSocketPath(threadId);
+  if (process.platform !== "win32") return [base];
+  return [
+    base,
+    `${base}-${randomBytes(3).toString("hex")}`,
+    `${base}-${randomBytes(3).toString("hex")}`,
+  ];
+}
+
+export async function createPermissionBroker(opts: {
+  /** Candidate bind paths, tried in order; the first that listens wins. */
+  socketPaths: string[];
   onAsk: (ask: Ask) => void;
   onResolve: (resolved: Ask & { behavior: AskBehavior; source: AskResolutionSource }) => void;
   isActive?: () => boolean;
@@ -264,10 +284,8 @@ function createPermissionBroker(opts: {
   // driver already forgot (`active.delete(threadId)` already ran), which can
   // never be answered — the "zombie card" in issue #211.
   let closed = false;
-  try {
-    unlinkSync(opts.socketPath);
-  } catch {}
-  const server = createNetServer((conn) => {
+  let boundPath = opts.socketPaths[0] ?? "";
+  const connectionHandler = (conn: import("node:net").Socket) => {
     conn.on("error", () => {});
     let buf = "";
     conn.on("data", (chunk) => {
@@ -315,7 +333,7 @@ function createPermissionBroker(opts: {
         if (pending.has(askId)) {
           // askId is client-controlled; JSON.stringify escapes newlines and
           // control characters so it can't corrupt the log line or terminal.
-          console.error(`permission broker on ${opts.socketPath}: duplicate ask id ${JSON.stringify(askId)} — denying`);
+          console.error(`permission broker on ${boundPath}: duplicate ask id ${JSON.stringify(askId)} — denying`);
           try {
             conn.write(JSON.stringify({ t: "answer", id: askId, behavior: "deny", message: DUPLICATE_ASK_ID_NOTE }) + "\n");
           } catch {}
@@ -342,14 +360,44 @@ function createPermissionBroker(opts: {
         opts.onAsk(ask);
       }
     });
-  });
-  // A broker that never came up used to be silent — every approval then
-  // timed out into a deny nobody could explain. Keep the turn fail-closed,
-  // but leave an actionable diagnostic.
-  server.on("error", (error) => {
-    console.error(`permission broker unavailable on ${opts.socketPath}: ${error.message}`);
-  });
-  server.listen(opts.socketPath);
+  };
+  // Bind the first candidate that will take a listener. A broker that
+  // never came up used to be silent — every approval then timed out into a
+  // deny nobody could explain. Keep the turn fail-closed on total failure,
+  // but leave an actionable diagnostic either way.
+  let server: ReturnType<typeof createNetServer> | null = null;
+  for (const [index, candidate] of opts.socketPaths.entries()) {
+    const attempt = createNetServer(connectionHandler);
+    try {
+      unlinkSync(candidate);
+    } catch {}
+    const outcome = await new Promise<"listening" | (Error & { code?: string })>((resolve) => {
+      attempt.once("listening", () => resolve("listening"));
+      // SAFETY: net 'error' events carry syscall errors; the optional
+      // `code` is only read defensively below.
+      attempt.once("error", (error) => resolve(error as Error & { code?: string }));
+      attempt.listen(candidate);
+    });
+    if (outcome === "listening") {
+      if (index > 0) {
+        console.error(`permission broker: ${opts.socketPaths[0]} is still held — bound fallback ${candidate}`);
+      }
+      boundPath = candidate;
+      server = attempt;
+      attempt.on("error", (error) => {
+        console.error(`permission broker error on ${candidate}: ${error.message}`);
+      });
+      break;
+    }
+    try {
+      attempt.close();
+    } catch {}
+    const retryable = outcome.code === "EADDRINUSE" || outcome.code === "EACCES";
+    if (!retryable || index === opts.socketPaths.length - 1) {
+      console.error(`permission broker unavailable on ${candidate}: ${outcome.message}`);
+      break;
+    }
+  }
   const drain = () => {
     for (const p of [...pending.values()]) {
       const { behavior, message } = systemEndedReply(p.ask.kind);
@@ -371,12 +419,15 @@ function createPermissionBroker(opts: {
       closed = true;
       drain();
       try {
-        server.close();
+        server?.close();
       } catch {}
       try {
-        unlinkSync(opts.socketPath);
+        unlinkSync(boundPath);
       } catch {}
     },
+    /** Where the broker actually listens — argv for the proxy child must
+     * use this, not the deterministic base, when a fallback was bound. */
+    socketPath: boundPath,
   };
 }
 
@@ -458,7 +509,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
     await refreshModels();
     const listeners = new Set<RuntimeEventListener>();
     // one active turn per thread; a second send while busy is a caller bug
-    const active = new Map<string, { stop: () => void; turnId: string; broker?: ReturnType<typeof createPermissionBroker> }>();
+    const active = new Map<string, { stop: () => void; turnId: string; broker?: Awaited<ReturnType<typeof createPermissionBroker>> }>();
 
     // One live CLI process per thread, kept across turns. Under
     // --input-format stream-json the CLI settles a turn with `result` while
@@ -470,7 +521,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
     // after SESSION_IDLE_MS of quiet, and resumed by --resume when needed.
     interface Session {
       child: ReturnType<typeof spawnCli>;
-      broker?: ReturnType<typeof createPermissionBroker>;
+      broker?: Awaited<ReturnType<typeof createPermissionBroker>>;
       mcpConfigPath: string | null;
       /** the spawn contract — a different one means a fresh process */
       argsKey: string;
@@ -644,7 +695,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // permission broker: anything acceptEdits would silently deny becomes
       // an Allow/Deny card in chat, and the agent gets ask_user. Skipped in
       // bypassPermissions (fullAuto) — nothing would ever ask.
-      let broker: ReturnType<typeof createPermissionBroker> | undefined;
+      let broker: Awaited<ReturnType<typeof createPermissionBroker>> | undefined;
       let socketPath: string | null = null;
       if (config.permissionMode !== "bypassPermissions") {
         socketPath = permissionSocketPath(threadId);
@@ -706,8 +757,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         // remembers which tool each pending ask came from, so the resolved
         // event can scope approvals to real desktop-control tools only
         const askTools = new Map<string, string | undefined>();
-        broker = createPermissionBroker({
-          socketPath,
+        broker = await createPermissionBroker({
+          socketPaths: brokerSocketCandidates(threadId),
           isActive: () => Boolean(sessions.get(threadId)?.turn),
           onAsk: (ask) => {
             const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
@@ -740,6 +791,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             askTools.delete(resolved.id);
           },
         });
+        // A fallback bind means the deterministic pipe is still held by an
+        // earlier process's child. The proxy learns its path from argv, so
+        // point it at the pipe we actually bound. argsKey deliberately keeps
+        // the base path: the nonce is not part of the spawn contract, and a
+        // retained session keeps its own broker object anyway.
+        if (broker.socketPath !== socketPath && mcpConfigPath) {
+          mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, broker.socketPath], env: { ...NODE_ENV_FLAG } };
+          writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
+        }
       }
       if (sessionId) args.push("--resume", sessionId);
       else args.push("--session-id", newSessionId!);


### PR DESCRIPTION
From a Windows user's diagnostics:

```
permission broker unavailable on \\.\pipe\openmausbot-perm-19040-529dfb2d: listen EADDRINUSE
```

## What was happening

The permission broker binds a **deterministic per-thread** name (pid + threadId prefix + digest). On POSIX that's safe — unlink-then-listen always wins. On Windows, named pipes are never unlinkable, and a hung CLI child from an earlier server process can hold the name open for **minutes** after its turn (this user hit it twice, 22 minutes apart). The new turn's `listen` fails EADDRINUSE, and because the broker fails closed, **every permission ask in that turn silently auto-denies** ("skip this action") — the bot just looks like it refused to work.

## The fix

`createPermissionBroker` now binds the **first candidate that will take a listener**:

- POSIX: candidates = `[base]`, byte-identical behavior.
- Windows: `[base, base-<nonce>, base-<nonce>]` — the deterministic name is still preferred (retained sessions, tests, and diagnostics all keep meaning), but a held pipe no longer takes the whole turn down.
- The proxy child learns its path from argv, so on a fallback bind the `mcpServers.ogb` entry and the mcp-config file are rewritten to the pipe actually bound. `argsKey` deliberately keeps the base path — the nonce is not part of the spawn contract, and a retained session keeps its own broker object.
- A fallback bind logs `permission broker: <base> is still held — bound fallback <path>`, so the next diagnostics bundle tells this story instantly instead of a bare EADDRINUSE.
- Total bind failure keeps today's fail-closed posture, with the same actionable diagnostic.

## How verified

- Unit (POSIX; mutation-checked both ways): an unbindable first candidate → broker binds the next one, reports the real `socketPath`, and a full ask→answer round-trip works on it. Reverting the candidate loop or the bound-path reporting each fails the suite.
- New fake-CLI e2e — runs on **Windows CI** where it matters: a squatter server holds the thread's deterministic path before the turn starts; the driver still comes up, the proxy's argv points at the actually-bound path (asserted ≠ base on win32), and the permission ask round-trips end to end.
- Existing deterministic-path tests unchanged and green (the base path is still candidate #1); claude suite 61 passed, index suite 135 passed; `tsc` + strict `typecheck` clean; lint parity exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission broker startup reliability when the preferred communication path is unavailable.
  * Automatically selects an available fallback path, including when a previous process is still holding the original path.
  * Updated broker connections to use the path that was successfully bound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->