### PR TITLE
fix(ios): add native iPad layout support

### DIFF
--- a/ios/App/AgentProfileView.swift
+++ b/ios/App/AgentProfileView.swift
@@ -80,7 +80,7 @@ struct AgentProfileView: View {
                 } header: {
                     Text("Avatar")
                 } footer: {
-                    Text("PNG, JPEG, GIF, or WebP, up to 10 MB. Images are stored on your paired computer and loaded with this phone's pairing token.")
+                    Text("PNG, JPEG, GIF, or WebP, up to 10 MB. Images are stored on your paired computer and loaded with this device's pairing token.")
                 }
 
                 Section {
@@ -94,8 +94,8 @@ struct AgentProfileView: View {
                     Text("Generate an avatar")
                 } footer: {
                     Text(imageGenerationReady
-                         ? "Generation uses the shared image provider configured on your computer. No provider key is sent to or stored on this phone."
-                         : "To generate images, configure the shared image provider in OpenMausBot on your computer. Provider keys cannot be added from a phone.")
+                         ? "Generation uses the shared image provider configured on your computer. No provider key is sent to or stored on this device."
+                         : "To generate images, configure the shared image provider in OpenMausBot on your computer. Provider keys cannot be added from this device.")
                 }
 
                 Section("Identity") {

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -92,14 +92,19 @@ struct ChatListView: View {
                 }
             }
             // top-aligned: the roster fills downward from the header
+            .frame(maxWidth: CompanionLayout.rosterWidth, maxHeight: .infinity, alignment: .top)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .overlay(alignment: .bottom) { bottomBar }
+            .overlay(alignment: .bottom) {
+                bottomBar.frame(maxWidth: CompanionLayout.rosterWidth)
+            }
             // a bot that stopped for you grows out of the island
             .overlay(alignment: .top) {
-                NeedsYouIsland(
-                    update: session.state.updates.first { $0.kind == .needsYou },
-                    hasIsland: IslandGeometry.hasIsland(topInset: geo.safeAreaInsets.top)
-                ) { chat in path.append(chat) }
+                if CompanionLayout.supportsIslandPresentation {
+                    NeedsYouIsland(
+                        update: session.state.updates.first { $0.kind == .needsYou },
+                        hasIsland: IslandGeometry.hasIsland(topInset: geo.safeAreaInsets.top)
+                    ) { chat in path.append(chat) }
+                }
             }
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -733,7 +738,7 @@ struct StatusBanner: View {
             case let .offline(reason):
                 banner(reason, systemImage: "wifi.slash", tint: .orange)
             case .unauthorized:
-                banner("This phone was unpaired on the computer.", systemImage: "lock.slash", tint: .red)
+                banner("This device was unpaired on the computer.", systemImage: "lock.slash", tint: .red)
             }
         }
         .animation(.default, value: session.status)

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -183,7 +183,8 @@ struct ChatView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxWidth: CompanionLayout.chatWidth, alignment: .leading)
+                    .frame(maxWidth: .infinity)
                 }
                 // The header lives in the scroll view's top safe area: the
                 // transcript starts below it and scrolls under it — that is
