### PR TITLE
feat(engines): update Claude Code in app

### DIFF
--- a/server/claude-update.test.ts
+++ b/server/claude-update.test.ts
@@ -1,0 +1,48 @@
+import type { ExecFileOptions } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import { updateClaudeCli } from "./claude-update.ts";
+
+type Callback = (error: Error | null, stdout: string, stderr?: string) => void;
+
+describe("updateClaudeCli", () => {
+  it("runs the official updater before verifying the installed version", async () => {
+    const calls: Array<{ cli: string; args: string[]; options: ExecFileOptions }> = [];
+    const execute = (cli: string, args: string[], options: ExecFileOptions, callback: Callback) => {
+      calls.push({ cli, args, options });
+      callback(null, args[0] === "--version" ? "2.1.257 (Claude Code)\n" : "updated\n");
+    };
+
+    await expect(updateClaudeCli("/opt/claude", { PATH: "/bin" }, execute)).resolves.toEqual({
+      version: "2.1.257 (Claude Code)",
+    });
+    expect(calls.map((call) => call.args)).toEqual([["update"], ["--version"]]);
+    expect(calls[0].options).toMatchObject({ timeout: 180_000, killSignal: "SIGKILL" });
+    expect(calls[0].options.env).toEqual({ PATH: "/bin" });
+  });
+
+  it("does not probe the version after a failed update and gives a manual fallback", async () => {
+    let calls = 0;
+    const execute = (_cli: string, _args: string[], _options: ExecFileOptions, callback: Callback) => {
+      calls += 1;
+      const error = Object.assign(new Error("exit 1"), { code: 1, stderr: "permission denied by updater\nmore" });
+      callback(error, "", "permission denied by updater");
+    };
+
+    await expect(updateClaudeCli("claude", {}, execute)).rejects.toThrow(
+      "Claude update failed: permission denied by updater. Run `claude update` in Terminal",
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("reports when the update finishes but version verification fails", async () => {
+    const execute = (_cli: string, args: string[], _options: ExecFileOptions, callback: Callback) => {
+      if (args[0] === "update") callback(null, "updated");
+      else callback(Object.assign(new Error("spawn failed"), { code: "ENOENT" }), "");
+    };
+
+    await expect(updateClaudeCli("claude", {}, execute)).rejects.toThrow(
+      "Claude finished updating, but OpenMausBot could not verify",
+    );
+  });
+});

--- a/server/claude-update.ts
+++ b/server/claude-update.ts
@@ -1,0 +1,90 @@
+import type { ExecFileOptions } from "node:child_process";
+
+import { describeSpawnFailure, execCli } from "./procs.ts";
+
+type ExecCli = (
+  cli: string,
+  args: string[],
+  options: ExecFileOptions,
+  callback: (error: Error | null, stdout: string, stderr?: string) => void,
+) => void;
+
+const FALLBACK = "Run `claude update` in Terminal, then refresh Engines.";
+
+function stderrOf(error: unknown): string {
+  const stderr = (error as { stderr?: unknown }).stderr;
+  return typeof stderr === "string"
+    ? stderr
+    : Buffer.isBuffer(stderr)
+      ? stderr.toString("utf8")
+      : "";
+}
+
+function run(
+  execute: ExecCli,
+  cli: string,
+  args: string[],
+  options: ExecFileOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execute(cli, args, options, (error, stdout, stderr) => {
+      if (error) {
+        if ((error as { stderr?: unknown }).stderr === undefined && stderr) {
+          Object.assign(error, { stderr });
+        }
+        reject(error);
+      }
+      else resolve(stdout);
+    });
+  });
+}
+
+function updateFailure(error: unknown, cli: string): Error {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const processError = err as NodeJS.ErrnoException & { killed?: boolean };
+  if (processError.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+    return new Error(`Claude update produced too much output. ${FALLBACK}`);
+  }
+  if (typeof processError.code === "string") {
+    return new Error(`${describeSpawnFailure(processError, cli).message}. ${FALLBACK}`);
+  }
+  if (processError.killed) {
+    return new Error(`Claude update timed out after 3 minutes. ${FALLBACK}`);
+  }
+  const detail = (stderrOf(err).trim() || err.message).split("\n")[0].slice(0, 400);
+  return new Error(`Claude update failed${detail ? `: ${detail}` : ""}. ${FALLBACK}`);
+}
+
+/** Run Claude Code's own updater, then prove which version is now installed.
+ * The caller owns the environment so credentials can be stripped before the
+ * executable (including a configured wrapper) is launched. */
+export async function updateClaudeCli(
+  cli: string,
+  env: NodeJS.ProcessEnv,
+  execute: ExecCli = execCli,
+): Promise<{ version: string }> {
+  try {
+    await run(execute, cli, ["update"], {
+      env,
+      timeout: 180_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 1024 * 1024,
+    });
+  } catch (error) {
+    throw updateFailure(error, cli);
+  }
+
+  try {
+    const stdout = await run(execute, cli, ["--version"], {
+      env,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 64 * 1024,
+    });
+    const version = stdout.trim().split("\n")[0];
+    if (!version) throw new Error("Claude returned an empty version");
+    return { version };
+  } catch {
+    throw new Error("Claude finished updating, but OpenMausBot could not verify the installed version. Refresh Engines to check it.");
+  }
+}

--- a/server/harness/registry.test.ts
+++ b/server/harness/registry.test.ts
@@ -49,6 +49,20 @@ describe("ProviderRegistry", () => {
     expect(described.untouched.access).toBe("subscription");
   });
 
+  it("resolves maintenance commands to the configured CLI or driver default", async () => {
+    const fake = makeFakeDriver();
+    fake.driver.defaultConfig = () => ({ cli: "fakebin" });
+    const registry = new ProviderRegistry([fake.driver]);
+    await registry.load({
+      defaulted: { driver: "fake" },
+      overridden: { driver: "fake", config: { cli: "/opt/fake/custom-bin" } },
+    });
+
+    expect(registry.cliTarget("defaulted")).toEqual({ driverKind: "fake", cli: "fakebin" });
+    expect(registry.cliTarget("overridden")).toEqual({ driverKind: "fake", cli: "/opt/fake/custom-bin" });
+    expect(registry.cliTarget("missing")).toBeNull();
+  });
+
   it("publishes custom-only access from driver metadata", async () => {
     const fake = makeFakeDriver();
     Object.assign(fake.driver.metadata, { access: "custom" });
@@ -68,6 +82,7 @@ describe("ProviderRegistry", () => {
     expect(described.snapshot.reason).toContain("from-the-future");
     expect(described.displayName).toBe("Tomorrow");
     expect(described.models.options).toHaveLength(0);
+    expect(registry.cliTarget("mystery")).toEqual({ driverKind: "from-the-future", cli: null });
   });
 
   it("downgrades a config-decode failure to a shadow with the error as reason", async () => {

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -109,6 +109,19 @@ export class ProviderRegistry {
     return this.byId.get(instanceId)?.live ?? null;
   }
 
+  /** The configured executable for instance-scoped maintenance actions.
+   * This deliberately comes from the registry/config, never an HTTP body. */
+  cliTarget(instanceId: InstanceId): { driverKind: string; cli: string | null } | null {
+    const entry = this.byId.get(instanceId);
+    if (!entry) return null;
+    const driverKind = entry.shadow?.driverKind ?? entry.live!.driverKind;
+    const driver = this.driversByKind.get(driverKind);
+    return {
+      driverKind,
+      cli: this.cliByInstance.get(instanceId) ?? entry.shadow?.cli ?? cliDefaultOf(driver) ?? null,
+    };
+  }
+
   entries(): RegistryEntry[] {
     return [...this.byId.values()];
   }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -5384,6 +5384,21 @@ describe("instance CLI override API", () => {
     expect(res.body.install).toBeUndefined();
   });
 
+  it("updates only the configured Claude instance and verifies its version", async () => {
+    const res = await api("POST", "/api/instances/claude/claude-update", {});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, version: "2.1.232 (Claude Code)" });
+
+    expect((await api("POST", "/api/instances/ghost/claude-update", {})).status).toBe(400);
+    expect((await api("POST", "/api/instances/missing/claude-update", {})).status).toBe(404);
+  });
+
+  it("requires JSON before launching the Claude updater", async () => {
+    const res = await fetch(`${BASE}/api/instances/claude/claude-update`, { method: "POST" });
+    expect(res.status).toBe(415);
+    expect(await res.json()).toEqual({ error: "content-type must be application/json" });
+  });
+
   it("rejects overlapping provider configuration writes", async () => {
     const slowConfigWrite = api("PUT", "/api/config", { box: { token: "box_slow" } });
     await new Promise((resolve) => setTimeout(resolve, 30));

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import {
 
 import { approvalKey, autoVerdict } from "./auto-approve.ts";
 import { requestReview, resolveAutoReviewMode, shouldReview } from "./auto-review.ts";
+import { updateClaudeCli } from "./claude-update.ts";
 import {
   BrowserCleanupCoordinator,
   finalizeBrowserCleanupMutation,
@@ -5014,6 +5015,9 @@ async function reloadProviders() {
 // and reload sequence single-flight so two settings requests cannot drop one
 // another's changes or dispose a fleet while another reload is creating it.
 let providerConfigBusy = false;
+// One updater per executable: multiple Claude instances can point at the same
+// install, and running two self-updates against it would race its files.
+const claudeUpdatesInFlight = new Set<string>();
 
 // ── HTTP plumbing ─────────────────────────────────────────────────────
 function json(res: ServerResponse, status: number, body: unknown) {
@@ -8106,6 +8110,45 @@ const server = createServer(async (req, res) => {
       // turn this endpoint into an inherited-secret reader.
       const probe = await testCliBinary(cli, driver);
       return json(res, 200, probe);
+    }
+
+    // ── instance-scoped Claude Code update ──
+    // No command or path comes from the request: the registry supplies the
+    // executable already configured for this Claude instance. The JSON gate
+    // keeps a hostile page from triggering a local process with a simple
+    // cross-origin form request.
+    const claudeUpdate = /^\/api\/instances\/([\w.-]+)\/claude-update$/.exec(path);
+    if (method === "POST" && claudeUpdate) {
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      await readBody(req);
+      const target = registry.cliTarget(claudeUpdate[1]);
+      if (!target) return json(res, 404, { error: "no such provider instance" });
+      if (target.driverKind !== "claudeAgent") {
+        return json(res, 400, { error: "only Claude Code instances can be updated here" });
+      }
+      if (!target.cli) return json(res, 409, { error: "this Claude instance has no configured executable" });
+      if (claudeUpdatesInFlight.has(target.cli)) {
+        return json(res, 409, { error: "this Claude installation is already updating" });
+      }
+      const active = store.bots.some((bot) =>
+        bot.busy && registry.cliTarget(bot.modelSelection.instanceId)?.cli === target.cli
+      );
+      if (active) {
+        return json(res, 409, { error: "wait for running Claude tasks to finish before updating" });
+      }
+
+      claudeUpdatesInFlight.add(target.cli);
+      try {
+        const result = await updateClaudeCli(target.cli, cliProbeEnvironment());
+        resetPathCache();
+        return json(res, 200, { ok: true, version: result.version });
+      } catch (error) {
+        return json(res, 500, { error: error instanceof Error ? error.message : String(error) });
+      } finally {
+        claudeUpdatesInFlight.delete(target.cli);
+      }
     }
 
     // ── per-instance CLI path override (custom builds / versioned bins) ──

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -67,6 +67,15 @@ if (argv[0] === "--version") {
   process.exit(0);
 }
 
+if (argv[0] === "update") {
+  if (process.env.FAKE_CLAUDE_UPDATE === "fail") {
+    process.stderr.write("fake-claude: simulated update failure\n");
+    process.exit(1);
+  }
+  process.stdout.write("Claude Code is up to date.\n");
+  process.exit(0);
+}
+
 if (argv[0] === "auth" && argv[1] === "status") {
   const auth = process.env.FAKE_CLAUDE_AUTH ?? "in";
   if (auth === "unsupported") {

--- a/src/components/EnginesSettings.tsx
+++ b/src/components/EnginesSettings.tsx
@@ -5,7 +5,7 @@
 // asks before registering — the classic miss is a path the terminal sees
 // but this GUI app can't.
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, Loader2, TriangleAlert } from "lucide-react";
+import { Check, ChevronDown, Loader2, RefreshCw, TriangleAlert } from "lucide-react";
 
 import { api, useStore, type InstanceInfo } from "@/state/store";
 import { EngineGroupLabel } from "./EngineGroupLabel";
@@ -202,6 +202,8 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
   const { refreshInstances } = useStore();
   const [open, setOpen] = useState(false);
   const [switching, setSwitching] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const [updatedVersion, setUpdatedVersion] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const wasOpenFor = useRef<string | null>(null);
 
@@ -217,7 +219,7 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
   }, [instance.cli]);
 
   const reset = () => {
-    if (switching) return;
+    if (switching || updating) return;
     setSwitching(true);
     setError(null);
     api(`/api/instances/${encodeURIComponent(instance.instanceId)}`, {
@@ -229,6 +231,23 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
       .then(() => Promise.resolve(refreshInstances()).catch(() => {}))
       .catch((e) => setError(e.message))
       .finally(() => setSwitching(false));
+  };
+
+  const updateClaude = () => {
+    if (switching || updating) return;
+    setUpdating(true);
+    setUpdatedVersion(null);
+    setError(null);
+    api(`/api/instances/${encodeURIComponent(instance.instanceId)}/claude-update`, {
+      method: "POST",
+      body: JSON.stringify({}),
+    })
+      .then(async ({ version }: { version: string }) => {
+        setUpdatedVersion(version);
+        await Promise.resolve(refreshInstances()).catch(() => {});
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setUpdating(false));
   };
 
   return (
@@ -246,11 +265,26 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
             <span className="truncate text-[11px] text-ink-secondary">{instance.cliDefault} · default</span>
           )
         )}
+        {instance.snapshot.version && (
+          <span className="shrink-0 text-[11px] text-ink-secondary" title={instance.snapshot.version}>
+            {instance.snapshot.version}
+          </span>
+        )}
         <span className="flex-1" />
+        {instance.driverKind === "claudeAgent" && (
+          <button
+            onClick={updateClaude}
+            disabled={switching || updating}
+            className="flex shrink-0 items-center gap-1 text-[11.5px] text-ink-secondary hover:text-ink disabled:opacity-50"
+          >
+            {updating ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+            {updating ? "Updating…" : "Update Claude"}
+          </button>
+        )}
         {instance.cli && (
           <button
             onClick={reset}
-            disabled={switching}
+            disabled={switching || updating}
             className="shrink-0 text-[11.5px] text-ink-secondary hover:text-ink disabled:opacity-50"
           >
             {switching ? "Resetting…" : "Reset"}
@@ -258,15 +292,20 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
         )}
         <button
           onClick={() => setOpen((v) => !v)}
+          disabled={updating}
           aria-expanded={open}
           className={cn(
             "shrink-0 rounded-lg border border-hairline/40 px-3 py-1 text-[12px]",
             open ? "bg-accent/15 text-accent" : "text-ink-secondary hover:bg-raised/50 hover:text-ink",
+            "disabled:opacity-50",
           )}
         >
           Set CLI…
         </button>
       </div>
+      {updatedVersion && (
+        <div role="status" className="mt-1 text-[12px] text-success">Claude updated — {updatedVersion}</div>
+      )}
       {error && <div role="alert" className="mt-1 text-[12px] text-danger">{error}</div>}
       {open && (
         <CustomPicker


### PR DESCRIPTION
## What changed

- adds **Update Claude** to Settings → Engines
- runs the configured Claude Code CLI’s official `claude update` command without opening Terminal
- verifies and displays the installed version, then refreshes engine/model state
- blocks duplicate updates and updates while the same Claude install is serving a live bot turn
- strips inherited provider credentials and provides a clear manual fallback when updating fails

## Verification

- `pnpm typecheck`
- `pnpm lint` (pre-existing warnings only)
- 2,870 core tests passed (20 skipped)
- 7 Composio broker tests passed
- 80 Electron tests passed
- packaged-server smoke passed
- focused updater/registry/API suite: 157 tests passed
