### PR TITLE
fix: keep language changes from interrupting turns

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2652,6 +2652,38 @@ describe("harness HTTP API", () => {
     expect(cleared.body.language).toBe("");
   });
 
+  it("keeps an active turn alive when the UI language changes", async () => {
+    const bot = (await api("POST", "/api/bots", {
+      modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    try {
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "stay active" })).status).toBe(202);
+      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
+
+      const saved = await api("PATCH", "/api/config", { language: "de" });
+      expect(saved.status).toBe(200);
+      expect(saved.body.language).toBe("de");
+
+      const active = (await api("GET", "/api/bots?messages=50")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(active?.busy).toBe(true);
+      expect(active?.messages.some((message: { tool?: { name?: string } }) =>
+        message.tool?.name?.includes("provider settings changed"),
+      )).toBe(false);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`, {}).catch(() => undefined);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((candidate: { id: string }) => candidate.id === bot.id)?.busy;
+      }, { timeout: 5_000 }).toBeFalsy();
+      await api("DELETE", `/api/bots/${bot.id}`).catch(() => undefined);
+      await api("PATCH", "/api/config", { language: "" }).catch(() => undefined);
+    }
+  });
+
   it("validates and persists the global room turn timeout", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -8160,12 +8160,13 @@ const server = createServer(async (req, res) => {
           browserReferenceCleanupError = error;
         }
       }
-      // Provider keys change the fleet. Profile, voice, VPS, and room timeout
-      // changes do not rebuild it: no driver reads them, and they should not
-      // interrupt in-flight turns.
+      // Provider keys change the fleet. Profile, language, voice, VPS, and
+      // room timeout changes do not rebuild it: no driver reads them, and they
+      // should not interrupt in-flight turns.
       const reloadKeys = Object.keys(patch).filter(
         (key) =>
           key !== "profile" &&
+          key !== "language" &&
           key !== "tts" &&
           key !== "imageGen" &&
           key !== "vps" &&


### PR DESCRIPTION
## Summary
- treat the UI language as a renderer-only setting
- avoid rebuilding providers when it changes
- cover an active hanging turn so future settings work cannot regress this

## Verification
- `pnpm exec vitest run server/index.test.ts` (137 passed)
- `pnpm typecheck`

Follow-up to #625.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the interface language no longer interrupts active bot conversations.
  * Active turns remain in progress without displaying an unnecessary provider settings change message.
* **Tests**
  * Added coverage to verify that language changes preserve active conversations and return the bot to an idle state during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->