### PR TITLE
control-omb: the verification lever + feature map for this repo's agents

### DIFF
--- a/.claude/skills/verify-omb/SKILL.md
+++ b/.claude/skills/verify-omb/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: verify-omb
+description: "Drive a real OpenMausBot harness server to prove changes work — launch an isolated instance, run turns on the fake engine, read transcripts, capture evidence. Use before claiming any server/product change works, and for reproducing user reports."
+---
+
+# Verify OpenMausBot
+
+The lever is `scripts/control-omb.mjs` (JSON out, teaching errors, `--help`).
+The map of driveable features is in [`features/`](features/README.md).
+
+## Launch (isolated — never drive the user's live app)
+
+```sh
+TMP=$(mktemp -d) && mkdir -p "$TMP/.openmausbot"
+# fake engine so full turns run headless with no credentials:
+cat > "$TMP/.openmausbot/config.json" <<'JSON'
+{ "instances": { "claude": { "driver": "claudeAgent",
+    "config": { "cli": "<REPO>/server/testing/fake-claude-cli.ts" } } } }
+JSON
+chmod +x server/testing/fake-claude-cli.ts
+HOME="$TMP" USERPROFILE="$TMP" OMB_PORT=18987 node server/index.ts &
+```
+
+Ready when `/api/health` answers (~10s). `export OMB_URL=http://127.0.0.1:18987`
+so every control-omb call targets this instance. Different fake behaviors:
+`FAKE_CLAUDE_MODE` env on the server (hang, exit-early, …) — see
+`server/testing/fake-claude-cli.ts` header.
+
+## Doctor
+
+`node scripts/control-omb.mjs doctor` — `ok: true` with at least one
+`availableEngines` entry, or it names what to fix. Run it first whenever
+anything looks off.
+
+## Drive
+
+One command per step; find recipes per feature in the map. Core loop:
+`new-bot` → `send <botId> "<text>"` → `wait-turn <botId>` →
+`transcript <botId> --last 5`.
+
+## Evidence
+
+The transcript IS the evidence for server-side behavior: capture the
+relevant `transcript` output (and server log lines from `$TMP/server.log`)
+into your report. Exercise the real user path (`send`), never internal
+setters. For renderer/Electron behavior this headless recipe cannot reach,
+say so explicitly instead of claiming visual verification.
+
+## Cleanup
+
+`delete-bot` what you created, `kill` the server PID you started (never by
+name), `rm -rf "$TMP"`. Evidence you captured must survive — keep it
+outside `$TMP`.

--- a/.claude/skills/verify-omb/features/README.md
+++ b/.claude/skills/verify-omb/features/README.md
@@ -1,0 +1,16 @@
+# OpenMausBot feature map (dev/verification)
+
+Driveable features of the harness server, from a user's point of view.
+One file per feature; each has `Sub-features`, `How to get to it (user
+POV)`, `Driving it`, and `Gotchas`.
+
+- [chat-turn.md](chat-turn.md) — send a message, run a turn, read the reply
+- [rooms.md](rooms.md) — multi-bot rooms and bot⇄bot channels
+- [routines.md](routines.md) — scheduled work with confirm cards
+- [engines.md](engines.md) — instances, custom ACP engines, model selection
+- [custom-mcp.md](custom-mcp.md) — user-configured MCP servers
+- [skills.md](skills.md) — bundled + user skills mounting into turns
+
+Renderer-only surfaces (browser tab, settings UI, VM panel) need the
+desktop app and are out of headless scope — verify those parts by test
+suite + note the gap.

--- a/.claude/skills/verify-omb/features/chat-turn.md
+++ b/.claude/skills/verify-omb/features/chat-turn.md
@@ -1,0 +1,25 @@
+# Chat turn
+
+Send a user message to a bot; a provider turn runs and replies.
+
+## Sub-features
+- steer queue: a mid-turn send waits and drains after the turn
+- branches: editing a message forks; ‹ › switches versions
+- turn artifacts: settle screenshots chain-insert at their turn
+
+## How to get to it (user POV)
+Pick a bot in the sidebar, type in the composer, press Enter.
+
+## Driving it
+```sh
+BOT=$(node scripts/control-omb.mjs new-bot --name Probe | jq -r .id)
+node scripts/control-omb.mjs send "$BOT" "hello"
+node scripts/control-omb.mjs wait-turn "$BOT"
+node scripts/control-omb.mjs transcript "$BOT" --last 5
+```
+Fake engine replies "hello from fake claude" + one Bash activity chip.
+
+## Gotchas
+- A send while busy returns 202 with `queued: true` — that's the steer
+  queue, not a failure; the text lands after the turn settles.
+- `wait-turn` default timeout is 120s; hang-mode fakes need `interrupt`.

