### PR TITLE
Agent-CLI doctrine + the auto-reproduce-feedback playbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,20 @@ The SPI in [`server/contracts.ts`](server/contracts.ts) is deliberately small. A
    failed spawn as a failed turn — never a hang, never a crash.
 5. Bring a contract test following the fake-CLI pattern (scripted fake process + `recordEvents`).
 
+## Agent-facing CLIs and proxies
+
+Anything an agent drives (MCP proxies, control CLIs, scripts/ helpers)
+follows the same rules the permission/routine errors already do:
+
+- **Errors teach.** Say what to do instead, with a copyable example — never
+  a bare enum or stack trace.
+- **`--dry-run` on anything destructive**, and the dry-run must actually
+  skip the side effect (verify by observing, not by trusting the name).
+- **Machine-readable output** (JSON) by default; humans get `--help`.
+- **Subcommands over flags-for-everything** — disclose gradually.
+- **Deep modules**: few commands that each do a whole job beat many that
+  each do a sliver.
+
 ## MCP tool schemas
 
 Tool `inputSchema`s travel through every engine's own MCP-to-provider conversion before a model

--- a/docs/playbooks/auto-reproduce-feedback.md
+++ b/docs/playbooks/auto-reproduce-feedback.md
@@ -5,7 +5,7 @@ human in the loop until there's something real to look at.
 
 ## Ingredients (all shipped)
 
-- a **webhook** delivering feedback into a bot's thread (Slack/форм/anything
+- a **webhook** delivering feedback into a bot's thread (Slack/a form/anything
   that can POST) — the webhook receiver runs on 127.0.0.1:8800
 - a **verification skill** for your app — ask any bot:
   `/create-verification-skill for <your app>` (it generates the skill, the

--- a/docs/playbooks/auto-reproduce-feedback.md
+++ b/docs/playbooks/auto-reproduce-feedback.md
@@ -1,0 +1,45 @@
+# Playbook: auto-reproduce user feedback
+
+Turn incoming user reports into reproduced, evidenced findings — without a
+human in the loop until there's something real to look at.
+
+## Ingredients (all shipped)
+
+- a **webhook** delivering feedback into a bot's thread (Slack/форм/anything
+  that can POST) — the webhook receiver runs on 127.0.0.1:8800
+- a **verification skill** for your app — ask any bot:
+  `/create-verification-skill for <your app>` (it generates the skill, the
+  feature map, and offers the maintenance routine)
+- a bot with the right **surface**: browser for web apps, a cloud/Local VM
+  computer for desktop apps, the phone harness for Android
+
+## The loop
+
+1. Feedback arrives → the bot's turn starts with the report text.
+2. The bot's standing instructions (persona or a routine) say: *"For every
+   incoming report, use the verify-<app> skill: doctor first, then follow
+   the feature map to the reported area, attempt to reproduce exactly what
+   the user described, and capture evidence either way."*
+3. Outcome lands in chat:
+   - **Reproduced** — steps + screenshots/transcript, feature-map entry
+     that covers it, ready for a fix task.
+   - **Not reproduced** — what was tried, on which paths, with evidence,
+     so a human triages with facts instead of vibes.
+4. Optional escalation: the bot delegates the fix to a coder bot
+   (`delegate_bot`) and the fix turn re-runs the same verification as its
+   own proof.
+
+## Why this works here
+
+The reproduction quality is exactly the quality of the verification skill —
+keep `/maintain-verification-skill` on its daily routine so drive recipes
+never go stale. Every claim carries evidence because the skill's Evidence
+rules demand it; a report the bot cannot reproduce is still valuable
+because the map shows what WAS checked.
+
+## Trust boundaries
+
+Feedback text is untrusted input. The bot acts under its normal permission
+cards; auto-fix without review is a choice you make per bot (auto mode),
+not a default. Destructive repro steps (deleting data, sending messages)
+must stop at a card.


### PR DESCRIPTION
Two small slices from the pstack adoption list: the CLI-design rules our proxies already half-follow, written down where contributors look; and the report→reproduce→evidence playbook that composes webhooks + verification skills (#641) + routines + delegation into the loop the article describes — with trust boundaries stated (feedback text is untrusted; cards still gate destructive steps). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for designing agent-facing command-line tools and proxies, including clear errors, dry-run support, JSON output, and practical command structure.
  * Added a playbook for reproducing user feedback, documenting required components, verification steps, and safety boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->