### PR TITLE
Bring-your-own engines: any ACP CLI or OpenAI-compatible endpoint via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ the composer mic) — see [`docs/voice-mode.md`](docs/voice-mode.md) for the des
 
 Contributions welcome — the driver SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately
 small; adding a provider is one file in [`server/drivers/`](server/drivers/) plus a one-line registration.
+No code needed at all for your own engines: any ACP-speaking CLI or OpenAI-compatible endpoint
+plugs in through config — see [`docs/custom-engines.md`](docs/custom-engines.md).
 
 ## Support the project
 

--- a/docs/custom-engines.md
+++ b/docs/custom-engines.md
@@ -1,0 +1,77 @@
+# Bring your own engine
+
+Two zero-code ways to run OpenMausBot bots on an engine the app doesn't ship.
+Both live in `~/.openmausbot/config.json` under `"instances"`; restart the app
+after editing (instance entries are read at boot).
+
+## Any ACP agent (a CLI you spawn)
+
+If an agent CLI speaks [ACP](https://agentclientprotocol.com) over stdio —
+`fx acp`, a Zed-style agent server, your own wrapper — point a `customAcp`
+instance at it:
+
+```json
+{
+  "instances": {
+    "my-agent": {
+      "driver": "customAcp",
+      "displayName": "My Agent",
+      "environment": { "MY_AGENT_TOKEN": "…" },
+      "config": { "cli": "my-agent acp" }
+    }
+  }
+}
+```
+
+- **`config.cli`** is the whole command, args included (`"npx -y some-agent acp"`
+  works). You can also set it from the app: Settings → Engines → *Set CLI…* on
+  the instance's row. An instance without a command shows up with exactly that
+  hint instead of failing at first message.
+- **Sign in first.** The driver has no auth flow of its own — run the CLI once
+  in a terminal and log in there; OpenMausBot spawns it with your login intact.
+- **Model choice stays inside the agent.** The picker shows a single
+  "Agent default" entry; whatever the CLI is configured to run is what runs.
+- **`environment`** is passed to the CLI child. Foreign provider keys
+  (XAI_API_KEY, OPENAI_COMPAT_API_KEY, …) are deliberately stripped so a
+  custom CLI can never bill against another engine's login.
+- **Permissions** ride ACP's own `session/request_permission` — if your agent
+  asks, the request becomes a normal approval card in chat.
+- Multiple instances are fine — one per agent.
+
+## Any OpenAI-compatible endpoint (no process at all)
+
+The built-in `openai-compat` driver supports multiple instances, so a local
+vLLM/LM Studio/Ollama-openai endpoint or any hosted compatible API is one
+entry:
+
+```json
+{
+  "instances": {
+    "my-endpoint": {
+      "driver": "openai-compat",
+      "displayName": "My Endpoint",
+      "environment": { "MY_ENDPOINT_KEY": "sk-…" },
+      "config": {
+        "url": "http://127.0.0.1:1234/v1",
+        "apiKeyEnv": "MY_ENDPOINT_KEY",
+        "model": "my-model"
+      }
+    }
+  }
+}
+```
+
+- `apiKeyEnv` names which `environment` value carries the key, so several
+  instances can hold different keys without colliding.
+- The driver lists the endpoint's `/models` when it can and keeps your
+  `model` as a custom option either way.
+- Honest limits: chat text + reasoning streams only — **no tool calls**, so
+  bots on these instances answer and write, but don't operate computers or
+  connected apps.
+
+## Notes
+
+- `config.json` is written with mode 0600; values in `environment` are stored
+  as plaintext in that file. Prefer keys scoped to the one engine.
+- A typo'd `driver` or invalid `config` never breaks the app: the instance
+  shows as unavailable with the reason, and the rest of the fleet loads.

--- a/server/drivers/acp/custom.test.ts
+++ b/server/drivers/acp/custom.test.ts
@@ -1,0 +1,129 @@
+// Contract tests for the bring-your-own ACP driver. The scripted fake ACP
+// CLI stands in for "any agent that speaks ACP over stdio" — exactly the
+// promise the driver makes to users.
+import { chmodSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ensureDirs } from "../../config.ts";
+import type { ProviderInstance } from "../../contracts.ts";
+import { recordEvents, type EventRecorder } from "../../testing/events.ts";
+import { CustomAcpDriver } from "./custom.ts";
+import { removeTempDir } from "../../testing/cleanup.ts";
+
+const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "testing", "fake-acp-cli.ts");
+
+describe("CustomAcpDriver config", () => {
+  it("teaches instead of ENOENT when the command is missing or blank", async () => {
+    expect(() => CustomAcpDriver.decodeConfig({})).toThrow(/Set CLI|config\.json/);
+    expect(() => CustomAcpDriver.decodeConfig({ cli: "   " })).toThrow(/<your-agent> acp/);
+    // registry uses defaultConfig() verbatim when the entry has no config —
+    // create() must reject with the same teaching message, never spawn ""
+    await expect(
+      CustomAcpDriver.create({
+        instanceId: "custom-blank",
+        displayName: undefined,
+        environment: {},
+        enabled: true,
+        config: CustomAcpDriver.defaultConfig(),
+      }),
+    ).rejects.toThrow(/<your-agent> acp/);
+  });
+
+  it("keeps a real command verbatim, wrapper strings included", () => {
+    expect(CustomAcpDriver.decodeConfig({ cli: "fx acp", fullAuto: true })).toMatchObject({
+      cli: "fx acp",
+      fullAuto: true,
+    });
+  });
+
+  it("advertises the custom rail, multi-instance, and the passthrough model", () => {
+    expect(CustomAcpDriver.metadata).toMatchObject({
+      access: "custom",
+      supportsMultipleInstances: true,
+    });
+    expect(CustomAcpDriver.models).toEqual({
+      default: "agent-default",
+      options: [{ id: "agent-default", label: "Agent default" }],
+    });
+    // no install descriptor: there is nothing generic to install
+    expect(CustomAcpDriver.install).toBeUndefined();
+  });
+});
+
+describe("CustomAcpDriver turns (fake CLI)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+  let scratch: string;
+
+  const create = async (environment: Record<string, string> = {}) => {
+    instance = await CustomAcpDriver.create({
+      instanceId: "custom-test",
+      displayName: "Custom Test",
+      environment,
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    recorder = recordEvents(instance.adapter);
+  };
+
+  beforeEach(() => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    scratch = mkdtempSync(join(tmpdir(), "omb-custom-acp-test-"));
+  });
+
+  afterEach(async () => {
+    delete process.env.FAKE_ACP_MODE;
+    delete process.env.FAKE_ACP_DUMP;
+    delete process.env.XAI_API_KEY;
+    recorder?.stop();
+    await instance?.dispose();
+    await removeTempDir(scratch);
+  });
+
+  it("runs a full turn through an arbitrary ACP CLI with canonical events", async () => {
+    await create();
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-custom", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const types = recorder.events.map((e) => e.type);
+    expect(types).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "item.completed", // assistant text
+      "item.started", // tool tc-1
+      "item.completed", // tool tc-1 done
+      "thread.token-usage.updated",
+      "turn.completed",
+    ]);
+    expect(recorder.events.every((e) => e.turnId === turnId && e.provider === "customAcp")).toBe(true);
+    const text = recorder.events.find((e) => e.type === "item.completed" && (e as { itemType?: string }).itemType === "assistant_text")!;
+    expect((text as { text?: string }).text).toBe("hello from fake acp");
+    expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true });
+  });
+
+  it("passes instance env to the child but strips foreign provider keys", async () => {
+    process.env.XAI_API_KEY = "xai-should-not-leak";
+    const dump = join(scratch, "dump.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await create({ MY_AGENT_TOKEN: "tok-123" });
+    await instance.adapter.sendTurn({ threadId: "t-custom-env", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8")) as { env: Record<string, string | undefined> };
+    expect(seen.env.MY_AGENT_TOKEN).toBe("tok-123");
+    // deny-by-default credential hygiene: a custom CLI never inherits
+    // another provider's billing key
+    expect(seen.env.XAI_API_KEY).toBeUndefined();
+  });
+
+  it("reports available with a working CLI and no sign-in requirement", async () => {
+    await create();
+    const snapshot = await instance.snapshot();
+    expect(snapshot).toMatchObject({ state: "available" });
+  });
+});

--- a/server/drivers/acp/custom.ts
+++ b/server/drivers/acp/custom.ts
@@ -1,0 +1,54 @@
+// Bring-your-own engine: any agent CLI that speaks ACP over stdio plugs in
+// as an instance of this driver — no code, one config entry:
+//
+//   { "instances": { "my-agent": {
+//       "driver": "customAcp",
+//       "displayName": "My Agent",
+//       "config": { "cli": "my-agent acp" } } } }
+//
+// The `cli` string carries the whole command (wrapper strings resolve via
+// splitCliString, so "npx -y some-agent acp" works too). There is no auth
+// story on purpose: the user's CLI is expected to be signed in from a
+// terminal already, exactly like the qwen harness. Model choice stays
+// inside the agent — we advertise a single passthrough id and never pass
+// a model on argv, because -m conventions differ per CLI.
+import { createAcpDriver, type AcpSupport } from "./core.ts";
+
+const CONFIGURE_HINT =
+  'a custom ACP engine needs its command — add "config": { "cli": "<your-agent> acp" } to this instance in config.json, or use Settings → Engines → Set CLI…';
+
+const support: AcpSupport = {
+  driverKind: "customAcp",
+  displayName: "Custom (ACP)",
+  access: "custom",
+  // One passthrough id: the agent runs whatever it is configured for.
+  // Advertising a made-up catalog would promise switching we cannot do.
+  models: { default: "agent-default", options: [{ id: "agent-default", label: "Agent default" }] },
+  defaultCli: "",
+  nativeSource: "custom.acp",
+  loginNote: CONFIGURE_HINT,
+  // Mode-entering args ride the cli string itself ("fx acp"), so nothing
+  // extra here.
+  spawnArgs: () => [],
+  pickAuthMethod: () => null,
+  authFailure: "continue",
+  isAuthenticated: () => true,
+};
+
+const base = createAcpDriver(support);
+
+export const CustomAcpDriver: typeof base = {
+  ...base,
+  // decodeAcpConfig never throws (a missing cli falls back to defaultCli,
+  // which is empty here). Turn every blank-command path into the same
+  // teaching shadow row instead of a bare spawn ENOENT at first send.
+  decodeConfig(raw) {
+    const decoded = base.decodeConfig(raw);
+    if (!decoded.cli.trim()) throw new Error(CONFIGURE_HINT);
+    return decoded;
+  },
+  async create(input) {
+    if (!input.config.cli.trim()) throw new Error(CONFIGURE_HINT);
+    return base.create(input);
+  },
+};

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -13,6 +13,7 @@ import { DroidAgentDriver } from "./acp/droid.ts";
 import { CursorAgentDriver } from "./acp/cursor.ts";
 import { OpenCodeDriver } from "./acp/opencode-go.ts";
 import { QwenAgentDriver } from "./acp/qwen.ts";
+import { CustomAcpDriver } from "./acp/custom.ts";
 import { HermesAgentDriver } from "./acp/hermes.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
 import { PiDriver } from "./pi.ts";
@@ -28,6 +29,7 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   OpenCodeDriver,
   QwenAgentDriver,
   HermesAgentDriver,
+  CustomAcpDriver,
   PiDriver,
   OpenAICompatDriver,
   ClaudeDriver,

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -100,6 +100,7 @@ const dumpEnv = Object.fromEntries(
     "KIMI_MODEL_PROVIDER_TYPE",
     "KIMI_MODEL_DISPLAY_NAME",
     "TEST_TURN_MODEL",
+    "MY_AGENT_TOKEN",
   ].flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]] as const)),
 );
 const dumpState: Record<string, unknown> = { argv, env: dumpEnv };


