### PR TITLE
Unify releases and automate the docs changelog

### DIFF
--- a/.claude/skills/windows-release/SKILL.md
+++ b/.claude/skills/windows-release/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: windows-release
-description: Build, verify, and publish the Windows desktop build (NSIS installer + latest.yml) to the openmausbot-releases repo. Use when cutting a release, shipping a new version to Windows users, or when a Windows user reports they are stuck on an old version. Windows only — does not cover the macOS dmg/notarization flow.
+description: Build and verify the Windows desktop build (NSIS installer + latest.yml) for the canonical OpenMausBot release and its legacy updater mirror. Use when cutting a release, shipping a new version to Windows users, or when a Windows user reports they are stuck on an old version. Windows only — does not cover the macOS dmg/notarization flow.
 ---
 
 # Windows release
 
 Ships `OpenMausBot-<version>-setup.exe` and its update feed to
-[milind-soni/openmausbot-releases](https://github.com/milind-soni/openmausbot-releases).
+[milind-soni/OpenMausBot](https://github.com/milind-soni/OpenMausBot/releases).
+The unified release workflow mirrors the same bytes to the legacy releases
+repository for apps installed before the updater migration.
 
 **Scope: Windows only.** The macOS build is a separate flow (dmg + notarytool +
 staple) that must run on a Mac. This skill never touches mac artifacts — but see
@@ -59,7 +61,7 @@ Get-Content release\win-unpacked\resources\app-update.yml  # feed config
 - Missing `server/index.js` → `utilityProcess.fork` fails → the 🐭 "Couldn't start
   the bot server" page.
 - Missing `ui/index.html` → server has nothing to serve → black window.
-- `app-update.yml` must point at `milind-soni/openmausbot-releases` and, while the
+- `app-update.yml` must point at `milind-soni/OpenMausBot` and, while the
   build is unsigned, **must not contain `publisherName`** — electron-updater would
   reject every update as untrusted.
 
@@ -80,12 +82,18 @@ carries both platforms.
 
 ```powershell
 Copy-Item release/OpenMausBot-<version>-setup.exe release/OpenMausBot-setup.exe
-gh release upload v<version> --repo milind-soni/openmausbot-releases `
+gh release upload v<version> --repo milind-soni/OpenMausBot `
   release/OpenMausBot-<version>-setup.exe `
   release/OpenMausBot-setup.exe `
   release/OpenMausBot-<version>-setup.exe.blockmap `
   release/latest.yml
 ```
+
+Prefer the repository's **Release** workflow, which builds all platforms from
+one pinned commit and mirrors the complete, byte-identical asset set safely.
+If this emergency manual path is used, the same four files must also be attached
+to the matching draft in `milind-soni/openmausbot-releases`; never replace the
+bytes of an already-published asset.
 
 Both names are required, for different consumers:
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - "apps/docs/**"
+      - "scripts/sync-assets.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/docs/**"
+      - "scripts/sync-assets.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Build, typecheck, and lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @openmausbot/docs types:check
+      - run: pnpm --filter @openmausbot/docs lint
+      - run: pnpm docs:build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -1,10 +1,10 @@
 # Ubuntu packages, built and exercised on the exact distribution we support.
 #
-# This workflow deliberately produces an artifact instead of publishing to the
-# separate public releases repository. That keeps cross-repository credentials
-# out of the source repository while still making every release candidate
+# This workflow deliberately produces an artifact instead of publishing a
+# partial release. That keeps release credentials and publication authority
+# in the unified release workflow while making every release candidate
 # reproducible from an exact ref. Attach the resulting files to the matching
-# openmausbot-releases release after the smoke test passes.
+# canonical OpenMausBot release after the smoke test passes.
 name: Package Ubuntu
 
 on:

--- a/.github/workflows/package-win.yml
+++ b/.github/workflows/package-win.yml
@@ -8,8 +8,8 @@
 # mac build — different trees under one version number. Run this from the
 # same commit as the mac build and attach the artifact to the release.
 #
-# Deliberately artifact-only: pushing straight to the separate releases
-# repo would need a cross-repo token this workflow has no business holding.
+# Deliberately artifact-only: the full release workflow is the one place
+# allowed to create a GitHub release.
 name: Package Windows
 
 on:
@@ -79,8 +79,8 @@ jobs:
           fi
           [ -f "$res/app-update.yml" ] || { echo "::error::missing $res/app-update.yml"; fail=1; }
           if [ -f "$res/app-update.yml" ]; then
-            grep -q "openmausbot-releases" "$res/app-update.yml" || {
-              echo "::error::app-update.yml does not point at openmausbot-releases"; fail=1; }
+            grep -Eq '^repo: OpenMausBot$' "$res/app-update.yml" || {
+              echo "::error::app-update.yml does not point at milind-soni/OpenMausBot"; fail=1; }
             # while the build is unsigned, a publisherName makes
             # electron-updater reject every update as untrusted
             if grep -q "publisherName" "$res/app-update.yml"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # One-button releases: builds macOS (arm64 + x64, signed, notarized, stapled),
-# Windows, and Ubuntu from ONE commit, assembles a complete draft on
-# openmausbot-releases with verified feeds, and publishes after a human
-# approves the draft.
+# Windows, and Ubuntu from ONE commit, assembles a complete draft in this
+# repository with verified feeds, and mirrors it to the legacy releases repo
+# so already-installed builds can cross the updater migration safely.
 #
 # Every gate below exists because its absence shipped (or nearly shipped) a
 # broken build from a laptop:
@@ -53,13 +53,23 @@ jobs:
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-      - name: Refuse to overwrite a published release
+      - name: Refuse to overwrite a published canonical release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          v="v$(node -p "require('./package.json').version")"
+          if gh release view "$v" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft 2>/dev/null | grep -q false; then
+            echo "::error::$v is already published on $GITHUB_REPOSITORY — bump the version first"
+            exit 1
+          fi
+      - name: Refuse to overwrite a published legacy mirror
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
         run: |
+          test -n "$GH_TOKEN" || { echo "::error::RELEASES_PAT is required for the updater bridge"; exit 1; }
           v="v$(node -p "require('./package.json').version")"
           if gh release view "$v" --repo milind-soni/openmausbot-releases --json isDraft --jq .isDraft 2>/dev/null | grep -q false; then
-            echo "::error::$v is already published on openmausbot-releases — bump the version first"
+            echo "::error::$v is already published on the legacy mirror — recover the canonical draft instead of rebuilding bytes"
             exit 1
           fi
 
@@ -101,6 +111,15 @@ jobs:
 
       - name: Package both architectures
         run: pnpm package:mac
+
+      - name: "Gate: both packaged apps use the canonical updater feed"
+        run: |
+          for app in release/mac-arm64/OpenMausBot.app release/mac/OpenMausBot.app; do
+            update="$app/Contents/Resources/app-update.yml"
+            test -f "$update" || { echo "::error::missing $update"; exit 1; }
+            grep -Eq '^owner: milind-soni$' "$update" || { echo "::error::wrong update owner in $update"; exit 1; }
+            grep -Eq '^repo: OpenMausBot$' "$update" || { echo "::error::wrong update repo in $update"; exit 1; }
+          done
 
       - name: "Gate: the signature must verify BEFORE notarization"
         run: |
@@ -242,7 +261,8 @@ jobs:
           "$res/cloudflared/cloudflared.exe" version | grep -Fq "cloudflared version 2026.8.2 " || {
             echo "::error::cloudflared has the wrong version"; exit 1; }
           [ -f "$res/app-update.yml" ] || { echo "::error::missing app-update.yml"; exit 1; }
-          grep -q "openmausbot-releases" "$res/app-update.yml" || { echo "::error::wrong update repo"; exit 1; }
+          grep -Eq '^owner: milind-soni$' "$res/app-update.yml" || { echo "::error::wrong update owner"; exit 1; }
+          grep -Eq '^repo: OpenMausBot$' "$res/app-update.yml" || { echo "::error::wrong update repo"; exit 1; }
           if grep -q "publisherName" "$res/app-update.yml"; then
             echo "::error::publisherName on an unsigned build breaks every update"; exit 1
           fi
@@ -299,6 +319,12 @@ jobs:
       - name: Prove overlay-free X11 input routing
         run: dbus-run-session -- xvfb-run -a pnpm smoke:cua-x11-input
       - run: pnpm package:linux
+      - name: Verify the packaged updater target
+        run: |
+          update=release/linux-unpacked/resources/app-update.yml
+          test -f "$update" || { echo "::error::missing $update"; exit 1; }
+          grep -Eq '^owner: milind-soni$' "$update" || { echo "::error::wrong update owner"; exit 1; }
+          grep -Eq '^repo: OpenMausBot$' "$update" || { echo "::error::wrong update repo"; exit 1; }
       - name: Verify package contents and metadata
         run: node scripts/verify-linux-package.mjs
       - name: Match a normal Ubuntu package parent on the ephemeral runner
@@ -351,24 +377,73 @@ jobs:
     needs: [prepare, mac, windows, linux]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    concurrency:
+      group: release-mirror-v${{ needs.prepare.outputs.version }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: assets
           merge-multiple: true
+      - name: Refuse an incomplete installer or updater set
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          required=(
+            latest-linux.yml latest-mac.yml latest.yml
+            "OpenMausBot-$VERSION-amd64.deb"
+            "OpenMausBot-$VERSION-arm64.dmg"
+            "OpenMausBot-$VERSION-arm64.dmg.blockmap"
+            "OpenMausBot-$VERSION-arm64.zip"
+            "OpenMausBot-$VERSION-arm64.zip.blockmap"
+            "OpenMausBot-$VERSION-setup.exe"
+            "OpenMausBot-$VERSION-setup.exe.blockmap"
+            "OpenMausBot-$VERSION-x64.dmg"
+            "OpenMausBot-$VERSION-x64.dmg.blockmap"
+            "OpenMausBot-$VERSION-x64.zip"
+            "OpenMausBot-$VERSION-x64.zip.blockmap"
+            "OpenMausBot-$VERSION-x86_64.AppImage"
+            OpenMausBot-amd64.deb OpenMausBot-intel.dmg OpenMausBot-setup.exe
+            OpenMausBot.AppImage OpenMausBot.dmg SHA256SUMS-ubuntu-x64.txt
+          )
+          for file in "${required[@]}"; do
+            test -s "assets/$file" || { echo "::error::missing or empty release asset: $file"; exit 1; }
+          done
+          test "$(find assets -maxdepth 1 -type f | wc -l | tr -d ' ')" = "${#required[@]}" || {
+            echo "::error::unexpected release asset set"; find assets -maxdepth 1 -type f -print; exit 1; }
       - name: Verify every feed hash against the actual bytes
         run: |
           cd assets
           node --input-type=module - <<'EOF'
           import { createHash } from "node:crypto";
-          import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+          import { readFileSync, readdirSync, statSync } from "node:fs";
           const sha512 = (f) => createHash("sha512").update(readFileSync(f)).digest("base64");
+          const expected = new Map([
+            ["latest-mac.yml", [
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-x64.zip",
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-arm64.zip",
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-x64.dmg",
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-arm64.dmg",
+            ]],
+            ["latest.yml", ["OpenMausBot-${{ needs.prepare.outputs.version }}-setup.exe"]],
+            ["latest-linux.yml", [
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-x86_64.AppImage",
+              "OpenMausBot-${{ needs.prepare.outputs.version }}-amd64.deb",
+            ]],
+          ]);
           let bad = 0;
-          for (const feed of ["latest-mac.yml", "latest.yml", "latest-linux.yml"]) {
-            if (!existsSync(feed)) continue;
+          for (const [feed, expectedUrls] of expected) {
             const text = readFileSync(feed, "utf8");
-            for (const [, url, hash, size] of text.matchAll(/url:\s+(\S+)[\s\S]*?sha512:\s+(\S+)\n\s+size:\s+(\d+)/g)) {
-              if (!existsSync(url)) { console.error(`MISSING ${url} (listed in ${feed})`); bad++; continue; }
+            const entries = [...text.matchAll(/url:\s+(\S+)[\s\S]*?sha512:\s+(\S+)\n\s+size:\s+(\d+)/g)];
+            const urls = entries.map(([, url]) => url).sort();
+            if (JSON.stringify(urls) !== JSON.stringify([...expectedUrls].sort())) {
+              console.error(`WRONG PATHS in ${feed}: ${urls.join(", ") || "none"}`);
+              bad++;
+              continue;
+            }
+            for (const [, url, hash, size] of entries) {
               const okHash = sha512(url) === hash;
               const okSize = statSync(url).size === Number(size);
               if (!okHash || !okSize) { console.error(`MISMATCH ${url} in ${feed}`); bad++; }
@@ -378,31 +453,98 @@ jobs:
           if (bad) process.exit(1);
           console.log(`\nall feeds verified; ${readdirSync(".").length} assets staged`);
           EOF
-      - name: Create or update the draft with the complete asset set
+      - name: Create or update the canonical draft
         env:
-          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
           SHA: ${{ needs.prepare.outputs.sha }}
         run: |
-          cd assets
+          tag="v$VERSION"
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$tag" --repo "$GITHUB_REPOSITORY" --target "$SHA" \
+              --draft --title "OpenMausBot $VERSION" \
+              --generate-notes
+          else
+            target=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json targetCommitish --jq .targetCommitish)
+            target_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$target" --jq .sha)
+            test "$target_sha" = "$SHA" || {
+              echo "::error::$tag draft targets $target_sha, not pinned release commit $SHA"
+              exit 1
+            }
+          fi
+          for file in assets/*; do
+            gh release upload "$tag" "$file" --repo "$GITHUB_REPOSITORY" --clobber
+          done
+          # A rerun preserves human edits made while reviewing the canonical
+          # draft, and mirrors that exact body into the compatibility release.
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json body --jq .body > "$RUNNER_TEMP/release-notes.md"
+          echo "canonical asset count: $(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets | length')"
+
+      - name: Mirror the same draft for installed legacy clients
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
           tag="v$VERSION"
           if ! gh release view "$tag" --repo milind-soni/openmausbot-releases > /dev/null 2>&1; then
             gh release create "$tag" --repo milind-soni/openmausbot-releases \
-              --draft --title "OpenMausBot $VERSION" \
-              --notes "Draft assembled by the release workflow from milind-soni/OpenMausBot@$SHA. Edit these notes, then publish."
+              --draft --title "OpenMausBot $VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
           fi
-          for f in *; do
-            gh release upload "$tag" "$f" --repo milind-soni/openmausbot-releases --clobber
+          gh release edit "$tag" --repo milind-soni/openmausbot-releases \
+            --title "OpenMausBot $VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
+          for file in assets/*; do
+            gh release upload "$tag" "$file" --repo milind-soni/openmausbot-releases --clobber
           done
-          echo "asset count: $(gh release view "$tag" --repo milind-soni/openmausbot-releases --json assets --jq '.assets | length')"
+          echo "legacy asset count: $(gh release view "$tag" --repo milind-soni/openmausbot-releases --json assets --jq '.assets | length')"
+
+      - name: Prove both drafts contain the exact staged bytes
+        env:
+          CANONICAL_TOKEN: ${{ github.token }}
+          LEGACY_TOKEN: ${{ secrets.RELEASES_PAT }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          node --input-type=module - "$VERSION" <<'EOF'
+          import { createHash } from "node:crypto";
+          import { execFileSync } from "node:child_process";
+          import { readFileSync, readdirSync } from "node:fs";
+          import { join } from "node:path";
+          const version = process.argv[2];
+          const expected = new Map(readdirSync("assets").map((name) => [
+            name,
+            `sha256:${createHash("sha256").update(readFileSync(join("assets", name))).digest("hex")}`,
+          ]));
+          for (const [repo, token] of [
+            [process.env.GITHUB_REPOSITORY, process.env.CANONICAL_TOKEN],
+            ["milind-soni/openmausbot-releases", process.env.LEGACY_TOKEN],
+          ]) {
+            const json = execFileSync("gh", ["release", "view", `v${version}`, "--repo", repo, "--json", "assets"], {
+              encoding: "utf8",
+              env: { ...process.env, GH_TOKEN: token },
+            });
+            const assets = JSON.parse(json).assets;
+            if (assets.length !== expected.size) throw new Error(`${repo}: expected ${expected.size} assets, got ${assets.length}`);
+            for (const asset of assets) {
+              if (expected.get(asset.name) !== asset.digest) throw new Error(`${repo}: digest mismatch for ${asset.name}`);
+            }
+            console.log(`ok: ${repo} has ${assets.length} byte-identical assets`);
+          }
+          EOF
 
       - name: Publish (only when asked to)
         if: ${{ inputs.publish }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+          CANONICAL_TOKEN: ${{ github.token }}
+          LEGACY_TOKEN: ${{ secrets.RELEASES_PAT }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          gh release edit "v$VERSION" --repo milind-soni/openmausbot-releases --draft=false --latest
-          # a draft that LOOKS published is the 0.1.24 failure mode — verify
-          gh release view "v$VERSION" --repo milind-soni/openmausbot-releases --json isDraft --jq .isDraft | grep -q false
-          echo "v$VERSION is live"
+          # The bridge build points at the canonical feed. Publish and verify
+          # that destination before making the build visible to legacy clients.
+          GH_TOKEN="$CANONICAL_TOKEN" gh release edit "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          GH_TOKEN="$CANONICAL_TOKEN" gh release view "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft | grep -q false
+          GH_TOKEN="$LEGACY_TOKEN" gh release edit "v$VERSION" \
+            --repo milind-soni/openmausbot-releases --draft=false --latest
+          GH_TOKEN="$LEGACY_TOKEN" gh release view "v$VERSION" \
+            --repo milind-soni/openmausbot-releases --json isDraft --jq .isDraft | grep -q false
+          echo "v$VERSION is live on the canonical feed and its legacy updater bridge"

--- a/.github/workflows/sync-published-release.yml
+++ b/.github/workflows/sync-published-release.yml
@@ -1,0 +1,190 @@
+name: Sync published release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published canonical tag to mirror (for recovery)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # A workflow-published release emits the same `release` event as a manual
+  # GitHub UI publish. Share the assemble lock so the recovery mirror waits
+  # instead of racing identical asset uploads.
+  group: release-mirror-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Preserve legacy updater compatibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Download and verify the canonical release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          test -n "$TAG" || { echo "::error::missing release tag"; exit 1; }
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::release tag must be vX.Y.Z, got: $TAG"; exit 1; }
+          version=${TAG#v}
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == false) | true' | grep -q true || {
+              echo "::error::$TAG is not a published stable release in $GITHUB_REPOSITORY"; exit 1; }
+          mkdir assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets
+          required=(
+            latest-linux.yml latest-mac.yml latest.yml
+            "OpenMausBot-$version-amd64.deb"
+            "OpenMausBot-$version-arm64.dmg"
+            "OpenMausBot-$version-arm64.dmg.blockmap"
+            "OpenMausBot-$version-arm64.zip"
+            "OpenMausBot-$version-arm64.zip.blockmap"
+            "OpenMausBot-$version-setup.exe"
+            "OpenMausBot-$version-setup.exe.blockmap"
+            "OpenMausBot-$version-x64.dmg"
+            "OpenMausBot-$version-x64.dmg.blockmap"
+            "OpenMausBot-$version-x64.zip"
+            "OpenMausBot-$version-x64.zip.blockmap"
+            "OpenMausBot-$version-x86_64.AppImage"
+            OpenMausBot-amd64.deb OpenMausBot-intel.dmg OpenMausBot-setup.exe
+            OpenMausBot.AppImage OpenMausBot.dmg SHA256SUMS-ubuntu-x64.txt
+          )
+          for file in "${required[@]}"; do
+            test -s "assets/$file" || { echo "::error::$TAG is missing $file"; exit 1; }
+          done
+          test "$(find assets -maxdepth 1 -type f | wc -l | tr -d ' ')" = "${#required[@]}" || {
+            echo "::error::$TAG has an unexpected release asset set"
+            find assets -maxdepth 1 -type f -print
+            exit 1
+          }
+          (
+            cd assets
+            node --input-type=module - "$version" <<'EOF'
+          import { createHash } from "node:crypto";
+          import { readFileSync, statSync } from "node:fs";
+          const version = process.argv[2];
+          const sha512 = (file) => createHash("sha512").update(readFileSync(file)).digest("base64");
+          const expected = new Map([
+            ["latest-mac.yml", [
+              `OpenMausBot-${version}-x64.zip`,
+              `OpenMausBot-${version}-arm64.zip`,
+              `OpenMausBot-${version}-x64.dmg`,
+              `OpenMausBot-${version}-arm64.dmg`,
+            ]],
+            ["latest.yml", [`OpenMausBot-${version}-setup.exe`]],
+            ["latest-linux.yml", [
+              `OpenMausBot-${version}-x86_64.AppImage`,
+              `OpenMausBot-${version}-amd64.deb`,
+            ]],
+          ]);
+          let bad = 0;
+          for (const [feed, expectedUrls] of expected) {
+            const text = readFileSync(feed, "utf8");
+            const entries = [...text.matchAll(/url:\s+(\S+)[\s\S]*?sha512:\s+(\S+)\n\s+size:\s+(\d+)/g)];
+            const urls = entries.map(([, url]) => url).sort();
+            if (JSON.stringify(urls) !== JSON.stringify([...expectedUrls].sort())) {
+              console.error(`WRONG PATHS in ${feed}: ${urls.join(", ") || "none"}`);
+              bad++;
+              continue;
+            }
+            for (const [, url, hash, size] of entries) {
+              if (sha512(url) !== hash || statSync(url).size !== Number(size)) {
+                console.error(`MISMATCH ${url} in ${feed}`);
+                bad++;
+              } else {
+                console.log(`ok ${url}`);
+              }
+            }
+          }
+          if (bad) process.exit(1);
+          console.log("ok: every updater feed matches the exact staged bytes");
+          EOF
+          )
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body > "$RUNNER_TEMP/release-notes.md"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json name --jq .name > "$RUNNER_TEMP/release-title.txt"
+          node --input-type=module - "$TAG" <<'EOF'
+          import { createHash } from "node:crypto";
+          import { execFileSync } from "node:child_process";
+          import { readFileSync, readdirSync } from "node:fs";
+          import { join } from "node:path";
+          const tag = process.argv[2];
+          const expected = new Map(readdirSync("assets").map((name) => [
+            name,
+            `sha256:${createHash("sha256").update(readFileSync(join("assets", name))).digest("hex")}`,
+          ]));
+          const remote = JSON.parse(execFileSync("gh", ["release", "view", tag, "--repo", process.env.GITHUB_REPOSITORY, "--json", "assets"], { encoding: "utf8" })).assets;
+          if (remote.length !== expected.size) throw new Error(`canonical release has ${remote.length} assets but ${expected.size} downloaded`);
+          for (const asset of remote) {
+            if (expected.get(asset.name) !== asset.digest) throw new Error(`canonical digest mismatch for ${asset.name}`);
+          }
+          console.log(`ok: downloaded ${remote.length} canonical assets with matching digests`);
+          EOF
+
+      - name: Create or update the legacy updater mirror
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+          CANONICAL_TOKEN: ${{ github.token }}
+          LEGACY_TOKEN: ${{ secrets.RELEASES_PAT }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          test -n "$GH_TOKEN" || { echo "::error::RELEASES_PAT is required for the updater bridge"; exit 1; }
+          title=$(cat "$RUNNER_TEMP/release-title.txt")
+          state=missing
+          if gh release view "$TAG" --repo milind-soni/openmausbot-releases > /dev/null 2>&1; then
+            state=$(gh release view "$TAG" --repo milind-soni/openmausbot-releases --json isDraft --jq .isDraft)
+          else
+            gh release create "$TAG" --repo milind-soni/openmausbot-releases \
+              --draft --title "$title" --notes-file "$RUNNER_TEMP/release-notes.md"
+            state=true
+          fi
+          if [ "$state" != false ]; then
+            for file in assets/*; do
+              gh release upload "$TAG" "$file" --repo milind-soni/openmausbot-releases --clobber
+            done
+          fi
+          # Published bytes are immutable. Draft uploads and already-published
+          # mirrors must both match before metadata or visibility changes.
+          node --input-type=module - "$TAG" <<'EOF'
+          import { execFileSync } from "node:child_process";
+          const tag = process.argv[2];
+          const assets = (repo, token) => new Map(JSON.parse(execFileSync(
+            "gh",
+            ["release", "view", tag, "--repo", repo, "--json", "assets"],
+            { encoding: "utf8", env: { ...process.env, GH_TOKEN: token } },
+          )).assets.map((asset) => [asset.name, asset.digest]));
+          const canonical = assets(process.env.GITHUB_REPOSITORY, process.env.CANONICAL_TOKEN);
+          const legacy = assets("milind-soni/openmausbot-releases", process.env.LEGACY_TOKEN);
+          if (canonical.size !== legacy.size) throw new Error(`legacy mirror has ${legacy.size} assets; canonical has ${canonical.size}`);
+          for (const [name, digest] of canonical) {
+            if (legacy.get(name) !== digest) throw new Error(`legacy mirror differs for ${name}`);
+          }
+          console.log(`ok: legacy mirror has ${legacy.size} byte-identical assets`);
+          EOF
+          # Keep recovery reruns idempotent: published bytes stay immutable,
+          # while the legacy title and notes follow the canonical release.
+          gh release edit "$TAG" --repo milind-soni/openmausbot-releases \
+            --title "$title" --notes-file "$RUNNER_TEMP/release-notes.md"
+          if [ "$state" != false ]; then
+            gh release edit "$TAG" --repo milind-soni/openmausbot-releases --draft=false --latest
+          fi
+          gh release view "$TAG" --repo milind-soni/openmausbot-releases \
+            --json isDraft --jq .isDraft | grep -q false
+
+      - name: Refresh the Vercel docs
+        env:
+          DOCS_DEPLOY_HOOK_URL: ${{ secrets.DOCS_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$DOCS_DEPLOY_HOOK_URL" ]; then
+            echo "::notice::DOCS_DEPLOY_HOOK_URL is not configured; the changelog will refresh on the next docs deployment"
+            exit 0
+          fi
+          curl --fail-with-body --silent --show-error --request POST "$DOCS_DEPLOY_HOOK_URL" > /dev/null
+          echo "requested a docs rebuild"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ and produces one release artifact containing:
 
 Before publishing, confirm that `package.json` has the release version and dispatch the workflow against the same
 commit used for the other platforms. Attach all five Ubuntu files to the matching release in the separate
-[`openmausbot-releases`](https://github.com/milind-soni/openmausbot-releases) repository. Then verify the checksum
+[OpenMausBot releases](https://github.com/milind-soni/OpenMausBot/releases). Then verify the checksum
 file and install the `.deb` plus launch the AppImage in a clean Ubuntu 24.04 x86_64 GNOME environment. Never combine
 packages built from different commits under one version.
 

--- a/README.md
+++ b/README.md
@@ -16,28 +16,28 @@ Talk to them like contacts. Watch them work. Approve what matters.
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
 ![Electron](https://img.shields.io/badge/Electron-macOS%20%C2%B7%20Windows%20%C2%B7%20Ubuntu-2B2E3A?logo=electron&logoColor=9FEAF9)
 ![Agents](https://img.shields.io/badge/agents-Claude%20·%20Codex-d97757)
-[![Release](https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?label=release&color=1084fe&cacheSeconds=300)](https://github.com/milind-soni/openmausbot-releases/releases/latest)
+[![Release](https://img.shields.io/github/v/release/milind-soni/OpenMausBot?label=release&color=1084fe&cacheSeconds=300)](https://github.com/milind-soni/OpenMausBot/releases/latest)
 ![PRs](https://img.shields.io/badge/PRs-welcome-38d591)
 
 <br>
 
-<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg">
-  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Apple%20silicon%29&labelColor=070707&color=1084fe&cacheSeconds=300" alt="Download the latest OpenMausBot for Mac with Apple silicon (.dmg)" height="40">
+<a href="https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.dmg">
+  <img src="https://img.shields.io/github/v/release/milind-soni/OpenMausBot?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Apple%20silicon%29&labelColor=070707&color=1084fe&cacheSeconds=300" alt="Download the latest OpenMausBot for Mac with Apple silicon (.dmg)" height="40">
 </a>
 &nbsp;
-<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg">
-  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Intel%29&labelColor=070707&color=2a9d8f&cacheSeconds=300" alt="Download the latest OpenMausBot for Intel Macs (.dmg)" height="40">
+<a href="https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-intel.dmg">
+  <img src="https://img.shields.io/github/v/release/milind-soni/OpenMausBot?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Mac%20%28Intel%29&labelColor=070707&color=2a9d8f&cacheSeconds=300" alt="Download the latest OpenMausBot for Intel Macs (.dmg)" height="40">
 </a>
 &nbsp;
-<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe">
-  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Windows&labelColor=070707&color=4cc2ff&cacheSeconds=300" alt="Download the latest OpenMausBot for Windows (.exe)" height="40">
+<a href="https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-setup.exe">
+  <img src="https://img.shields.io/github/v/release/milind-soni/OpenMausBot?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Windows&labelColor=070707&color=4cc2ff&cacheSeconds=300" alt="Download the latest OpenMausBot for Windows (.exe)" height="40">
 </a>
 &nbsp;
-<a href="https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb">
-  <img src="https://img.shields.io/github/v/release/milind-soni/openmausbot-releases?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Ubuntu&labelColor=070707&color=e95420&cacheSeconds=300" alt="Download the latest OpenMausBot for Ubuntu (.deb)" height="40">
+<a href="https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-amd64.deb">
+  <img src="https://img.shields.io/github/v/release/milind-soni/OpenMausBot?style=for-the-badge&label=%E2%AC%87%EF%B8%8F%20%20Download%20for%20Ubuntu&labelColor=070707&color=e95420&cacheSeconds=300" alt="Download the latest OpenMausBot for Ubuntu (.deb)" height="40">
 </a>
 
-<sub>[latest release](https://github.com/milind-soni/openmausbot-releases/releases/latest) &nbsp;·&nbsp; macOS: Apple silicon & Intel · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/openmausbot-releases/releases)</sub>
+<sub>[latest release](https://github.com/milind-soni/OpenMausBot/releases/latest) &nbsp;·&nbsp; macOS: Apple silicon & Intel · signed & notarized .dmg &nbsp;·&nbsp; Windows: x64 installer &nbsp;·&nbsp; Ubuntu 24.04 x64: .deb or AppImage beta &nbsp;·&nbsp; [all releases](https://github.com/milind-soni/OpenMausBot/releases)</sub>
 
 <br>
 
@@ -223,14 +223,14 @@ See [MCP server setup and tool reference](docs/mcp-server.md).
 
 ## Quick start
 
-**Released builds ([latest release](https://github.com/milind-soni/openmausbot-releases/releases/latest)):** the harness server is embedded, so no separate server setup is required.
+**Released builds ([latest release](https://github.com/milind-soni/OpenMausBot/releases/latest)):** the harness server is embedded, so no separate server setup is required.
 
 | | Download | Install |
 |---|---|---|
-| **macOS** (Apple silicon) | [OpenMausBot.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Drag it to Applications, open it. Signed & notarized. |
-| **macOS** (Intel) | [OpenMausBot-intel.dmg](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg) | Same app, built for Intel Macs. Signed & notarized. |
-| **Windows** (x64) | [OpenMausBot-setup.exe](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Run it — one-click, per-user, no admin rights. The installer isn't code-signed yet, so SmartScreen shows "unknown publisher": **More info → Run anyway**. |
-| **Ubuntu 24.04** (x64) | [OpenMausBot-amd64.deb](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) · [OpenMausBot.AppImage](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) | Install the `.deb` with APT (recommended), or make the AppImage executable and run it. Beta; GNOME is the supported desktop. |
+| **macOS** (Apple silicon) | [OpenMausBot.dmg](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.dmg) | Drag it to Applications, open it. Signed & notarized. |
+| **macOS** (Intel) | [OpenMausBot-intel.dmg](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-intel.dmg) | Same app, built for Intel Macs. Signed & notarized. |
+| **Windows** (x64) | [OpenMausBot-setup.exe](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-setup.exe) | Run it — one-click, per-user, no admin rights. The installer isn't code-signed yet, so SmartScreen shows "unknown publisher": **More info → Run anyway**. |
+| **Ubuntu 24.04** (x64) | [OpenMausBot-amd64.deb](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-amd64.deb) · [OpenMausBot.AppImage](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.AppImage) | Install the `.deb` with APT (recommended), or make the AppImage executable and run it. Beta; GNOME is the supported desktop. |
 
 See the [Ubuntu Desktop guide](docs/linux-desktop.md) for installation, capabilities, and troubleshooting.
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -21,9 +21,16 @@ pnpm --filter @openmausbot/docs types:check
 pnpm --filter @openmausbot/docs lint
 ```
 
+The changelog reads published releases from `milind-soni/OpenMausBot` plus the
+legacy updater archive, deduplicates them into one complete history, and caches
+the result for five minutes. If one repository is temporarily unavailable, the
+other still renders; if both fail, the page links directly to GitHub.
+
 ## Deploy to Vercel
 
-This is a fully static site. Deploying it does not deploy the Electron app, local harness, credentials, agents, or user data.
+This deploys only the public documentation. It does not deploy the Electron app,
+local harness, credentials, agents, or user data. The changelog page uses Next.js
+incremental regeneration so published releases appear without a source commit.
 
 Create a second Vercel project beside the existing `openmausbot.com` project:
 
@@ -33,4 +40,12 @@ Create a second Vercel project beside the existing `openmausbot.com` project:
 4. Set the production branch to `main` and deploy.
 5. Add `docs.openmausbot.com` under **Settings → Domains**.
 
-Vercel will build the static `out` directory, publish every push to `main`, and create preview URLs for documentation pull requests. Keep `openmausbot.com` on the existing marketing project and add a Docs link there after the new domain is live.
+For an immediate changelog refresh after each desktop release, create a Vercel
+Deploy Hook for the production branch and save it in the GitHub repository as
+the `DOCS_DEPLOY_HOOK_URL` Actions secret. Without the optional hook, the next
+normal docs deployment still pulls the current published releases.
+
+Vercel will build the Next.js docs app, publish every push to `main`, and create
+preview URLs for documentation pull requests. Keep `openmausbot.com` on the
+existing marketing project and add a Docs link there after the new domain is
+live.

--- a/apps/docs/components/release-changelog.tsx
+++ b/apps/docs/components/release-changelog.tsx
@@ -1,0 +1,159 @@
+import type { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
+
+const RELEASE_REPOSITORIES = [
+  'milind-soni/OpenMausBot',
+  'milind-soni/openmausbot-releases',
+] as const;
+const RELEASES_PER_PAGE = 100;
+const MAX_RELEASE_PAGES = 10;
+const LEGACY_DRAFT_NOTES =
+  /^Draft assembled by the release workflow from milind-soni\/OpenMausBot@([0-9a-f]{40})\. Edit these notes, then publish\.\s*$/i;
+
+interface GitHubRelease {
+  body: string | null;
+  draft: boolean;
+  html_url: string;
+  name: string | null;
+  prerelease: boolean;
+  published_at: string | null;
+  tag_name: string;
+}
+
+const markdownComponents: Components = {
+  h1: ({ node: _node, ...props }) => <h3 {...props} />,
+  h2: ({ node: _node, ...props }) => <h3 {...props} />,
+  h3: ({ node: _node, ...props }) => <h4 {...props} />,
+  a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
+};
+
+function displayVersion(release: GitHubRelease) {
+  return release.tag_name.replace(/^v(?=\d)/i, '') || release.name || 'Release';
+}
+
+function displayDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function parseVersion(tag: string): readonly [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(tag.trim());
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function compareVersions(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+) {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function releaseNotes(release: GitHubRelease) {
+  const body = release.body?.trim();
+  if (!body) return 'No release notes were provided for this build.';
+
+  const legacyDraft = LEGACY_DRAFT_NOTES.exec(body);
+  if (!legacyDraft) return body;
+
+  const commit = legacyDraft[1];
+  return `This build predates curated release notes. [View its source commit (${commit.slice(0, 7)})](https://github.com/milind-soni/OpenMausBot/commit/${commit}).`;
+}
+
+async function fetchPublishedReleases(repository: string): Promise<GitHubRelease[]> {
+  try {
+    const token = process.env.GITHUB_RELEASES_TOKEN ?? process.env.GITHUB_TOKEN;
+    const releases: GitHubRelease[] = [];
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
+      const endpoint = `https://api.github.com/repos/${repository}/releases?per_page=${RELEASES_PER_PAGE}&page=${page}`;
+      const response = await fetch(endpoint, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'OpenMausBot-docs',
+          'X-GitHub-Api-Version': '2022-11-28',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        next: { revalidate: 300 },
+      });
+      if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
+      const pageReleases: unknown = await response.json();
+      if (!Array.isArray(pageReleases)) throw new Error('GitHub returned an invalid release list');
+      releases.push(...(pageReleases as GitHubRelease[]));
+      if (pageReleases.length < RELEASES_PER_PAGE) break;
+      if (page === MAX_RELEASE_PAGES) throw new Error('release history exceeded the pagination limit');
+    }
+    return releases.filter(
+      (release) => !release.draft && !release.prerelease && release.published_at,
+    );
+  } catch (error) {
+    console.warn(`[docs] Could not load releases from ${repository}:`, error);
+    return [];
+  }
+}
+
+async function publishedReleases(): Promise<GitHubRelease[]> {
+  const [canonical, legacy] = await Promise.all(
+    RELEASE_REPOSITORIES.map((repository) => fetchPublishedReleases(repository)),
+  );
+  const byTag = new Map<string, GitHubRelease>();
+
+  for (const release of [...canonical, ...legacy]) {
+    const tag = release.tag_name.trim().toLowerCase();
+    if (!byTag.has(tag)) byTag.set(tag, release);
+  }
+
+  return [...byTag.values()]
+    .map((release) => ({ release, version: parseVersion(release.tag_name) }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        release: GitHubRelease;
+        version: readonly [number, number, number];
+      } => Boolean(entry.version),
+    )
+    .sort((left, right) => compareVersions(right.version, left.version))
+    .map(({ release }) => release);
+}
+
+export async function ReleaseChangelog() {
+  const releases = await publishedReleases();
+  if (releases.length === 0) {
+    return (
+      <p>
+        The live release history is temporarily unavailable.{' '}
+        <a href="https://github.com/milind-soni/OpenMausBot/releases">Browse releases on GitHub</a>.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-8">
+      {releases.map((release) => {
+        const version = displayVersion(release);
+        return (
+          <article className="mb-12" key={release.tag_name}>
+            <h2>
+              {version} — {displayDate(release.published_at!)}
+            </h2>
+            <ReactMarkdown components={markdownComponents}>
+              {releaseNotes(release)}
+            </ReactMarkdown>
+            <p>
+              <a href={release.html_url} rel="noreferrer" target="_blank">
+                Full {version} release notes
+              </a>
+            </p>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -1,65 +1,15 @@
 ---
 title: Changelog
-description: Highlights from recent OpenMausBot desktop releases.
+description: The complete history of published OpenMausBot desktop releases.
 icon: Clock
 ---
 
+import { ReleaseChangelog } from '@/components/release-changelog';
+
 The changelog tracks published desktop builds. Changes merged into `main` after a release are not listed as shipped until a new build is published.
 
-## 0.1.32 — August 23, 2026
-
-- Expanded the OpenCode engine from a Go-only catalog to the installed CLI's live Zen, Go, third-party, and local provider inventory.
-- Existing OpenCode logins and anonymous free models now work without duplicate setup in OpenMausBot.
-
-[Full 0.1.32 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.32)
-
-## 0.1.29 — August 23, 2026
-
-- Fixed OpenCode Go's live cloud models appearing as local models and bypassing sign-in.
-- Added direct latest-build downloads for Apple silicon, Intel Mac, Windows, and Ubuntu.
-
-[Full 0.1.29 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.29)
-
-## 0.1.27 — August 20, 2026
-
-- Added the Cursor Agent CLI engine with ACP model discovery.
-- Added pasted screenshot attachments and labeled sidebar sections.
-- Repaired the macOS update restart path and made browser join links resilient to popup blocking.
-- Added approval audit records, credential hardening, pinned messages, more reactions, room timeouts, and temporary computer takeover.
-- Adopted Apache License 2.0.
-
-[Full 0.1.27 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.27)
-
-## 0.1.25 — August 20, 2026
-
-- Added a signed and notarized Intel macOS build.
-- Shipped the first Ubuntu 24.04 x64 `.deb` and AppImage beta packages.
-- Added four themes, spoiler text, safer additive team import, and several approval and model-routing fixes.
-
-[Full 0.1.25 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.25)
-
-## 0.1.24 — August 19, 2026
-
-- Added the native iOS companion and USB Android control.
-- Added readable bot memory, working folders, cost tracking, message search, and a raw event inspector.
-- Added Bring Your Own VPS computers and major harness reliability fixes.
-
-[Full 0.1.24 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.24)
-
-## 0.1.23 — August 17, 2026
-
-- Fixed the Composio OAuth completion flow.
-- Added clear updater states, a new app icon, and correct delegated-turn terminal status.
-
-[Full 0.1.23 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.23)
-
-## 0.1.22 — August 17, 2026
-
-- Replaced the legacy two-key connector setup with one validated Composio project key.
-- Moved connector lifecycle to Composio Sessions and added true upstream revocation.
-
-[Full 0.1.22 release notes](https://github.com/milind-soni/openmausbot-releases/releases/tag/v0.1.22)
+<ReleaseChangelog />
 
 <Callout type="info" title="Every release remains available">
-  Browse checksums, installers, and older notes in the [OpenMausBot releases repository](https://github.com/milind-soni/openmausbot-releases/releases).
+  Browse current installers and notes in [OpenMausBot releases](https://github.com/milind-soni/OpenMausBot/releases). Releases before the updater migration remain in the [legacy archive](https://github.com/milind-soni/openmausbot-releases/releases).
 </Callout>

--- a/apps/docs/content/docs/contributing/documentation.mdx
+++ b/apps/docs/content/docs/contributing/documentation.mdx
@@ -41,4 +41,5 @@ pnpm docs:build
 - Lead with user outcomes and include exact recovery steps for known failure modes.
 - State platform and security boundaries plainly.
 - Prefer links to stable public docs over duplicating long internal design records.
-- Update the changelog only when a release is actually published.
+- Keep unreleased claims out of the changelog. Entries are read from GitHub
+  only after a release is published.

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -10,10 +10,10 @@ Choose your computer below. Each link always downloads the latest published buil
 
 | Platform | Recommended package | Notes |
 |---|---|---|
-| macOS Apple silicon | [Download `.dmg`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.dmg) | Signed and notarized. Drag to Applications. |
-| macOS Intel | [Download `.dmg`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-intel.dmg) | Signed and notarized. |
-| Windows x64 | [Download installer](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-setup.exe) | Per-user installer; Windows signing is not yet available. |
-| Ubuntu 24.04 x64 | [Download `.deb`](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) · [AppImage](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) | The `.deb` is recommended; the AppImage is portable. |
+| macOS Apple silicon | [Download `.dmg`](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.dmg) | Signed and notarized. Drag to Applications. |
+| macOS Intel | [Download `.dmg`](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-intel.dmg) | Signed and notarized. |
+| Windows x64 | [Download installer](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-setup.exe) | Per-user installer; Windows signing is not yet available. |
+| Ubuntu 24.04 x64 | [Download `.deb`](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-amd64.deb) · [AppImage](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.AppImage) | The `.deb` is recommended; the AppImage is portable. |
 
 <Callout type="warn" title="Windows SmartScreen">
   The Windows installer is not code-signed yet. Windows may show “Unknown publisher.” Verify that you downloaded it from the official OpenMausBot releases repository before choosing **More info → Run anyway**.

--- a/apps/docs/content/docs/troubleshooting/updates.mdx
+++ b/apps/docs/content/docs/troubleshooting/updates.mdx
@@ -21,7 +21,7 @@ Reopen OpenMausBot once it finishes to be running the new version.
 
 ## The download keeps spinning
 
-Leave the app open long enough for one complete attempt, then quit and reopen it. A failed differential update should fall back to the full package. If the same release remains stuck, download the current installer from the [official releases repository](https://github.com/milind-soni/openmausbot-releases/releases/latest) and install it over the existing copy.
+Leave the app open long enough for one complete attempt, then quit and reopen it. A failed differential update should fall back to the full package. If the same release remains stuck, download the current installer from the [official releases page](https://github.com/milind-soni/OpenMausBot/releases/latest) and install it over the existing copy.
 
 ## Restart to update does nothing
 

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -12,7 +12,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       { text: 'Website', url: 'https://www.openmausbot.com', external: true },
       { text: 'Changelog', url: '/docs/changelog' },
-      { type: 'button', text: 'Download', url: 'https://github.com/milind-soni/openmausbot-releases/releases/latest', external: true },
+      { type: 'button', text: 'Download', url: 'https://github.com/milind-soni/OpenMausBot/releases/latest', external: true },
     ],
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,7 +21,8 @@
     "lucide-react": "^1.31.0",
     "next": "16.3.2",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -32,12 +32,12 @@ CUA supply-chain work is tracked in [issue #113](https://github.com/milind-soni/
 
 Choose one Ubuntu 24.04 x86_64 package from the latest release:
 
-- [Debian package (`OpenMausBot-amd64.deb`)](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot-amd64.deb) — recommended; APT installs its desktop dependencies.
-- [Portable AppImage (`OpenMausBot.AppImage`)](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/OpenMausBot.AppImage) — does not install system files.
-- [SHA-256 checksums](https://github.com/milind-soni/openmausbot-releases/releases/latest/download/SHA256SUMS-ubuntu-x64.txt)
+- [Debian package (`OpenMausBot-amd64.deb`)](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot-amd64.deb) — recommended; APT installs its desktop dependencies.
+- [Portable AppImage (`OpenMausBot.AppImage`)](https://github.com/milind-soni/OpenMausBot/releases/latest/download/OpenMausBot.AppImage) — does not install system files.
+- [SHA-256 checksums](https://github.com/milind-soni/OpenMausBot/releases/latest/download/SHA256SUMS-ubuntu-x64.txt)
 
 Versioned packages and previous releases remain available on the
-[releases page](https://github.com/milind-soni/openmausbot-releases/releases).
+[releases page](https://github.com/milind-soni/OpenMausBot/releases).
 
 ## Build packages
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,14 +3,43 @@
 One workflow builds everything: **Actions → Release → Run workflow**. It
 builds macOS (arm64 + x64, signed, notarized, stapled), Windows, and Ubuntu
 from a single pinned commit, verifies every artifact the way a user would
-receive it, assembles a complete draft on
-[openmausbot-releases](https://github.com/milind-soni/openmausbot-releases),
-and — if you ticked **publish** — flips it live. Leave publish unticked to
-review the draft notes first, then publish from the GitHub UI.
+receive it, and assembles the canonical draft in
+[OpenMausBot releases](https://github.com/milind-soni/OpenMausBot/releases).
+The exact same assets are also staged in the public legacy releases repo so
+installed builds from 0.1.46 and earlier can update across the repository
+migration.
+
+Tick **publish** to publish and verify the canonical release first, then make
+the identical legacy updater bridge visible. Leave it unticked to review the
+canonical draft; when you publish that draft in GitHub's UI, the **Sync
+published release** workflow
+verifies and publishes its legacy mirror automatically. Never publish only the
+legacy draft.
 
 The workflow refuses to overwrite an already-published version, so the only
 prerequisite per release is that `package.json`'s version is bumped on the
-ref you run it against.
+ref you run it against. A release is rejected if any installer, stable download
+name, updater feed, blockmap, size, or digest is absent or inconsistent.
+
+GitHub generates the release body from pull requests since the previous
+canonical tag. The docs changelog combines published canonical releases with
+the legacy archive into one complete history and caches it for five minutes.
+Configure the optional Vercel hook below to rebuild the docs immediately after
+publication; otherwise the live cache or the next normal docs deployment
+refreshes it.
+
+## Updater migration invariant
+
+`app-update.yml` is baked into every packaged desktop app. Builds through
+0.1.46 point to `milind-soni/openmausbot-releases`; newer builds point to
+`milind-soni/OpenMausBot`. For that reason:
+
+1. Every new release is published byte-for-byte to both repositories during
+   the bridge period.
+2. `openmausbot-releases` must stay public. Do not delete its final bridge
+   release, feeds, or assets.
+3. README and docs downloads point at the canonical repo, while the legacy
+   mirror exists only for installed updater clients and historical releases.
 
 ## Why the gates exist
 
@@ -22,7 +51,7 @@ stapling silently invalidating every published hash, and a finished release
 sitting invisible as a draft. Don't remove a gate without reading the comment
 above it.
 
-## One-time setup: four secrets
+## One-time setup: release secrets
 
 Set these in **OpenMausBot → Settings → Secrets and variables → Actions**.
 
@@ -54,10 +83,18 @@ base64 -i AuthKey_XXXXXXXX.p8 | pbcopy   # → APPLE_API_KEY_P8_BASE64
 ### 3. `RELEASES_PAT`
 
 A fine-grained personal access token that lets the workflow write to the
-separate releases repo: **GitHub → Settings → Developer settings →
+legacy updater mirror: **GitHub → Settings → Developer settings →
 Fine-grained tokens** → repository access: only `openmausbot-releases` →
 permissions: **Contents: Read and write**. Set a long expiry and a calendar
-reminder.
+reminder. The canonical release uses the workflow's scoped `GITHUB_TOKEN` and
+does not need a PAT.
+
+### 4. Optional `DOCS_DEPLOY_HOOK_URL`
+
+In Vercel, open the docs project and create a **Deploy Hook** for its production
+branch. Store that private URL as the `DOCS_DEPLOY_HOOK_URL` repository secret.
+Publishing a release then requests a fresh docs deployment so the generated
+changelog appears immediately. Do not put the hook URL in source control.
 
 ### Local fallback
 
@@ -65,5 +102,7 @@ The hand-cut path still works when Actions is down or a release needs
 surgery: `pnpm package:mac`, gate with `codesign --verify --deep --strict`,
 notarize with the local keychain profile (`xcrun notarytool submit …
 --keychain-profile AC_PASSWORD`), staple, re-zip, regenerate blockmaps and
-`node scripts/regenerate-mac-feed.mjs`, upload, publish, and always verify
-the published bytes against the published feed by downloading them back.
+`node scripts/regenerate-mac-feed.mjs`, upload the identical complete asset set
+to both repositories, publish and verify the canonical release before the
+legacy mirror, and always verify the published bytes against the published feed
+by downloading them back.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,8 +7,8 @@ protocols:
     schemes: [openmausbot]
 
 # In-app auto-update reads latest-mac.yml + the .zip (macOS) or latest.yml +
-# the NSIS .exe (Windows) from this PUBLIC releases repo (separate from the
-# source repo). Public → no token on users' machines. Baked into
+# the NSIS .exe (Windows) from the PUBLIC releases in this source repo.
+# Public → no token on users' machines. Baked into
 # app-update.yml; both metadata files are emitted here even with
 # --publish never, and must be uploaded to the GitHub release alongside the
 # artifacts — a release missing latest.yml leaves every Windows install
@@ -16,7 +16,7 @@ protocols:
 publish:
   - provider: github
     owner: milind-soni
-    repo: openmausbot-releases
+    repo: OpenMausBot
 
 directories:
   buildResources: build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.3.3

--- a/scripts/smoke-linux-update.mjs
+++ b/scripts/smoke-linux-update.mjs
@@ -3,7 +3,7 @@
 //
 // The unit tests drive AppImageUpdater.doInstall with hand-made files. This
 // drives the whole thing: the shipped bundle, extracted from the packaged
-// AppImage, checking the real openmausbot-releases feed, downloading the real
+// AppImage, checking the real canonical release feed, downloading the real
 // asset, and installing it over a copy that carries a version in its name —
 // the exact shape that used to orphan the launcher.
 //

--- a/scripts/verify-linux-package.mjs
+++ b/scripts/verify-linux-package.mjs
@@ -71,6 +71,15 @@ function requirePackageType(resources, label, expected) {
   }
 }
 
+function requireUpdaterTarget(resources, label) {
+  const updateFile = path.join(resources, "app-update.yml");
+  requireFile(updateFile);
+  const update = readFileSync(updateFile, "utf8");
+  if (!/^owner: milind-soni$/m.test(update) || !/^repo: OpenMausBot$/m.test(update)) {
+    fail(`${label} app-update.yml does not point at milind-soni/OpenMausBot`);
+  }
+}
+
 function sha256(file) {
   return createHash("sha256").update(readFileSync(file)).digest("hex");
 }
@@ -406,6 +415,7 @@ for (const forbidden of ["speech-helper", "cua-driver", "cua-sdk"]) {
 }
 const unpackedCuaHashes = verifyCuaResources(resources, "linux-unpacked");
 const unpackedCloudflaredHash = verifyCloudflaredResources(resources, "linux-unpacked");
+requireUpdaterTarget(resources, "linux-unpacked");
 
 const fields = execFileSync(
   "dpkg-deb",
@@ -430,6 +440,7 @@ try {
   const debResources = path.join(debAppRoot, "resources");
   // Routes the in-app updater to the package-manager hand-off.
   requirePackageType(debResources, "DEB", "deb");
+  requireUpdaterTarget(debResources, "DEB");
   const debHashes = verifyCuaResources(debResources, "DEB");
   const debCloudflaredHash = verifyCloudflaredResources(debResources, "DEB");
   if (debCloudflaredHash !== unpackedCloudflaredHash) {
@@ -495,6 +506,7 @@ try {
   const appImageResources = path.join(squashRoot, "resources");
   // No marker: the AppImage keeps the in-place restart-to-update path.
   requirePackageType(appImageResources, "AppImage", null);
+  requireUpdaterTarget(appImageResources, "AppImage");
   // Depending on the pinned appimagetool runtime, SquashFS directories are
   // emitted as root:root 0755 or 0775. Require one mode consistently across
   // the reviewed resource tree. The app never executes through that path:


### PR DESCRIPTION
## What changed

- makes `milind-soni/OpenMausBot` the canonical release and auto-update repository
- mirrors every byte-identical release to `openmausbot-releases` so installs through 0.1.46 can cross the migration safely
- fails closed on missing assets, wrong updater paths, or mismatched feed hashes/sizes/digests
- moves README and docs downloads to the canonical release page
- generates release notes from merged PRs using GitHub's native release-note configuration
- renders the complete published changelog (canonical + legacy, deduplicated) in the Fumadocs site with five-minute ISR
- adds docs CI and an optional Vercel deploy-hook refresh

## Migration safety

The canonical `v0.1.46` release has already been seeded with the exact original 21 assets. All remote SHA-256 digests, updater feed SHA-512 values/sizes, stable download URLs, and source commit `eb959ec180b1382344cf937c1bc08cd67969f53e` were verified before switching README links.

Future releases publish canonical first, then the legacy bridge. The legacy repository must remain public for older installed clients.

## Verification

- `pnpm test` (2,804 passed, 20 skipped; plus broker, Electron, and packaged-server suites)
- `pnpm typecheck`
- docs typecheck + Oxlint + production build
- Actionlint 1.7.12 and YAML parse
- real `v0.1.46` feeds passed the new exact-path/hash/size verifier
- rendered docs contain every published version from 0.1.46 through 0.1.0
- `git diff --check`
