### PR TITLE
Add scoped team exports and bounded package previews

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1820,6 +1820,35 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("exports only the requested visible bot scope", async () => {
+    const first = (await api("POST", "/api/bots", { name: "Scoped Mira" })).body.bot;
+    const second = (await api("POST", "/api/bots", { name: "Scoped Scout" })).body.bot;
+    const hidden = (await api("POST", "/api/bots", { name: "Scoped Hidden" })).body.bot;
+    await api("PATCH", `/api/bots/${hidden.id}`, { hidden: true });
+    try {
+      const scope = { botIds: [first.id], groupIds: [] };
+      const team = await api("POST", "/api/teams/export", { name: "Scoped Team", scope });
+      expect(team.status).toBe(200);
+      expect(team.body.team.members.map((member: { name: string }) => member.name)).toEqual(["Scoped Mira"]);
+
+      const packageExport = await api("POST", "/api/teams/export", { name: "Scoped Team", format: "package", scope });
+      expect(packageExport.status).toBe(200);
+      expect(packageExport.body.members).toBe(1);
+      expect(packageExport.body.markdown).toContain("Scoped Mira");
+      expect(packageExport.body.markdown).not.toMatch(/Scoped Scout|Scoped Hidden/);
+
+      const hiddenScope = await api("POST", "/api/teams/export", {
+        scope: { botIds: [hidden.id], groupIds: [] },
+      });
+      expect(hiddenScope.status).toBe(400);
+      expect(hiddenScope.body.error).toContain("hidden bot");
+    } finally {
+      await api("DELETE", `/api/bots/${first.id}`);
+      await api("DELETE", `/api/bots/${second.id}`);
+      await api("DELETE", `/api/bots/${hidden.id}`);
+    }
+  });
+
   it("imports a team as a project: one room, on a folder", async () => {
     // The manifest still describes only people. Room name and folder come
     // from the CALLER, so a manifest fetched from the library cannot create

--- a/server/index.ts
+++ b/server/index.ts
@@ -791,6 +791,61 @@ function checkedMemberIds(value: unknown): { ok: true; memberIds: string[] } | {
   }
   return { ok: true, memberIds };
 }
+
+type ExportSelection = { botIds: string[]; groupIds: string[] };
+
+/** Validate and normalize a requested team export scope against visible bots and non-DM rooms. */
+function checkedExportSelection(
+  value: unknown,
+  bots: readonly { id: string; hidden?: boolean }[],
+  groups: readonly GroupRecord[],
+): { ok: true; selection: ExportSelection } | { ok: false; error: string } {
+  if (value === "all") {
+    const botIds = bots.filter((bot) => !bot.hidden).map((bot) => bot.id);
+    if (!botIds.length) return { ok: false, error: "scope selects no visible bots" };
+    return {
+      ok: true,
+      selection: {
+        botIds,
+        groupIds: groups
+          .filter((group) => !group.dm && group.memberIds.some((id) => botIds.includes(id)))
+          .map((group) => group.id),
+      },
+    };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: 'scope must be "all" or an object with botIds' };
+  }
+  const scope = value as { botIds?: unknown; groupIds?: unknown };
+  if (!Array.isArray(scope.botIds) || !scope.botIds.length || scope.botIds.some((id) => typeof id !== "string" || !id.trim())) {
+    return { ok: false, error: "scope.botIds must be a non-empty list of bot IDs" };
+  }
+  const botIds = [...scope.botIds] as string[];
+  if (new Set(botIds).size !== botIds.length) return { ok: false, error: "scope.botIds must not contain duplicates" };
+  for (const id of botIds) {
+    const bot = bots.find((candidate) => candidate.id === id);
+    if (!bot) return { ok: false, error: `scope.botIds contains unknown bot ID "${id}"` };
+    if (bot.hidden) return { ok: false, error: `scope.botIds contains hidden bot ID "${id}"` };
+  }
+  let groupIds: string[] = [];
+  if (scope.groupIds !== undefined) {
+    if (!Array.isArray(scope.groupIds) || scope.groupIds.some((id) => typeof id !== "string" || !id.trim())) {
+      return { ok: false, error: "scope.groupIds must be a list of room IDs" };
+    }
+    groupIds = [...scope.groupIds] as string[];
+    if (new Set(groupIds).size !== groupIds.length) return { ok: false, error: "scope.groupIds must not contain duplicates" };
+  }
+  for (const id of groupIds) {
+    const group = groups.find((candidate) => candidate.id === id);
+    if (!group) return { ok: false, error: `scope.groupIds contains unknown room ID "${id}"` };
+    if (group.dm) return { ok: false, error: `scope.groupIds cannot include direct-message room "${id}"` };
+    if (!group.memberIds.some((memberId) => botIds.includes(memberId))) {
+      return { ok: false, error: `scope.groupIds room "${id}" has no selected visible bots` };
+    }
+  }
+  return { ok: true, selection: { botIds, groupIds } };
+}
+
 let bootSelection = { instanceId: "", model: "" };
 const store = new Store(() => bootSelection);
 const sendSequencer = new SendSequencer();