### PR DESCRIPTION
First slice of #532 (modularity): **bring-your-own engines with zero code** — the plugin surface is a protocol, not a framework.

## What

A new `customAcp` driver: any agent CLI that speaks ACP over stdio becomes an engine instance through one config entry:

```json
{ "instances": { "my-agent": {
    "driver": "customAcp",
    "displayName": "My Agent",
    "config": { "cli": "my-agent acp" } } } }
```

- The `cli` string carries the whole command (wrapper strings like `npx -y some-agent acp` resolve through the existing `splitCliString` machinery), and Settings → Engines → *Set CLI…* works on these rows, so after a bare entry exists the command can be set from the UI.
- **Teaching failure modes**: a missing/blank command becomes a shadow row that says exactly what to add — never a spawn-ENOENT at first message. A typo'd driver slug already degrades to an honest shadow via the registry's existing forward-compat path.
- **No auth story on purpose** (the qwen-harness pattern): the user signs the CLI in from a terminal; `pickAuthMethod: null`, `authFailure: "continue"`.
- **Model choice stays inside the agent** — one honest "Agent default" passthrough entry instead of a fake catalog; no `-m` is ever passed (argv conventions differ per CLI).
- **Credential hygiene is inherited, deny-by-default**: instance `environment` reaches the child, but foreign provider keys (XAI_API_KEY, …) are stripped by acp/core's allowlist, so a custom CLI can never bill against another engine's login. Permission asks ride ACP `session/request_permission` into normal approval cards.
- `access: "custom"`, multi-instance, no install descriptor (nothing generic to install).

