### PR TITLE
feat(picker): show model provider in pi model catalog

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -320,6 +320,10 @@ export interface ModelCatalog {
     label: string;
     custom?: boolean;
     loaded?: boolean;
+    /** upstream provider id (e.g. "zai", "nous") when the engine can report
+     * it — the picker shows it as a muted badge so BYOK duplicates of the
+     * same model id stay distinguishable. */
+    provider?: string;
     /** total context window in tokens, when the driver knows it — sizes
      * the model-facing rebuild (server/context-rebuild.ts). Unknown falls
      * back to a pattern table over the model id, then a conservative default. */

--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -35,14 +35,26 @@ describe("parsePiCatalog", () => {
     const catalog = parsePiCatalog(MODELS_LINE + "\n");
     expect(catalog.default).toBe("ollama-cloud/glm-5.2");
     expect(catalog.options).toEqual([
-      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true },
-      { id: "openai/gpt-4o", label: "GPT-4o", custom: true },
+      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true, provider: "ollama-cloud" },
+      { id: "openai/gpt-4o", label: "GPT-4o", custom: true, provider: "openai" },
     ]);
   });
 
   it("uses the fallback default when the response omits one and a settings file is absent", () => {
     const catalog = parsePiCatalog(MODELS_LINE + "\n", "openai/gpt-4o");
     expect(catalog.default).toBe("openai/gpt-4o");
+  });
+
+  it("reports the provider so BYOK duplicates of one model stay distinguishable", () => {
+    const line =
+      '{"type":"response","command":"get_available_models","success":true,"data":{"models":[' +
+      '{"provider":"zai","id":"glm-5.3","name":"GLM-5.3"},' +
+      '{"provider":"nous","id":"glm-5.3","name":"GLM-5.3"}]}}\n';
+    const catalog = parsePiCatalog(line);
+    expect(catalog.options.map((o) => [o.id, o.provider])).toEqual([
+      ["zai/glm-5.3", "zai"],
+      ["nous/glm-5.3", "nous"],
+    ]);
   });
 
   it("keeps an empty catalog when the probe fails or reports no models", () => {
@@ -161,8 +173,8 @@ describe("PiDriver catalog (fake CLI)", () => {
   it("probes the live catalog and flags every option custom", async () => {
     const catalog = await fetchPiModels(FAKE_CLI, { PATH: process.env.PATH ?? "", HOME: join(tmpdir(), "omb-pi-no-settings") });
     expect(catalog.options).toEqual([
-      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true },
-      { id: "openai/gpt-4o", label: "gpt-4o", custom: true },
+      { id: "ollama-cloud/glm-5.2", label: "glm-5.2", custom: true, provider: "ollama-cloud" },
+      { id: "openai/gpt-4o", label: "gpt-4o", custom: true, provider: "openai" },
     ]);
     // no ~/.pi/agent/settings.json in the throwaway home → first option wins
     expect(catalog.default).toBe("ollama-cloud/glm-5.2");

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -114,7 +114,7 @@ interface PiModelsResponse {
  *  Every option is `custom` (pi is BYOK) and id is the `provider/modelId`
  *  composite the picker and `set_model` both use. Exported for the test. */
 export function parsePiCatalog(stdout: string, fallbackDefault = ""): ModelCatalog {
-  const options: Array<{ id: string; label: string; custom: true }> = [];
+  const options: Array<{ id: string; label: string; custom: true; provider: string }> = [];
   let def = fallbackDefault;
   for (const line of stdout.split("\n")) {
     if (!line.trim()) continue;
@@ -129,7 +129,7 @@ export function parsePiCatalog(stdout: string, fallbackDefault = ""): ModelCatal
     for (const m of res.data?.models ?? []) {
       if (!m?.provider || !m?.id) continue;
       const id = `${m.provider}/${m.id}`;
-      options.push({ id, label: m.name ?? m.id, custom: true });
+      options.push({ id, label: m.name ?? m.id, custom: true, provider: m.provider });
     }
     break;
   }

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -19,6 +19,10 @@ function modelLabel(instance: InstanceInfo | undefined, model: string): string {
   return instance?.models.options.find((option) => option.id === model)?.label ?? model;
 }
 
+function modelProvider(instance: InstanceInfo | undefined, model: string): string | undefined {
+  return instance?.models.options.find((option) => option.id === model)?.provider;
+}
+
 function engineStatus(instance: InstanceInfo): string {
   if (needsCli(instance)) return "Not installed";
   if (needsSignIn(instance)) return "Sign-in required";
@@ -47,6 +51,14 @@ function ModelRow({
     >
       <span className="flex min-w-0 items-center gap-2">
         <span className="truncate">{option.label}</span>
+        {option.provider && (
+          <span
+            className="shrink-0 rounded bg-inset px-1.5 py-px text-[10px] text-ink-secondary"
+            title={`Provider: ${option.provider}`}
+          >
+            {option.provider}
+          </span>
+        )}
         {option.id === defaultId && (
           <span className="shrink-0 rounded bg-inset px-1.5 py-px text-[10px] text-ink-secondary">Default</span>
         )}
@@ -225,11 +237,20 @@ export function ModelPicker({
         // resolved engine keeps its label — the mark is what would hide it)
         !contained && active && COMPACT_SQUARE,
       )}
-      title={active ? `${active.displayName} · ${modelLabel(active, selection.model)}` : selection.model}
+      title={
+        active
+          ? `${active.displayName} · ${modelLabel(active, selection.model)}${
+              modelProvider(active, selection.model) ? ` · ${modelProvider(active, selection.model)}` : ""
+            }`
+          : selection.model
+      }
     >
       {active && <ProviderMark driverKind={active.driverKind} size={14} />}
       <span className={cn("max-w-[160px] truncate", !contained && active && "@max-4xl/chathead:hidden")}>
         {modelLabel(active, selection.model)}
+        {active && modelProvider(active, selection.model) && (
+          <span className="text-ink-secondary"> · {modelProvider(active, selection.model)}</span>
+        )}
       </span>
       <ChevronDown
         size={14}

--- a/src/lib/custom-models.ts
+++ b/src/lib/custom-models.ts
@@ -1,14 +1,17 @@
 // Custom picker: search the live inject list, and pin models the host
 // already has in memory so the user can pick them without scrolling.
 
-export function filterCustomModels<T extends { id: string; label: string }>(
+export function filterCustomModels<T extends { id: string; label: string; provider?: string }>(
   options: readonly T[],
   query: string,
 ): T[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return [...options];
   return options.filter(
-    (option) => option.label.toLowerCase().includes(needle) || option.id.toLowerCase().includes(needle),
+    (option) =>
+      option.label.toLowerCase().includes(needle) ||
+      option.id.toLowerCase().includes(needle) ||
+      (option.provider?.toLowerCase().includes(needle) ?? false),
   );
 }
 

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -371,7 +371,7 @@ export interface InstanceInfo {
     /** a reported cost on a subscription is notional; the UI says so */
     billing?: "metered" | "subscription";
   };
-  models: { default: string; options: Array<{ id: string; label: string; custom?: boolean; loaded?: boolean }> };
+  models: { default: string; options: Array<{ id: string; label: string; custom?: boolean; loaded?: boolean; provider?: string }> };
   capabilities?: {
     computerMcp?: boolean;
     agentsMcp?: boolean;


### PR DESCRIPTION
## What

pi is BYOK, so the same model id can arrive from several configured providers (`zai`, `nous`, `openrouter`, …). The pi RPC already returns each model's `provider`, but `parsePiCatalog` dropped it — the picker listed bare "GLM-5.3" rows with no way to tell them apart.

This PR propagates the provider end-to-end and shows it in the UI:

- **`server/contracts.ts`** — `ModelCatalog.options[]` gains an optional `provider` field
- **`server/drivers/pi.ts`** — `parsePiCatalog` keeps the provider from `get_available_models` (composite `provider/model` ids unchanged, so `set_model` is untouched)
- **`src/components/ModelPicker.tsx`** — row shows a muted provider badge (same visual family as the existing Default/Loaded badges); the header chip gets a "· provider" suffix and tooltip
- **`src/lib/custom-models.ts`** — search matches the provider (typing `zai` finds its models)

## Why

With multiple keys configured, two bots on "GLM-5.3" could be on different providers with different billing/limits and nothing in the UI said which. Mirrors what pi's own TUI does (`model.id [provider]`) and the existing `niceLabel` convention in the Codex driver.

## Compatibility

- `provider` is optional in the contract; drivers that don't set it render exactly as before
- local inject rows keep their "`(host)`" labels — no duplicate badges
- no new dependencies

## Screenshots

**After** (picker rows with provider badges + header chip suffix):

<!-- TODO: attach screenshot here — see comment below -->

## Testing

- `pi.test.ts`: expectations updated + new case asserting the same model id from two providers stays distinguishable
- `tsc --noEmit` clean for src and server configs
- full `server/drivers/` suite: 584 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model options now display their provider, making duplicate model names easier to distinguish.
  * Provider information appears in model picker labels, badges, and tooltips.
  * Searching models now also matches provider names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->