@@ -6222,6 +6277,9 @@ const server = createServer(async (req, res) => {
     }
     if (method === "POST" && path === "/api/teams/export") {
       const body = await readBody(req);
+      const requestedScope = Object.hasOwn(body, "scope") ? body.scope : "all";
+      const checkedScope = checkedExportSelection(requestedScope, store.bots, store.groups);
+      if (!checkedScope.ok) return json(res, 400, { error: checkedScope.error });
       const profileName = cfg.profile?.name?.trim();
       const name =
         typeof body.name === "string" && body.name.trim()
@@ -6229,15 +6287,17 @@ const server = createServer(async (req, res) => {
           : profileName
             ? `${profileName}'s Team`
             : "My OpenMaus Team";
-      const memberIds = store.bots.filter((bot) => !bot.hidden).map((bot) => bot.id);
+      const { botIds: memberIds, groupIds } = checkedScope.selection;
       if (memberIds.length === 0) return json(res, 400, { error: "Create a bot before exporting your team" });
+      const selectedBots = store.bots.filter((bot) => memberIds.includes(bot.id));
+      const selectedGroups = store.groups.filter((group) => groupIds.includes(group.id));
       try {
         if (body.format === "package") {
           const document = createBotPackageExport({
             name,
             authorName: profileName,
-            bots: store.bots,
-            groups: store.groups,
+            bots: selectedBots,
+            groups: selectedGroups,
             routines: routines!.listRoutines(),
           });
           return json(res, 200, {
@@ -6254,7 +6314,7 @@ const server = createServer(async (req, res) => {
               name,
               memberIds,
             },
-            store.bots,
+            selectedBots,
           ),
         );
       } catch (error) {

--- a/src/components/TeamLibraryPanel.test.ts
+++ b/src/components/TeamLibraryPanel.test.ts
@@ -1,0 +1,38 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { buildExportScopeOptions } from "@/lib/team-files";
+import { BotAvatar } from "./Avatar";
+import { exportScopeAvatarProps } from "./TeamLibraryPanel";
+
+describe("TeamLibrary export scope avatar presentation", () => {
+  const bots = [
+    { id: "ada", name: "Ada", color: "blue" as const, section: "Engineering" },
+    { id: "bea", name: "Bea", color: "purple" as const, section: "Design" },
+  ];
+
+  it("uses a static BotAvatar for every existing individual option and falls back only for a missing id", () => {
+    const options = buildExportScopeOptions({ projectFilter: "all", bots, groups: [] });
+    const individual = options.filter((option) => option.category === "bot");
+
+    expect(individual).toHaveLength(bots.length);
+    for (const option of individual) {
+      const props = exportScopeAvatarProps(option, bots);
+      expect(props).toMatchObject({ bot: { id: option.botIds[0] }, state: "idle", size: 28, animated: false });
+      const avatar = createElement(BotAvatar, props!);
+      expect(avatar.type).toBe(BotAvatar);
+      expect(avatar.props.animated).toBe(false);
+      expect(renderToStaticMarkup(avatar)).toContain("<svg");
+    }
+
+    expect(exportScopeAvatarProps({
+      key: "bot:missing",
+      category: "bot",
+      label: "Missing",
+      detail: "Single bot",
+      scope: { botIds: ["missing"], groupIds: [] },
+      botIds: ["missing"],
+    }, bots)).toBeUndefined();
+  });
+});

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -1,6 +1,7 @@
 import { track } from "@/lib/analytics";
 import { cn } from "@/lib/cn";
 import { teamImportPreview, type PendingTeamImport } from "@/lib/team-import";
+import { buildExportRequest, buildExportScopeOptions, downloadExportPackage, resolveExportScopeBot, type ExportedPackage, type ExportScopeOption } from "@/lib/team-files";
 import type { Routine } from "@/lib/routines";
 import { api, useStore, type Bot, type Group } from "@/state/store";
 import {
@@ -8,6 +9,7 @@ import {
   BookOpen,
   CalendarClock,
   Check,
+  ChevronDown,
   Compass,
   Crown,
   ExternalLink,
@@ -17,11 +19,13 @@ import {
   MessageSquare,
   Plug,
   Search,
+  Sparkles,
   UploadCloud,
   Users,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { BotAvatar } from "./Avatar";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 const MAX_TEAM_FILE_BYTES = 1_000_000;
@@ -63,7 +67,7 @@ export interface TeamImportResult {
 }
 
 type ImportSource = "library" | "file" | "github";
-type TeamTab = "explore" | "import" | "scout";
+type TeamTab = "export" | "explore" | "import" | "scout";
 type ImportMode = "replace" | "add";
 
 /** the scout endpoint's answer, as far as this panel renders it — the
@@ -116,6 +120,83 @@ function TeamGlyph({ index }: { index: number }) {
   );
 }
 
+/** Build static avatar props for a single-bot export-scope option. */
+export function exportScopeAvatarProps<T extends { id: string }>(option: ExportScopeOption, bots: readonly T[]) {
+  const bot = resolveExportScopeBot(option, bots);
+  return bot ? { bot, state: "idle" as const, size: 28, animated: false as const } : undefined;
+}
+
+/** Render the export-scope picker and its option list. */
+function ExportScopeSelect({
+  options,
+  bots,
+  value,
+  onChange,
+  disabled,
+}: {
+  options: ExportScopeOption[];
+  bots: Bot[];
+  value: ExportScopeOption["key"] | "";
+  onChange: (key: ExportScopeOption["key"]) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((option) => option.key === value) ?? options[0];
+  /** Choose the icon or avatar that represents an export-scope option. */
+  const iconFor = (option: ExportScopeOption, size: number) => {
+    if (option.key.startsWith("bot:")) {
+      const avatarProps = exportScopeAvatarProps(option, bots);
+      return avatarProps ? <BotAvatar {...avatarProps} size={size} /> : <Sparkles size={size} className="text-ink-secondary" />;
+    }
+    if (option.category === "project") return <FolderOpen size={size} className="text-ink-secondary" />;
+    if (option.category === "team") return <MessageSquare size={size} className="text-ink-secondary" />;
+    return <Users size={size} className="text-ink-secondary" />;
+  };
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        disabled={disabled || options.length === 0}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-center gap-3 rounded-xl bg-raised/70 px-3 py-2.5 text-left hover:bg-raised disabled:opacity-50"
+      >
+        {selected ? iconFor(selected, 28) : <Sparkles size={28} className="text-ink-secondary" />}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13.5px] font-medium text-ink">{selected?.label ?? "No bots available"}</span>
+          <span className="block truncate text-[11.5px] text-ink-secondary">{selected?.detail ?? "Create a bot before exporting"}</span>
+        </span>
+        <ChevronDown size={15} className={cn("text-ink-secondary transition-transform", open && "rotate-180")} />
+      </button>
+      {open && options.length > 0 && (
+        <div role="listbox" aria-label="Export scope" className="absolute inset-x-0 top-full z-10 mt-1 max-h-64 overflow-y-auto rounded-xl border border-hairline/50 bg-panel p-1 shadow-xl">
+          {options.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              role="option"
+              aria-selected={option.key === selected?.key}
+              onClick={() => {
+                onChange(option.key);
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left hover:bg-raised"
+            >
+              {iconFor(option, option.key.startsWith("bot:") ? 28 : 20)}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13px] text-ink">{option.label}</span>
+                <span className="block truncate text-[11px] text-ink-secondary">{option.detail}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Render the team library modal for exporting, browsing, importing, and scouting teams. */
 export function TeamLibraryPanel({
   onClose,
   onImported,
@@ -130,7 +211,7 @@ export function TeamLibraryPanel({
   const { state, dispatch } = useStore();
   const dialogRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [tab, setTab] = useState<TeamTab>("explore");
+  const [tab, setTab] = useState<TeamTab>("export");
   const [catalog, setCatalog] = useState<TeamCatalog | null>(null);
   const [catalogLoading, setCatalogLoading] = useState(true);
   const [catalogError, setCatalogError] = useState("");
@@ -150,6 +231,9 @@ export function TeamLibraryPanel({
   // the folder the current `scouted` result was actually read from — the
   // import must pin the room to THIS, not to whatever the input says now
   const [scoutedFolder, setScoutedFolder] = useState("");
+  const [exportScopeKey, setExportScopeKey] = useState<ExportScopeOption["key"] | "">("");
+  const [exportName, setExportName] = useState("My OpenMaus Team");
+  const [exporting, setExporting] = useState(false);
   // null = not asked yet or still loading; [] = asked, nothing (or offline)
   const [directory, setDirectory] = useState<DirectoryCandidate[] | null>(null);
   const [pickedDirectory, setPickedDirectory] = useState<Set<string>>(new Set());
@@ -161,6 +245,16 @@ export function TeamLibraryPanel({
   const scoutRequest = useRef(0);
 
   const currentBotCount = state.bots.filter((bot) => !bot.hidden).length;
+  const exportOptions = useMemo(
+    () => buildExportScopeOptions({ projectFilter: "all", bots: state.bots, groups: state.groups }),
+    [state.bots, state.groups],
+  );
+  const selectedExportOption = exportOptions.find((option) => option.key === exportScopeKey) ?? exportOptions[0];
+  const selectedExportBotIds = selectedExportOption?.botIds ?? [];
+  const selectedExportBots = state.bots.filter((bot) => selectedExportBotIds.includes(bot.id) && !bot.hidden);
+  useEffect(() => {
+    if (selectedExportOption && selectedExportOption.key !== exportScopeKey) setExportScopeKey(selectedExportOption.key);
+  }, [exportScopeKey, selectedExportOption]);
 
   const loadCatalog = useCallback(async () => {
     setCatalogLoading(true);
@@ -315,6 +409,24 @@ export function TeamLibraryPanel({
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setImporting(false);
+    }
+  };
+
+  /** Request the selected team package and trigger its local download. */
+  const exportTeam = async () => {
+    if (!selectedExportOption || exporting) return;
+    setExporting(true);
+    setError("");
+    try {
+      const packageFile = await api("/api/teams/export", {
+        method: "POST",
+        body: JSON.stringify(buildExportRequest(exportName, selectedExportOption.scope, [])),
+      });
+      downloadExportPackage(packageFile as ExportedPackage);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -503,9 +615,16 @@ export function TeamLibraryPanel({
               <div className="mt-2 grid grid-cols-1 gap-x-10 md:grid-cols-2">
                 {pending.members.map((member, index) => (
                   <div key={`${member.name}-${index}`} className="flex min-h-[72px] items-center gap-3 border-b border-hairline/35 px-1 py-3">
-                    <div className={cn("flex size-9 shrink-0 items-center justify-center rounded-lg text-[13px] font-semibold", TEAM_GLYPHS[index % TEAM_GLYPHS.length])}>
-                      {member.name.slice(0, 1).toUpperCase()}
-                    </div>
+                    <BotAvatar
+                      bot={{
+                        name: member.name,
+                        color: member.appearance?.color ?? "green",
+                        mascotBody: member.appearance?.mascotBody,
+                      }}
+                      state={member.appearance?.mascotExpression ?? "idle"}
+                      size={36}
+                      animated={false}
+                    />
                     <div className="min-w-0">
                       <div className="truncate text-[14px] font-medium text-ink">{member.name}</div>
                       <div className="mt-0.5 truncate text-[12.5px] text-ink-secondary">{member.title || "General assistant"}</div>
@@ -566,6 +685,20 @@ export function TeamLibraryPanel({
               <div className="flex w-fit rounded-xl bg-raised/70 p-1" role="tablist" aria-label="Team source">
                 <button
                   role="tab"
+                  aria-selected={tab === "export"}
+                  onClick={() => {
+                    setTab("export");
+                    setError("");
+                  }}
+                  className={cn(
+                    "rounded-lg px-4 py-2 text-[13.5px] transition-colors",
+                    tab === "export" ? "bg-card text-ink shadow-sm" : "text-ink-secondary hover:text-ink",
+                  )}
+                >
+                  Export &amp; share
+                </button>
+                <button
+                  role="tab"
                   aria-selected={tab === "explore"}
                   onClick={() => {
                     setTab("explore");
@@ -622,6 +755,56 @@ export function TeamLibraryPanel({
             </div>
 
             <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-7 pt-5 sm:px-8">
+              {tab === "export" && (
+                <div className="max-w-2xl">
+                  <div className="mb-3 text-[12px] font-medium text-ink-secondary">Export your team</div>
+                  <h3 className="text-[18px] font-semibold text-ink">Choose what to include</h3>
+                  <p className="mt-1 max-w-xl text-[12.5px] leading-relaxed text-ink-secondary">
+                    Export a portable package with the selected bots and rooms. Conversations and private connections stay local.
+                  </p>
+                  <label className="mt-5 block text-[12px] font-medium text-ink-secondary" htmlFor="team-export-name">Package name</label>
+                  <input
+                    id="team-export-name"
+                    value={exportName}
+                    onChange={(event) => setExportName(event.target.value)}
+                    className="mt-1.5 w-full rounded-xl bg-raised/70 px-3 py-2.5 text-[13.5px] text-ink focus:outline-none"
+                  />
+                  <div className="mt-4 text-[12px] font-medium text-ink-secondary">Scope</div>
+                  <div className="mt-1.5">
+                    <ExportScopeSelect
+                      options={exportOptions}
+                      bots={state.bots.filter((bot) => !bot.hidden)}
+                      value={selectedExportOption?.key ?? ""}
+                      onChange={setExportScopeKey}
+                      disabled={exporting}
+                    />
+                  </div>
+                  {selectedExportBots.length > 0 && (
+                    <div className="mt-5 rounded-2xl bg-raised/25 px-4 py-3.5">
+                      <div className="text-[12px] font-medium text-ink-secondary">Selected bots</div>
+                      <div className="mt-2.5 flex flex-wrap gap-2">
+                        {selectedExportBots.map((bot) => (
+                          <div key={bot.id} className="flex items-center gap-2 rounded-full bg-inset py-1 pl-1 pr-2.5">
+                            <BotAvatar bot={bot} state="idle" size={28} animated={false} />
+                            <span className="max-w-40 truncate text-[12px] text-ink">{bot.name}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => void exportTeam()}
+                    disabled={!selectedExportOption || selectedExportBots.length === 0 || exporting}
+                    className="mt-5 flex items-center justify-center gap-2 rounded-full bg-accent px-5 py-2.5 text-[13.5px] font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+                  >
+                    {exporting && <Loader2 size={15} className="animate-spin" />}
+                    {exporting ? "Preparing package…" : "Export package"}
+                  </button>
+                  {error && <div role="alert" className="mt-4 rounded-lg bg-danger/10 px-3 py-2 text-[12.5px] text-danger">{error}</div>}
+                </div>
+              )}
+
               {tab === "explore" && (
                 <div>
                   <div className="mb-3 text-[12px] font-medium text-ink-secondary">

--- a/src/lib/team-files.test.ts
+++ b/src/lib/team-files.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { buildExportRequest, buildExportScopeOptions, exportFilename, resolveExportScopeBot } from "./team-files";
+
+describe("team export helpers", () => {
+  const bots = [
+    { id: "ada", name: "Ada", section: "Engineering" },
+    { id: "bea", name: "Bea", section: "Design" },
+    { id: "hidden", name: "Hidden", hidden: true },
+  ];
+  const groups = [{ id: "eng", name: "Engineering room", memberIds: ["ada"], section: "Engineering" }];
+
+  it("builds a project scope with relevant non-DM rooms", () => {
+    const options = buildExportScopeOptions({ projectFilter: "Engineering", bots, groups });
+    expect(options[0]).toMatchObject({
+      key: "project:Engineering",
+      scope: { botIds: ["ada"], groupIds: ["eng"] },
+    });
+  });
+
+  it("excludes same-section rooms with only hidden members from project scope", () => {
+    const options = buildExportScopeOptions({
+      projectFilter: "Engineering",
+      bots,
+      groups: [
+        { id: "visible-eng", name: "Visible Engineering room", memberIds: ["ada"], section: "Engineering" },
+        { id: "hidden-eng", name: "Hidden Engineering room", memberIds: ["hidden"], section: "Engineering" },
+      ],
+    });
+    expect(options[0]).toMatchObject({
+      key: "project:Engineering",
+      scope: { botIds: ["ada"], groupIds: ["visible-eng"] },
+    });
+  });
+
+  it("keeps all active bots as an explicit final option", () => {
+    const options = buildExportScopeOptions({ projectFilter: "all", bots, groups });
+    expect(options.map((option) => option.category)).toEqual(["project", "project", "team", "bot", "bot", "other"]);
+    expect(options.at(-1)).toMatchObject({ key: "all", category: "other", scope: "all" });
+    expect(options.some((option) => option.scope === "all")).toBe(true);
+  });
+
+  it("omits empty teams and hidden bots without disturbing the final broad scope", () => {
+    const options = buildExportScopeOptions({
+      projectFilter: "Missing",
+      bots,
+      groups: [{ id: "empty", name: "Empty", memberIds: ["hidden"] }, ...groups],
+    });
+    expect(options.map((option) => option.key)).toEqual(["project:Design", "project:Engineering", "group:eng", "bot:ada", "bot:bea", "all"]);
+    expect(options.at(-1)?.key).toBe("all");
+    expect(options.some((option) => option.label === "Empty")).toBe(false);
+    expect(options.some((option) => option.label === "Hidden")).toBe(false);
+  });
+
+  it("builds an exact package request and safe filename", () => {
+    expect(buildExportRequest("  Notes Crew ", { botIds: ["ada"], groupIds: [] }, ["notes"])).toEqual({
+      name: "Notes Crew",
+      scope: { botIds: ["ada"], groupIds: [] },
+      skillIds: ["notes"],
+      format: "package",
+    });
+    expect(exportFilename("Résumé / Team 2026")).toBe("resume-team-2026.md");
+    expect(exportFilename("  ")).toBe("openmaus-package.md");
+  });
+
+  it("keeps each single-bot option scoped to its visible bot", () => {
+    const options = buildExportScopeOptions({ projectFilter: "all", bots, groups });
+    expect(options.find((option) => option.key === "bot:bea")).toMatchObject({
+      category: "bot",
+      label: "Bea",
+      scope: { botIds: ["bea"], groupIds: [] },
+      botIds: ["bea"],
+    });
+    expect(options.some((option) => option.key === "bot:hidden")).toBe(false);
+  });
+
+  it("resolves every visible individual option and returns undefined only for a missing id", () => {
+    const options = buildExportScopeOptions({ projectFilter: "all", bots, groups });
+    const individual = options.filter((option) => option.category === "bot");
+    expect(individual.map((option) => resolveExportScopeBot(option, bots))).toEqual([bots[0], bots[1]]);
+    expect(resolveExportScopeBot({
+      key: "bot:missing",
+      category: "bot",
+      label: "Missing",
+      detail: "Single bot",
+      scope: { botIds: ["missing"], groupIds: [] },
+      botIds: ["missing"],
+    }, bots)).toBeUndefined();
+  });
+});

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -1,23 +1,140 @@
 import { api } from "@/state/store";
 
-interface ExportedPlaybook {
+export type ExportScope = "all" | { botIds: string[]; groupIds: string[] };
+
+export interface ExportScopeContext {
+  projectFilter: string;
+  bots: readonly { id: string; name?: string; section?: string; hidden?: boolean }[];
+  groups: readonly { id: string; name?: string; memberIds: string[]; dm?: boolean; section?: string }[];
+}
+
+export interface ExportScopeOption {
+  key: `project:${string}` | `group:${string}` | `bot:${string}` | "all";
+  category: "project" | "team" | "bot" | "other";
+  label: string;
+  detail: string;
+  scope: ExportScope;
+  botIds: string[];
+}
+
+export interface ExportRequest {
+  name: string;
+  scope: ExportScope;
+  skillIds: string[];
+  format: "package";
+}
+
+/** Resolve the bot represented by a single-bot export option. */
+export function resolveExportScopeBot<T extends { id: string }>(
+  option: ExportScopeOption,
+  bots: readonly T[],
+): T | undefined {
+  if (!option.key.startsWith("bot:")) return undefined;
+  return bots.find((bot) => bot.id === option.botIds[0]);
+}
+
+export interface ExportedPackage {
   name: string;
   members: number;
   markdown: string;
 }
 
-function downloadPlaybook(playbook: ExportedPlaybook): { name: string; members: number } {
-  const slug =
-    playbook.name
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "") || "botmrr-team";
+/** Convert a package name into a safe Markdown download filename. */
+export function exportFilename(name: string): string {
+  const slug = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "openmaus-package";
+  return `${slug}.md`;
+}
+
+/** Build the server request for exporting a selected package scope. */
+export function buildExportRequest(name: string, scope: ExportScope, skillIds: readonly string[]): ExportRequest {
+  return {
+    name: name.trim() || "OpenMaus package",
+    scope,
+    skillIds: [...skillIds],
+    format: "package",
+  };
+}
+
+/** Build project, room, bot, and all-bot options for the export picker. */
+export function buildExportScopeOptions({ projectFilter, bots, groups }: ExportScopeContext): ExportScopeOption[] {
+  const activeBots = bots.filter((bot) => !bot.hidden);
+  const activeIds = new Set(activeBots.map((bot) => bot.id));
+  const options: ExportScopeOption[] = [];
+
+  const sections = [...new Set(activeBots.map((bot) => bot.section?.trim()).filter((section): section is string => Boolean(section)))];
+  sections.sort((a, b) => a.localeCompare(b));
+  if (projectFilter !== "all" && sections.includes(projectFilter)) {
+    sections.splice(sections.indexOf(projectFilter), 1);
+    sections.unshift(projectFilter);
+  }
+  for (const section of sections) {
+    const projectBotIds = activeBots.filter((bot) => bot.section?.trim() === section).map((bot) => bot.id);
+    const projectIdSet = new Set(projectBotIds);
+    const groupIds = groups
+      .filter((group) => !group.dm && group.memberIds.some((id) => projectIdSet.has(id)) && group.memberIds.filter((id) => activeIds.has(id)).every((id) => projectIdSet.has(id)) && (group.section?.trim() === section || (!group.section && group.memberIds.some((id) => projectIdSet.has(id)))))
+      .map((group) => group.id)
+      .sort((a, b) => a.localeCompare(b));
+    options.push({
+      key: `project:${section}`,
+      category: "project",
+      label: section,
+      detail: section === projectFilter ? `Current project · ${projectBotIds.length} ${projectBotIds.length === 1 ? "bot" : "bots"}` : `${projectBotIds.length} ${projectBotIds.length === 1 ? "bot" : "bots"}`,
+      scope: { botIds: projectBotIds, groupIds },
+      botIds: projectBotIds,
+    });
+  }
+
+  for (const group of [...groups].sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id) || a.id.localeCompare(b.id))) {
+    if (group.dm) continue;
+    const memberIds = group.memberIds.filter((id) => activeIds.has(id));
+    if (!memberIds.length) continue;
+    options.push({
+      key: `group:${group.id}`,
+      category: "team",
+      label: group.section && group.section !== projectFilter ? `${group.name ?? group.id} · ${group.section}` : group.name ?? group.id,
+      detail: `${memberIds.length} ${memberIds.length === 1 ? "bot" : "bots"} · channel/team`,
+      scope: { botIds: memberIds, groupIds: [group.id] },
+      botIds: memberIds,
+    });
+  }
+
+  for (const bot of activeBots) {
+    options.push({
+      key: `bot:${bot.id}`,
+      category: "bot",
+      label: bot.name || bot.id,
+      detail: "Single bot",
+      scope: { botIds: [bot.id], groupIds: [] },
+      botIds: [bot.id],
+    });
+  }
+
+  if (activeBots.length) {
+    options.push({
+      key: "all",
+      category: "other",
+      label: "All active bots",
+      detail: `${activeBots.length} ${activeBots.length === 1 ? "bot" : "bots"} · explicit full selection`,
+      scope: "all",
+      botIds: activeBots.map((bot) => bot.id),
+    });
+  }
+  return options;
+}
+
+/** Download a rendered team package as a local Markdown file. */
+export function downloadExportPackage(playbook: ExportedPackage) {
   const blob = new Blob([playbook.markdown], { type: "text/markdown;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = `${slug}.md`;
+  link.download = exportFilename(playbook.name);
   document.body.appendChild(link);
   link.click();
   link.remove();
@@ -30,6 +147,6 @@ export async function downloadAllBots(): Promise<{ name: string; members: number
   const playbook = (await api("/api/teams/export", {
     method: "POST",
     body: JSON.stringify({ format: "package" }),
-  })) as ExportedPlaybook;
-  return downloadPlaybook(playbook);
+  })) as ExportedPackage;
+  return downloadExportPackage(playbook);
 }

--- a/src/lib/team-import.test.ts
+++ b/src/lib/team-import.test.ts
@@ -24,6 +24,34 @@ describe("team import preview", () => {
     });
   });
 
+  it("preserves safe mascot bodies for static import preview", () => {
+    const preview = teamImportPreview({
+      format: "openmaus.team",
+      version: 2,
+      team: {
+        name: "Appearance team",
+        members: [{
+          name: "Ada",
+          appearance: {
+            color: "cyan",
+            mascotExpression: "happy",
+            mascotBody: "cursor",
+          },
+        }, {
+          name: "Fallback",
+          appearance: { color: "not-a-color", mascotBody: "not-a-body" },
+        }],
+      },
+    });
+
+    expect(preview.members[0]?.appearance).toEqual({
+      color: "cyan",
+      mascotExpression: "happy",
+      mascotBody: "cursor",
+    });
+    expect(preview.members[1]?.appearance).toBeUndefined();
+  });
+
   it("rejects unsupported and empty files", () => {
     expect(() => teamImportPreview({ format: "openmaus.team", version: 3, team: {} })).toThrow("not supported");
     expect(() =>
@@ -67,6 +95,33 @@ describe("team import preview", () => {
         { label: "Google Sheets", optional: true },
       ],
     });
+  });
+
+  it("marks manual-only routines as paused without inventing a schedule", () => {
+    const preview = teamImportPreview({
+      format: "openmaus.package",
+      version: 1,
+      package: {
+        name: "Manual team",
+        agents: [{ key: "reviewer", name: "Reviewer" }],
+        routines: [{
+          name: "Imported review",
+          agent: "reviewer",
+          prompt: "Review when asked.",
+          runOn: "maus",
+          schedule: { type: "manual" },
+          durationMinutes: 30,
+          enabledAfterInstall: false,
+        }],
+      },
+    });
+
+    expect(preview.routineEntries).toMatchObject([{
+      name: "Imported review",
+      owner: "Reviewer",
+      schedule: "Manual only",
+      status: "Paused after import",
+    }]);
   });
 
   it("previews a portable Markdown playbook", () => {

--- a/src/lib/team-import.ts
+++ b/src/lib/team-import.ts
@@ -1,16 +1,126 @@
 import { parse as parseYaml } from "yaml";
+import { MASCOT_BODY_IDS, type MascotBodyId } from "../../shared/mascot-bodies";
+import { MAUS_COLOR_NAMES, MAUS_STATES, type MausColor, type MausState } from "./mascot";
+const BOT_INSTRUCTIONS_MAX_CHARS = 4_000;
+
+export interface PendingTeamImportMember {
+  key: string;
+  name: string;
+  title: string;
+  description: string;
+  appearance?: {
+    color: MausColor;
+    mascotBody?: MascotBodyId;
+    mascotExpression?: MausState;
+  };
+}
+
+export interface PendingTeamImportRoom {
+  name: string;
+  members: string[];
+  defaultResponder: string;
+  bulletin: string;
+}
+
+export interface PendingTeamImportPlaybook {
+  name: string;
+  summary: string;
+  triggers: string[];
+  instructions: string;
+}
+
+export interface PendingTeamImportRoutine {
+  name: string;
+  owner: string;
+  prompt: string;
+  schedule: string;
+  runOn: string;
+  duration: string;
+  status: "Paused after import";
+}
 
 export interface PendingTeamImport {
   manifest: unknown;
   kind: "team" | "package";
   name: string;
   description: string;
-  members: Array<{ name: string; title: string }>;
+  authorName?: string;
+  members: PendingTeamImportMember[];
   chiefOfStaff?: string;
   rooms: number;
   playbooks: number;
   routines: number;
   apps: Array<{ label: string; optional: boolean }>;
+  roomEntries: PendingTeamImportRoom[];
+  playbookEntries: PendingTeamImportPlaybook[];
+  routineEntries: PendingTeamImportRoutine[];
+}
+
+/** Bound and normalize one textual package value. */
+function boundedText(value: unknown, max: number): string {
+  return typeof value === "string" && value.trim().length <= max ? value.trim() : "";
+}
+
+/** Bound and normalize a list of textual package values. */
+function boundedList(value: unknown, maxItems: number, maxText: number): string[] {
+  return Array.isArray(value) ? value.slice(0, maxItems).map((item) => boundedText(item, maxText)).filter(Boolean) : [];
+}
+
+/** Render a package schedule as a short human-readable label. */
+function humanSchedule(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "Not specified";
+  const schedule = value as Record<string, unknown>;
+  if (schedule.type === "manual") return "Manual only";
+  if (schedule.type === "daily") return `Daily at ${boundedText(schedule.time, 5) || "unspecified time"}`;
+  if (schedule.type === "once" && typeof schedule.at === "number" && Number.isFinite(schedule.at)) {
+    return `Once · ${new Date(schedule.at).toLocaleString()}`;
+  }
+  return "Not specified";
+}
+
+/** Resolve a package responder reference to a display label. */
+function responderLabel(value: unknown, agents: Map<string, string>): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "Mentions only";
+  const responder = value as Record<string, unknown>;
+  if (responder.kind === "everyone") return "Everyone";
+  if (responder.kind === "agent") return agents.get(boundedText(responder.agent, 64)) ?? "Named agent";
+  return "Mentions only";
+}
+
+const MASCOT_BODY_SET = new Set<string>(MASCOT_BODY_IDS);
+
+/** Keep only supported mascot color, expression, and avatar data from a package. */
+function safeAppearance(value: unknown): PendingTeamImportMember["appearance"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const color = MAUS_COLOR_NAMES.includes(source.color as MausColor) ? source.color as MausColor : undefined;
+  const mascotBody = typeof source.mascotBody === "string" && MASCOT_BODY_SET.has(source.mascotBody)
+    ? source.mascotBody as MascotBodyId
+    : undefined;
+  const mascotExpression = typeof source.mascotExpression === "string" && MAUS_STATES.includes(source.mascotExpression as MausState)
+    ? source.mascotExpression as MausState
+    : undefined;
+  if (!color && !mascotBody && !mascotExpression) return undefined;
+  return {
+    color: color ?? "green",
+    ...(mascotBody ? { mascotBody } : {}),
+    ...(mascotExpression ? { mascotExpression } : {}),
+  };
+}
+
+/** Validate and normalize one imported bot entry for the client preview. */
+function safeMember(value: unknown, index: number): PendingTeamImportMember {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Bot ${index + 1} is invalid.`);
+  const source = value as Record<string, unknown>;
+  const name = boundedText(source.name, 100);
+  if (!name) throw new Error(`Bot ${index + 1} does not have a name.`);
+  return {
+    key: boundedText(source.key, 64) || `member-${index + 1}`,
+    name,
+    title: boundedText(source.title, 200),
+    description: boundedText(source.description, BOT_INSTRUCTIONS_MAX_CHARS),
+    appearance: safeAppearance(source.appearance),
+  };
 }
 
 /** Small client-side preview only; the server remains the trust boundary. */
@@ -30,19 +140,7 @@ export function teamImportPreview(manifest: unknown): PendingTeamImport {
   if (typeof team.name !== "string" || !team.name.trim()) throw new Error("This team does not have a name.");
   if (!Array.isArray(team.members) || team.members.length === 0) throw new Error("This team has no members.");
   if (team.members.length > 200) throw new Error("This team has too many members.");
-  const members = team.members.map((member, index) => {
-    if (!member || typeof member !== "object" || Array.isArray(member)) {
-      throw new Error(`Team member ${index + 1} is invalid.`);
-    }
-    const value = member as Record<string, unknown>;
-    if (typeof value.name !== "string" || !value.name.trim()) {
-      throw new Error(`Team member ${index + 1} does not have a name.`);
-    }
-    return {
-      name: value.name.trim(),
-      title: typeof value.title === "string" ? value.title.trim() : "",
-    };
-  });
+  const members = team.members.map((member, index) => safeMember(member, index));
   return {
     manifest,
     kind: "team",
@@ -53,6 +151,9 @@ export function teamImportPreview(manifest: unknown): PendingTeamImport {
     playbooks: 0,
     routines: 0,
     apps: [],
+    roomEntries: [],
+    playbookEntries: [],
+    routineEntries: [],
   };
 }
 
@@ -73,6 +174,7 @@ function markdownPackage(markdown: string): unknown {
   return { format: "openmaus.package", version: 1, package: pkg };
 }
 
+/** Build a bounded client preview of package bots and deferred setup entries. */
 function packagePreview(root: Record<string, unknown>, manifest: unknown): PendingTeamImport {
   if (root.version !== 1) throw new Error(`BotMRR playbook version ${String(root.version)} is not supported.`);
   if (!root.package || typeof root.package !== "object" || Array.isArray(root.package)) {
@@ -82,16 +184,10 @@ function packagePreview(root: Record<string, unknown>, manifest: unknown): Pendi
   if (typeof pkg.name !== "string" || !pkg.name.trim()) throw new Error("This playbook does not have a name.");
   if (!Array.isArray(pkg.agents) || pkg.agents.length === 0) throw new Error("This playbook has no bots.");
   if (pkg.agents.length > 200) throw new Error("This playbook has too many bots.");
-  const members = pkg.agents.map((agent, index) => {
-    if (!agent || typeof agent !== "object" || Array.isArray(agent)) throw new Error(`Bot ${index + 1} is invalid.`);
-    const value = agent as Record<string, unknown>;
-    if (typeof value.name !== "string" || !value.name.trim()) throw new Error(`Bot ${index + 1} does not have a name.`);
-    return { name: value.name.trim(), title: typeof value.title === "string" ? value.title.trim() : "" };
-  });
+  const members = pkg.agents.map((agent, index) => safeMember(agent, index));
   const chiefKey = typeof pkg.chiefOfStaff === "string" ? pkg.chiefOfStaff : undefined;
-  const chief = chiefKey
-    ? (pkg.agents as Array<Record<string, unknown>>).find((agent) => agent.key === chiefKey)?.name
-    : undefined;
+  const chief = chiefKey ? members.find((agent) => agent.key === chiefKey)?.name : undefined;
+  const agentNames = new Map(members.map((member) => [member.key, member.name]));
   const requirements = pkg.requirements && typeof pkg.requirements === "object" && !Array.isArray(pkg.requirements)
     ? pkg.requirements as Record<string, unknown>
     : {};
@@ -104,16 +200,55 @@ function packagePreview(root: Record<string, unknown>, manifest: unknown): Pendi
           : [];
       })
     : [];
+  const roomEntries = Array.isArray(pkg.rooms) ? pkg.rooms.slice(0, 30).flatMap((room) => {
+    if (!room || typeof room !== "object" || Array.isArray(room)) return [];
+    const value = room as Record<string, unknown>;
+    return [{
+      name: boundedText(value.name, 100) || "Unnamed room",
+      members: boundedList(value.members, 200, 64).map((key) => agentNames.get(key) ?? key),
+      defaultResponder: responderLabel(value.defaultResponder, agentNames),
+      bulletin: boundedText(value.bulletin, 12_000),
+    }];
+  }) : [];
+  const playbookEntries = Array.isArray(pkg.playbooks) ? pkg.playbooks.slice(0, 80).flatMap((playbook) => {
+    if (!playbook || typeof playbook !== "object" || Array.isArray(playbook)) return [];
+    const value = playbook as Record<string, unknown>;
+    return [{
+      name: boundedText(value.name, 100) || "Unnamed playbook",
+      summary: boundedText(value.summary, 300),
+      triggers: boundedList(value.triggers, 30, 100),
+      instructions: boundedText(value.instructions, 24_000),
+    }];
+  }) : [];
+  const routineEntries = Array.isArray(pkg.routines) ? pkg.routines.slice(0, 50).flatMap((routine) => {
+    if (!routine || typeof routine !== "object" || Array.isArray(routine)) return [];
+    const value = routine as Record<string, unknown>;
+    return [{
+      name: boundedText(value.name, 80) || "Unnamed routine",
+      owner: agentNames.get(boundedText(value.agent, 64)) ?? boundedText(value.agent, 64),
+      prompt: boundedText(value.prompt, 20_000),
+      schedule: humanSchedule(value.schedule),
+      runOn: boundedText(value.runOn, 20),
+      duration: typeof value.durationMinutes === "number" ? `${value.durationMinutes} min` : "Not specified",
+      status: "Paused after import" as const,
+    }];
+  }) : [];
   return {
     manifest,
     kind: "package",
     name: pkg.name.trim(),
     description: typeof pkg.summary === "string" ? pkg.summary.trim() : "",
+    ...(pkg.author && typeof pkg.author === "object" && !Array.isArray(pkg.author) && boundedText((pkg.author as Record<string, unknown>).name, 100)
+      ? { authorName: boundedText((pkg.author as Record<string, unknown>).name, 100) }
+      : {}),
     members,
     ...(typeof chief === "string" ? { chiefOfStaff: chief } : {}),
     rooms: Array.isArray(pkg.rooms) ? pkg.rooms.length : 0,
     playbooks: Array.isArray(pkg.playbooks) ? pkg.playbooks.length : 0,
     routines: Array.isArray(pkg.routines) ? pkg.routines.length : 0,
     apps,
+    roomEntries,
+    playbookEntries,
+    routineEntries,
   };
 }


### PR DESCRIPTION
## What changed

Adds an explicit **Export & share** surface to Team Library and bounds the client-side package preview.

### Scoped export

Users can export:

- one visible bot;
- one non-DM room/team;
- one project section;
- all active bots.

The server validates every requested bot and room ID, rejects duplicates, hidden bots, unknown IDs, and direct-message rooms, then exports only the selected records. Conversations, credentials, permissions, paths, and private runtime state remain outside the package.

### Bounded preview

Package previews now show bounded public fields for bots, rooms, playbooks, routines, and connection requirements. Imported routines are labeled paused, and manual routines are shown as `Manual only` without inventing a schedule.

Avatar previews use the current upstream `mascotBody` catalog and validated mascot states. The obsolete custom avatar-definition list, including removed Moon/Hex entries, is not used.

## Scope corrections

- Removed an unused managed-share URL helper and documentation that implied a working fetch path when no caller existed.
- Removed the stale dependency on #571; the current official mascot-body renderer is already in upstream main.
- No managed publishing, account authority, credential transfer, or remote share fetch is added here.

## Verification

- 154 focused tests passed; 1 skipped.
- Client and server TypeScript checks passed.
- Production Vite build passed.
- Electron syntax check passed across 90 modules.
- Targeted lint passed with one unrelated existing warning in `server/index.ts`.
- Streaming secret-diff scan passed across 751 added lines.
- Rebuilt from official main `6dd974c`.
- Accepted head: `e2e587eb736790e77fe5e1a68ecc6fa461238cbf`.

## Visual acceptance

This PR changes rendered Team Library UI. No fresh screenshot is attached, so visual acceptance is not claimed.

## External checks

Maintainer workflow approval and Vercel authorization remain outside this contribution. Neither was triggered or authorized by this PR update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Export & share” tab to the team library.
  * Export entire projects, teams, or selected bots as portable packages.
  * Added clear bot avatars and improved export option previews.
  * Enhanced team import previews with member, room, playbook, and routine details.
* **Bug Fixes**
  * Export requests now reject hidden, unknown, duplicate, or invalid selections.
  * Improved handling of manual-only routines and unsafe appearance data during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->