--- a/.claude/skills/verify-omb/features/custom-mcp.md
+++ b/.claude/skills/verify-omb/features/custom-mcp.md
@@ -1,0 +1,17 @@
+# Custom MCP servers
+
+User-configured stdio MCP servers mounted into every capable engine,
+permission-carded by default.
+
+## How to get to it (user POV)
+`"mcpServers"` section in config.json; restart; tools appear to bots.
+
+## Driving it
+Configure in the isolated $TMP config, run a turn, then read the engine's
+dump: claude → mcp-config file must contain the server but NOT its
+`mcp__<name>` in --allowedTools (that's the carding).
+
+## Gotchas
+- Reserved names (computer/agents/composio/…) are skipped with a logged
+  teaching line — absence from a dump may mean a name collision, not a bug.
+- stdio only; url entries skip with a note.

--- a/.claude/skills/verify-omb/features/engines.md
+++ b/.claude/skills/verify-omb/features/engines.md
@@ -1,0 +1,23 @@
+# Engines & instances
+
+Provider instances from config; custom ACP engines and OpenAI-compat
+endpoints are zero-code config entries.
+
+## Sub-features
+- instances map in config.json (driver/environment/config.cli)
+- customAcp: any ACP-stdio CLI; teaching shadow rows for blank cli
+- model picker rail (subscription vs custom), Set CLI override
+
+## How to get to it (user POV)
+Model picker on a bot; Settings → Engines for CLI overrides.
+
+## Driving it
+`GET /api/instances` lists rows + snapshots. Add instances only via the
+isolated $TMP config.json, then restart that server. Fake engines:
+claudeAgent→fake-claude-cli.ts, grokAgent→fake-acp-cli.ts.
+
+## Gotchas
+- A schema-invalid config.json silently falls back to defaults for that
+  boot — check `doctor`'s engine list matches what you configured.
+- describe() probes CLIs; a missing binary is unavailable+reason, never
+  an error.

--- a/.claude/skills/verify-omb/features/rooms.md
+++ b/.claude/skills/verify-omb/features/rooms.md
@@ -1,0 +1,20 @@
+# Rooms & channels
+
+Several bots in one thread; bot⇄bot ask/delegate mirrors into channels.
+
+## Sub-features
+- @mention routing, room lead, everyone/mentions policies
+- ask_bot (sync) and delegate_bot (async ledger with receipts)
+
+## How to get to it (user POV)
+New Room from the sidebar, add members, @mention a bot.
+
+## Driving it
+`POST /api/groups` then `POST /api/groups/:id/messages` (control-omb has no
+room verbs yet — use curl with the same JSON bodies; see server/comms.test.ts
+for canonical payloads). Peer traffic: watch for "Messaged @X" activity
+chips and the auto-created channel in `GET /api/bots` groups.
+
+## Gotchas
+- Busy peers queue as delegations ("asked while busy") instead of bouncing.
+- Depth cap: one hop; a delegated turn cannot delegate further.

--- a/.claude/skills/verify-omb/features/routines.md
+++ b/.claude/skills/verify-omb/features/routines.md
@@ -1,0 +1,21 @@
+# Routines
+
+Scheduled/recurring work, always behind a user confirm card.
+
+## Sub-features
+- propose_routine / propose_routine_action (agent-side, card-gated)
+- for_bot_id: schedule onto ANOTHER bot (runs under its engine)
+- detached execution thread + run receipts
+
+## How to get to it (user POV)
+Ask a bot to schedule something; confirm the card it shows. Manage in the
+Routines page.
+
+## Driving it
+Internal API needs the per-turn comms token (see the fake-claude dump's
+mcpConfig in server/index.test.ts "keeps chat-created routines inert").
+User-level: `POST /api/routines/:id/run`, `GET /api/routines`.
+
+## Gotchas
+- Nothing exists until the card is confirmed — a proposal is not a routine.
+- Cloud-destination proposals 409 without a configured runner.

--- a/.claude/skills/verify-omb/features/skills.md
+++ b/.claude/skills/verify-omb/features/skills.md
@@ -1,0 +1,18 @@
+# Skills
+
+Bundled skills (repo skills/) + user skills (~/.openmausbot/skills) mount
+into turns by trigger terms and capabilities.
+
+## How to get to it (user POV)
+Just type a trigger ("/create-verification-skill …"); the bot receives the
+skill's instructions that turn.
+
+## Driving it
+Send trigger text via control-omb, then assert in the engine dump's
+--append-system-prompt for `<openmaus-skill id="…">` tags (pattern:
+index.test "mounts the verification skill into a real turn").
+
+## Gotchas
+- Selection is substring on lowercased text — generic trigger terms
+  over-mount; test both directions when adding one.
+- User skills hot-load per turn; bundled skills load at boot.

--- a/scripts/control-omb.mjs
+++ b/scripts/control-omb.mjs
@@ -24,11 +24,12 @@ function die(message, hint) {
 async function api(method, path, body) {
   let res;
   try {
-    res = await fetch(`${BASE}${path}`, {
-      method,
-      headers: body ? { "content-type": "application/json" } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-    });
+    const init = { method };
+    if (body !== undefined) {
+      init.headers = { "content-type": "application/json" };
+      init.body = JSON.stringify(body);
+    }
+    res = await fetch(`${BASE}${path}`, init);
   } catch {
     die(`no OpenMausBot server answering at ${BASE}`,
       "start one with `pnpm dev:server` (or set OMB_URL); for an isolated instance use OMB_DATA_DIR + OMB_PORT");

--- a/scripts/control-omb.mjs
+++ b/scripts/control-omb.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// control-omb — the agent-facing remote control for a running OpenMausBot
+// harness server. One lever, shared by every agent working on this repo:
+// drive the real product in single commands instead of improvising HTTP
+// calls per session. JSON out, teaching errors, no dependencies.
+//
+//   node scripts/control-omb.mjs doctor
+//   node scripts/control-omb.mjs new-bot --name Probe
+//   node scripts/control-omb.mjs send <botId> "hello"
+//   node scripts/control-omb.mjs wait-turn <botId>
+//   node scripts/control-omb.mjs transcript <botId> --last 5
+//   node scripts/control-omb.mjs delete-bot <botId>
+//
+// Server selection: OMB_URL (default http://127.0.0.1:8799). The companion
+// feature map lives in .claude/skills/verify-omb/.
+const BASE = (process.env.OMB_URL ?? "http://127.0.0.1:8799").replace(/\/+$/, "");
+
+function die(message, hint) {
+  console.error(`error: ${message}`);
+  if (hint) console.error(`hint: ${hint}`);
+  process.exit(1);
+}
+
+async function api(method, path, body) {
+  let res;
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    die(`no OpenMausBot server answering at ${BASE}`,
+      "start one with `pnpm dev:server` (or set OMB_URL); for an isolated instance use OMB_DATA_DIR + OMB_PORT");
+  }
+  const text = await res.text();
+  let parsed;
+  try { parsed = text ? JSON.parse(text) : {}; } catch { parsed = { raw: text }; }
+  if (!res.ok && res.status !== 202) {
+    die(`${method} ${path} → ${res.status}: ${parsed.error ?? text.slice(0, 200)}`);
+  }
+  return parsed;
+}
+
+const out = (value) => console.log(JSON.stringify(value, null, 2));
+const flag = (name, fallback) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? fallback : args[index + 1];
+};
+
+const [, , command, ...args] = process.argv;
+
+const HELP = `control-omb — drive a running OpenMausBot server (JSON out)
+
+commands:
+  doctor                       server up? engines available? bot/group counts
+  bots                         id, name, engine, busy for every bot
+  new-bot [--name N]           create a bot (uses the default engine selection)
+  send <botId> <text>          send a chat message (starts a turn)
+  wait-turn <botId> [--timeout-s 120]   block until the bot's turn settles
+  transcript <botId> [--last N]         newest N messages, compacted
+  interrupt <botId>            stop the bot's current turn
+  delete-bot <botId>           remove a bot created for verification
+  config                       configured-or-not summary (never secrets)
+
+environment:
+  OMB_URL   server base (default http://127.0.0.1:8799)`;
+
+switch (command) {
+  case "doctor": {
+    const [state, instances] = await Promise.all([
+      api("GET", "/api/bots?messages=0"),
+      api("GET", "/api/instances"),
+    ]);
+    const available = instances.instances.filter((i) => i.snapshot?.state === "available");
+    out({
+      server: BASE,
+      ok: available.length > 0,
+      availableEngines: available.map((i) => i.instanceId),
+      note: available.length ? undefined : "no engine available — verification sends will fail; configure an instance (tests use the fake CLI via config.json instances)",
+      bots: state.bots.length,
+      groups: state.groups.length,
+      busy: state.bots.filter((b) => b.busy).map((b) => b.id),
+    });
+    break;
+  }
+  case "bots": {
+    const state = await api("GET", "/api/bots?messages=0");
+    out(state.bots.map((b) => ({ id: b.id, name: b.name, busy: Boolean(b.busy), engine: b.modelSelection?.instanceId, model: b.modelSelection?.model })));
+    break;
+  }
+  case "new-bot": {
+    const created = await api("POST", "/api/bots", {});
+    const name = flag("name");
+    if (name) await api("PATCH", `/api/bots/${created.bot.id}`, { name });
+    out({ id: created.bot.id, threadId: created.bot.threadId, name: name ?? created.bot.name });
+    break;
+  }
+  case "send": {
+    const [botId, ...rest] = args.filter((a) => !a.startsWith("--"));
+    const text = rest.join(" ");
+    if (!botId || !text) die("send needs <botId> and <text>", "find ids with `bots`");
+    out(await api("POST", `/api/bots/${botId}/messages`, { text }));
+    break;
+  }
+  case "wait-turn": {
+    const botId = args[0];
+    if (!botId || botId.startsWith("--")) die("wait-turn needs <botId>");
+    const timeoutS = Number(flag("timeout-s", "120"));
+    const deadline = Date.now() + timeoutS * 1000;
+    for (;;) {
+      const state = await api("GET", "/api/bots?messages=0");
+      const bot = state.bots.find((b) => b.id === botId);
+      if (!bot) die(`no bot ${botId}`, "find ids with `bots`");
+      if (!bot.busy) { out({ settled: true, botId }); break; }
+      if (Date.now() > deadline) die(`turn still running after ${timeoutS}s`, "raise --timeout-s, or `interrupt` the bot");
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    break;
+  }
+  case "transcript": {
+    const botId = args[0];
+    if (!botId || botId.startsWith("--")) die("transcript needs <botId>");
+    const last = Number(flag("last", "10"));
+    const state = await api("GET", "/api/bots");
+    const bot = state.bots.find((b) => b.id === botId);
+    if (!bot) die(`no bot ${botId}`, "find ids with `bots`");
+    out(bot.messages.slice(-last).map((m) => ({
+      role: m.role,
+      kind: m.kind,
+      text: m.text?.slice(0, 400),
+      tool: m.tool?.name,
+      at: m.at,
+    })));
+    break;
+  }
+  case "interrupt": {
+    const botId = args[0];
+    if (!botId) die("interrupt needs <botId>");
+    out(await api("POST", `/api/bots/${botId}/interrupt`));
+    break;
+  }
+  case "delete-bot": {
+    const botId = args[0];
+    if (!botId) die("delete-bot needs <botId>");
+    out(await api("DELETE", `/api/bots/${botId}`));
+    break;
+  }
+  case "config": {
+    out(await api("GET", "/api/config"));
+    break;
+  }
+  case "help":
+  case "--help":
+  case undefined:
+    console.log(HELP);
+    break;
+  default:
+    die(`unknown command ${JSON.stringify(command)}`, "run with --help for the command list");
+}


### PR DESCRIPTION
Dev-side slice of the pstack adoption: a single agent-facing CLI to drive a running harness server, and a `.claude/skills/verify-omb` skill + six-entry feature map (chat turns, rooms, routines, engines, custom MCP, skills) so any agent — Claude Code, codex, contributors — verifies changes against the real product in a handful of commands instead of improvising HTTP per session.

Proved end-to-end before this PR existed: isolated server (temp HOME + fake engine) → `doctor` → `new-bot` → `send` → `wait-turn` → `transcript` returned the fake engine's reply; cleanup left nothing behind. The skill's Launch section is that exact recipe.

No product code touched — scripts/ + .claude/ only; zero lint hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for checking server health, managing bots, sending messages, monitoring turns, viewing transcripts, and inspecting configuration.
  * Added verification guidance covering chat turns, rooms, routines, engines, custom MCP servers, and skills.
  * Added documentation for isolated harness testing and feature-specific verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->