### PR TITLE
feat(deploy): Docker tenant image, Caddy edge stack, advertised webhook URL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+**/node_modules
+dist
+dist-server
+dist-electron
+release
+.git
+.github
+.claude
+*.dmg
+*.zip
+*.log
+electron/resources/cloudflared*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,14 +84,20 @@ jobs:
           H=https://localhost
           test "$(code $H/api/health)" = 401                                      # login wall
           test "$(code -u ci:wrong $H/api/health)" = 401
-          curl -sk -u ci:ci-pass $H/api/health | grep -q openmausbot                # Host rule satisfies the loopback gate
-          curl -sk -u ci:ci-pass $H/ | grep -qi '<html'                             # UI served through the proxy
+          # Bodies are captured before grepping: with pipefail, `curl | grep -q`
+          # can fail on SIGPIPE when grep closes the pipe early.
+          body() { curl -sk --max-time 10 "$@"; }
+          grep -q openmausbot <<<"$(body -u ci:ci-pass $H/api/health)"             # Host rule satisfies the loopback gate
+          grep -qi '<html' <<<"$(body -u ci:ci-pass $H/)"                          # UI served through the proxy
           test "$(code -u ci:ci-pass -H 'Origin: https://evil.example' $H/api/health)" = 403   # CSRF gate survives the proxy
           test "$(code -u ci:ci-pass -H 'Origin: https://localhost' $H/api/health)" = 200      # own origin is mapped
-          curl -sk -X POST $H/hooks/wh_nope | grep -q error                        # hook path reaches the receiver without login
+          grep -q error <<<"$(body -X POST $H/hooks/wh_nope)"                      # hook path reaches the receiver without login
           test "$(code http://localhost/)" = 308                                   # HTTP redirects to HTTPS
-          curl -sk -u ci:ci-pass -N --max-time 4 $H/api/events | head -c 1 | grep -q .   # SSE streams, not buffered
-          curl -sk -u ci:ci-pass $H/api/webhooks | grep -q '"baseUrl":"https://localhost"'   # OMB_WEBHOOK_PUBLIC_URL is advertised
+          # The event stream never ends, so curl's own --max-time exit (28) is expected;
+          # the proof is that bytes arrived within the window (a buffering proxy sends none).
+          sse=$( (curl -sk -u ci:ci-pass -N --max-time 4 $H/api/events || true) | head -c 64 )
+          test -n "$sse"                                                           # SSE streams, not buffered
+          grep -q '"baseUrl":"https://localhost"' <<<"$(body -u ci:ci-pass $H/api/webhooks)"   # OMB_WEBHOOK_PUBLIC_URL is advertised
           docker compose -f deploy/docker-compose.yml down -v
 
   publish:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           docker rm -f omb >/dev/null
-          docker tag openmausbot:ci openmausbot:latest
+          docker tag openmausbot:ci ghcr.io/milind-soni/openmausbot:latest
           hash=$(docker run --rm caddy:2 caddy hash-password --plaintext 'ci-pass')
           printf 'DOMAIN=localhost\nBASIC_AUTH_USER=ci\nBASIC_AUTH_HASH=%s\nENGINES=\n' "$(printf '%s' "$hash" | sed 's/\$/$$/g')" > deploy/.env
           docker compose -f deploy/docker-compose.yml up -d --no-build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,128 @@
