### PR TITLE
feat(enterprise): source-available layer scaffold with signed entitlement keys

### DIFF
--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -1,0 +1,28 @@
+OpenMausBot Enterprise License
+
+Copyright (c) 2026 Milind Soni. All rights reserved.
+
+This directory ("enterprise") and everything in it is NOT covered by the
+Apache License 2.0 that applies to the rest of this repository.
+
+1. Source-available. You may read, build, and evaluate this code, and you may
+   modify it for your own evaluation, so that you know exactly what runs.
+
+2. Use requires a license key. Running this code with enterprise features
+   enabled in production requires a valid, unexpired license key issued by
+   the copyright holder for your organization, under a separate agreement
+   that sets the licensed features, seats, and term.
+
+3. No redistribution. You may not redistribute, sublicense, sell, host for
+   third parties, or offer as a service this directory or any modified
+   version of it, and you may not remove or circumvent the license check.
+
+4. Everything else is open source. Delete this directory and the remainder
+   of the repository builds and runs as the open-source edition under
+   Apache 2.0, with no obligation under this license.
+
+5. No warranty. This code is provided "as is", without warranty of any kind.
+   To the extent permitted by law, the copyright holder is not liable for
+   any damages arising from its use.
+
+Questions and license keys: soni.mil2001@gmail.com

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -1,0 +1,60 @@
+# OpenMausBot Enterprise
+
+Source-available features for hosted and white-labelled deployments. This
+folder has its own [LICENSE](./LICENSE); everything outside it is Apache 2.0.
+
+**Delete this folder and you have the open-source edition.** Core only
+reaches the layer through one hook point, `server/enterprise.ts`, which
+loads `enterprise/server/index.ts` if it exists and otherwise reports the
+open-source edition. No core file imports anything from here.
+
+## How a deployment turns enterprise
+
+Set `OMB_LICENSE_KEY` on the server. The key is `omb1.<claims>.<signature>`:
+the claims are visible JSON (who it is for, which entitlements, when it
+expires), signed with an Ed25519 key whose public half is baked into
+`server/license.ts`. Verification is offline, and one build serves every
+customer, because the key decides the feature set rather than the code.
+
+`GET /api/edition` reports the outcome:
+
+```json
+{ "edition": "enterprise", "customer": "Acme", "features": ["sso", "whitelabel"], "expiresAt": "2027-09-02" }
+{ "edition": "oss", "features": [], "notice": "OMB_LICENSE_KEY expired on 2027-09-02; renew it to keep enterprise features" }
+```
+
+A missing, altered, or expired key never stops the server: it runs the
+open-source edition and the notice says what to fix.
+
+## Entitlement ids
+
+| id | grants |
+|---|---|
+| `whitelabel` | product name, logo and colours from `brand.json` (next PR) |
+| `sso` | identity-header trust behind an OIDC proxy |
+| `admin` | the admin panel routes |
+| `budgets` | per-bot and per-section spend limits |
+
+Core gates a feature with `entitled("id")` from `server/enterprise.ts`.
+Unknown ids are carried in the key but grant nothing, so keys can be issued
+ahead of a feature landing.
+
+## Issuing keys
+
+```sh
+node enterprise/scripts/issue-license.mjs keygen          # once; prints the public key to add to license.ts
+node enterprise/scripts/issue-license.mjs issue --customer "Acme" --features whitelabel,sso --expires 2027-09-02
+```
+
+The signing key lives outside the repo (default
+`~/.config/openmausbot-enterprise/signing-key.json`). Rotate by generating a
+new pair and appending its public key: keys signed by older pairs keep
+working until they expire.
+
+## What goes where
+
+- Could any open-source user want it? It goes in core, as a public PR.
+- Org-, admin- or tier-flavoured, or something the next enterprise lead
+  would be shown? It lives here, behind an entitlement.
+- Customer-specific brand, skills, packages, connectors? The customer's own
+  repo: data and config, never a fork.

