### PR TITLE
fix(channels): auto-dispatch queued messages

### DIFF
--- a/server/channel-queue.test.ts
+++ b/server/channel-queue.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  _queuedChannelCount,
+  cancelChannelMessage,
+  drainChannelMessages,
+  queuedChannelMessage,
+  queueChannelMessage,
+} from "./channel-queue.ts";
+
+describe("channel queue", () => {
+  it("keeps messages off the running channel and drains one follow-up at a time", () => {
+    let working = true;
+    const run = vi.fn(() => {
+      working = true;
+    });
+    const first = queueChannelMessage("group-a", "thread-a", "first follow-up", {
+      sendId: "send_first_123456",
+    });
+    queueChannelMessage("group-a", "thread-a", "second follow-up", {
+      sendId: "send_second_123456",
+      mode: "goal",
+    });
+
+    drainChannelMessages(() => working, run);
+    expect(run).not.toHaveBeenCalled();
+    expect(_queuedChannelCount("thread-a")).toBe(2);
+    expect(queuedChannelMessage("group-a", "thread-a", "send_first_123456")?.id).toBe(first.id);
+
+    working = false;
+    drainChannelMessages(() => working, run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenLastCalledWith(expect.objectContaining({
+      groupId: "group-a",
+      threadId: "thread-a",
+      text: "first follow-up",
+      mode: "chat",
+    }));
+    expect(_queuedChannelCount("thread-a")).toBe(1);
+
+    working = false;
+    drainChannelMessages(() => working, run);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenLastCalledWith(expect.objectContaining({
+      text: "second follow-up",
+      mode: "goal",
+    }));
+    expect(_queuedChannelCount("thread-a")).toBe(0);
+  });
+
+  it("cancels only the requested channel message", () => {
+    const keep = queueChannelMessage("group-b", "thread-b", "keep");
+    const drop = queueChannelMessage("group-b", "thread-b", "drop");
+
+    expect(cancelChannelMessage("group-b", drop.id)).toBe(true);
+    expect(cancelChannelMessage("group-b", drop.id)).toBe(false);
+    expect(_queuedChannelCount("thread-b")).toBe(1);
+
+    const run = vi.fn();
+    drainChannelMessages(() => false, run);
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ id: keep.id, text: "keep" }));
+  });
+});

