### PR TITLE
Self-hosting guide + Remote Workspace plan

### DIFF
--- a/docs/plans/remote-workspace.md
+++ b/docs/plans/remote-workspace.md
@@ -1,0 +1,73 @@
+# Plan: Remote Workspace
+
+Run the OpenMausBot server anywhere; connect from the desktop app, any
+browser, or the phone — with real authentication instead of the loopback
+trust model.
+
+## Why
+
+Three independent demand signals in one week: community members already
+self-hosting on VPSes and asking how to connect from their Mac; users
+wanting "the chat window from any PC or mobile" because a Linux server
+outruns their laptop; and the standing product promise that routines keep
+working with the laptop closed. The workload benefits are real: server
+hardware is faster, always on, and every engine CLI runs happily headless.
+
+## Design in one paragraph
+
+The app learns **environments**: a saved list of workspaces (Local is just
+the default), each with a name, URL, and session. Adding one uses
+**one-time pairing** — the server mints a short-lived token shown as a QR
+or pairing URL; the client exchanges it once for a durable per-device
+session credential (hashed at rest). This generalizes the exact mechanism
+the iOS companion already uses, to every client. The server's own served
+web UI becomes the "any PC" client behind the same session — no separate
+web app to build.
+
+## Transports
+
+1. **Managed tunnel (the default "just works" path):** the production
+   cloudflared managed-tunnel channel the companion already uses — remote
+   access with zero network configuration.
+2. **Explicit URL** for self-hosters: SSH tunnel or private networks
+   (Tailscale et al.), documented in `docs/self-hosting.md`.
+
+## Auth phases
+
+- **Spike (first):** verify whether the companion sidecar's authenticated
+  proxy covers the full API + SSE surface. If yes, desktop/browser remote
+  v1 rides the companion channel with near-zero harness changes.
+- **Phase 1:** a single `OMB_ACCESS_TOKEN` session path in the harness for
+  authenticated non-loopback clients, TLS terminated by a fronting proxy.
+- **Phase 2 (enterprise track):** multi-user sessions, `users` + ownership
+  + ACLs — extends the same seam; see the enterprise plan.
+
+## Capability matrix (v1, stated honestly in the UI)
+
+| Capability | Remote |
+|---|---|
+| Chats, rooms, coordination, routines, webhooks | ✅ full |
+| Engines (all CLIs, custom ACP, OpenAI-compat) | ✅ run on the server |
+| Connected apps / custom MCP | ✅ |
+| Computer use (cloud/container) | ✅ server-side already |
+| Web UI from any browser | ✅ served by the server |
+| Built-in browser panel | ❌ local-only for now |
+| Skill recorder, dictation, host-desktop control | ❌ local-only |
+
+Version skew between client and server gets a visible warning with the
+update path — cheap to build, prevents a whole class of confusing reports.
+
+## Non-goals (v1)
+
+- Desktop-managed SSH launch of remote servers (the VPS/docker path covers
+  it without inheriting a shell-environment support burden).
+- Auto-detected endpoint pickers (LAN/tailnet lists) — explicit URL and the
+  managed tunnel first; polish later.
+- Public-internet exposure without the tunnel or a fronting auth proxy.
+
+## Sequencing
+
+1. `docs/self-hosting.md` (shipped with this plan) — blesses today's path.
+2. The companion-proxy spike (a day).
+3. Environments UI + pairing + chosen transport (~1–2 weeks).
+4. Enterprise multi-user sessions extend the seam (separate track).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,106 @@
+# Self-hosting the OpenMausBot server
+
+Run the harness server on an always-on Linux box (a VPS, a home server, a
+Mac mini in a closet) and use it from other devices. This is the supported
+path **today**; first-class remote access is coming — see
+[`docs/plans/remote-workspace.md`](plans/remote-workspace.md).
+
+> **Security first:** the server deliberately trusts only loopback — any
+> process that can reach `127.0.0.1:8799` has full control, including the
+> shell your bots can use. **Never reverse-proxy it to the public internet
+> and never bind it to a public interface.** Reach it through an SSH tunnel
+> (below) or a private network you trust. Proper token-based remote auth is
+> exactly what the Remote Workspace plan adds.
+
+## What works headless (and what doesn't)
+
+Runs fully on a server:
+
+- every engine CLI (Claude, Codex, Grok, custom ACP engines — install and
+  log them in **on the server**)
+- chats, rooms, bot-to-bot coordination, routines (they keep running with
+  every laptop on the planet closed — this is the point)
+- connected apps / custom MCP servers, webhooks, Company Brain
+- computer use on **cloud or container computers** (the bot's computer runs
+  server-side anyway)
+- text-to-speech (with a key), the web UI (the server serves it itself)
+
+Desktop-only for now (needs the Mac/Linux app):
+
+- the built-in browser panel, the skill recorder, dictation/voice,
+  controlling the host desktop
+
+## Setup
+
+Requirements: Node 24+, pnpm, and at least one agent CLI installed and
+signed in on the server.
+
+```sh
+git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot
+pnpm install
+
+# choose where data lives and start the server
+OMB_DATA_DIR="$HOME/.openmausbot" OMB_PORT=8799 \
+  node --experimental-strip-types server/index.ts
+```
+
+For something durable, run it under systemd:
+
+```ini
+# /etc/systemd/system/openmausbot.service
+[Unit]
+Description=OpenMausBot harness
+After=network.target
+
+[Service]
+User=maus
+WorkingDirectory=/home/maus/OpenMausBot
+Environment=OMB_DATA_DIR=/home/maus/.openmausbot
+Environment=OMB_PORT=8799
+ExecStart=/usr/bin/node --experimental-strip-types server/index.ts
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Engine CLIs read their logins from the service user's home — sign in as
+that user (`sudo -u maus claude` etc.) before starting the service.
+
+## Using it from your computer
+
+Open an SSH tunnel and use the web UI in any browser:
+
+```sh
+ssh -L 8799:localhost:8799 you@your-server
+# then open http://localhost:8799
+```
+
+The server serves the full app UI itself — no desktop install needed on the
+client. The tunnel keeps the loopback trust model intact: to the server,
+you look local, because through the tunnel you are.
+
+Note: plain `tailscale serve`/reverse proxies will currently be refused —
+the server checks that requests look like loopback on purpose. Use the SSH
+tunnel until Remote Workspace lands.
+
+## Using it from your phone
+
+The iOS companion pairs with a running server. Start the companion process
+next to the harness and pair by QR:
+
+```sh
+node --experimental-strip-types companion/src/index.ts
+```
+
+It advertises on your private networks (Tailscale-aware) and issues
+per-device credentials on pairing — see the pairing screen in the iOS app.
+
+## Updating
+
+```sh
+git pull && pnpm install && sudo systemctl restart openmausbot
+```
+
+Routines and queued work survive restarts; in-flight turns do not, so
+update between runs.


### PR DESCRIPTION
Answers the two community threads asking to run the server on a VPS and use it from Mac/any browser/phone: an honest self-hosting doc for today's supported path (SSH-tunnel web UI — the server already serves its own renderer — plus headless companion pairing, with the security model stated plainly), and the Remote Workspace plan: environments + one-time pairing generalized from the companion, managed-tunnel-first transports, phased auth, capability matrix, non-goals. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for running the server continuously on a self-hosted Linux machine.
  * Documented secure access through SSH tunnels and private-network device pairing.
  * Added setup, configuration, service management, and update instructions.
  * Added a planning document for future remote workspace access from desktop, browser, and phone, including authentication and connection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->