### PR TITLE
Route configured Codex models through NVIDIA and OpenRouter

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -329,6 +329,43 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(seen.env.OPENMAUSBOT_LOCAL_UNSLOTH_API_KEY).toBe("unsloth-secret");
   });
 
+  it("routes direct NVIDIA and OpenRouter models with only the selected key", async () => {
+    const environment = {
+      OPENMAUSBOT_NVIDIA_API_KEY: "nvidia-secret",
+      OPENMAUSBOT_OPENROUTER_API_KEY: "openrouter-secret",
+    };
+    await create({ environment });
+    expect(instance.models.options.map((option) => option.id)).toEqual(
+      expect.arrayContaining(["nvidia::z-ai/glm-5.2", "openrouter::z-ai/glm-5.2"]),
+    );
+    const nvidiaDump = join(scratch, "nvidia.json");
+    process.env.FAKE_CODEX_DUMP = nvidiaDump;
+    await instance.adapter.sendTurn({ threadId: "t-nvidia", text: "route", model: "nvidia::z-ai/glm-5.2" });
+    await recorder.until((event) => event.type === "turn.completed");
+    const nvidia = JSON.parse(readFileSync(nvidiaDump, "utf8"));
+    expect(nvidia.env.OPENMAUSBOT_NVIDIA_API_KEY).toBe("nvidia-secret");
+    expect(nvidia.env.OPENMAUSBOT_OPENROUTER_API_KEY).toBeUndefined();
+    expect(nvidia.argv).toContain('model_providers.nvidia.base_url="https://integrate.api.nvidia.com/v1"');
+    expect(nvidia.argv).toContain('model_providers.nvidia.env_key="OPENMAUSBOT_NVIDIA_API_KEY"');
+    expect(JSON.stringify(nvidia.argv)).not.toContain("nvidia-secret");
+    expect(JSON.stringify(nvidia.argv)).not.toContain("openrouter-secret");
+
+    await instance.dispose();
+    recorder.stop();
+    await create({ environment });
+    const openrouterDump = join(scratch, "openrouter.json");
+    process.env.FAKE_CODEX_DUMP = openrouterDump;
+    await instance.adapter.sendTurn({ threadId: "t-openrouter", text: "route", model: "openrouter::z-ai/glm-5.2" });
+    await recorder.until((event) => event.type === "turn.completed");
+    const openrouter = JSON.parse(readFileSync(openrouterDump, "utf8"));
+    expect(openrouter.env.OPENMAUSBOT_OPENROUTER_API_KEY).toBe("openrouter-secret");
+    expect(openrouter.env.OPENMAUSBOT_NVIDIA_API_KEY).toBeUndefined();
+    expect(openrouter.argv).toContain('model_providers.openrouter.base_url="https://openrouter.ai/api/v1"');
+    expect(openrouter.argv).toContain('model_providers.openrouter.env_key="OPENMAUSBOT_OPENROUTER_API_KEY"');
+    expect(JSON.stringify(openrouter.argv)).not.toContain("nvidia-secret");
+    expect(JSON.stringify(openrouter.argv)).not.toContain("openrouter-secret");
+  });
+
   it("streams agentMessage deltas without re-emitting the settled text", async () => {
     process.env.FAKE_CODEX_MODE = "stream";
     await create();

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -18,6 +18,7 @@ import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 
 import type {
   DriverCreateInput,
+  ModelCatalog,
   ProviderDriver,
   ProviderInstance,
   ProviderSnapshot,
@@ -52,6 +53,60 @@ function decodeConfig(raw: unknown): CodexConfig {
 const QUESTION_TIMEOUT_NOTE = "No answer was given — use your best judgment.";
 const DENY_TIMEOUT_NOTE =
   "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
+
+type DirectCodexProvider = "nvidia" | "openrouter";
+
+const DIRECT_CODEX_PROVIDERS: Record<DirectCodexProvider, {
+  baseUrl: string;
+  envKey: string;
+  model: string;
+  label: string;
+}> = {
+  nvidia: {
+    baseUrl: "https://integrate.api.nvidia.com/v1",
+    envKey: "OPENMAUSBOT_NVIDIA_API_KEY",
+    model: "z-ai/glm-5.2",
+    label: "GLM 5.2 (NVIDIA NIM)",
+  },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    envKey: "OPENMAUSBOT_OPENROUTER_API_KEY",
+    model: "z-ai/glm-5.2",
+    label: "GLM 5.2 (OpenRouter)",
+  },
+};
+
+function directCodexProvider(modelId: string | null | undefined): DirectCodexProvider | null {
+  const provider = decodeCodexSelection(modelId).modelProvider;
+  return provider === "nvidia" || provider === "openrouter" ? provider : null;
+}
+
+function configuredDirectCodexModels(environment: Record<string, string>): ModelCatalog {
+  const options = (Object.entries(DIRECT_CODEX_PROVIDERS) as Array<[DirectCodexProvider, typeof DIRECT_CODEX_PROVIDERS[DirectCodexProvider]]>)
+    .filter(([, provider]) => Boolean(environment[provider.envKey]))
+    .map(([id, provider]) => ({
+      id: `${id}::${provider.model}`,
+      label: provider.label,
+      custom: true,
+    }));
+  return { default: options[0]?.id ?? "", options };
+}
+
+function directCodexProviderArgs(
+  env: Record<string, string | undefined>,
+  modelId: string | null | undefined,
+  keys: Record<DirectCodexProvider, string | undefined>,
+): string[] {
+  const providerId = directCodexProvider(modelId);
+  if (!providerId) return [];
+  const provider = DIRECT_CODEX_PROVIDERS[providerId];
+  if (keys[providerId]) env[provider.envKey] = keys[providerId];
+  return [
+    "-c", `model_providers.${providerId}.name=${JSON.stringify(providerId)}`,
+    "-c", `model_providers.${providerId}.base_url=${JSON.stringify(provider.baseUrl)}`,
+    "-c", `model_providers.${providerId}.env_key=${JSON.stringify(provider.envKey)}`,
+  ];
+}
 
 type StdioMcpServer = { command: string; args: string[]; env: Record<string, string> };
 
@@ -97,7 +152,11 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
 
   async create(input: DriverCreateInput<CodexConfig>): Promise<ProviderInstance> {
     const { instanceId, config } = input;
-    const childEnv = (): Record<string, string | undefined> => {
+    const directProviderKeys: Record<DirectCodexProvider, string | undefined> = {
+      nvidia: input.environment.OPENMAUSBOT_NVIDIA_API_KEY,
+      openrouter: input.environment.OPENMAUSBOT_OPENROUTER_API_KEY,
+    };
+    const childEnv = (modelId?: string): Record<string, string | undefined> => {
       const env: Record<string, string | undefined> = {
         ...process.env,
         ...input.environment,
@@ -110,14 +169,27 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       // The harness process may hold workspace credentials (xai/box/voice
       // keys, env-injected at boot); none of them are this CLI's to see.
       stripWorkspaceCredentialEnv(env);
+      for (const provider of Object.values(DIRECT_CODEX_PROVIDERS)) delete env[provider.envKey];
+      const selectedProvider = directCodexProvider(modelId);
+      if (selectedProvider && directProviderKeys[selectedProvider]) {
+        env[DIRECT_CODEX_PROVIDERS[selectedProvider].envKey] = directProviderKeys[selectedProvider];
+      }
       return env;
     };
-    const catalogEnv = childEnv();
-    let models = STATIC_CODEX_MODELS;
+    const catalogEnv = { ...input.environment };
+    const directModels = configuredDirectCodexModels(catalogEnv);
+    const withDirectModels = (catalog: ModelCatalog): ModelCatalog => {
+      const seen = new Set(catalog.options.map((option) => option.id));
+      return {
+        default: catalog.default || directModels.default,
+        options: [...catalog.options, ...directModels.options.filter((option) => !seen.has(option.id))],
+      };
+    };
+    let models = withDirectModels(STATIC_CODEX_MODELS);
     const refreshModels = async () => {
       try {
         const resolved = await readCodexModelCatalog(catalogEnv, fetch, config.cli);
-        if (resolved.options.length) models = resolved;
+        if (resolved.options.length) models = withDirectModels(resolved);
       } catch {
         // Keep the last usable catalog when a local provider is down.
       }
@@ -154,8 +226,12 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       const retryScale = Number(process.env.FAKE_CODEX_RETRY_SCALE ?? "1");
 
       const launchAttempt = async (attempt: number): Promise<void> => {
-        const env = childEnv();
-        const appServerArgs = ["app-server", ...codexLocalProviderArgs(env, turn.model)];
+        const env = childEnv(turn.model);
+        const appServerArgs = [
+          "app-server",
+          ...directCodexProviderArgs(env, turn.model, directProviderKeys),
+          ...codexLocalProviderArgs(env, turn.model),
+        ];
         if (turn.integrations?.composio) {
           mountMcpServer(appServerArgs, env, "openmausbot_connectors", turn.integrations.composio);
         }
@@ -614,6 +690,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       );
     });
     if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+    if (directProviderKeys.nvidia || directProviderKeys.openrouter) {
+      return { state: "available", version, authenticated: true, billing: "metered" };
+    }
     const authenticated = await new Promise<boolean>((resolve) => {
       execCli(config.cli, ["login", "status"], { timeout: 8000, env }, (err, stdout, stderr) =>
         resolve(!err && /^logged in\b/im.test(`${stdout}\n${stderr ?? ""}`)),


### PR DESCRIPTION
## What changed

Adds two explicitly configured Codex app-server provider routes:

- `nvidia::z-ai/glm-5.2` through NVIDIA NIM.
- `openrouter::z-ai/glm-5.2` through OpenRouter.

A row is exposed only when its corresponding instance environment key is configured:

- `OPENMAUSBOT_NVIDIA_API_KEY`
- `OPENMAUSBOT_OPENROUTER_API_KEY`

For each turn, the driver removes both provider keys from the inherited child environment, restores only the selected provider key, and passes only provider metadata in argv. Key values never enter argv.

## Scope

This PR now contains only provider routing and its focused test. The duplicated permission-review implementation was removed; that subsystem remains isolated in #612.

No settings UI, credential store, permission reviewer, or unrelated Codex refactor is included.

## Verification

- Focused Codex driver suite: 31 passed.
- Client and server TypeScript checks passed.
- Production Vite build passed.
- Electron syntax check passed across 90 modules.
- Streaming secret-diff scan passed across 122 added lines.
- Rebuilt from official main `6dd974c`.
- Accepted head: `86fbe65667dc717227efba8990235787ae3c783a`.

Tests verify that:

- only the selected provider key reaches the child environment;
- the other provider key is absent;
- neither key value appears in argv;
- both configured model rows are exposed.

## External checks

Maintainer workflow approval and Vercel authorization remain outside this contribution. Neither was triggered or authorized by this PR update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting directly to NVIDIA NIM and OpenRouter models.
  * Available models now reflect configured provider access.
  * Requests use the selected provider and securely apply its credentials.
  * Direct provider connections report authenticated and metered status.

* **Bug Fixes**
  * Prevented credentials for unselected providers from being sent or exposed in request arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->