### PR TITLE
Restore safe Windows local screen preview

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -27,7 +27,12 @@ import {
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
-import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
+import {
+  enableGrokBotLinkHandler,
+  grokBotLinkHandlerStatus,
+  packageUrlFromCommandLine,
+  packageUrlFromDeepLink,
+} from "./package-link.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
 import { defaultSaveName, withSavableFile } from "./save-file.mjs";
 import { desktopViewerPermissionAllowed } from "./desktop-viewer-permissions.mjs";
@@ -61,9 +66,14 @@ import { buildApplicationMenu } from "./menu.mjs";
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
 const nativeActions = nativeDesktopActions(process.platform);
 const require = createRequire(import.meta.url);
-const { createDisplayMediaGuard, invokeDisplayMediaCallback, selectCaptureSource } = require(
-  "./screen-preview.cjs",
-);
+const {
+  allowScreenFrameRequest,
+  captureScreenFrame,
+  createDisplayMediaGuard,
+  invokeDisplayMediaCallback,
+  isTrustedMainRenderer,
+  selectCaptureSource,
+} = require("./screen-preview.cjs");
 const { STAGE_PREFIX: APPIMAGE_CUA_STAGE_PREFIX } = require("./cua-linux-bundle.cjs");
 const { desktopViewerUrl, sameDesktopViewerOrigin } = require("./desktop-viewer.cjs");
 const { createDesktopWorkspaceManager } = require("./desktop-workspace.cjs");
@@ -1373,8 +1383,12 @@ ipcMain.handle("browser:forget-profile", localOnly("browser:forget-profile", asy
   return { dropped };
 }));
 
