### PR TITLE
feat(sidebar): fold the utility rows behind one chevron

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1727,6 +1727,47 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             onOpen={() => dispatch(phoneSettingsAction())}
           />
         )}
+          {density !== "icons" && (
+          <SidebarMoreMenu
+            items={[
+              {
+                key: "team-map",
+                label: "Team map",
+                icon: <Network size={18} />,
+                active: state.activeView === "team-map",
+                onSelect: () => dispatch({ type: "showTeamMap" }),
+              },
+              ...(skillRecorderEnabled(state.config)
+                ? [
+                    {
+                      key: "skill-recorder",
+                      label: "Teach a skill",
+                      icon: <Sparkles size={18} />,
+                      active: state.activeView === "skill-recorder",
+                      onSelect: () => dispatch({ type: "showSkillRecorder" }),
+                    },
+                  ]
+                : []),
+              {
+                key: "routines",
+                label: "Tasks & routines",
+                icon: <CalendarDays size={18} />,
+                active: state.activeView === "routines",
+                // folded away, this dot would otherwise vanish with the row
+                attention: state.routineRuns.some(
+                  (run) => ["failed", "missed"].includes(run.status) && !run.seenAt,
+                ),
+                onSelect: () => dispatch({ type: "showRoutines" }),
+              },
+              {
+                key: "plugins",
+                label: "Connected apps",
+                icon: <Puzzle size={18} />,
+                onSelect: () => dispatch({ type: "togglePlugins", open: true }),
+              },
+            ]}
+          />
+        )}
         <div className={cn("flex items-center", density === "icons" && "justify-center")}>
           <button
             onClick={() => dispatch({ type: "toggleAppSettings" })}
@@ -1743,47 +1784,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             <SidebarPhoneButton
               density={density}
               onOpen={() => dispatch(phoneSettingsAction())}
-            />
-          )}
-          {density !== "icons" && (
-            <SidebarMoreMenu
-              items={[
-                {
-                  key: "team-map",
-                  label: "Team map",
-                  icon: <Network size={18} />,
-                  active: state.activeView === "team-map",
-                  onSelect: () => dispatch({ type: "showTeamMap" }),
-                },
-                ...(skillRecorderEnabled(state.config)
-                  ? [
-                      {
-                        key: "skill-recorder",
-                        label: "Teach a skill",
-                        icon: <Sparkles size={18} />,
-                        active: state.activeView === "skill-recorder",
-                        onSelect: () => dispatch({ type: "showSkillRecorder" }),
-                      },
-                    ]
-                  : []),
-                {
-                  key: "routines",
-                  label: "Tasks & routines",
-                  icon: <CalendarDays size={18} />,
-                  active: state.activeView === "routines",
-                  // folded away, this dot would otherwise vanish with the row
-                  attention: state.routineRuns.some(
-                    (run) => ["failed", "missed"].includes(run.status) && !run.seenAt,
-                  ),
-                  onSelect: () => dispatch({ type: "showRoutines" }),
-                },
-                {
-                  key: "plugins",
-                  label: "Connected apps",
-                  icon: <Puzzle size={18} />,
-                  onSelect: () => dispatch({ type: "togglePlugins", open: true }),
-                },
-              ]}
             />
           )}
           {density !== "icons" && <UpdateButton />}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -77,6 +77,7 @@ import {
 } from "@/lib/sidebar-layout";
 import { sidebarSectionAttention } from "@/lib/sidebar-attention";
 import { phoneSettingsAction, SidebarPhoneButton } from "./SidebarPhoneButton";
+import { SidebarMoreMenu } from "./SidebarMoreMenu";
 import { SidebarSectionHeader } from "./SidebarSectionHeader";
 
 /** "Milind Soni" → "MS", "milind" → "M", "you@x.dev" → "Y", unset → "?" */
@@ -1663,59 +1664,63 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
 
       {/* Footer */}
       <div className={cn("pb-3 pt-2", density === "icons" ? "px-2" : "px-3")}>
