### PR TITLE
Language setting: pick a UI language or follow the system

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -251,6 +251,9 @@ const appConfigSchema = z.object({
   imageGen: z.object({ key: optionalText }).optional(),
   /** Non-secret profile details shown in the sidebar. */
   profile: z.object({ name: optionalText, email: optionalText }).optional(),
+  /** UI language override (BCP-47, lowercase). Empty/absent = follow the
+   * system language. Unknown tags degrade to English in the renderer. */
+  language: optionalText,
   rooms: roomConfigSchema.optional(),
   localVm: localVmConfigSchema.optional(),
   features: featureConfigSchema.optional(),
@@ -270,6 +273,7 @@ const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   mcpServers?: Record<string, unknown>;
+  language?: string;
   xai?: { key?: string; url?: string };
   openaiCompat?: { key?: string; url?: string; model?: string; provider?: string };
   composio?: { apiKey?: string; userId?: string; sessionId?: string };
@@ -586,6 +590,8 @@ export function saveConfig(patch: Partial<AppConfig>): void {
     disk[key] = merged;
   }
   if (checkedPatch.vps !== undefined) disk.vps = normalizeVpsConfig(checkedPatch.vps);
+  // scalar, not a section: the merge loop above only walks objects
+  if (checkedPatch.language !== undefined) disk.language = checkedPatch.language;
   // the whole list is the unit of change: an add or a delete arrives as the
   // new list, never as a per-item merge
   if (checkedPatch.browserProfiles !== undefined) {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2640,6 +2640,18 @@ describe("harness HTTP API", () => {
     expect(nothing.status).toBe(400);
   });
 
+  it("round-trips the UI language and clears it back to system", async () => {
+    const set = await api("PUT", "/api/config", { language: "de" });
+    expect(set.status).toBe(200);
+    expect(set.body.language).toBe("de");
+    const after = await api("GET", "/api/config");
+    expect(after.body.language).toBe("de");
+
+    const cleared = await api("PUT", "/api/config", { language: "" });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body.language).toBe("");
+  });
+
   it("validates and persists the global room turn timeout", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -4810,6 +4810,8 @@ function configStatus() {
     imageGen: { configured: Boolean(cfg.imageGen?.key) },
     // not a secret — the sidebar shows it
     profile: { name: cfg.profile?.name ?? "", email: cfg.profile?.email ?? "" },
+    // not a secret — the settings picker shows it; "" = follow the system
+    language: cfg.language ?? "",
     rooms: { turnTimeoutMinutes: roomTurnTimeoutMinutes(cfg) },
     localVm: {
       mode: localVmMode(cfg),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { SkillRecorderPage } from "@/components/SkillRecorderPage";
 import { TeamMapPage } from "@/components/TeamMapPage";
 import { heldComputerControlBotIds } from "@/lib/computer-control";
 import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { setLocale } from "@/lib/i18n";
 
 function Shell() {
   const { state, dispatch } = useStore();
@@ -34,6 +35,15 @@ function Shell() {
   // turn the aside into a containing block for its fixed descendants (see
   // Sidebar.tsx's className comment).
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Apply the configured UI language the moment config arrives or changes;
+  // "" follows the system. The epoch bump re-renders extracted strings —
+  // t() reads a module variable, so React needs this nudge.
+  const language = state.config?.language ?? "";
+  const [, setLocaleEpoch] = useState(0);
+  useEffect(() => {
+    setLocale(language || globalThis.navigator?.language);
+    setLocaleEpoch((epoch) => epoch + 1);
+  }, [language]);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [localVmWorkspaceBotId, setLocalVmWorkspaceBotId] = useState<string | null>(null);
   // the Browser tab, expanded into the main column (the small preview in

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import { Coins, FlaskConical, Globe, KeyRound, Monitor, Search, Smartphone, Term
 import { api, useStore, type AppSettingsSection, type ConfigStatus } from "@/state/store";
 import { analyticsEnabled, setAnalyticsEnabled } from "@/lib/analytics";
 import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "@/lib/feature-flags";
+import { localeChoices } from "@/locales";
 import { ApiKeyRow, VpsConnection } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
 import { EnginesSettings } from "./EnginesSettings";
@@ -138,6 +139,53 @@ function AnalyticsRow() {
           setOn(next);
         }}
       />
+    </Card>
+  );
+}
+
+function LanguageRow() {
+  const { state, dispatch } = useStore();
+  const current = state.config?.language ?? "";
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const save = async (language: string) => {
+    if (saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      const config: ConfigStatus = await api("/api/config", {
+        method: "PATCH",
+        body: JSON.stringify({ language }),
+      });
+      dispatch({ type: "configStatus", config });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save the language.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Language"
+      subtitle="The app follows your system language unless you pick one here. Only part of the interface is translated so far — untranslated text stays in English."
+    >
+      <select
+        value={current}
+        disabled={saving}
+        aria-label="App language"
+        onChange={(event) => void save(event.target.value)}
+        className="w-full max-w-[280px] rounded-lg border border-hairline/40 bg-inset px-2.5 py-1.5 text-[13.5px] text-ink disabled:cursor-wait disabled:opacity-50"
+      >
+        <option value="">System</option>
+        {localeChoices.map(({ code, label }) => (
+          <option key={code} value={code}>
+            {label}
+          </option>
+        ))}
+      </select>
+      {error ? <p role="alert" className="mt-2 text-[12px] text-danger">{error}</p> : null}
     </Card>
   );
 }
@@ -603,7 +651,8 @@ export function SettingsModal() {
                 <Card title="Channel turns" subtitle="Set one maximum duration for every bot turn in a channel.">
                   <RoomTurnTimeoutSettings />
                 </Card>
-                <ToolCallsRow />
+                <LanguageRow />
+          <ToolCallsRow />
                 <UpdatesRow />
                 <DiagnosticsRow />
                 <AnalyticsRow />

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -27,3 +27,16 @@ export const locales: Record<string, LocalePack> = {
   "pt-br": ptBr,
   zh,
 };
+
+/** Pickable languages for the settings dropdown. Alias keys ("pt") are
+ * routing, not choices, so they are not listed here. */
+export const localeChoices: ReadonlyArray<{ code: string; label: string }> = [
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "es", label: "Español" },
+  { code: "fr", label: "Français" },
+  { code: "hi", label: "हिन्दी" },
+  { code: "ja", label: "日本語" },
+  { code: "pt-br", label: "Português (Brasil)" },
+  { code: "zh", label: "中文" },
+];

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -309,6 +309,8 @@ export interface ConfigStatus {
   imageGen?: { configured: boolean };
   /** who's using the app — collected in onboarding, shown in the sidebar */
   profile?: { name: string; email: string };
+  /** UI language override; "" (or absent) follows the system language. */
+  language?: string;
   /** Opt-in flags. Absent means off. */
   features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean };
   /** Named browser sessions any bot can be pointed at. */
@@ -325,7 +327,7 @@ export interface BrowserProfile {
 
 export type ConfigStatusFrame = Pick<
   ConfigStatus,
-  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "features" | "browserProfiles"
+  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "browserProfiles"
 >;
 
 export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
@@ -340,6 +342,7 @@ export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
     tts: frame.tts,
     imageGen: frame.imageGen,
     profile: frame.profile,
+    language: frame.language,
     features: frame.features,
     browserProfiles: frame.browserProfiles,
   };


### PR DESCRIPTION
Completes the picker seam #623 left open — now that #624 ships eight locales, the dropdown has something to pick.

## What

**Settings → General → Language**: a dropdown with System (default, follows `navigator.language`) plus the eight registered languages under their native names (English, Deutsch, Español, Français, हिन्दी, 日本語, Português (Brasil), 中文).

- Persisted as a top-level `language` key in config (non-secret, PATCHable like the feature flags; `""` = system). `saveConfig` learned that scalars exist — its merge loop only walked object sections, which silently dropped the key (caught by the round-trip test before it ever shipped, and now mutation-guarded on both halves).
- Reported through `configStatus` → SSE → the renderer's `ConfigStatus`, so every client stays in sync.
- Applied live in `Shell`: config arrives/changes → `setLocale(language || system)` → epoch bump re-renders extracted strings (t() reads a module variable; React needs the nudge). No restart.
- `localeChoices` lives beside the registry; alias keys (`pt`) are routing, not choices, so they don't appear in the picker.

## How verified

- API round-trip test: PUT `language: "de"` → echoed + persisted; PUT `""` clears to system.
- Mutation checks: dropping the `configStatus` report or the `saveConfig` scalar persistence each fails the suite.
- Full index + i18n suites green (146); `tsc` + strict typecheck clean; zero lint hits on touched files.
- UI note: no screenshot attached — the row is a stock Card + native select styled like the existing inputs; happy to add one post-merge from a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a language setting in General settings, allowing users to select a supported UI language or follow the system language.
  * The selected language is saved and applied throughout the app.
  * Added support for displaying the current language configuration and resetting it to the system default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->