### PR TITLE
feat(composer): inject a queued message with a green send

### DIFF
--- a/scripts/check-skin-contrast.mjs
+++ b/scripts/check-skin-contrast.mjs
@@ -97,6 +97,7 @@ const PAIRS = [
   ["--color-ink", "--color-bubble-user", 4.5],
   ["--color-accent-ink", "--color-accent", 4.5],
   ["--color-danger-ink", "--color-danger", 4.5],
+  ["--color-success-ink", "--color-success", 4.5],
   ["--color-accent-text", "--color-app", 4.5],
   ["--color-accent-text", "--color-panel", 4.5],
   ["--color-accent-text", "--color-card", 4.5],

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1275,7 +1275,7 @@ export function ChatView({ bot }: { bot: Bot }) {
                 </div>
                 <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
                   <Clock size={11} aria-hidden="true" />
-                  <span>Queued — sends when this turn finishes</span>
+                  <span>Queued — wait, or inject now</span>
                   <button
                     type="button"
                     onClick={() =>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -34,6 +34,7 @@ import { goalCoordinatorForComposer, groupComposerHint, roomRespondersForCompose
 import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "./PendingApproval";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { ReplyQuote } from "./ReplyQuote";
+import { ComposerInjectNow, composerCanInjectNow } from "./ComposerInjectNow";
 
 /** The active @mention query at the caret: the text between an `@` that
  * starts a word and the caret. null = no mention being typed. */
@@ -360,7 +361,18 @@ export function Composer({
   // its own cancel); the composer chip remains only for rooms, whose queue
   // is local to this component.
   const pendingChip = group ? queued?.text : undefined;
-  // a chip on its own is a message: the send control has to appear for it
+  const pendingCount = group
+    ? queued
+      ? 1
+      : 0
+    : bot
+      ? (state.pendingQueued[bot.threadId] ?? []).length
+      : 0;
+  const canInject = composerCanInjectNow(busy, locked, pendingCount);
+  const interruptTurn = () => {
+    if (group) dispatch({ type: "interruptGroup", groupId: group.id });
+    else if (bot) dispatch({ type: "interrupt", botId: bot.id });
+  };
   const fileInput = useRef<HTMLInputElement>(null);
   const [autoWarn, setAutoWarn] = useState(false);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
@@ -590,7 +602,7 @@ export function Composer({
           <div className="mb-2 flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel px-3 py-2 text-[12.5px] text-ink-secondary">
             <Clock size={13} className="shrink-0" />
             <span className="min-w-0 flex-1 truncate">
-              Queued — sends when {busyName} finishes: “{pendingChip}”
+              Queued — wait, or inject now: “{pendingChip}”
             </span>
             <button
               type="button"
@@ -647,10 +659,7 @@ export function Composer({
               pending={approval}
               threadId={threadId}
               bot={approvalBot}
-              onCancelTurn={() => {
-                if (group) dispatch({ type: "interruptGroup", groupId: group.id });
-                else if (bot) dispatch({ type: "interrupt", botId: bot.id });
-              }}
+              onCancelTurn={interruptTurn}
             />
           </div>
         )}
@@ -814,6 +823,8 @@ export function Composer({
               ? "Answer the approval above to continue"
               : recording
               ? "Listening…"
+              : canInject
+                ? `${busyName} is working — inject now to interrupt with the queued message`
               : busy && canSteer
                 ? `${busyName} is working — Enter sends this into the running turn`
               : busy
@@ -830,12 +841,13 @@ export function Composer({
             className="max-h-[9rem] min-h-6 min-w-0 flex-1 resize-none overflow-y-auto self-center bg-transparent px-1 py-1 text-[15px] leading-6 text-ink placeholder:text-ink-secondary focus:outline-none"
           />
           <div className="flex items-center gap-1">
-          {busy && !locked && (
+          {/* Inject is stop-then-steer made visible. The square stop would
+              drain the same queue, so it yields while a send is waiting.
+              Cancelling the ghost/chip brings Stop back. */}
+          {canInject && <ComposerInjectNow onInject={interruptTurn} />}
+          {busy && !locked && !canInject && (
           <button
-            onClick={() => {
-              if (group) dispatch({ type: "interruptGroup", groupId: group.id });
-              else if (bot) dispatch({ type: "interrupt", botId: bot.id });
-            }}
+            onClick={interruptTurn}
             aria-label="Stop this turn"
             className="flex size-8 shrink-0 items-center justify-center rounded-full text-ink-secondary hover:bg-raised hover:text-ink"
             title="Stop"

--- a/src/components/ComposerInjectNow.test.ts
+++ b/src/components/ComposerInjectNow.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ComposerInjectNow, composerCanInjectNow } from "./ComposerInjectNow";
+
+describe("composerCanInjectNow", () => {
+  it("offers inject only while a turn is live and a send is waiting", () => {
+    expect(composerCanInjectNow(true, false, 1)).toBe(true);
+    expect(composerCanInjectNow(true, false, 2)).toBe(true);
+  });
+
+  it("keeps the square stop when nothing is queued", () => {
+    expect(composerCanInjectNow(true, false, 0)).toBe(false);
+  });
+
+  it("does not offer inject on an idle or locked composer", () => {
+    expect(composerCanInjectNow(false, false, 1)).toBe(false);
+    expect(composerCanInjectNow(true, true, 1)).toBe(false);
+  });
+});
+
+describe("ComposerInjectNow", () => {
+  it("labels the green send control inject now", () => {
+    const markup = renderToStaticMarkup(createElement(ComposerInjectNow, { onInject: () => undefined }));
+    expect(markup).toContain("inject now");
+    expect(markup).toContain("Inject queued message now");
+    expect(markup).toContain("bg-success");
+  });
+});

--- a/src/components/ComposerInjectNow.tsx
+++ b/src/components/ComposerInjectNow.tsx
@@ -1,0 +1,26 @@
+import { ArrowUp } from "lucide-react";
+
+/** A mid-turn send is waiting: the composer can interrupt so those words
+ * run now instead of after the current turn finishes. */
+export function composerCanInjectNow(busy: boolean, locked: boolean, pendingCount: number): boolean {
+  return busy && !locked && pendingCount > 0;
+}
+
+/** Green send control shown while a queued message is waiting. Clicking it
+ * interrupts the live turn so the queued words drain immediately. */
+export function ComposerInjectNow({ onInject }: { onInject: () => void }) {
+  return (
+    <>
+      <span className="whitespace-nowrap pr-0.5 text-[13px] font-medium text-success">inject now</span>
+      <button
+        type="button"
+        onClick={onInject}
+        aria-label="Inject queued message now"
+        title="Interrupt this turn and send the queued message now"
+        className="flex size-8 shrink-0 items-center justify-center rounded-full bg-success hover:brightness-110"
+      >
+        <ArrowUp size={17} />
+      </button>
+    </>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -66,6 +66,7 @@
      bottom of this file, which is what makes them take effect) */
   --color-accent-ink: #ffffff;
   --color-danger-ink: #ffffff;
+  --color-success-ink: #072114;
   --color-scrollbar: #3d3d3d;
   /* second speed line of the mascot — contrasts against the app ground */
   --color-maus-line: #fcfcfc;
@@ -100,6 +101,7 @@
   --color-success: #38d591;
   --color-danger: #ff5667;
   --color-danger-ink: #ffffff;
+  --color-success-ink: #072114;
   --color-warning: #ff9800;
   --color-scrollbar: #3d3d3d;
   --color-maus-line: #fcfcfc;
@@ -145,6 +147,7 @@
   --color-success: #3f6b47;
   --color-danger: #a33a32;
   --color-danger-ink: #ffffff;
+  --color-success-ink: #ffffff;
   --color-warning: #7a5f31;       /* darkened → 4.98:1 */
   --color-scrollbar: #c9c0ae;
   --color-maus-line: #6b6559;
@@ -197,6 +200,7 @@
   --color-success: #57b078;
   --color-danger: #e0685e;        /* a lamp, not a paint chip */
   --color-danger-ink: #1c0d0b;
+  --color-success-ink: #1c150c;
   --color-warning: #dfa441;
   --color-scrollbar: #3d3529;
   --color-maus-line: #b0a696;
@@ -255,6 +259,7 @@
   --color-success: #2f6b4f;
   --color-danger: #a8382f;
   --color-danger-ink: #ffffff;
+  --color-success-ink: #ffffff;
   --color-warning: #7a5a2a;
   --color-scrollbar: #a6b8b6;
   --color-maus-line: #4d5c5b;
@@ -895,7 +900,7 @@ body {
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
-   Filled accent / danger surfaces
+   Filled accent / danger / success surfaces
 
    Components hardcode `text-white` on these fills (~20 call sites). That works
    only as long as every skin's accent is dark enough to carry white — which
@@ -909,6 +914,9 @@ body {
 }
 .bg-danger {
   color: var(--color-danger-ink);
+}
+.bg-success {
+  color: var(--color-success-ink);
 }
 
 /* Disabled buttons.


### PR DESCRIPTION
## What

When a 1:1 (or room) send is waiting while the bot is still working, the composer currently only shows the square **Stop** control. That already drains the queue (stop-then-steer), but it is easy to miss.

This makes that path visible:

1. Agent is working — square Stop, as before
2. Type a follow-up and send — it queues (ghost row / room chip)
3. Composer shows **inject now** and a green send
4. That button interrupts the live turn so the queued words run immediately

Stop is hidden while something is queued, because it would drain the same queue. Cancel the ghost row or chip first if you want Stop back without sending those words.

No new server endpoint: `POST /interrupt` already drains `steer-queue` on `turn.completed`, including interrupted turns.

## Testing

- `pnpm exec vitest run src/components/ComposerInjectNow.test.ts` (4 passed)
- `pnpm exec tsc -b`
- `node scripts/check-skin-contrast.mjs` (atelier / foundry / lagoon clear; midnight advisory gaps unchanged)

Existing server coverage: `server/steer-queue.test.ts` — "drains the queue after an interrupt — stop-then-steer".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Inject now” action for sending queued messages immediately during an active turn.
  * Updated queued-message guidance and composer states to clearly indicate when immediate injection is available.
* **Style**
  * Improved text contrast on success-colored surfaces across all visual themes.
* **Tests**
  * Added coverage for the new injection control and its availability states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->