+name: Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - deploy/**
+      - server/**
+      - src/**
+      - package.json
+      - pnpm-lock.yaml
+      - .github/workflows/docker.yml
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - deploy/**
+      - .github/workflows/docker.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke:
+    name: build image + boot smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build image
+        run: docker build -t openmausbot:ci .
+      - name: Boot the container and prove the server + UI answer
+        run: |
+          set -euo pipefail
+          docker run -d --name omb openmausbot:ci
+          for i in $(seq 1 40); do
+            if docker exec omb curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot; then break; fi
+            sleep 2
+            if [ "$i" = "40" ]; then docker logs omb; echo "server never became healthy"; exit 1; fi
+          done
+          # the renderer is served by the server itself (OMB_STATIC_DIR)
+          docker exec omb curl -sf http://127.0.0.1:8799/ | grep -qi "<html" || { docker logs omb; echo "UI not served"; exit 1; }
+          docker logs omb | tail -5
+      - name: Prove the server never binds a public interface
+        # The loopback-trust model is the auth model, so the image must keep
+        # the server unreachable from the container's own network. Probe from a
+        # sibling container on the same bridge; a positive control first proves
+        # the probe can see a socket that does bind 0.0.0.0.
+        run: |
+          set -euo pipefail
+          probe() { docker run --rm --network bridge curlimages/curl:8.14.1 -s --max-time 3 "http://$1:$2/" >/dev/null; }
+          docker run -d --name leaky --entrypoint node openmausbot:ci -e "require('http').createServer((q,s)=>s.end('leak')).listen(8799,'0.0.0.0')"
+          sleep 2
+          leaky_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' leaky)
+          test -n "$leaky_ip"
+          probe "$leaky_ip" 8799 || { echo "probe cannot see a 0.0.0.0 listener; the check would be vacuous"; exit 1; }
+          docker rm -f leaky >/dev/null
+          ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' omb)
+          test -n "$ip"
+          if probe "$ip" 8799 || probe "$ip" 8800; then
+            echo "server answered on $ip — it must only bind 127.0.0.1"; exit 1
+          fi
+          echo "unreachable on $ip: loopback-only holds"
+      - name: Run the tenant stack (server + Caddy) and use it like a browser would
+        # deploy/docker-compose.yml is the product here: prove the login wall,
+        # the Host/Origin rules that satisfy the server's loopback gates, the
+        # unbuffered SSE stream, and the advertised webhook base — through TLS.
+        run: |
+          set -euo pipefail
+          docker rm -f omb >/dev/null
+          docker tag openmausbot:ci openmausbot:latest
+          hash=$(docker run --rm caddy:2 caddy hash-password --plaintext 'ci-pass')
+          printf 'DOMAIN=localhost\nBASIC_AUTH_USER=ci\nBASIC_AUTH_HASH=%s\nENGINES=\n' "$(printf '%s' "$hash" | sed 's/\$/$$/g')" > deploy/.env
+          docker compose -f deploy/docker-compose.yml up -d --no-build
+          for i in $(seq 1 45); do
+            curl -sk -o /dev/null --max-time 2 https://localhost/api/health && break
+            sleep 2
+            if [ "$i" = "45" ]; then docker compose -f deploy/docker-compose.yml logs; echo "caddy never answered"; exit 1; fi
+          done
+          code() { curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$@"; }
+          H=https://localhost
+          test "$(code $H/api/health)" = 401                                      # login wall
+          test "$(code -u ci:wrong $H/api/health)" = 401
+          curl -sk -u ci:ci-pass $H/api/health | grep -q openmausbot                # Host rule satisfies the loopback gate
+          curl -sk -u ci:ci-pass $H/ | grep -qi '<html'                             # UI served through the proxy
+          test "$(code -u ci:ci-pass -H 'Origin: https://evil.example' $H/api/health)" = 403   # CSRF gate survives the proxy
+          test "$(code -u ci:ci-pass -H 'Origin: https://localhost' $H/api/health)" = 200      # own origin is mapped
+          curl -sk -X POST $H/hooks/wh_nope | grep -q error                        # hook path reaches the receiver without login
+          test "$(code http://localhost/)" = 308                                   # HTTP redirects to HTTPS
+          curl -sk -u ci:ci-pass -N --max-time 4 $H/api/events | head -c 1 | grep -q .   # SSE streams, not buffered
+          curl -sk -u ci:ci-pass $H/api/webhooks | grep -q '"baseUrl":"https://localhost"'   # OMB_WEBHOOK_PUBLIC_URL is advertised
+          docker compose -f deploy/docker-compose.yml down -v
+
+  publish:
+    name: publish to GHCR
+    needs: build-and-smoke
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long
+            type=ref,event=tag
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ cloudflare/control-plane/worker-configuration.d.ts
 *.jks
 *.keystore
 *.p12
+
+# per-tenant deploy settings (see deploy/.env.example)
+deploy/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# OpenMausBot harness server — hosted/self-hosted tenant image.
+#
+# Two stages: build the renderer + the self-contained server bundle, then ship
+# only those artifacts on a slim Node runtime. The server keeps binding
+# 127.0.0.1 inside the container (the loopback-trust invariant is the auth
+# model); deploy/docker-compose.yml puts Caddy in the same network namespace
+# to terminate TLS and authentication at the edge.
+#
+#   docker build -t openmausbot .
+#   docker build --build-arg ENGINES="@anthropic-ai/claude-code @openai/codex" -t openmausbot .
+#
+# HOME is the /data volume, so engine CLI logins (~/.claude, ~/.codex, ...) and
+# OpenMausBot's own state (~/.openmausbot) persist across container restarts.
+
+FROM node:24-bookworm-slim AS build
+WORKDIR /src
+# pinned to package.json#packageManager; corepack is being removed from Node
+RUN npm install -g pnpm@10.33.0
+# The image never runs Electron, so skip its ~100MB postinstall download.
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# every workspace member's manifest must exist before install resolves the lockfile
+COPY apps/docs/package.json ./apps/docs/package.json
+COPY cloudflare/control-plane/package.json ./cloudflare/control-plane/package.json
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build:server && pnpm exec vite build
+
+FROM node:24-bookworm-slim
+# git + curl: agent CLIs shell out to git; curl backs the healthcheck
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --create-home --home-dir /data --shell /bin/bash maus
+WORKDIR /app
+COPY --from=build --chown=maus:maus /src/dist-server ./dist-server
+COPY --from=build --chown=maus:maus /src/dist ./dist
+# Optional engine CLIs baked into the image (space-separated npm packages).
+ARG ENGINES=""
+RUN if [ -n "$ENGINES" ]; then npm install -g $ENGINES; fi
+ENV HOME=/data \
+    OMB_DATA_DIR=/data/.openmausbot \
+    OMB_STATIC_DIR=/app/dist \
+    OMB_PORT=8799 \
+    OMB_WEBHOOK_PORT=8800 \
+    NODE_ENV=production
+VOLUME ["/data"]
+USER maus
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot || exit 1
+CMD ["node", "dist-server/index.js"]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,12 @@
+# Public hostname for automatic HTTPS (must resolve to this machine)
+DOMAIN=maus.example.com
+
+# Login for the web UI. Compose treats `$` in this file as a variable, so the
+# bcrypt hash must have every `$` doubled. This prints it ready to paste:
+#   docker run --rm caddy:2 caddy hash-password --plaintext 'your-password' | sed 's/\$/$$/g'
+BASIC_AUTH_USER=maus
+BASIC_AUTH_HASH=$$2a$$14$$replace-me-with-the-escaped-hash
+
+# Engine CLIs baked into the image at build time (space-separated npm packages).
+# Sign in afterwards with:  docker compose exec omb claude   (etc.)
+ENGINES=@anthropic-ai/claude-code

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,33 @@
+# Edge for one OpenMausBot tenant: automatic HTTPS + login in front of a server
+# that only listens on loopback. The two header rules are load-bearing —
+# see docs/self-hosting.md "Putting a proxy in front" before changing them.
+{$DOMAIN} {
+	encode zstd gzip
+
+	# Webhook ingress (/hooks/wh_...) is meant to be reachable by third parties
+	# — every hook carries its own secret — so it sits outside the login wall.
+	handle /hooks/* {
+		reverse_proxy 127.0.0.1:8800 {
+			header_up Host 127.0.0.1:8800
+		}
+	}
+
+	handle {
+		basic_auth {
+			{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+		}
+
+		# The server accepts browser requests only from its own origin. Map
+		# THIS site's origin onto the loopback origin it expects; any other
+		# Origin passes through unchanged and is still refused — CSRF
+		# protection survives the proxy.
+		@own header Origin https://{$DOMAIN}
+		request_header @own Origin http://127.0.0.1:8799
+
+		reverse_proxy 127.0.0.1:8799 {
+			header_up Host 127.0.0.1:8799
+			# SSE: stream events as they arrive
+			flush_interval -1
+		}
+	}
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,54 @@
+# One OpenMausBot tenant: the harness server plus Caddy for TLS + login.
+#
+# Caddy runs in the server's network namespace, so it reaches the server on
+# 127.0.0.1 — the server never binds a public interface. Ports are therefore
+# declared on the `omb` service (the namespace owner).
+#
+#   cp .env.example .env   # set DOMAIN, BASIC_AUTH_USER, BASIC_AUTH_HASH
+#   docker compose pull omb && docker compose up -d     # prebuilt image
+#   docker compose up -d --build                        # or build from source
+services:
+  omb:
+    build:
+      context: ..
+      args:
+        ENGINES: ${ENGINES:-}
+    # prebuilt on every main push; `docker compose up --build` builds from source instead
+    image: ghcr.io/milind-soni/openmausbot:latest
+    restart: unless-stopped
+    volumes:
+      - data:/data
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      OMB_PORT: "8799"
+      OMB_WEBHOOK_PORT: "8800"
+      # what the app prints as hook URLs — Caddy passes /hooks/* straight through
+      OMB_WEBHOOK_PUBLIC_URL: https://${DOMAIN}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    network_mode: "service:omb"
+    depends_on:
+      omb:
+        condition: service_healthy
+    environment:
+      DOMAIN: ${DOMAIN}
+      BASIC_AUTH_USER: ${BASIC_AUTH_USER}
+      BASIC_AUTH_HASH: ${BASIC_AUTH_HASH}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  data:
+  caddy_data:
+  caddy_config:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -7,10 +7,11 @@ path **today**; first-class remote access is coming — see
 
 > **Security first:** the server deliberately trusts only loopback — any
 > process that can reach `127.0.0.1:8799` has full control, including the
-> shell your bots can use. **Never reverse-proxy it to the public internet
-> and never bind it to a public interface.** Reach it through an SSH tunnel
-> (below) or a private network you trust. Proper token-based remote auth is
-> exactly what the Remote Workspace plan adds.
+> shell your bots can use. **Never expose that port directly and never bind
+> it to a public interface.** Reach it through an SSH tunnel, a private
+> network you trust, or the Docker stack below, which puts a login wall
+> (Caddy) in front. Proper token-based remote auth is exactly what the
+> Remote Workspace plan adds.
 
 ## What works headless (and what doesn't)
 
@@ -30,7 +31,56 @@ Desktop-only for now (needs the Mac/Linux app):
 - the built-in browser panel, the skill recorder, dictation/voice,
   controlling the host desktop
 
-## Setup
+## Docker (recommended)
+
+One tenant = one container for the server plus Caddy for HTTPS and login.
+Requirements: Docker with Compose, a DNS name pointing at the machine, and
+ports 80/443 open.
+
+```sh
+git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot/deploy
+cp .env.example .env
+# set DOMAIN, BASIC_AUTH_USER and BASIC_AUTH_HASH (the file says how;
+# the hash's `$` signs must be doubled, Compose interpolates them)
+docker compose pull omb && docker compose up -d
+```
+
+That uses the image CI publishes on every `main` push
+(`ghcr.io/milind-soni/openmausbot`, tagged `latest`, `sha-…` and `v…`).
+To build from your checkout instead: `docker compose up -d --build`.
+
+Then sign the engine CLIs in **inside the container** — their logins live
+on the `data` volume, so they survive restarts and image upgrades:
+
+```sh
+docker compose exec omb claude     # each CLI you listed in ENGINES
+```
+
+Open `https://<DOMAIN>` and log in with the basic-auth user. Webhook URLs
+(`https://<DOMAIN>/hooks/wh_…`) work without the login — every hook
+carries its own secret — and that is the base the app prints on new hooks,
+because the stack sets `OMB_WEBHOOK_PUBLIC_URL`.
+
+What the stack does, so you can adapt it:
+
+- [`Dockerfile`](../Dockerfile) builds the UI and the self-contained
+  server bundle, and runs them as an unprivileged user with `HOME=/data`.
+  `--build-arg ENGINES="…"` (or `ENGINES=` in `.env`) bakes engine CLIs
+  into the image.
+- [`deploy/docker-compose.yml`](../deploy/docker-compose.yml) runs Caddy
+  **in the server's network namespace**, so Caddy reaches the server on
+  `127.0.0.1` and the server never binds anything public. The loopback
+  invariant above holds unchanged.
+- [`deploy/Caddyfile`](../deploy/Caddyfile) carries the two header rules
+  from "Putting a proxy in front" below. Swap `basic_auth` for
+  `forward_auth` to an identity provider (Authentik, oauth2-proxy) when you
+  outgrow a shared password — nothing in the server needs to change.
+
+Upgrade with `docker compose pull omb && docker compose up -d` (or
+`git pull && docker compose up -d --build`). State (chats, routines,
+engine logins) is on the `data` volume; back that up.
+
+## From source
 
 Requirements: Node 24+, pnpm, and at least one agent CLI installed and
 signed in on the server.
@@ -80,9 +130,29 @@ The server serves the full app UI itself — no desktop install needed on the
 client. The tunnel keeps the loopback trust model intact: to the server,
 you look local, because through the tunnel you are.
 
-Note: plain `tailscale serve`/reverse proxies will currently be refused —
-the server checks that requests look like loopback on purpose. Use the SSH
-tunnel until Remote Workspace lands.
+Note: a plain `tailscale serve` or reverse proxy is refused — the server
+checks that requests look like loopback on purpose. A proxy can satisfy
+that check; see "Putting a proxy in front" below. Only do it behind a login.
+
+## Putting a proxy in front
+
+The server has two request gates, both aimed at browsers:
+
+1. **Host** must be loopback (`localhost`, `127.x.x.x`, `::1`). The proxy
+   must rewrite `Host` to `127.0.0.1:8799` on the way in.
+2. **Origin**, when present, must be a loopback origin. Browsers send the
+   proxy's origin (`https://your.domain`), so the proxy must map exactly
+   that one origin onto `http://127.0.0.1:8799` — and leave every other
+   Origin untouched, so cross-site requests are still refused.
+
+Plus two non-security rules: the UI streams events over SSE, so the proxy
+must not buffer responses (`flush_interval -1` in Caddy,
+`proxy_buffering off` in nginx); and the webhook receiver (port 8800,
+paths `/hooks/...`) only knows its loopback address, so set
+`OMB_WEBHOOK_PUBLIC_URL=https://your.domain` to make the app print hook
+URLs senders can reach. [`deploy/Caddyfile`](../deploy/Caddyfile) is the
+reference implementation. The proxy itself must add the login — the
+server has none — so never point it at the internet without one.
 
 ## Using it from your phone
 
@@ -99,7 +169,8 @@ per-device credentials on pairing — see the pairing screen in the iOS app.
 ## Updating
 
 ```sh
-git pull && pnpm install && sudo systemctl restart openmausbot
+docker compose -f deploy/docker-compose.yml pull omb && docker compose -f deploy/docker-compose.yml up -d   # Docker
+git pull && pnpm install && sudo systemctl restart openmausbot          # from source
 ```
 
 Routines and queued work survive restarts; in-flight turns do not, so

--- a/server/index.ts
+++ b/server/index.ts
@@ -240,6 +240,8 @@ import { createGracefulShutdown } from "./graceful-shutdown.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
+// Behind a proxy or tunnel, the base URL senders should use (docs/self-hosting.md).
+const WEBHOOK_PUBLIC_URL = process.env.OMB_WEBHOOK_PUBLIC_URL || undefined;
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
 const MIME: Record<string, string> = {
   ".html": "text/html",
@@ -3329,8 +3331,9 @@ const webhooks = new WebhookManager({
 let webhookIngress: WebhookIngress | null = null;
 let webhookIngressError: string | null = null;
 try {
-  webhookIngress = await listenWebhookIngress(webhooks, { port: WEBHOOK_PORT });
-  console.log(`openmausbot webhook receiver on ${webhookIngress.baseUrl}`);
+  webhookIngress = await listenWebhookIngress(webhooks, { port: WEBHOOK_PORT, publicBaseUrl: WEBHOOK_PUBLIC_URL });
+  const advertised = WEBHOOK_PUBLIC_URL ? ` (advertised as ${webhookIngress.baseUrl})` : "";
+  console.log(`openmausbot webhook receiver on http://${webhookIngress.host}:${webhookIngress.port}${advertised}`);
 } catch (error) {
   webhookIngressError = error instanceof Error ? error.message : String(error);
   console.error(`openmausbot webhook receiver unavailable: ${webhookIngressError}`);

--- a/server/webhook-ingress.test.ts
+++ b/server/webhook-ingress.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { listenWebhookIngress, MAX_WEBHOOK_BODY_BYTES, webhookCredential, type WebhookIngress } from "./webhook-ingress.ts";
+import {
+  advertisedWebhookBase,
+  listenWebhookIngress,
+  MAX_WEBHOOK_BODY_BYTES,
+  webhookCredential,
+  type WebhookIngress,
+} from "./webhook-ingress.ts";
 import { WebhookManager } from "./webhooks.ts";
 
 let dir: string;
@@ -114,5 +120,29 @@ describe("webhook-only ingress", () => {
     });
     expect(oversized.status).toBe(413);
     expect(manager.listAttempts().filter((attempt) => attempt.webhookId === manager.list().find((webhook) => webhook.endpointId === endpointId)?.id && attempt.outcome === "rejected").length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("advertised base URL", () => {
+  it("hands senders the public base instead of the loopback listener", async () => {
+    const proxied = await listenWebhookIngress(manager, { port: 0, publicBaseUrl: "https://bots.example.com/" });
+    try {
+      expect(proxied.baseUrl).toBe("https://bots.example.com");
+      expect(proxied.host).toBe("127.0.0.1");
+      const credential = webhookCredential(proxied.baseUrl, endpointId, secret);
+      expect(credential.endpointUrl).toBe(`https://bots.example.com/hooks/${endpointId}`);
+      // the listener itself is still local: the public base only changes what is advertised
+      const health = await fetch(`http://127.0.0.1:${proxied.port}/health`);
+      expect(health.status).toBe(200);
+    } finally {
+      await new Promise<void>((resolve) => proxied.server.close(() => resolve()));
+    }
+  });
+
+  it("refuses a base that is not an absolute http(s) URL, naming the fix", () => {
+    for (const bad of ["bots.example.com", "ftp://bots.example.com", "", "/hooks"]) {
+      expect(() => advertisedWebhookBase(bad)).toThrow(/absolute http\(s\) URL such as https:\/\//);
+    }
+    expect(advertisedWebhookBase("http://10.0.0.5:8800///")).toBe("http://10.0.0.5:8800");
   });
 });

--- a/server/webhook-ingress.ts
+++ b/server/webhook-ingress.ts
@@ -140,11 +140,30 @@ export function createWebhookIngressHandler(manager: WebhookManager) {
   };
 }
 
+/** The base senders are told to use. Behind a proxy or tunnel the listening
+ * address is unreachable from outside, so the operator supplies the public
+ * one; a trailing slash is tolerated because every hook path adds its own. */
+export function advertisedWebhookBase(raw: string): string {
+  let parsed: URL | undefined;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    parsed = undefined;
+  }
+  if (!parsed || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) {
+    throw new Error(
+      `webhook public base URL must be an absolute http(s) URL such as https://bots.example.com, got "${raw}"`,
+    );
+  }
+  return raw.replace(/\/+$/, "");
+}
+
 export async function listenWebhookIngress(
   manager: WebhookManager,
-  options: { host?: string; port: number },
+  options: { host?: string; port: number; publicBaseUrl?: string },
 ): Promise<WebhookIngress> {
   const host = options.host ?? "127.0.0.1";
+  const advertised = options.publicBaseUrl === undefined ? undefined : advertisedWebhookBase(options.publicBaseUrl);
   const server = createServer(createWebhookIngressHandler(manager));
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error) => reject(error);
@@ -159,7 +178,12 @@ export async function listenWebhookIngress(
     server.close();
     throw new Error("Webhook receiver did not get a TCP address");
   }