--- a/server/channel-queue.ts
+++ b/server/channel-queue.ts
@@ -1,0 +1,102 @@
+// Follow-up messages sent while a channel is working.
+//
+// The renderer must hand these to the harness immediately. Keeping them in a
+// mounted composer loses the auto-send intent on navigation, reconnect, or a
+// renderer reload. They stay off the transcript until the active channel
+// operation settles so the current responder cannot appear to answer words it
+// never saw.
+
+import { newId } from "./contracts.ts";
+
+interface ChannelQueueItem {
+  id: string;
+  text: string;
+  replyToId?: string;
+  sendId?: string;
+  mode: "chat" | "goal";
+}
+
+interface ChannelQueueEntry {
+  groupId: string;
+  items: ChannelQueueItem[];
+}
+
+const queues = new Map<string, ChannelQueueEntry>(); // threadId -> waiting sends
+
+export interface QueuedChannelMessage {
+  id: string;
+}
+
+export function queueChannelMessage(
+  groupId: string,
+  threadId: string,
+  text: string,
+  options: {
+    replyToId?: string;
+    sendId?: string;
+    mode?: "chat" | "goal";
+  } = {},
+): QueuedChannelMessage {
+  const entry = queues.get(threadId) ?? { groupId, items: [] };
+  if (entry.groupId !== groupId) throw new Error("queued task belongs to another channel");
+  const item: ChannelQueueItem = {
+    id: newId(),
+    text,
+    replyToId: options.replyToId,
+    sendId: options.sendId,
+    mode: options.mode ?? "chat",
+  };
+  entry.items.push(item);
+  queues.set(threadId, entry);
+  return { id: item.id };
+}
+
+/** Find the stable receipt for an HTTP retry that is still waiting. */
+export function queuedChannelMessage(
+  groupId: string,
+  threadId: string,
+  sendId: string,
+): ChannelQueueItem | null {
+  const entry = queues.get(threadId);
+  if (!entry || entry.groupId !== groupId) return null;
+  return entry.items.find((item) => item.sendId === sendId) ?? null;
+}
+
+/** Remove one queued message before it starts. */
+export function cancelChannelMessage(groupId: string, queueId: string): boolean {
+  for (const [threadId, entry] of queues) {
+    if (entry.groupId !== groupId) continue;
+    const items = entry.items.filter((item) => item.id !== queueId);
+    if (items.length === entry.items.length) continue;
+    if (items.length === 0) queues.delete(threadId);
+    else queues.set(threadId, { groupId, items });
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Start at most one follow-up per idle channel. Starting it synchronously
+ * marks the channel working again; its completion calls this drain for the
+ * next item. Removing first makes repeated settle notifications harmless.
+ */
+export function drainChannelMessages(
+  isWorking: (groupId: string) => boolean,
+  run: (input: ChannelQueueItem & { groupId: string; threadId: string }) => void,
+): void {
+  for (const [threadId, entry] of queues) {
+    if (isWorking(entry.groupId)) continue;
+    const item = entry.items.shift();
+    if (!item) {
+      queues.delete(threadId);
+      continue;
+    }
+    if (entry.items.length === 0) queues.delete(threadId);
+    run({ ...item, groupId: entry.groupId, threadId });
+  }
+}
+
+/** Test helper. */
+export function _queuedChannelCount(threadId: string): number {
+  return queues.get(threadId)?.items.length ?? 0;
+}

--- a/server/group-goal-run.e2e.test.ts
+++ b/server/group-goal-run.e2e.test.ts
@@ -78,6 +78,16 @@ beforeAll(async () => {
         environment: { FAKE_CLAUDE_MODE: "exit-early" },
         config: { cli: FAKE_CLAUDE },
       },
+      slow: {
+        driver: "claudeAgent",
+        displayName: "Queue fixture",
+        environment: {
+          FAKE_CLAUDE_MODE: "slow",
+          FAKE_CLAUDE_REPLIES: JSON.stringify(["first response", "second response"]),
+          FAKE_CLAUDE_REPLY_STATE: join(home, "slow-replies.txt"),
+        },
+        config: { cli: FAKE_CLAUDE },
+      },
     },
   }));
   const port = await freePortBlock([0, 1]);
