### PR TITLE
fix(companion): make Tailscale pairing clear and reliable

### DIFF
--- a/companion/README.md
+++ b/companion/README.md
@@ -91,7 +91,7 @@ switch — running it *is* the opt-in, so there is no toggle to forget.
 
 That is the standalone way to run it, and it is what to reach for when the
 harness is running on its own — a headless box, or `pnpm dev:server` in a
-terminal. **The normal desktop workflow is Settings → Companion**, which
+terminal. **The normal desktop workflow is Settings → Phone**, which
 starts and stops this same sidecar as a child process and offers pairing and
 revocation inline; the loopback page above is the same API rendered for
 people not running the desktop app. Either way the sidecar only listens while

--- a/companion/src/control.ts
+++ b/companion/src/control.ts
@@ -35,6 +35,9 @@ export interface ControlOptions {
   connectedDeviceIds?: () => string[];
   /** Terminate every authenticated event stream owned by a revoked device. */
   disconnectDevice?: (deviceId: string) => void;
+  /** Re-read Tailscale after the sidecar has started. People commonly install,
+   * sign in, or enable Tailscale while OpenMausBot is already running. */
+  refreshTailscale?: () => Promise<void>;
 }
 
 /** The host out of a `Host` header, port removed.
@@ -259,6 +262,13 @@ export function createControlServer(options: ControlOptions): Server {
       return res.end(html);
     }
     if (method === "GET" && path === "/state") return json(res, 200, companionState(options));
+    if (method === "POST" && path === "/tailscale/refresh" && options.refreshTailscale) {
+      void options.refreshTailscale().then(
+        () => json(res, 200, companionState(options)),
+        () => json(res, 500, { error: "could not refresh Tailscale" }),
+      );
+      return;
+    }
     if (method === "POST" && path === "/pairing") {
       const window = options.devices.openPairing();
       // Keep the freshly issued credentials at the top level as well as in

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -160,6 +160,7 @@ const control = createControlServer({
   discovery: () => ({ advertising: mdns.advertising, name: service().name }),
   connectedDeviceIds: connectedDevices.ids,
   disconnectDevice: connectedDevices.disconnect,
+  refreshTailscale: () => refreshTailnetName(),
 });
 
 /** Bind a server, turning a bind failure into a sentence rather than a stack

--- a/companion/src/listener.ts
+++ b/companion/src/listener.ts
@@ -75,9 +75,11 @@ export function tailscaleAddress(addresses: string[] = lanAddresses()): string |
  * one of the private ranges that exemption covers. A `ts.net` hostname can
  * be exempted by name, which an address cannot.
  *
- * Read once when the listener comes up and cached — asking Tailscale is a
- * subprocess, and nothing here is worth spawning one per request. */
+ * Read when the listener comes up and cached — asking Tailscale is a
+ * subprocess, so normal state reads stay cheap. An explicit setup action can
+ * refresh this cache when Tailscale changes later. */
 let cachedTailnetName: string | null = null;
