### PR TITLE
fix(browser): stop a navigation from locking the bot out of its own tab

### DIFF
--- a/electron/browser-surface.cjs
+++ b/electron/browser-surface.cjs
@@ -572,6 +572,10 @@ function createBrowserSurfaceManager({
     return true;
   };
 
+  /** Records what the agent just dispatched so the native event it produces
+   * can be recognized on the way back. Returns the echo so the caller can
+   * restamp it once the CDP command returns — the window has to start when
+   * Electron can actually deliver the event, not when the command was sent. */
   const rememberAgentEcho = (entry, method, params) => {
     const until = now() + AGENT_INPUT_SUPPRESS_MS;
     let echo = null;
@@ -588,18 +592,33 @@ function createBrowserSurfaceManager({
       entry.agentEchoes.push(echo);
       if (entry.agentEchoes.length > 20) entry.agentEchoes.splice(0, entry.agentEchoes.length - 20);
     }
+    return echo;
   };
 
-  const claimHumanControl = (entry, kind = "focus", details) => {
+  /** Restart an echo's window from now. A dispatch slower than
+   * AGENT_INPUT_SUPPRESS_MS would otherwise outlive its own echo, and the
+   * native event arriving after it would be charged to the person. */
+  const restampAgentEcho = (echo) => {
+    if (echo) echo.until = now() + AGENT_INPUT_SUPPRESS_MS;
+  };
+
+  /** Did a person just do this? Only a concrete pointer or key event can
+   * claim the wheel. Focus deliberately cannot: it carries no source details,
+   * and Chromium raises it for reasons that have nothing to do with a person
+   * — a navigation commit, a view attach, focus moving between views in the
+   * same window. Trusting it charged the agent's own page loads to the person
+   * and left the bot locked out of a browser nobody had taken. */
+  const claimHumanControl = (entry, kind, details) => {
     const control = controlFor(entry.botId);
     // Once held, browser agents cannot generate input. Any further native
     // event is therefore human input and remains relevant to document taint.
     if (control.held) return true;
+    // A synthetic dispatch is still in flight: every native event this view
+    // reports is that dispatch arriving, and a person's event cannot be told
+    // apart from it. Suppress before matching so the echo survives for the
+    // event that lands after the CDP call returns.
+    if (entry.agentInputDepth > 0) return false;
     if (agentEchoMatches(entry, kind, details)) return false;
-    // Focus carries no source details. A concrete mouse/key event follows a
-    // real interaction and is compared against the exact synthetic echo;
-    // only the ambiguous focus signal needs the short time guard.
-    if (kind === "focus" && (entry.agentInputDepth > 0 || now() < entry.agentInputUntil)) return false;
     botControl.set(entry.botId, { ...control, held: true, epoch: control.epoch + 1 });
     void neutralizeAgentInput(entry);
     emitUserInteraction({ botId: entry.botId, profile: entry.profile });
@@ -828,15 +847,12 @@ function createBrowserSurfaceManager({
         emitUserInteraction({ botId: entry.botId, profile: entry.profile });
       }
     };
-    contents.on("focus", () => {
-      const wasHeld = controlFor(entry.botId).held;
-      const human = claimHumanControl(entry, "focus");
-      // A newly acquired hold emits above and may expand before Electron
-      // delivers its mouse event, so latch that gesture. An already-held view
-      // must wait for a concrete pointer event; merely restoring its focus
-      // while shrinking should not bounce the workspace open again.
-      if (human && !wasHeld && entry.mode === "compact") beginCompactGestureGuard(false);
-    });
+    // No `focus` listener on purpose. Focus is not evidence of a person: with
+    // focusOnNavigation disabled the agent's loads no longer raise it, but a
+    // view attach or a focus move between views in the same window still can,
+    // and none of those mean a hand on the wheel. The pointer and key
+    // listeners below are the only way control changes hands, and they are
+    // also the only events that can carry a secret into the page.
     contents.on("before-input-event", (_event, input) => {
       const human = claimHumanControl(entry, "keyboard", input);
       // A page can transform/copy a password on input and immediately clear
@@ -962,6 +978,13 @@ function createBrowserSurfaceManager({
         sandbox: true,
         webSecurity: true,
         allowRunningInsecureContent: false,
+        // Chromium focuses a WebContents on every navigation by default, so
+        // each agent loadURL made this child view the window's first
+        // responder — indistinguishable from the person clicking into the
+        // page, which claimed the control lease and locked the bot out of
+        // its own browser. The bot's tab must never steal focus from the
+        // chat; focus emulation below already keeps synthetic input landing.
+        focusOnNavigation: false,
         partition,
       },
     });
@@ -986,7 +1009,6 @@ function createBrowserSurfaceManager({
       dialogs: [],
       notices: [],
       agentInputDepth: 0,
-      agentInputUntil: 0,
       agentEchoes: [],
       pressedMouse: new Map(),
       pressedKeys: new Map(),
@@ -1309,14 +1331,13 @@ function createBrowserSurfaceManager({
         // but they are still synthetic. Mark them exactly like normal CDP
         // input so Electron's before-input-event cannot mistake keyUp for a
         // person taking control and leave the bot stuck behind a false hold.
-        rememberAgentEcho(entry, method, params);
+        const echo = rememberAgentEcho(entry, method, params);
         entry.agentInputDepth += 1;
-        entry.agentInputUntil = Math.max(entry.agentInputUntil, now() + AGENT_INPUT_SUPPRESS_MS);
         try {
           await dbg.sendCommand(method, params);
         } finally {
           entry.agentInputDepth = Math.max(0, entry.agentInputDepth - 1);
-          entry.agentInputUntil = Math.max(entry.agentInputUntil, now() + AGENT_INPUT_SUPPRESS_MS);
+          restampAgentEcho(echo);
         }
       };
       for (const press of mouse) {
@@ -1365,11 +1386,11 @@ function createBrowserSurfaceManager({
       commandParams = presentationMouseParams(entry, commandParams);
     }
     const isAgentInput = method.startsWith("Input.");
+    let agentEcho = null;
     if (isAgentInput) {
       assertAgentLease(entry, lease);
-      rememberAgentEcho(entry, method, commandParams);
+      agentEcho = rememberAgentEcho(entry, method, commandParams);
       entry.agentInputDepth += 1;
-      entry.agentInputUntil = Math.max(entry.agentInputUntil, now() + AGENT_INPUT_SUPPRESS_MS);
     }
     try {
       const result = await dbg.sendCommand(method, commandParams);
@@ -1385,8 +1406,10 @@ function createBrowserSurfaceManager({
       return result;
     } finally {
       if (isAgentInput) {
+        // Depth guarded the whole dispatch; the echo's window starts here, so
+        // it is measured from the moment Electron can deliver the event.
         entry.agentInputDepth = Math.max(0, entry.agentInputDepth - 1);
-        entry.agentInputUntil = Math.max(entry.agentInputUntil, now() + AGENT_INPUT_SUPPRESS_MS);
+        restampAgentEcho(agentEcho);
       }
     }
   };

--- a/electron/browser-surface.test.mjs
+++ b/electron/browser-surface.test.mjs
@@ -252,6 +252,7 @@ function fakeView(partition) {
 
 function harness(options = {}) {
   const views = [];
+  const prefs = [];
   const sessions = new Map();
   const owner = {
     isDestroyed: () => false,
@@ -272,6 +273,7 @@ function harness(options = {}) {
   const manager = createBrowserSurfaceManager({
     owner,
     createView: (viewOptions) => {
+      prefs.push(viewOptions.webPreferences);
       const view = fakeView(viewOptions.webPreferences.partition);
       const shared = sessions.get(viewOptions.webPreferences.partition);
       if (shared) view.webContents.session = shared;
@@ -286,7 +288,7 @@ function harness(options = {}) {
     now: () => Date.now() + (clock += 1),
     ...options,
   });
-  return { manager, owner, views, states };
+  return { manager, owner, views, states, prefs };
 }
 
 const cdpCalls = (view) => view.calls.filter(([name]) => /^[A-Z]/.test(name) && name.includes("."));
@@ -865,7 +867,10 @@ describe("browser surface manager", () => {
     const interactions = [];
     const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
     await manager.navigate("bot-a", "https://example.com");
-    views[0].listeners.get("focus")?.();
+    // A pointer event, not focus: only a concrete gesture is a person. A
+    // wheel claims the wheel without tainting the document, so this stays a
+    // test about control gating — pointer taint has its own test below.
+    views[0].listeners.get("before-mouse-event")?.({}, { type: "mouseWheel", deltaY: 120 });
     expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
     await expect(manager.click("bot-a", "b11")).rejects.toThrow(/held by the user/);
     // Renderer-driven address-bar navigation stays available while the user
@@ -873,6 +878,77 @@ describe("browser surface manager", () => {
     await manager.navigate("bot-a", "https://example.org", "", { source: "user" });
     expect(manager.setHumanControl("bot-a", false, "")).toBe(true);
     await expect(manager.click("bot-a", "b11")).resolves.toBeTruthy();
+  });
+
+  it("asks Chromium not to focus the bot's view when it navigates", () => {
+    // Chromium's default made every agent loadURL steal first responder,
+    // which the lease then read as the person clicking into the page.
+    const { manager, prefs } = harness();
+    manager.layout("bot-a", BOUNDS, "", "expanded");
+    expect(prefs[0]).toMatchObject({ focusOnNavigation: false });
+  });
+
+  it("never treats a bare focus event as the person taking the wheel", async () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    await manager.navigate("bot-a", "https://example.com");
+
+    // Focus carries no source details, and Chromium raises it for a commit,
+    // a view attach, or focus moving between views in the same window. None
+    // of those is a hand on the wheel, so nothing listens for it any more.
+    expect(views[0].listeners.has("focus")).toBe(false);
+
+    expect(interactions).toEqual([]);
+    expect(manager.controlLease("bot-a", "")).toMatchObject({ held: false, epoch: 0 });
+    // The bot keeps working: this is the lockout the lease used to cause.
+    await expect(manager.click("bot-a", "b11")).resolves.toBeTruthy();
+    await expect(manager.navigate("bot-a", "https://example.com/second")).resolves.toBeTruthy();
+    expect(manager.controlLease("bot-a", "")).toMatchObject({ held: false, epoch: 0 });
+  });
+
+  it("does not blame the user for a synthetic click whose native event outlives its dispatch", async () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    await manager.navigate("bot-a", "https://example.com");
+
+    // An echo stamped when the command was SENT expires while a slow dispatch
+    // is still in flight, so the agent's own click came back looking human.
+    // The window has to start when Electron can deliver the event.
+    const dbg = views[0].webContents.debugger;
+    const send = dbg.sendCommand;
+    let dispatched = null;
+    dbg.sendCommand = async (method, params) => {
+      const result = await send(method, params);
+      if (method === "Input.dispatchMouseEvent" && params.type === "mousePressed") {
+        dispatched = params;
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      }
+      return result;
+    };
+
+    await manager.click("bot-a", "b11");
+    views[0].listeners.get("before-mouse-event")?.({}, {
+      type: "mouseDown",
+      button: dispatched.button,
+      x: dispatched.x,
+      y: dispatched.y,
+    });
+
+    expect(interactions).toEqual([]);
+    expect(manager.controlLease("bot-a", "")).toMatchObject({ held: false });
+    await expect(manager.read("bot-a")).resolves.toMatchObject({ title: "Loaded" });
+  });
+
+  it("still hands control over on a native event that lands while agent input is in flight", async () => {
+    const interactions = [];
+    const { manager, views } = harness({ onUserInteraction: (event) => interactions.push(event) });
+    await manager.navigate("bot-a", "https://example.com");
+
+    // Suppression during a dispatch is scoped to that dispatch. Once it
+    // returns, a gesture that matches no echo takes the wheel as before.
+    views[0].listeners.get("before-mouse-event")?.({}, { type: "mouseDown", button: "left", x: 700, y: 500 });
+    expect(interactions).toEqual([{ botId: "bot-a", profile: "" }]);
+    await expect(manager.click("bot-a", "b11")).rejects.toThrow(/held by the user/);
   });
 
   it.each(["mouseDown", "contextMenu", "mouseWheel"])("keeps compact human %s input watch-only while expanding", async (type) => {

--- a/server/drivers/browser-proxy.test.ts
+++ b/server/drivers/browser-proxy.test.ts
@@ -239,6 +239,22 @@ describe("browser takeover", () => {
     const missing = await callTool("browser_request_takeover", {});
     expect(missing.result.isError).toBe(true);
   }, 20_000);
+
+  it("pages the user even when the wheel is already held", async () => {
+    held = true;
+    helpOpen = false;
+    helpRequests.length = 0;
+    const pending = callTool("browser_request_takeover", { reason: "Solve the CAPTCHA" });
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    // A hold the person never took deliberately puts no card on their screen,
+    // so staying quiet here left the bot waiting on a plea nobody was shown.
+    expect(helpRequests[0]).toEqual({ method: "POST", body: { reason: "Solve the CAPTCHA" } });
+    held = false;
+    helpOpen = false;
+    const res = await pending;
+    expect(res.result.isError).toBeFalsy();
+    expect(text(res)).toMatch(/handed control back/);
+  }, 20_000);
 });
 
 describe("classifyWall", () => {

--- a/server/drivers/browser-proxy.ts
+++ b/server/drivers/browser-proxy.ts
@@ -356,9 +356,13 @@ async function requestTakeover(reason: string, request: HostRequest, waitMs = TA
     return textResult("Nobody can be paged for this browser right now. Tell the user in chat what you need them to do in the Browser panel.", true);
   }
   const initial = await control.state(true);
-  // if the person is already driving, don't clobber whatever plea they are reading
-  const requestId = initial.held ? null : await control.requestHelp(reason);
-  if (!initial.held && requestId === null) {
+  // Page unless a plea is already open. Skipping this whenever the person
+  // merely *held* the wheel was the silent-freeze bug: a hold they never took
+  // deliberately has no plea for them to read, so nothing appeared in the app
+  // while the bot waited out its whole window. The harness keeps an existing
+  // plea rather than replacing it, so asking while they drive is safe.
+  const requestId = initial.helpOpen ? null : await control.requestHelp(reason);
+  if (!initial.helpOpen && requestId === null) {
     return textResult("The user could not be paged right now. Tell them in chat what you need them to do in the Browser panel.", true);
   }
   let sawHold = initial.held;


### PR DESCRIPTION
## What changed

Four changes that together stop the built-in browser from locking a bot out of its own tab.

1. **`focusOnNavigation: false` on the bot's `WebContentsView`.** Chromium focuses a `WebContents` on every navigation by default, so each agent `loadURL` made the bot's view the window's first responder.
2. **Removed the `focus` listener.** Only a concrete pointer or key event claims control now.
3. **Extended the in-flight input guard to pointer and key events** (it was `focus`-only), and an echo is now restamped when its CDP command *returns* rather than when it was sent.
4. **`browser_request_takeover` pages the user unless a plea is already open** — previously it stayed silent whenever the person was already recorded as holding the wheel.

## Why

`claimHumanControl` treated any `focus` event as the person reaching for the wheel. Because `focusOnNavigation` was never disabled, the agent's own navigation raised that event, set `held`, and bumped the epoch — so the loopback host rejected the very action that caused it:

> Browser control changed while the request was running — retry after the user hands it back

Nobody had touched the page. In a real session the **first** `browser_navigate` of the thread was rejected, and the bot reported that the user had taken control.

Two details made it self-sustaining rather than merely annoying:

- **The escape hatch was silent.** `requestTakeover` skipped paging whenever `held` was already true, on the reasoning that it must not clobber a plea the person was reading. A hold created by a stray focus claim has no plea, so nothing appeared in the app while the bot blocked. It looked frozen, and in the session that prompted this it was killed twice mid-wait.
- **The same defect had a second door.** `echo.until` was stamped when a CDP input command was *sent*, and only `agentInputUntil` was refreshed on return. A dispatch slower than `AGENT_INPUT_SUPPRESS_MS` (100ms) outlived its own echo, so the agent's own click came back looking like a person's. Fixing focus alone would have left that live.

Dropping focus as a claim signal is not a credential regression: document taint was always keyed to `before-input-event` and `before-mouse-event`, never to `focus`, and the compact surface's watch-only first gesture is a pointer event. The cost is that a Tab-into-page now claims control on the first keystroke rather than on focus, a few tens of milliseconds later; the populated-protected-field scan still fails reads closed in that window.

`agentInputUntil` had no readers left once the focus branch went, so the per-echo restamp replaces it.

## How it was verified

```
pnpm typecheck        ✓
pnpm check:electron   ✓  (86 Electron modules)
pnpm test             242/244 files, 2724 passed
```

**On the one failure:** `server/steer-e2e.test.ts > mid-turn steering e2e` fails under full-suite load and passes in isolation. It fails **identically on a clean `main` (2fae3ec) with this branch's changes stashed**, and the file references neither changed module. Pre-existing flake, not introduced here.

Each of the four changes has a regression test, and each was confirmed to fail without its fix by reverting the source and re-running:

| Test | Guards |
|---|---|
| `asks Chromium not to focus the bot's view when it navigates` | 1 |
| `never treats a bare focus event as the person taking the wheel` | 2 |
| `does not blame the user for a synthetic click whose native event outlives its dispatch` | 3 |
| `pages the user even when the wheel is already held` | 4 |

Takeover is still verified to work: `hands native input to the user immediately and gates agent actions until hand-back` and `still hands control over on a native event that lands while agent input is in flight` both cover a real gesture claiming the lease and blocking agent actions until hand-back.

**One existing test changed.** `hands native input to the user immediately…` asserted the old behaviour by firing a bare `focus`. It now fires a `mouseWheel`, which claims control *without* tainting the document — the same shape the focus event had, so the test keeps asserting control gating rather than quietly also asserting taint. Pointer taint keeps its own dedicated test.

## Screenshots (UI changes)

None — no renderer changes. `src/` is untouched.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally — modulo the pre-existing `steer-e2e` flake documented above
- [x] `pnpm check:electron` passes (desktop-shell change)
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building — no platform-specific code added
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control handoff between automated browser actions and user input.
  * Prevented page navigation from unexpectedly taking focus away from the chat.
  * Ensured genuine user interactions during automated actions correctly reclaim control.
  * Fixed takeover requests so help is still requested when control is currently held.
  * Avoided duplicate help requests when one is already pending.

* **Tests**
  * Added coverage for focus behavior, delayed input events, navigation preferences, and takeover requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->