### PR TITLE
Bump version to 0.1.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop app version from 0.1.46 to 0.1.47 so the next release workflow publishes a new version.

Validation:
- parsed package.json and confirmed version 0.1.47
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.47.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->