### PR TITLE
Seven language packs + a zero-config pack generator

### DIFF
--- a/scripts/generate-locale.mjs
+++ b/scripts/generate-locale.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Draft a language pack from src/locales/en.ts using the locally installed
+// `claude` CLI (your existing login — no API key, nothing leaves your
+// machine except the prompt). The output is a DRAFT: review it like any
+// community PR before registering it.
+//
+//   node scripts/generate-locale.mjs de "German"
+//   node scripts/generate-locale.mjs --check        # coverage report
+//
+// The en.ts catalog stays a flat map of "key": "value" string pairs on
+// purpose — this script (and translators) parse it without a TS toolchain.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "locales");
+const PAIR = /"((?:[^"\\]|\\.)+)":\s*\n?\s*"((?:[^"\\]|\\.)*)"/g;
+
+function readCatalog(file) {
+  const source = readFileSync(join(LOCALES_DIR, file), "utf8");
+  const entries = {};
+  for (const match of source.matchAll(PAIR)) entries[JSON.parse(`"${match[1]}"`)] = JSON.parse(`"${match[2]}"`);
+  return entries;
+}
+
+const en = readCatalog("en.ts");
+const enKeys = Object.keys(en);
+if (!enKeys.length) {
+  console.error("could not parse any keys from en.ts — the catalog must stay flat \"key\": \"value\" pairs");
+  process.exit(1);
+}
+
+if (process.argv[2] === "--check") {
+  for (const file of readdirSync(LOCALES_DIR).filter((f) => f.endsWith(".ts") && !["en.ts", "index.ts"].includes(f))) {
+    const pack = readCatalog(file);
+    const missing = enKeys.filter((key) => !(key in pack));
+    const pct = Math.round(((enKeys.length - missing.length) / enKeys.length) * 100);
+    console.log(`${file}: ${pct}% (${enKeys.length - missing.length}/${enKeys.length})${missing.length ? ` — missing: ${missing.join(", ")}` : ""}`);
+  }
+  process.exit(0);
+}
+
+const code = (process.argv[2] ?? "").toLowerCase();
+const label = process.argv[3] ?? code;
+if (!/^[a-z]{2,3}(-[a-z]{2,8})?$/.test(code)) {
+  console.error("usage: node scripts/generate-locale.mjs <bcp47-code> [label]   (or --check)");
+  process.exit(1);
+}
+const outFile = join(LOCALES_DIR, `${code}.ts`);
+if (existsSync(outFile) && !process.argv.includes("--force")) {
+  console.error(`${code}.ts already exists — pass --force to overwrite the draft`);
+  process.exit(1);
+}
+
+const prompt = [
+  `Translate this UI string catalog for a desktop app (OpenMausBot, a multi-agent bot workbench) into ${label} (${code}).`,
+  "Rules: natural product copy, keep placeholders like {name} verbatim, keep product names (OpenMausBot, CLI, AI) as-is,",
+  "match the register of professional desktop apps in that language.",
+  "Reply with ONLY a JSON object mapping every key to its translation — no prose, no code fences.",
+  "",
+  JSON.stringify(en, null, 2),
+].join("\n");
+
+console.error(`asking claude to draft ${enKeys.length} strings for ${label}…`);
+const raw = execFileSync("claude", ["-p", prompt], { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 });
+const jsonStart = raw.indexOf("{");
+const jsonEnd = raw.lastIndexOf("}");
+if (jsonStart === -1 || jsonEnd === -1) {
+  console.error("claude did not return a JSON object; raw output:\n" + raw);
+  process.exit(1);
+}
+const draft = JSON.parse(raw.slice(jsonStart, jsonEnd + 1));
+const unknown = Object.keys(draft).filter((key) => !enKeys.includes(key));
+if (unknown.length) {
+  console.error(`draft invented keys (${unknown.join(", ")}) — refusing to write`);
+  process.exit(1);
+}
+
+const exportName = code.replace(/-(\w)/g, (_m, c) => c.toUpperCase());
+const body = enKeys
+  .filter((key) => typeof draft[key] === "string" && draft[key].trim())
+  .map((key) => `  ${JSON.stringify(key)}: ${JSON.stringify(draft[key])},`)
+  .join("\n");
+writeFileSync(
+  outFile,
+  `// ${label} — community pack, machine-drafted (review before registering).\n` +
+    `// Partial by design: keys omitted here fall back to English.\n` +
+    `// See CONTRIBUTING.md "Adding a language".\n` +
+    `import type { LocalePack } from "./index";\n\n` +
+    `export const ${exportName}: LocalePack = {\n${body}\n};\n`,
+);
+console.error(`wrote ${outFile} — review it, then register "${code}" in src/locales/index.ts`);

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { resolveLocale, setLocale, t } from "./i18n";
 import { locales } from "@/locales";
+import { en } from "@/locales/en";
 
 afterEach(() => {
   setLocale("en");
@@ -31,10 +32,38 @@ describe("t", () => {
     expect(t("engines.cloud")).toBe("Cloud");
   });
 
-  it("setLocale reports the fallback that actually took effect", () => {
-    // only "en" ships today — any tag resolves back to it
-    expect(setLocale("de-AT")).toBe("en");
+  it("setLocale reports the locale that actually took effect", () => {
+    // a shipped base pack catches its regional variants…
+    expect(setLocale("de-AT")).toBe("de");
+    expect(t("engines.local")).toBe("Lokal");
+    // …and a genuinely unknown tag falls back to English
+    expect(setLocale("xx-YY")).toBe("en");
     expect(t("engines.local")).toBe("Local");
+  });
+
+  it("resolves every registered locale to itself", () => {
+    const available = new Set(Object.keys(locales));
+    for (const code of available) {
+      expect(resolveLocale(code, available)).toBe(code);
+    }
+  });
+
+  it("routes common system tags onto the shipped packs", () => {
+    const available = new Set(Object.keys(locales));
+    expect(resolveLocale("zh-CN", available)).toBe("zh");
+    expect(resolveLocale("ja-JP", available)).toBe("ja");
+    expect(resolveLocale("pt-BR", available)).toBe("pt-br");
+    expect(resolveLocale("pt-PT", available)).toBe("pt");
+    expect(resolveLocale("hi-IN", available)).toBe("hi");
+  });
+
+  it("every registered pack carries only known keys with non-empty values", () => {
+    for (const pack of Object.values(locales)) {
+      for (const [key, value] of Object.entries(pack)) {
+        expect(Object.hasOwn(en, key)).toBe(true);
+        expect((value ?? "").trim().length).toBeGreaterThan(0);
+      }
+    }
   });
 
   it("overlays a partial pack and falls back to English for missing keys", () => {

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1,0 +1,13 @@
+// Deutsch — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const de: LocalePack = {
+  "noEngines.title": "Installiere eine KI-Engine, um loszulegen",
+  "noEngines.intro":
+    "OpenMausBot bringt kein eigenes Modell mit — deine Bots laufen über eine auf diesem Rechner installierte KI-CLI mit deinem bestehenden Login. Richte eine davon ein und deine Bots erwachen zum Leben.",
+  "engines.cloud": "Cloud",
+  "engines.local": "Lokal",
+  "common.checkAgain": "Erneut prüfen",
+  "common.checking": "Prüfe…",
+};

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,0 +1,13 @@
+// Español — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const es: LocalePack = {
+  "noEngines.title": "Instala un motor de IA para empezar",
+  "noEngines.intro":
+    "OpenMausBot no incluye un modelo propio: tus bots funcionan con una CLI de IA instalada en este equipo, usando tu sesión existente. Configura cualquiera de ellas y tus bots cobrarán vida.",
+  "engines.cloud": "Nube",
+  "engines.local": "Local",
+  "common.checkAgain": "Comprobar de nuevo",
+  "common.checking": "Comprobando…",
+};

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,0 +1,13 @@
+// Français — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const fr: LocalePack = {
+  "noEngines.title": "Installez un moteur d'IA pour commencer",
+  "noEngines.intro":
+    "OpenMausBot n'embarque pas de modèle : vos bots s'appuient sur une CLI d'IA installée sur cet ordinateur, avec votre session existante. Configurez l'une d'elles et vos bots prennent vie.",
+  "engines.cloud": "Cloud",
+  "engines.local": "Local",
+  "common.checkAgain": "Revérifier",
+  "common.checking": "Vérification…",
+};

--- a/src/locales/hi.ts
+++ b/src/locales/hi.ts
@@ -1,0 +1,13 @@
+// हिन्दी — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const hi: LocalePack = {
+  "noEngines.title": "शुरू करने के लिए एक AI इंजन इंस्टॉल करें",
+  "noEngines.intro":
+    "OpenMausBot अपना कोई मॉडल नहीं देता — आपके बॉट इस कंप्यूटर पर इंस्टॉल की गई AI CLI पर, आपके मौजूदा लॉगिन से चलते हैं। इनमें से कोई भी सेट कर लें, और आपके बॉट चल पड़ेंगे।",
+  "engines.cloud": "क्लाउड",
+  "engines.local": "लोकल",
+  "common.checkAgain": "फिर से जाँचें",
+  "common.checking": "जाँच जारी…",
+};

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -3,10 +3,27 @@
 // pack omits falls back to English, so a half-translated language is a
 // usable language, not a broken one.
 import { en } from "./en";
+import { de } from "./de";
+import { es } from "./es";
+import { fr } from "./fr";
+import { hi } from "./hi";
+import { ja } from "./ja";
+import { ptBr } from "./pt-br";
+import { zh } from "./zh";
 
 export type LocaleKey = keyof typeof en;
 export type LocalePack = Partial<Record<LocaleKey, string>>;
 
 export const locales: Record<string, LocalePack> = {
   en,
+  de,
+  es,
+  fr,
+  hi,
+  ja,
+  // both keys, one pack: pt-BR is the registered dialect, and a plain
+  // "pt" system language should land on it rather than English
+  pt: ptBr,
+  "pt-br": ptBr,
+  zh,
 };

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -1,0 +1,13 @@
+// 日本語 — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const ja: LocalePack = {
+  "noEngines.title": "AI エンジンをインストールして始めましょう",
+  "noEngines.intro":
+    "OpenMausBot 自体はモデルを持ちません。ボットはこのコンピューターにインストール済みの AI CLI 上で、既存のログインを使って動きます。どれか一つをセットアップすれば、ボットが動き出します。",
+  "engines.cloud": "クラウド",
+  "engines.local": "ローカル",
+  "common.checkAgain": "再チェック",
+  "common.checking": "チェック中…",
+};

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -1,0 +1,13 @@
+// Português (Brasil) — community pack. Partial by design: keys omitted
+// here fall back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const ptBr: LocalePack = {
+  "noEngines.title": "Instale um mecanismo de IA para começar",
+  "noEngines.intro":
+    "O OpenMausBot não traz um modelo próprio — seus bots rodam em uma CLI de IA instalada neste computador, usando seu login existente. Configure qualquer uma delas e seus bots ganham vida.",
+  "engines.cloud": "Nuvem",
+  "engines.local": "Local",
+  "common.checkAgain": "Verificar novamente",
+  "common.checking": "Verificando…",
+};

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,0 +1,13 @@
+// 简体中文 — community pack. Partial by design: keys omitted here fall
+// back to English. See CONTRIBUTING.md "Adding a language".
+import type { LocalePack } from "./index";
+
+export const zh: LocalePack = {
+  "noEngines.title": "安装一个 AI 引擎，开始使用",
+  "noEngines.intro":
+    "OpenMausBot 本身不自带模型——你的机器人依托这台电脑上已安装的 AI 命令行工具运行，使用你现有的登录。任选其一完成设置，机器人即可开始工作。",
+  "engines.cloud": "云端",
+  "engines.local": "本地",
+  "common.checkAgain": "重新检测",
+  "common.checking": "检测中…",
+};


### PR DESCRIPTION
Follow-up to #623: **seven language packs at 100% coverage of the current catalog, plus a generator that needs no API keys.**

## Packs

简体中文 (`zh`), 日本語 (`ja`), Español (`es`), Deutsch (`de`), Français (`fr`), Português do Brasil (`pt-br`, with a plain-`pt` alias so Portuguese systems don't fall to English), and हिन्दी (`hi`). Written directly as product copy — no external translation service involved. The app picks them up from the OS language automatically (`zh-CN → zh`, `pt-BR → pt-br`, `de-AT → de`, …).

They're small today because the catalog is small (the onboarding screen) — that's the design: packs grow automatically in coverage terms as extraction spreads, and `--check` makes staleness visible.

## Generator — zero configuration

`node scripts/generate-locale.mjs <code> [label]` drafts a pack for any language through the **locally installed `claude` CLI** (the user's existing login — no API keys, no service accounts, nothing for contributors to set up). Guardrails: refuses to overwrite without `--force`, refuses drafts that invent keys, writes a header marking the file as machine-drafted for review, and parses the catalog with a deliberately dumb flat-pairs parser so the catalog format stays translator-friendly. `--check` prints per-pack coverage:

```
de.ts: 100% (6/6)
…
```

## Tests

Pack integrity is enforced three ways: compile-time (`LocalePack` keys must exist in `en`), runtime suite (every registered locale resolves to itself, common system tags route onto shipped packs, packs carry only known keys with non-empty values), and the coverage check. The suite also caught and corrected the now-stale "only English ships" fallback assertion the moment the German pack made it false.

Prior art: #357 (@08820048) validated the provider/picker design for zh — its strings predate this catalog, so the zh pack here is fresh; worth pinging them for native review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
