### PR TITLE
fix(chat): fold intermediate assistant narration

### DIFF
--- a/server/group-goal-run.test.ts
+++ b/server/group-goal-run.test.ts
@@ -4,6 +4,7 @@ import {
   GROUP_GOAL_CONTROL_OPEN,
   GROUP_GOAL_MAX_TURNS,
   groupGoalAssignmentKey,
+  groupGoalCompletionTurnId,
   parseGroupGoalDecision,
   resolveGroupGoalMember,
   selectGroupGoalCoordinator,
@@ -16,6 +17,11 @@ const members = [
 ];
 
 describe("group goal runs", () => {
+  it("keeps the bound provider identity when a completion event omits its turn id", () => {
+    expect(groupGoalCompletionTurnId(undefined, "bound-turn")).toBe("bound-turn");
+    expect(groupGoalCompletionTurnId("event-turn", "bound-turn")).toBe("event-turn");
+  });
+
   it("strips and validates a coordinator decision", () => {
     const parsed = parseGroupGoalDecision(
       `I am asking Scout to verify it.\n${GROUP_GOAL_CONTROL_OPEN}`

--- a/server/group-goal-run.ts
+++ b/server/group-goal-run.ts
@@ -22,6 +22,16 @@ export interface ParsedGroupGoalDecision {
   decision: GroupGoalDecision | null;
 }
 
+/** Turn-scoped events normally identify themselves. A coordinator completion
+ * can omit that field after its guard was already bound by turn.started; keep
+ * the bound identity so its public transcript message still settles cleanly. */
+export function groupGoalCompletionTurnId(
+  eventTurnId: string | undefined,
+  boundTurnId: string | undefined,
+): string | undefined {
+  return eventTurnId ?? boundTurnId;
+}
+
 const bounded = (value: unknown, max: number): string =>
   typeof value === "string" ? value.trim().slice(0, max) : "";
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1670,7 +1670,7 @@ bus.subscribe((event: RuntimeEvent) => {
   };
 
   if (coordinatorVisibleText) {
-    pushMessage({ role: "bot", kind: "text", text: coordinatorVisibleText });
+    pushMessage({ role: "bot", kind: "text", text: coordinatorVisibleText, turnId: event.turnId });
     lastReply.set(event.threadId, coordinatorVisibleText);
   }
 
@@ -1683,7 +1683,7 @@ bus.subscribe((event: RuntimeEvent) => {
     case "item.completed":
       if (event.itemType === "assistant_text") {
         const text = event.text;
-        pushMessage({ role: "bot", kind: "text", text });
+        pushMessage({ role: "bot", kind: "text", text, turnId: event.turnId });
         // kept so "finished" can say what it finished with, rather than
         // just that something ended
         lastReply.set(event.threadId, text);
@@ -1959,6 +1959,7 @@ bus.subscribe((event: RuntimeEvent) => {
       turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
+      if (event.turnId) store.markTerminalAssistantMessage(event.threadId, event.turnId);
       const reply = lastReply.get(event.threadId) ?? "";
       lastReply.delete(event.threadId);
       const lastReported = turnUsage.get(event.threadId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -108,6 +108,7 @@ import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
 import {
   GROUP_GOAL_MAX_TURNS,
   groupGoalAssignmentKey,
+  groupGoalCompletionTurnId,
   groupGoalCoordinatorInstructions,
   groupGoalWorkerInstructions,
   parseGroupGoalDecision,
@@ -1621,6 +1622,9 @@ bus.subscribe((event: RuntimeEvent) => {
   const coordinatorTurnsForThread = groupGoalCoordinatorTurns.get(event.threadId);
   const ambiguousCoordinatorText = !event.turnId && (coordinatorTurnsForThread?.size ?? 0) > 1;
   const goalCoordinatorTurn = groupGoalCoordinatorTurnForEvent(event);
+  const completedTurnId = event.type === "turn.completed"
+    ? groupGoalCompletionTurnId(event.turnId, goalCoordinatorTurn?.turnId)
+    : event.turnId;
   if (goalCoordinatorTurn?.discard && retiredProviderTurns.has(event.turnId)) {
     removeGroupGoalCoordinatorTurn(event.threadId, goalCoordinatorTurn);
     return;
@@ -1670,7 +1674,7 @@ bus.subscribe((event: RuntimeEvent) => {
   };
 
   if (coordinatorVisibleText) {
-    pushMessage({ role: "bot", kind: "text", text: coordinatorVisibleText, turnId: event.turnId });
+    pushMessage({ role: "bot", kind: "text", text: coordinatorVisibleText, turnId: completedTurnId });
     lastReply.set(event.threadId, coordinatorVisibleText);
   }
 
@@ -1959,7 +1963,7 @@ bus.subscribe((event: RuntimeEvent) => {
       turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
-      if (event.turnId) store.markTerminalAssistantMessage(event.threadId, event.turnId);
+      if (completedTurnId) store.markTerminalAssistantMessage(event.threadId, completedTurnId);
       const reply = lastReply.get(event.threadId) ?? "";
       lastReply.delete(event.threadId);
       const lastReported = turnUsage.get(event.threadId);

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -65,6 +65,28 @@ describe("Store", () => {
     expect(store.messagesFor(bot.threadId)[1]?.card?.dismissed).toBeUndefined();
   });
 
+  it("marks only the last assistant message from a settled provider turn as terminal", () => {
+    const store = new Store(selection);
+    const bot = store.createBot({}, { seedMessages: false });
+    const progress = store.appendMessage(bot.threadId, {
+      role: "bot",
+      kind: "text",
+      text: "Checking connected apps.",
+      turnId: "turn-1",
+    });
+    const final = store.appendMessage(bot.threadId, {
+      role: "bot",
+      kind: "text",
+      text: "Here are your tasks.",
+      turnId: "turn-1",
+    });
+
+    expect(store.markTerminalAssistantMessage(bot.threadId, "turn-1")?.id).toBe(final.id);
+    expect(store.messagesFor(bot.threadId).find((message) => message.id === progress.id)?.turnTerminal).toBeUndefined();
+    expect(store.messagesFor(bot.threadId).find((message) => message.id === final.id)?.turnTerminal).toBe(true);
+    expect(new Store(selection).messagesFor(bot.threadId).find((message) => message.id === final.id)?.turnTerminal).toBe(true);
+  });
+
   it("createBot with seedMessages:false starts with an empty transcript", () => {
     const store = new Store(selection);
     const bot = store.createBot({ name: "Imported" }, { seedMessages: false });

--- a/server/store.ts
+++ b/server/store.ts
@@ -115,6 +115,13 @@ export interface Message {
    * model saw it mid-turn, so the transcript marks it — a reader should
    * know the reply above it may already account for this line */
   steered?: boolean;
+  /** Provider turn that produced this message. Assistant output can arrive
+   * in several pieces around tool calls; the UI uses this identity to keep
+   * those pieces together without discarding them. */
+  turnId?: string;
+  /** The last assistant text item from a settled provider turn. Earlier text
+   * with the same turnId is progress narration, not another final answer. */
+  turnTerminal?: boolean;
   /** screen messages: a frame of the bot's computer (base64 image) */
   png?: string;
   mime?: string;
@@ -1009,6 +1016,21 @@ export class Store {
       cur = cur.parentId ? byId.get(cur.parentId) : undefined;
     }
     return path.reverse();
+  }
+
+  /** Mark the last assistant text on the active branch as this turn's final
+   * visible answer. If a provider ends after commentary without emitting a
+   * separate answer, that commentary remains visible as the safe fallback. */
+  markTerminalAssistantMessage(threadId: string, turnId: string): Message | null {
+    const path = this.activePath(threadId);
+    for (let i = path.length - 1; i >= 0; i -= 1) {
+      const message = path[i];
+      if (message.role === "bot" && message.kind === "text" && message.turnId === turnId) {
+        if (message.turnTerminal) return message;
+        return this.patchMessage(threadId, message.id, { turnTerminal: true });
+      }
+    }
+    return null;
   }
 
   appendMessage(threadId: string, message: Omit<Message, "id" | "at"> & { at?: number }): Message {

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -62,8 +62,9 @@ import { CallButton, CallOverlay } from "./CallView";
 import { cn } from "@/lib/cn";
 import { COMPACT_BUBBLE, COMPACT_SQUARE } from "@/lib/compact-chip";
 import { useFocusMessage } from "@/lib/focus-message";
-import { groupActivityRuns } from "@/lib/activity-runs";
+import { groupTranscript } from "@/lib/activity-runs";
 import { ActivityRun } from "./ActivityRun";
+import { TurnNarrationRun } from "./TurnNarrationRun";
 import { webhookMessageView } from "@/lib/webhook-message";
 import { splitTranscriptAttachments } from "@/lib/composer-attachments";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
@@ -82,6 +83,7 @@ import { useReplyDraft } from "@/lib/drafts";
  * bury the conversation; bots get full markdown. */
 const USER_COLLAPSE_CHARS = 600;
 const USER_COLLAPSE_LINES = 8;
+const noop = () => {};
 
 /** "Today" / "Yesterday" / "Mon, Aug 11" — real dates, not a hardcoded label. */
 function dayLabel(at: number): string {
@@ -633,9 +635,9 @@ const MessagesList = memo(function MessagesList({
 }) {
   const { state, dispatch } = useStore();
   const showToolCalls = showToolCallsEnabled(state.config);
-  // Fold finished tool chips into runs, so a stretch of them cannot bury
-  // what the bot actually said. Hidden unless Settings → Tool calls is on.
-  const items = useMemo(() => groupActivityRuns(messages), [messages]);
+  // Finished tool chips become compact runs; settled assistant narration
+  // becomes one reversible turn row while the terminal answer stays visible.
+  const items = useMemo(() => groupTranscript(messages), [messages]);
   // A search hit inside a folded run has to open it: the fold keeps the
   // row out of the DOM, and there is nothing for the scroll to land on.
   const focus = state.focusMessage;
@@ -658,9 +660,38 @@ const MessagesList = memo(function MessagesList({
       )}
       {items.map((item, i) => {
         const previous = items[i - 1];
-        const prev = previous && (previous.kind === "run" ? previous.messages.at(-1) : previous.message);
-        const first = item.kind === "run" ? item.messages[0] : item.message;
+        const prev = previous && (previous.kind === "message" ? previous.message : previous.messages.at(-1));
+        const first = item.kind === "message" ? item.message : item.messages[0];
         const newDay = !prev || new Date(prev.at).toDateString() !== new Date(first.at).toDateString();
+        if (item.kind === "turn") {
+          return (
+            <div key={item.id} className="contents">
+              {newDay && <DaySeparator at={first.at} />}
+              <TurnNarrationRun
+                label={item.label}
+                forceOpen={item.messages.some((message) => message.id === focusedId)}
+              >
+                {item.messages.map((message) => (
+                  <div key={message.id} className="contents" data-mid={message.id}>
+                    <Bubble
+                      bot={bot}
+                      message={message}
+                      editing={false}
+                      isLastBotText={false}
+                      onStartEdit={noop}
+                      onCancelEdit={noop}
+                      onSubmitEdit={noop}
+                      replyTarget={message.replyToId
+                        ? bot.messages.find((candidate) => candidate.id === message.replyToId)
+                        : undefined}
+                      onReply={() => onReply(message)}
+                    />
+                  </div>
+                ))}
+              </TurnNarrationRun>
+            </div>
+          );
+        }
         if (item.kind === "run") {
           if (!showToolCalls) return null;
           return (

--- a/src/components/TurnNarrationRun.tsx
+++ b/src/components/TurnNarrationRun.tsx
@@ -1,0 +1,39 @@
+// A settled turn's intermediate assistant messages. Providers such as Grok
+// narrate before tools; the messages stay available without looking like six
+// separate final answers after the turn is done.
+import { useEffect, useState } from "react";
+import { Check, ChevronRight } from "lucide-react";
+
+export function TurnNarrationRun({
+  label,
+  forceOpen = false,
+  children,
+}: {
+  label: string;
+  forceOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(forceOpen);
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-start">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          title={open ? "Hide progress messages" : "Show progress messages"}
+          className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-control"
+        >
+          <Check size={13} className="text-success" />
+          <span>{label}</span>
+          <ChevronRight size={13} className={open ? "rotate-90" : undefined} />
+        </button>
+      </div>
+      {open && children}
+    </div>
+  );
+}

--- a/src/lib/activity-runs.test.ts
+++ b/src/lib/activity-runs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeRun, groupActivityRuns } from "./activity-runs";
+import { describeRun, groupActivityRuns, groupTranscript } from "./activity-runs";
 import type { Message } from "@/state/store";
 
 let seq = 0;
@@ -103,5 +103,61 @@ describe("describeRun", () => {
     expect(describeRun([tool("Edit"), tool("Bash"), tool("Write"), tool("Grep"), tool("Read")])).toBe(
       "5 steps · Edit, Bash, Write +2 more",
     );
+  });
+});
+
+describe("groupTranscript", () => {
+  const assistant = (
+    body: string,
+    turnId: string,
+    turnTerminal = false,
+    at = ++seq * 1_000,
+  ): Message => ({
+    id: `m${++seq}`,
+    at,
+    role: "bot",
+    kind: "text",
+    text: body,
+    turnId,
+    turnTerminal,
+  });
+
+  it("folds settled progress messages and leaves the terminal answer visible", () => {
+    const user: Message = { id: "u1", at: 1_000, role: "user", kind: "text", text: "check todoist" };
+    const first = assistant("I'm checking connected apps.", "turn-1", false, 2_000);
+    const second = assistant("I'm reading your tasks.", "turn-1", false, 3_000);
+    const final = assistant("You have three tasks.", "turn-1", true, 5_000);
+
+    const items = groupTranscript([user, first, second, final]);
+    expect(items.map((item) => item.kind)).toEqual(["message", "turn", "message"]);
+    expect(items[1]).toMatchObject({
+      kind: "turn",
+      id: "turn:turn-1",
+      label: "Worked for 4s",
+      messages: [first, second],
+    });
+    expect(items[2].kind === "message" && items[2].message).toBe(final);
+  });
+
+  it("keeps every message visible until the turn settles", () => {
+    const first = assistant("Checking.", "turn-live");
+    const second = assistant("Still checking.", "turn-live");
+    expect(groupTranscript([first, second]).map((item) => item.kind)).toEqual(["message", "message"]);
+  });
+
+  it("keeps a lone terminal message as the answer", () => {
+    const only = assistant("I could not finish, but here is what I found.", "turn-short", true);
+    expect(groupTranscript([only])).toEqual([{ kind: "message", message: only }]);
+  });
+
+  it("does not fold narration from a different turn", () => {
+    const older = assistant("Previous answer.", "turn-old");
+    const progress = assistant("Checking.", "turn-new");
+    const final = assistant("Done.", "turn-new", true);
+    expect(groupTranscript([older, progress, final]).map((item) => item.kind)).toEqual([
+      "message",
+      "turn",
+      "message",
+    ]);
   });
 });

--- a/src/lib/activity-runs.ts
+++ b/src/lib/activity-runs.ts
@@ -6,10 +6,15 @@
 // text between two stretches breaks the run, so the bot's words always
 // separate one run from the next.
 import type { Message } from "@/state/store";
+import { formatElapsed } from "@/lib/working-time";
 
-export type TranscriptItem =
+export type ActivityTranscriptItem =
   | { kind: "message"; message: Message }
   | { kind: "run"; id: string; messages: Message[] };
+
+export type TranscriptItem =
+  | ActivityTranscriptItem
+  | { kind: "turn"; id: string; turnId: string; label: string; messages: Message[] };
 
 /** A step that may be folded away: finished, a real tool, and not a
  * bot⇄bot chip (those are navigation, not work) or a failed turn (that
@@ -23,8 +28,64 @@ function foldable(message: Message): boolean {
   return !tool.name.startsWith("error:");
 }
 
-export function groupActivityRuns(messages: Message[]): TranscriptItem[] {
+type TurnFold = Extract<TranscriptItem, { kind: "turn" }>;
+
+/** Settled providers may emit several ordinary assistant messages around
+ * tool calls. Keep the terminal answer in the transcript and replace the
+ * earlier narration with one reversible row, matching T3 Code's turn fold. */
+function assistantTurnFolds(messages: Message[]): {
+  byAnchorId: Map<string, TurnFold>;
+  hiddenIds: Set<string>;
+} {
+  const byAnchorId = new Map<string, TurnFold>();
+  const hiddenIds = new Set<string>();
+
+  messages.forEach((terminal, terminalIndex) => {
+    if (
+      terminal.role !== "bot" ||
+      terminal.kind !== "text" ||
+      !terminal.turnId ||
+      !terminal.turnTerminal
+    ) return;
+
+    const narration = messages.slice(0, terminalIndex).filter((message) =>
+      message.role === "bot" &&
+      message.kind === "text" &&
+      message.turnId === terminal.turnId &&
+      !message.turnTerminal
+    );
+    if (!narration.length) return;
+
+    const anchor = narration[0];
+    const anchorIndex = messages.findIndex((message) => message.id === anchor.id);
+    let startedAt = anchor.at;
+    for (let i = anchorIndex - 1; i >= 0; i -= 1) {
+      if (messages[i].role === "user") {
+        startedAt = messages[i].at;
+        break;
+      }
+    }
+    const elapsed = Math.max(0, terminal.at - startedAt);
+    const label = elapsed >= 1_000 ? `Worked for ${formatElapsed(elapsed)}` : "Worked";
+    const fold: TurnFold = {
+      kind: "turn",
+      id: `turn:${terminal.turnId}`,
+      turnId: terminal.turnId,
+      label,
+      messages: narration,
+    };
+    byAnchorId.set(anchor.id, fold);
+    for (const message of narration) hiddenIds.add(message.id);
+  });
+
+  return { byAnchorId, hiddenIds };
+}
+
+function group(messages: Message[], foldAssistantTurns: boolean): TranscriptItem[] {
   const items: TranscriptItem[] = [];
+  const folds = foldAssistantTurns
+    ? assistantTurnFolds(messages)
+    : { byAnchorId: new Map<string, TurnFold>(), hiddenIds: new Set<string>() };
   let run: Message[] = [];
   const flush = () => {
     // one step on its own is cheaper to read than a fold that hides it
@@ -33,6 +94,13 @@ export function groupActivityRuns(messages: Message[]): TranscriptItem[] {
     run = [];
   };
   for (const message of messages) {
+    const turn = folds.byAnchorId.get(message.id);
+    if (turn) {
+      flush();
+      items.push(turn);
+      continue;
+    }
+    if (folds.hiddenIds.has(message.id)) continue;
     if (foldable(message)) {
       const first = run[0];
       if (
@@ -51,6 +119,14 @@ export function groupActivityRuns(messages: Message[]): TranscriptItem[] {
   }
   flush();
   return items;
+}
+
+export function groupActivityRuns(messages: Message[]): ActivityTranscriptItem[] {
+  return group(messages, false) as ActivityTranscriptItem[];
+}
+
+export function groupTranscript(messages: Message[]): TranscriptItem[] {
+  return group(messages, true);
 }
 
 const MAX_NAMES = 3;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -97,6 +97,10 @@ export interface Message {
   tool?: { name: string; ok?: boolean; spoken?: string; setup?: boolean };
   /** user messages sent into a running turn — the model saw it mid-turn */
   steered?: boolean;
+  /** Provider turn that produced this message. */
+  turnId?: string;
+  /** Last assistant text item from a settled provider turn. */
+  turnTerminal?: boolean;
   /** screen messages: a frame of the bot's computer (base64) */
   png?: string;
   mime?: string;


### PR DESCRIPTION
## What changed

- preserve provider turn IDs on assistant transcript messages
- mark the terminal assistant message when a turn settles
- collapse earlier Grok-style progress messages behind one reversible `Worked for …` row
- keep live narration visible while work is active and preserve the last message when no separate final answer arrives

This follows T3 Code’s turn-folding model instead of trying to prompt individual providers into silence or deleting their narration.

## Validation

- `pnpm test` (2,747 core tests, 7 broker tests, 59 Electron tests, packaged-server smoke)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant progress updates are now grouped into collapsible narration sections, keeping conversations easier to scan.
  * Completed turns show a clear work-duration label while preserving the final assistant response separately.
  * Intermediate narration remains visible during an active turn and becomes grouped once the turn finishes.
* **Bug Fixes**
  * Improved transcript handling so narration from separate assistant turns is not combined.
  * Ensured only the final response in a completed turn is treated as the terminal message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->