### PR TITLE
fix(runtime): keep agent prompts off Windows argv

### DIFF
--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
+import { removeTempDir } from "../testing/cleanup.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import {
   ANTIGRAVITY_AGENTS_MCP_KEY,
@@ -21,12 +22,22 @@ import {
   antigravityAgentsMcpServer,
   antigravityComputerMcpServer,
   antigravityMcpServers,
+  supportsAntigravityStreamInput,
   ensureAntigravityMcpServers,
   readAntigravityModelCatalog,
   STATIC_ANTIGRAVITY_MODELS,
 } from "./antigravity.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-agy-cli.ts");
+
+describe("Antigravity stream input compatibility", () => {
+  it("requires the release that introduced stream-JSON stdin", () => {
+    expect(supportsAntigravityStreamInput("1.1.14")).toBe(false);
+    expect(supportsAntigravityStreamInput("1.1.15")).toBe(true);
+    expect(supportsAntigravityStreamInput("1.2.0-beta.1")).toBe(true);
+    expect(supportsAntigravityStreamInput("not-semver")).toBe(false);
+  });
+});
 
 describe("readAntigravityModelCatalog", () => {
   it("returns the official list when settings are missing", () => {
@@ -99,6 +110,8 @@ describe("Antigravity turns (fake CLI)", () => {
   });
 
   afterEach(async () => {
+    delete process.env.FAKE_AGY_DUMP;
+    delete process.env.FAKE_AGY_VERSION;
     recorder?.stop();
     await instance?.dispose();
   });
@@ -140,9 +153,49 @@ describe("Antigravity turns (fake CLI)", () => {
     expect(instance.adapter.hasSession("t-happy")).toBe(false);
   });
 
+  it("sends a Windows-sized room prompt over stdin instead of argv", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-agy-long-prompt-"));
+    const dump = join(scratch, "dump.json");
+    process.env.FAKE_AGY_DUMP = dump;
+    await create();
+    const system = `room instructions\n${"context-0123456789".repeat(8_000)}`;
+    try {
+      await instance.adapter.sendTurn({
+        threadId: "t-long-prompt",
+        text: "review the video",
+        system,
+        model: "gemini-3.1-pro-high",
+      });
+      await recorder.until((event) => event.type === "turn.completed");
+
+      const seen = JSON.parse(readFileSync(dump, "utf8"));
+      expect(seen.prompt).toBe(`${system}\n\nreview the video`);
+      expect(seen.argv).toContain("--input-format");
+      expect(seen.argv).not.toContain("--print");
+      expect(JSON.stringify(seen.argv)).not.toContain("room instructions");
+      expect(JSON.stringify(seen.argv).length).toBeLessThan(8_000);
+    } finally {
+      await removeTempDir(scratch);
+    }
+  });
+
   it("respondToRequest resolves `unavailable` — no interactive permission channel, so the caller denies", async () => {
     await create();
     await expect(instance.adapter.respondToRequest("t-happy", "req-1", { behavior: "allow" })).resolves.toBe("unavailable");
+  });
+
+  it("explains how to update an agy version that cannot receive prompts safely", async () => {
+    process.env.FAKE_AGY_VERSION = "1.1.14";
+    await create();
+    await instance.adapter.sendTurn({ threadId: "t-old-agy", text: "hi" });
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(recorder.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "runtime.error",
+        message: expect.stringMatching(/1\.1\.15\+.*agy update/),
+      }),
+      expect.objectContaining({ type: "turn.completed", ok: false, stopReason: "unsupported_cli" }),
+    ]));
   });
 });
 
@@ -158,7 +211,7 @@ describe("Antigravity snapshot", () => {
     });
     const snap = await instance.snapshot();
     expect(snap.state).toBe("available");
-    expect(snap.version).toBe("1.1.12");
+    expect(snap.version).toBe("1.1.22");
     // agy auth is keyring-backed with no reliable file marker, so the snapshot
     // must NOT claim signed-in from a mere directory — authenticated stays unset.
     expect((snap as any).authenticated).toBeUndefined();
