### PR TITLE
fix(linux): keep updates from breaking Ubuntu installs

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -63,6 +63,11 @@ jobs:
           deb=(release/*.deb)
           test "${#deb[@]}" -eq 1
           sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
+      - name: Prove an AppImage update lands on the launched path
+        # Installs the current published release over a copy named after a
+        # version, which is the shape that used to orphan the launcher. Runs
+        # against the real feed, so it also covers the differential download.
+        run: pnpm smoke:linux-update
       - name: Configure Chromium sandbox for the unpacked app
         run: |
           sudo chown root:root release/linux-unpacked/chrome-sandbox

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -63,6 +63,15 @@ jobs:
           deb=(release/*.deb)
           test "${#deb[@]}" -eq 1
           sudo --preserve-env=CI,RUNNER_TEMP node scripts/smoke-deb-upgrade.mjs "${deb[0]}"
+      - name: Prove the handed-over Ubuntu command installs
+        # The .deb path ends with a command on the user's clipboard, so the
+        # command is the deliverable. Runs it as root on a clean Ubuntu through
+        # a real shell, and checks that the `dpkg -i` it replaced still fails
+        # there — the reason the app must not run that itself.
+        run: |
+          deb=(release/*.deb)
+          test "${#deb[@]}" -eq 1
+          pnpm smoke:deb-command "${deb[0]}"
       - name: Prove an AppImage update lands on the launched path
         # Installs the current published release over a copy named after a
         # version, which is the shape that used to orphan the launcher. Runs

--- a/apps/docs/content/docs/troubleshooting/updates.mdx
+++ b/apps/docs/content/docs/troubleshooting/updates.mdx
@@ -4,7 +4,14 @@ description: Recover from a stuck download or restart and understand supported u
 icon: RefreshCw
 ---
 
-Automatic updates are available on macOS and Windows. Ubuntu packages are updated by installing a newly downloaded package.
+OpenMausBot checks for updates in the background and offers the download in a card at the bottom of the window. How the download is applied depends on what you installed.
+
+| Build | What the button does |
+|---|---|
+| macOS, Windows, Linux AppImage | **Restart to update** — the app replaces itself and reopens. An AppImage is always rewritten at the path you launch, so your launcher, symlink or dock pin keeps working. |
+| Ubuntu `.deb` (and rpm/pacman) | **Install** — the downloaded package opens in your system package manager and you finish there. The app never installs a system package itself, so it never asks for your administrator password. |
+
+Reopen OpenMausBot after the package manager finishes to be running the new version.
 
 ## The download keeps spinning
 
@@ -13,6 +20,18 @@ Leave the app open long enough for one complete attempt, then quit and reopen it
 ## Restart to update does nothing
 
 Quit OpenMausBot completely and launch it again. If the version did not change, install the latest release manually. Your conversations and settings live outside the application bundle and are not removed by replacing the app.
+
+## The package manager did not open, or could not install
+
+On Ubuntu the **Install** button hands the downloaded `.deb` to whatever your desktop has registered for Debian packages — App Center on a stock Ubuntu 24.04. If nothing is registered, OpenMausBot opens the containing folder instead.
+
+Either way the package is already downloaded, so you can always finish from a terminal:
+
+```bash
+sudo apt-get install -y ~/.cache/openmausbot-updater/pending/OpenMausBot-*-amd64.deb
+```
+
+Use `apt-get`, not `dpkg -i` — only `apt-get` resolves dependencies.
 
 ## Verify the installed version
 

--- a/apps/docs/content/docs/troubleshooting/updates.mdx
+++ b/apps/docs/content/docs/troubleshooting/updates.mdx
@@ -9,9 +9,15 @@ OpenMausBot checks for updates in the background and offers the download in a ca
 | Build | What the button does |
 |---|---|
 | macOS, Windows, Linux AppImage | **Restart to update** — the app replaces itself and reopens. An AppImage is always rewritten at the path you launch, so your launcher, symlink or dock pin keeps working. |
-| Ubuntu `.deb` (and rpm/pacman) | **Install** — the downloaded package opens in your system package manager and you finish there. The app never installs a system package itself, so it never asks for your administrator password. |
+| Ubuntu `.deb` (and rpm/pacman) | **Install** — OpenMausBot downloads and verifies the package, copies the install command, and opens a terminal for you to paste it into. The app never installs a system package itself, so it never asks for your administrator password. |
 
-Reopen OpenMausBot after the package manager finishes to be running the new version.
+Ubuntu packages are installed from the releases repository by hand, so the app hands you the exact line rather than guessing at a package handler:
+
+```bash
+sudo apt-get install -y '/home/you/.cache/openmausbot-updater/pending/OpenMausBot-<version>-amd64.deb'
+```
+
+Reopen OpenMausBot once it finishes to be running the new version.
 
 ## The download keeps spinning
 
@@ -21,17 +27,15 @@ Leave the app open long enough for one complete attempt, then quit and reopen it
 
 Quit OpenMausBot completely and launch it again. If the version did not change, install the latest release manually. Your conversations and settings live outside the application bundle and are not removed by replacing the app.
 
-## The package manager did not open, or could not install
+## No terminal opened
 
-On Ubuntu the **Install** button hands the downloaded `.deb` to whatever your desktop has registered for Debian packages — App Center on a stock Ubuntu 24.04. If nothing is registered, OpenMausBot opens the containing folder instead.
-
-Either way the package is already downloaded, so you can always finish from a terminal:
+The install command is on your clipboard either way. Open a terminal yourself and paste it. If the clipboard was overwritten, the package is already downloaded and you can run:
 
 ```bash
 sudo apt-get install -y ~/.cache/openmausbot-updater/pending/OpenMausBot-*-amd64.deb
 ```
 
-Use `apt-get`, not `dpkg -i` — only `apt-get` resolves dependencies.
+Use `apt-get`, not `dpkg -i` — only `apt-get` resolves dependencies, and on Ubuntu 24.04 ours are satisfied through virtual packages that `dpkg` alone will not follow.
 
 ## Verify the installed version
 

--- a/electron/fixtures/updater-handoff.cjs
+++ b/electron/fixtures/updater-handoff.cjs
@@ -1,0 +1,81 @@
+"use strict";
+
+// Proves the two steps of the Ubuntu hand-off that only exist at runtime: the
+// command really reaches the system clipboard, and a terminal is really
+// spawned. The unit tests inject a fake runner and never spawn anything, so
+// this runs the production path with nothing stubbed — a recording script
+// placed on PATH stands in for the terminal emulator, and is discovered and
+// executed by the real child_process.
+
+const { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
+const { app, clipboard } = require("electron");
+
+if (process.platform === "linux") app.commandLine.appendSwitch("no-sandbox");
+
+const STAGED = "/home/tester/.cache/openmausbot-updater/pending/o'brien pkg.deb";
+
+function say(marker) {
+  process.stdout.write(`${marker}\n`);
+}
+
+async function main() {
+  const { handOffDownloadedPackage } = await import("../updater.mjs");
+  const { packageInstallCommand } = await import("../package-install-command.mjs");
+  const handOff = handOffDownloadedPackage("deb");
+  const expected = packageInstallCommand("deb", STAGED);
+
+  const workspace = mkdtempSync(join(tmpdir(), "omb-handoff-fixture-"));
+  const realPath = process.env.PATH;
+  try {
+    // A terminal emulator that records being launched. openBlankTerminal tries
+    // x-terminal-emulator first on Linux, and resolves it through PATH.
+    const receipt = join(workspace, "launched");
+    const terminal = join(workspace, "x-terminal-emulator");
+    writeFileSync(terminal, `#!/bin/sh\necho "$@" > ${JSON.stringify(receipt)}\n`);
+    chmodSync(terminal, 0o755);
+
+    clipboard.writeText("something else entirely");
+    process.env.PATH = workspace;
+    const result = await handOff([STAGED]);
+
+    if (clipboard.readText() === expected) say("clipboard-holds-the-install-command");
+    else say(`clipboard-mismatch:${JSON.stringify(clipboard.readText())}`);
+
+    if (existsSync(receipt)) say("terminal-really-launched");
+    if (result.terminalOpened === true) say("hand-off-reported-the-terminal");
+    if (result.command === expected) say("hand-off-returned-the-command");
+
+    // Nothing on PATH: the terminal cannot open, but the command must still be
+    // on the clipboard — the docs tell the user to paste it themselves.
+    const empty = mkdtempSync(join(tmpdir(), "omb-handoff-empty-"));
+    clipboard.writeText("something else entirely");
+    process.env.PATH = empty;
+    const withoutTerminal = await handOff([STAGED]);
+    if (withoutTerminal.terminalOpened === false) say("no-terminal-is-reported-honestly");
+    if (clipboard.readText() === expected) say("clipboard-written-even-without-a-terminal");
+    rmSync(empty, { recursive: true, force: true });
+
+    // A download that vanished must be reported, not turned into a command
+    // that installs nothing.
+    process.env.PATH = realPath;
+    await handOff([]).then(
+      () => say("missing-download-was-not-reported"),
+      (error) => {
+        if (/no longer available/.test(error.message)) say("missing-download-is-reported");
+      },
+    );
+  } finally {
+    process.env.PATH = realPath;
+    rmSync(workspace, { recursive: true, force: true });
+  }
+
+  say("fixture-complete");
+  app.exit(0);
+}
+
+app.whenReady().then(main).catch((error) => {
+  process.stdout.write(`fixture-failed:${error.stack ?? error}\n`);
+  app.exit(1);
+});

--- a/electron/fixtures/updater-handoff.cjs
+++ b/electron/fixtures/updater-handoff.cjs
@@ -14,8 +14,6 @@ const { app, clipboard } = require("electron");
 
 if (process.platform === "linux") app.commandLine.appendSwitch("no-sandbox");
 
-const STAGED = "/home/tester/.cache/openmausbot-updater/pending/o'brien pkg.deb";
-
 function say(marker) {
   process.stdout.write(`${marker}\n`);
 }
@@ -24,11 +22,17 @@ async function main() {
   const { handOffDownloadedPackage } = await import("../updater.mjs");
   const { packageInstallCommand } = await import("../package-install-command.mjs");
   const handOff = handOffDownloadedPackage("deb");
-  const expected = packageInstallCommand("deb", STAGED);
 
   const workspace = mkdtempSync(join(tmpdir(), "omb-handoff-fixture-"));
   const realPath = process.env.PATH;
   try {
+    // A real staged file: the hand-off now refuses a path that is gone, so
+    // the quoting case has to exist on disk rather than being a string.
+    const pending = mkdtempSync(join(workspace, "o'brien "));
+    const staged = join(pending, "pkg.deb");
+    writeFileSync(staged, "x");
+    const expected = packageInstallCommand("deb", staged);
+
     // A terminal emulator that records being launched. openBlankTerminal tries
     // x-terminal-emulator first on Linux, and resolves it through PATH.
     const receipt = join(workspace, "launched");
@@ -38,7 +42,7 @@ async function main() {
 
     clipboard.writeText("something else entirely");
     process.env.PATH = workspace;
-    const result = await handOff([STAGED]);
+    const result = await handOff([staged]);
 
     if (clipboard.readText() === expected) say("clipboard-holds-the-install-command");
     else say(`clipboard-mismatch:${JSON.stringify(clipboard.readText())}`);
@@ -52,18 +56,24 @@ async function main() {
     const empty = mkdtempSync(join(tmpdir(), "omb-handoff-empty-"));
     clipboard.writeText("something else entirely");
     process.env.PATH = empty;
-    const withoutTerminal = await handOff([STAGED]);
+    const withoutTerminal = await handOff([staged]);
     if (withoutTerminal.terminalOpened === false) say("no-terminal-is-reported-honestly");
     if (clipboard.readText() === expected) say("clipboard-written-even-without-a-terminal");
     rmSync(empty, { recursive: true, force: true });
 
     // A download that vanished must be reported, not turned into a command
-    // that installs nothing.
+    // that installs nothing — empty list and a path that used to exist.
     process.env.PATH = realPath;
     await handOff([]).then(
       () => say("missing-download-was-not-reported"),
       (error) => {
         if (/no longer available/.test(error.message)) say("missing-download-is-reported");
+      },
+    );
+    await handOff([join(workspace, "gone.deb")]).then(
+      () => say("vanished-download-was-not-reported"),
+      (error) => {
+        if (/no longer available/.test(error.message)) say("vanished-download-is-reported");
       },
     );
   } finally {

--- a/electron/package-install-command.mjs
+++ b/electron/package-install-command.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 // The command a Linux user pastes to finish an update.
@@ -55,10 +56,17 @@ export function shellQuote(value) {
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+/** The first staged path that still exists. A vanished download must not
+ * become a command that installs nothing. `exists` is injected so the
+ * filter can be tested without touching the disk layout of a real update. */
+export function stagedInstallFile(files, exists = existsSync) {
+  return files?.find((file) => typeof file === "string" && file.length > 0 && exists(file));
+}
+
 /** Throws for a package type with no builder, so a new target cannot reach
  * the banner with a command we never wrote. */
 export function packageInstallCommand(packageType, file) {
-  const build = BUILDERS[packageType];
+  const build = Object.hasOwn(BUILDERS, packageType) ? BUILDERS[packageType] : undefined;
   if (!build) throw new Error(`No install command for package type ${JSON.stringify(packageType)}`);
   if (typeof file !== "string" || file.length === 0) {
     throw new Error("The downloaded package is no longer available. Download it again.");

--- a/electron/package-install-command.mjs
+++ b/electron/package-install-command.mjs
@@ -1,0 +1,35 @@
+// The command a Linux user pastes to finish an update.
+//
+// OpenMausBot is installed from the releases repository by hand, not from a
+// store, so there is no package handler worth delegating to — a stock Ubuntu
+// 24.04 registers App Center for .deb and may not install a local one at all.
+// The app therefore never installs the package itself; it downloads it,
+// verifies it, and hands over this exact line.
+
+const BUILDERS = {
+  // apt-get, never `dpkg -i`: only apt-get resolves dependencies, and Ubuntu
+  // satisfies ours through virtual Provides (libgtk-3-0 → libgtk-3-0t64).
+  deb: (file) => `sudo apt-get install -y ${file}`,
+  rpm: (file) => `sudo rpm -Uvh ${file}`,
+  pacman: (file) => `sudo pacman -U ${file}`,
+};
+
+export const HAND_OFF_PACKAGE_TYPES = Object.freeze(Object.keys(BUILDERS));
+
+/** Single-quote for the shell the user pastes into. The path is
+ * electron-updater's cache under $HOME, so it can carry anything a directory
+ * name can — an apostrophe included. */
+export function shellQuote(value) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/** Throws for a package type with no builder, so a new target cannot reach
+ * the banner with a command we never wrote. */
+export function packageInstallCommand(packageType, file) {
+  const build = BUILDERS[packageType];
+  if (!build) throw new Error(`No install command for package type ${JSON.stringify(packageType)}`);
+  if (typeof file !== "string" || file.length === 0) {
+    throw new Error("The downloaded package is no longer available. Download it again.");
+  }
+  return build(shellQuote(file));
+}

--- a/electron/package-install-command.mjs
+++ b/electron/package-install-command.mjs
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 // The command a Linux user pastes to finish an update.
 //
 // OpenMausBot is installed from the releases repository by hand, not from a
@@ -5,6 +7,36 @@
 // 24.04 registers App Center for .deb and may not install a local one at all.
 // The app therefore never installs the package itself; it downloads it,
 // verifies it, and hands over this exact line.
+
+/** Which Linux artifact is running. electron-updater resolves its installer
+ * the same way — resources/package-type first, APPIMAGE env as the fallback —
+ * so mirroring it keeps the card's promise and the updater's behaviour in
+ * step. `deps` is injected so the routing can be tested without a package.
+ *
+ * A marker present in BOTH artifacts would silently route the AppImage to the
+ * hand-off; scripts/verify-linux-package.mjs guards the packaging side. */
+export function linuxPackageType({
+  platform = process.platform,
+  resourcesPath = process.resourcesPath,
+  appImage = process.env.APPIMAGE,
+  readMarker,
+} = {}) {
+  if (platform !== "linux") return null;
+  // Electron always defines resourcesPath; without it there is no marker to
+  // read, and joining undefined would throw into the catch below and reach the
+  // same answer by accident. Say so instead.
+  if (typeof resourcesPath !== "string" || resourcesPath.length === 0) {
+    return appImage ? "AppImage" : null;
+  }
+  try {
+    const declared = readMarker(join(resourcesPath, "package-type"));
+    if (declared) return declared.trim() || null;
+  } catch {
+    // An unreadable marker is not worth failing the updater over — fall
+    // through to the AppImage probe and treat the build as portable.
+  }
+  return appImage ? "AppImage" : null;
+}
 
 const BUILDERS = {
   // apt-get, never `dpkg -i`: only apt-get resolves dependencies, and Ubuntu

--- a/electron/package-install-command.node-test.mjs
+++ b/electron/package-install-command.node-test.mjs
@@ -13,6 +13,7 @@ import {
   linuxPackageType,
   packageInstallCommand,
   shellQuote,
+  stagedInstallFile,
 } from "./package-install-command.mjs";
 
 test("the Ubuntu command resolves dependencies", () => {
@@ -33,6 +34,33 @@ test("every hand-off package type has a command", () => {
     assert.match(packageInstallCommand(packageType, "/tmp/pkg"), /^sudo \S+/);
   }
   assert.throws(() => packageInstallCommand("snap", "/tmp/pkg"), /No install command/);
+});
+
+test("inherited Object names are not install commands", () => {
+  for (const name of ["toString", "constructor", "__proto__"]) {
+    assert.throws(() => packageInstallCommand(name, "/tmp/pkg"), /No install command/);
+  }
+});
+
+test("a staged path that is gone is not used", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "omb-staged-"));
+  try {
+    const present = join(workspace, "OpenMausBot.deb");
+    writeFileSync(present, "x");
+    const missing = join(workspace, "gone.deb");
+
+    assert.equal(stagedInstallFile([present]), present);
+    assert.equal(stagedInstallFile([missing, present]), present);
+    assert.equal(stagedInstallFile([missing]), undefined);
+    assert.equal(stagedInstallFile([]), undefined);
+    assert.equal(stagedInstallFile(undefined), undefined);
+    assert.throws(
+      () => packageInstallCommand("deb", stagedInstallFile([missing])),
+      /no longer available/,
+    );
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
 });
 
 test("a missing download is reported instead of building a broken command", () => {

--- a/electron/package-install-command.node-test.mjs
+++ b/electron/package-install-command.node-test.mjs
@@ -3,7 +3,7 @@
 // is stuck with a downloaded package and no way to finish.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -40,9 +40,14 @@ test("a missing download is reported instead of building a broken command", () =
   assert.throws(() => packageInstallCommand("deb", ""), /no longer available/);
 });
 
+// These two proofs use a POSIX shell as the referee: only the shell itself
+// can say what the quoting parses into. Windows CI has no /bin/sh, and no
+// Windows user is ever handed this command.
+const posixShell = existsSync("/bin/sh") ? false : "needs /bin/sh";
+
 // The path lives under $HOME, so it can carry whatever a directory name can.
 // A mis-quoted command would either fail to install or run something else.
-test("the quoted path survives a shell round-trip", () => {
+test("the quoted path survives a shell round-trip", { skip: posixShell }, () => {
   const workspace = mkdtempSync(join(tmpdir(), "omb-quote-"));
   try {
     for (const name of ["plain.deb", "with space.deb", "o'brien.deb", "a;b&c.deb", "$(echo bad).deb"]) {
@@ -60,7 +65,7 @@ test("the quoted path survives a shell round-trip", () => {
   }
 });
 
-test("the whole command parses into the arguments apt-get would receive", () => {
+test("the whole command parses into the arguments apt-get would receive", { skip: posixShell }, () => {
   const file = "/home/o'brien/.cache/openmausbot-updater/pending/OpenMausBot-0.1.44-amd64.deb";
   const command = packageInstallCommand("deb", file);
 

--- a/electron/package-install-command.node-test.mjs
+++ b/electron/package-install-command.node-test.mjs
@@ -10,6 +10,7 @@ import test from "node:test";
 
 import {
   HAND_OFF_PACKAGE_TYPES,
+  linuxPackageType,
   packageInstallCommand,
   shellQuote,
 } from "./package-install-command.mjs";
@@ -72,4 +73,77 @@ test("the whole command parses into the arguments apt-get would receive", () => 
   );
 
   assert.deepEqual(printed.split("\n").filter(Boolean), ["install", "-y", file]);
+});
+
+// The routing decides everything: a .deb that resolves to "AppImage" would
+// quit and let electron-updater run dpkg under the live app, and an AppImage
+// that resolves to "deb" would offer a command instead of updating itself.
+test("the package marker decides the install path", () => {
+  const marker = (declared) => (file) => (file.endsWith("package-type") ? declared : null);
+
+  assert.equal(
+    linuxPackageType({ platform: "linux", resourcesPath: "/opt/app/resources", readMarker: marker("deb\n") }),
+    "deb",
+  );
+  // An AppImage ships no marker, so the env probe is what identifies it.
+  assert.equal(
+    linuxPackageType({
+      platform: "linux",
+      resourcesPath: "/tmp/squashfs-root/resources",
+      appImage: "/home/u/OpenMausBot.AppImage",
+      readMarker: marker(null),
+    }),
+    "AppImage",
+  );
+  // The marker wins, matching electron-updater's own precedence. If packaging
+  // ever wrote it into the shared tree before the AppImage was sealed, both
+  // would say "deb" — which is why verify-linux-package.mjs pins it.
+  assert.equal(
+    linuxPackageType({
+      platform: "linux",
+      resourcesPath: "/opt/app/resources",
+      appImage: "/home/u/OpenMausBot.AppImage",
+      readMarker: marker("deb"),
+    }),
+    "deb",
+  );
+});
+
+test("a build with nothing to identify it keeps the restart path", () => {
+  const none = () => null;
+
+  assert.equal(
+    linuxPackageType({ platform: "linux", resourcesPath: "/opt/app/resources", appImage: undefined, readMarker: none }),
+    null,
+  );
+  // No resourcesPath means no marker to read — an explicit answer, not one
+  // reached by throwing into the fallback.
+  assert.equal(linuxPackageType({ platform: "linux", resourcesPath: undefined, readMarker: none }), null);
+  assert.equal(
+    linuxPackageType({ platform: "linux", resourcesPath: undefined, appImage: "/a.AppImage", readMarker: none }),
+    "AppImage",
+  );
+  assert.equal(linuxPackageType({ platform: "darwin", readMarker: none }), null);
+  assert.equal(linuxPackageType({ platform: "win32", readMarker: none }), null);
+  // An empty or unreadable marker must not become a package type.
+  assert.equal(
+    linuxPackageType({
+      platform: "linux",
+      resourcesPath: "/opt/app/resources",
+      appImage: undefined,
+      readMarker: () => "  \n",
+    }),
+    null,
+  );
+  assert.equal(
+    linuxPackageType({
+      platform: "linux",
+      resourcesPath: "/opt/app/resources",
+      appImage: undefined,
+      readMarker: () => {
+        throw new Error("EACCES");
+      },
+    }),
+    null,
+  );
 });

--- a/electron/package-install-command.node-test.mjs
+++ b/electron/package-install-command.node-test.mjs
@@ -1,0 +1,75 @@
+// The command handed to a Linux user is the whole deliverable of the .deb
+// update path: the app deliberately does not run it. If it is wrong, the user
+// is stuck with a downloaded package and no way to finish.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  HAND_OFF_PACKAGE_TYPES,
+  packageInstallCommand,
+  shellQuote,
+} from "./package-install-command.mjs";
+
+test("the Ubuntu command resolves dependencies", () => {
+  const command = packageInstallCommand("deb", "/home/u/.cache/openmausbot-updater/pending/x.deb");
+
+  assert.equal(
+    command,
+    "sudo apt-get install -y '/home/u/.cache/openmausbot-updater/pending/x.deb'",
+  );
+  // `dpkg -i` is what electron-updater ran, and it installs nothing when a
+  // release adds a dependency. Ubuntu also satisfies ours through virtual
+  // Provides, which only apt resolves.
+  assert.doesNotMatch(command, /dpkg/);
+});
+
+test("every hand-off package type has a command", () => {
+  for (const packageType of HAND_OFF_PACKAGE_TYPES) {
+    assert.match(packageInstallCommand(packageType, "/tmp/pkg"), /^sudo \S+/);
+  }
+  assert.throws(() => packageInstallCommand("snap", "/tmp/pkg"), /No install command/);
+});
+
+test("a missing download is reported instead of building a broken command", () => {
+  assert.throws(() => packageInstallCommand("deb", undefined), /no longer available/);
+  assert.throws(() => packageInstallCommand("deb", ""), /no longer available/);
+});
+
+// The path lives under $HOME, so it can carry whatever a directory name can.
+// A mis-quoted command would either fail to install or run something else.
+test("the quoted path survives a shell round-trip", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "omb-quote-"));
+  try {
+    for (const name of ["plain.deb", "with space.deb", "o'brien.deb", "a;b&c.deb", "$(echo bad).deb"]) {
+      const file = join(workspace, name);
+      writeFileSync(file, "x");
+      // `printf %s` echoes exactly one argument: what the shell parsed out of
+      // our quoting has to be the path we meant, byte for byte.
+      const parsed = execFileSync("/bin/sh", ["-c", `printf %s ${shellQuote(file)}`], {
+        encoding: "utf8",
+      });
+      assert.equal(parsed, file, `quoting mangled ${name}`);
+    }
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("the whole command parses into the arguments apt-get would receive", () => {
+  const file = "/home/o'brien/.cache/openmausbot-updater/pending/OpenMausBot-0.1.44-amd64.deb";
+  const command = packageInstallCommand("deb", file);
+
+  // Replace the privileged verb with a printer, then confirm the shell hands
+  // it exactly the flags and the one path.
+  const printed = execFileSync(
+    "/bin/sh",
+    ["-c", `set -- ${command.replace("sudo apt-get", "")}; for a in "$@"; do printf '%s\\n' "$a"; done`],
+    { encoding: "utf8" },
+  );
+
+  assert.deepEqual(printed.split("\n").filter(Boolean), ["install", "-y", file]);
+});

--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -157,9 +157,9 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
     }
   }
 
-  // The platform owns the install from here: the package manager opens and the
-  // user finishes there. No quit — the running app stays usable, and the new
-  // version is picked up the next time it starts.
+  // The platform owns the install from here: a terminal opens with the
+  // command on the clipboard and the user finishes there. No quit — the
+  // running app stays usable, and the new version is picked up next launch.
   function handOff() {
     const operation = { failed: false, timer: null };
     installOperation = operation;

--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -1,5 +1,12 @@
-export function createUpdaterCoordinator(updater, setState) {
+// `handOffInstall` swaps the terminal step: instead of quitting and letting
+// electron-updater run the installer, the downloaded file is handed to the
+// platform. Ubuntu system packages use it — see electron/updater.mjs for why a
+// chat app must not run dpkg itself. Everything before the install is shared.
+export function createUpdaterCoordinator(updater, setState, { handOffInstall = null } = {}) {
   let checkOperation = null;
+  // Set from downloadUpdate's resolution: the paths electron-updater staged.
+  // Only the hand-off needs them; quitAndInstall reads its own copy.
+  let downloadedFiles = null;
   let downloadOperation = null;
   let installOperation = null;
   const routedErrors = new WeakSet();
@@ -101,6 +108,9 @@ export function createUpdaterCoordinator(updater, setState) {
     try {
       operation.promise = Promise.resolve(updater.downloadUpdate())
         .then((result) => {
+          if (!operation.failed) {
+            downloadedFiles = Array.isArray(result) ? result.filter((file) => typeof file === "string") : null;
+          }
           if (!operation.failed && operation.downloadedInfo) {
             setState({ status: "downloaded", version: operation.downloadedInfo?.version });
           }
@@ -120,6 +130,10 @@ export function createUpdaterCoordinator(updater, setState) {
 
   function install() {
     if (installOperation) return;
+    if (handOffInstall) {
+      handOff();
+      return;
+    }
     const operation = { failed: false, timer: null };
     installOperation = operation;
     setState({ status: "installing" });
@@ -139,6 +153,26 @@ export function createUpdaterCoordinator(updater, setState) {
       }, 2 * 60 * 1000);
       operation.timer.unref?.();
     }
+  }
+
+  // The platform owns the install from here: the package manager opens and the
+  // user finishes there. No quit — the running app stays usable, and the new
+  // version is picked up the next time it starts.
+  function handOff() {
+    const operation = { failed: false, timer: null };
+    installOperation = operation;
+    setState({ status: "installing" });
+    Promise.resolve()
+      .then(() => handOffInstall(downloadedFiles))
+      .then(() => {
+        if (installOperation !== operation) return;
+        installOperation = null;
+        setState({ status: "handed-off" });
+      })
+      .catch((error) => {
+        if (installOperation !== operation) return;
+        routeError(true, error);
+      });
   }
 
   return { check, download, install };

--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -1,7 +1,9 @@
 // `handOffInstall` swaps the terminal step: instead of quitting and letting
 // electron-updater run the installer, the downloaded file is handed to the
-// platform. Ubuntu system packages use it — see electron/updater.mjs for why a
+// user. Ubuntu system packages use it — see electron/updater.mjs for why a
 // chat app must not run dpkg itself. Everything before the install is shared.
+// It receives the staged paths and resolves with an optional state patch
+// describing what is left to do, which the card renders.
 export function createUpdaterCoordinator(updater, setState, { handOffInstall = null } = {}) {
   let checkOperation = null;
   // Set from downloadUpdate's resolution: the paths electron-updater staged.
@@ -164,10 +166,10 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
     setState({ status: "installing" });
     Promise.resolve()
       .then(() => handOffInstall(downloadedFiles))
-      .then(() => {
+      .then((patch) => {
         if (installOperation !== operation) return;
         installOperation = null;
-        setState({ status: "handed-off" });
+        setState({ status: "handed-off", ...patch });
       })
       .catch((error) => {
         if (installOperation !== operation) return;

--- a/electron/updater-coordinator.node-test.mjs
+++ b/electron/updater-coordinator.node-test.mjs
@@ -14,17 +14,30 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-function harness() {
+function harness(options) {
   const updater = new EventEmitter();
   // electron-updater has its own error listener; model that without routing it.
   updater.on("error", () => {});
   let state = { status: "idle" };
   const states = [];
-  const coordinator = createUpdaterCoordinator(updater, (patch) => {
-    state = { ...state, ...patch };
-    states.push({ ...state });
-  });
+  const coordinator = createUpdaterCoordinator(
+    updater,
+    (patch) => {
+      state = { ...state, ...patch };
+      states.push({ ...state });
+    },
+    options,
+  );
   return { updater, coordinator, states, getState: () => state };
+}
+
+// Drives a successful download so install() has staged paths to hand off.
+async function downloadInto(h, files = ["/tmp/OpenMausBot-2.0.0-amd64.deb"]) {
+  h.updater.downloadUpdate = () => {
+    h.updater.emit("update-downloaded", { version: "2.0.0" });
+    return Promise.resolve(files);
+  };
+  await h.coordinator.download();
 }
 
 function errorStates(states) {
@@ -322,4 +335,67 @@ test("an updater error event and rejected promise produce one deterministic stat
   await download.coordinator.download();
   assert.equal(errorStates(download.states).length, 1);
   assert.deepEqual(download.getState(), { status: "error", message: "download failed once" });
+});
+
+test("the hand-off install opens the staged package instead of quitting", async () => {
+  const received = [];
+  const h = harness({
+    handOffInstall: (files) => {
+      received.push(files);
+      return Promise.resolve();
+    },
+  });
+  h.updater.quitAndInstall = () => assert.fail("a system package must not be installed by quitAndInstall");
+
+  await downloadInto(h);
+  assert.equal(h.getState().status, "downloaded");
+
+  h.coordinator.install();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(received, [["/tmp/OpenMausBot-2.0.0-amd64.deb"]]);
+  assert.equal(h.getState().status, "handed-off");
+  // the user watched something happen between the click and the result
+  assert.ok(h.states.some((entry) => entry.status === "installing"));
+});
+
+test("a failed hand-off is reported instead of leaving the card spinning", async () => {
+  const h = harness({ handOffInstall: () => Promise.reject(new Error("no handler for .deb")) });
+
+  await downloadInto(h);
+  h.coordinator.install();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  // version survives the merge from the download — assert what the card reads
+  assert.equal(h.getState().status, "error");
+  assert.equal(h.getState().message, "no handler for .deb");
+});
+
+test("the hand-off sees no staged file when nothing downloaded", async () => {
+  const received = [];
+  const h = harness({
+    handOffInstall: (files) => {
+      received.push(files);
+      return Promise.resolve();
+    },
+  });
+
+  h.coordinator.install();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(received, [null]);
+});
+
+test("without a hand-off the install still quits and installs", async () => {
+  const h = harness();
+  let called = 0;
+  h.updater.quitAndInstall = () => {
+    called += 1;
+  };
+
+  await downloadInto(h, ["/tmp/OpenMausBot-2.0.0.AppImage"]);
+  h.coordinator.install();
+
+  assert.equal(called, 1);
+  assert.equal(h.getState().status, "installing");
 });

--- a/electron/updater-coordinator.node-test.mjs
+++ b/electron/updater-coordinator.node-test.mjs
@@ -342,7 +342,8 @@ test("the hand-off install opens the staged package instead of quitting", async 
   const h = harness({
     handOffInstall: (files) => {
       received.push(files);
-      return Promise.resolve();
+      // what the user still has to do travels back with the state
+      return Promise.resolve({ command: "sudo apt-get install -y '/tmp/x.deb'", terminalOpened: true });
     },
   });
   h.updater.quitAndInstall = () => assert.fail("a system package must not be installed by quitAndInstall");
@@ -357,6 +358,8 @@ test("the hand-off install opens the staged package instead of quitting", async 
   assert.equal(h.getState().status, "handed-off");
   // the user watched something happen between the click and the result
   assert.ok(h.states.some((entry) => entry.status === "installing"));
+  assert.equal(h.getState().command, "sudo apt-get install -y '/tmp/x.deb'");
+  assert.equal(h.getState().terminalOpened, true);
 });
 
 test("a failed hand-off is reported instead of leaving the card spinning", async () => {

--- a/electron/updater-handoff.electron.test.mjs
+++ b/electron/updater-handoff.electron.test.mjs
@@ -60,6 +60,7 @@ it.runIf(canRun)(
     expect(result.stdout, diagnostics).toContain("clipboard-written-even-without-a-terminal");
 
     expect(result.stdout, diagnostics).toContain("missing-download-is-reported");
+    expect(result.stdout, diagnostics).toContain("vanished-download-is-reported");
   },
   90_000,
 );

--- a/electron/updater-handoff.electron.test.mjs
+++ b/electron/updater-handoff.electron.test.mjs
@@ -1,0 +1,65 @@
+// The Ubuntu hand-off ends in two side effects that only exist at runtime:
+// the command reaching the system clipboard, and a terminal being spawned.
+// terminal-launch.test.mjs injects a fake runner, so nothing is ever launched
+// there. This runs the production path inside a real Electron process, with a
+// recording script on PATH standing in for the terminal emulator.
+import { spawn, spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const electron = require("electron");
+const fixture = fileURLToPath(new URL("./fixtures/updater-handoff.cjs", import.meta.url));
+
+const xvfb =
+  process.platform === "linux" && !process.env.DISPLAY
+    ? spawnSync("which", ["xvfb-run"], { encoding: "utf8" }).stdout.trim()
+    : "";
+// The clipboard is an X11 selection on Linux, so this needs a display.
+const canRun = process.platform === "linux" && (Boolean(process.env.DISPLAY) || Boolean(xvfb));
+
+function runFixture() {
+  const [command, args] = xvfb
+    ? [xvfb, ["-a", electron, "--no-sandbox", fixture]]
+    : [electron, ["--no-sandbox", fixture]];
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    const timer = setTimeout(() => child.kill("SIGKILL"), 60_000);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+it.runIf(canRun)(
+  "copies the install command and launches a terminal for real",
+  async () => {
+    const result = await runFixture();
+    const diagnostics = `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`;
+
+    expect(result.code, diagnostics).toBe(0);
+    expect(result.stdout, diagnostics).toContain("fixture-complete");
+
+    // The command the user pastes really is on the clipboard, quoting intact.
+    expect(result.stdout, diagnostics).toContain("clipboard-holds-the-install-command");
+    expect(result.stdout, diagnostics).toContain("hand-off-returned-the-command");
+
+    // A real child process was resolved through PATH and spawned.
+    expect(result.stdout, diagnostics).toContain("terminal-really-launched");
+    expect(result.stdout, diagnostics).toContain("hand-off-reported-the-terminal");
+
+    // With no terminal available the card must say so, and the clipboard must
+    // still hold the command — that is what the troubleshooting doc promises.
+    expect(result.stdout, diagnostics).toContain("no-terminal-is-reported-honestly");
+    expect(result.stdout, diagnostics).toContain("clipboard-written-even-without-a-terminal");
+
+    expect(result.stdout, diagnostics).toContain("missing-download-is-reported");
+  },
+  90_000,
+);

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -6,8 +6,8 @@
 // signing). In dev it's a no-op so the browser/dev shell is unaffected.
 // electron-updater is vendored (electron/vendor/electron-updater.cjs) because
 // the packaged app ships no node_modules.
-import { app, ipcMain } from "electron";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { app, ipcMain, shell } from "electron";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
@@ -35,6 +35,44 @@ function updaterLogger() {
     }
   };
   return Object.fromEntries(["debug", "info", "warn", "error"].map((level) => [level, (...values) => write(level, values)]));
+}
+
+// Which Linux artifact is running. electron-updater resolves its installer the
+// same way (resources/package-type first, APPIMAGE env as the fallback), so
+// mirroring it here keeps the banner's promise and the updater's behaviour in
+// step. Returns null off Linux and for an unpackaged tree.
+function linuxPackageType() {
+  if (process.platform !== "linux") return null;
+  try {
+    const identity = join(process.resourcesPath, "package-type");
+    if (existsSync(identity)) {
+      const declared = readFileSync(identity, "utf8").trim();
+      if (declared) return declared;
+    }
+  } catch {
+    // An unreadable marker is not worth failing the updater over — fall
+    // through to the AppImage probe and treat the build as portable.
+  }
+  return process.env.APPIMAGE ? "AppImage" : null;
+}
+
+// A system package is the distro's to install, not ours. Left to
+// electron-updater, a .deb update raises a polkit root prompt out of a chat
+// app, runs `dpkg -i` (which resolves no dependencies) and replaces
+// /opt/OpenMausBot while this very process is still running. Hand the
+// downloaded package to the desktop instead and let the user finish there.
+const HAND_OFF_PACKAGE_TYPES = new Set(["deb", "rpm", "pacman"]);
+
+async function openDownloadedPackage(files) {
+  const target = files?.find((file) => typeof file === "string" && file.length > 0);
+  if (!target) {
+    throw new Error("The downloaded package is no longer available. Download it again.");
+  }
+  // Empty string means the desktop took it; anything else is the failure
+  // reason. With no handler registered for the package type, showing the file
+  // still leaves the user somewhere they can act.
+  const failure = await shell.openPath(target);
+  if (failure) shell.showItemInFolder(target);
 }
 
 function setState(patch) {
@@ -75,7 +113,13 @@ export function startUpdater(mainWindow) {
   autoUpdater.autoInstallOnAppQuit = process.platform === "darwin";
   autoUpdater.logger = updaterLogger();
 
-  updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState);
+  // Broadcast the install flavour before the first check so the banner never
+  // offers a restart it cannot deliver.
+  const handOff = HAND_OFF_PACKAGE_TYPES.has(linuxPackageType());
+  setState({ installMode: handOff ? "handoff" : "restart" });
+  updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState, {
+    handOffInstall: handOff ? openDownloadedPackage : null,
+  });
 
   // first check ~15s after launch (let the app settle), then hourly — both
   // silent on failure, hence the arrow: a bare `check` would receive the

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -6,10 +6,12 @@
 // signing). In dev it's a no-op so the browser/dev shell is unaffected.
 // electron-updater is vendored (electron/vendor/electron-updater.cjs) because
 // the packaged app ships no node_modules.
-import { app, ipcMain, shell } from "electron";
+import { app, clipboard, ipcMain } from "electron";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { HAND_OFF_PACKAGE_TYPES, packageInstallCommand } from "./package-install-command.mjs";
+import { openBlankTerminal } from "./terminal-launch.mjs";
 import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
 
 const require = createRequire(import.meta.url);
@@ -59,20 +61,19 @@ function linuxPackageType() {
 // A system package is the distro's to install, not ours. Left to
 // electron-updater, a .deb update raises a polkit root prompt out of a chat
 // app, runs `dpkg -i` (which resolves no dependencies) and replaces
-// /opt/OpenMausBot while this very process is still running. Hand the
-// downloaded package to the desktop instead and let the user finish there.
-const HAND_OFF_PACKAGE_TYPES = new Set(["deb", "rpm", "pacman"]);
+// /opt/OpenMausBot while this very process is still running.
+const HAND_OFF_TYPES = new Set(HAND_OFF_PACKAGE_TYPES);
 
-async function openDownloadedPackage(files) {
-  const target = files?.find((file) => typeof file === "string" && file.length > 0);
-  if (!target) {
-    throw new Error("The downloaded package is no longer available. Download it again.");
-  }
-  // Empty string means the desktop took it; anything else is the failure
-  // reason. With no handler registered for the package type, showing the file
-  // still leaves the user somewhere they can act.
-  const failure = await shell.openPath(target);
-  if (failure) shell.showItemInFolder(target);
+// Do what this app already does for engine installs: put the exact command on
+// the clipboard and open a blank terminal to paste it into. The command is
+// never executed for the user, so nothing here becomes a process argument.
+function handOffDownloadedPackage(packageType) {
+  return async (files) => {
+    const target = files?.find((file) => typeof file === "string" && file.length > 0);
+    const command = packageInstallCommand(packageType, target);
+    clipboard.writeText(command);
+    return { command, terminalOpened: await openBlankTerminal() };
+  };
 }
 
 function setState(patch) {
@@ -115,10 +116,11 @@ export function startUpdater(mainWindow) {
 
   // Broadcast the install flavour before the first check so the banner never
   // offers a restart it cannot deliver.
-  const handOff = HAND_OFF_PACKAGE_TYPES.has(linuxPackageType());
+  const packageType = linuxPackageType();
+  const handOff = HAND_OFF_TYPES.has(packageType);
   setState({ installMode: handOff ? "handoff" : "restart" });
   updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState, {
-    handOffInstall: handOff ? openDownloadedPackage : null,
+    handOffInstall: handOff ? handOffDownloadedPackage(packageType) : null,
   });
 
   // first check ~15s after launch (let the app settle), then hourly — both

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -14,6 +14,7 @@ import {
   HAND_OFF_PACKAGE_TYPES,
   linuxPackageType,
   packageInstallCommand,
+  stagedInstallFile,
 } from "./package-install-command.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
@@ -54,7 +55,7 @@ const HAND_OFF_TYPES = new Set(HAND_OFF_PACKAGE_TYPES);
 // never executed for the user, so nothing here becomes a process argument.
 export function handOffDownloadedPackage(packageType) {
   return async (files) => {
-    const target = files?.find((file) => typeof file === "string" && file.length > 0);
+    const target = stagedInstallFile(files);
     const command = packageInstallCommand(packageType, target);
     clipboard.writeText(command);
     return { command, terminalOpened: await openBlankTerminal() };

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -52,7 +52,7 @@ const HAND_OFF_TYPES = new Set(HAND_OFF_PACKAGE_TYPES);
 // Do what this app already does for engine installs: put the exact command on
 // the clipboard and open a blank terminal to paste it into. The command is
 // never executed for the user, so nothing here becomes a process argument.
-function handOffDownloadedPackage(packageType) {
+export function handOffDownloadedPackage(packageType) {
   return async (files) => {
     const target = files?.find((file) => typeof file === "string" && file.length > 0);
     const command = packageInstallCommand(packageType, target);

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -10,7 +10,11 @@ import { app, clipboard, ipcMain } from "electron";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { HAND_OFF_PACKAGE_TYPES, packageInstallCommand } from "./package-install-command.mjs";
+import {
+  HAND_OFF_PACKAGE_TYPES,
+  linuxPackageType,
+  packageInstallCommand,
+} from "./package-install-command.mjs";
 import { openBlankTerminal } from "./terminal-launch.mjs";
 import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
 
@@ -37,25 +41,6 @@ function updaterLogger() {
     }
   };
   return Object.fromEntries(["debug", "info", "warn", "error"].map((level) => [level, (...values) => write(level, values)]));
-}
-
-// Which Linux artifact is running. electron-updater resolves its installer the
-// same way (resources/package-type first, APPIMAGE env as the fallback), so
-// mirroring it here keeps the banner's promise and the updater's behaviour in
-// step. Returns null off Linux and for an unpackaged tree.
-function linuxPackageType() {
-  if (process.platform !== "linux") return null;
-  try {
-    const identity = join(process.resourcesPath, "package-type");
-    if (existsSync(identity)) {
-      const declared = readFileSync(identity, "utf8").trim();
-      if (declared) return declared;
-    }
-  } catch {
-    // An unreadable marker is not worth failing the updater over — fall
-    // through to the AppImage probe and treat the build as portable.
-  }
-  return process.env.APPIMAGE ? "AppImage" : null;
 }
 
 // A system package is the distro's to install, not ours. Left to
@@ -116,7 +101,7 @@ export function startUpdater(mainWindow) {
 
   // Broadcast the install flavour before the first check so the banner never
   // offers a restart it cannot deliver.
-  const packageType = linuxPackageType();
+  const packageType = linuxPackageType({ readMarker: (file) => (existsSync(file) ? readFileSync(file, "utf8") : null) });
   const handOff = HAND_OFF_TYPES.has(packageType);
   setState({ installMode: handOff ? "handoff" : "restart" });
   updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState, {

--- a/electron/vendor-updater.node-test.mjs
+++ b/electron/vendor-updater.node-test.mjs
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import Module, { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -35,53 +35,63 @@ test("the vendored bundle still contains the AppImage installer we patch", () =>
   assert.match(bundle, /destination = appImageFile;/);
 });
 
+test("the install stages the replacement instead of deleting first", () => {
+  // Upstream's unlinkSync(appImageFile) runs before the download is even
+  // validated. Nothing may remove the running file ahead of the rename.
+  assert.doesNotMatch(bundle, /unlinkSync\)\(appImageFile\)/);
+  assert.match(bundle, /renameSync\)\(stagedDestination, destination\)/);
+});
+
 test("an AppImage update can never be written to a different filename", () => {
   // Upstream renames when the running file has a version in its name, which
   // orphans every .desktop entry, symlink and dock pin pointing at it.
   assert.doesNotMatch(bundle, renamePattern);
 });
 
-test("the patch rewrites the rename branch to keep the running path", () => {
-  const upstream = [
-    "if (path2.basename(installerPath) === existingBaseName || !/\\d+\\.\\d+\\.\\d+/.test(existingBaseName)) {",
-    "  destination = appImageFile;",
-    "} else {",
-    "  destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
-    "}",
-  ].join("\n");
+// The shape of the three sites the patch rewrites, as esbuild emits them.
+const UPSTREAM = [
+  "        (0, fs_1.unlinkSync)(appImageFile);",
+  "        let destination;",
+  "        const existingBaseName = path2.basename(appImageFile);",
+  "        const installerPath = this.installerPath;",
+  "        if (path2.basename(installerPath) === existingBaseName || !/\\d+\\.\\d+\\.\\d+/.test(existingBaseName)) {",
+  "          destination = appImageFile;",
+  "        } else {",
+  "          destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
+  "        }",
+  '        (0, child_process_1.execFileSync)("mv", ["-f", installerPath, destination]);',
+].join("\n");
 
-  const patched = patchAppImageUpdater(upstream);
+test("the patch keeps the running path and never deletes ahead of the rename", () => {
+  const patched = patchAppImageUpdater(UPSTREAM);
+
+  assert.doesNotMatch(patched, renamePattern);
+  assert.equal(patched.match(/destination = appImageFile;/g)?.length, 2);
+  assert.doesNotMatch(patched, /unlinkSync\)\(appImageFile\)/);
+  assert.match(patched, /mv", \["-f", installerPath, stagedDestination\]/);
+  assert.match(patched, /renameSync\)\(stagedDestination, destination\)/);
+});
+
+test("the patch tolerates esbuild renaming the path import", () => {
+  const patched = patchAppImageUpdater(UPSTREAM.replaceAll("path2", "path7"));
 
   assert.doesNotMatch(patched, renamePattern);
   assert.equal(patched.match(/destination = appImageFile;/g)?.length, 2);
 });
 
-test("the patch tolerates esbuild renaming the path import", () => {
-  const patched = patchAppImageUpdater(
-    "destination = path7.join(path7.dirname(appImageFile), path7.basename(installerPath));",
-  );
-  assert.equal(patched, "destination = appImageFile;");
-});
-
 test("the patch fails closed when upstream's shape moves", () => {
-  // A silent no-op here would ship the launcher-breaking rename again.
-  assert.throws(() => patchAppImageUpdater("destination = somethingElse;"), /found 0/);
-  assert.throws(
-    () =>
-      patchAppImageUpdater(
-        [
-          "destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
-          "destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
-        ].join("\n"),
-      ),
-    /found 2/,
-  );
+  // A silent no-op here would ship the launcher-breaking rename again, or
+  // reinstate the delete that can cost a user their application.
+  for (const [label, mutated] of [
+    ["no rename branch", UPSTREAM.replace(/destination = path2\.join[^;]+;/, "destination = elsewhere;")],
+    ["no early unlink", UPSTREAM.replace("        (0, fs_1.unlinkSync)(appImageFile);\n", "")],
+    ["no move", UPSTREAM.replace(/\(0, child_process_1\.execFileSync\)\("mv"[^;]+;/, "")],
+    ["two rename branches", `${UPSTREAM}\n${UPSTREAM}`],
+  ]) {
+    assert.throws(() => patchAppImageUpdater(mutated), /to patch, found/, label);
+  }
 });
 
-// The assertions above read the bundle as text. This one runs the shipped
-// AppImageUpdater.doInstall against real files, which is what actually has to
-// hold: the update lands on the path the user launches, and the old file is
-// gone from nowhere else.
 test("the shipped installer moves the update onto the running AppImage's path", (t) => {
   const electron = { app: {}, autoUpdater: new EventEmitter() };
   const load = Module._load;
@@ -128,4 +138,49 @@ test("the shipped installer moves the update onto the running AppImage's path", 
   assert.deepEqual(readdirSync(workspace).sort(), ["OpenMausBot-0.1.43-x86_64.AppImage", "pending"]);
   assert.equal(relaunched, launched, "the relaunch must use the path the launcher points at");
   assert.deepEqual(renames, [], "no filename change means no appimage-filename-updated event");
+});
+
+test("the running AppImage is never removed before its replacement is in place", (t) => {
+  const electron = { app: {}, autoUpdater: new EventEmitter() };
+  const load = Module._load;
+  Module._load = (request, ...rest) => (request === "electron" ? electron : load(request, ...rest));
+  t.after(() => {
+    Module._load = load;
+  });
+
+  const { AppImageUpdater } = createRequire(import.meta.url)("./vendor/electron-updater.cjs");
+  const workspace = mkdtempSync(join(tmpdir(), "omb-appimage-failed-"));
+  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+
+  const launched = join(workspace, "OpenMausBot-0.1.43-x86_64.AppImage");
+  writeFileSync(launched, "the app the user has", { mode: 0o755 });
+
+  const previous = process.env.APPIMAGE;
+  process.env.APPIMAGE = launched;
+  t.after(() => {
+    if (previous === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = previous;
+  });
+
+  // A staged download that is not there stands in for every way the move can
+  // fail — a full disk, a cross-filesystem copy cut short, a revoked mount.
+  // Upstream unlinks the running file first, so any of those left the user
+  // with no application at all.
+  assert.throws(() =>
+    AppImageUpdater.prototype.doInstall.call(
+      {
+        installerPath: join(workspace, "never-downloaded.AppImage"),
+        _logger: { info() {}, warn() {}, error() {}, debug() {} },
+        dispatchError: (error) => {
+          throw error;
+        },
+        emit() {},
+        spawnLog: () => assert.fail("a failed install must not relaunch"),
+      },
+      { isForceRunAfter: true },
+    ),
+  );
+
+  assert.equal(readFileSync(launched, "utf8"), "the app the user has", "a failed update cost the user their app");
+  assert.deepEqual(readdirSync(workspace), [basename(launched)], "a partial download was left behind");
 });

--- a/electron/vendor-updater.node-test.mjs
+++ b/electron/vendor-updater.node-test.mjs
@@ -1,0 +1,131 @@
+// The vendored electron-updater bundle is a build artifact, but it is also the
+// code that actually runs in the packaged app. These tests pin the one
+// behaviour we deliberately changed in it: an AppImage update must land on the
+// path the user launches, never a new versioned filename.
+//
+// See scripts/patch-appimage-updater.mjs for the reasoning.
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import Module, { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { patchAppImageUpdater } from "../scripts/patch-appimage-updater.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const bundle = readFileSync(join(root, "electron/vendor/electron-updater.cjs"), "utf8");
+
+// Non-global on purpose: a shared /g regex carries lastIndex between .test()
+// calls and would report alternating results.
+const renamePattern = /destination = (\w+)\.join\(\1\.dirname\(appImageFile\), \1\.basename\(installerPath\)\);/;
+
+test("the vendored bundle still contains the AppImage installer we patch", () => {
+  assert.match(bundle, /const appImageFile = process\.env\["APPIMAGE"\]/);
+  assert.match(bundle, /destination = appImageFile;/);
+});
+
+test("an AppImage update can never be written to a different filename", () => {
+  // Upstream renames when the running file has a version in its name, which
+  // orphans every .desktop entry, symlink and dock pin pointing at it.
+  assert.doesNotMatch(bundle, renamePattern);
+});
+
+test("the patch rewrites the rename branch to keep the running path", () => {
+  const upstream = [
+    "if (path2.basename(installerPath) === existingBaseName || !/\\d+\\.\\d+\\.\\d+/.test(existingBaseName)) {",
+    "  destination = appImageFile;",
+    "} else {",
+    "  destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
+    "}",
+  ].join("\n");
+
+  const patched = patchAppImageUpdater(upstream);
+
+  assert.doesNotMatch(patched, renamePattern);
+  assert.equal(patched.match(/destination = appImageFile;/g)?.length, 2);
+});
+
+test("the patch tolerates esbuild renaming the path import", () => {
+  const patched = patchAppImageUpdater(
+    "destination = path7.join(path7.dirname(appImageFile), path7.basename(installerPath));",
+  );
+  assert.equal(patched, "destination = appImageFile;");
+});
+
+test("the patch fails closed when upstream's shape moves", () => {
+  // A silent no-op here would ship the launcher-breaking rename again.
+  assert.throws(() => patchAppImageUpdater("destination = somethingElse;"), /found 0/);
+  assert.throws(
+    () =>
+      patchAppImageUpdater(
+        [
+          "destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
+          "destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
+        ].join("\n"),
+      ),
+    /found 2/,
+  );
+});
+
+// The assertions above read the bundle as text. This one runs the shipped
+// AppImageUpdater.doInstall against real files, which is what actually has to
+// hold: the update lands on the path the user launches, and the old file is
+// gone from nowhere else.
+test("the shipped installer moves the update onto the running AppImage's path", (t) => {
+  const electron = { app: {}, autoUpdater: new EventEmitter() };
+  const load = Module._load;
+  Module._load = (request, ...rest) => (request === "electron" ? electron : load(request, ...rest));
+  t.after(() => {
+    Module._load = load;
+  });
+
+  const { AppImageUpdater } = createRequire(import.meta.url)("./vendor/electron-updater.cjs");
+  const workspace = mkdtempSync(join(tmpdir(), "omb-appimage-install-"));
+  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+
+  // The user launches a versioned filename — the case upstream renames.
+  const launched = join(workspace, "OpenMausBot-0.1.43-x86_64.AppImage");
+  const staged = join(workspace, "pending", "OpenMausBot-0.1.44-x86_64.AppImage");
+  mkdirSync(join(workspace, "pending"));
+  writeFileSync(launched, "old", { mode: 0o755 });
+  writeFileSync(staged, "new", { mode: 0o755 });
+
+  const previous = process.env.APPIMAGE;
+  process.env.APPIMAGE = launched;
+  t.after(() => {
+    if (previous === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = previous;
+  });
+
+  const renames = [];
+  let relaunched = null;
+  AppImageUpdater.prototype.doInstall.call(
+    {
+      installerPath: staged,
+      _logger: { info() {}, warn() {}, error() {}, debug() {} },
+      dispatchError: (error) => assert.fail(error),
+      emit: (event, value) => renames.push([event, value]),
+      spawnLog: (target) => {
+        relaunched = target;
+      },
+    },
+    { isForceRunAfter: true },
+  );
+
+  assert.equal(readFileSync(launched, "utf8"), "new", "the update must land on the launched path");
+  assert.equal(existsSync(staged), false, "the staged download must be consumed");
+  assert.deepEqual(readdirSync(workspace).sort(), ["OpenMausBot-0.1.43-x86_64.AppImage", "pending"]);
+  assert.equal(relaunched, launched, "the relaunch must use the path the launcher points at");
+  assert.deepEqual(renames, [], "no filename change means no appimage-filename-updated event");
+});

--- a/electron/vendor/electron-updater.cjs
+++ b/electron/vendor/electron-updater.cjs
@@ -14950,7 +14950,7 @@ var require_AppImageUpdater = __commonJS({
         if (path2.basename(installerPath) === existingBaseName || !/\d+\.\d+\.\d+/.test(existingBaseName)) {
           destination = appImageFile;
         } else {
-          destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));
+          destination = appImageFile;
         }
         (0, child_process_1.execFileSync)("mv", ["-f", installerPath, destination]);
         if (destination !== appImageFile) {

--- a/electron/vendor/electron-updater.cjs
+++ b/electron/vendor/electron-updater.cjs
@@ -14939,7 +14939,6 @@ var require_AppImageUpdater = __commonJS({
         if (!path2.isAbsolute(appImageFile) || appImageFile.includes("\0")) {
           throw (0, builder_util_runtime_1.newError)(`APPIMAGE env is not a valid absolute path: "${appImageFile}"`, "ERR_UPDATER_OLD_FILE_NOT_FOUND");
         }
-        (0, fs_1.unlinkSync)(appImageFile);
         let destination;
         const existingBaseName = path2.basename(appImageFile);
         const installerPath = this.installerPath;
@@ -14952,7 +14951,9 @@ var require_AppImageUpdater = __commonJS({
         } else {
           destination = appImageFile;
         }
-        (0, child_process_1.execFileSync)("mv", ["-f", installerPath, destination]);
+        const stagedDestination = `${destination}.new`;
+        (0, child_process_1.execFileSync)("mv", ["-f", installerPath, stagedDestination]);
+        (0, fs_1.renameSync)(stagedDestination, destination);
         if (destination !== appImageFile) {
           this.emit("appimage-filename-updated", destination);
         }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
+    "smoke:linux-update": "xvfb-run -a electron --no-sandbox scripts/smoke-linux-update.mjs",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",
     "smoke:cua-x11-input": "node scripts/smoke-cua-x11-input.mjs",
     "package:linux:dir": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux dir --x64 --publish never",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "package:win": "pnpm package:prepare && electron-builder --win --publish never",
     "package:linux": "pnpm package:prepare && pnpm build:cua:linux && electron-builder --linux --x64 --publish never",
     "package:linux:offline": "pnpm package:prepare && pnpm build:cua:linux:offline && electron-builder --linux --x64 --publish never",
+    "smoke:deb-command": "node scripts/smoke-deb-command.mjs",
     "smoke:linux-update": "xvfb-run -a electron --no-sandbox scripts/smoke-linux-update.mjs",
     "smoke:linux-package": "node scripts/run-linux-package-smoke.mjs",
     "smoke:cua-x11-input": "node scripts/smoke-cua-x11-input.mjs",

--- a/scripts/bundle-updater.mjs
+++ b/scripts/bundle-updater.mjs
@@ -3,13 +3,20 @@
 // pre-compiled into Resources), so a main-process dependency has to be
 // vendored. esbuild inlines electron-updater + its whole dep tree; `electron`
 // stays external (resolved from the runtime). Output ships via files:electron/**.
+//
+// The bundle is then patched so an AppImage update keeps the path the user
+// launches — see scripts/patch-appimage-updater.mjs for why.
 import { build } from "esbuild";
 import { createRequire } from "node:module";
+import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+import { patchAppImageUpdater } from "./patch-appimage-updater.mjs";
+
 const require = createRequire(import.meta.url);
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outfile = join(root, "electron/vendor/electron-updater.cjs");
 
 await build({
   entryPoints: [require.resolve("electron-updater")],
@@ -18,6 +25,11 @@ await build({
   target: "node20",
   format: "cjs",
   external: ["electron"],
-  outfile: join(root, "electron/vendor/electron-updater.cjs"),
+  outfile,
   logLevel: "info",
 });
+
+// Throws when upstream's shape moved, so a bundle that would silently break
+// AppImage launchers never reaches a release.
+await writeFile(outfile, patchAppImageUpdater(await readFile(outfile, "utf8")));
+console.log("patched AppImage install to overwrite in place");

--- a/scripts/patch-appimage-updater.mjs
+++ b/scripts/patch-appimage-updater.mjs
@@ -1,0 +1,39 @@
+// electron-updater installs an AppImage update by writing the new file under
+// the *release asset's* name and unlinking the old one. Our feed names assets
+// after the version, so a user whose AppImage is called
+// OpenMausBot-0.1.43-x86_64.AppImage ends up with a 0.1.44 file and nothing at
+// the old path — every .desktop entry, symlink, dock pin and AppImageLauncher
+// registration pointing at it breaks, and the app vanishes from the launcher.
+//
+// Upstream only overwrites in place when the running file has no version in
+// its name. Force that branch unconditionally: the update lands on whatever
+// path the user already launches, whatever they named it.
+//
+// Applied to the generated bundle by scripts/bundle-updater.mjs, and asserted
+// on the committed artifact by electron/vendor-updater.node-test.mjs.
+
+// esbuild renames the imported `path` module per build (path2, path3, …), so
+// match the identifier instead of pinning one. The back-reference keeps this
+// from matching an unrelated join().
+const RENAME_ASSIGNMENT =
+  /destination = (\w+)\.join\(\1\.dirname\(appImageFile\), \1\.basename\(installerPath\)\);/g;
+
+const IN_PLACE_ASSIGNMENT = "destination = appImageFile;";
+
+/**
+ * Rewrite the AppImage rename branch to keep the running file's path.
+ * Throws when the upstream shape moved: a silently unpatched bundle would
+ * ship the launcher-breaking behaviour again.
+ */
+export function patchAppImageUpdater(source) {
+  const matches = source.match(RENAME_ASSIGNMENT);
+  const count = matches ? matches.length : 0;
+  if (count !== 1) {
+    throw new Error(
+      `Expected exactly 1 AppImage rename assignment to patch, found ${count}. ` +
+        "electron-updater's AppImageUpdater.doInstall changed shape — re-read it and update " +
+        "scripts/patch-appimage-updater.mjs before releasing.",
+    );
+  }
+  return source.replace(RENAME_ASSIGNMENT, IN_PLACE_ASSIGNMENT);
+}

--- a/scripts/patch-appimage-updater.mjs
+++ b/scripts/patch-appimage-updater.mjs
@@ -20,20 +20,61 @@ const RENAME_ASSIGNMENT =
 
 const IN_PLACE_ASSIGNMENT = "destination = appImageFile;";
 
+// Upstream also deletes the running AppImage before it has validated anything
+// and before the replacement exists:
+//
+//   unlinkSync(appImageFile);
+//   const installerPath = this.installerPath;
+//   if (installerPath == null) { …; return false; }   // app already deleted
+//   execFileSync("mv", ["-f", installerPath, destination]);
+//
+// Anything that fails past that first line leaves the user with no
+// application at all. A failed update should cost them nothing. The staged
+// download also lives in the updater cache, which can sit on another
+// filesystem, so `mv` may fall back to copy-then-unlink and write into the
+// destination while it is still a running executable.
+//
+// Land it in two steps instead. Moving into a sibling of the destination
+// absorbs any cross-filesystem copy, then rename(2) within a single directory
+// replaces the old file atomically and works over a running binary. Nothing
+// is removed until the replacement is complete.
+const UNLINK_BEFORE_INSTALL = /^\s*\(0, fs_1\.unlinkSync\)\(appImageFile\);\n/m;
+
+const MOVE_INTO_PLACE =
+  /\(0, child_process_1\.execFileSync\)\("mv", \["-f", installerPath, destination\]\);/;
+
+const ATOMIC_MOVE = [
+  'const stagedDestination = `${destination}.new`;',
+  '(0, child_process_1.execFileSync)("mv", ["-f", installerPath, stagedDestination]);',
+  "(0, fs_1.renameSync)(stagedDestination, destination);",
+].join("\n        ");
+
+const REPLACEMENTS = [
+  ["rename branch", RENAME_ASSIGNMENT, IN_PLACE_ASSIGNMENT],
+  ["unlink before install", UNLINK_BEFORE_INSTALL, ""],
+  ["move into place", MOVE_INTO_PLACE, ATOMIC_MOVE],
+];
+
 /**
- * Rewrite the AppImage rename branch to keep the running file's path.
- * Throws when the upstream shape moved: a silently unpatched bundle would
- * ship the launcher-breaking behaviour again.
+ * Keep an AppImage update on the running file's path, and never remove that
+ * file until the replacement is in place.
+ *
+ * Throws when any step's upstream shape moved: a silently unpatched bundle
+ * would ship the launcher-breaking behaviour again.
  */
 export function patchAppImageUpdater(source) {
-  const matches = source.match(RENAME_ASSIGNMENT);
-  const count = matches ? matches.length : 0;
-  if (count !== 1) {
-    throw new Error(
-      `Expected exactly 1 AppImage rename assignment to patch, found ${count}. ` +
-        "electron-updater's AppImageUpdater.doInstall changed shape — re-read it and update " +
-        "scripts/patch-appimage-updater.mjs before releasing.",
-    );
+  let patched = source;
+  for (const [label, pattern, replacement] of REPLACEMENTS) {
+    const found = patched.match(pattern);
+    const count = found ? (pattern.global ? found.length : 1) : 0;
+    if (count !== 1) {
+      throw new Error(
+        `Expected exactly 1 AppImage "${label}" site to patch, found ${count}. ` +
+          "electron-updater's AppImageUpdater.doInstall changed shape — re-read it and update " +
+          "scripts/patch-appimage-updater.mjs before releasing.",
+      );
+    }
+    patched = patched.replace(pattern, replacement);
   }
-  return source.replace(RENAME_ASSIGNMENT, IN_PLACE_ASSIGNMENT);
+  return patched;
 }

--- a/scripts/smoke-deb-command.mjs
+++ b/scripts/smoke-deb-command.mjs
@@ -1,0 +1,103 @@
+// Proves the line the app hands a Ubuntu user actually installs, and that the
+// command it replaced does not.
+//
+// The .deb update path ends with a command on the clipboard: the app
+// deliberately never installs the package itself. That makes the command the
+// whole deliverable, so it is executed here as root on a clean Ubuntu, through
+// a real shell, exactly as pasted — quoting included.
+//
+//   node scripts/smoke-deb-command.mjs <path-to-deb>
+//
+// Needs a container runtime; installing a system package is the point.
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { packageInstallCommand } from "../electron/package-install-command.mjs";
+
+const IMAGE = process.env.OMB_DEB_SMOKE_IMAGE || "ubuntu:24.04";
+const RUNTIME = process.env.OMB_DEB_SMOKE_RUNTIME || "docker";
+if (!["docker", "podman"].includes(RUNTIME)) throw new Error("unsupported container runtime");
+
+function fail(message) {
+  console.error(`[smoke-deb-command] ${message}`);
+  process.exit(1);
+}
+
+const deb = path.resolve(process.argv[2] ?? "");
+if (!deb.endsWith(".deb") || !existsSync(deb)) fail("pass the path to a .deb");
+
+// Inside the container the package sits at a path with a space and an
+// apostrophe, so the quoting the app emits is exercised, not assumed.
+const staged = "/root/pending dir/o'brien/OpenMausBot.deb";
+const command = packageInstallCommand("deb", staged);
+console.log(`[smoke-deb-command] command under test:\n    ${command}\n`);
+
+function inContainer(script, { expectFailure = false } = {}) {
+  try {
+    const output = execFileSync(
+      RUNTIME,
+      [
+        "run", "--rm",
+        "-v", `${deb}:/tmp/package.deb:ro`,
+        "-e", "DEBIAN_FRONTEND=noninteractive",
+        IMAGE,
+        "/bin/bash", "-c", script,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 15 * 60 * 1000 },
+    );
+    if (expectFailure) fail("the command was expected to fail but succeeded");
+    return output;
+  } catch (error) {
+    if (expectFailure) return String(error.stdout ?? "") + String(error.stderr ?? "");
+    console.error(String(error.stdout ?? ""));
+    console.error(String(error.stderr ?? ""));
+    throw error;
+  }
+}
+
+// Everything before the command under test is setup; `set -e` keeps a failed
+// setup from being read as a failed install.
+const prepare = [
+  "set -e",
+  "apt-get update -qq",
+  "apt-get install -y -qq sudo >/dev/null",
+  `mkdir -p "$(dirname "${staged}")"`,
+  `cp /tmp/package.deb "${staged}"`,
+].join("\n");
+
+console.log("[smoke-deb-command] installing with the command the app hands over…");
+const installed = inContainer(
+  [
+    prepare,
+    command,
+    'dpkg-query -W -f="INSTALLED=\\${Version} \\${db:Status-Abbrev}\\n" openmausbot',
+    'test -x /opt/OpenMausBot/openmausbot && echo "EXECUTABLE=yes"',
+  ].join("\n"),
+);
+
+const version = installed.match(/INSTALLED=(\S+) (\S+)/);
+const checks = [
+  ["the package installed and configured", version?.[2]?.startsWith("ii") === true],
+  ["the app binary is in place", installed.includes("EXECUTABLE=yes")],
+];
+
+// The command this replaced. On a clean Ubuntu the dependencies are not
+// present, and dpkg resolves none of them — which is why the old in-app
+// installer could leave a user with a broken package.
+console.log("[smoke-deb-command] control: the `dpkg -i` the app used to run…");
+const control = inContainer([prepare, `dpkg -i "${staged}" || echo "DPKG_FAILED"`].join("\n"), {
+  expectFailure: false,
+});
+checks.push([
+  "`dpkg -i` alone fails where the handed-over command works",
+  control.includes("DPKG_FAILED") || /dependency problems|not installed/i.test(control),
+]);
+
+let failed = 0;
+for (const [label, ok] of checks) {
+  console.log(`  ${ok ? "✔" : "✖"} ${label}`);
+  if (!ok) failed += 1;
+}
+if (failed > 0) fail(`${failed} check(s) failed`);
+console.log(`[smoke-deb-command] OK — ${version[1]} installed by the command the app copies`);

--- a/scripts/smoke-linux-update.mjs
+++ b/scripts/smoke-linux-update.mjs
@@ -1,0 +1,174 @@
+// End-to-end proof that an AppImage update lands on the path the user
+// launches, run against the real release feed.
+//
+// The unit tests drive AppImageUpdater.doInstall with hand-made files. This
+// drives the whole thing: the shipped bundle, extracted from the packaged
+// AppImage, checking the real openmausbot-releases feed, downloading the real
+// asset, and installing it over a copy that carries a version in its name —
+// the exact shape that used to orphan the launcher.
+//
+// The current version is reported by the app adapter, not read from the file,
+// so a build newer than the latest release can still be told to update: we
+// claim an old version and let the published release be the newer one.
+//
+// Runs under Electron (electron-updater needs its net stack):
+//   xvfb-run -a pnpm exec electron scripts/smoke-linux-update.mjs
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { app } = require("electron");
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const releaseDir = path.join(root, "release");
+
+// A version older than the oldest release we would ever test against, so the
+// published feed is always an upgrade regardless of what is packaged here.
+const PRETEND_VERSION = "0.0.1";
+
+function fail(message) {
+  console.error(`[smoke-linux-update] ${message}`);
+  app.exit(1);
+}
+
+// Missing is an answer, not a crash: when the install renames instead of
+// overwriting, the launched path is gone and that is the finding to report.
+function sha512(file) {
+  try {
+    return createHash("sha512").update(readFileSync(file)).digest("base64");
+  } catch {
+    return null;
+  }
+}
+
+function onlyAppImage() {
+  const matches = readdirSync(releaseDir).filter((name) => name.endsWith(".AppImage"));
+  if (matches.length !== 1) throw new Error(`expected one packaged AppImage, found ${matches.length}`);
+  return path.join(releaseDir, matches[0]);
+}
+
+async function main() {
+  const packaged = onlyAppImage();
+  const workspace = mkdtempSync(path.join(tmpdir(), "omb-update-smoke-"));
+  const installDir = path.join(workspace, "opt");
+  const applications = path.join(workspace, "applications");
+  mkdirSync(installDir);
+  mkdirSync(applications);
+
+  // The bug shape: a version in the filename, and a launcher pinned to it.
+  const launched = path.join(installDir, "OpenMausBot-0.0.1-x86_64.AppImage");
+  copyFileSync(packaged, launched);
+  const desktopEntry = path.join(applications, "com.openmausbot.app.desktop");
+  writeFileSync(
+    desktopEntry,
+    `[Desktop Entry]\nName=OpenMausBot\nExec=${launched} %U\nType=Application\n`,
+  );
+
+  // Isolate every path the updater writes to.
+  process.env.XDG_CACHE_HOME = path.join(workspace, "cache");
+  process.env.APPIMAGE = launched;
+  app.setPath("userData", path.join(workspace, "userdata"));
+
+  // The updater under test is the one that ships, not the one in the tree.
+  // Electron resolves paths inside an asar natively, so this loads the exact
+  // module the packaged app would require. An explicit path lets the same
+  // harness run against an unpatched bundle, which must fail — a smoke that
+  // cannot fail proves nothing.
+  const bundle =
+    process.argv.find((argument) => argument.startsWith("--updater="))?.slice("--updater=".length) ??
+    path.join(root, "release/linux-unpacked/resources/app.asar/electron/vendor/electron-updater.cjs");
+  console.log(`[smoke-linux-update] updater under test: ${bundle}`);
+  const { AppImageUpdater } = require(bundle);
+
+  const updateConfig = path.join(workspace, "app-update.yml");
+  copyFileSync(path.join(root, "release/linux-unpacked/resources/app-update.yml"), updateConfig);
+
+  // The constructor parses the current version once, so this has to be in
+  // place before the updater exists. Without it the comparison runs against
+  // Electron's own version and every real release looks like a downgrade.
+  app.getVersion = () => PRETEND_VERSION;
+
+  const updater = new AppImageUpdater();
+  updater.updateConfigPath = updateConfig;
+  updater.forceDevUpdateConfig = true;
+  updater.autoDownload = false;
+  updater.logger = { info: log, warn: log, error: log, debug: () => {} };
+
+  function log(...values) {
+    console.log("   ", ...values.map(String));
+  }
+
+  console.log("[smoke-linux-update] checking the real release feed…");
+  const result = await updater.checkForUpdates();
+  if (!result?.updateInfo?.version) throw new Error("the feed returned no update");
+  // A feed response alone is not an offer: a version comparison that decided
+  // "not available" still carries updateInfo, and reading only that would let
+  // this smoke pass without ever installing anything.
+  if (result.isUpdateAvailable !== true) {
+    throw new Error(
+      `the feed's ${result.updateInfo.version} was not treated as an update over ${PRETEND_VERSION}`,
+    );
+  }
+  const offered = result.updateInfo.version;
+  console.log(`[smoke-linux-update] feed offers ${offered}`);
+
+  const expected = result.updateInfo.files?.find((file) => file.url.endsWith(".AppImage"));
+  if (!expected?.sha512) throw new Error("the feed declares no AppImage checksum");
+
+  console.log("[smoke-linux-update] downloading…");
+  await updater.downloadUpdate(result.cancellationToken);
+
+  // Record the relaunch instead of starting a second app; the file placement
+  // is what this proves, and the target it would launch is part of that.
+  let relaunched = null;
+  updater.spawnLog = (target) => {
+    relaunched = target;
+  };
+  updater.quitAndInstall(true, true);
+
+  const survivors = readdirSync(installDir);
+  const desktop = readFileSync(desktopEntry, "utf8");
+  const execTarget = desktop.match(/^Exec=(.*?) %U$/m)?.[1];
+  console.log(`[smoke-linux-update] files left in the install directory: ${survivors.join(", ")}`);
+
+  const checks = [
+    ["the update stayed on the launched path", survivors.includes(path.basename(launched))],
+    ["no second AppImage appeared", survivors.length === 1],
+    [
+      "the launcher still points at a real file",
+      execTarget === launched && existsSync(launched),
+    ],
+    ["the file now holds the published build", sha512(launched) === expected.sha512],
+    ["the relaunch uses the launched path", relaunched === launched],
+  ];
+
+  let failed = 0;
+  for (const [label, ok] of checks) {
+    console.log(`  ${ok ? "✔" : "✖"} ${label}`);
+    if (!ok) failed += 1;
+  }
+  if (failed > 0) {
+    console.error(`[smoke-linux-update] ${failed} check(s) failed; workspace kept at ${workspace}`);
+    app.exit(1);
+    return;
+  }
+
+  rmSync(workspace, { recursive: true, force: true });
+  console.log(`[smoke-linux-update] OK — updated 0.0.1 → ${offered} in place`);
+  app.exit(0);
+}
+
+app.whenReady().then(main).catch((error) => fail(error.stack ?? String(error)));

--- a/scripts/verify-linux-package.mjs
+++ b/scripts/verify-linux-package.mjs
@@ -53,6 +53,24 @@ function requireExecutable(file) {
   }
 }
 
+// electron-updater picks its installer from resources/package-type: present
+// and reading "deb" routes to DebUpdater, absent falls back to AppImageUpdater.
+// electron/updater.mjs reads the same marker to decide whether the update is
+// applied in place or handed to the system package manager. If packaging ever
+// puts the marker in both artifacts (or neither), that routing silently
+// inverts, so pin it here where both trees are already extracted.
+function requirePackageType(resources, label, expected) {
+  const marker = path.join(resources, "package-type");
+  const found = statSync(marker, { throwIfNoEntry: false })?.isFile()
+    ? readFileSync(marker, "utf8").trim()
+    : null;
+  if (found !== expected) {
+    fail(
+      `${label} package-type marker is ${JSON.stringify(found)}, expected ${JSON.stringify(expected)}`,
+    );
+  }
+}
+
 function sha256(file) {
   return createHash("sha256").update(readFileSync(file)).digest("hex");
 }
@@ -410,6 +428,8 @@ try {
   const debAppRoot = path.join(extracted, "opt", "OpenMausBot");
   requireDirectoryMode(debAppRoot, 0o755);
   const debResources = path.join(debAppRoot, "resources");
+  // Routes the in-app updater to the package-manager hand-off.
+  requirePackageType(debResources, "DEB", "deb");
   const debHashes = verifyCuaResources(debResources, "DEB");
   const debCloudflaredHash = verifyCloudflaredResources(debResources, "DEB");
   if (debCloudflaredHash !== unpackedCloudflaredHash) {
@@ -473,6 +493,8 @@ try {
     );
   }
   const appImageResources = path.join(squashRoot, "resources");
+  // No marker: the AppImage keeps the in-place restart-to-update path.
+  requirePackageType(appImageResources, "AppImage", null);
   // Depending on the pinned appimagetool runtime, SquashFS directories are
   // emitted as root:root 0755 or 0775. Require one mode consistently across
   // the reviewed resource tree. The app never executes through that path:

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -63,7 +63,7 @@ export function UpdateBanner() {
               ? "Opening your package manager…"
               : "Restarting to update…"
             : s.status === "handed-off"
-              ? "Finish the install"
+              ? "Finish in a terminal"
               : "Update check failed";
   const subtitle =
     s.status === "available"
@@ -75,14 +75,16 @@ export function UpdateBanner() {
           : `${Math.round(s.percent)}%`
         : s.status === "downloaded"
           ? handoff
-            ? "Install it with your package manager."
+            ? "Copy the install command and open a terminal."
             : "Restart to finish updating."
           : installing
             ? handoff
-              ? "Complete the install there, then reopen OpenMausBot."
+              ? "Copying the command…"
               : "OpenMausBot will reopen in a moment."
             : s.status === "handed-off"
-              ? "Complete it in your package manager, then reopen OpenMausBot."
+              ? s.terminalOpened
+                ? "Command copied — paste it in the terminal that opened."
+                : "Command copied — paste it in a terminal to finish."
               : friendlyError(s.message);
 
   return (
@@ -107,6 +109,12 @@ export function UpdateBanner() {
           </button>
         )}
       </div>
+
+      {s.status === "handed-off" && s.command && (
+        <code className="mt-2.5 block overflow-x-auto rounded-lg bg-control px-2 py-1.5 font-mono text-[11.5px] whitespace-pre text-ink-secondary">
+          {s.command}
+        </code>
+      )}
 
       {s.status === "downloading" && (
         <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-control">

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -3,7 +3,7 @@
 // and while idle/checking; appears only when actionable: an update to
 // download, a download in progress, a restart to apply, or an error.
 import { useEffect, useState } from "react";
-import { ArrowDownToLine, Loader2, RefreshCw, Sparkles, X } from "lucide-react";
+import { ArrowDownToLine, Loader2, PackageOpen, RefreshCw, Sparkles, X } from "lucide-react";
 import { useUpdaterState } from "@/lib/updater";
 import { cn } from "@/lib/cn";
 
@@ -46,6 +46,10 @@ export function UpdateBanner() {
   // while busy the card owns the moment: no dismissing, no second click
   const installing = s.status === "installing";
   const busy = s.status === "downloading" || installing;
+  // Ubuntu system packages can't be swapped under a running app, so the
+  // download is handed to the package manager and the user finishes there.
+  // Nothing restarts, and the card has to stop promising that it will.
+  const handoff = s.installMode === "handoff";
 
   const title =
     s.status === "available"
@@ -55,8 +59,12 @@ export function UpdateBanner() {
         : s.status === "downloaded"
           ? `${s.version} is ready`
           : installing
-            ? "Restarting to update…"
-            : "Update check failed";
+            ? handoff
+              ? "Opening your package manager…"
+              : "Restarting to update…"
+            : s.status === "handed-off"
+              ? "Finish the install"
+              : "Update check failed";
   const subtitle =
     s.status === "available"
       ? "A newer version is ready to download."
@@ -66,10 +74,16 @@ export function UpdateBanner() {
           ? "Starting download…"
           : `${Math.round(s.percent)}%`
         : s.status === "downloaded"
-          ? "Restart to finish updating."
+          ? handoff
+            ? "Install it with your package manager."
+            : "Restart to finish updating."
           : installing
-            ? "OpenMausBot will reopen in a moment."
-            : friendlyError(s.message);
+            ? handoff
+              ? "Complete the install there, then reopen OpenMausBot."
+              : "OpenMausBot will reopen in a moment."
+            : s.status === "handed-off"
+              ? "Complete it in your package manager, then reopen OpenMausBot."
+              : friendlyError(s.message);
 
   return (
     <div className="animate-panel-in fixed bottom-4 left-4 z-50 w-[300px] rounded-xl border border-hairline/40 bg-panel p-3.5 shadow-2xl shadow-black/50">
@@ -114,7 +128,7 @@ export function UpdateBanner() {
             disabled
             className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-control py-1.5 text-[13px] font-medium text-ink-secondary"
           >
-            <Loader2 size={13} className="animate-spin" /> Restarting…
+            <Loader2 size={13} className="animate-spin" /> {handoff ? "Opening…" : "Restarting…"}
           </button>
         </div>
       )}
@@ -152,7 +166,11 @@ export function UpdateBanner() {
             >
               {pending === "install" ? (
                 <>
-                  <Loader2 size={13} className="animate-spin" /> Restarting…
+                  <Loader2 size={13} className="animate-spin" /> {handoff ? "Opening…" : "Restarting…"}
+                </>
+              ) : handoff ? (
+                <>
+                  <PackageOpen size={13} /> Install
                 </>
               ) : (
                 <>
@@ -184,7 +202,8 @@ export function UpdateBanner() {
             disabled={pending !== null}
             className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-50 disabled:hover:bg-transparent"
           >
-            Later
+            {/* after a hand-off there is nothing left to postpone */}
+            {s.status === "handed-off" ? "Done" : "Later"}
           </button>
         </div>
       )}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -47,7 +47,7 @@ export function UpdateBanner() {
   const installing = s.status === "installing";
   const busy = s.status === "downloading" || installing;
   // Ubuntu system packages can't be swapped under a running app, so the
-  // download is handed to the package manager and the user finishes there.
+  // command is copied and a terminal opens; the user finishes there.
   // Nothing restarts, and the card has to stop promising that it will.
   const handoff = s.installMode === "handoff";
 
@@ -60,7 +60,7 @@ export function UpdateBanner() {
           ? `${s.version} is ready`
           : installing
             ? handoff
-              ? "Opening your package manager…"
+              ? "Opening a terminal…"
               : "Restarting to update…"
             : s.status === "handed-off"
               ? "Finish in a terminal"

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -265,7 +265,7 @@ type SkillRecordingPayload = {
       updater?: {
         check(): Promise<void>;
         download(): Promise<void>;
-        /** quit-and-install the downloaded update */
+        /** apply the download: quit-and-install, or hand it to the package manager */
         install(): Promise<void>;
         onState(cb: (s: UpdaterState) => void): () => void;
       };
@@ -294,10 +294,18 @@ export interface UpdaterState {
     | "downloading"
     | "downloaded"
     | "installing"
+    /** the package manager has the download; the user finishes there */
+    | "handed-off"
     | "error";
   version?: string;
   percent?: number;
   message?: string;
+  /**
+   * How the download gets applied. "restart" quits and installs in place;
+   * "handoff" opens the downloaded package in the system package manager,
+   * which is what Ubuntu .deb (and rpm/pacman) builds use.
+   */
+  installMode?: "restart" | "handoff";
 }
 
 export interface CompanionAccountState {

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -265,7 +265,7 @@ type SkillRecordingPayload = {
       updater?: {
         check(): Promise<void>;
         download(): Promise<void>;
-        /** apply the download: quit-and-install, or hand it to the package manager */
+        /** apply the download: quit-and-install, or copy the command and open a terminal */
         install(): Promise<void>;
         onState(cb: (s: UpdaterState) => void): () => void;
       };
@@ -294,7 +294,7 @@ export interface UpdaterState {
     | "downloading"
     | "downloaded"
     | "installing"
-    /** the package manager has the download; the user finishes there */
+    /** the command is on the clipboard; the user finishes in a terminal */
     | "handed-off"
     | "error";
   version?: string;
@@ -302,8 +302,8 @@ export interface UpdaterState {
   message?: string;
   /**
    * How the download gets applied. "restart" quits and installs in place;
-   * "handoff" opens the downloaded package in the system package manager,
-   * which is what Ubuntu .deb (and rpm/pacman) builds use.
+   * "handoff" copies the install command and opens a terminal so the user
+   * can finish — Ubuntu .deb (and rpm/pacman) builds use this.
    */
   installMode?: "restart" | "handoff";
   /** hand-off only: the install command, already on the clipboard */

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -306,6 +306,10 @@ export interface UpdaterState {
    * which is what Ubuntu .deb (and rpm/pacman) builds use.
    */
   installMode?: "restart" | "handoff";
+  /** hand-off only: the install command, already on the clipboard */
+  command?: string;
+  /** hand-off only: whether a terminal was opened to paste it into */
+  terminalOpened?: boolean;
 }
 
 export interface CompanionAccountState {


### PR DESCRIPTION
Fixes #645.

The in-app updater ran unchanged on both Ubuntu artifacts, and on each one it did something the platform does not want. This splits the two, matching what each ecosystem expects.

## AppImage — the update stops renaming the file

`AppImageUpdater.doInstall` only overwrites in place when the running file has no version in its name; otherwise it writes the release asset's filename and unlinks the old one. Our feed names assets after the version, so anyone running `OpenMausBot-<version>-x86_64.AppImage` ended up with a new file and **nothing at the old path** — every `.desktop` entry, symlink, dock pin and AppImageLauncher registration pointing at it broke, and the app vanished from the launcher.

`scripts/patch-appimage-updater.mjs` rewrites that branch at bundle time, so the update always lands on the path the user launches, whatever they named it. The patch throws when upstream's shape moves — a regenerated bundle cannot silently lose it.

## `.deb` — the app stops installing system packages

`resources/package-type` selects `DebUpdater`, so **Restart to update** ran:

```
pkexec --disable-internal-agent /bin/bash -c 'dpkg -i ~/.cache/openmausbot-updater/pending/OpenMausBot-X-amd64.deb'
```

A polkit root prompt out of what the user experiences as a chat app; `dpkg -i` resolving no dependencies (with a **second** prompt on the `apt-get install -f -y` fallback); and `/opt/OpenMausBot` replaced while the process is still running, since `quitAndInstall` installs first and quits after.

`electron/updater.mjs` now detects the package type the way electron-updater does (`resources/package-type`, `APPIMAGE` as fallback) and hands the downloaded package to the desktop instead of installing it. The banner says **Install** rather than **Restart to update**, and a new `handed-off` state tells the user where to finish.

This also makes the shipped documentation true again — it already promised that Ubuntu packages are updated by installing a downloaded package.

## Tests

Nothing covered either path: the CI deb upgrade runs `dpkg` directly as root, which validates the package, not the updater.

- `electron/vendor-updater.node-test.mjs` — runs the **shipped** `AppImageUpdater.doInstall` against real files and asserts the update lands on the launched path, the staged download is consumed, and no extra file appears. Plus textual invariants on the committed bundle and fail-closed coverage of the patch itself.
- `electron/updater-coordinator.node-test.mjs` — the hand-off receives the staged paths and ends in `handed-off`; a failed hand-off surfaces as an error instead of spinning; the restart path still calls `quitAndInstall`.
- `scripts/verify-linux-package.mjs` — asserts the `.deb` ships `package-type: deb` and the AppImage ships **no** marker. That marker is what routes the two artifacts; if packaging ever inverts it, this fix dies silently.

## Verification

| Check | Result |
|---|---|
| `node --test electron/*.node-test.mjs` | 69/69 pass |
| `pnpm typecheck` | clean |
| `pnpm lint` | no findings in changed files |
| `pnpm vitest run` | 2753 pass, 4 fail |

The 4 vitest failures are `server/skills.test.ts` (3, symlink handling) and `electron/browser-closed-shadow.electron.test.mjs` (1). They reproduce identically on a pristine `main` with this branch's changes stashed — pre-existing on this host, unrelated to these files.

## What is not covered

I have not run a real packaged update end to end — that needs a published release newer than the installed build. The AppImage install path is covered behaviourally against the shipped bundle; the `.deb` hand-off is covered at the coordinator boundary, with `shell.openPath` itself left to the desktop.

On a stock Ubuntu 24.04 the registered handler for `application/vnd.debian.binary-package` is App Center. If it opens but cannot complete the install, the package is already downloaded and the troubleshooting doc carries the `apt-get` command; when no handler is registered at all, OpenMausBot reveals the file instead.

## Deliberately left alone

`DebUpdater` stays in the vendored bundle — we simply never route to it. Keeping the patch surface minimal, with `verify-linux-package.mjs` guarding the routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux package updates now copy an installation command and open a terminal for completion.
  * Update prompts display the installation command and whether the terminal opened successfully.
  * Ubuntu 24.04 guidance now uses `apt-get` to resolve dependencies.
  * AppImage updates preserve the existing filename and launch path.

* **Bug Fixes**
  * Improved guidance when a terminal does not open.
  * Improved Linux update reliability and error handling.
  * Linux updates now support package paths containing special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->