--- a/enterprise/scripts/issue-license.mjs
+++ b/enterprise/scripts/issue-license.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Issue OpenMausBot enterprise license keys.
+//
+//   node enterprise/scripts/issue-license.mjs keygen [--out ~/.config/openmausbot-enterprise/signing-key.json]
+//     Creates an Ed25519 signing key (file mode 0600) and prints the public
+//     part to append to LICENSE_PUBLIC_KEYS in enterprise/server/license.ts.
+//
+//   node enterprise/scripts/issue-license.mjs issue --customer "Acme" --features whitelabel,sso \
+//        [--expires 2027-09-02] [--key <path>]
+//     Prints a key for OMB_LICENSE_KEY. Claims are visible to the customer
+//     (base64url JSON); only the signature is secret-derived.
+//
+// The private key never enters the repo, a chat, or a container image.
+import { generateKeyPairSync } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { issueLicenseKey } from "../server/license.ts";
+
+const DEFAULT_KEY_PATH = join(homedir(), ".config", "openmausbot-enterprise", "signing-key.json");
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function flags(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) fail(`unexpected argument "${arg}"`);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) fail(`--${arg.slice(2)} needs a value`);
+    out[arg.slice(2)] = value;
+    i += 1;
+  }
+  return out;
+}
+
+const [command, ...rest] = process.argv.slice(2);
+const opts = flags(rest);
+
+if (command === "keygen") {
+  const out = opts.out ?? DEFAULT_KEY_PATH;
+  if (existsSync(out)) fail(`${out} already exists; move it away first (a lost key means reissuing every customer)`);
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, JSON.stringify(privateKey.export({ format: "jwk" }), null, 2) + "\n");
+  chmodSync(out, 0o600);
+  console.log(`signing key written to ${out} (keep it out of the repo; back it up)`);
+  console.log(`append this to LICENSE_PUBLIC_KEYS in enterprise/server/license.ts:\n  "${publicKey.export({ format: "jwk" }).x}",`);
+} else if (command === "issue") {
+  const keyPath = opts.key ?? DEFAULT_KEY_PATH;
+  if (!existsSync(keyPath)) fail(`no signing key at ${keyPath}; run "keygen" first or pass --key`);
+  if (!opts.customer) fail("--customer is required (who the license is for)");
+  if (!opts.features) fail("--features is required (comma-separated entitlement ids, e.g. whitelabel,sso)");
+  const privateJwk = JSON.parse(readFileSync(keyPath, "utf8"));
+  const key = issueLicenseKey(
+    {
+      v: 1,
+      customer: opts.customer,
+      features: opts.features.split(",").map((f) => f.trim()).filter(Boolean),
+      issued: new Date().toISOString().slice(0, 10),
+      expires: opts.expires ?? null,
+    },
+    privateJwk,
+  );
+  console.log(key);
+} else {
+  fail('usage: issue-license.mjs keygen [--out path] | issue --customer "Name" --features a,b [--expires YYYY-MM-DD] [--key path]');
+}