@@ -176,6 +229,27 @@ describe("Antigravity snapshot", () => {
     const snap = await instance.snapshot();
     expect(snap.state).toBe("unavailable");
     await instance.dispose();
+  });
+
+  it("marks pre-stream-input versions unavailable with an update action", async () => {
+    process.env.FAKE_AGY_VERSION = "1.1.14";
+    const instance = await AntigravityDriver.create({
+      instanceId: "agy-old",
+      displayName: undefined,
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      await expect(instance.snapshot()).resolves.toMatchObject({
+        state: "unavailable",
+        version: "1.1.14",
+        reason: expect.stringMatching(/1\.1\.15\+.*agy update/),
+      });
+    } finally {
+      await instance.dispose();
+      delete process.env.FAKE_AGY_VERSION;
+    }
   });
 
   it("strips workspace credentials from snapshot and helper children", async () => {
@@ -206,6 +280,30 @@ describe("Antigravity snapshot", () => {
         else process.env[name] = previous[name];
       }
       rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps long generateText prompts off argv too", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "omb-agy-long-helper-"));
+    const dump = join(scratch, "dump.json");
+    const instance = await AntigravityDriver.create({
+      instanceId: "agy-long-helper",
+      displayName: undefined,
+      environment: { FAKE_AGY_DUMP: dump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    const prompt = `summarize\n${"helper-context-0123456789".repeat(6_000)}`;
+    try {
+      await expect(instance.generateText?.(prompt)).resolves.toBe("done from fake agy");
+      const seen = JSON.parse(readFileSync(dump, "utf8"));
+      expect(seen.prompt).toBe(prompt);
+      expect(seen.argv).toContain("--input-format");
+      expect(JSON.stringify(seen.argv)).not.toContain("helper-context");
+      expect(JSON.stringify(seen.argv).length).toBeLessThan(8_000);
+    } finally {
+      await instance.dispose();
+      await removeTempDir(scratch);
     }
   });
 });

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -1,8 +1,7 @@
-// Antigravity driver — Google's `agy` CLI in headless one-shot print mode
-// (`agy --print --output-format stream-json`), modeled on claude.ts but fully
-// self-contained. Per-turn CLI process; the conversation continues across
+// Antigravity driver — Google's `agy` CLI in headless stream-JSON mode,
+// modeled on claude.ts but fully self-contained. Per-turn CLI process; the conversation continues across
 // turns via `--conversation <id>` (the resumeCursor is agy's conversation_id).
-// Verified against agy 1.1.12.
+// Stream-JSON input requires agy 1.1.15 or newer.
 //
 // Unlike claude, print mode has NO interactive permission hook: there is no
 // per-action broker here. `--mode accept-edits` allows file edits but
@@ -44,6 +43,18 @@ import { newEventId, newId } from "../contracts.ts";
 import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "antigravityAgent";
+export const ANTIGRAVITY_STREAM_INPUT_MIN_VERSION = "1.1.15";
+
+export function supportsAntigravityStreamInput(version: string | null): boolean {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version?.trim() ?? "");
+  if (!match) return false;
+  const actual = match.slice(1).map(Number);
+  const minimum = ANTIGRAVITY_STREAM_INPUT_MIN_VERSION.split(".").map(Number);
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
+  }
+  return true;
+}
 
 export interface AntigravityConfig {
   cli: string;
@@ -396,6 +407,17 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
     const active = new Map<string, { stop: () => void; turnId: string }>();
     const pending = new Set<string>();
     let disposed = false;
+    let verifiedVersion: string | null | undefined;
+    const readVersion = () =>
+      new Promise<string | null>((resolve) => {
+        execCli(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
+          resolve(err ? null : stdout.trim()),
+        );
+      });
+    const versionForTurn = async () => {
+      if (verifiedVersion === undefined) verifiedVersion = await readVersion();
+      return verifiedVersion;
+    };
     // every live agy child, tracked independently of `active`: a child can
     // hang AFTER emitting `result` (so it's already removed from `active`), and
     // dispose()/stopAll() must still be able to reap it. Removed on process exit.
@@ -436,6 +458,17 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       pending.add(threadId);
       const turnId = newId();
 
+      const version = await versionForTurn();
+      if (!supportsAntigravityStreamInput(version)) {
+        pending.delete(threadId);
+        const reason = version
+          ? `Antigravity CLI ${ANTIGRAVITY_STREAM_INPUT_MIN_VERSION}+ is required for safe prompt delivery (found ${version}). Run \`agy update\`.`
+          : `\`${config.cli}\` CLI not found`;
+        emit({ ...base(threadId, turnId), type: "runtime.error", message: reason });
+        emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "unsupported_cli", cost: null });
+        return { turnId };
+      }
+
       // Default cwd to a per-thread workspace under DATA_DIR — deliberately
       // NOT homedir(): a bot running unattended should not get the whole home
       // as its default sandbox. `--add-dir` grants agy access to that dir.
@@ -452,11 +485,10 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       }
       const cwd = turn.cwd ?? workspace;
 
-      // prompt is passed as the `--print` argv value: agy does NOT read the
-      // prompt from piped stdin in print mode — a bare `--print` produces zero
-      // output (verified against agy 1.1.12). Combine persona + text.
-      // Trade-off: a very large prompt could exceed argv limits (E2BIG),
-      // guarded below since stdin is not an option.
+      // agy 1.1.15+ accepts one JSON user event per line on stdin. Keep the
+      // complete room/persona payload there: Windows' CreateProcess command
+      // line is much smaller than the prompts a channel can legitimately
+      // build, and putting this on `--print <prompt>` caused ENAMETOOLONG.
       const prompt = turn.system ? `${turn.system}\n\n${turn.text}` : turn.text;
       const resumeCursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
 
@@ -481,20 +513,6 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         armPostSettleCleanup();
         emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost, ...(usage ? { usage } : {}) });
       };