+        {density === "icons" && (
+          <>
         <button
-          onClick={() => dispatch({ type: "showTeamMap" })}
-          aria-label={density === "icons" ? "Team map" : undefined}
-          title={density === "icons" ? "Team map" : undefined}
-          className={cn(
-            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-            state.activeView === "team-map" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-          )}
-        >
-          <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
-        </button>
-        {skillRecorderEnabled(state.config) && (
-          <button
-            onClick={() => dispatch({ type: "showSkillRecorder" })}
-            aria-label={density === "icons" ? "Teach a skill" : undefined}
-            title={density === "icons" ? "Teach a skill" : undefined}
+            onClick={() => dispatch({ type: "showTeamMap" })}
+            aria-label={density === "icons" ? "Team map" : undefined}
+            title={density === "icons" ? "Team map" : undefined}
             className={cn(
               "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
               density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-              state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+              state.activeView === "team-map" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
             )}
           >
-            <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
-            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
+            <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
+            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
           </button>
+          {skillRecorderEnabled(state.config) && (
+            <button
+              onClick={() => dispatch({ type: "showSkillRecorder" })}
+              aria-label={density === "icons" ? "Teach a skill" : undefined}
+              title={density === "icons" ? "Teach a skill" : undefined}
+              className={cn(
+                "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+                density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+                state.activeView === "skill-recorder" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+              )}
+            >
+              <Sparkles size={20} className={state.activeView === "skill-recorder" ? "text-accent" : "text-ink-secondary"} />
+              <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Teach a skill</span>
+            </button>
+          )}
+          <button
+            onClick={() => dispatch({ type: "showRoutines" })}
+            aria-label={density === "icons" ? "Calendar" : undefined}
+            title={density === "icons" ? "Calendar" : undefined}
+            className={cn(
+              "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+              density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+              state.activeView === "routines" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
+            )}
+          >
+            <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
+            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Calendar</span>
+            {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
+              <span className="size-2 rounded-full bg-danger" />
+            )}
+          </button>
+          <button
+            onClick={() => dispatch({ type: "togglePlugins", open: true })}
+            className={cn("flex min-h-10 w-full items-center rounded-xl py-2 text-left hover:bg-raised/50", density === "icons" ? "justify-center px-2" : "gap-3 px-3")}
+            aria-label={density === "icons" ? "Connected apps" : undefined}
+            title={density === "icons" ? "Connected apps" : undefined}
+          >
+            <Puzzle size={20} className="text-ink-secondary" />
+            <span className={cn("text-[14px] text-ink", density === "icons" && "hidden")}>Connected apps</span>
+          </button>
+          </>
         )}
-        <button
-          onClick={() => dispatch({ type: "showRoutines" })}
-          aria-label={density === "icons" ? "Calendar" : undefined}
-          title={density === "icons" ? "Calendar" : undefined}
-          className={cn(
-            "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
-            density === "icons" ? "justify-center px-2" : "gap-3 px-3",
-            state.activeView === "routines" ? "bg-raised text-ink" : "text-ink hover:bg-raised/50",
-          )}
-        >
-          <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
-          <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Calendar</span>
-          {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
-            <span className="size-2 rounded-full bg-danger" />
-          )}
-        </button>
-        <button
-          onClick={() => dispatch({ type: "togglePlugins", open: true })}
-          className={cn("flex min-h-10 w-full items-center rounded-xl py-2 text-left hover:bg-raised/50", density === "icons" ? "justify-center px-2" : "gap-3 px-3")}
-          aria-label={density === "icons" ? "Connected apps" : undefined}
-          title={density === "icons" ? "Connected apps" : undefined}
-        >
-          <Puzzle size={20} className="text-ink-secondary" />
-          <span className={cn("text-[14px] text-ink", density === "icons" && "hidden")}>Connected apps</span>
-        </button>
         {density === "icons" && (
           <SidebarPhoneButton
             density={density}
@@ -1738,6 +1743,47 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             <SidebarPhoneButton
               density={density}
               onOpen={() => dispatch(phoneSettingsAction())}
+            />
+          )}
+          {density !== "icons" && (
+            <SidebarMoreMenu
+              items={[
+                {
+                  key: "team-map",
+                  label: "Team map",
+                  icon: <Network size={18} />,
+                  active: state.activeView === "team-map",
+                  onSelect: () => dispatch({ type: "showTeamMap" }),
+                },
+                ...(skillRecorderEnabled(state.config)
+                  ? [
+                      {
+                        key: "skill-recorder",
+                        label: "Teach a skill",
+                        icon: <Sparkles size={18} />,
+                        active: state.activeView === "skill-recorder",
+                        onSelect: () => dispatch({ type: "showSkillRecorder" }),
+                      },
+                    ]
+                  : []),
+                {
+                  key: "routines",
+                  label: "Tasks & routines",
+                  icon: <CalendarDays size={18} />,
+                  active: state.activeView === "routines",
+                  // folded away, this dot would otherwise vanish with the row
+                  attention: state.routineRuns.some(
+                    (run) => ["failed", "missed"].includes(run.status) && !run.seenAt,
+                  ),
+                  onSelect: () => dispatch({ type: "showRoutines" }),
+                },
+                {
+                  key: "plugins",
+                  label: "Connected apps",
+                  icon: <Puzzle size={18} />,
+                  onSelect: () => dispatch({ type: "togglePlugins", open: true }),
+                },
+              ]}
             />
           )}
           {density !== "icons" && <UpdateButton />}

--- a/src/components/SidebarMoreMenu.tsx
+++ b/src/components/SidebarMoreMenu.tsx
@@ -1,0 +1,150 @@
+// The sidebar's utility rows, folded behind one chevron.
+//
+// Team map, Teach a skill, Tasks & routines and Connected apps are places you
+// visit occasionally; they were costing four permanent rows at the bottom of a
+// list whose whole job is showing bots. They now live in a menu that opens on
+// hover from a chevron beside your name.
+//
+// Hover alone would make them unreachable by keyboard and fragile with a
+// trackpad, so: hovering opens it, a click pins it, Escape and an outside
+// click close it, and the trigger is an ordinary focusable button.
+import { useEffect, useId, useRef, useState } from "react";
+import { ChevronUp } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export interface MoreMenuItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  active?: boolean;
+  /** the item wants attention (a failed routine); folded items cannot show
+   * their own dot, so the trigger carries one on their behalf */
+  attention?: boolean;
+  onSelect: () => void;
+}
+
+/** Opening is quick enough to feel like a hover, closing is slow enough to
+ * forgive a diagonal path from the chevron to the menu. */
+const OPEN_DELAY_MS = 80;
+const CLOSE_DELAY_MS = 250;
+
+export function SidebarMoreMenu({ items, compact = false }: { items: MoreMenuItem[]; compact?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const menuId = useId();
+
+  const clearTimers = () => {
+    if (openTimer.current) clearTimeout(openTimer.current);
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    openTimer.current = null;
+    closeTimer.current = null;
+  };
+  useEffect(() => clearTimers, []);
+
+  const hoverOpen = () => {
+    if (pinned) return;
+    clearTimers();
+    openTimer.current = setTimeout(() => setOpen(true), OPEN_DELAY_MS);
+  };
+  const hoverClose = () => {
+    if (pinned) return;
+    clearTimers();
+    closeTimer.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS);
+  };
+  const close = () => {
+    clearTimers();
+    setPinned(false);
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => event.key === "Escape" && close();
+    const onDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) close();
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onDown);
+    };
+  }, [open]);
+
+  const attention = items.some((item) => item.attention);
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative"
+      onPointerEnter={hoverOpen}
+      onPointerLeave={hoverClose}
+      // a keyboard user tabbing in gets the same menu a pointer gets
+      onFocus={() => setOpen(true)}
+      onBlur={(event) => {
+        if (pinned) return;
+        if (!event.relatedTarget || !rootRef.current?.contains(event.relatedTarget as Node)) setOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        aria-label="More"
+        title="More"
+        onClick={() => {
+          clearTimers();
+          if (open && pinned) close();
+          else {
+            setPinned(true);
+            setOpen(true);
+          }
+        }}
+        className={cn(
+          "relative flex items-center justify-center rounded-md text-ink-secondary hover:bg-raised hover:text-ink",
+          compact ? "size-8" : "size-10",
+          open && "bg-raised text-ink",
+        )}
+      >
+        <ChevronUp size={18} className={cn("transition-transform", open && "rotate-180")} />
+        {attention && !open && (
+          <span className="absolute right-1.5 top-1.5 size-2 rounded-full border border-panel bg-danger" />
+        )}
+      </button>
+
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="More"
+          className="animate-pop-in absolute bottom-full left-1/2 z-40 mb-1 w-[196px] -translate-x-1/2 overflow-hidden rounded-xl border border-hairline/50 bg-card py-1.5 shadow-2xl shadow-black/50"
+        >
+          {items.map((item) => (
+            <button
+              key={item.key}
+              role="menuitem"
+              onClick={() => {
+                item.onSelect();
+                close();
+              }}
+              className={cn(
+                "flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px]",
+                item.active ? "bg-raised text-ink" : "text-ink hover:bg-raised/70",
+              )}
+            >
+              <span className={cn("flex size-5 items-center justify-center", item.active ? "text-accent" : "text-ink-secondary")}>
+                {item.icon}
+              </span>
+              <span className="flex-1">{item.label}</span>
+              {item.attention && <span className="size-2 rounded-full bg-danger" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SidebarMoreMenu.tsx
+++ b/src/components/SidebarMoreMenu.tsx
@@ -2,8 +2,10 @@
 //
 // Team map, Teach a skill, Tasks & routines and Connected apps are places you
 // visit occasionally; they were costing four permanent rows at the bottom of a
-// list whose whole job is showing bots. They now live in a menu that opens on
-// hover from a chevron beside your name.
+// list whose whole job is showing bots. They now live behind a slim bar that
+// sits directly above the profile row and opens on hover — the pull-up handle
+// shape, so the arrow reads as "there is more above" rather than as a button
+// whose purpose you have to guess.
 //
 // Hover alone would make them unreachable by keyboard and fragile with a
 // trackpad, so: hovering opens it, a click pins it, Escape and an outside
@@ -105,14 +107,14 @@ export function SidebarMoreMenu({ items, compact = false }: { items: MoreMenuIte
           }
         }}
         className={cn(
-          "relative flex items-center justify-center rounded-md text-ink-secondary hover:bg-raised hover:text-ink",
-          compact ? "size-8" : "size-10",
-          open && "bg-raised text-ink",
+          "relative flex w-full items-center justify-center rounded-xl py-1.5 text-ink-secondary transition-colors hover:bg-raised hover:text-ink",
+          compact ? "py-1" : "py-1.5",
+          open ? "bg-raised text-ink" : "bg-raised/40",
         )}
       >
-        <ChevronUp size={18} className={cn("transition-transform", open && "rotate-180")} />
+        <ChevronUp size={16} className={cn("transition-transform", open && "rotate-180")} />
         {attention && !open && (
-          <span className="absolute right-1.5 top-1.5 size-2 rounded-full border border-panel bg-danger" />
+          <span className="absolute right-3 top-1/2 size-2 -translate-y-1/2 rounded-full bg-danger" />
         )}
       </button>
 
@@ -121,7 +123,7 @@ export function SidebarMoreMenu({ items, compact = false }: { items: MoreMenuIte
           id={menuId}
           role="menu"
           aria-label="More"
-          className="animate-pop-in absolute bottom-full left-1/2 z-40 mb-1 w-[196px] -translate-x-1/2 overflow-hidden rounded-xl border border-hairline/50 bg-card py-1.5 shadow-2xl shadow-black/50"
+          className="animate-pop-in absolute bottom-full left-0 right-0 z-40 mb-1 overflow-hidden rounded-xl border border-hairline/50 bg-card py-1.5 shadow-2xl shadow-black/50"
         >
           {items.map((item) => (
             <button


### PR DESCRIPTION
## What changed

Team map, Teach a skill, Tasks & routines and Connected apps are places you visit occasionally, and they were costing four permanent rows at the bottom of a list whose whole job is showing bots. They now live behind a slim bar directly above the profile row.

```
before                        after
┌─────────────────┐          ┌─────────────────┐
│ ⌗ Team map      │          │  ⌃  Team map    │   ← menu, on hover
│ ✦ Teach a skill │          │     Tasks & r…  │
│ ▦ Tasks & rou…  │          │     Connected…  │
│ ⧉ Connected a…  │          ├─────────────────┤
├─────────────────┤          │       ⌃         │   ← the handle
│ (●) You   ▯ ⚙   │          ├─────────────────┤
└─────────────────┘          │ (●) You   ▯ ⚙   │   ← unchanged
                             └─────────────────┘
```

The handle is a full-width bar with a small chevron centred on it — the pull-up shape, so it reads as "there is more above" without needing a label, and the menu opens across the same width.

Hovering opens it. Hover *alone* would leave those four destinations unreachable by keyboard and fragile with a trackpad, so it's hover plus the ordinary things: a click pins it open, Escape and an outside click close it, focus opens it, and the trigger is a real button with `aria-haspopup` / `aria-expanded`. Opening waits 80ms so a passing cursor doesn't flash it; closing waits 250ms so a diagonal path from handle to menu doesn't lose it.

## Two things that would otherwise have been quiet regressions

- **The routine dot.** Tasks & routines shows a red dot when a routine has failed or been missed. Folded away, that dot would have vanished with the row — so the handle carries it on the items' behalf, and the item keeps its own inside the menu.
- **The icon rail is untouched.** In `icons` density all four rows stay exactly as they were. That mode is already one icon per destination; hiding icons behind a hover menu inside an icon rail helps nobody.

## How it was verified

Driven in a real browser with synthetic pointer events, since this is all interaction:

- the four rows are gone from the footer, which is back to `You · phone · settings`
- hovering the handle opens the menu (`aria-expanded` false → true) with the right items
- moving the pointer away closes it after the grace period
- clicking pins it — it stays open with the pointer well away
- Escape closes it
- choosing Team map actually navigates
- in `icons` density the rail still exposes Team map / Calendar / Connected apps, and no handle is rendered

`pnpm typecheck` clean, 2804 tests pass, `oxlint` clean.

One note for whoever reviews: `server/drivers/pi-mcp-extension.test.ts` fails on a stale `node_modules` with `Cannot find package 'typebox'` — unrelated to this change, fixed by `pnpm install`.

## Screenshots

Resting state (handle above the footer) and open state (menu across the same width). (Adding the images in a follow-up comment.)

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — none; this is renderer-only
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “More” menu to the sidebar for accessing Team map, Teach a skill, Calendar, and Connected apps.
  * Utility actions now adapt to the sidebar’s display density.
  * Menu items are available through hover, click, keyboard navigation, and Escape-to-close behavior.
  * Added visual indicators for routines requiring attention.
  * Skill recording options remain available only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->