--- a/enterprise/scripts/issue-license.mjs
+++ b/enterprise/scripts/issue-license.mjs
@@ -12,7 +12,7 @@
 //
 // The private key never enters the repo, a chat, or a container image.
 import { generateKeyPairSync } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -45,9 +45,9 @@ if (command === "keygen") {
   const out = opts.out ?? DEFAULT_KEY_PATH;
   if (existsSync(out)) fail(`${out} already exists; move it away first (a lost key means reissuing every customer)`);
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
-  mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, JSON.stringify(privateKey.export({ format: "jwk" }), null, 2) + "\n");
-  chmodSync(out, 0o600);
+  mkdirSync(dirname(out), { recursive: true, mode: 0o700 });
+  // created owner-only in one step: no window where a 0666 file holds the key
+  writeFileSync(out, JSON.stringify(privateKey.export({ format: "jwk" }), null, 2) + "\n", { mode: 0o600, flag: "wx" });
   console.log(`signing key written to ${out} (keep it out of the repo; back it up)`);
   console.log(`append this to LICENSE_PUBLIC_KEYS in enterprise/server/license.ts:\n  "${publicKey.export({ format: "jwk" }).x}",`);
 } else if (command === "issue") {

--- a/enterprise/server/index.ts
+++ b/enterprise/server/index.ts
@@ -1,0 +1,16 @@
+// Entry point core loads when this folder exists (see server/enterprise.ts).
+// Turn the configured license key into entitlements, or throw a message that
+// tells the operator what to fix; core degrades to the open-source edition.
+import { verifyLicenseKey } from "./license.ts";
+
+export interface RegisteredLayer {
+  customer: string;
+  features: string[];
+  expiresAt: string | null;
+}
+
+export function register(options: { licenseKey: string | undefined }): RegisteredLayer | null {
+  if (!options.licenseKey) return null;
+  const claims = verifyLicenseKey(options.licenseKey);
+  return { customer: claims.customer, features: claims.features, expiresAt: claims.expires };
+}

--- a/enterprise/server/license.test.ts
+++ b/enterprise/server/license.test.ts
@@ -1,0 +1,65 @@
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { register } from "./index.ts";
+import { issueLicenseKey, verifyLicenseKey, type LicenseClaims } from "./license.ts";
+
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const pub = publicKey.export({ format: "jwk" });
+  return { x: String(pub.x), privateJwk: privateKey.export({ format: "jwk" }) };
+}
+
+const claims: LicenseClaims = {
+  v: 1,
+  customer: "Reliable Back Office",
+  features: ["whitelabel", "sso"],
+  issued: "2026-09-02",
+  expires: "2027-09-02",
+};
+
+describe("license keys", () => {
+  it("round-trips claims through a signed key", () => {
+    const { x, privateJwk } = keypair();
+    const key = issueLicenseKey(claims, privateJwk);
+    expect(key.startsWith("omb1.")).toBe(true);
+    expect(verifyLicenseKey(key, { publicKeys: [x], now: new Date("2026-12-01") })).toEqual(claims);
+  });
+
+  it("accepts a key signed by any listed public key, so rotation is append-only", () => {
+    const old = keypair();
+    const fresh = keypair();
+    const key = issueLicenseKey(claims, old.privateJwk);
+    expect(() => verifyLicenseKey(key, { publicKeys: [fresh.x], now: new Date("2026-12-01") })).toThrow(/does not match any OpenMausBot signing key/);
+    expect(verifyLicenseKey(key, { publicKeys: [fresh.x, old.x], now: new Date("2026-12-01") }).customer).toBe(claims.customer);
+  });
+
+  it("refuses altered claims: the signature covers exactly what is granted", () => {
+    const { x, privateJwk } = keypair();
+    const key = issueLicenseKey(claims, privateJwk);
+    const [prefix, , signature] = key.split(".");
+    const upgraded = Buffer.from(JSON.stringify({ ...claims, features: ["whitelabel", "sso", "budgets"] })).toString("base64url");
+    expect(() => verifyLicenseKey(`${prefix}.${upgraded}.${signature}`, { publicKeys: [x] })).toThrow(/altered/);
+  });
+
+  it("explains malformed keys and expiry in operator terms", () => {
+    const { x, privateJwk } = keypair();
+    expect(() => verifyLicenseKey("not-a-key", { publicKeys: [x] })).toThrow(/expected "omb1\.<claims>\.<signature>"/);
+    expect(() => verifyLicenseKey("omb1..", { publicKeys: [x] })).toThrow(/expected "omb1/);
+    const key = issueLicenseKey(claims, privateJwk);
+    expect(() => verifyLicenseKey(key, { publicKeys: [x], now: new Date("2027-09-02") })).toThrow(/expired on 2027-09-02; renew it/);
+    const perpetual = issueLicenseKey({ ...claims, expires: null }, privateJwk);
+    expect(verifyLicenseKey(perpetual, { publicKeys: [x], now: new Date("2099-01-01") }).expires).toBeNull();
+  });
+
+  it("refuses to issue claims that would not verify", () => {
+    const { privateJwk } = keypair();
+    // SAFETY: deliberately wrong shape to exercise the issuer's own validation
+    expect(() => issueLicenseKey({ ...claims, features: [] as string[], customer: "" }, privateJwk)).toThrow();
+  });
+
+  it("register() turns a key into the layer contract and passes verification errors through", () => {
+    expect(register({ licenseKey: undefined })).toBeNull();
+    expect(() => register({ licenseKey: "omb1.bad.key" })).toThrow(/OMB_LICENSE_KEY/);
+  });
+});

--- a/enterprise/server/license.test.ts
+++ b/enterprise/server/license.test.ts
@@ -52,6 +52,15 @@ describe("license keys", () => {
     expect(verifyLicenseKey(perpetual, { publicKeys: [x], now: new Date("2099-01-01") }).expires).toBeNull();
   });
 
+  it("refuses dates that are not YYYY-MM-DD on both sides", () => {
+    const { x, privateJwk } = keypair();
+    expect(() => issueLicenseKey({ ...claims, expires: "not-a-date" }, privateJwk)).toThrow(/expires must be a YYYY-MM-DD date/);
+    expect(() => issueLicenseKey({ ...claims, issued: "2026-9-2" }, privateJwk)).toThrow(/issued must be a YYYY-MM-DD date/);
+    const forged = Buffer.from(JSON.stringify({ ...claims, expires: "someday" })).toString("base64url");
+    const [prefix, , signature] = issueLicenseKey(claims, privateJwk).split(".");
+    expect(() => verifyLicenseKey(`${prefix}.${forged}.${signature}`, { publicKeys: [x] })).toThrow(/altered/);
+  });
+
   it("refuses to issue claims that would not verify", () => {
     const { privateJwk } = keypair();
     // SAFETY: deliberately wrong shape to exercise the issuer's own validation

--- a/enterprise/server/license.ts
+++ b/enterprise/server/license.ts
@@ -1,0 +1,85 @@
+// License keys: signed entitlement claims.
+//
+// A key is `omb1.<claims>.<signature>`: base64url JSON claims, Ed25519-signed
+// by an OpenMausBot signing key. The public keys are baked in below, so one
+// build serves every customer — the key, not the code, decides the feature
+// set. Verification is offline; nothing phones home.
+import { createPrivateKey, createPublicKey, sign, verify, type JsonWebKeyInput } from "node:crypto";
+import { z } from "zod";
+
+/** Ed25519 public keys (JWK `x`), oldest first. Rotate by appending; never edit or remove
+ * an entry while a key signed with it is still in the field. The matching private keys are
+ * generated with scripts/issue-license.mjs and stay outside the repo. */
+export const LICENSE_PUBLIC_KEYS: readonly string[] = [
+  "6CHdwwJzxKJFimRkC79eQ5FR__bX2WaU2BBGNGPQTQU",
+];
+
+export const claimsSchema = z.object({
+  v: z.literal(1),
+  /** Who the license was issued to; shown in the UI and the startup log. */
+  customer: z.string().min(1),
+  /** Entitlement ids, e.g. whitelabel, sso, admin, budgets. Unknown ids are carried, not rejected. */
+  features: z.array(z.string().min(1)),
+  /** ISO date the key was issued. */
+  issued: z.string().min(1),
+  /** ISO date the key stops working, or null for perpetual. */
+  expires: z.string().nullable(),
+});
+
+export type LicenseClaims = z.infer<typeof claimsSchema>;
+
+const PREFIX = "omb1";
+
+function publicKeyFromX(x: string) {
+  return createPublicKey({ key: { kty: "OKP", crv: "Ed25519", x }, format: "jwk" });
+}
+
+/** Verify a key and return its claims. Every failure names what to do next. */
+export function verifyLicenseKey(
+  key: string,
+  options: { publicKeys?: readonly string[]; now?: Date } = {},
+): LicenseClaims {
+  const parts = key.trim().split(".");
+  if (parts.length !== 3 || parts[0] !== PREFIX || !parts[1] || !parts[2]) {
+    throw new Error(`OMB_LICENSE_KEY is not an OpenMausBot license key (expected "${PREFIX}.<claims>.<signature>")`);
+  }
+  const [, claimsPart, signaturePart] = parts;
+  const signature = Buffer.from(signaturePart, "base64url");
+  const signed = Buffer.from(claimsPart, "utf8");
+  const trusted = (options.publicKeys ?? LICENSE_PUBLIC_KEYS).some((x) =>
+    verify(null, signed, publicKeyFromX(x), signature),
+  );
+  if (!trusted) {
+    throw new Error(
+      "OMB_LICENSE_KEY signature does not match any OpenMausBot signing key: the key was altered, or it was issued for a different build",
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(claimsPart, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("OMB_LICENSE_KEY claims are not JSON; ask for the key to be reissued");
+  }
+  const result = claimsSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`OMB_LICENSE_KEY claims are malformed (${result.error.issues[0]?.message ?? "invalid"}); ask for the key to be reissued`);
+  }
+  const claims = result.data;
+  if (claims.expires !== null) {
+    const expires = new Date(claims.expires);
+    if (Number.isNaN(expires.getTime())) {
+      throw new Error(`OMB_LICENSE_KEY has an unreadable expiry "${claims.expires}"; ask for the key to be reissued`);
+    }
+    if ((options.now ?? new Date()) >= expires) {
+      throw new Error(`OMB_LICENSE_KEY expired on ${claims.expires}; renew it to keep enterprise features`);
+    }
+  }
+  return claims;
+}
+
+/** Issue a key. Used by scripts/issue-license.mjs and by tests; the private JWK never enters the repo. */
+export function issueLicenseKey(claims: LicenseClaims, privateJwk: JsonWebKeyInput["key"]): string {
+  const claimsPart = Buffer.from(JSON.stringify(claimsSchema.parse(claims)), "utf8").toString("base64url");
+  const signature = sign(null, Buffer.from(claimsPart, "utf8"), createPrivateKey({ key: privateJwk, format: "jwk" }));
+  return `${PREFIX}.${claimsPart}.${signature.toString("base64url")}`;
+}

--- a/enterprise/server/license.ts
+++ b/enterprise/server/license.ts
@@ -20,10 +20,10 @@ export const claimsSchema = z.object({
   customer: z.string().min(1),
   /** Entitlement ids, e.g. whitelabel, sso, admin, budgets. Unknown ids are carried, not rejected. */
   features: z.array(z.string().min(1)),
-  /** ISO date the key was issued. */
-  issued: z.string().min(1),
-  /** ISO date the key stops working, or null for perpetual. */
-  expires: z.string().nullable(),
+  /** ISO date (YYYY-MM-DD) the key was issued. */
+  issued: z.iso.date("issued must be a YYYY-MM-DD date"),
+  /** ISO date (YYYY-MM-DD) the key stops working, or null for perpetual. */
+  expires: z.iso.date("expires must be a YYYY-MM-DD date").nullable(),
 });
 
 export type LicenseClaims = z.infer<typeof claimsSchema>;
@@ -67,9 +67,6 @@ export function verifyLicenseKey(
   const claims = result.data;
   if (claims.expires !== null) {
     const expires = new Date(claims.expires);
-    if (Number.isNaN(expires.getTime())) {
-      throw new Error(`OMB_LICENSE_KEY has an unreadable expiry "${claims.expires}"; ask for the key to be reissued`);
-    }
     if ((options.now ?? new Date()) >= expires) {
       throw new Error(`OMB_LICENSE_KEY expired on ${claims.expires}; renew it to keep enterprise features`);
     }

--- a/server/enterprise.test.ts
+++ b/server/enterprise.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { describeEdition, editionStatus, entitled, loadEnterpriseLayer } from "./enterprise.ts";
+
+const dirs: string[] = [];
+
+/** A stand-in enterprise layer: the folder shape core looks for, with the given register(). */
+function fakeLayer(registerSource: string, file = "index.ts"): string {
+  const dir = mkdtempSync(join(tmpdir(), "omb-enterprise-"));
+  mkdirSync(join(dir, "server"));
+  writeFileSync(join(dir, "server", file), registerSource);
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await loadEnterpriseLayer({ dir: join(tmpdir(), "omb-enterprise-absent"), licenseKey: undefined });
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("enterprise hook point", () => {
+  it("is the open-source edition when the folder is absent, and says so if a key was set anyway", async () => {
+    const absent = join(tmpdir(), "omb-enterprise-absent");
+    expect(await loadEnterpriseLayer({ dir: absent, licenseKey: undefined })).toEqual({ edition: "oss", features: [] });
+    const status = await loadEnterpriseLayer({ dir: absent, licenseKey: "omb1.x.y" });
+    expect(status.edition).toBe("oss");
+    expect(status.notice).toContain("OMB_LICENSE_KEY is set but no enterprise layer exists");
+    expect(entitled("whitelabel")).toBe(false);
+    expect(describeEdition(status)).toContain("open-source edition (OMB_LICENSE_KEY is set");
+  });
+
+  it("registers the layer's entitlements from the key", async () => {
+    const dir = fakeLayer(`export async function register({ licenseKey }) {
+      if (licenseKey !== "good") throw new Error("bad key");
+      return { customer: "Acme", features: ["sso", "whitelabel", "sso"], expiresAt: "2027-01-01" };
+    }`);
+    const status = await loadEnterpriseLayer({ dir, licenseKey: "good" });
+    expect(status).toEqual({ edition: "enterprise", customer: "Acme", features: ["sso", "whitelabel"], expiresAt: "2027-01-01" });
+    expect(editionStatus()).toEqual(status);
+    expect(entitled("whitelabel")).toBe(true);
+    expect(entitled("budgets")).toBe(false);
+    expect(describeEdition(status)).toBe("openmausbot enterprise edition for Acme until 2027-01-01: sso, whitelabel");
+  });
+
+  it("loads a compiled layer (server/index.js) the way an image ships it", async () => {
+    const dir = fakeLayer(`export function register() { return { customer: "Built", features: ["admin"], expiresAt: null }; }`, "index.js");
+    const status = await loadEnterpriseLayer({ dir, licenseKey: "k" });
+    expect(status).toEqual({ edition: "enterprise", customer: "Built", features: ["admin"], expiresAt: null });
+    expect(describeEdition(status)).toBe("openmausbot enterprise edition for Built: admin");
+  });
+
+  it("degrades to open-source with the layer's own message when the key is refused", async () => {
+    const dir = fakeLayer(`export function register() { throw new Error("license expired on 2025-01-01"); }`);
+    const status = await loadEnterpriseLayer({ dir, licenseKey: "stale" });
+    expect(status.edition).toBe("oss");
+    expect(status.notice).toBe("enterprise layer disabled: license expired on 2025-01-01");
+    expect(entitled("sso")).toBe(false);
+  });
+
+  it("tells the operator when the layer is present but no key is configured", async () => {
+    const dir = fakeLayer(`export function register() { return { customer: "x", features: [], expiresAt: null }; }`);
+    const status = await loadEnterpriseLayer({ dir, licenseKey: undefined });
+    expect(status).toEqual({ edition: "oss", features: [], notice: "enterprise layer present but OMB_LICENSE_KEY is not set" });
+  });
+
+  it("refuses a layer that does not honour the contract", async () => {
+    const noRegister = fakeLayer(`export const version = 1;`);
+    expect((await loadEnterpriseLayer({ dir: noRegister, licenseKey: "k" })).notice).toContain("does not export register()");
+    const badShape = fakeLayer(`export function register() { return { customer: "", features: "all" }; }`);
+    const status = await loadEnterpriseLayer({ dir: badShape, licenseKey: "k" });
+    expect(status.edition).toBe("oss");
+    expect(status.notice).toContain("enterprise layer disabled:");
+    expect(entitled("all")).toBe(false);
+  });
+});

--- a/server/enterprise.test.ts
+++ b/server/enterprise.test.ts
@@ -52,6 +52,19 @@ describe("enterprise hook point", () => {
     expect(describeEdition(status)).toBe("openmausbot enterprise edition for Built: admin");
   });
 
+  it("stops granting features the moment the license expires, without a restart", async () => {
+    const dir = fakeLayer(`export function register() { return { customer: "Acme", features: ["sso"], expiresAt: "2027-01-01" }; }`);
+    await loadEnterpriseLayer({ dir, licenseKey: "k" });
+    const before = new Date("2026-12-31T23:59:59Z").getTime();
+    const after = new Date("2027-01-01T00:00:00Z").getTime();
+    expect(entitled("sso", before)).toBe(true);
+    expect(entitled("sso", after)).toBe(false);
+    expect(editionStatus(before).edition).toBe("enterprise");
+    const lapsed = editionStatus(after);
+    expect(lapsed.edition).toBe("oss");
+    expect(lapsed.notice).toMatch(/expired on 2027-01-01; renew it/);
+  });
+
   it("degrades to open-source with the layer's own message when the key is refused", async () => {
     const dir = fakeLayer(`export function register() { throw new Error("license expired on 2025-01-01"); }`);
     const status = await loadEnterpriseLayer({ dir, licenseKey: "stale" });

--- a/server/enterprise.ts
+++ b/server/enterprise.ts
@@ -74,14 +74,26 @@ export async function loadEnterpriseLayer(
   }
 }
 
-export function editionStatus(): EditionStatus {
-  return current;
+/** A license that expires while the server keeps running stops granting
+ * features at that moment, not at the next restart. */
+function expired(now: number): boolean {
+  if (current.edition !== "enterprise" || !current.expiresAt) return false;
+  return now >= new Date(current.expiresAt).getTime();
+}
+
+export function editionStatus(now: number = Date.now()): EditionStatus {
+  if (!expired(now)) return current;
+  return {
+    edition: "oss",
+    features: [],
+    notice: `enterprise layer disabled: OMB_LICENSE_KEY expired on ${current.expiresAt}; renew it to keep enterprise features`,
+  };
 }
 
 /** Feature gates in core ask this and nothing else. Unknown ids are simply not
  * granted, and the open-source edition always carries an empty feature list. */
-export function entitled(feature: string): boolean {
-  return current.features.includes(feature);
+export function entitled(feature: string, now: number = Date.now()): boolean {
+  return !expired(now) && current.features.includes(feature);
 }
 
 /** One line for the startup log. */

--- a/server/enterprise.ts
+++ b/server/enterprise.ts
@@ -1,0 +1,94 @@
+// Neutral hook point for the source-available enterprise layer.
+//
+// The layer lives in ../enterprise (its own LICENSE) and is loaded only if that
+// folder is present: delete it and this file still compiles, the server still
+// starts, and /api/edition reports the open-source edition. Core never imports
+// the layer statically, so the bundle and the packaged app carry no trace of it.
+// The layer's only obligation is `register()`, which turns OMB_LICENSE_KEY into
+// entitlements; core keeps the resulting status and answers `entitled()`.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { z } from "zod";
+
+import { SERVER_ROOT } from "./proxy-paths.ts";
+
+export interface EditionStatus {
+  edition: "oss" | "enterprise";
+  /** Enterprise only: who the license was issued to. */
+  customer?: string;
+  /** Entitlement ids the license grants (sorted). Empty for the open-source edition. */
+  features: string[];
+  /** Enterprise only: ISO date the license stops working, null for perpetual. */
+  expiresAt?: string | null;
+  /** Why the server is not running the enterprise edition although something hinted it should. */
+  notice?: string;
+}
+
+/** What the enterprise layer's register() must return; validated because it is external code. */
+const layerSchema = z.object({
+  customer: z.string().min(1),
+  features: z.array(z.string().min(1)),
+  expiresAt: z.string().nullable(),
+});
+
+const DEFAULT_DIR = join(SERVER_ROOT, "..", "enterprise");
+
+let current: EditionStatus = { edition: "oss", features: [] };
+
+function oss(notice?: string): EditionStatus {
+  current = notice ? { edition: "oss", features: [], notice } : { edition: "oss", features: [] };
+  return current;
+}
+
+/** Resolve the edition once at startup. Never throws: a broken layer or key
+ * degrades to the open-source edition with a notice that says what to fix. */
+export async function loadEnterpriseLayer(
+  options: { dir?: string; licenseKey?: string } = {},
+): Promise<EditionStatus> {
+  const dir = options.dir ?? process.env.OMB_ENTERPRISE_DIR ?? DEFAULT_DIR;
+  const licenseKey = options.licenseKey ?? process.env.OMB_LICENSE_KEY;
+  // Source in a checkout, a compiled bundle in an image: same convention as proxy-paths.ts.
+  const entry = [join(dir, "server", "index.ts"), join(dir, "server", "index.js")].find((candidate) => existsSync(candidate));
+  if (!entry) {
+    return oss(
+      licenseKey ? `OMB_LICENSE_KEY is set but no enterprise layer exists at ${dir}` : undefined,
+    );
+  }
+  try {
+    const loaded: unknown = await import(pathToFileURL(entry).href);
+    const register: unknown = Reflect.get(Object(loaded), "register");
+    if (typeof register !== "function") throw new Error(`${entry} does not export register()`);
+    if (!licenseKey) return oss("enterprise layer present but OMB_LICENSE_KEY is not set");
+    const registered: unknown = await register({ licenseKey });
+    const layer = layerSchema.parse(registered);
+    current = {
+      edition: "enterprise",
+      customer: layer.customer,
+      features: [...new Set(layer.features)].sort(),
+      expiresAt: layer.expiresAt,
+    };
+    return current;
+  } catch (error) {
+    return oss(`enterprise layer disabled: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export function editionStatus(): EditionStatus {
+  return current;
+}
+
+/** Feature gates in core ask this and nothing else. Unknown ids are simply not
+ * granted, and the open-source edition always carries an empty feature list. */
+export function entitled(feature: string): boolean {
+  return current.features.includes(feature);
+}
+
+/** One line for the startup log. */
+export function describeEdition(status: EditionStatus): string {
+  if (status.edition === "enterprise") {
+    const until = status.expiresAt ? ` until ${status.expiresAt}` : "";
+    return `openmausbot enterprise edition for ${status.customer}${until}: ${status.features.join(", ") || "no features"}`;
+  }
+  return `openmausbot open-source edition${status.notice ? ` (${status.notice})` : ""}`;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -237,6 +237,7 @@ import {
   isTurnEventQuarantined,
 } from "./turn-dispatch-guard.ts";
 import { createGracefulShutdown } from "./graceful-shutdown.ts";
+import { describeEdition, editionStatus, loadEnterpriseLayer } from "./enterprise.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
@@ -8029,6 +8030,10 @@ const server = createServer(async (req, res) => {
     if (method === "GET" && path === "/api/health") {
       return json(res, 200, { app: "openmausbot", pid: process.pid, static: Boolean(STATIC_DIR) });
     }
+    // Which edition this server runs and why (see server/enterprise.ts). Read-only.
+    if (method === "GET" && path === "/api/edition") {
+      return json(res, 200, editionStatus());
+    }
 
     // ── inspector: a thread's runtime events + native protocol tee ──
     // Both logs already exist on disk; this only reads them back. Threads
@@ -8705,6 +8710,9 @@ const server = createServer(async (req, res) => {
 });
 
 calendarCalls.start();
+
+// Resolve the edition before accepting requests so /api/edition is never a guess.
+console.log(describeEdition(await loadEnterpriseLayer()));
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -20,7 +20,8 @@
   },
   "include": [
     "server",
-    "companion"
+    "companion",
+    "enterprise"
   ],
   "exclude": [
     "server/drivers/pi-mcp-extension.ts"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "electron/**/*.test.mjs",
       "src/**/*.test.ts",
       "companion/**/*.test.ts",
+      "enterprise/**/*.test.ts",
       "scripts/**/*.test.mjs",
     ],
     setupFiles: ["server/testing/setup.ts"],


### PR DESCRIPTION
Second foundation PR of the enterprise plan: the commercial repo structure (Track D), landed before any paid feature so every later one has a place to go and a gate to sit behind.

## The shape

One public repo, two editions:

- **Core (Apache 2.0)** reaches the layer through exactly one neutral hook point, `server/enterprise.ts`. It loads `enterprise/server/index.{ts,js}` **only if that folder exists**, validates what its `register()` returns, and keeps the result. Delete the folder and the server, the bundle, the tests and the packaged app are unchanged: the open-source edition.
- **`/enterprise` (own LICENSE, source-available)** turns `OMB_LICENSE_KEY` into entitlements. Keys are `omb1.<claims>.<signature>`: visible JSON claims (`customer`, `features`, `issued`, `expires`) signed with Ed25519. Public keys are baked in and append-only, so rotation never breaks keys in the field; verification is offline, nothing phones home. One build serves every customer because **the key decides the feature set, not the code**.

Core gates a feature with `entitled("id")` and nothing else. `GET /api/edition` says which edition is running and, when it is not enterprise although something hinted it should be, exactly why:

```json
{ "edition": "enterprise", "customer": "Reliable Back Office", "features": ["sso", "whitelabel"], "expiresAt": "2027-09-02" }
{ "edition": "oss", "features": [], "notice": "enterprise layer disabled: OMB_LICENSE_KEY expired on 2027-09-02; renew it to keep enterprise features" }
```

A missing, altered, malformed or expired key never stops the server.

## Issuing keys

```sh
node enterprise/scripts/issue-license.mjs keygen      # once: 0600 file outside the repo, prints the public key for license.ts
node enterprise/scripts/issue-license.mjs issue --customer "Acme" --features whitelabel,sso --expires 2027-09-02
```

The first signing key is generated and its public half is embedded in this PR; the private key is on Milind's laptop at `~/.config/openmausbot-enterprise/signing-key.json` (back it up: losing it means reissuing every customer).

## Verified

| check | result |
|---|---|
| `vitest` server/enterprise + enterprise/server/license | ✅ 12/12 |
| mutations: skip signature, skip expiry, no dedupe, drop absent-notice | ✅ each breaks tests |
| real server booted 5 ways (valid key / no key / folder absent / tampered key / absent+key) → `/api/edition` + startup line | ✅ all as designed |
| `npm run typecheck`, `npm run lint` | ✅ |
| `build:server` bundle contains the hook only, zero license code; packaged-server smoke | ✅ |

## Not in this PR

- `brand.json` white-label behind `whitelabel` (next PR, the first real entitlement).
- The enterprise image variant (needs #677 merged first: a build arg that bundles `enterprise/server` to `index.js`, which the hook already accepts).
- SSO header trust, admin routes, budgets: each lands behind its id when its track comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enterprise editions with signed license keys and feature entitlements.
  * Added an edition status endpoint showing the active edition, customer, enabled features, and expiry.
  * Added offline license validation with key rotation and optional expiration dates.
  * Added a command-line tool for generating signing keys and issuing licenses.
* **Bug Fixes**
  * Invalid, missing, altered, or expired licenses now safely fall back to the open-source edition with a notice.
* **Documentation**
  * Added enterprise licensing, deployment, entitlement, and license-issuance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->