### PR TITLE
Bundled verification skills: bots that prove their own work on any surface

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2708,6 +2708,30 @@ describe("harness HTTP API", () => {
     await api("PUT", "/api/config", { rooms: { turnTimeoutMinutes: 5 } });
   });
 
+  it("mounts the verification skill into a real turn when its trigger appears", async () => {
+    const bot = (await api("POST", "/api/bots", {})).body.bot;
+    try {
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, {
+        text: "/create-verification-skill for my notes app",
+      })).status).toBe(202);
+      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
+      const seen = JSON.parse(readFileSync(fakeClaudeDump, "utf8"));
+      const system = seen.argv[seen.argv.indexOf("--append-system-prompt") + 1] ?? "";
+      // the skill's instructions ride the system prompt the agent receives
+      expect(system).toContain('<openmaus-skill id="create-verification-skill"');
+      // the sibling is only MENTIONED by create's handoff text — it must not
+      // be mounted as its own skill on an untriggered turn
+      expect(system).not.toContain('<openmaus-skill id="maintain-verification-skill"');
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("keeps Teach a skill off by default and persists an explicit opt-in", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);

--- a/server/skill-library.test.ts
+++ b/server/skill-library.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { loadUserSkills, mergeSkills, parseSkillManifest, skillInstructionsFor, type BundledSkill } from "./skill-library.ts";
+import { loadBundledSkills, loadUserSkills, mergeSkills, parseSkillManifest, selectBundledSkills, skillInstructionsFor, type BundledSkill } from "./skill-library.ts";
 
 const phone: BundledSkill = {
   directory: "/skills/phone-harness",
@@ -63,5 +63,44 @@ describe("bundled skill library", () => {
     const file = join(root, "not-a-directory");
     writeFileSync(file, "nope");
     expect(loadUserSkills(file)).toEqual([]);
+  });
+});
+
+describe("bundled verification skills", () => {
+  const skills = loadBundledSkills(join(process.cwd(), "skills"));
+
+  it("ship enabled with valid manifests", () => {
+    const ids = skills.map((skill) => skill.manifest.id);
+    expect(ids).toContain("create-verification-skill");
+    expect(ids).toContain("maintain-verification-skill");
+    for (const skill of skills) {
+      expect(skill.manifest.defaultEnabled).toBe(true);
+      expect(skill.instructions.startsWith("---")).toBe(true);
+    }
+  });
+
+  it("the slash form and natural phrasing both select create, and only create", () => {
+    for (const text of [
+      "/create-verification-skill for my notes app",
+      "can you make a verification skill so you can prove changes work",
+    ]) {
+      const selected = selectBundledSkills(text, [], skills).map((skill) => skill.manifest.id);
+      expect(selected).toContain("create-verification-skill");
+      expect(selected).not.toContain("maintain-verification-skill");
+    }
+  });
+
+  it("maintenance phrasing selects maintain without dragging in create", () => {
+    const selected = selectBundledSkills("/maintain-verification-skill for atlas", [], skills)
+      .map((skill) => skill.manifest.id);
+    expect(selected).toContain("maintain-verification-skill");
+    expect(selected).not.toContain("create-verification-skill");
+  });
+
+  it("ordinary chat selects neither", () => {
+    const selected = selectBundledSkills("please verify the numbers in this invoice", [], skills)
+      .map((skill) => skill.manifest.id);
+    expect(selected).not.toContain("create-verification-skill");
+    expect(selected).not.toContain("maintain-verification-skill");
   });
 });