Also documents the **second zero-code path that already worked but was invisible**: multiple `openai-compat` instances (any OpenAI-compatible endpoint — local vLLM/LM Studio or hosted) with per-instance `apiKeyEnv` so keys don't collide. `docs/custom-engines.md` covers both with honest limits (openai-compat = chat text only, no tool calls), linked from the README.

## Why this shape

Per the modularity discussion on #532: every extension here is **config, never code the core executes**. ACP is the industry's engine-plugin protocol (Zed's `agent_servers`, fx); exposing our existing `acp/core.ts` as a user-facing slot is the 80% of "agent engine plugins" at ~5% of the cost, with none of the ABI-stability or code-execution burden of a plugin framework.

## How verified

- Contract tests against the fake ACP CLI: canonical event sequence end-to-end under `customAcp`, env passthrough + foreign-key stripping (fixture dump), availability snapshot, metadata (custom rail, multi-instance, passthrough catalog), and both blank-command paths rejecting with the teaching message (decodeConfig throw → shadow; defaultConfig create → rejection → shadow).
- Mutation checks: removing either teaching guard fails the suite.
- ACP core suite (43), registry + config suites green; `tsc` + strict typecheck clean; lint parity exact (zero hits on all new files).

## Scope notes

- No add-instance UI yet — instances are file-edited (now documented for the first time); an instance-create flow is a natural follow-up.
- Part 2 (bring-your-own MCP servers) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting custom ACP-compatible agent CLIs through configuration.
  * Added support for OpenAI-compatible engines, including local and hosted endpoints.
  * Custom engine instances can use separate API keys, select models, and pass approved environment settings.
  * Invalid configurations are reported as unavailable without preventing other configured engines from loading.
  * ACP permission requests are shown as approval cards.

* **Documentation**
  * Added a custom engines guide and README links explaining setup, configuration, limitations, and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->