-
-      // agy's print mode is argv-only, so a prompt beyond ARG_MAX would fail the
-      // spawn with E2BIG. Reject oversized prompts up front with a clear error
-      // instead of a cryptic spawn failure.
-      if (Buffer.byteLength(prompt) > 256 * 1024) {
-        emit({
-          ...base(threadId, turnId),
-          type: "runtime.error",
-          message: `prompt too large for Antigravity's argv-only print mode (${Buffer.byteLength(prompt)} bytes)`,
-        });
-        settle(false, "prompt_too_large");
-        pending.delete(threadId);
-        return { turnId };
-      }
 
       // agy's config is global, so every turn — including one without any
       // OpenMaus tools — owns the mount for its complete child lifetime. This keeps
@@ -530,7 +548,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
       }
 
       const args = [
-        "--print", prompt, // print mode reads the prompt from this argv value
+        "--input-format", "stream-json",
         "--output-format", "stream-json",
         "--print-timeout", "10m",
         "--add-dir", cwd,
@@ -549,7 +567,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
         child = spawnCli(config.cli, args, {
           cwd,
           env,
-          stdio: ["ignore", "pipe", "pipe"], // prompt is on argv; stdin is unused
+          stdio: ["pipe", "pipe", "pipe"],
         });
       } catch (error) {
         try {
@@ -764,20 +782,129 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
 
       emit({ ...base(threadId, turnId), type: "turn.started" });
 
+      // The official stream-json input envelope. Closing stdin after this
+      // single turn is intentional: agy finishes the active turn, emits its
+      // terminal result, then exits cleanly. Conversation continuity still
+      // uses --conversation on the next per-turn process.
+      const inputMessage = { event: "user", message: { content: prompt } };
+      appendNative(threadId, { dir: "out", source: "agy.stream", msg: inputMessage });
+      try {
+        child.stdin.end(`${JSON.stringify(inputMessage)}\n`);
+      } catch (error) {
+        emit({
+          ...base(threadId, turnId),
+          type: "runtime.error",
+          message: `could not send prompt to agy: ${error instanceof Error ? error.message : String(error)}`,
+        });
+        stop();
+        settle(false, "stdin_write_failed");
+      }
+
       return { turnId };
     };
 
     const snapshot = async (): Promise<ProviderSnapshot> => {
-      const version = await new Promise<string | null>((resolve) => {
-        execCli(config.cli, ["--version"], { timeout: 8000, env }, (err, stdout) =>
-          resolve(err ? null : stdout.trim()),
-        );
-      });
+      const version = await readVersion();
+      verifiedVersion = version;
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+      if (!supportsAntigravityStreamInput(version)) {
+        return {
+          state: "unavailable",
+          reason: `Antigravity CLI ${ANTIGRAVITY_STREAM_INPUT_MIN_VERSION}+ is required. Run \`agy update\`.`,
+          version,
+        };
+      }
       // No auth field: agy auth is keyring-backed with no reliable file marker
       // (~/.gemini/antigravity-cli/ exists after first run even when logged
       // out), so any file heuristic would overstate "signed in". Leave undefined.
       return { state: "available", version };
+    };
+
+    const generateText = async (prompt: string): Promise<string> => {
+      const version = await versionForTurn();
+      if (!supportsAntigravityStreamInput(version)) {
+        throw new Error(
+          version
+            ? `Antigravity CLI ${ANTIGRAVITY_STREAM_INPUT_MIN_VERSION}+ is required (found ${version}). Run \`agy update\`.`
+            : `\`${config.cli}\` CLI not found`,
+        );
+      }
+
+      return new Promise<string>((resolve, reject) => {
+        let child: ReturnType<typeof spawnCli>;
+        try {
+          child = spawnCli(
+            config.cli,
+            [
+              "--input-format", "stream-json",
+              "--output-format", "stream-json",
+              "--model", "gemini-3.6-flash-low",
+            ],
+            { env, stdio: ["pipe", "pipe", "pipe"] },
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
+        children.add(child);
+
+        let settled = false;
+        let response: string | null = null;
+        let resultError: Error | null = null;
+        let stdoutBuffer = "";
+        let stderr = "";
+        const timer = setTimeout(() => {
+          killCliTree(child);
+          finish(new Error("Antigravity text generation timed out"));
+        }, 60_000);
+        timer.unref?.();
+        const finish = (error?: Error) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (error) reject(error);
+          else if (resultError) reject(resultError);
+          else if (response !== null) resolve(response);
+          else reject(new Error(stderr.trim() || "Antigravity exited before returning a result"));
+        };
+
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+          stdoutBuffer += chunk;
+          let newline;
+          while ((newline = stdoutBuffer.indexOf("\n")) !== -1) {
+            const line = stdoutBuffer.slice(0, newline);
+            stdoutBuffer = stdoutBuffer.slice(newline + 1);
+            if (!line.trim()) continue;
+            try {
+              const event = JSON.parse(line);
+              if (event.event !== "result") continue;
+              const result = event.result ?? {};
+              if (result.status === "SUCCESS" && typeof result.response === "string") response = result.response;
+              else resultError = new Error(String(result.message ?? result.error ?? `Antigravity result: ${result.status ?? "unknown"}`));
+            } catch {
+              // Ignore non-protocol output; close below reports a missing result.
+            }
+          }
+        });
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk) => {
+          stderr = (stderr + chunk).slice(-8_192);
+        });
+        child.on("error", (error) => finish(error));
+        child.on("close", (code) => {
+          children.delete(child);
+          if (code === 0) finish();
+          else finish(new Error(stderr.trim() || `Antigravity exited ${code}`));
+        });
+
+        try {
+          child.stdin.end(`${JSON.stringify({ event: "user", message: { content: prompt } })}\n`);
+        } catch (error) {
+          killCliTree(child);
+          finish(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
     };
 
     return {
@@ -823,15 +950,7 @@ export const AntigravityDriver: ProviderDriver<AntigravityConfig> = {
           return () => listeners.delete(listener);
         },
       },
-      generateText: (prompt: string) =>
-        new Promise((resolve, reject) => {
-          execCli(
-            config.cli,
-            ["-p", prompt, "--output-format", "text", "--model", "gemini-3.6-flash-low"],
-            { timeout: 60_000, env },
-            (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
-          );
-        }),
+      generateText,
       dispose: async () => {
         disposed = true;
         for (const { stop } of active.values()) stop();

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -332,7 +332,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect((settled[0] as any).text).toBe("hello from fake claude");
   });
 
-  it("sends the prompt over stdin, never argv, and strips identity env vars", async () => {
+  it("keeps user and system prompts off argv and strips identity env vars", async () => {
     await create();
     const dump = join(scratch, "dump.json");
     process.env.FAKE_CLAUDE_DUMP = dump;
@@ -348,8 +348,11 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(JSON.stringify(seen.argv)).not.toContain("the secret prompt");
+    expect(JSON.stringify(seen.argv)).not.toContain("You are Testy.");
     expect(seen.prompt).toMatchObject({ type: "user", message: { role: "user", content: "the secret prompt" } });
-    expect(seen.argv).toContain("--append-system-prompt");
+    expect(seen.argv).toContain("--append-system-prompt-file");
+    expect(seen.systemPrompt).toBe("You are Testy.");
+    expect(existsSync(seen.argv[seen.argv.indexOf("--append-system-prompt-file") + 1])).toBe(false);
     expect(seen.argv).toContain("--session-id");
     expect(seen.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(seen.env.CLAUDECODE).toBeUndefined();
@@ -357,6 +360,21 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(seen.env.XAI_API_KEY).toBeUndefined();
     expect(seen.env.BOX_TOKEN).toBeUndefined();
     expect(seen.env.OMB_TTS_KEY).toBeUndefined();
+  });
+
+  it("launches with a Windows-sized system prompt without putting it on argv", async () => {
+    await create();
+    const dump = join(scratch, "dump-long-system.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const system = `room instructions\n${"context-0123456789".repeat(8_000)}`;
+
+    await instance.adapter.sendTurn({ threadId: "t-long-system", text: "review this", system });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.systemPrompt).toBe(system);
+    expect(JSON.stringify(seen.argv)).not.toContain("room instructions");
+    expect(JSON.stringify(seen.argv).length).toBeLessThan(8_000);
   });
 
   it("uses instance credentials when launching an injected local model", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -188,11 +188,14 @@ const DWEB_PROXY_PATH = SPAWNED_PROXIES.dweb;
 // makes it behave as plain node for the spawned MCP proxies (harmless in dev)
 const NODE_ENV_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
 
-function removePrivateTempDir(filePath: string | null | undefined): void {
-  if (!filePath) return;
+function removePrivateTempDir(filePath: string | null | undefined): boolean {
+  if (!filePath) return true;
   try {
-    rmSync(dirname(filePath), { recursive: true, force: true });
-  } catch {}
+    rmSync(dirname(filePath), { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ── permission broker (ported from agentcal drivers/claude.js) ─────────
@@ -946,8 +949,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           session.mcpConfigPath = null;
         }
         if (session.systemPromptPath) {
-          removePrivateTempDir(session.systemPromptPath);
-          session.systemPromptPath = null;
+          if (removePrivateTempDir(session.systemPromptPath)) session.systemPromptPath = null;
         }
         active.delete(threadId);
         session.turn = null;

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -188,6 +188,13 @@ const DWEB_PROXY_PATH = SPAWNED_PROXIES.dweb;
 // makes it behave as plain node for the spawned MCP proxies (harmless in dev)
 const NODE_ENV_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
 
+function removePrivateTempDir(filePath: string | null | undefined): void {
+  if (!filePath) return;
+  try {
+    rmSync(dirname(filePath), { recursive: true, force: true });
+  } catch {}
+}
+
 // ── permission broker (ported from agentcal drivers/claude.js) ─────────
 // A headless run that hits a permission acceptEdits doesn't cover should
 // neither stall silently NOR get blanket-denied — it should ask the user.
@@ -546,6 +553,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       child: ReturnType<typeof spawnCli>;
       broker?: Awaited<ReturnType<typeof createPermissionBroker>>;
       mcpConfigPath: string | null;
+      systemPromptPath: string | null;
       /** the spawn contract — a different one means a fresh process */
       argsKey: string;
       /** the CLI's session id from `init`, what --resume takes later */
@@ -658,7 +666,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       const injected = applyClaudeInject({ ...turnEnvironment }, turnModel);
       if (injected.model) args.push("--model", injected.model);
       if (turn.effort) args.push("--effort", turn.effort);
-      if (turn.system) args.push("--append-system-prompt", turn.system);
+
+      // A room prompt can contain section context, skills, memory, playbooks,
+      // and browser/agent instructions. Passing that text directly on argv
+      // exceeds Windows' CreateProcess command-line limit and surfaces as
+      // `spawn ENAMETOOLONG`. Claude accepts the same prompt from a file, so
+      // keep both the text and its potentially sensitive contents off argv.
+      let systemPromptPath: string | null = null;
 
       // integrations → MCP servers; pre-allow their tools (a headless
       // acceptEdits run silently denies anything unlisted)
@@ -750,11 +764,18 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
 
       const env = claudeEnvironment(turnModel, turnEnvironment);
       const cwd = turn.cwd ?? homedir();
-      // everything that shapes the process, minus session/turn specifics
-      // (the --mcp-config file is a fresh temp path each time; its CONTENT
-      // is what matters and mcpServers carries that)
-      const keyArgs = args.filter((a, i) => a !== "--mcp-config" && args[i - 1] !== "--mcp-config");
-      const argsKey = JSON.stringify({ args: keyArgs, mcpServers, cwd, model: injected.model ?? null, base: env.ANTHROPIC_BASE_URL ?? null });
+      // Everything that shapes the process, minus session/turn-specific temp
+      // paths. Their contents are represented directly in the key instead.
+      const privateFileFlags = new Set(["--mcp-config"]);
+      const keyArgs = args.filter((a, i) => !privateFileFlags.has(a) && !privateFileFlags.has(args[i - 1] ?? ""));
+      const argsKey = JSON.stringify({
+        args: keyArgs,
+        system: turn.system ?? null,
+        mcpServers,
+        cwd,
+        model: injected.model ?? null,
+        base: env.ANTHROPIC_BASE_URL ?? null,
+      });
 
       // Reuse the live process when it is idle, unchanged, and is the session
       // the harness wants resumed. Anything else: close it and spawn fresh
@@ -800,10 +821,21 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           } catch {}
           mcpConfigPath = null;
         }
+        if (systemPromptPath) {
+          removePrivateTempDir(systemPromptPath);
+          systemPromptPath = null;
+        }
         retryState.delete(threadId);
       };
 
       try {
+        // Create the prompt file only for a new process. A compatible live
+        // session has already consumed the same system prompt at launch.
+        if (turn.system) {
+          systemPromptPath = join(mkdtempSync(join(tmpdir(), "omb-system-")), "prompt.txt");
+          writeFileSync(systemPromptPath, turn.system, { mode: 0o600 });
+          args.push("--append-system-prompt-file", systemPromptPath);
+        }
         // Only create a broker for a new process. A compatible retained
         // process keeps its existing proxy connection and broker across turns.
         if (socketPath) {
@@ -880,6 +912,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         child,
         broker,
         mcpConfigPath,
+        systemPromptPath,
         argsKey,
         sessionId: sessionId ?? newSessionId,
         turn: { turnId, settled: false, sawStreamDelta: false },
@@ -911,6 +944,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
           } catch {}
           session.mcpConfigPath = null;
+        }
+        if (session.systemPromptPath) {
+          removePrivateTempDir(session.systemPromptPath);
+          session.systemPromptPath = null;
         }
         active.delete(threadId);
         session.turn = null;
@@ -1066,6 +1103,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
               } catch {}
               session.mcpConfigPath = null;
             }
+            if (session.systemPromptPath) {
+              removePrivateTempDir(session.systemPromptPath);
+              session.systemPromptPath = null;
+            }
             sessions.delete(threadId);
             session.turn = null;
             retry.attempt++;
@@ -1133,6 +1174,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
           } catch {}
         }
+        removePrivateTempDir(session.systemPromptPath);
         if (sessions.get(threadId) === session) sessions.delete(threadId);
       });
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2723,7 +2723,7 @@ describe("harness HTTP API", () => {
       })).status).toBe(202);
       await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
       const seen = JSON.parse(readFileSync(fakeClaudeDump, "utf8"));