@@ -223,5 +233,74 @@ describe("goal-driven channel runs", () => {
 
     const dm = (await api("GET", "/api/bots?messages=0")).body.groups.find((group: { dm?: boolean }) => group.dm);
     if (dm) expect((await api("POST", `/api/groups/${dm.id}/messages`, { text: "goal", mode: "goal" })).status).toBe(400);
+  });
+
+  it("automatically dispatches channel messages queued during a running turn", async () => {
+    const bot = (await api("POST", "/api/bots", {
+      name: "Queue worker",
+      modelSelection: { instanceId: "slow", model: "claude-sonnet-5" },
+      requireAvailableModel: true,
+    })).body.bot;
+    const room = (await api("POST", "/api/groups", {
+      name: "Queue checks",
+      memberIds: [bot.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: bot.id } },
+    })).body.group;
+    const firstSendId = "channel_queue_first_1234";
+    const secondSendId = "channel_queue_second_123";
+
+    const first = await api("POST", `/api/groups/${room.id}/messages`, {
+      text: "first request",
+      sendId: firstSendId,
+    });
+    expect(first.status).toBe(202);
+    expect(first.body.message).toMatchObject({ role: "user", text: "first request", sendId: firstSendId });
+
+    await expect.poll(async () => {
+      const state = (await api("GET", "/api/bots?messages=0")).body;
+      return state.groups.find((candidate: { id: string }) => candidate.id === room.id)?.working;
+    }).toBe(true);
+
+    const queuedBody = { text: "second request", sendId: secondSendId };
+    const queued = await api("POST", `/api/groups/${room.id}/messages`, queuedBody);
+    expect(queued.status).toBe(202);
+    expect(queued.body).toMatchObject({ queued: true, threadId: room.threadId });
+    expect(queued.body.queueId).toEqual(expect.any(String));
+    expect(queued.body.message).toBeUndefined();
+
+    const retryWhileQueued = await api("POST", `/api/groups/${room.id}/messages`, queuedBody);
+    expect(retryWhileQueued.body).toMatchObject({ queued: true, queueId: queued.body.queueId });
+
+    await expect.poll(async () => {
+      const state = (await api("GET", "/api/bots?messages=30")).body;
+      const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+      const userLines = current?.messages.filter((message: { role?: string }) => message.role === "user") ?? [];
+      return {
+        working: current?.working,
+        sends: userLines.map((message: { sendId?: string }) => message.sendId),
+      };
+    }, { timeout: 10_000 }).toEqual({ working: false, sends: [firstSendId, secondSendId] });
+
+    const state = (await api("GET", "/api/bots?messages=30")).body;
+    const current = state.groups.find((candidate: { id: string }) => candidate.id === room.id);
+    const firstUserAt = current.messages.findIndex((message: { sendId?: string }) => message.sendId === firstSendId);
+    const secondUserAt = current.messages.findIndex((message: { sendId?: string }) => message.sendId === secondSendId);
+    const firstReplyAt = current.messages.findIndex(
+      (message: { role?: string }, index: number) => index > firstUserAt && message.role === "bot",
+    );
+    const secondReplyAt = current.messages.findIndex(
+      (message: { role?: string }, index: number) => index > secondUserAt && message.role === "bot",
+    );
+    expect(firstUserAt).toBeGreaterThanOrEqual(0);
+    expect(firstReplyAt).toBeGreaterThan(firstUserAt);
+    expect(secondUserAt).toBeGreaterThan(firstReplyAt);
+    expect(secondReplyAt).toBeGreaterThan(secondUserAt);
+    expect(current.messages[secondUserAt]).toMatchObject({ queueId: queued.body.queueId });
+
+    const retryAfterDrain = await api("POST", `/api/groups/${room.id}/messages`, queuedBody);
+    expect(retryAfterDrain.body.message).toMatchObject({
+      sendId: secondSendId,
+      queueId: queued.body.queueId,
+    });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -130,6 +130,12 @@ import {
   queueSteeredMessage,
 } from "./steer-queue.ts";
 import {
+  cancelChannelMessage,
+  drainChannelMessages,
+  queuedChannelMessage,
+  queueChannelMessage,
+} from "./channel-queue.ts";
+import {
   acceptedSendMatch,
   parseSendId,
   sendFingerprint,
@@ -977,6 +983,10 @@ function finishGroupTurnOperation(groupId: string, operation: GroupTurnOperation
   if (operations?.size === 0) groupTurnOperations.delete(groupId);
   const group = store.group(groupId);
   if (group) broadcast({ kind: "group", group: publicGroupState(group) });
+  // A follow-up sent while this operation was running belongs to the
+  // harness, not whichever composer happened to be mounted. Hand the next
+  // one to the ordinary channel runner as soon as the channel is truly idle.
+  drainQueuedChannelSends();
 }
 
 function finishGroupGoalRun(
@@ -4059,6 +4069,7 @@ function startGroupTurn(
   replyTo?: Message,
   sendId?: string,
   channelMode: "chat" | "goal" = "chat",
+  queueId?: string,
 ) {
   const group = store.group(groupId);
   if (!group) throw Object.assign(new Error("no such group"), { status: 404 });
@@ -4075,6 +4086,7 @@ function startGroupTurn(
     replyToId: replyTo?.id,
     sendId,
     channelMode,
+    queueId,
   });
   if (!group.dm) store.titleGroupTaskFromFirstMessage(group.id, text, threadId);
 
@@ -4183,6 +4195,37 @@ function startGroupTurn(
   const tracked = next.finally(() => finishGroupTurnOperation(groupId, operation));
   groupQueues.set(groupId, tracked.catch(() => {}));
   return message;
+}
+
+function drainQueuedChannelSends(): void {
+  drainChannelMessages(
+    (groupId) => {
+      const group = store.group(groupId);
+      return group ? groupIsWorking(group) : false;
+    },
+    ({ groupId, threadId, text, replyToId, sendId, mode, id }) => {
+      const group = store.group(groupId);
+      const ownsThread = group?.dm
+        ? group.threadId === threadId
+        : Boolean(group && store.groupTaskByThread(group.id, threadId));
+      if (!group || !ownsThread) return;
+      try {
+        startGroupTurn(groupId, text, resolveReplyTarget(threadId, replyToId), sendId, mode, id);
+      } catch (error) {
+        store.appendMessage(threadId, {
+          role: "bot",
+          kind: "activity",
+          tool: {
+            name: `error: queued channel message could not start — ${(error instanceof Error ? error.message : String(error)).slice(0, 120)}`,
+            ok: false,
+          },
+        });
+      }
+      // A message with no eligible responder creates no operation. Continue
+      // draining instead of leaving later user messages behind it forever.
+      queueMicrotask(drainQueuedChannelSends);
+    },
+  );
 }
 
 function sameCalendarRoster(group: GroupRecord, botIds: readonly string[]): boolean {
@@ -6745,6 +6788,17 @@ const server = createServer(async (req, res) => {
             if (accepted.kind === "match") {
               return { ok: true as const, threadId, message: accepted.message };
             }
+            const queued = queuedChannelMessage(group.id, threadId, sendId);
+            if (queued) {
+              if (
+                queued.text !== text ||
+                queued.replyToId !== replyTo?.id ||
+                queued.mode !== channelMode
+              ) {
+                throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
+              }
+              return { ok: true as const, queued: true as const, queueId: queued.id, threadId };
+            }
           }
           const current = store.group(group.id);
           if (!current) throw Object.assign(new Error("no such group"), { status: 404 });
@@ -6753,11 +6807,28 @@ const server = createServer(async (req, res) => {
               status: 409,
             });
           }
+          if (groupIsWorking(current)) {
+            const queued = queueChannelMessage(current.id, threadId, text, {
+              replyToId: replyTo?.id,
+              sendId,
+              mode: channelMode,
+            });
+            return { ok: true as const, queued: true as const, queueId: queued.id, threadId };
+          }
           const message = startGroupTurn(current.id, text, replyTo, sendId, channelMode);
           return { ok: true as const, threadId, message };
         },
       );
       return json(res, 202, receipt);
+    }
+    m = path.match(/^\/api\/groups\/([\w-]+)\/queue\/([\w-]+)$/);
+    if (m && method === "DELETE") {
+      const group = store.group(m[1]);
+      if (!group) return json(res, 404, { error: "no such group" });
+      if (!cancelChannelMessage(group.id, m[2])) {
+        return json(res, 404, { error: "no such queued message" });
+      }
+      return json(res, 200, { ok: true });
     }
     m = path.match(/^\/api\/groups\/([\w-]+)\/interrupt$/);
     if (m && method === "POST") {

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -54,13 +54,6 @@ interface ComposerDraftSnapshot extends ComposerSendSnapshot {
   reply: Message | null;
 }
 
-interface QueuedGroupSend {
-  text: string;
-  replyToId?: string;
-  mode: "chat" | "goal";
-  draft: ComposerDraftSnapshot;
-}
-
 /** Composer chip for Auto mode. Compact label (Ask / Auto); the menu still
  * uses the full names. Same `autoApprove` bit as the profile switch — picking
  * Auto mode here turns that on. The chip only changes its name, not its color. */
@@ -340,34 +333,10 @@ export function Composer({
     });
   };
 
-  // Rooms hold one message client-side while a member speaks; it auto-sends
-  // the moment the room settles. 1:1 mid-turn sends still POST (the harness
-  // queue), but stay off the transcript until drain — the chip here is the
-  // pending row so they cannot become the active leaf mid-turn.
-  const [queued, setQueued] = useState<QueuedGroupSend | null>(null);
-  const queuedRef = useRef(queued);
-  const clearQueued = useCallback(() => {
-    queuedRef.current = null;
-    setQueued(null);
-  }, []);
-  useEffect(
-    () => () => {
-      const unsent = queuedRef.current;
-      if (unsent) restoreDraft(unsent.draft);
-    },
-    [draftId, restoreDraft],
-  );
-  // 1:1 queued sends render as ghost rows in the transcript tail (each with
-  // its own cancel); the composer chip remains only for rooms, whose queue
-  // is local to this component.
-  const pendingChip = group ? queued?.text : undefined;
-  const pendingCount = group
-    ? queued
-      ? 1
-      : 0
-    : bot
-      ? (state.pendingQueued[bot.threadId] ?? []).length
-      : 0;
+  // Busy sends are owned by the harness immediately for both channels and
+  // 1:1 chats. Keeping a channel follow-up in this component used to lose its
+  // auto-send intent whenever navigation unmounted the composer.
+  const pendingCount = (state.pendingQueued[threadId] ?? []).length;
   const canInject = composerCanInjectNow(busy, locked, pendingCount);
   const interruptTurn = () => {
     if (group) dispatch({ type: "interruptGroup", groupId: group.id });
@@ -434,10 +403,7 @@ export function Composer({
     }
   };
   const send = () => {
-    // A busy channel already has one locally held send. Keep any newer text
-    // as an editable draft until that send is dispatched; replacing the slot
-    // here would silently lose the first message.
-    if (locked || (group && queued)) return;
+    if (locked) return;
     if (attachments.some((attachment) => attachment.kind === "image") && !imageTargetsSupport(text, channelMode)) {
       dispatch({ type: "error", message: "The selected responder does not support image attachments." });
       return;
@@ -456,16 +422,6 @@ export function Composer({
       threadId,
       channelMode: group ? channelMode : undefined,
     };
-    if (busy && group) {
-      const pending = { text: t, replyToId: replyTo?.id, mode: channelMode, draft: sentDraft };
-      queuedRef.current = pending;
-      setQueued(pending);
-      setText("");
-      setAttachments([]);
-      onConsumeReply?.();
-      setChannelMode("chat");
-      return;
-    }
     if (group) {
       dispatch({
         type: "sendGroup",
@@ -477,7 +433,7 @@ export function Composer({
         mode: channelMode,
         onError: () => restoreDraft(sentDraft),
       });
-      track("message_sent", { room: true, mode: channelMode });
+      track("message_sent", { room: true, mode: channelMode, queued: busy });
     } else if (bot) {
       dispatch({
         type: "send",
@@ -495,29 +451,6 @@ export function Composer({
     onConsumeReply?.();
     if (group) setChannelMode("chat");
   };
-  useEffect(() => {
-    if (busy || !queued) return;
-    if (group) {
-      if (queued.text.includes("<attached-image ") && !imageTargetsSupport(queued.text, queued.mode)) {
-        dispatch({ type: "error", message: "The selected responder does not support image attachments." });
-        clearQueued();
-        restoreDraft(queued.draft);
-        return;
-      }
-      clearQueued();
-      dispatch({
-        type: "sendGroup",
-        groupId: group.id,
-        text: queued.text,
-        sendId: queued.draft.sendId,
-        replyToId: queued.replyToId,
-        threadId: queued.draft.threadId,
-        mode: queued.mode,
-        onError: () => restoreDraft(queued.draft),
-      });
-      track("message_sent", { room: true, queued: true, mode: queued.mode });
-    }
-  }, [busy, queued, group, members, state.instances, dispatch, clearQueued, restoreDraft]);
 
   // native dictation: partials stream into the input while the Swift
   // helper runs; the final transcript stays in the box, ready to edit/send
@@ -598,23 +531,6 @@ export function Composer({
             </button>
           </div>
         ))}
-        {pendingChip && (
-          <div className="mb-2 flex items-center gap-2 rounded-lg border border-hairline/40 bg-panel px-3 py-2 text-[12.5px] text-ink-secondary">
-            <Clock size={13} className="shrink-0" />
-            <span className="min-w-0 flex-1 truncate">
-              Queued — wait, or inject now: “{pendingChip}”
-            </span>
-            <button
-              type="button"
-              onClick={clearQueued}
-              aria-label="Cancel queued message"
-              title="Cancel queued message"
-              className="ml-auto flex size-5 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
-            >
-              <X size={13} strokeWidth={2.5} />
-            </button>
-          </div>
-        )}
         {pickerOpen && (
           <div
             role="listbox"
@@ -873,20 +789,15 @@ export function Composer({
         {hasContent && !locked && (
           <button
             onClick={send}
-            disabled={Boolean(group && queued)}
             aria-label={
-              group && queued
-                ? "Waiting for queued message"
-                : busy && canSteer
+              busy && canSteer
                   ? "Send into the running turn"
                   : busy
                     ? "Queue message"
                     : "Send message"
             }
             title={
-              group && queued
-                ? "Your earlier message will send when the current turn finishes"
-                : busy && canSteer
+              busy && canSteer
                   ? "Send into the running turn"
                   : busy
                     ? "Sends when the current turn finishes"
@@ -894,9 +805,7 @@ export function Composer({
             }
             className={cn(
               "flex size-8 shrink-0 items-center justify-center rounded-full text-white",
-              group && queued
-                ? "cursor-not-allowed bg-raised text-ink-secondary"
-                : busy && !canSteer
+              busy && !canSteer
                   ? "bg-raised text-ink-secondary hover:bg-raised-hover"
                   : "bg-accent hover:brightness-110",
             )}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Check, ChevronDown, Folder, FolderOpen, Loader2, MessageSquareReply, Pin, PinOff, Plus, Search, X } from "lucide-react";
+import { ArrowDown, Check, ChevronDown, Clock, Folder, FolderOpen, Loader2, MessageSquareReply, Pin, PinOff, Plus, Search, X } from "lucide-react";
 import {
   api,
   useStore,
@@ -1267,6 +1267,33 @@ export function GroupView({ group }: { group: Group }) {
               ) : null}
             </TurnPresence>
           )}
+          {(state.pendingQueued[group.threadId] ?? []).map((entry) => (
+            <div key={entry.queueId} className="flex flex-col items-end">
+              <div className="w-fit max-w-[min(42rem,78%)] whitespace-pre-wrap rounded-2xl border border-dashed border-hairline/70 bg-panel/60 px-4 py-2.5 text-[15px] leading-relaxed text-ink-secondary">
+                {entry.text}
+              </div>
+              <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
+                <Clock size={11} aria-hidden="true" />
+                <span>{group.working ? "Queued — wait, or inject now" : "Queued — sending now"}</span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    dispatch({
+                      type: "cancelGroupQueued",
+                      groupId: group.id,
+                      threadId: group.threadId,
+                      queueId: entry.queueId,
+                    })
+                  }
+                  aria-label="Cancel queued message"
+                  title="Cancel queued message"
+                  className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
+                >
+                  <X size={11} strokeWidth={2.5} />
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
         )}
       </div>

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -659,6 +659,22 @@ describe("pending queued chip", () => {
     });
     expect(cancelled.pendingQueued).toEqual({});
   });
+
+  it("drops a cancelled channel follow-up from its original task", () => {
+    const queued = reducer(initialState, {
+      type: "pendingQueued",
+      threadId: "room-task-1",
+      queueId: "q-room-drop",
+      text: "never mind",
+    });
+    const cancelled = reducer(queued, {
+      type: "cancelGroupQueued",
+      groupId: "room-1",
+      threadId: "room-task-1",
+      queueId: "q-room-drop",
+    });
+    expect(cancelled.pendingQueued).toEqual({});
+  });
 });
 
 describe("messageAdded leaf adoption", () => {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -453,7 +453,7 @@ export interface AppState {
     nonce: number;
     kind: Exclude<MausMotion, "none">;
   } | null;
-  /** 1:1 queue-fallback lines waiting for drain; keyed by threadId.
+  /** Queued follow-up lines waiting for drain; keyed by threadId.
    * Each entry is identified by the server queueId, not by text. */
   pendingQueued: Record<string, Array<{ queueId: string; text: string }>>;
   /** queueIds whose drain frame beat the POST continuation. One-shot and
@@ -576,6 +576,7 @@ export type Action =
   | { type: "pendingQueued"; threadId: string; queueId: string; text: string }
   | { type: "consumePendingQueued"; threadId: string; queueId: string }
   | { type: "cancelQueued"; botId: string; queueId: string }
+  | { type: "cancelGroupQueued"; groupId: string; threadId: string; queueId: string }
   | { type: "editMessage"; botId: string; messageId: string; text: string }
   | { type: "switchBranch"; botId: string; messageId: string }
   | { type: "threadActive"; threadId: string; activeLeafId: string }
@@ -1199,6 +1200,15 @@ export function reducer(state: AppState, action: Action): AppState {
       else delete pendingQueued[bot.threadId];
       return { ...state, pendingQueued };
     }
+    case "cancelGroupQueued": {
+      const prev = state.pendingQueued[action.threadId] ?? [];
+      const rest = prev.filter((entry) => entry.queueId !== action.queueId);
+      if (rest.length === prev.length) return state;
+      const pendingQueued = { ...state.pendingQueued };
+      if (rest.length) pendingQueued[action.threadId] = rest;
+      else delete pendingQueued[action.threadId];
+      return { ...state, pendingQueued };
+    }
     case "send":
       return withMascotMotion(dismissOnboardingCard(state, action.botId), action.botId, "working");
     case "editMessage":
@@ -1460,7 +1470,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       if (action.type === "deleteBot") botPatchQueue.cancel(action.botId);
       // A queued message is still real until the server confirms deletion.
       // All other actions keep their existing optimistic behavior.
-      if (action.type !== "cancelQueued") rawDispatch(action);
+      if (action.type !== "cancelQueued" && action.type !== "cancelGroupQueued") rawDispatch(action);
       switch (action.type) {
         case "createRoutine":
           api("/api/routines", { method: "POST", body: JSON.stringify(action.input) }).catch(showError);
@@ -1485,6 +1495,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
         case "cancelQueued":
           void api(`/api/bots/${action.botId}/queue/${action.queueId}`, { method: "DELETE" })
+            .then(() => rawDispatch(action))
+            .catch(showError);
+          break;
+        case "cancelGroupQueued":
+          void api(`/api/groups/${action.groupId}/queue/${action.queueId}`, { method: "DELETE" })
             .then(() => rawDispatch(action))
             .catch(showError);
           break;
@@ -1687,6 +1702,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             .then((body) => {
               if (body?.message && typeof body.threadId === "string") {
                 rawDispatch({ type: "messageAdded", threadId: body.threadId, message: body.message });
+              }
+              if (
+                body?.queued &&
+                typeof body.threadId === "string" &&
+                typeof body.queueId === "string"
+              ) {
+                rawDispatch({
+                  type: "pendingQueued",
+                  threadId: body.threadId,
+                  queueId: body.queueId,
+                  text: action.text,
+                });
               }
             })
             .catch((error) => {


### PR DESCRIPTION
## What changed

- hand busy-channel sends to a server-owned FIFO queue immediately
- auto-dispatch each follow-up when the active channel turn settles
- keep queued messages visible across navigation with cancel and inject-now controls
- deduplicate retries before and after queue drain

## Why

The composer previously owned one queued channel message in local React state. If that composer unmounted or missed the busy-to-idle render, the send-later intent was lost and the message remained a draft until manually resent. This follows the backend/outbox ownership pattern used by T3 Code.

## Verification

- 2,791 tests passed, 19 skipped
- production build and typecheck passed
- lint and i18n checks passed
- isolated OpenMausBot fixture processed three concurrent channel sends one turn at a time and settled with all three replies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Messages sent while a channel is busy are now queued automatically and delivered in order when the active response finishes.
  - Queued messages retain their text and message mode, with support for retrying and cancelling before delivery.
  - Added visible queued-message indicators and cancellation controls in group conversations.
  - Busy sends now work consistently across channels and direct chats.

- **Tests**
  - Added coverage for queue ordering, cancellation, retry behavior, and automatic delivery after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->