### PR TITLE
Bring-your-own MCP servers via config, permission-carded by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ the composer mic) — see [`docs/voice-mode.md`](docs/voice-mode.md) for the des
 
 Contributions welcome — the driver SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately
 small; adding a provider is one file in [`server/drivers/`](server/drivers/) plus a one-line registration.
+Users can add their own MCP tool servers with zero code via [`docs/custom-mcp-servers.md`](docs/custom-mcp-servers.md).
 
 ## Support the project
 

--- a/docs/custom-mcp-servers.md
+++ b/docs/custom-mcp-servers.md
@@ -1,0 +1,42 @@
+# Bring your own MCP servers
+
+Give every capable engine extra tools by listing MCP servers in
+`~/.openmausbot/config.json` — the same shape Claude Code and friends use:
+
+```json
+{
+  "mcpServers": {
+    "notes": {
+      "command": "npx",
+      "args": ["-y", "@example/notes-mcp"],
+      "env": { "NOTES_TOKEN": "…" }
+    }
+  }
+}
+```
+
+Restart the app after editing. Every bot whose engine can mount MCP servers
+(Claude, Codex, and all ACP engines — Grok, Gemini, Kimi, Droid, Cursor,
+opencode, Qwen, Hermes, and `customAcp`) gets the tools on its next turn.
+
+## Rules that keep this safe
+
+- **Permission cards by default.** Custom servers are never pre-approved:
+  on Claude their tools route through the permission broker into Allow/Deny
+  cards; on Codex they keep the on-request approval policy; ACP engines
+  relay the agent's own permission asks. Built-ins stay pre-quieted — only
+  *your* servers ask.
+- **Reserved names are refused** (`computer`, `agents`, `composio`,
+  `browser`, `phone`, `dweb`, `ogb`, …) so a custom entry can never shadow
+  a built-in tool surface. Names are lowercase letters/digits/`_`/`-`, max
+  32 chars, starting with a letter.
+- **One bad entry never takes the fleet down.** Invalid entries are skipped
+  with a logged reason; the rest still mount.
+- **Credentials stay off argv.** `env` values travel in the child
+  environment (Codex argv carries env *names* only; Claude uses the private
+  0600 mcp-config file; ACP passes them in the session payload with the
+  wire log redacted). They do persist as plaintext in the 0600 config file —
+  prefer tokens scoped to the one server.
+- `"enabled": false` parks an entry without deleting it.
+- Stdio servers only for now — `url` transports are a planned follow-up and
+  are skipped with a note.

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import {
+import { customMcpServers,
   DATA_DIR,
   instanceConfigs,
   isValidSshAlias,
@@ -733,5 +733,71 @@ describe("workspace credential env strip", () => {
     expect(WORKSPACE_CREDENTIAL_ENV).toContain("OMB_OPENAI_IMAGE_KEY");
     expect(WORKSPACE_CREDENTIAL_ENV).toContain("OMB_BROWSER_CONNECTION");
     expect(WORKSPACE_CREDENTIAL_ENV).toContain("OMB_USER_DATA");
+  });
+});
+
+describe("customMcpServers", () => {
+  const cfg = (mcpServers: Record<string, unknown>) =>
+    ({ mcpServers }) as Parameters<typeof customMcpServers>[0];
+
+  it("normalizes a valid stdio entry and defaults args/env", () => {
+    expect(
+      customMcpServers(
+        cfg({
+          notes: { command: "npx", args: ["-y", "@x/notes-mcp"], env: { NOTES_TOKEN: "t" } },
+          bare: { command: "/usr/local/bin/server" },
+        }),
+      ),
+    ).toEqual({
+      notes: { command: "npx", args: ["-y", "@x/notes-mcp"], env: { NOTES_TOKEN: "t" } },
+      bare: { command: "/usr/local/bin/server", args: [], env: {} },
+    });
+  });
+
+  it("returns {} when the section is absent", () => {
+    expect(customMcpServers({} as Parameters<typeof customMcpServers>[0])).toEqual({});
+  });
+
+  it("skips disabled entries silently", () => {
+    expect(customMcpServers(cfg({ off: { command: "x", enabled: false } }))).toEqual({});
+  });
+
+  it("skips reserved names — a custom entry can never shadow a built-in", () => {
+    const out = customMcpServers(
+      cfg({
+        ogb: { command: "evil" },
+        computer: { command: "evil" },
+        agents: { command: "evil" },
+        fine: { command: "ok" },
+      }),
+    );
+    expect(Object.keys(out)).toEqual(["fine"]);
+  });
+
+  it("skips names that could not survive every driver's namespace", () => {
+    const out = customMcpServers(
+      cfg({
+        "Bad.Name": { command: "x" },
+        "1leading-digit": { command: "x" },
+        "way-too-long-name-way-too-long-name-x": { command: "x" },
+        good_name: { command: "x" },
+      }),
+    );
+    expect(Object.keys(out)).toEqual(["good_name"]);
+  });
+
+  it("skips url transports with a teaching message, not a crash", () => {
+    expect(customMcpServers(cfg({ api: { url: "https://x/mcp" } }))).toEqual({});
+  });
+
+  it("skips malformed entries without dropping the valid ones", () => {
+    const out = customMcpServers(
+      cfg({
+        broken: { args: ["no-command"] },
+        alsoBad: "not-an-object",
+        keeper: { command: "ok" },
+      }),
+    );
+    expect(Object.keys(out)).toEqual(["keeper"]);
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -256,14 +256,20 @@ const appConfigSchema = z.object({
   features: featureConfigSchema.optional(),
   browserProfiles: browserProfilesSchema.optional(),
   instances: instanceConfigMapSchema.optional(),
+  /** User-configured MCP servers, mounted into every capable engine. Kept
+   * loosely typed HERE on purpose: parseStoredConfig throws away the whole
+   * file on a schema error, and one bad server entry must degrade to a
+   * skipped entry (customMcpServers), never to a vanished config. */
+  mcpServers: z.record(z.string(), z.unknown()).optional(),
 });
 const storedAppConfigSchema = appConfigSchema.extend({
   browserProfiles: storedBrowserProfilesSchema.optional(),
 });
-const appConfigPatchSchema = appConfigSchema.omit({ instances: true });
+const appConfigPatchSchema = appConfigSchema.omit({ instances: true, mcpServers: true });
 const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
+  mcpServers?: Record<string, unknown>;
   xai?: { key?: string; url?: string };
   openaiCompat?: { key?: string; url?: string; model?: string; provider?: string };
   composio?: { apiKey?: string; userId?: string; sessionId?: string };
@@ -775,4 +781,79 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     }
   }
   return map;
+}
+
+// ── user-configured MCP servers ─────────────────────────────────────────
+// config.json: { "mcpServers": { "notes": { "command": "npx", "args":
+// ["-y", "@x/notes-mcp"], "env": { "NOTES_TOKEN": "…" } } } }
+// stdio only for now; validate-with-skip so one bad entry never takes the
+// fleet down, and each skip is logged once with a sentence that teaches.
+
+export interface CustomMcpServer {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+const customMcpEntrySchema = z
+  .object({
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+const CUSTOM_MCP_NAME = /^[a-z][a-z0-9_-]{0,31}$/;
+/** Server keys the harness mounts itself — a custom entry must never
+ * shadow or clobber one of these across any driver's namespace. */
+const RESERVED_MCP_NAMES = new Set([
+  "ogb",
+  "computer",
+  "agents",
+  "composio",
+  "browser",
+  "phone",
+  "dweb",
+  "openmausbot_connectors",
+  "openmausbot_phone",
+]);
+
+const reportedMcpSkips = new Set<string>();
+function skipMcpEntry(name: string, why: string): void {
+  const key = `${name}: ${why}`;
+  if (reportedMcpSkips.has(key)) return;
+  reportedMcpSkips.add(key);
+  console.error(`mcpServers.${JSON.stringify(name)} skipped — ${why}`);
+}
+
+/** The validated, normalized custom servers from config — or {}. */
+export function customMcpServers(cfg: AppConfig): Record<string, CustomMcpServer> {
+  const out: Record<string, CustomMcpServer> = {};
+  for (const [name, raw] of Object.entries(cfg.mcpServers ?? {})) {
+    if (!CUSTOM_MCP_NAME.test(name)) {
+      skipMcpEntry(name, "server names are lowercase letters, digits, _ or - (max 32 chars), starting with a letter");
+      continue;
+    }
+    if (RESERVED_MCP_NAMES.has(name)) {
+      skipMcpEntry(name, "that name is reserved for a built-in server — pick another");
+      continue;
+    }
+    if (raw && typeof raw === "object" && "url" in raw) {
+      skipMcpEntry(name, 'only stdio servers ("command") are supported so far — HTTP transports are a planned follow-up');
+      continue;
+    }
+    const parsed = customMcpEntrySchema.safeParse(raw);
+    if (!parsed.success) {
+      skipMcpEntry(name, `invalid entry (${parsed.error.issues[0]?.message ?? "schema mismatch"}) — expected { "command": "npx", "args": [...], "env": { ... } }`);
+      continue;
+    }
+    if (parsed.data.enabled === false) continue;
+    out[name] = {
+      command: parsed.data.command,
+      args: parsed.data.args ?? [],
+      env: parsed.data.env ?? {},
+    };
+  }
+  return out;
 }

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -198,6 +198,10 @@ export interface SendTurnInput {
     /** dweb network daemon: an MCP proxy exposing dweb status, repo, and
      * opencode model access as tools. url is the dweb HTTP base. */
     dweb?: { url: string };
+    /** User-configured MCP servers (config.json `mcpServers`), already
+     * validated and normalized by customMcpServers(). Mounted WITHOUT any
+     * pre-allow: their tools ride each driver's normal permission flow. */
+    custom?: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
   };
   cwd?: string;
 }
@@ -246,6 +250,10 @@ export interface ProviderAdapter {
     /** True only when local MCP calls can reach the human approval channel.
      * Full-auto/bypass provider instances must leave this false. */
     localComputerMcp?: boolean;
+    /** True when the driver mounts turn.integrations.custom (the user's own
+     * MCP servers from config). Same rule as composioMcp: an entry in the
+     * config says the servers exist, not that this engine can reach them. */
+    customMcp?: boolean;
   };
   sendTurn(input: SendTurnInput): Promise<TurnStartResult>;
   interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void>;

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -451,6 +451,30 @@ describe("ACP turns (fake CLI)", () => {
     expect(instance.adapter.capabilities.localComputerMcp).toBe(true);
   });
 
+  it("mounts user-configured custom MCP servers after the built-ins", async () => {
+    await create();
+    const dump = join(scratch, "custom-dump.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await instance.adapter.sendTurn({
+      threadId: "t-custom-mcp",
+      text: "go",
+      integrations: {
+        custom: {
+          notes: { command: "npx", args: ["-y", "@x/notes-mcp"], env: { NOTES_TOKEN: "tok-1" } },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.mcpServers).toContainEqual({
+      name: "notes",
+      command: "npx",
+      args: ["-y", "@x/notes-mcp"],
+      env: [{ name: "NOTES_TOKEN", value: "tok-1" }],
+    });
+    expect(instance.adapter.capabilities.customMcp).toBe(true);
+  });
+
   it("surfaces a permission ask as request.opened and completes once allowed", async () => {
     await create(GrokAgentDriver, "permission");
     await instance.adapter.sendTurn({

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -283,6 +283,13 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             env: acpEnv(local.env ?? {}),
           });
         }
+        // user-configured servers, after the built-ins: a residual name
+        // collision keeps the built-in (reserved names are filtered at the
+        // config boundary; this is defense in depth).
+        for (const [name, server] of Object.entries(turn.integrations?.custom ?? {})) {
+          if (servers.some((existing) => existing.name === name)) continue;
+          servers.push({ name, command: server.command, args: server.args, env: acpEnv(server.env) });
+        }
         return servers;
       };
 
@@ -753,6 +760,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           capabilities: {
             sessionModelSwitch: "unsupported",
             agentsMcp: true,
+        customMcp: true,
             computerMcp: true,
             composioMcp: true,
             browserMcp: true,

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -412,6 +412,43 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(allowed).toContain("mcp__agents");
   });
 
+  it("mounts custom MCP servers without pre-allowing their tools", async () => {
+    await create();
+    const dump = join(scratch, "custom-mcp.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-custom-mcp",
+      text: "hi",
+      integrations: {
+        custom: {
+          notes: { command: "npx", args: ["-y", "@x/notes-mcp"], env: { NOTES_TOKEN: "tok-notes" } },
+        },
+        agents: {
+          command: process.execPath,
+          args: ["/fake/agents-proxy.js"],
+          env: { OMB_HARNESS_URL: "http://127.0.0.1:1", OMB_BOT_ID: "b1", OMB_COMMS_TOKEN: "tok", OMB_TURN_DEPTH: "0" },
+        },
+      },
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    // the server reaches the CLI through the private mcp-config file…
+    expect(seen.mcpConfig.mcpServers.notes).toMatchObject({
+      command: "npx",
+      args: ["-y", "@x/notes-mcp"],
+      env: { NOTES_TOKEN: "tok-notes" },
+    });
+    // …but its tools are NOT pre-allowed: acceptEdits denies unlisted tools,
+    // which routes every custom call through the ogb broker into a card.
+    const allowed = seen.argv[seen.argv.indexOf("--allowedTools") + 1];
+    expect(allowed).toContain("mcp__agents");
+    expect(allowed).not.toContain("mcp__notes");
+    // and its credential value stays out of argv
+    expect(JSON.stringify(seen.argv)).not.toContain("tok-notes");
+  });
+
   it("passes normalized available and denied built-in tool sets to Claude", async () => {
     await create(undefined, {}, {
       tools: ["Read", "WebFetch"],

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -692,6 +692,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         };
         allowed.push("mcp__dweb");
       }
+      // user-configured servers mount like any integration but are NOT
+      // pre-allowed: acceptEdits silently denies unlisted tools, which
+      // routes every custom tool call through the ogb permission broker
+      // into an Allow/Deny card. Reserved names were filtered upstream;
+      // skip any residual collision instead of clobbering a built-in.
+      for (const [name, server] of Object.entries(turn.integrations?.custom ?? {})) {
+        if (name in mcpServers) continue;
+        mcpServers[name] = { ...server };
+      }
       // permission broker: anything acceptEdits would silently deny becomes
       // an Allow/Deny card in chat, and the agent gets ask_user. Skipped in
       // bypassPermissions (fullAuto) — nothing would ever ask.
@@ -1184,6 +1193,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         capabilities: {
           sessionModelSwitch: "in-session",
           agentsMcp: true,
+        customMcp: true,
           computerMcp: true,
           composioMcp: true,
           phoneMcp: true,

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -190,6 +190,40 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(seen.env.OMB_COMMS_TOKEN).toBe("per-boot-token");
   });
 
+  it("mounts custom MCP servers on-request while built-ins stay pre-quieted", async () => {
+    await create();
+    const dump = join(scratch, "custom-mcp.json");
+    process.env.FAKE_CODEX_DUMP = dump;
+    expect(instance.adapter.capabilities.customMcp).toBe(true);
+
+    await instance.adapter.sendTurn({
+      threadId: "t-custom-mcp",
+      text: "go",
+      integrations: {
+        custom: {
+          notes: { command: "npx", args: ["-y", "@x/notes-mcp"], env: { NOTES_TOKEN: "tok-notes" } },
+        },
+        composio: {
+          command: process.execPath,
+          args: ["/tmp/connector-proxy.js"],
+          env: { OMB_COMMS_TOKEN: "per-boot-token" },
+        },
+      },
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    const argv = seen.argv.join(" ");
+    expect(argv).toContain("mcp_servers.notes.command");
+    // env value stays in the child env; argv carries names only
+    expect(argv).toContain("NOTES_TOKEN");
+    expect(argv).not.toContain("tok-notes");
+    expect(seen.env.NOTES_TOKEN).toBe("tok-notes");
+    // the built-in keeps codex's pre-quieted approval mode; the custom
+    // server does NOT — its tool calls arrive as approval cards
+    expect(argv).toContain('mcp_servers.openmausbot_connectors.default_tools_approval_mode');
+    expect(argv).not.toContain('mcp_servers.notes.default_tools_approval_mode');
+  });
+
   it("mounts peer-agent comms without placing the comms token in argv", async () => {
     await create();
     const dump = join(scratch, "agents.json");

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -60,6 +60,7 @@ function mountMcpServer(
   env: Record<string, string | undefined>,
   name: string,
   server: StdioMcpServer,
+  preApproved = true,
 ): void {
   Object.assign(env, server.env);
   const prefix = `mcp_servers.${name}`;
@@ -69,8 +70,12 @@ function mountMcpServer(
     // Values stay in the child environment; argv contains names only so
     // credentials never appear in process listings or diagnostics.
     "-c", `${prefix}.env_vars=${JSON.stringify(Object.keys(server.env))}`,
-    "-c", `${prefix}.default_tools_approval_mode="auto"`,
   );
+  // Harness-owned servers are pre-quieted; a user-configured server keeps
+  // codex's on-request policy so its tool calls become approval cards.
+  if (preApproved) {
+    appServerArgs.push("-c", `${prefix}.default_tools_approval_mode="auto"`);
+  }
 }
 
 export const CodexDriver: ProviderDriver<CodexConfig> = {
@@ -179,6 +184,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         }
         if (turn.integrations?.browser) {
           mountMcpServer(appServerArgs, env, "browser", turn.integrations.browser);
+        }
+        for (const [name, server] of Object.entries(turn.integrations?.custom ?? {})) {
+          mountMcpServer(appServerArgs, env, name, server, false);
         }
         if (turn.integrations?.phone) {
           const bridge = turn.integrations.phone;
@@ -633,6 +641,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         localComputerMcp: true,
         composioMcp: true,
         agentsMcp: true,
+      customMcp: true,
         phoneMcp: true,
         browserMcp: true,
         images: true,

--- a/server/index.ts
+++ b/server/index.ts
@@ -90,6 +90,7 @@ import {
   DATA_DIR,
   EVENTS_DIR,
   NATIVE_DIR,
+  customMcpServers,
 } from "./config.ts";
 import { ComputerControl } from "./computer-control.ts";
 import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts";
@@ -2597,6 +2598,13 @@ async function startTurn(
         const connection = await connectedAppsIntegration(bot.id, threadId);
         if (connection) integrations.composio = connection;
       }
+      // user-configured MCP servers (config.json mcpServers): same rule as
+      // composio — only to a driver that can mount them. Their tools are
+      // never pre-allowed, so every call rides the normal permission flow.
+      if (instance.adapter.capabilities.customMcp === true) {
+        const custom = customMcpServers(cfg);
+        if (Object.keys(custom).length) integrations.custom = custom;
+      }
       // CLI engines work inside the bot's own workspace directory rather
       // than the user's home: a bot with file tools and acceptEdits gets a
       // desk, not the whole house — and the workspace is where its
@@ -3459,6 +3467,11 @@ async function runGroupMemberTurn(
     });
     onDispatchError?.(message);
     return true;
+  }
+  // user-configured MCP servers: same gating as the 1:1 site above.
+  if (instance.adapter.capabilities.customMcp === true) {
+    const custom = customMcpServers(cfg);
+    if (Object.keys(custom).length) integrations.custom = custom;
   }
   // Connected-app discovery is intentionally awaited before a provider owns
   // the bot. An interrupt during that setup window must still stop the queued


### PR DESCRIPTION
Second slice of #532: **bring-your-own MCP servers** — the connected-app "plugin format" is MCP itself, not a bespoke API.

## What

A `mcpServers` section in config.json (the schema Claude Code/Zed/Cline users already know):

```json
{ "mcpServers": { "notes": {
    "command": "npx", "args": ["-y", "@example/notes-mcp"],
    "env": { "NOTES_TOKEN": "…" } } } }
```

One shared funnel: `customMcpServers(cfg)` validates/normalizes, both integration-assembly sites (1:1 + rooms) attach `integrations.custom` gated on a new `customMcp` capability flag, and each capable driver mounts it in its native way:

- **Claude**: into the private 0600 mcp-config file, **deliberately NOT pre-allowed** — acceptEdits denies unlisted tools, which routes every custom tool call through the ogb permission broker into an Allow/Deny card.
- **Codex**: `mountMcpServer(..., preApproved: false)` — built-ins keep `default_tools_approval_mode="auto"`, custom servers keep codex's on-request policy so their calls card. Argv still carries env *names* only.
- **ACP engines** (all of them, incl. `customAcp` from #620): appended to the `session/new` mcpServers payload after the built-ins; permission asks ride ACP's own `session/request_permission`.
- antigravity (fullAuto-only, no approval channel) and pi (its extension only gates local-computer scopes) deliberately do **not** get the flag — mounting where calls can't card would be the unsafe default.

## Safety rails

- **Reserved names refused** (`computer/agents/composio/browser/phone/dweb/ogb/…`) so a custom entry can never shadow a built-in tool surface, plus a strict name charset (also prevents codex `-c` config-key injection). Drivers keep a defense-in-depth collision skip.
- **Validate-with-skip**: one malformed entry logs a teaching sentence once and is skipped — it can never take the config (or the fleet) down. The schema section is deliberately loose at parse level because `parseStoredConfig` throws away the *whole file* on a schema error.
- `url` transports are skipped with an honest "stdio only so far" note; `enabled: false` parks an entry.
- `/api/config` PATCH cannot write the section (same posture as `instances`).

## How verified

- Config helper unit suite: normalization + defaults, absent section, disabled/reserved/bad-name/url/malformed all skipped without losing valid entries.
- Driver tests in all three families: Claude (server lands in mcp-config file, **absent from `--allowedTools`**, credential value absent from argv), Codex (argv has the mount + env names, **no approval-auto for the custom server**, value only in child env), ACP (session payload contains the entry in wire shape, after built-ins).
- Mutation checks: dropping the reserved-name guard, the name regex, or claude's not-pre-allowed property each fails the suite.
- `tsc` + strict `typecheck` clean; 202 tests green across the four touched suites; lint parity exact.

Part 3 (i18n groundwork) is next. 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring custom MCP tool servers without code.
  - Custom servers can be defined in the application configuration using stdio commands, arguments, and environment variables.
  - Supported providers can load custom tools alongside built-in integrations.
  - Custom tool actions use the standard permission approval flow.

- **Documentation**
  - Added setup guidance covering configuration, credentials, supported options, naming restrictions, disabling servers, and troubleshooting invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->