### PR TITLE
Add Claude Fable 5.1

### DIFF
--- a/server/drivers/claude-catalog.test.ts
+++ b/server/drivers/claude-catalog.test.ts
@@ -12,8 +12,12 @@ afterEach(() => {
 });
 
 describe("readClaudeModelCatalog", () => {
-  it("returns the official four when settings are missing", () => {
+  it("returns the official models when settings are missing", () => {
     expect(readClaudeModelCatalog({ HOME: join(tmpdir(), "omb-claude-missing-home") })).toEqual(STATIC_CLAUDE_MODELS);
+    expect(STATIC_CLAUDE_MODELS.options.slice(0, 2)).toEqual([
+      { id: "claude-fable-5-1", label: "Claude Fable 5.1" },
+      { id: "claude-fable-5", label: "Claude Fable 5" },
+    ]);
   });
 
   it("tags extra settings models as custom and leaves official rows untagged", () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -104,6 +104,7 @@ export interface ClaudeConfig {
 export const STATIC_CLAUDE_MODELS: ModelCatalog = {
   default: "claude-sonnet-5",
   options: [
+    { id: "claude-fable-5-1", label: "Claude Fable 5.1" },
     { id: "claude-fable-5", label: "Claude Fable 5" },
     { id: "claude-opus-5", label: "Claude Opus 5" },
     { id: "claude-sonnet-5", label: "Claude Sonnet 5" },


### PR DESCRIPTION
## What changed

- adds `claude-fable-5-1` to the built-in Claude model picker
- keeps Fable 5 available for compatibility
- leaves Sonnet 5 as the default model

OpenMausBot uses the user's installed Claude Code CLI rather than bundling an Anthropic SDK. Claude Code 2.1.257 is the first verified build for this model.

## Verification

- upgraded the local Claude Code install from 2.1.251 to 2.1.257
- completed an isolated, tool-free live turn on `claude-fable-5-1`
- 68 focused Claude driver/catalog tests passed (1 skipped)
- `pnpm typecheck`
- focused Oxlint and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Fable 5.1 to the available Claude model options.

* **Tests**
  * Updated coverage to verify the new model appears in the catalog and that the model list supports more than four entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->