### PR TITLE
fix(desktop): capture crashes and harden permission broker setup

### DIFF
--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -1,11 +1,13 @@
 // One-click bug-report bundle: app facts, a safe config summary and the
-// server.log tail, formatted for pasting into a public issue. Pure string
-// work lives here so redaction stays unit-testable without Electron; main.mjs
-// owns the fs and dialog plumbing. Safety is layered: the collector never
-// reads secret fields at all (only the server's booleans-only config status),
+// server.log tail, formatted for pasting into a public issue. Formatting and
+// bounded log reads live here so redaction and path safety stay unit-testable
+// without Electron; main.mjs owns the dialog plumbing. Safety is layered: the
+// collector never reads secret fields at all (only the server's booleans-only config status),
 // and everything that does get in is scrubbed again here before it lands on
 // disk — so a future collector mistake still cannot leak a credential.
 //
+import fs from "node:fs";
+
 // CREDENTIAL_ENV_NAMES mirrors WORKSPACE_CREDENTIAL_ENV (server/config.ts).
 // Duplicated because the desktop shell cannot import TypeScript; a test
 // asserts the two lists never drift apart.
@@ -84,6 +86,154 @@ export function decodeLogTail(buffer, truncated = false) {
   return { tail: complete.toString("utf8"), bytes: complete.length };
 }
 
+/** Read a bounded regular-file tail without following a replaced log-path
+ * symlink into unrelated user data. The pre/post-open identity check closes
+ * the Windows gap where O_NOFOLLOW is unavailable; POSIX uses both. */
+export function readSafeLogTail(logPath, maxBytes = 256 * 1024, platform = process.platform) {
+  let handle = null;
+  try {
+    const before = fs.lstatSync(logPath);
+    if (!before.isFile() || before.nlink !== 1) return null;
+    const flags = fs.constants.O_RDONLY | (platform === "win32" ? 0 : fs.constants.O_NOFOLLOW);
+    handle = fs.openSync(logPath, flags);
+    const after = fs.fstatSync(handle);
+    if (!after.isFile() || after.nlink !== 1) return null;
+    if (before.dev !== after.dev || before.ino !== after.ino) return null;
+    const start = Math.max(0, after.size - maxBytes);
+    const buffer = Buffer.alloc(after.size - start);
+    fs.readSync(handle, buffer, 0, buffer.length, start);
+    return decodeLogTail(buffer, start > 0);
+  } catch {
+    return null;
+  } finally {
+    if (handle !== null) {
+      try {
+        fs.closeSync(handle);
+      } catch {}
+    }
+  }
+}
+
+// Desktop crash records are written synchronously from Electron's main
+// process, including from uncaughtExceptionMonitor where an async stream may
+// never flush. Keep them deliberately metadata-only: no URL, title, error
+// message, command line or absolute path can reach the public diagnostics
+// export. Main-process failures retain only their origin and standard error
+// class, enough to distinguish a genuine fatal path without exposing content.
+const PROCESS_GONE_REASONS = new Set([
+  "abnormal-exit",
+  "clean-exit",
+  "crashed",
+  "integrity-failure",
+  "killed",
+  "launch-failed",
+  "oom",
+]);
+const CHILD_PROCESS_TYPES = new Set([
+  "GPU",
+  "Pepper Plugin",
+  "Pepper Plugin Broker",
+  "Sandbox helper",
+  "Unknown",
+  "Utility",
+  "Zygote",
+]);
+const MAIN_FAILURE_ORIGINS = new Set(["uncaughtException", "unhandledRejection"]);
+const ERROR_NAMES = new Set([
+  "AggregateError",
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+]);
+
+function known(value, allowed, fallback = "unknown") {
+  return typeof value === "string" && allowed.has(value) ? value.replaceAll(" ", "-") : fallback;
+}
+
+function exitCode(value) {
+  return Number.isSafeInteger(value) ? value : "unknown";
+}
+
+function safeErrorName(error) {
+  try {
+    return known(error?.name, ERROR_NAMES, "Error");
+  } catch {
+    return "Error";
+  }
+}
+
+/** Build one privacy-safe line for desktop-crashes.log. Unknown event shapes
+ * are dropped rather than serialised, so new Electron fields cannot leak by
+ * accident. clean-exit is normal lifecycle noise and is not a crash record. */
+export function formatDesktopCrashRecord(event = {}) {
+  try {
+    if (event.kind === "renderer") {
+      const reason = known(event.reason, PROCESS_GONE_REASONS);
+      if (reason === "clean-exit") return null;
+      const surface = event.surface === "main-window" ? "main-window" : "auxiliary";
+      return `event=render-process-gone surface=${surface} reason=${reason} exitCode=${exitCode(event.exitCode)}`;
+    }
+    if (event.kind === "child") {
+      const reason = known(event.reason, PROCESS_GONE_REASONS);
+      if (reason === "clean-exit") return null;
+      const type = known(event.type, CHILD_PROCESS_TYPES);
+      return `event=child-process-gone type=${type} reason=${reason} exitCode=${exitCode(event.exitCode)}`;
+    }
+    if (event.kind === "main") {
+      const origin = known(event.origin, MAIN_FAILURE_ORIGINS, "uncaughtException");
+      return `event=main-process-failure origin=${origin} error=${safeErrorName(event.error)}`;
+    }
+  } catch {
+    // Crash reporting must be safer than the failure it is trying to record.
+  }
+  return null;
+}
+
+/** Register Electron/Node crash observers without changing their lifecycle.
+ * Dependencies are injected so the exact event wiring stays unit-testable
+ * without importing Electron. The returned disposer is primarily for tests;
+ * production keeps these observers for the lifetime of the app. */
+export function installDesktopCrashListeners({
+  appTarget,
+  processTarget,
+  record,
+  isShuttingDown = () => false,
+  mainWebContents = () => null,
+}) {
+  const onMainFailure = (error, origin) => record({ kind: "main", error, origin });
+  const onRendererGone = (_event, contents, details) => {
+    if (isShuttingDown()) return;
+    record({
+      kind: "renderer",
+      surface: contents === mainWebContents() ? "main-window" : "auxiliary",
+      reason: details?.reason,
+      exitCode: details?.exitCode,
+    });
+  };
+  const onChildGone = (_event, details) => {
+    if (isShuttingDown()) return;
+    record({
+      kind: "child",
+      type: details?.type,
+      reason: details?.reason,
+      exitCode: details?.exitCode,
+    });
+  };
+
+  processTarget.on("uncaughtExceptionMonitor", onMainFailure);
+  appTarget.on("render-process-gone", onRendererGone);
+  appTarget.on("child-process-gone", onChildGone);
+  return () => {
+    processTarget.off("uncaughtExceptionMonitor", onMainFailure);
+    appTarget.off("render-process-gone", onRendererGone);
+    appTarget.off("child-process-gone", onChildGone);
+  };
+}
+
 const APP_INFO_KEYS = ["version", "platform", "arch", "electron", "node", "packaged", "uptimeSeconds"];
 
 // A config summary entry is publishable only when it carries no credential:
@@ -113,6 +263,7 @@ function flattenSummary(input, prefix = "", depth = 0, out = {}) {
 export function buildDiagnosticsReport({
   appInfo = {},
   configSummary = {},
+  desktopLogTail,
   logTail,
   now = new Date().toISOString(),
 } = {}) {
@@ -136,6 +287,13 @@ export function buildDiagnosticsReport({
     shown += 1;
   }
   if (!shown) lines.push("(no configuration summary available)");
+  lines.push("");
+  lines.push("## Desktop crash events — privacy-safe metadata only");
+  if (desktopLogTail && desktopLogTail.trim()) {
+    for (const line of redactSecretsInLine(desktopLogTail).split(/\r?\n/)) lines.push(line);
+  } else {
+    lines.push("(no desktop crash events available)");
+  }
   lines.push("");
   lines.push(logTail && logTail.trim() ? "## Server log tail — known credential patterns auto-masked" : "## Server log tail");
   if (logTail && logTail.trim()) {

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
-import { readFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const require = createRequire(import.meta.url);
 const {
   buildDiagnosticsReport,
   decodeLogTail,
   diagnosticsFileName,
+  formatDesktopCrashRecord,
+  installDesktopCrashListeners,
+  readSafeLogTail,
   redactSecretsInLine,
   CREDENTIAL_ENV_NAMES,
 } = require("./diagnostics.mjs");
@@ -52,7 +58,33 @@ describe("buildDiagnosticsReport", () => {
     expect(report).toContain("xai.configured=true");
     expect(report).toContain("box.configured=false");
     expect(report).toContain("rooms.turnTimeoutMinutes=5");
+    expect(report).toContain("(no desktop crash events available)");
     expect(report).toContain("(server log unavailable)");
+  });
+
+  it("includes privacy-safe desktop crash metadata separately from the server log", () => {
+    const desktopLogTail =
+      "[2026-08-31T11:00:00.000Z] event=render-process-gone surface=main-window reason=crashed exitCode=5";
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      desktopLogTail,
+      logTail: "server ready",
+    });
+    expect(report).toContain("## Desktop crash events — privacy-safe metadata only");
+    expect(report).toContain(desktopLogTail);
+    expect(report.indexOf(desktopLogTail)).toBeLessThan(report.indexOf("server ready"));
+  });
+
+  it("redacts desktop crash lines again before exporting them", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      configSummary: {},
+      desktopLogTail: "event=future-crash token=abcdefghijklmnop",
+      logTail: "",
+    });
+    expect(report).not.toContain("abcdefghijklmnop");
+    expect(report).toContain("token=«redacted");
   });
 
   it("drops strings, non-scalars and credential-shaped summary values", () => {
@@ -164,6 +196,112 @@ describe("buildDiagnosticsReport", () => {
   });
 });
 
