### PR TITLE
Document downstream fork and release ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,22 @@ API keys are write-only: they land in `~/.openmausbot/config.json` via `PUT /api
 only ever reports `configured` booleans. Keep it that way — no logging keys, no echoing them in
 responses or events, no baking them into argv where another local process could read them.
 
+## Downstream forks and release ownership
+
+Changes prepared in a downstream fork should keep provenance in the pull request, not add
+fork-specific branding or ownership claims to the upstream source tree. Record the exact upstream
+commit used as the comparison base, the head branch, and the checks run after the final rebase.
+
+Fork maintainers own the binaries and update channels they publish. Before distributing a fork,
+review the application name and identifiers, signing configuration, update metadata, and every
+`electron-builder` publish target. Never upload fork artifacts or update metadata to the official
+OpenMausBot release repository, and never change the upstream publish target in a feature PR unless
+that release migration was explicitly agreed with the maintainer.
+
+An upstream PR should contain only the portable product change. Keep local build paths, account
+names, credentials, private endpoints, machine-specific configuration, and fork-only release notes
+out of its commits and screenshots.
+
 ## Before you open the PR
 
 - [ ] `pnpm typecheck` and `pnpm test` pass


### PR DESCRIPTION
## What changed

Replaces the earlier fork-specific provenance document with a portable contribution rule in `CONTRIBUTING.md`.

The new guidance tells every downstream fork to:

- keep fork provenance in the pull request instead of adding fork branding to upstream files;
- record the exact upstream comparison commit, head branch, and final checks;
- treat fork binaries and update channels as the fork maintainer's responsibility;
- review app identifiers, signing, update metadata, and publish targets before distribution;
- never publish fork artifacts to the official OpenMausBot release repository;
- keep local paths, account names, credentials, private endpoints, and machine-specific settings out of upstream commits and screenshots.

## Why

The previous revision described one contributor fork inside the official repository and was not appropriate for upstream. This version preserves the useful release-safety lesson as a general rule for all contributors.

## Verification

Validated after rebasing onto current official `main`:

- documentation-only diff reviewed in context
- `git diff --check` passed
- no fork account name remains in the changed file
- staged additions were checked for private emails and common secret-token formats

## Scope

- 1 commit
- 1 file changed
- 16 lines added
- no runtime, UI, dependency, lockfile, release-target, or credential changes

Current head: `6f49e6a2f667591eabc0352754b40477b0941cea`.