@@ -222,7 +223,7 @@ struct ChatView: View {
                 }
                 .task {
                     // grow, hold a beat, shrink — the face rides along
-                    guard !reduceMotion else { return }
+                    guard CompanionLayout.supportsIslandPresentation, !reduceMotion else { return }
                     // The intro is a greeting, and a greeting repeated every
                     // time you open a chat stops being one.
                     let intro = IslandIntro(rawValue: islandIntro) ?? .oncePerBot
@@ -387,6 +388,8 @@ struct ChatView: View {
         .padding(.horizontal, 16)
         .padding(.top, 4)
         .padding(.bottom, 8)
+        .frame(maxWidth: CompanionLayout.headerWidth)
+        .frame(maxWidth: .infinity)
         .background(
             Rectangle()
                 .fill(.ultraThinMaterial)
@@ -503,11 +506,11 @@ struct ChatView: View {
                     }
                 }
                 .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: CompanionLayout.chatWidth, alignment: .leading)
                 .glassSheet(cornerRadius: 30)
-                .padding(.leading, 12)
-                .padding(.trailing, 44)
+                .padding(.horizontal, 12)
                 .padding(.bottom, 70)
+                .frame(maxWidth: .infinity)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
             .transition(.opacity)
@@ -768,6 +771,8 @@ struct ChatView: View {
         .padding(.horizontal, 12)
         .padding(.top, 6)
         .padding(.bottom, 8)
+        .frame(maxWidth: CompanionLayout.chatWidth)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -182,7 +182,7 @@ struct UnpairedView: View {
     var body: some View {
         NavigationStack {
             ContentUnavailableView {
-                Label("This phone was unpaired", systemImage: "lock.slash")
+                Label("This device was unpaired", systemImage: "lock.slash")
             } description: {
                 Text("The connection was removed on your computer. Pair again to keep using your chats here.")
             } actions: {

--- a/ios/App/CompanionLayout.swift
+++ b/ios/App/CompanionLayout.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import UIKit
+
+/// Readable columns for the phone-first surfaces when they run in a wider
+/// iPad window. Compact windows naturally remain narrower than these caps.
+enum CompanionLayout {
+    static let rosterWidth: CGFloat = 680
+    static let chatWidth: CGFloat = 760
+    static let headerWidth: CGFloat = 900
+
+    /// The expanding island animation is anchored to iPhone hardware. On an
+    /// iPad it reads as an unexplained floating black card.
+    static var supportsIslandPresentation: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
+    }
+}

--- a/ios/App/ComputerView.swift
+++ b/ios/App/ComputerView.swift
@@ -86,7 +86,7 @@ struct ComputerView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(openingDesktop)
-                    Text("Interactive VNC session. Access must be enabled for this phone in the Mac's Phone settings.")
+                    Text("Interactive VNC session. Access must be enabled for this device in the Mac's Phone settings.")
                         .font(.caption)
                         .foregroundStyle(Color.white.opacity(0.6))
                         .multilineTextAlignment(.center)
@@ -100,7 +100,7 @@ struct ComputerView: View {
             Button("Cancel", role: .cancel) {}
             Button("Open desktop") { Task { await openDesktop() } }
         } message: {
-            Text("This gives this phone full control of the cloud computer, including anything signed in inside it.")
+            Text("This gives this device full control of the cloud computer, including anything signed in inside it.")
         }
         .sheet(
             isPresented: Binding(

--- a/ios/App/ConnectedAppsView.swift
+++ b/ios/App/ConnectedAppsView.swift
@@ -65,7 +65,7 @@ struct ConnectedAppsView: View {
                     ContentUnavailableView(
                         "Connected apps need setup",
                         systemImage: "link.badge.plus",
-                        description: Text("Configure Composio on your computer first. Provider credentials are never returned to this phone.")
+                        description: Text("Configure Composio on your computer first. Provider credentials are never returned to this device.")
                     )
                 }
             }

--- a/ios/App/Discovery.swift
+++ b/ios/App/Discovery.swift
@@ -132,7 +132,7 @@ final class Discovery: ObservableObject {
     private static func failureMessage(for error: NWError) -> String {
         if case let .dns(code) = error,
            Int(code) == kDNSServiceErr_PolicyDenied {
-            return "Local Network access is off. Enable it in iPhone Settings, or enter a Tailscale address below."
+            return "Local Network access is off. Enable it in Settings, or enter a Tailscale address below."
         }
         return "Local discovery isn't available right now. Enter the address shown in Phone settings."
     }

--- a/ios/App/NewSectionSheet.swift
+++ b/ios/App/NewSectionSheet.swift
@@ -454,7 +454,7 @@ struct NewSectionSheet: View {
                 VStack(alignment: .leading, spacing: 7) {
                     Text("What should this section be called?")
                         .font(.system(size: 24, weight: .bold, design: .rounded))
-                    Text("It will appear on both your phone and computer.")
+                    Text("It will appear on both this device and your computer.")
                         .font(.system(size: 15))
                         .foregroundStyle(Color.secondary)
                 }

--- a/ios/App/OnboardingViews.swift
+++ b/ios/App/OnboardingViews.swift
@@ -21,7 +21,7 @@ struct CompanionWelcomeView: View {
                     Text("Take your bots with you")
                         .font(.largeTitle.bold())
                         .multilineTextAlignment(.center)
-                    Text("Open chats, approve actions, and send new work from your iPhone.")
+                    Text("Open chats, approve actions, and send new work from this device.")
                         .font(.title3)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -41,7 +41,7 @@ struct CompanionWelcomeView: View {
                     WelcomeBenefit(
                         icon: "lock.shield.fill",
                         title: "Private by design",
-                        detail: "You choose which trusted computer this phone connects to."
+                        detail: "You choose which trusted computer this device connects to."
                     )
                 }
                 .padding(.top, 4)
@@ -128,7 +128,7 @@ struct UnpairedHomeView: View {
                     VStack(spacing: 8) {
                         Text("Connect when you're ready")
                             .font(.title2.bold())
-                        Text("Pair this iPhone with OpenMausBot to see your chats and respond to your bots.")
+                        Text("Pair this device with OpenMausBot to see your chats and respond to your bots.")
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
                             .fixedSize(horizontal: false, vertical: true)

--- a/ios/App/PairingScanner.swift
+++ b/ios/App/PairingScanner.swift
@@ -43,7 +43,7 @@ struct PairingScannerSheet: View {
                     ContentUnavailableView {
                         Label("Scanner unavailable", systemImage: "qrcode.viewfinder")
                     } description: {
-                        Text("Use this iPhone's Camera app to scan the QR code, or enter the address and code manually.")
+                        Text("Use the Camera app to scan the QR code, or enter the address and code manually.")
                     }
                 } else {
                     ZStack(alignment: .bottom) {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -186,7 +186,7 @@ final class Session: ObservableObject {
             restorePending = true
             status = .offline(
                 (error as? KeychainError)?.isLocked == true
-                    ? "Unlock this phone to reach your computer."
+                    ? "Unlock this device to reach your computer."
                     : error.localizedDescription
             )
             return
@@ -331,12 +331,12 @@ final class Session: ObservableObject {
             stored = try Keychain.token(for: id)
         } catch {
             actionError = (error as? KeychainError)?.isLocked == true
-                ? "Unlock this iPhone, then try switching computers again."
+                ? "Unlock this device, then try switching computers again."
                 : error.localizedDescription
             return
         }
         guard let stored else {
-            actionError = "This saved connection is no longer available on this iPhone. Remove it and pair again."
+            actionError = "This saved connection is no longer available on this device. Remove it and pair again."
             return
         }
 
@@ -1152,7 +1152,7 @@ final class Session: ObservableObject {
                 pendingNotification = target
                 connect()
             } else {
-                actionError = "Pair this phone with your computer to open that task."
+                actionError = "Pair this device with your computer to open that task."
             }
             return
         }

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -141,7 +141,7 @@ struct SettingsView: View {
 
     private var notificationAccessibilityHint: String {
         if notificationsAreEnabled { return "Notifications are enabled" }
-        if session.notificationAuthorization == .denied { return "Opens iPhone Settings" }
+        if session.notificationAuthorization == .denied { return "Opens device Settings" }
         return "Asks for permission to send notifications"
     }
 
@@ -299,14 +299,14 @@ struct ConnectedComputersView: View {
             ),
             titleVisibility: .visible
         ) {
-            Button("Remove from this iPhone", role: .destructive) {
+            Button("Remove from this device", role: .destructive) {
                 guard let pendingRemoval else { return }
                 session.forgetConnection(id: pendingRemoval.id)
                 self.pendingRemoval = nil
             }
             Button("Cancel", role: .cancel) { pendingRemoval = nil }
         } message: {
-            Text("This removes the saved connection from this iPhone only.")
+            Text("This removes the saved connection from this device only.")
         }
     }
 }
@@ -404,7 +404,7 @@ struct ConnectionSecurityView: View {
                 }
 
                 Section {
-                    Button("Remove connection from this iPhone", role: .destructive) {
+                    Button("Remove connection from this device", role: .destructive) {
                         confirmingSignOut = true
                     }
                 }
@@ -432,13 +432,13 @@ struct ConnectionSecurityView: View {
             isPresented: $confirmingSignOut,
             titleVisibility: .visible
         ) {
-            Button("Remove from this iPhone", role: .destructive) {
+            Button("Remove from this device", role: .destructive) {
                 session.signOut()
                 dismiss()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This removes the connection from this iPhone only. It does not revoke this phone on your Mac. To remove Mac-side access, open OpenMausBot → Settings → Phone and remove this device.")
+            Text("This removes the connection from this device only. It does not revoke this device on your Mac. To remove Mac-side access, open OpenMausBot → Settings → Phone and remove it there.")
         }
     }
 
@@ -451,9 +451,9 @@ struct ConnectionSecurityView: View {
         case let .offline(reason):
             return reason
         case .unauthorized:
-            return "This phone was removed from the computer. Pair it again to reconnect."
+            return "This device was removed from the computer. Pair it again to reconnect."
         case .unpaired:
-            return "This phone is not paired with a computer."
+            return "This device is not paired with a computer."
         }
     }
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -37,7 +37,7 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "5.9"
-        TARGETED_DEVICE_FAMILY: "1"
+        TARGETED_DEVICE_FAMILY: "1,2"
         # The catalog lives in App/, which is already a source path.
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
     entitlements:
@@ -78,6 +78,11 @@ targets:
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         # Without these two, NWBrowser returns no results at all — silently.
@@ -134,7 +139,7 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "5.9"
-        TARGETED_DEVICE_FAMILY: "1"
+        TARGETED_DEVICE_FAMILY: "1,2"
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: true
     entitlements:
@@ -188,7 +193,7 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "5.9"
-        TARGETED_DEVICE_FAMILY: "1"
+        TARGETED_DEVICE_FAMILY: "1,2"
         SKIP_INSTALL: true
     info:
       path: Widgets/Info.plist


### PR DESCRIPTION
## What changed

- ship the companion as a universal iPhone and iPad app instead of stretched iPhone compatibility mode
- keep chats, the roster, headers, and composer at readable widths in wide iPad windows
- remove the iPhone Dynamic Island presentation from iPad
- support all native iPad orientations across the app, share extension, and widgets
- make visible device copy work on both iPhone and iPad

## Verification

- `swift test` — 258 passed
- built `OpenMausCompanion` for an iPad Pro 13-inch simulator
- installed and launched the app in iPadOS Stage Manager
- verified the built app declares both iPhone and iPad device families and all iPad orientations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iPad support across the app, share extension, and widget extension.
  * Improved layouts on wider screens with centered, width-constrained content.
  * Limited expanding island presentations to supported iPhone devices.

* **Improvements**
  * Updated setup, pairing, onboarding, settings, and error messages to use device-neutral language.
  * Clarified instructions for computer-based configuration and device management.
  * Refined spacing and sizing for chat, roster, headers, sheets, and floating controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->