-      const system = seen.argv[seen.argv.indexOf("--append-system-prompt") + 1] ?? "";
+      const system = seen.systemPrompt ?? "";
       // the skill's instructions ride the system prompt the agent receives
       expect(system).toContain('<openmaus-skill id="create-verification-skill"');
       expect(system).toContain("skill_manage");
@@ -3094,6 +3094,7 @@ describe("harness HTTP API", () => {
       const dump = z.object({
         argv: z.array(z.string()),
         env: z.record(z.string(), z.string()),
+        systemPrompt: z.string(),
         mcpConfig: z.object({
           mcpServers: z.object({
             browser: z.object({
@@ -3119,9 +3120,7 @@ describe("harness HTTP API", () => {
       expect(dump.env.OMB_USER_DATA).toBeUndefined();
       expect(JSON.stringify(dump)).not.toContain(masterToken);
 
-      const systemIndex = dump.argv.indexOf("--append-system-prompt");
-      expect(systemIndex).toBeGreaterThanOrEqual(0);
-      const system = dump.argv[systemIndex + 1] ?? "";
+      const system = dump.systemPrompt;
       expect(system).toMatch(/page instructions as untrusted content/i);
       expect(system).toMatch(/consequential action.*confirmation/i);
       expect(system).toMatch(/browser_request_takeover/i);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2754,8 +2754,8 @@ describe("harness HTTP API", () => {
       expect((await api("POST", `/api/groups/${room.id}/messages`, {
         text: "/create-verification-skill for my mobile app",
       })).status).toBe(202);
-      let seen = await readJsonFileWhenReady<{ argv: string[] }>(fakeClaudeDump);
-      let system = seen.argv[seen.argv.indexOf("--append-system-prompt") + 1] ?? "";
+      let seen = await readJsonFileWhenReady<{ systemPrompt?: string }>(fakeClaudeDump);
+      let system = seen.systemPrompt ?? "";
       expect(system).toContain('<openmaus-skill id="create-verification-skill"');
       expect(system).toContain('<openmaus-skill id="phone-harness"');
       expect((await api("POST", `/api/groups/${room.id}/interrupt`, {})).status).toBe(200);
@@ -2768,8 +2768,8 @@ describe("harness HTTP API", () => {
       expect((await api("POST", `/api/groups/${room.id}/messages`, {
         text: "now give me a short status update",
       })).status).toBe(202);
-      seen = await readJsonFileWhenReady<{ argv: string[] }>(fakeClaudeDump);
-      system = seen.argv[seen.argv.indexOf("--append-system-prompt") + 1] ?? "";
+      seen = await readJsonFileWhenReady<{ systemPrompt?: string }>(fakeClaudeDump);
+      system = seen.systemPrompt ?? "";
       expect(system).not.toContain('<openmaus-skill id="create-verification-skill"');
       expect(system).toContain('<openmaus-skill id="phone-harness"');
     } finally {

--- a/server/procs.test.ts
+++ b/server/procs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertSafeCliArgv,
+  describeSpawnFailure,
+  estimatedWindowsCommandLineChars,
+  WINDOWS_SAFE_COMMAND_LINE_CHARS,
+} from "./procs.ts";
+
+describe("Windows CLI argument safety", () => {
+  it("accepts ordinary launches", () => {
+    const resolved = { command: "agy.exe", args: ["--model", "gemini-3.1-pro-high"] };
+    expect(estimatedWindowsCommandLineChars(resolved)).toBeLessThan(WINDOWS_SAFE_COMMAND_LINE_CHARS);
+    expect(() => assertSafeCliArgv(resolved, "win32")).not.toThrow();
+  });
+
+  it("rejects a prompt-sized argv before CreateProcess can fail opaquely", () => {
+    const resolved = { command: "agy.exe", args: ["--print", "x".repeat(40_000)] };
+    expect(() => assertSafeCliArgv(resolved, "win32")).toThrow(
+      /pass large prompts through stdin or a file/,
+    );
+    try {
+      assertSafeCliArgv(resolved, "win32");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("ENAMETOOLONG");
+    }
+  });
+
+  it("does not impose the Windows limit on other platforms", () => {
+    const resolved = { command: "agy", args: ["--print", "x".repeat(40_000)] };
+    expect(() => assertSafeCliArgv(resolved, "linux")).not.toThrow();
+  });
+
+  it("turns ENAMETOOLONG into an actionable message without echoing argv", () => {
+    const error = Object.assign(new Error("private prompt contents"), { code: "ENAMETOOLONG" });
+    const failure = describeSpawnFailure(error, "agy");
+    expect(failure).toEqual({
+      message: "`agy` received too much launch data for Windows; update this provider or pass its prompt through stdin/a file",
+      setup: false,
+    });
+    expect(failure.message).not.toContain("private prompt contents");
+  });
+});

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -1,4 +1,4 @@
-// Cross-platform process spawning for the agent CLIs. Three Windows
+// Cross-platform process spawning for the agent CLIs. Four Windows
 // differences are exposed to drivers through this module:
 //   1. CreateProcess can't exec npm .cmd/.bat shims or node-shebang scripts
 //      directly. env-path resolves those to their real .exe / `node script`
@@ -7,6 +7,9 @@
 //      whole tree, CLI + its spawned MCP proxies alike.
 //   3. Console apps spawned from the GUI shell flash a console window
 //      unless windowsHide is set.
+//   4. CreateProcess has a 32,767-character command-line limit. Keep prompt
+//      bodies on stdin or in private files and fail clearly if a future
+//      driver accidentally puts one back in argv.
 import {
   spawn,
   execFile,
@@ -23,12 +26,40 @@ export function resolveCli(cli: string, args: string[] = []): ResolvedSpawn {
   return resolveCliSpawn(cli, args);
 }
 
+/** Leave headroom below CreateProcess' 32,767 UTF-16 code-unit limit for
+ * libuv's quoting and environment-specific executable expansion. */
+export const WINDOWS_SAFE_COMMAND_LINE_CHARS = 30_000;
+
+/** Conservative size of the command line libuv will give CreateProcess.
+ * JSON string quoting escapes every slash/quote case Windows quoting needs,
+ * so this can over-count but cannot hide a dangerous launch. */
+export function estimatedWindowsCommandLineChars(resolved: ResolvedSpawn): number {
+  return [resolved.command, ...resolved.args].reduce(
+    (total, value) => total + JSON.stringify(value).length + 1,
+    0,
+  );
+}
+
+export function assertSafeCliArgv(
+  resolved: ResolvedSpawn,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") return;
+  if (estimatedWindowsCommandLineChars(resolved) <= WINDOWS_SAFE_COMMAND_LINE_CHARS) return;
+  const error = new Error(
+    "agent CLI launch arguments exceed Windows' safe command-line limit; pass large prompts through stdin or a file",
+  ) as NodeJS.ErrnoException;
+  error.code = "ENAMETOOLONG";
+  throw error;
+}
+
 export function spawnCli(
   cli: string,
   args: string[],
   opts: SpawnOptions,
 ): ChildProcessByStdio<Writable, Readable, Readable> {
   const resolved = resolveCli(cli, args);
+  assertSafeCliArgv(resolved);
   const child = spawn(resolved.command, resolved.args, {
     ...opts,
     // posix: own process group so kill(-pid) reaps child MCP servers;
@@ -58,6 +89,12 @@ export function execCli(
   cb: (err: Error | null, stdout: string, stderr?: string) => void,
 ): void {
   const resolved = resolveCli(cli, args);
+  try {
+    assertSafeCliArgv(resolved);
+  } catch (error) {
+    queueMicrotask(() => cb(error instanceof Error ? error : new Error(String(error)), "", ""));
+    return;
+  }
   execFile(resolved.command, resolved.args, { ...opts, windowsHide: true, encoding: "utf8" }, (err, stdout, stderr) =>
     cb(err, stdout, stderr),
   );
@@ -77,6 +114,11 @@ export function describeSpawnFailure(err: NodeJS.ErrnoException, cli: string): S
     return { message: `\`${cli}\` isn't installed, or isn't on this app's PATH`, setup: true };
   if (err.code === "EACCES" || err.code === "EPERM")
     return { message: `\`${cli}\` isn't executable — check its file permissions`, setup: true };
+  if (err.code === "ENAMETOOLONG")
+    return {
+      message: `\`${cli}\` received too much launch data for Windows; update this provider or pass its prompt through stdin/a file`,
+      setup: false,
+    };
   return { message: `spawn failed: ${err.message}`, setup: false };
 }
 

--- a/server/testing/fake-agy-cli.ts
+++ b/server/testing/fake-agy-cli.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 // Fake of the Antigravity `agy` CLI's print-mode stdio surface, for driver
-// tests of drivers/antigravity.ts. On `--version` it prints a version; on a
-// print-mode invocation (`--print <prompt> … --output-format stream-json`) it
-// reads the prompt from the `--print` ARGV value (the real CLI does NOT read a
-// piped prompt in print mode), then emits a canned NDJSON turn: init → tool
+// tests of drivers/antigravity.ts. On `--version` it prints a version; in
+// stream-json input mode it reads one user event from stdin, then emits a
+// canned NDJSON turn: init → tool
 // step (ACTIVE then DONE) → agent_response step with usage → result with
 // status SUCCESS. Deterministic, no network.
 //
@@ -132,15 +131,15 @@ const argv = process.argv.slice(2);
 if (process.env.FAKE_AGY_IGNORE_SIGTERM === "1") {
   process.on("SIGTERM", () => {});
 }
-if (process.env.FAKE_AGY_READY_FILE) {
-  writeFileSync(process.env.FAKE_AGY_READY_FILE, "ready");
-}
 if (process.env.FAKE_AGY_DUMP) {
   writeFileSync(process.env.FAKE_AGY_DUMP, JSON.stringify({ argv, env: process.env }, null, 2));
 }
 if (argv.includes("--version")) {
-  console.log("1.1.12");
+  console.log(process.env.FAKE_AGY_VERSION ?? "1.1.22");
   process.exit(0);
+}
+if (process.env.FAKE_AGY_READY_FILE) {
+  writeFileSync(process.env.FAKE_AGY_READY_FILE, "ready");
 }
 
 const delayMs = Number(process.env.FAKE_AGY_DELAY_MS ?? 0);
@@ -159,11 +158,31 @@ if (process.env.FAKE_AGY_MCP_DUMP) {
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
 const CONV = "conv-fake-123";
 
-// The prompt is the value that follows --print on argv (mirrors the driver,
-// which no longer pipes stdin). A bare --print with no value yields no turn.
-const printIdx = argv.indexOf("--print");
-const prompt = printIdx !== -1 ? argv[printIdx + 1] : undefined;
+const streamInput = argv[argv.indexOf("--input-format") + 1] === "stream-json";
+let prompt: string | undefined;
+if (streamInput) {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) input += chunk;
+  const line = input.split("\n").find((candidate) => candidate.trim());
+  try {
+    const message = line ? JSON.parse(line) : null;
+    const content = message?.event === "user" ? message.message?.content : undefined;
+    prompt = typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content.filter((block) => block?.type === "text").map((block) => block.text).join("")
+        : undefined;
+  } catch {}
+} else {
+  // Retained for tests of old callers; production prompt paths use stdin.
+  const printIdx = Math.max(argv.indexOf("--print"), argv.indexOf("-p"));
+  prompt = printIdx !== -1 ? argv[printIdx + 1] : undefined;
+}
 if (!prompt) process.exit(0);
+if (process.env.FAKE_AGY_DUMP) {
+  writeFileSync(process.env.FAKE_AGY_DUMP, JSON.stringify({ argv, env: process.env, prompt }, null, 2));
+}
 
 const toolName = mode === "ask-peer" ? "ask_bot" : "write_to_file";
 out({ event: "init", conversation_id: CONV, init: { cwd: process.cwd(), tools: ["run_command", "write_to_file", ...(mode === "ask-peer" ? ["list_bots", "ask_bot"] : [])], permission_mode: "accept-edits" } });

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -7,7 +7,8 @@
 //   FAKE_CLAUDE_MODE   happy (default) | exit-early | hang | malformed
 //                      | stream (partial-message text deltas before the
 //                        whole-message frame, plus subagent noise to drop)
-//   FAKE_CLAUDE_DUMP   path to write {argv, env, prompt, mcpConfig} as JSON,
+//   FAKE_CLAUDE_DUMP   path to write {argv, env, prompt, systemPrompt,
+//                      mcpConfig} as JSON,
 //                      so the test can assert on argv shape and env hygiene.
 //                      mcpConfig is read back from the --mcp-config file the
 //                      way the real CLI reads it — the driver writes it to a
@@ -157,7 +158,19 @@ const playTurn = (prompt: JsonValue) => {
         /* leave null — the test will see it */
       }
     }
-    writeFileSync(process.env.FAKE_CLAUDE_DUMP, JSON.stringify({ pid: process.pid, argv, env: process.env, prompt, mcpConfig }, null, 2));
+    const systemPromptPath = argAfter("--append-system-prompt-file");
+    let systemPrompt: string | null = null;
+    if (systemPromptPath) {
+      try {
+        systemPrompt = readFileSync(systemPromptPath, "utf8");
+      } catch {
+        /* leave null — the test will see it */
+      }
+    }
+    writeFileSync(
+      process.env.FAKE_CLAUDE_DUMP,
+      JSON.stringify({ pid: process.pid, argv, env: process.env, prompt, systemPrompt, mcpConfig }, null, 2),
+    );
   }
 
   if (mode === "exit-early") {


### PR DESCRIPTION
## What this fixes

Windows users could hit repeated `spawn ENAMETOOLONG` failures when a provider received a large channel/system prompt. The Gemini 3.1 Pro screenshot came from Antigravity passing the complete prompt through `--print`, which crosses the Windows CreateProcess command-line limit.

## Changes

- send all Antigravity turn and helper prompts through the official stream-JSON stdin protocol
- require Antigravity CLI 1.1.15+ and show an actionable `agy update` message for older installs
- pass Claude system prompts through a private 0600 temporary file and clean it after the process settles
- reject oversized Windows CLI argument vectors centrally with a safe, actionable error that never echoes prompt contents
- add 150 KB regression prompts for both Gemini/Antigravity and Claude

## Verification

- 98 provider/runtime tests passed (1 skipped)
- 235 integrated Claude/Gemini/server tests passed (1 skipped) before rebasing
- full Vitest run: 2,762 passed, 19 skipped; one unrelated steering timing test failed once and passed 3/3 immediately in isolation
- broker tests: 7 passed
- Electron tests: 59 passed
- packaged-server smoke passed
- typecheck, lint, and production build passed

The decisive Windows CI jobs are required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large prompts to prevent command-line length issues, including on Windows.
  * Kept system prompts out of process arguments for improved privacy and reliability.
  * Ensured temporary prompt data is cleaned up after sessions, retries, and process exits.

* **Compatibility**
  * Updated Antigravity interactions to use stream input for long prompts.
  * Antigravity now requires version 1.1.15 or later for supported operations.
  * Added clearer guidance when an unsupported Antigravity version is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->