-  return { server, host, port: address.data.port, baseUrl: `http://${host}:${address.data.port}` };
+  return {
+    server,
+    host,
+    port: address.data.port,
+    baseUrl: advertised ?? `http://${host}:${address.data.port}`,
+  };
 }
 
 export function webhookCredential(baseUrl: string, endpointId: string, secret: string) {


### PR DESCRIPTION
First foundation PR of the deployability track (refs #672): a self-hoster or a hosted tenant gets one container per workspace, with TLS and a login wall in front, and nothing in the server's trust model changes.

## What

- **`Dockerfile`** — multi-stage: builds the renderer and the self-contained server bundle, ships them on `node:24-bookworm-slim` as an unprivileged user with `HOME=/data` (a volume), so engine CLI logins and `~/.openmausbot` persist. `--build-arg ENGINES="@anthropic-ai/claude-code …"` bakes agent CLIs in.
- **`deploy/docker-compose.yml` + `deploy/Caddyfile`** — Caddy runs **in the server's network namespace**, so it reaches the server on `127.0.0.1` and the server never binds a public interface. Two load-bearing header rules: `Host` → `127.0.0.1:8799` (satisfies the loopback gate) and *this site's* `Origin` → `http://127.0.0.1:8799` (any other Origin passes through and is still refused, so CSRF protection survives). `/hooks/*` sits outside the login; SSE is unbuffered. `basic_auth` is the v0 login; swapping it for `forward_auth` to Authentik/oauth2-proxy needs no server change.
- **`OMB_WEBHOOK_PUBLIC_URL`** (server, ~20 lines + tests) — the webhook receiver only knew its loopback address, so behind any proxy the app printed unreachable hook URLs. The operator now supplies the advertised base; malformed values fail with a message that says what to set.
- **`docs/self-hosting.md`** — Docker quickstart, "Putting a proxy in front" (the rules any nginx/Traefik setup must follow), GHCR note.
- **`.github/workflows/docker.yml`** — build → boot → loopback-only proof (with a positive control that first shows the probe *can* see a `0.0.0.0` listener, so the check cannot be vacuous) → the full compose stack driven through TLS like a browser → publish to `ghcr.io/milind-soni/openmausbot` on pushes to `main`.

## Verified locally (Docker 29.4.3)

| check | result |
|---|---|
| image builds, boots as `maus`, `HOME=/data` | ✅ 510 MB |
| `/api/health`, `/` (UI), `/health` on 8800 inside the container | ✅ |
| server unreachable on the bridge IP (8799 + 8800), positive control reachable | ✅ |
| through Caddy: no auth 401, wrong password 401, auth 200 + UI | ✅ |
| foreign `Origin` 403, own `Origin` mapped 200 | ✅ |
| `/hooks/wh_x` reaches the receiver without login (its own 401, no `WWW-Authenticate`) | ✅ |
| HTTP → HTTPS 308, SSE `hello` frame within 4 s, API reports `baseUrl: https://…` | ✅ |
| `vitest` webhook-ingress 8/8; 3 mutations of the new code each break a test | ✅ |
| `npm run typecheck`, `npm run lint` (no new warnings) | ✅ |

The CI job runs the same checks on every PR that touches `deploy/`, and the image build on every `main` push.

## After merge

- Make the GHCR package public once (repo → Packages → openmausbot → settings), otherwise `image: ghcr.io/…` pulls need a token.
- Next PR: the `/enterprise` scaffold (license-key entitlement check + `brand.json` white-label), kept separate so this deploy change reviews on its own.

## Not in this PR

OIDC login (documented swap), the companion sidecar in compose, Remote Workspace itself (#672).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker-based self-hosting with Compose, automatic HTTPS, persistent storage, and authenticated web access.
  * Added support for configuring a public webhook URL while keeping webhook services bound to the local interface.
  * Added automated container health, security, streaming, webhook, and deployment checks.
  * Added continuous Docker image publishing for supported builds.

* **Documentation**
  * Updated self-hosting instructions with Docker setup, configuration, proxy guidance, webhook details, and upgrade steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->