--- a/skills/create-verification-skill/SKILL.md
+++ b/skills/create-verification-skill/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: create-verification-skill
+description: "Generate a project-local verification skill: a scripted way to launch the user's app, drive one of its features the way a user would, and capture evidence — on whichever surface this bot actually has (browser, computer, phone, or plain Bash). Use when asked to create a verification skill, a control CLI, or a feature map, or when work on an app keeps ending without proof."
+---
+
+# Create a verification skill
+
+A verification skill is how you prove your own work: launch the real app,
+exercise a feature the way a user would, and capture evidence. Build it once
+and every later turn — yours or another bot's — verifies in a few tool calls
+instead of improvising. Write everything you generate for the next agent, not
+for a human: it will be read cold by a bot that has never seen the app.
+
+## 1. Pick the surface from the tools you actually have
+
+- **Web app, or anything reachable by URL** → the built-in browser tools
+  (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_fill`,
+  `browser_wait_for`, `browser_screenshot`). Refs from snapshots are the
+  lever; screenshots are the evidence.
+- **Desktop app** → the computer tools on this bot's computer. Prefer an
+  isolated computer (cloud or Local VM) over the user's own desktop.
+- **Physical Android app** → the phone tools, when mounted.
+- **CLI, service, or library** → Bash in the workspace: build once, drive
+  each run in its own process, use curl for services.
+
+If the right surface tool is not mounted, say exactly that and name the
+setting that adds it (the bot's Computer or Browser toggle). Never fake a
+surface with a weaker one.
+
+## 2. Interview the repo, not the user
+
+Answer from the codebase; ask the user only what you cannot observe: how the
+app starts locally (the repo's own dev command), how you can tell it is
+ready (log line, port answering), seed data and test accounts, whether two
+instances can run side by side. If the checkout does not start as-is, fix or
+report that first — a skill written against a broken base teaches wrong steps.
+
+## 3. Build the lever
+
+When the surface is Bash-reachable, write a small control CLI into the
+project (for example `scripts/control-<app>.mjs`) instead of leaving prose
+instructions: subcommands like `doctor`, `launch`, `send`, `snapshot`,
+`screenshot`, `wait-settle`, `cleanup`. Rules for the CLI: descriptive
+errors that say what to do instead, `--dry-run` on anything destructive,
+machine-readable output, rich `--help`. When the surface is the browser,
+computer, or phone tools, those ARE the lever — the drive recipes belong in
+the feature map instead of a wrapper script.
+
+## 4. Generate the skill where it becomes real
+
+Write the skill to `~/.openmausbot/skills/verify-<app>/` (the user-skills
+folder; hot-loaded, no restart):
+
+- `manifest.json` — `id` must equal the folder name (kebab-case), plus
+  `name`, `version` "0.1.0", `description`, `defaultEnabled` true,
+  `triggerTerms` (include "/verify-<app>" and the app's name), and
+  `requiredCapabilities` naming the surface it needs (for example
+  `["browserMcp"]`) so it never triggers on a bot that cannot run it.
+- `SKILL.md` — frontmatter, then exactly these sections, each grounded in
+  what the interview found, no placeholders: **Launch** (command + ready
+  signal + teardown), **Doctor** (one read-only "is this instance worth
+  driving?" check), **Drive** (real selectors, refs, routes, or commands
+  from this app — stable handles, never coordinates), **Evidence** (what to
+  capture and where it survives; real user path, action AND resulting
+  state, side effects checked alongside what is visible), **Cleanup** (kill
+  what you started, never by process name; cleanup must not eat evidence).
+- `features/README.md` plus one file per major feature (top 3-5 to start),
+  each with exactly four H2s: `Sub-features`, `How to get to it (user
+  POV)`, `Driving it`, `Gotchas`. This map is compact shared memory — it is
+  why the second verification costs a fraction of the first.
+
+## 4b. Recordings are seeds
+
+If the user has recorded a workflow with the skill recorder (or offers to
+demonstrate one), treat the recording as ground truth for that feature's
+`How to get to it (user POV)` section and its drive recipe — a
+demonstration beats your exploration. The reverse also holds: when you
+finish a feature-map entry, it upgrades any recorded skill for the same
+flow with a Doctor check, evidence standards, and cleanup it did not have.
+
+## 5. Prove it before you announce it
+
+Run the generated skill end to end once: launch, doctor, drive ONE mapped
+feature, capture evidence, clean up, then confirm the evidence still exists.
+A generated skill that was never executed is a draft, not a deliverable.
+Show the user the evidence when you report.
+
+## 6. Offer the maintenance routine
+
+Offer to keep the skill honest with a daily routine: propose it with
+propose_routine (instructions: "run /maintain-verification-skill for
+<app>"). The routine only exists after the user confirms the card — never
+claim it is scheduled before that.
+
+Prior art: this distills the verification practice from poteto's pstack,
+adapted to this app's surfaces and skill format.

--- a/skills/create-verification-skill/manifest.json
+++ b/skills/create-verification-skill/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "create-verification-skill",
+  "name": "Create Verification Skill",
+  "version": "0.1.0",
+  "description": "Generate a project-local verification skill and feature map so this bot can drive the user's app like a real user and prove its own work.",
+  "defaultEnabled": true,
+  "triggerTerms": [
+    "/create-verification-skill",
+    "create a verification skill",
+    "make a verification skill",
+    "verification skill",
+    "verify your work with proof",
+    "make a control cli",
+    "feature map for"
+  ],
+  "requiredCapabilities": []
+}

--- a/skills/maintain-verification-skill/SKILL.md
+++ b/skills/maintain-verification-skill/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: maintain-verification-skill
+description: "Keep a generated verify-<app> skill honest: re-walk its feature map against the live app, fix drifted drive recipes, add stubs for new features, and surface real product bugs instead of papering over them. Use for /maintain-verification-skill or when a verification skill's instructions stopped matching the app."
+---
+
+# Maintain a verification skill
+
+1. **Load** the target skill from `~/.openmausbot/skills/verify-<app>/`
+   (ask which app only if several exist). Read `SKILL.md` and every file in
+   `features/`.
+2. **Doctor first.** Run the skill's own Doctor check. If the app will not
+   launch at all, stop and report that as the finding — do not rewrite a
+   map against an app you could not run.
+3. **Walk the map.** For each feature file (all of them if quick, else the
+   most-used plus any the user named): follow `Driving it` exactly as
+   written. Three outcomes:
+   - **Works** — leave it alone.
+   - **Drifted** — the app changed (renamed control, moved route, new
+     step): update the recipe and `Gotchas` to match reality.
+   - **Broken product** — the feature itself fails when driven correctly:
+     report it as a bug with evidence. Never edit the map to hide a
+     product bug.
+4. **Catch what is new.** Note user-facing features you encountered that
+   the map does not cover; add stub files for the significant ones with at
+   least `How to get to it (user POV)` filled in.
+5. **Version and report.** Bump the skill's manifest patch version, clean
+   up whatever you launched, and summarize: features checked, entries
+   updated, stubs added, product bugs found — with evidence for anything
+   you changed or reported.

--- a/skills/maintain-verification-skill/manifest.json
+++ b/skills/maintain-verification-skill/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "maintain-verification-skill",
+  "name": "Maintain Verification Skill",
+  "version": "0.1.0",
+  "description": "Refresh an existing verify-<app> skill and its feature map against the live app so drive recipes never go stale.",
+  "defaultEnabled": true,
+  "triggerTerms": [
+    "/maintain-verification-skill",
+    "maintain the verification skill",
+    "refresh the feature map",
+    "update the verification skill",
+    "verification skill is stale"
+  ],
+  "requiredCapabilities": []
+}


### PR DESCRIPTION
First product slice from the pstack read (the verification-is-all-you-need guide by Grok Bot's own maintainer): **two bundled skills that make any bot able to prove its own work — on every surface this app controls.**

## What

- **`create-verification-skill`** — triggered by `/create-verification-skill` *or* natural phrasing ("make a verification skill for my app"): the bot picks the surface from the tools it actually has (web → built-in browser refs, desktop → cloud/VM/host computer, Android → phone harness, CLI/service → Bash), interviews the repo instead of the user, builds a small control lever where Bash applies, and generates a real user skill into `~/.openmausbot/skills/verify-<app>/` — manifest + Launch/Doctor/Drive/Evidence/Cleanup + a feature map (four fixed H2s per feature). Hot-loaded, so it's live for every later turn without a restart. Hard rules baked in: **prove it end-to-end once before announcing it**, evidence must survive cleanup, and the maintenance cadence is offered via `propose_routine` — so the daily upkeep rides our confirm-card scheduler.
- **`maintain-verification-skill`** — the routine's target: doctor first, re-walk the map, three verdicts per feature (works / drifted → update recipe / **broken product → report with evidence, never edit the map to hide a bug**), stub newly-found features, bump the version.
- **Teach synergy, not replacement**: recordings from the skill recorder are declared *seeds* — a demonstration is ground truth for a feature's "How to get to it (user POV)"; the map upgrades recorded skills with the Doctor/Evidence/Cleanup structure they lack. Converging the recorder's output on this same format is the follow-up PR.

The multi-surface part is the piece the original can't do: pstack verifies in browsers and cloud sandboxes; a MausBot can verify on a real desktop, in an isolated VM, on a physical phone, and on the web — same discipline, one skill.

## How verified

- Selection suite: slash form and natural phrasing mount create (and only create); maintenance phrasing mounts maintain (and only maintain); ordinary chat mounts neither; both ship enabled with valid manifests/frontmatter.
- **Real-turn e2e**: a fake-engine turn with the trigger shows `<openmaus-skill id="create-verification-skill">` in the actual `--append-system-prompt` the agent receives — and asserts the sibling is *mentioned* by the handoff text but never *mounted*.
- Mutation checks: deleting the slash trigger or flipping `defaultEnabled` each fails the suite.
- `tsc` + strict typecheck clean; index suite green; zero lint hits.

Prior art credited in the skill body. 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a skill for creating project-specific verification workflows.
  * Added a skill for maintaining and refreshing existing verification workflows.
  * Both skills are enabled by default and support slash commands and natural-language triggers.
  * Verification skills can use available tools, validate workflows end to end, and report unsupported capabilities clearly.

* **Bug Fixes**
  * Ensured only the skill matching the requested action is activated, preventing unrelated instructions from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->