### PR TITLE
fix(ios): open iPad app in a large window

### DIFF
--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -37,6 +37,7 @@ struct CompanionApp: App {
                     }
                 }
         }
+        .defaultSize(CompanionLayout.defaultWindowSize)
     }
 }
 
@@ -99,6 +100,7 @@ struct RootView: View {
                 )
             }
         }
+        .background(Color(uiColor: .systemBackground).ignoresSafeArea())
         .onChange(of: session.pairingInvite) { _, invite in
             guard invite != nil else { return }
             hasSeenWelcome = true

--- a/ios/App/CompanionLayout.swift
+++ b/ios/App/CompanionLayout.swift
@@ -4,6 +4,12 @@ import UIKit
 /// Readable columns for the phone-first surfaces when they run in a wider
 /// iPad window. Compact windows naturally remain narrower than these caps.
 enum CompanionLayout {
+    /// Ask iPadOS for a large landscape window on first launch. The system
+    /// clamps this to the current display and still lets the person resize or
+    /// tile the app. Previously SwiftUI inferred its initial window from the
+    /// 680-point roster column, which produced a tall, phone-like window.
+    static let defaultWindowSize = CGSize(width: 1_366, height: 1_024)
+
     static let rosterWidth: CGFloat = 680
     static let chatWidth: CGFloat = 760
     static let headerWidth: CGFloat = 900


### PR DESCRIPTION
## What changed
- give new iPad scenes a large landscape default instead of inheriting the 680-point roster width
- fill the complete app scene with the system background
- preserve iPad multitasking and user resizing

## Why
The narrow, phone-like surface in iPadOS was the app window itself. SwiftUI inferred its first size from the roster column, so the app opened at roughly 680 points wide.

## Verification
- `cd ios && swift test`
- generated and built the iOS app target for a generic iOS Simulator
- installed and launched on a fresh iPad Pro 13-inch simulator; the app occupied the full iPad canvas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iPadOS now opens the app in a wider landscape-oriented window by default.
  * The initial window can still be resized, tiled, or adjusted to fit the display.

* **Style**
  * The app background now consistently fills the entire screen, including areas outside the safe area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->