+describe("formatDesktopCrashRecord", () => {
+  it("records renderer and child failures without accepting arbitrary fields", () => {
+    expect(
+      formatDesktopCrashRecord({
+        kind: "renderer",
+        surface: "main-window",
+        reason: "crashed",
+        exitCode: 9,
+        url: "https://example.test/private?token=secret",
+      }),
+    ).toBe("event=render-process-gone surface=main-window reason=crashed exitCode=9");
+    expect(
+      formatDesktopCrashRecord({
+        kind: "child",
+        type: "GPU",
+        reason: "oom",
+        exitCode: 34,
+        commandLine: "--password=secret",
+      }),
+    ).toBe("event=child-process-gone type=GPU reason=oom exitCode=34");
+  });
+
+  it("omits normal clean exits", () => {
+    expect(formatDesktopCrashRecord({ kind: "renderer", reason: "clean-exit" })).toBeNull();
+    expect(formatDesktopCrashRecord({ kind: "child", reason: "clean-exit" })).toBeNull();
+  });
+
+  it("reduces a fatal main-process error to its type without reading its message or stack", () => {
+    const error = new TypeError("secret user text from C:\\Users\\Ada\\private.txt");
+    error.stack = [
+      "TypeError: secret user text from C:\\Users\\Ada\\private.txt",
+      "secret-client.ts:1:1",
+      "    at boot (file:///C:/Users/Ada/OpenMausBot/electron/main.mjs:412:7)",
+    ].join("\n");
+    const record = formatDesktopCrashRecord({ kind: "main", origin: "unhandledRejection", error });
+    expect(record).toBe("event=main-process-failure origin=unhandledRejection error=TypeError");
+    expect(record).not.toContain("Ada");
+    expect(record).not.toContain("secret user text");
+    expect(record).not.toContain("secret-client");
+  });
+
+  it("fails closed for unknown Electron metadata", () => {
+    expect(
+      formatDesktopCrashRecord({
+        kind: "renderer",
+        surface: "private-window-name",
+        reason: "token=super-secret",
+        exitCode: "5; password=secret",
+      }),
+    ).toBe("event=render-process-gone surface=auxiliary reason=unknown exitCode=unknown");
+    expect(formatDesktopCrashRecord({ kind: "anything", payload: "secret" })).toBeNull();
+  });
+});
+
+describe("installDesktopCrashListeners", () => {
+  it("observes fatal, renderer and child failures through structural fields only", () => {
+    const appTarget = new EventEmitter();
+    const processTarget = new EventEmitter();
+    const records = [];
+    const mainContents = {};
+    const dispose = installDesktopCrashListeners({
+      appTarget,
+      processTarget,
+      record: (event) => records.push(event),
+      mainWebContents: () => mainContents,
+    });
+    const error = new TypeError("private message");
+    processTarget.emit("uncaughtExceptionMonitor", error, "unhandledRejection");
+    appTarget.emit(
+      "render-process-gone",
+      {},
+      mainContents,
+      { reason: "crashed", exitCode: 7, url: "https://private.test" },
+    );
+    appTarget.emit(
+      "child-process-gone",
+      {},
+      { type: "GPU", reason: "oom", exitCode: 34, name: "private-service" },
+    );
+    expect(records).toEqual([
+      { kind: "main", error, origin: "unhandledRejection" },
+      { kind: "renderer", surface: "main-window", reason: "crashed", exitCode: 7 },
+      { kind: "child", type: "GPU", reason: "oom", exitCode: 34 },
+    ]);
+    dispose();
+    expect(processTarget.listenerCount("uncaughtExceptionMonitor")).toBe(0);
+    expect(appTarget.listenerCount("render-process-gone")).toBe(0);
+    expect(appTarget.listenerCount("child-process-gone")).toBe(0);
+  });
+
+  it("ignores process exits after Electron has begun its normal shutdown", () => {
+    const appTarget = new EventEmitter();
+    const processTarget = new EventEmitter();
+    const records = [];
+    installDesktopCrashListeners({
+      appTarget,
+      processTarget,
+      record: (event) => records.push(event),
+      isShuttingDown: () => true,
+    });
+    appTarget.emit("render-process-gone", {}, {}, { reason: "killed", exitCode: 0 });
+    appTarget.emit("child-process-gone", {}, { type: "Utility", reason: "killed", exitCode: 0 });
+    expect(records).toEqual([]);
+  });
+});
+
 describe("decodeLogTail", () => {
   it("preserves the full buffer when the read starts at the beginning", () => {
     expect(decodeLogTail(Buffer.from("first\nsecond"), false)).toEqual({ tail: "first\nsecond", bytes: 12 });
@@ -177,6 +315,32 @@ describe("decodeLogTail", () => {
 
   it("returns an empty tail when a truncated buffer has no complete line", () => {
     expect(decodeLogTail(Buffer.from("partial-secret"), true)).toEqual({ tail: "", bytes: 0 });
+  });
+});
+
+describe("readSafeLogTail", () => {
+  it("reads a bounded tail from a regular app-owned log", () => {
+    const directory = mkdtempSync(join(tmpdir(), "openmausbot-log-tail-"));
+    try {
+      const log = join(directory, "server.log");
+      writeFileSync(log, "partial-secret\nfirst\nsecond\n", { mode: 0o600 });
+      expect(readSafeLogTail(log, 17)).toEqual({ tail: "first\nsecond\n", bytes: 13 });
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("rejects a log-path symlink", () => {
+    const directory = mkdtempSync(join(tmpdir(), "openmausbot-log-symlink-"));
+    try {
+      const privateFile = join(directory, "private.txt");
+      const log = join(directory, "desktop-crashes.log");
+      writeFileSync(privateFile, "private user content", { mode: 0o600 });
+      symlinkSync(privateFile, log);
+      expect(readSafeLogTail(log)).toBeNull();
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
   });
 });
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -17,7 +17,13 @@ import {
 } from "./skill-recorder.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { startUpdater, registerUpdaterIpc } from "./updater.mjs";
-import { buildDiagnosticsReport, decodeLogTail, diagnosticsFileName } from "./diagnostics.mjs";
+import {
+  buildDiagnosticsReport,
+  diagnosticsFileName,
+  formatDesktopCrashRecord,
+  installDesktopCrashListeners,
+  readSafeLogTail,
+} from "./diagnostics.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
@@ -345,7 +351,10 @@ function composioBrokerUrl() {
 // why stdio is piped, not inherited — under a Finder/Explorer launch the
 // parent's stdio leads nowhere and a failed boot is otherwise undiagnosable.
 const LOG_DIR = app.getPath("logs");
+const DESKTOP_CRASH_LOG = path.join(LOG_DIR, "desktop-crashes.log");
+const DESKTOP_CRASH_LOG_MAX_BYTES = 512 * 1024;
 let logStream = null;
+let desktopShutdownStarted = false;
 import {
   companionAdvertisedHostedUrl,
   companionEnabledAtRest,
@@ -386,6 +395,74 @@ function slog(line) {
     /* logging must never break startup */
   }
 }
+
+// The server stream is intentionally asynchronous, but a fatal main-process
+// exception may terminate Electron before such a write is flushed. Crash
+// metadata gets its own tiny synchronous file. The formatter admits only a
+// fixed set of fields, so renderer URLs, page titles, exception messages and
+// absolute paths never land on disk or in a public bug report.
+function recordDesktopCrash(event) {
+  let handle = null;
+  try {
+    const record = formatDesktopCrashRecord(event);
+    if (!record) return;
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+
+    const flags =
+      fs.constants.O_WRONLY |
+      fs.constants.O_APPEND |
+      (process.platform === "win32" ? 0 : fs.constants.O_NOFOLLOW);
+    let before = null;
+    try {
+      before = fs.lstatSync(DESKTOP_CRASH_LOG);
+      if (!before.isFile() || before.nlink !== 1) return;
+      handle = fs.openSync(DESKTOP_CRASH_LOG, flags);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return;
+      // O_EXCL makes first creation race-safe on Windows, where O_NOFOLLOW is
+      // unavailable, as well as on POSIX.
+      try {
+        handle = fs.openSync(
+          DESKTOP_CRASH_LOG,
+          flags | fs.constants.O_CREAT | fs.constants.O_EXCL,
+          0o600,
+        );
+      } catch {
+        return;
+      }
+    }
+
+    const stats = fs.fstatSync(handle);
+    // A hard-linked or non-regular target is not an app-owned crash log.
+    if (!stats.isFile() || stats.nlink !== 1) return;
+    if (before && (before.dev !== stats.dev || before.ino !== stats.ino)) return;
+    // A renderer crash loop must not grow a persistent log without bound.
+    // The diagnostics export reads only a bounded tail, so dropping older
+    // crash metadata here preserves the useful part of the record.
+    if (stats.size >= DESKTOP_CRASH_LOG_MAX_BYTES) fs.ftruncateSync(handle, 0);
+    if (process.platform !== "win32") fs.fchmodSync(handle, 0o600);
+    fs.writeFileSync(handle, `[${new Date().toISOString()}] ${record}\n`, "utf8");
+  } catch {
+    /* crash diagnostics must never change app lifecycle */
+  } finally {
+    if (handle !== null) {
+      try {
+        fs.closeSync(handle);
+      } catch {}
+    }
+  }
+}
+
+// uncaughtExceptionMonitor observes Node's fatal path without converting it
+// into a handled exception. In particular, an unhandled rejection still
+// follows Node's normal exit behaviour after its metadata is persisted.
+installDesktopCrashListeners({
+  appTarget: app,
+  processTarget: process,
+  record: recordDesktopCrash,
+  isShuttingDown: () => desktopShutdownStarted,
+  mainWebContents: () => mainWindow?.webContents ?? null,
+});
 
 // ── managed companion connection ───────────────────────────────────────
 // Account onboarding provisions one remote Cloudflare Tunnel per desktop,
@@ -637,25 +714,6 @@ function ensureCompanionAccountService() {
   return companionAccountService;
 }
 
-const LOG_TAIL_BYTES = 256 * 1024;
-
-function readLogTail(logPath) {
-  try {
-    const size = fs.statSync(logPath).size;
-    const start = Math.max(0, size - LOG_TAIL_BYTES);
-    const handle = fs.openSync(logPath, "r");
-    try {
-      const buffer = Buffer.alloc(size - start);
-      fs.readSync(handle, buffer, 0, buffer.length, start);
-      return decodeLogTail(buffer, start > 0);
-    } finally {
-      fs.closeSync(handle);
-    }
-  } catch {
-    return null;
-  }
-}
-
 // Everything the bug-report bundle needs. The config summary comes from the
 // server's own booleans-only /api/config status (credentials are never
 // echoed), and the log goes through the redactor in diagnostics.mjs — so the
@@ -668,7 +726,8 @@ async function gatherDiagnostics() {
     .then((res) => (res.ok ? res.json() : null))
     .catch(() => null);
   const logPath = path.join(LOG_DIR, "server.log");
-  const log = readLogTail(logPath);
+  const log = readSafeLogTail(logPath);
+  const desktopLog = readSafeLogTail(DESKTOP_CRASH_LOG);
   return buildDiagnosticsReport({
     appInfo: {
       version: app.getVersion(),
@@ -680,6 +739,7 @@ async function gatherDiagnostics() {
       uptimeSeconds: Math.round(process.uptime()),
     },
     configSummary: serverStatus ?? {},
+    desktopLogTail: desktopLog?.tail ?? "",
     logTail: log?.tail ?? "",
   });
 }
@@ -2009,6 +2069,7 @@ process.once("SIGINT", requestSignalQuit);
 process.once("SIGTERM", requestSignalQuit);
 
 app.on("before-quit", (e) => {
+  desktopShutdownStarted = true;
   if (cuaCleanedUp) return;
   e.preventDefault();
   try {

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -208,6 +208,28 @@ describe("ClaudeDriver.decodeConfig", () => {
       }
     },
   );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects instead of returning an occupied path when every candidate is unavailable",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "omb-broker-unavailable-"));
+      const heldOne = join(dir, "held-one.sock");
+      const heldTwo = join(dir, "held-two.sock");
+      mkdirSync(heldOne);
+      mkdirSync(heldTwo);
+      try {
+        await expect(
+          createPermissionBroker({
+            socketPaths: [heldOne, heldTwo],
+            onAsk: () => {},
+            onResolve: () => {},
+          }),
+        ).rejects.toThrow(/could not bind a local socket/);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("ClaudeDriver turns (fake CLI)", () => {

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -159,8 +159,11 @@ describe("ClaudeDriver.decodeConfig", () => {
       expect(candidates.length).toBeGreaterThan(1);
       expect(new Set(candidates).size).toBe(candidates.length);
     } else {
-      // unlink-then-listen always wins on POSIX; one candidate suffices
-      expect(candidates).toEqual([permissionSocketPath("t-candidates")]);
+      // macOS has a small Unix-socket path limit, so a deep HOME needs a
+      // short fallback under the OS temp root.
+      expect(candidates).toHaveLength(2);
+      expect(candidates[1]).toMatch(/omb-perm-[0-9a-f]{16}\.sock$/);
+      expect(candidates[1]).not.toBe(candidates[0]);
     }
   });
 

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -398,6 +398,10 @@ export async function createPermissionBroker(opts: {
       break;
     }
   }
+  // Never hand the proxy an occupied candidate when every bind failed. That
+  // could connect it to a stale (or unrelated) listener instead of this
+  // broker, defeating the fail-closed boundary.
+  if (!server) throw new Error("claude: permission broker could not bind a local socket");
   const drain = () => {
     for (const p of [...pending.values()]) {
       const { behavior, message } = systemEndedReply(p.ask.kind);
@@ -712,7 +716,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       let mcpConfigPath: string | null = null;
       if (Object.keys(mcpServers).length) {
         mcpConfigPath = join(mkdtempSync(join(tmpdir(), "omb-mcp-")), "mcp.json");
-        writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
         args.push("--mcp-config", mcpConfigPath);
         args.push("--allowedTools", allowed.join(","));
       }
@@ -739,6 +742,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           active.delete(threadId);
           live.turn = null;
           closeSession(threadId, "stdin write failed");
+          if (mcpConfigPath) {
+            try {
+              rmSync(dirname(mcpConfigPath), { recursive: true, force: true });
+            } catch {}
+          }
           throw new Error("claude session stdin is not writable");
         }
         // the MCP config was for the first spawn; nothing to clean here
@@ -751,64 +759,94 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
       if (live) closeSession(threadId, "spawn contract changed");
 
-      // Only create a broker for a new process. A compatible retained process
-      // keeps its existing proxy connection and broker across turns.
-      if (socketPath) {
-        // remembers which tool each pending ask came from, so the resolved
-        // event can scope approvals to real desktop-control tools only
-        const askTools = new Map<string, string | undefined>();
-        broker = await createPermissionBroker({
-          socketPaths: brokerSocketCandidates(threadId),
-          isActive: () => Boolean(sessions.get(threadId)?.turn),
-          onAsk: (ask) => {
-            const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
-            askTools.set(ask.id, typeof ask.tool === "string" ? ask.tool : undefined);
-            emit({
-              ...base(threadId, eventTurnId),
-              type: "request.opened",
-              requestId: ask.id,
-              requestType: ask.kind,
-              tool: ask.tool,
-              summary: askSummary(ask),
-              approvalScope:
-                typeof ask.tool === "string" && controlsHost && ask.tool.startsWith("mcp__computer")
-                  ? "local-computer"
-                  : undefined,
-              choices: Array.isArray(ask.input?.choices) ? (ask.input.choices as string[]).slice(0, 5) : undefined,
-            });
-          },
-          onResolve: (resolved) => {
-            const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
-            emit({
-              ...base(threadId, eventTurnId),
-              type: "request.resolved",
-              requestId: resolved.id,
-              behavior: resolved.behavior,
-              source: resolved.source,
-              approvalScope:
-                controlsHost && typeof askTools.get(resolved.id) === "string" && askTools.get(resolved.id)!.startsWith("mcp__computer") ? "local-computer" : undefined,
-            });
-            askTools.delete(resolved.id);
-          },
-        });
-        // A fallback bind means the deterministic pipe is still held by an
-        // earlier process's child. The proxy learns its path from argv, so
-        // point it at the pipe we actually bound. argsKey deliberately keeps
-        // the base path: the nonce is not part of the spawn contract, and a
-        // retained session keeps its own broker object anyway.
-        if (broker.socketPath !== socketPath && mcpConfigPath) {
-          mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, broker.socketPath], env: { ...NODE_ENV_FLAG } };
+      // Until sessions.set() below, this turn owns every launch resource.
+      // Any bind, private-config or synchronous spawn failure must release
+      // them here rather than leave a live listener or credential temp file.
+      const cleanupUnownedLaunch = () => {
+        broker?.close();
+        broker = undefined;
+        if (mcpConfigPath) {
+          try {
+            rmSync(dirname(mcpConfigPath), { recursive: true, force: true });
+          } catch {}
+          mcpConfigPath = null;
+        }
+        retryState.delete(threadId);
+      };
+
+      try {
+        // Only create a broker for a new process. A compatible retained
+        // process keeps its existing proxy connection and broker across turns.
+        if (socketPath) {
+          // remembers which tool each pending ask came from, so the resolved
+          // event can scope approvals to real desktop-control tools only
+          const askTools = new Map<string, string | undefined>();
+          broker = await createPermissionBroker({
+            socketPaths: brokerSocketCandidates(threadId),
+            isActive: () => Boolean(sessions.get(threadId)?.turn),
+            onAsk: (ask) => {
+              const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
+              askTools.set(ask.id, typeof ask.tool === "string" ? ask.tool : undefined);
+              emit({
+                ...base(threadId, eventTurnId),
+                type: "request.opened",
+                requestId: ask.id,
+                requestType: ask.kind,
+                tool: ask.tool,
+                summary: askSummary(ask),
+                approvalScope:
+                  typeof ask.tool === "string" && controlsHost && ask.tool.startsWith("mcp__computer")
+                    ? "local-computer"
+                    : undefined,
+                choices: Array.isArray(ask.input?.choices) ? (ask.input.choices as string[]).slice(0, 5) : undefined,
+              });
+            },
+            onResolve: (resolved) => {
+              const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
+              emit({
+                ...base(threadId, eventTurnId),
+                type: "request.resolved",
+                requestId: resolved.id,
+                behavior: resolved.behavior,
+                source: resolved.source,
+                approvalScope:
+                  controlsHost && typeof askTools.get(resolved.id) === "string" && askTools.get(resolved.id)!.startsWith("mcp__computer") ? "local-computer" : undefined,
+              });
+              askTools.delete(resolved.id);
+            },
+          });
+          // A fallback bind means the deterministic pipe is still held by an
+          // earlier process's child. The proxy learns its path from argv, so
+          // point it at the pipe we actually bound. argsKey deliberately keeps
+          // the base path: the nonce is not part of the spawn contract, and a
+          // retained session keeps its own broker object anyway.
+          if (broker.socketPath !== socketPath && mcpConfigPath) {
+            mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, broker.socketPath], env: { ...NODE_ENV_FLAG } };
+          }
+        }
+
+        // Write once, only after the broker has selected its real endpoint.
+        if (mcpConfigPath) {
           writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
         }
+        if (sessionId) args.push("--resume", sessionId);
+        else args.push("--session-id", newSessionId!);
+      } catch (error) {
+        cleanupUnownedLaunch();
+        throw error;
       }
-      if (sessionId) args.push("--resume", sessionId);
-      else args.push("--session-id", newSessionId!);
 
-      const child = spawnCli(config.cli, args, {
-        cwd,
-        env,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      let child: ReturnType<typeof spawnCli>;
+      try {
+        child = spawnCli(config.cli, args, {
+          cwd,
+          env,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (error) {
+        cleanupUnownedLaunch();
+        throw error;
+      }
       const session: Session = {
         child,
         broker,

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -761,6 +761,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           active.delete(threadId);
           live.turn = null;
           closeSession(threadId, "stdin write failed");
+          retryState.delete(threadId);
           if (mcpConfigPath) {
             try {
               rmSync(dirname(mcpConfigPath), { recursive: true, force: true });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -9,7 +9,7 @@
 //   - the bot's cloud computer (box.ascii.dev) via server/computer-proxy.ts
 //     — screenshot/exec/open_url, the CUA-on-the-box bridge
 import { createHash, randomBytes } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -244,18 +244,22 @@ export function permissionSocketPath(threadId: string) {
   return brokerSocketPath(DATA_DIR, `${prefix}${digest}`);
 }
 
-/** Paths the broker may bind, tried in order. POSIX needs only the
- * deterministic path — unlink-then-listen always wins there. Windows named
- * pipes are never unlinkable, and a hung CLI child from an earlier server
- * process can hold the name open for MINUTES after its turn: the next turn's
- * listen then fails EADDRINUSE and every permission ask fail-closes into a
- * deny nobody can explain (seen live in a user's diagnostics). Fresh
- * suffixed fallbacks let the new broker bind immediately; the proxy child
- * learns the real path from its argv, so nothing else needs the name. Pipe
- * names have no sun_path length limit, so the longer tag is safe there. */
+/** Paths the broker may bind, tried in order. Windows named pipes are never
+ * unlinkable, and a hung CLI child from an earlier server process can hold a
+ * name for minutes, so fresh suffixes let the new broker bind immediately.
+ * POSIX gets a short temp fallback because macOS rejects Unix socket paths
+ * longer than its small `sun_path` limit; a deep test HOME or long username
+ * can otherwise make every approval silently unavailable. The proxy learns
+ * the actual bound path from its argv, so either fallback is transparent. */
 export function brokerSocketCandidates(threadId: string): string[] {
   const base = permissionSocketPath(threadId);
-  if (process.platform !== "win32") return [base];
+  if (process.platform !== "win32") {
+    const scope = createHash("sha256")
+      .update(`${DATA_DIR}\0${process.pid}\0${threadId}`)
+      .digest("hex")
+      .slice(0, 16);
+    return [base, join(tmpdir(), `omb-perm-${scope}.sock`)];
+  }
   return [
     base,
     `${base}-${randomBytes(3).toString("hex")}`,
@@ -371,13 +375,29 @@ export async function createPermissionBroker(opts: {
     try {
       unlinkSync(candidate);
     } catch {}
-    const outcome = await new Promise<"listening" | (Error & { code?: string })>((resolve) => {
+    let outcome = await new Promise<"listening" | (Error & { code?: string })>((resolve) => {
       attempt.once("listening", () => resolve("listening"));
       // SAFETY: net 'error' events carry syscall errors; the optional
       // `code` is only read defensively below.
       attempt.once("error", (error) => resolve(error as Error & { code?: string }));
       attempt.listen(candidate);
     });
+    // A fallback under the shared OS temp root must not be connectable by
+    // another local account. DATA_DIR is private already, but applying the
+    // same mode to every POSIX socket keeps the rule simple and fail-closed.
+    if (outcome === "listening" && process.platform !== "win32") {
+      try {
+        chmodSync(candidate, 0o600);
+      } catch (error) {
+        try {
+          attempt.close();
+        } catch {}
+        try {
+          unlinkSync(candidate);
+        } catch {}
+        outcome = error as Error & { code?: string };
+      }
+    }
     if (outcome === "listening") {
       if (index > 0) {
         console.error(`permission broker: ${opts.socketPaths[0]} is still held — bound fallback ${candidate}`);
@@ -392,8 +412,7 @@ export async function createPermissionBroker(opts: {
     try {
       attempt.close();
     } catch {}
-    const retryable = outcome.code === "EADDRINUSE" || outcome.code === "EACCES";
-    if (!retryable || index === opts.socketPaths.length - 1) {
+    if (index === opts.socketPaths.length - 1) {
       console.error(`permission broker unavailable on ${candidate}: ${outcome.message}`);
       break;
     }


### PR DESCRIPTION
## Summary

- record privacy-safe Electron renderer, utility-process, and main-process crash metadata in exported diagnostics
- harden diagnostic log reads and writes against symlink, hard-link, and path-swap attacks
- ensure the Claude permission broker never connects to an occupied fallback pipe
- use a short, mode-0600 POSIX fallback when deep user-data paths exceed macOS socket limits
- clean up broker, temporary MCP, and retry state when setup, spawning, or retained-session writes fail

## Context

PR #619 fixed the common Windows named-pipe collision by trying fallback pipe names. This follow-up closes the remaining setup-failure edges found during review and adds the crash evidence needed to diagnose future field reports without collecting message content or credentials.

## Verification

- 98 focused diagnostics/Claude tests passed, 1 Windows-only test skipped
- 3 browser lifecycle race regressions passed under the CI Node 24 runtime
- TypeScript checks passed
- Electron module syntax checks passed
- targeted lint: 0 errors (4 pre-existing warnings in the Claude driver)

Related: #619