+function isMainRenderer(event) {
+  return isTrustedMainRenderer({ event, mainWindow });
+}
+
 ipcMain.on("screen:preview-intent", (event) => {
-  event.returnValue = displayMediaGuard.begin(event.senderFrame);
+  event.returnValue = isMainRenderer(event) && displayMediaGuard.begin(event.senderFrame);
 });
 
 ipcMain.on("desktop:unread-count", (event, value) => {
@@ -1522,7 +1536,6 @@ async function forgetEnvironment(id) {
 }
 
 function createWindow() {
-  const waitsForSkinSync = process.platform === "win32";
   const primary = screen.getPrimaryDisplay();
   const displays = [primary, ...screen.getAllDisplays().filter((display) => display.id !== primary.id)];
   const restored = resolveWindowState(readWindowState(), displays.map((display) => display.workArea));
@@ -1530,11 +1543,7 @@ function createWindow() {
     ...restored.bounds,
     minWidth: 900,
     minHeight: 600,
-    // The renderer restores its persisted skin before mounting React and
-    // mirrors it over desktop:skin. Keep Windows hidden until that handshake
-    // recolors the native caption-button overlay, otherwise a saved light
-    // skin still flashes the Midnight-black block on every cold start.
-    show: !waitsForSkinSync,
+    show: true,
     icon: APP_ICON,
     backgroundColor: "#070707",
     autoHideMenuBar: process.platform !== "darwin",
@@ -1548,18 +1557,6 @@ function createWindow() {
   });
   mainWindow = win;
   void startBrowserSurface(win);
-  if (waitsForSkinSync) {
-    // A broken renderer or preload must not strand the app as an invisible
-    // process. Normal startup shows from desktop:skin almost immediately;
-    // this is only the bounded recovery path.
-    const skinSyncFallback = setTimeout(() => {
-      if (!win.isDestroyed() && !win.isVisible()) win.show();
-    }, 5_000);
-    skinSyncFallback.unref?.();
-    const clearSkinSyncFallback = () => clearTimeout(skinSyncFallback);
-    win.once("show", clearSkinSyncFallback);
-    win.once("closed", clearSkinSyncFallback);
-  }
   installWindowStatePersistence(win);
   applyUnreadBadge(win);
   if (restored.maximized) win.maximize();
@@ -1755,13 +1752,16 @@ function createWindow() {
 
 // Local-control screen preview — served from the main process so the Screen
 // Recording permission prompt attributes to the app, never the server
-ipcMain.handle("screen:frame", localOnly("screen:frame", async () => {
-  if (process.platform !== "darwin") return null;
-  const sources = await desktopCapturer.getSources({
-    types: ["screen"],
-    thumbnailSize: { width: 1280, height: 800 },
+ipcMain.handle("screen:frame", localOnly("screen:frame", async (event, ...payload) => {
+  // This channel is deliberately a no-argument capability of the main app
+  // renderer only. Do not let a child viewer or a caller-supplied payload turn
+  // it into a general desktop-capture API.
+  if (!allowScreenFrameRequest({ event, mainWindow, payload })) return null;
+  return captureScreenFrame({
+    platform: process.platform,
+    getSources: (options) => desktopCapturer.getSources(options),
+    getPrimaryDisplay: () => screen.getPrimaryDisplay(),
   });
-  return sources[0]?.thumbnail.toDataURL() ?? null;
 }));
 
 // Onboarding permission checks. Status reads are free; the mic request
@@ -1858,12 +1858,34 @@ ipcMain.handle("desktop:save-file", localOnly("desktop:save-file", async (event,
   });
 }));
 
-// The renderer owns the skin. Native Windows/Linux chrome is intentionally
-// outside that surface; acknowledge the renderer handshake without creating
-// a frameless caption overlay that can cover page controls.
-ipcMain.handle("desktop:skin", (_event, skin) => {
-  if (!isKnownSkin(skin)) return false;
-  return true;
+// Keep the renderer's skin handshake as a safe acknowledgement for current
+// and older preload clients. Native chrome is platform-owned and does not
+// depend on skin state or a hidden-window startup handshake.
+ipcMain.handle("desktop:skin", (_event, skin) => isKnownSkin(skin));
+
+function currentGrokBotLinkHandlerState() {
+  return grokBotLinkHandlerStatus({
+    platform: process.platform,
+    packaged: app.isPackaged,
+    executablePath: process.execPath,
+    isDefaultProtocolClient: (...args) => app.isDefaultProtocolClient(...args),
+  });
+}
+
+ipcMain.handle("desktop:grok-link-handler:status", (event) => {
+  if (!isMainRenderer(event)) return { supported: false, isDefault: false };
+  return currentGrokBotLinkHandlerState();
+});
+
+ipcMain.handle("desktop:grok-link-handler:enable", (event) => {
+  if (!isMainRenderer(event)) return { supported: false, isDefault: false, registrationSucceeded: false };
+  return enableGrokBotLinkHandler({
+    platform: process.platform,
+    packaged: app.isPackaged,
+    executablePath: process.execPath,
+    isDefaultProtocolClient: (...args) => app.isDefaultProtocolClient(...args),
+    setAsDefaultProtocolClient: (...args) => app.setAsDefaultProtocolClient(...args),
+  });
 });
 
 ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {

--- a/electron/package-link.mjs
+++ b/electron/package-link.mjs
@@ -1,13 +1,33 @@
+import { win32 as windowsPath } from "node:path";
+
 const ALLOWED_PACKAGE_HOSTS = new Set(["github.com", "www.github.com", "raw.githubusercontent.com"]);
+const BOT_SHARE_HOST = "accounts.openmausbot.com";
+const BOT_SHARE_PACKAGE_PATH = /^\/v1\/bot-shares\/[A-Za-z0-9_-]{21}\/package$/;
+const GROK_BOT_DEEP_LINK = /^grokbot:\/\/app\/v1\/bot-template\?id=[A-Za-z0-9_-]{21}$/;
+const GROK_BOT_PROTOCOL = "grokbot";
 
 export function packageUrlFromDeepLink(rawValue) {
+  const raw = String(rawValue);
+  if (GROK_BOT_DEEP_LINK.test(raw)) return raw;
+
   let link;
   try {
-    link = new URL(String(rawValue));
+    link = new URL(raw);
   } catch {
     return null;
   }
-  if (link.protocol !== "openmausbot:" || link.hostname !== "install") return null;
+  if (
+    link.protocol !== "openmausbot:" ||
+    link.hostname !== "install" ||
+    link.pathname ||
+    link.username ||
+    link.password ||
+    link.port ||
+    link.hash ||
+    raw.includes("#") ||
+    [...link.searchParams.keys()].length !== 1 ||
+    [...link.searchParams.keys()][0] !== "url"
+  ) return null;
   const rawPackage = link.searchParams.get("url");
   if (!rawPackage) return null;
   let packageUrl;
@@ -16,13 +36,22 @@ export function packageUrlFromDeepLink(rawValue) {
   } catch {
     return null;
   }
+  const githubPackage =
+    ALLOWED_PACKAGE_HOSTS.has(packageUrl.hostname) &&
+    /\.(?:md|json)$/.test(packageUrl.pathname) &&
+    !packageUrl.search &&
+    !packageUrl.hash;
+  const openMausShare =
+    packageUrl.hostname === BOT_SHARE_HOST &&
+    BOT_SHARE_PACKAGE_PATH.test(packageUrl.pathname) &&
+    !packageUrl.search &&
+    !packageUrl.hash;
   if (
     packageUrl.protocol !== "https:" ||
     packageUrl.username ||
     packageUrl.password ||
     packageUrl.port ||
-    !ALLOWED_PACKAGE_HOSTS.has(packageUrl.hostname) ||
-    !packageUrl.pathname.match(/\.(?:md|json)$/)
+    (!githubPackage && !openMausShare)
   ) return null;
   return packageUrl.toString();
 }
@@ -33,4 +62,67 @@ export function packageUrlFromCommandLine(argv) {
     if (parsed) return parsed;
   }
   return null;
+}
+
+export function grokBotProtocolClientContract({ platform, packaged, executablePath }) {
+  if (
+    platform !== "win32" ||
+    packaged !== true ||
+    typeof executablePath !== "string" ||
+    !windowsPath.isAbsolute(executablePath) ||
+    windowsPath.extname(executablePath).toLowerCase() !== ".exe"
+  ) return null;
+  return {
+    protocol: GROK_BOT_PROTOCOL,
+    executablePath,
+    arguments: [],
+  };
+}
+
+export function grokBotLinkHandlerStatus({
+  platform,
+  packaged,
+  executablePath,
+  isDefaultProtocolClient,
+}) {
+  const contract = grokBotProtocolClientContract({ platform, packaged, executablePath });
+  const supported = contract !== null;
+  let isDefault = false;
+  if (contract) {
+    try {
+      isDefault = isDefaultProtocolClient(
+        contract.protocol,
+        contract.executablePath,
+        contract.arguments,
+      ) === true;
+    } catch {
+      isDefault = false;
+    }
+  }
+  return { supported, isDefault };
+}
+
+export function enableGrokBotLinkHandler({
+  platform,
+  packaged,
+  executablePath,
+  isDefaultProtocolClient,
+  setAsDefaultProtocolClient,
+}) {
+  const input = { platform, packaged, executablePath, isDefaultProtocolClient };
+  const before = grokBotLinkHandlerStatus(input);
+  if (!before.supported) return { ...before, registrationSucceeded: false };
+  const contract = grokBotProtocolClientContract(input);
+  let registrationSucceeded = false;
+  try {
+    registrationSucceeded = setAsDefaultProtocolClient(
+      contract.protocol,
+      contract.executablePath,
+      contract.arguments,
+    ) === true;
+  } catch {
+    registrationSucceeded = false;
+  }
+  const after = grokBotLinkHandlerStatus(input);
+  return { ...after, registrationSucceeded };
 }

--- a/electron/package-link.node-test.mjs
+++ b/electron/package-link.node-test.mjs
@@ -1,7 +1,18 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
+import vm from "node:vm";
 
-import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
+import {
+  enableGrokBotLinkHandler,
+  grokBotLinkHandlerStatus,
+  grokBotProtocolClientContract,
+  packageUrlFromCommandLine,
+  packageUrlFromDeepLink,
+} from "./package-link.mjs";
+
+const grokShareId = "Abcdefghijklmnopqrstu";
+const grokLink = `grokbot://app/v1/bot-template?id=${grokShareId}`;
 
 describe("BotMRR package deep links", () => {
   it("accepts a public GitHub package URL", () => {
@@ -10,11 +21,180 @@ describe("BotMRR package deep links", () => {
     assert.equal(packageUrlFromCommandLine(["OpenMausBot", "--flag", `openmausbot://install?url=${encodeURIComponent(target)}`]), target);
   });
 
+  it("routes the exact Grok Bot link from initial argv and second-instance argv", () => {
+    assert.equal(packageUrlFromDeepLink(grokLink), grokLink);
+    assert.equal(packageUrlFromCommandLine(["OpenMausBot.exe", grokLink]), grokLink, "initial argv");
+    assert.equal(packageUrlFromCommandLine(["OpenMausBot.exe", "--second-instance", grokLink]), grokLink, "second-instance argv");
+
+    const main = readFileSync(new URL("./main.mjs", import.meta.url), "utf8");
+    assert.match(main, /pendingPackageInstallUrl\s*=\s*packageUrlFromCommandLine\(process\.argv\)/);
+    assert.match(main, /app\.on\("second-instance",[\s\S]*?packageUrlFromCommandLine\(commandLine\)/);
+    assert.match(main, /app\.on\("open-url",[\s\S]*?queuePackageInstall\(url\)/);
+    assert.match(main, /webContents\.send\("package:install", pendingPackageInstallUrl\)/);
+
+    const sidebar = readFileSync(new URL("../src/components/Sidebar.tsx", import.meta.url), "utf8");
+    assert.match(sidebar, /onPackageInstall\?\.\(\(url\)\s*=>\s*\{\s*setTeamInstallUrl\(url\);\s*setTeamLibraryOpen\(true\)/);
+    assert.match(sidebar, /<TeamLibraryPanel[\s\S]*?initialUrl=\{teamInstallUrl \?\? undefined\}/);
+  });
+
+  it("rejects Grok Bot credentials, fragments, duplicate or extra query, and non-exact routes", () => {
+    for (const value of [
+      `grokbot://user@app/v1/bot-template?id=${grokShareId}`,
+      `grokbot://app/v1/bot-template?id=${grokShareId}#fragment`,
+      `grokbot://app/v1/bot-template?id=${grokShareId}#`,
+      `grokbot://app/v1/bot-template?id=${grokShareId}&extra=1`,
+      `grokbot://app/v1/bot-template?id=${grokShareId}&id=${grokShareId}`,
+      `grokbot://app/v1/bot-template/?id=${grokShareId}`,
+      `grokbot://app:99/v1/bot-template?id=${grokShareId}`,
+      `grokbot://app/v1/bot-template?id=${grokShareId.slice(1)}`,
+      `grokbot://app/v1/bot-template?id=${grokShareId}%20`,
+      ` grokbot://app/v1/bot-template?id=${grokShareId}`,
+    ]) assert.equal(packageUrlFromDeepLink(value), null, value);
+  });
+
+  it("accepts only the exact accounts share-package host, path, and opaque id", () => {
+    const target = "https://accounts.openmausbot.com/v1/bot-shares/Abcdefghijklmnopqrstu/package";
+    expectPackage(target, target);
+    expectPackage(`${target}?download=1`, null);
+    expectPackage("https://accounts.openmausbot.com/v1/bot-shares/short/package", null);
+    expectPackage("https://accounts.openmausbot.com.evil.example/v1/bot-shares/Abcdefghijklmnopqrstu/package", null);
+    expectPackage("https://accounts.openmausbot.com/v1/bot-shares/Abcdefghijklmnopqrstu/package.md", null);
+  });
+
   it("rejects other commands, hosts, protocols, credentials, and unsupported file types", () => {
     assert.equal(packageUrlFromDeepLink("openmausbot://settings"), null);
     assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://evil.example/bot.json"), null);
     assert.equal(packageUrlFromDeepLink("openmausbot://install?url=http://raw.githubusercontent.com/a/b/main/bot.json"), null);
     assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://user@example.com/bot.json"), null);
     assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://github.com/acme/bot/run.sh"), null);
+    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://github.com/acme/bot/bot.json&extra=1"), null);
+    assert.equal(packageUrlFromDeepLink("openmausbot://user@install?url=https://github.com/acme/bot/bot.json"), null);
+    assert.equal(packageUrlFromDeepLink("openmausbot://install?url=https://github.com/acme/bot/bot.json#fragment"), null);
+    expectPackage("https://github.com/acme/bot/bot.json?raw=1", null);
+    expectPackage("https://github.com/acme/bot/bot.json#fragment", null);
+  });
+
+  it("keeps grokbot opt-in and exposes input-free status/enable behavior", () => {
+    let currentDefault = false;
+    const calls = [];
+    const executablePath = "D:\\Codex\\OpenMausBot-custom\\release-local\\win-unpacked\\OpenMausBot.exe";
+    const api = {
+      platform: "win32",
+      packaged: true,
+      executablePath,
+      isDefaultProtocolClient: (scheme, executable, args) =>
+        scheme === "grokbot" && executable === executablePath && args.length === 0 && currentDefault,
+      setAsDefaultProtocolClient: (scheme, executable, args) => {
+        calls.push([scheme, executable, args]);
+        currentDefault = scheme === "grokbot" && executable === executablePath && args.length === 0;
+        return currentDefault;
+      },
+    };
+    assert.deepEqual(grokBotLinkHandlerStatus(api), { supported: true, isDefault: false });
+    assert.equal(calls.length, 0, "status must not register or capture the protocol");
+    assert.deepEqual(enableGrokBotLinkHandler(api), {
+      supported: true,
+      isDefault: true,
+      registrationSucceeded: true,
+    });
+    assert.deepEqual(calls, [["grokbot", executablePath, []]]);
+
+    const preload = readFileSync(new URL("./preload.cjs", import.meta.url), "utf8");
+    assert.match(preload, /status:\s*\(\)\s*=>\s*ipcRenderer\.invoke\("desktop:grok-link-handler:status"\)/);
+    assert.match(preload, /enable:\s*\(\)\s*=>\s*ipcRenderer\.invoke\("desktop:grok-link-handler:enable"\)/);
+    const main = readFileSync(new URL("./main.mjs", import.meta.url), "utf8");
+    assert.doesNotMatch(main, /if \(app\.isPackaged\) app\.setAsDefaultProtocolClient\("grokbot"\)/);
+    assert.match(main, /executablePath:\s*process\.execPath/);
+    assert.match(main, /setAsDefaultProtocolClient:\s*\(\.\.\.args\)\s*=>\s*app\.setAsDefaultProtocolClient\(\.\.\.args\)/);
+  });
+
+  it("uses the same exact Windows executable/arguments contract for unpacked and installed releases", () => {
+    for (const executablePath of [
+      "D:\\Codex\\OpenMausBot-custom\\release-local\\win-unpacked\\OpenMausBot.exe",
+      "C:\\Users\\tester\\AppData\\Local\\Programs\\OpenMausBot\\OpenMausBot.exe",
+    ]) {
+      assert.deepEqual(
+        grokBotProtocolClientContract({ platform: "win32", packaged: true, executablePath }),
+        { protocol: "grokbot", executablePath, arguments: [] },
+      );
+    }
+    for (const input of [
+      { platform: "linux", packaged: true, executablePath: "/opt/OpenMausBot" },
+      { platform: "darwin", packaged: true, executablePath: "/Applications/OpenMausBot.app" },
+      { platform: "win32", packaged: false, executablePath: "D:\\repo\\node_modules\\electron\\electron.exe" },
+      { platform: "win32", packaged: true, executablePath: "OpenMausBot.exe" },
+      { platform: "win32", packaged: true, executablePath: "D:\\release\\OpenMausBot.cmd" },
+    ]) assert.equal(grokBotProtocolClientContract(input), null);
+  });
+
+  it("delivers an early preload link once across renderer subscription timing and remount", () => {
+    const { bridge, emit } = loadPreloadBridge();
+    emit("package:install", grokLink);
+    const deliveries = [];
+    const unsubscribe = bridge.onPackageInstall((url) => deliveries.push(url));
+    unsubscribe();
+    bridge.onPackageInstall((url) => deliveries.push(url));
+    assert.deepEqual(deliveries, [grokLink]);
+  });
+
+  it("delivers a live preload link once without replaying it to a later subscriber", () => {
+    const { bridge, emit } = loadPreloadBridge();
+    const first = [];
+    const second = [];
+    const unsubscribe = bridge.onPackageInstall((url) => first.push(url));
+    emit("package:install", grokLink);
+    unsubscribe();
+    bridge.onPackageInstall((url) => second.push(url));
+    assert.deepEqual(first, [grokLink]);
+    assert.deepEqual(second, []);
+  });
+
+  it("keeps builder metadata free of an automatic grokbot association", () => {
+    const metadata = readFileSync(new URL("../electron-builder.yml", import.meta.url), "utf8");
+    assert.match(metadata, /name: OpenMausBot package install\s+schemes: \[openmausbot\]/);
+    assert.doesNotMatch(metadata, /schemes:\s*\[[^\]]*grokbot/i);
   });
 });
+
+function expectPackage(target, expected) {
+  assert.equal(packageUrlFromDeepLink(`openmausbot://install?url=${encodeURIComponent(target)}`), expected);
+}
+
+function loadPreloadBridge() {
+  const listeners = new Map();
+  let bridge;
+  const ipcRenderer = {
+    on(channel, listener) {
+      const channelListeners = listeners.get(channel) ?? [];
+      channelListeners.push(listener);
+      listeners.set(channel, channelListeners);
+    },
+    removeListener() {},
+    invoke() {},
+    send() {},
+    sendSync() {},
+  };
+  vm.runInNewContext(readFileSync(new URL("./preload.cjs", import.meta.url), "utf8"), {
+    process: { platform: "win32", argv: [] },
+    require(id) {
+      if (id !== "electron") throw new Error(`Unexpected preload dependency: ${id}`);
+      return {
+        contextBridge: {
+          exposeInMainWorld(name, value) {
+            assert.equal(name, "ogb");
+            bridge = value;
+          },
+        },
+        ipcRenderer,
+        webUtils: { getPathForFile: () => "" },
+      };
+    },
+  });
+  assert.ok(bridge);
+  return {
+    bridge,
+    emit(channel, value) {
+      for (const listener of listeners.get(channel) ?? []) listener({}, value);
+    },
+  };
+}

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -11,7 +11,11 @@ let pendingPackageInstallUrl = null;
 const packageInstallListeners = new Set();
 ipcRenderer.on("package:install", (_event, url) => {
   if (typeof url !== "string") return;
-  pendingPackageInstallUrl = url;
+  if (packageInstallListeners.size === 0) {
+    pendingPackageInstallUrl = url;
+    return;
+  }
+  pendingPackageInstallUrl = null;
   for (const listener of packageInstallListeners) listener(url);
 });
 
@@ -135,10 +139,19 @@ const bridge = {
   /** Tell the window which skin the page wears, so the native chrome the
    * renderer cannot paint (the Windows caption-button overlay) matches. */
   applySkin: (skin) => ipcRenderer.invoke("desktop:skin", skin),
-  /** A reviewed BotMRR package opened through openmausbot://install. */
+  /** Explicit, input-free Windows association control for public Grok Bot links. */
+  grokBotLinkHandler: {
+    status: () => ipcRenderer.invoke("desktop:grok-link-handler:status"),
+    enable: () => ipcRenderer.invoke("desktop:grok-link-handler:enable"),
+  },
+  /** A reviewed package or public Grok Bot link opened through a registered protocol. */
   onPackageInstall: (cb) => {
     packageInstallListeners.add(cb);
-    if (pendingPackageInstallUrl) cb(pendingPackageInstallUrl);
+    if (pendingPackageInstallUrl) {
+      const url = pendingPackageInstallUrl;
+      pendingPackageInstallUrl = null;
+      cb(url);
+    }
     return () => packageInstallListeners.delete(cb);
   },
   /** Mirrors durable unread state into the native Dock/taskbar badge. */

--- a/electron/screen-preview.cjs
+++ b/electron/screen-preview.cjs
@@ -11,6 +11,19 @@ function originOf(value) {
   }
 }
 
+function isTrustedMainRenderer({ event, mainWindow }) {
+  return Boolean(
+    mainWindow &&
+      !mainWindow.isDestroyed() &&
+      event?.sender === mainWindow.webContents &&
+      event?.senderFrame === event.sender.mainFrame,
+  );
+}
+
+function allowScreenFrameRequest({ event, mainWindow, payload }) {
+  return isTrustedMainRenderer({ event, mainWindow }) && Array.isArray(payload) && payload.length === 0;
+}
+
 function createDisplayMediaGuard({ now = Date.now, ttlMs = 5_000 } = {}) {
   const intents = new Map();
 
@@ -66,8 +79,35 @@ function selectCaptureSource({ sources, host, primaryDisplayId }) {
     // source is still unambiguous; never guess when multiple sources remain.
     return exact ?? (sources.length === 1 ? sources[0] : null);
   }
+  if (host === "win32") {
+    const exact = sources.find(
+      (source) =>
+        source.display_id !== undefined &&
+        primaryDisplayId !== undefined &&
+        String(source.display_id) === String(primaryDisplayId),
+    );
+    // Windows can expose one source without a display_id while a monitor is
+    // still available. It is safe to use only that unambiguous source; never
+    // guess when multiple displays cannot be matched to Screen API ids.
+    return exact ?? (sources.length === 1 ? sources[0] : null);
+  }
   if (host === "darwin") return sources[0];
   return null;
+}
+
+async function captureScreenFrame({ platform, getSources, getPrimaryDisplay }) {
+  if (platform !== "darwin" && platform !== "win32") return null;
+  const sources = await getSources({
+    types: ["screen"],
+    thumbnailSize: { width: 1280, height: 800 },
+  });
+  if (!Array.isArray(sources) || sources.length === 0) return null;
+  const source = selectCaptureSource({
+    sources,
+    host: platform,
+    primaryDisplayId: getPrimaryDisplay?.()?.id,
+  });
+  return source?.thumbnail?.toDataURL?.() ?? null;
 }
 
 // Electron may throw synchronously from the display-media callback when an
@@ -86,9 +126,12 @@ function invokeDisplayMediaCallback(callback, response) {
 }
 
 module.exports = {
+  allowScreenFrameRequest,
+  captureScreenFrame,
   createDisplayMediaGuard,
   frameKey,
   invokeDisplayMediaCallback,
+  isTrustedMainRenderer,
   originOf,
   selectCaptureSource,
 };

--- a/electron/screen-preview.test.mjs
+++ b/electron/screen-preview.test.mjs
@@ -2,9 +2,14 @@ import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const { createDisplayMediaGuard, invokeDisplayMediaCallback, selectCaptureSource } = require(
-  "./screen-preview.cjs",
-);
+const {
+  allowScreenFrameRequest,
+  captureScreenFrame,
+  createDisplayMediaGuard,
+  invokeDisplayMediaCallback,
+  isTrustedMainRenderer,
+  selectCaptureSource,
+} = require("./screen-preview.cjs");
 
 const frame = { processId: 10, routingId: 20 };
 const validRequest = {
@@ -56,6 +61,70 @@ describe("display media request guard", () => {
   });
 });
 
+describe("screen frame IPC boundary", () => {
+  const mainFrame = {};
+  const webContents = { mainFrame };
+  const mainWindow = { webContents, isDestroyed: () => false };
+  const event = { sender: webContents, senderFrame: mainFrame };
+
+  it("accepts only the live main app renderer and an empty payload", () => {
+    expect(isTrustedMainRenderer({ event, mainWindow })).toBe(true);
+    expect(allowScreenFrameRequest({ event, mainWindow, payload: [] })).toBe(true);
+    expect(allowScreenFrameRequest({ event, mainWindow, payload: ["screen:0"] })).toBe(false);
+  });
+
+  it.each([
+    ["a child renderer", { event: { sender: webContents, senderFrame: {} } }],
+    ["a destroyed window", { mainWindow: { webContents, isDestroyed: () => true } }],
+    ["a missing payload array", { payload: undefined }],
+  ])("rejects %s", (_name, change) => {
+    expect(allowScreenFrameRequest({ event, mainWindow, payload: [], ...change })).toBe(false);
+  });
+});
+
+describe("Electron screen frame capture", () => {
+  it("uses the existing screen thumbnail substrate for the Windows primary display", async () => {
+    const calls = [];
+    const source = {
+      id: "screen:primary:0",
+      display_id: "42",
+      thumbnail: { toDataURL: () => "data:image/png;base64,windows-frame" },
+    };
+    await expect(
+      captureScreenFrame({
+        platform: "win32",
+        getSources: async (options) => {
+          calls.push(options);
+          return [
+            { id: "screen:secondary:0", display_id: "41", thumbnail: { toDataURL: () => "wrong" } },
+            source,
+          ];
+        },
+        getPrimaryDisplay: () => ({ id: 42 }),
+      }),
+    ).resolves.toBe("data:image/png;base64,windows-frame");
+    expect(calls).toEqual([{ types: ["screen"], thumbnailSize: { width: 1280, height: 800 } }]);
+  });
+
+  it("returns no frame when the Windows desktop has no display source", async () => {
+    const getPrimaryDisplay = () => {
+      throw new Error("must not inspect a display when no source exists");
+    };
+    await expect(
+      captureScreenFrame({ platform: "win32", getSources: async () => [], getPrimaryDisplay }),
+    ).resolves.toBeNull();
+  });
+
+  it("keeps the local thumbnail path disabled on Linux", async () => {
+    const getSources = async () => {
+      throw new Error("Linux uses the explicit display-media preview");
+    };
+    await expect(
+      captureScreenFrame({ platform: "linux", getSources, getPrimaryDisplay: () => ({ id: 1 }) }),
+    ).resolves.toBeNull();
+  });
+});
+
 describe("display source selection", () => {
   const sources = [
     { id: "first", display_id: "41" },
@@ -67,6 +136,18 @@ describe("display source selection", () => {
       sources[1],
     );
     expect(selectCaptureSource({ sources, host: "x11", primaryDisplayId: 99 })).toBeNull();
+  });
+
+  it("matches the Windows primary display and fails closed when displays are ambiguous", () => {
+    expect(selectCaptureSource({ sources, host: "win32", primaryDisplayId: 42 })).toEqual(sources[1]);
+    expect(selectCaptureSource({ sources, host: "win32", primaryDisplayId: 99 })).toBeNull();
+    expect(
+      selectCaptureSource({
+        sources: [{ id: "only", display_id: "" }],
+        host: "win32",
+        primaryDisplayId: 42,
+      }),
+    ).toEqual({ id: "only", display_id: "" });
   });
 
   it("uses an unambiguous Xorg source when display_id is absent or mismatched", () => {

--- a/electron/window-chrome.mjs
+++ b/electron/window-chrome.mjs
@@ -1,12 +1,13 @@
 /**
- * Keep custom inset chrome only where the platform owns a stable inset model.
- * Windows' titleBarOverlay sits on top of renderer content, so every new page
- * must otherwise remember to reserve its width. Native Windows/Linux chrome
- * keeps caption controls outside the app layout and cannot cover actions.
+ * Keep native window chrome outside the renderer content on Windows and Linux.
+ * macOS retains the inset traffic-light treatment used by the app header.
  */
 export function windowChromeOptions(platform) {
   if (platform === "darwin") {
-    return { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 16 } };
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 16 },
+    };
   }
-  return {};
+  return { frame: true };
 }

--- a/electron/window-chrome.test.mjs
+++ b/electron/window-chrome.test.mjs
@@ -1,20 +1,25 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { windowChromeOptions } from "./window-chrome.mjs";
 
 describe("window chrome", () => {
-  it("uses inset traffic lights on macOS", () => {
+  it("keeps Windows and Linux caption controls outside renderer content", () => {
+    expect(windowChromeOptions("win32")).toEqual({ frame: true });
+    expect(windowChromeOptions("linux")).toEqual({ frame: true });
+  });
+
+  it("keeps the macOS inset traffic lights", () => {
     expect(windowChromeOptions("darwin")).toEqual({
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 16, y: 16 },
     });
   });
 
-  it("keeps Windows controls in the native title bar, outside app content", () => {
-    expect(windowChromeOptions("win32")).toEqual({});
-  });
-
-  it("keeps Linux window chrome native", () => {
-    expect(windowChromeOptions("linux")).toEqual({});
+  it("keeps the skin IPC as validation-only acknowledgement", () => {
+    const main = readFileSync(new URL("./main.mjs", import.meta.url), "utf8");
+    expect(main).toContain('ipcMain.handle("desktop:skin", (_event, skin) => isKnownSkin(skin));');
+    expect(main).not.toContain("titleBarOverlay");
+    expect(main).not.toContain("waitsForSkinSync");
   });
 });

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -1,7 +1,8 @@
 // The bot's computer, in the right-side slot. Where it runs decides the
 // whole flow: cloud → provision the box on open (idempotent) and preview
-// via SSE frames or a ~4s screenshot poll. macOS local mode keeps the legacy
-// in-panel capture. Linux local mode is an automation readiness state and its
+// via SSE frames or a ~4s screenshot poll. macOS and Windows local modes use
+// the Electron-owned in-panel capture. Windows control still starts from a
+// separate preview. Linux local mode is an automation readiness state and its
 // separate preview remains explicitly user-initiated. Auto never selects a
 // Linux user's desktop.
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -51,6 +52,7 @@ import {
   writeComputerPanelView,
   type ComputerPanelView,
 } from "@/lib/computer-panel-view";
+import { SCREEN_FRAME_FIRST_RETRY_MS, startScreenFramePoll } from "@/lib/screen-preview";
 
 interface VpsComputerStatus {
   configured: boolean;
@@ -181,6 +183,7 @@ export function ComputerPanel({
   const { capabilities, ready: capabilitiesReady } = useDesktopCapabilities();
   const localAvailable = capabilities.localComputer.available;
   const isLinux = capabilities.host.platform === "linux";
+  const isWindows = capabilities.host.platform === "win32";
   const providerSupportsLocal = instanceSupportsLocalComputer(state.instances, bot);
   const localSelectable = localComputerSelectable({ capabilities, providerSupportsLocal });
   const [localAutoWarning, setLocalAutoWarning] = useState(false);
@@ -572,33 +575,22 @@ export function ComputerPanel({
     };
   }, [panelView, phase, bot.id, viewerOpen, pageVisible, bot.busy]);
 
-  // local preview: frames from the Electron main process. The FIRST capture
+  // local preview: frames from the Electron main process on macOS and Windows. The FIRST capture
   // attempt is what makes macOS show the Screen Recording prompt (there is
   // no reliable pre-grant flow on macOS 15+), so repeated empty frames mean
   // the user denied — surface the Settings repair path instead of spinning.
   const [localMisses, setLocalMisses] = useState(0);
   useEffect(() => {
     if (panelView !== "computer" || phase !== "local" || !window.ogb || isLinux || !pageVisible) return;
-    let alive = true;
     setLocalMisses(0);
-    const shoot = async () => {
-      try {
-        const url = await window.ogb!.screenFrame();
-        if (alive && url) setLocalFrame(url);
-        else if (alive) setLocalMisses((n) => n + 1);
-      } catch {
-        if (alive) setLocalMisses((n) => n + 1);
-      }
-    };
-    void shoot();
-    // A real ScreenCaptureKit capture + PNG encode per tick: idle bots get a
-    // slow heartbeat, working ones the live cadence.
-    const timer = setInterval(shoot, bot.busy ? 3000 : 30_000);
-    return () => {
-      alive = false;
-      clearInterval(timer);
-    };
-  }, [panelView, phase, isLinux, pageVisible, bot.busy, bot.id]);
+    return startScreenFramePoll({
+      capture: () => window.ogb!.screenFrame(),
+      onFrame: setLocalFrame,
+      onMiss: () => setLocalMisses((n) => n + 1),
+      busy: bot.busy === true,
+      firstFrameRetryMs: isWindows ? SCREEN_FRAME_FIRST_RETRY_MS : null,
+    });
+  }, [panelView, phase, isLinux, isWindows, pageVisible, bot.busy]);
 
   const lastScreenMessage = [...bot.messages].reverse().find((m) => m.kind === "screen" && m.png);
   const cloudFrame =
@@ -986,7 +978,7 @@ export function ComputerPanel({
             />
           ) : (
             <div className="flex flex-col items-center gap-2 px-6 text-center text-ink-secondary">
-              {phase === "checking" || phase === "starting" || phase === "vm" || (phase === "local" && !isLinux) ? (
+              {phase === "checking" || phase === "starting" || phase === "vm" || (phase === "local" && !isLinux && !isWindows) ? (
                 <Loader2 size={18} className="animate-spin" />
               ) : phase === "off" ? (
                 <Power size={22} />
@@ -1001,12 +993,14 @@ export function ComputerPanel({
                   : phase === "local"
                     ? isLinux
                       ? "Ready for approved bot actions. Start the separate preview below when you want to watch the screen."
+                    : isWindows
+                      ? "Local control is ready, but live preview is unavailable right now. Check that a display is connected."
                       : localMisses >= 3
                       ? "No frames yet — the preview needs Screen Recording permission. After granting, relaunch the app."
                       : "Capturing this computer's screen…"
                     : emptyState[phase]}
               </span>
-              {phase === "local" && !isLinux && localMisses >= 3 && (
+              {phase === "local" && !isLinux && !isWindows && localMisses >= 3 && (
                 <button
                   onClick={() => window.ogb?.permOpenSettings?.("screen")}
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"

--- a/src/lib/screen-preview.test.ts
+++ b/src/lib/screen-preview.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   requestScreenPreview,
   screenPreviewFailure,
+  SCREEN_FRAME_CADENCE_MS,
+  SCREEN_FRAME_FIRST_RETRY_MS,
+  startScreenFramePoll,
   stopScreenPreview,
 } from "./screen-preview";
 
@@ -65,5 +68,79 @@ describe("screen preview request", () => {
     const { stream, tracks } = fakeStream(2);
     stopScreenPreview(stream);
     for (const track of tracks) expect(track.stop).toHaveBeenCalledOnce();
+  });
+});
+
+describe("local screen frame poll", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("retries Windows' first frame quickly, then uses busy cadence", async () => {
+    const capture = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("data:image/png;base64,frame")
+      .mockResolvedValue(null);
+    const onFrame = vi.fn();
+    const onMiss = vi.fn();
+    const cancel = startScreenFramePoll({
+      capture,
+      onFrame,
+      onMiss,
+      busy: true,
+      firstFrameRetryMs: SCREEN_FRAME_FIRST_RETRY_MS,
+    });
+
+    await Promise.resolve();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(onMiss).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_FIRST_RETRY_MS);
+    expect(capture).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_FIRST_RETRY_MS);
+    expect(capture).toHaveBeenCalledTimes(3);
+    expect(onFrame).toHaveBeenCalledWith("data:image/png;base64,frame");
+
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_CADENCE_MS.busy - 1);
+    expect(capture).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(capture).toHaveBeenCalledTimes(4);
+    cancel();
+  });
+
+  it("keeps the idle cadence and cancels the cadence after cleanup", async () => {
+    const capture = vi.fn<() => Promise<string | null>>().mockResolvedValue("frame");
+    const onFrame = vi.fn();
+    const cancel = startScreenFramePoll({ capture, onFrame, busy: false, firstFrameRetryMs: null });
+
+    await Promise.resolve();
+    expect(capture).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_CADENCE_MS.idle - 1);
+    expect(capture).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(capture).toHaveBeenCalledTimes(2);
+    cancel();
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_CADENCE_MS.idle);
+    expect(capture).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not publish a frame after cleanup while capture is in flight", async () => {
+    let resolve!: (frame: string) => void;
+    const capture = vi.fn(() => new Promise<string>((done) => { resolve = done; }));
+    const onFrame = vi.fn();
+    const cancel = startScreenFramePoll({
+      capture,
+      onFrame,
+      busy: true,
+      firstFrameRetryMs: SCREEN_FRAME_FIRST_RETRY_MS,
+    });
+
+    cancel();
+    resolve("late-frame");
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(SCREEN_FRAME_FIRST_RETRY_MS * 2);
+    expect(onFrame).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/screen-preview.ts
+++ b/src/lib/screen-preview.ts
@@ -4,6 +4,93 @@ export type ScreenPreviewStartResult =
   | { ok: true; stream: MediaStream }
   | { ok: false; phase: ScreenPreviewFailurePhase; message: string };
 
+export const SCREEN_FRAME_FIRST_RETRY_MS = 250;
+export const SCREEN_FRAME_CADENCE_MS = {
+  busy: 3_000,
+  idle: 30_000,
+} as const;
+
+interface ScreenFramePollOptions {
+  capture: () => Promise<string | null>;
+  onFrame: (frame: string) => void;
+  onMiss?: () => void;
+  busy: boolean;
+  /** Windows needs a short retry loop while Electron warms its first capture.
+   * null preserves the existing macOS cadence from the first attempt. */
+  firstFrameRetryMs?: number | null;
+}
+
+/** Start a visibility-scoped local screen poll and return its cancellation
+ * function. A first-frame retry loop is intentionally separate from the
+ * steady-state cadence so a successful capture never creates two timers. */
+export function startScreenFramePoll({
+  capture,
+  onFrame,
+  onMiss,
+  busy,
+  firstFrameRetryMs = null,
+}: ScreenFramePollOptions): () => void {
+  let cancelled = false;
+  let inFlight = false;
+  let hasFrame = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let cadenceTimer: ReturnType<typeof setInterval> | null = null;
+
+  const startCadence = () => {
+    if (cancelled || cadenceTimer !== null) return;
+    cadenceTimer = globalThis.setInterval(
+      () => void shoot(),
+      busy ? SCREEN_FRAME_CADENCE_MS.busy : SCREEN_FRAME_CADENCE_MS.idle,
+    );
+  };
+
+  const scheduleFirstRetry = () => {
+    if (cancelled || hasFrame || firstFrameRetryMs == null || retryTimer !== null) return;
+    retryTimer = globalThis.setTimeout(() => {
+      retryTimer = null;
+      void shoot();
+    }, firstFrameRetryMs);
+  };
+
+  const shoot = async () => {
+    if (cancelled || inFlight) return;
+    inFlight = true;
+    try {
+      const frame = await capture();
+      if (cancelled) return;
+      if (frame) {
+        hasFrame = true;
+        onFrame(frame);
+        if (retryTimer !== null) {
+          globalThis.clearTimeout(retryTimer);
+          retryTimer = null;
+        }
+        startCadence();
+      } else {
+        onMiss?.();
+        scheduleFirstRetry();
+      }
+    } catch {
+      if (cancelled) return;
+      onMiss?.();
+      scheduleFirstRetry();
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  if (firstFrameRetryMs == null) startCadence();
+  void shoot();
+
+  return () => {
+    cancelled = true;
+    if (retryTimer !== null) globalThis.clearTimeout(retryTimer);
+    if (cadenceTimer !== null) globalThis.clearInterval(cadenceTimer);
+    retryTimer = null;
+    cadenceTimer = null;
+  };
+}
+
 type ScreenPreviewRequest = {
   beginIntent: () => boolean;
   getDisplayMedia: (constraints: DisplayMediaStreamOptions) => Promise<MediaStream>;


### PR DESCRIPTION
## What changed

Restores local screen-preview support on Windows while keeping Electron's desktop-capture boundary fail closed.

The revision now:

- allows `screen:frame` only from the live main renderer;
- rejects child frames, destroyed windows, and caller-supplied payloads;
- selects the Windows primary display by Electron display id and refuses ambiguous multi-display results;
- keeps Linux on its explicit display-media path;
- preserves the existing macOS capture behavior;
- adds a short Windows first-frame warm-up retry;
- bounds that retry loop before falling back to the normal idle/busy cadence;
- cancels timers and ignores late frames after component cleanup;
- keeps Windows and Linux controls in native window chrome;
- removes the stale Windows hidden-window skin handshake.

The earlier Grok protocol-registration code was removed from this PR. It did not provide a reliable Windows app chooser and belonged to a different problem domain.

## Why

Windows local control was available, but its in-panel preview path was disabled. Re-enabling capture without validating the IPC sender would expose a general desktop-capture channel to other renderers, while an unbounded warm-up loop could poll continuously when no display frame was available.

## Verification

Validated after rebasing onto current official `main`:

- 33 focused preview/chrome tests passed
- client TypeScript check passed
- server TypeScript check passed
- 90 Electron modules passed syntax checks
- `git diff --check` passed
- staged additions were checked for private emails and common secret-token formats

## Scope

- 1 commit
- 8 files changed
- no dependencies or lockfile changes
- no Grok protocol ownership or registration
- no credentials or private account data included

## Screenshots

No fresh visual screenshot is claimed in this revision. The behavior is covered by deterministic selection, IPC-boundary, polling, and cleanup tests; final packaged Windows visual acceptance still belongs to the maintainer smoke gate.

Current head: `4247444d8e820ee96351f897e7a6f53efe814d52`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local screen previews on Windows, including faster initial frame loading and efficient ongoing updates.
  * Added native window framing on Windows and Linux.
  * Added support for managing local and paired remote servers, including pairing-link imports and server switching.
  * Added Grok Bot link handling and optional Windows protocol registration.
* **Bug Fixes**
  * Improved screen-preview reliability and security across supported platforms.
  * Windows startup no longer waits for skin synchronization.
  * Improved external-link validation and remote-session access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->