+let activeTailnetRefresh: Promise<void> | null = null;
 
 /** The cached MagicDNS name, or null until `refreshTailnetName` finds one. */
 export function tailnetName(): string | null {
@@ -120,7 +122,7 @@ const searchPath = (): string =>
  * has MagicDNS on is worse than no message, and there was no way to tell
  * which of these paths had been tried. `onAttempt` is how the caller can say.
  */
-export async function refreshTailnetName(
+async function refreshTailnetNameOnce(
   onAttempt?: (cli: string, outcome: string) => void,
 ): Promise<void> {
   // A budget for the whole loop, not per probe. Seven candidates at five
@@ -179,4 +181,18 @@ export async function refreshTailnetName(
     }
   }
   cachedTailnetName = null;
+}
+
+/** Coalesce startup and user-triggered probes so a slower failure cannot
+ * overwrite a successful MagicDNS result from another concurrent probe. */
+export function refreshTailnetName(
+  onAttempt?: (cli: string, outcome: string) => void,
+): Promise<void> {
+  if (activeTailnetRefresh) return activeTailnetRefresh;
+  let refresh: Promise<void>;
+  refresh = refreshTailnetNameOnce(onAttempt).finally(() => {
+    if (activeTailnetRefresh === refresh) activeTailnetRefresh = null;
+  });
+  activeTailnetRefresh = refresh;
+  return refresh;
 }

--- a/companion/test/control.test.ts
+++ b/companion/test/control.test.ts
@@ -15,6 +15,8 @@ let port = 0;
 let devices: DeviceRegistry;
 let connectedDeviceIds: string[] = [];
 let disconnectedDeviceIds: string[] = [];
+let tailscaleRefreshes = 0;
+let completedTailscaleRefreshes = 0;
 
 const ask = async (
   method: string,
@@ -46,6 +48,11 @@ beforeAll(async () => {
     disconnectDevice: (deviceId) => {
       disconnectedDeviceIds.push(deviceId);
       connectedDeviceIds = connectedDeviceIds.filter((connectedId) => connectedId !== deviceId);
+    },
+    refreshTailscale: async () => {
+      tailscaleRefreshes += 1;
+      await Promise.resolve();
+      completedTailscaleRefreshes += 1;
     },
   });
   port = await new Promise<number>((resolve) =>
@@ -135,6 +142,22 @@ describe("origins the control server will change state for", () => {
     // desktop path. A CSRF check aimed at it would break the toggle.
     expect((await ask("POST", "/pairing")).status).toBe(201);
     await ask("DELETE", "/pairing");
+  });
+
+  it("refreshes Tailscale before returning state without opening pairing", async () => {
+    const before = tailscaleRefreshes;
+    const refreshed = await ask("POST", "/tailscale/refresh");
+
+    expect(refreshed.status).toBe(200);
+    expect(tailscaleRefreshes).toBe(before + 1);
+    expect(completedTailscaleRefreshes).toBe(tailscaleRefreshes);
+    expect(refreshed.body.pairing).toBeNull();
+  });
+
+  it("refuses a Tailscale refresh from a foreign page", async () => {
+    const before = tailscaleRefreshes;
+    expect((await ask("POST", "/tailscale/refresh", { origin: "https://evil.example" })).status).toBe(403);
+    expect(tailscaleRefreshes).toBe(before);
   });
 
   it("does not let a stale conditional close cancel a replacement code", async () => {

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -119,10 +119,15 @@ direct LAN requires choosing that computer or address again.
 ### Tailscale
 
 Tailscale is an optional route away from home and on Wi-Fi networks that
-isolate clients. When both devices share a tailnet, choose **Pair over
-Tailscale** in the desktop setup alternatives. OpenMausBot then places the
-Mac's MagicDNS name in that dedicated QR; it never silently replaces the
-default hosted HTTPS route. Manual entry remains available as a fallback.
+isolate clients. In desktop **Settings → Phone**, the primary card remains
+**Secure HTTPS pairing — Recommended**. The separate **Tailscale pairing**
+card is only for people who already use Tailscale. Install or open Tailscale
+on both devices, sign in to the same tailnet, leave MagicDNS enabled, and
+choose **Turn on phone access & check** followed by **Pair over Tailscale**.
+That first action explicitly starts Phone access so the phone has a listener
+to reach. OpenMausBot then places the computer's MagicDNS name in that
+dedicated QR; it never silently replaces the default hosted HTTPS route.
+Manual entry remains available as a fallback.
 
 The URL is still `http`, but the path is encrypted and authenticated by
 WireGuard inside the tailnet. Use the MagicDNS name rather than the
@@ -144,7 +149,7 @@ The desktop runs an outbound connector to Cloudflare, so no inbound router
 configuration or Tailscale installation is required. The hosted address is
 included in a pairing invitation only after it is ready. The default setup
 waits for that HTTPS address instead of silently substituting Tailscale;
-Tailscale pairing remains an explicit choice under the alternative routes.
+Tailscale pairing remains an explicit choice in its own optional card.
 
 Cloudflare terminates and proxies the encrypted connection to the connector.
 The OpenMausBot control plane stores account and installation metadata plus
@@ -161,8 +166,8 @@ local port cannot inherit the public route.
 
 ## Pairing and device security
 
-1. On the Mac, open **Settings → Phone**, turn on phone access, and choose
-   **Set up a phone**.
+1. On the Mac, open **Settings → Phone** and choose **Pair a phone**. The app
+   starts phone access as part of setup.
 2. On the iPhone, choose **Connect my computer** and scan the QR.
 3. Confirm the computer name and the displayed transport — **HTTPS connection**,
    **Tailscale connection**, or **Trusted local connection**. The phone stores

--- a/electron/companion.mjs
+++ b/electron/companion.mjs
@@ -114,10 +114,10 @@ export function rememberCompanionKeepAwake(keepAwake) {
 /** Ask the sidecar's own control server, which is the same API the standalone
  * page uses. Short timeout: this is loopback, and a spinner in Settings that
  * never resolves is worse than an error. */
-async function control(method, urlPath, body) {
+async function control(method, urlPath, body, { timeoutMs = 4_000 } = {}) {
   const options = {
     method,
-    signal: AbortSignal.timeout(4000),
+    signal: AbortSignal.timeout(timeoutMs),
   };
   if (body !== undefined) {
     options.body = JSON.stringify(body);
@@ -386,6 +386,30 @@ export async function companionState() {
       connectedDeviceIds: [],
       pairing: null,
       error: "the companion is not responding",
+    };
+  }
+}
+
+/** Re-read Tailscale without restarting the sidecar or dropping connected
+ * phones. Tailscale may be installed, signed in, or enabled after OpenMausBot
+ * starts, so startup-only detection makes an otherwise healthy route look
+ * permanently unavailable. */
+export async function companionRefreshTailscale() {
+  if (!proc) return companionState();
+  try {
+    // The CLI hunt is itself bounded to five seconds. Give the loopback call
+    // enough room to receive that bounded answer instead of aborting first.
+    const state = await control("POST", "/tailscale/refresh", undefined, { timeoutMs: 6_000 });
+    return {
+      enabled: true,
+      keepAwake: companionKeepAwakeAtRest(),
+      ...state,
+    };
+  } catch {
+    const state = await companionState();
+    return {
+      ...state,
+      error: state.error ?? "Tailscale could not be checked.",
     };
   }
 }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -360,6 +360,7 @@ import {
   companionEnabledAtRest,
   companionOriginTarget,
   companionPairing,
+  companionRefreshTailscale,
   companionCloudDesktopAccess,
   companionRevoke,
   companionRunning,
@@ -617,6 +618,14 @@ async function stopDesktopCompanion({ remember = true } = {}) {
   await managedCompanionConnector?.stop();
   await stopCompanion();
   return desktopCompanionState();
+}
+
+async function refreshDesktopCompanionTailscale() {
+  if (!companionRunning()) {
+    const started = await startDesktopCompanion({ waitForHosted: false });
+    if (!started.enabled || started.error) return started;
+  }
+  return decorateDesktopCompanionState(await companionRefreshTailscale());
 }
 
 setCompanionLifecycleListener(({ expected, pid }) => {
@@ -1791,6 +1800,7 @@ ipcMain.handle("companion:keep-awake", async (_event, enabled) => {
   rememberCompanionKeepAwake(Boolean(enabled));
   return desktopCompanionState();
 });
+ipcMain.handle("companion:refresh-tailscale", () => refreshDesktopCompanionTailscale());
 ipcMain.handle("companion:pairing", (_event, open, expectedToken) =>
   companionPairing(Boolean(open), expectedToken).then(decorateDesktopCompanionState),
 );

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -33,6 +33,7 @@ contextBridge.exposeInMainWorld("ogb", {
     start: () => ipcRenderer.invoke("companion:start"),
     stop: () => ipcRenderer.invoke("companion:stop"),
     keepAwake: (enabled) => ipcRenderer.invoke("companion:keep-awake", enabled),
+    refreshTailscale: () => ipcRenderer.invoke("companion:refresh-tailscale"),
     pairing: (open, expectedToken) => ipcRenderer.invoke("companion:pairing", open, expectedToken),
     cloudDesktop: (deviceId, allowed) => ipcRenderer.invoke("companion:cloud-desktop", deviceId, allowed),
     revoke: (deviceId) => ipcRenderer.invoke("companion:revoke", deviceId),

--- a/ios/TESTING.md
+++ b/ios/TESTING.md
@@ -84,7 +84,8 @@ pnpm dev                  # 127.0.0.1:5199
 pnpm dev:desktop          # Electron starts the harness
 ```
 
-In the app: **Settings → Companion**. Turn it on. You should see either
+In the app: **Settings → Phone → Advanced & troubleshooting**. Turn on
+**Phone access**. You should see either
 
 - *"Your phone will find this computer as …"* — Bonjour is advertising, or
 - *"Listening on 192.168.x.x:8810 — enter that on your phone."* — it is not.
@@ -175,8 +176,8 @@ paid account is required to run on your own phone.
 
 On the phone, in order:
 
-1. **Pair.** In OpenMausBot → Settings → Companion, choose **Set up a
-   phone**. Scan the QR code with the phone's Camera, open OpenMausMobile,
+1. **Pair.** In OpenMausBot → Settings → Phone, choose **Pair a phone**.
+   Scan the QR code with the phone's Camera, open OpenMausMobile,
    confirm that the computer and six-digit code are filled in, then tap
    **Connect**. The computer should also appear by name for the manual path:
    tap it and type the same code.
@@ -232,7 +233,7 @@ On the phone, in order:
    and the result should remain editable before sending. The first attempt
    requests Microphone and Speech Recognition access. Locking or
    backgrounding the phone mid-sentence must release the mic.
-8. **Revoke.** Remove the device in Settings → Companion on the computer. The
+8. **Revoke.** Remove the device in Settings → Phone on the computer. The
    phone should land on "This phone was unpaired" rather than silently failing.
 
 ---
@@ -255,12 +256,14 @@ so this is also how the phone reaches the Mac over cellular.
 2. **On the phone:** install Tailscale from the App Store, sign in to the *same*
    account, and turn the VPN on.
 3. **In OpenMausBot → Settings → Phone:** with Phone access on, the panel now
-   prints the tailnet name — something like `macbook.tail1234.ts.net:8810`, with
-   the LAN address listed separately underneath. If it still only shows a
-   `192.168.x.x` address, the sidecar could not find the Tailscale CLI — it
-   asks once at startup, so turn the Companion toggle off and on again (or
-   restart `pnpm companion` if running it by hand) after Tailscale is up.
-4. **In the desktop setup alternatives, choose Pair over Tailscale.** Scan its
+   shows a separate **Tailscale pairing** card. Choose **Turn on phone access &
+   check** (or **Check again** when Phone access is already on); it should
+   report a tailnet name such as `macbook.tail1234.ts.net`. If it
+   finds Tailscale without a name, verify that MagicDNS is on and choose
+   **Check again**. This check refreshes a running sidecar, so restarting the
+   desktop app or dropping existing phone connections is not required.
+4. **Choose Pair over Tailscale.** The settings panel should move back to the
+   top pairing surface and label it **Tailscale pairing**. Scan its
    dedicated QR, which carries that MagicDNS name, or pair by typing the name.
    Discovery does not help here — Bonjour is multicast and a tailnet does not
    carry it — so the Tailscale QR/manual address is the path, and it is the one

--- a/src/components/CompanionSection.test.ts
+++ b/src/components/CompanionSection.test.ts
@@ -11,7 +11,9 @@ import {
   companionAccountActionError,
   companionPairingMode,
   deriveCompanionPanelStatus,
+  deriveTailscalePairingStatus,
   loadCompanionBridgeState,
+  pairingSurfaceCopy,
   shouldHydrateCompanionEmail,
 } from "./CompanionSection";
 
@@ -191,5 +193,48 @@ describe("companion pairing availability", () => {
       companionPairingMode({ available: false, status: "signed-out" }, localCompanion(true)),
     ).toBe("local-only");
     expect(companionPairingMode(account("error"), localCompanion(true))).toBe("local-only");
+  });
+});
+
+describe("Tailscale pairing onboarding", () => {
+  it("keeps HTTPS as the recommended default surface", () => {
+    expect(pairingSurfaceCopy({ localFallback: false, tailscaleFallback: false })).toEqual({
+      title: "Secure HTTPS pairing",
+      subtitle: "Recommended — the simplest setup, and it keeps working when your phone leaves this Wi-Fi.",
+    });
+    expect(pairingSurfaceCopy({ localFallback: false, tailscaleFallback: true }).title).toBe(
+      "Tailscale pairing",
+    );
+  });
+
+  it("explains every step between unchecked and ready", () => {
+    expect(deriveTailscalePairingStatus({ enabled: false }, false)).toMatchObject({
+      kind: "unchecked",
+      detail: expect.stringContaining("turns on Phone access"),
+    });
+    expect(deriveTailscalePairingStatus({ enabled: true }, false).kind).toBe("unavailable");
+    expect(deriveTailscalePairingStatus({
+      enabled: true,
+      tailscale: "100.99.1.2",
+    }, false).kind).toBe("magicdns");
+    expect(deriveTailscalePairingStatus({
+      enabled: true,
+      tailscale: "100.99.1.2",
+      tailnetName: "mac.tail1234.ts.net",
+    }, true)).toMatchObject({
+      kind: "ready",
+      title: "Ready on mac.tail1234.ts.net",
+    });
+  });
+
+  it("surfaces sidecar failures instead of pretending Tailscale is merely absent", () => {
+    expect(deriveTailscalePairingStatus({
+      enabled: true,
+      error: "the companion is not responding",
+    }, false)).toEqual({
+      kind: "error",
+      title: "Phone access needs attention",
+      detail: "the companion is not responding",
+    });
   });
 });

--- a/src/components/CompanionSection.tsx
+++ b/src/components/CompanionSection.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import {
   Cloud,
   Loader2,
@@ -14,6 +15,7 @@ import {
   loadCompanionBridgeState,
   shouldHydrateCompanionEmail,
   type CompanionState,
+  type PhoneSetupController,
   usePhoneSetupController,
 } from "./PhoneSetupFlow";
 import { companionPairingMode } from "../lib/phone-setup";
@@ -30,6 +32,72 @@ export {
 export interface CompanionPanelStatus {
   label: string;
   good: boolean;
+}
+
+export interface TailscalePairingStatus {
+  kind: "unchecked" | "unavailable" | "magicdns" | "ready" | "error";
+  title: string;
+  detail: string;
+}
+
+export function deriveTailscalePairingStatus(
+  state: Pick<CompanionState, "enabled" | "tailscale" | "tailnetName" | "error">,
+  routeAvailable: boolean,
+): TailscalePairingStatus {
+  if (state.error) {
+    return {
+      kind: "error",
+      title: "Phone access needs attention",
+      detail: state.error,
+    };
+  }
+  if (routeAvailable && state.tailnetName) {
+    return {
+      kind: "ready",
+      title: `Ready on ${state.tailnetName}`,
+      detail: "Keep Tailscale connected on this computer and your phone while they pair.",
+    };
+  }
+  if (state.tailscale) {
+    return {
+      kind: "magicdns",
+      title: "Tailscale found — MagicDNS is still needed",
+      detail: "Turn on MagicDNS in Tailscale, then check again so the iPhone gets a secure tailnet name.",
+    };
+  }
+  if (state.enabled) {
+    return {
+      kind: "unavailable",
+      title: "Tailscale is not connected yet",
+      detail: "Open Tailscale on both devices, sign in to the same tailnet, then check again.",
+    };
+  }
+  return {
+    kind: "unchecked",
+    title: "Already use Tailscale?",
+    detail: "Connect both devices to the same tailnet. Checking turns on Phone access so your phone can reach this computer.",
+  };
+}
+
+export function pairingSurfaceCopy(
+  route: Pick<PhoneSetupController, "localFallback" | "tailscaleFallback">,
+): { title: string; subtitle: string } {
+  if (route.tailscaleFallback) {
+    return {
+      title: "Tailscale pairing",
+      subtitle: "Private pairing through the tailnet shared by this computer and your phone.",
+    };
+  }
+  if (route.localFallback) {
+    return {
+      title: "Direct Wi-Fi pairing",
+      subtitle: "Use only on a trusted network where both devices can see each other.",
+    };
+  }
+  return {
+    title: "Secure HTTPS pairing",
+    subtitle: "Recommended — the simplest setup, and it keeps working when your phone leaves this Wi-Fi.",
+  };
 }
 
 export function deriveCompanionPanelStatus(
@@ -66,6 +134,7 @@ const endpointHost = (url: string): string => {
 export function CompanionSection({ profileEmail = "" }: { profileEmail?: string }) {
   const c = usePhoneSetupController(profileEmail);
   const state = c.state;
+  const pairingFlow = useRef<HTMLDivElement>(null);
 
   if (!companionBridge()) {
     return (
@@ -87,6 +156,8 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
   const pairedCount = state.devices.length;
   const panelStatus = deriveCompanionPanelStatus(state);
   const accountActionError = companionAccountActionError(c.account, c.accountError);
+  const pairingCopy = pairingSurfaceCopy(c);
+  const tailscaleStatus = deriveTailscalePairingStatus(state, c.tailscaleAvailable);
   const hosted = state.endpoints?.find((endpoint) => endpoint.kind === "hosted");
   const localRoutes = [
     state.tailnetName ? { label: "Tailscale", value: `${state.tailnetName}:${state.port}` } : null,
@@ -101,27 +172,72 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
 
   return (
     <div className="flex flex-col gap-4">
-      <Card>
-        {(panelStatus || (pairedCount > 0 && c.hostedReady)) && (
-          <div className="mb-4 flex items-center justify-between gap-3">
-            {panelStatus && (
-              <div
-                className={`flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] ${
-                  panelStatus.good ? "bg-success/10 text-success" : "bg-control text-ink-secondary"
-                }`}
-              >
-                <span className={`size-1.5 rounded-full ${panelStatus.good ? "bg-success" : "bg-ink-secondary/50"}`} />
-                {panelStatus.label}
+      <div ref={pairingFlow} tabIndex={-1} className="scroll-mt-4 focus:outline-none">
+        <Card title={pairingCopy.title} subtitle={pairingCopy.subtitle}>
+          {(panelStatus || (pairedCount > 0 && c.hostedReady)) && (
+            <div className="mb-4 flex items-center justify-between gap-3">
+              {panelStatus && (
+                <div
+                  className={`flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] ${
+                    panelStatus.good ? "bg-success/10 text-success" : "bg-control text-ink-secondary"
+                  }`}
+                >
+                  <span className={`size-1.5 rounded-full ${panelStatus.good ? "bg-success" : "bg-ink-secondary/50"}`} />
+                  {panelStatus.label}
+                </div>
+              )}
+              {pairedCount > 0 && c.hostedReady && (
+                <div className="flex items-center gap-1.5 text-[11.5px] text-ink-secondary">
+                  <ShieldCheck size={13} className="text-accent" /> Works away from home
+                </div>
+              )}
+            </div>
+          )}
+          <PhoneSetupFlowView controller={c} variant="settings" />
+        </Card>
+      </div>
+
+      <Card
+        title="Tailscale pairing"
+        subtitle="Optional — for people who already use Tailscale. Secure HTTPS above remains the recommended setup."
+      >
+        <div className="rounded-xl bg-inset px-3 py-3" aria-live="polite">
+          <div className="flex items-start gap-2.5">
+            <ShieldCheck
+              size={16}
+              className={`mt-0.5 shrink-0 ${tailscaleStatus.kind === "ready" ? "text-success" : "text-ink-secondary"}`}
+            />
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium text-ink">{tailscaleStatus.title}</div>
+              <div className="mt-0.5 text-[11.5px] leading-relaxed text-ink-secondary">
+                {tailscaleStatus.detail}
               </div>
-            )}
-            {pairedCount > 0 && c.hostedReady && (
-              <div className="flex items-center gap-1.5 text-[11.5px] text-ink-secondary">
-                <ShieldCheck size={13} className="text-accent" /> Works away from home
-              </div>
-            )}
+            </div>
           </div>
+        </div>
+        {tailscaleStatus.kind === "ready" ? (
+          <button
+            disabled={c.busy || c.accountBusy}
+            onClick={() => {
+              c.useTailscale();
+              window.requestAnimationFrame(() => {
+                pairingFlow.current?.scrollIntoView({ block: "start" });
+                pairingFlow.current?.focus({ preventScroll: true });
+              });
+            }}
+            className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[12px] text-ink hover:bg-control disabled:opacity-40"
+          >
+            Pair over Tailscale
+          </button>
+        ) : (
+          <button
+            disabled={c.busy || c.accountBusy}
+            onClick={c.refreshTailscale}
+            className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[12px] text-ink hover:bg-control disabled:opacity-40"
+          >
+            {c.busy ? "Checking…" : state.enabled ? "Check again" : "Turn on phone access & check"}
+          </button>
         )}
-        <PhoneSetupFlowView controller={c} variant="settings" />
       </Card>
 
       <Card
@@ -260,26 +376,6 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
           </div>
 
           <div className="border-t border-hairline/30 pt-4">
-            {c.tailscaleAvailable && (
-              <div className="mb-4 border-b border-hairline/30 pb-4">
-                <div className="flex items-start gap-2.5">
-                  <ShieldCheck size={15} className="mt-0.5 shrink-0 text-accent" />
-                  <div>
-                    <div className="text-[13px] text-ink">Tailscale pairing</div>
-                    <div className="mt-0.5 text-[11.5px] leading-relaxed text-ink-secondary">
-                      Keep pairing on your private tailnet, even when a secure hosted route is available.
-                    </div>
-                  </div>
-                </div>
-                <button
-                  disabled={c.busy || c.accountBusy}
-                  onClick={c.useTailscale}
-                  className="mt-3 rounded-lg border border-hairline/40 px-3 py-1.5 text-[12px] text-ink hover:bg-control disabled:opacity-40"
-                >
-                  Pair over Tailscale
-                </button>
-              </div>
-            )}
             <div className="flex items-start gap-2.5">
               <Wifi size={15} className="mt-0.5 shrink-0 text-ink-secondary" />
               <div>
@@ -298,11 +394,6 @@ export function CompanionSection({ profileEmail = "" }: { profileEmail?: string 
             </button>
           </div>
 
-          {state.enabled && !hosted && state.tailscale && !state.tailnetName && (
-            <div className="rounded-lg bg-warning/10 px-3 py-2 text-[11.5px] leading-relaxed text-ink-secondary">
-              Tailscale is connected, but its device name could not be read. Check MagicDNS in Tailscale or use the secure account above.
-            </div>
-          )}
           {state.enabled && !hosted && !state.tailscale && (
             <div className="rounded-lg bg-inset px-3 py-2 text-[11.5px] leading-relaxed text-ink-secondary">
               Without secure phone access or Tailscale, this computer is reachable only on a compatible local network.

--- a/src/components/PhoneSetupFlow.tsx
+++ b/src/components/PhoneSetupFlow.tsx
@@ -44,6 +44,7 @@ import {
   phonePairingGate,
   phoneSetupBaseline,
   phoneSetupReducer,
+  preparePhonePairingRoute,
   queuePhonePairingAttempt,
   releasePhonePairingAttempt,
   shouldArmPhoneSetupProvisioningTimeout,
@@ -85,6 +86,7 @@ export type CompanionBridge = {
   start: () => Promise<CompanionState>;
   stop: () => Promise<CompanionState>;
   keepAwake: (enabled: boolean) => Promise<CompanionState>;
+  refreshTailscale: () => Promise<CompanionState>;
   pairing: (open: boolean, expectedToken?: string) => Promise<CompanionState>;
   cloudDesktop: (deviceId: string, allowed: boolean) => Promise<CompanionState>;
   revoke: (deviceId: string) => Promise<CompanionState>;
@@ -202,6 +204,7 @@ export interface PhoneSetupController {
   start: () => void;
   useLocal: () => void;
   useTailscale: () => void;
+  refreshTailscale: () => void;
   requestCode: () => void;
   verifyCode: () => void;
   retryAccount: () => void;
@@ -375,12 +378,22 @@ export function usePhoneSetupController(profileEmail = ""): PhoneSetupController
       }
       setError(null);
       try {
-        const started = state?.enabled
-          ? await companion.state()
-          : await mutateCompanionBridgeState(
+        const started = await preparePhonePairingRoute(
+          routeMode,
+          Boolean(state?.enabled),
+          {
+            read: () => companion.state(),
+            start: () => mutateCompanionBridgeState(
               companionMutationEpoch,
               () => companion.start(),
-            );
+            ),
+            refreshTailscale: () => mutateCompanionBridgeState(
+              companionMutationEpoch,
+              () => companion.refreshTailscale(),
+            ),
+            shouldContinue: isCurrent,
+          },
+        );
         if (!isCurrent()) return;
         setState(started);
         const startFailure = companionStartFailure(started);
@@ -539,6 +552,10 @@ export function usePhoneSetupController(profileEmail = ""): PhoneSetupController
     setAccountError(null);
     void openPairing("tailscale", undefined, generation);
   }, [flow.active, openPairing, state?.devices]);
+
+  const refreshTailscale = useCallback(() => {
+    void act((companion) => companion.refreshTailscale());
+  }, [act]);
 
   const requestCode = useCallback(() => {
     const remote = companionAccountBridge();
@@ -840,6 +857,7 @@ export function usePhoneSetupController(profileEmail = ""): PhoneSetupController
     start,
     useLocal,
     useTailscale,
+    refreshTailscale,
     requestCode,
     verifyCode,
     retryAccount,
@@ -1048,7 +1066,7 @@ export function PhoneSetupFlowView({
         <div className="my-4 flex items-center gap-3 text-[11px] text-ink-secondary">
           <span className="h-px flex-1 bg-hairline/40" /> or <span className="h-px flex-1 bg-hairline/40" />
         </div>
-        {c.tailscaleAvailable && (
+        {variant === "onboarding" && c.tailscaleAvailable && (
           <>
             <button
               disabled={c.busy || c.accountBusy}
@@ -1065,7 +1083,7 @@ export function PhoneSetupFlowView({
         <button
           disabled={c.busy || c.accountBusy}
           onClick={c.useLocal}
-          className={`${c.tailscaleAvailable ? "mt-3" : ""} flex items-center justify-center gap-2 rounded-lg border border-hairline/50 py-2.5 text-[13px] text-ink hover:bg-control disabled:opacity-40`}
+          className={`${variant === "onboarding" && c.tailscaleAvailable ? "mt-3" : ""} flex items-center justify-center gap-2 rounded-lg border border-hairline/50 py-2.5 text-[13px] text-ink hover:bg-control disabled:opacity-40`}
         >
           <Wifi size={15} /> Pair on this Wi-Fi instead
         </button>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -34,7 +34,7 @@ const SECTIONS: Array<{
   { id: "experimental", label: "Experimental", icon: FlaskConical, keywords: ["early", "preview", "teach", "skill", "browser", "profiles"] },
   { id: "connections", label: "Connections", icon: KeyRound, keywords: ["keys", "api", "composio", "box", "xai", "vps"] },
   { id: "engines", label: "Engines", icon: Terminal, keywords: ["models", "claude", "grok", "providers", "cli"] },
-  { id: "companion", label: "Phone", icon: Smartphone, keywords: ["companion", "phone", "pair", "mobile"] },
+  { id: "companion", label: "Phone", icon: Smartphone, keywords: ["companion", "phone", "pair", "pairing", "mobile", "https", "secure", "tailscale", "wifi", "advanced"] },
   { id: "computer", label: "Local VM", icon: Monitor, keywords: ["vm", "virtual", "desktop"] },
   { id: "usage", label: "Usage", icon: Coins, keywords: ["tokens", "cost", "billing"] },
 ];

--- a/src/lib/phone-setup.test.ts
+++ b/src/lib/phone-setup.test.ts
@@ -15,6 +15,7 @@ import {
   phonePairingGate,
   phoneSetupBaseline,
   phoneSetupReducer,
+  preparePhonePairingRoute,
   invalidatePhonePairingAttempt,
   queuePhonePairingAttempt,
   releasePhonePairingAttempt,
@@ -30,6 +31,73 @@ const account = (status: CompanionAccountState["status"]): CompanionAccountState
 });
 
 describe("phone setup flow", () => {
+  it("refreshes Tailscale before validating an explicit tailnet route", async () => {
+    const calls: string[] = [];
+    const initial = { enabled: true };
+    const refreshed = { enabled: true, endpoints: [] };
+    const result = await preparePhonePairingRoute("tailscale", true, {
+      read: vi.fn(async () => {
+        calls.push("read");
+        return initial;
+      }),
+      start: vi.fn(async () => {
+        calls.push("start");
+        return initial;
+      }),
+      refreshTailscale: vi.fn(async () => {
+        calls.push("refresh");
+        return refreshed;
+      }),
+    });
+
+    expect(calls).toEqual(["read", "refresh"]);
+    expect(result).toBe(refreshed);
+  });
+
+  it("does not probe Tailscale for HTTPS or direct Wi-Fi pairing", async () => {
+    for (const route of ["automatic", "local"] as const) {
+      const refreshTailscale = vi.fn(async () => ({ enabled: true }));
+      await preparePhonePairingRoute(route, false, {
+        read: vi.fn(async () => ({ enabled: true })),
+        start: vi.fn(async () => ({ enabled: true })),
+        refreshTailscale,
+      });
+      expect(refreshTailscale).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not begin a Tailscale probe after the setup attempt is cancelled", async () => {
+    const refreshTailscale = vi.fn(async () => ({ enabled: true }));
+    await preparePhonePairingRoute("tailscale", true, {
+      read: vi.fn(async () => ({ enabled: true })),
+      start: vi.fn(async () => ({ enabled: true })),
+      refreshTailscale,
+      shouldContinue: () => false,
+    });
+    expect(refreshTailscale).not.toHaveBeenCalled();
+  });
+
+  it("starts a sidecar that stopped after the panel's last enabled snapshot", async () => {
+    const calls: string[] = [];
+    const result = await preparePhonePairingRoute("tailscale", true, {
+      read: vi.fn(async () => {
+        calls.push("read");
+        return { enabled: false };
+      }),
+      start: vi.fn(async () => {
+        calls.push("start");
+        return { enabled: true };
+      }),
+      refreshTailscale: vi.fn(async () => {
+        calls.push("refresh");
+        return { enabled: true };
+      }),
+    });
+
+    expect(calls).toEqual(["read", "start", "refresh"]);
+    expect(result.enabled).toBe(true);
+  });
+
   it("moves from intro to sign-in and preserves the profile-independent resume path", () => {
     const started = phoneSetupReducer(initialPhoneSetupFlowState, {
       type: "start",

--- a/src/lib/phone-setup.ts
+++ b/src/lib/phone-setup.ts
@@ -1,5 +1,5 @@
 import type { CompanionAccountState } from "../types/ogb";
-import type { CompanionEndpoint } from "./companion-pairing";
+import type { CompanionEndpoint, CompanionPairingRouteMode } from "./companion-pairing";
 
 export type PhoneSetupPhase = "intro" | "sign-in" | "verifying" | "qr" | "success";
 
@@ -121,6 +121,41 @@ export type CompanionPairingMode =
 export interface PhoneSetupCompanionSnapshot {
   enabled: boolean;
   endpoints?: CompanionEndpoint[];
+}
+
+/** Load the freshest state needed to validate a selected pairing route.
+ * Tailscale is the only route whose availability can change behind a running
+ * sidecar, so automatic HTTPS and direct Wi-Fi never pay for a CLI probe. */
+export async function preparePhonePairingRoute<State extends { enabled: boolean; error?: string }>(
+  routeMode: CompanionPairingRouteMode,
+  alreadyEnabled: boolean,
+  actions: {
+    read: () => Promise<State>;
+    start: () => Promise<State>;
+    refreshTailscale: () => Promise<State>;
+    shouldContinue?: () => boolean;
+  },
+): Promise<State> {
+  let state = await (alreadyEnabled ? actions.read() : actions.start());
+  if (
+    alreadyEnabled
+    && !state.enabled
+    && (actions.shouldContinue?.() ?? true)
+  ) {
+    // The panel is polled, so its last snapshot can say "on" after the
+    // sidecar exits. A deliberate Pair click should recover by starting it,
+    // not fail because the stale renderer snapshot chose read over start.
+    state = await actions.start();
+  }
+  if (
+    routeMode === "tailscale"
+    && state.enabled
+    && !state.error
+    && (actions.shouldContinue?.() ?? true)
+  ) {
+    state = await actions.refreshTailscale();
+  }
+  return state;
 }
 
 /** Automatic setup is hosted-HTTPS only. Tailscale and plain local pairing


### PR DESCRIPTION
## What changed

- keeps secure HTTPS as the recommended primary phone-pairing path
- moves Tailscale into its own clearly optional card outside Advanced
- scrolls and focuses the active pairing surface so Pair over Tailscale no longer looks like a no-op
- adds explicit same-tailnet and MagicDNS setup states
- adds a bounded, single-flight Tailscale refresh without restarting the sidecar or dropping phones
- refreshes Tailscale before minting a pairing code and recovers from stale sidecar state
- keeps the Settings menu named Phone and expands its pairing/Tailscale search terms

## Verification

- focused companion, pairing, and route suites pass
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:companion`
- `pnpm test:electron`
- `pnpm check:electron`
- isolated sidecar on dedicated ports confirmed refresh preserves the MagicDNS route and does not open pairing
- full Vitest run: 2,797 passed; two unrelated timing failures both passed on immediate isolated rerun

T3 Code was reviewed for comparison. Its useful product pattern agrees with this implementation: Tailscale remains an optional endpoint, while its `tailscale serve` machinery is intentionally not copied because OpenMausBot uses a native iOS client and a narrow `.ts.net` transport exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Tailscale pairing card with clearer status guidance and one-click refresh.
  * Tailscale pairing now refreshes phone access without restarting the desktop app.
  * Improved pairing setup for secure HTTPS, local Wi-Fi, and Tailscale routes.
  * Expanded Settings search to include pairing and connection-related terms.

* **Documentation**
  * Updated setup instructions and testing guidance to reflect the renamed Phone settings and revised Tailscale pairing flow.
  * Clarified Tailscale sign-in, MagicDNS, and pairing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->