### PR TITLE
fix(computer): harden remote command boundaries

### DIFF
--- a/server/box-lifecycle.test.ts
+++ b/server/box-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 describe("cloud computer lifecycle", () => {
   let api: Server;
   let sleepBox: typeof import("./box.ts").sleepBox;
+  let execOnBox: typeof import("./box.ts").execOnBox;
   const requests: Array<{ method: string; path: string; command?: string }> = [];
   const botId = "browser-session-test";
 
@@ -22,6 +23,8 @@ describe("cloud computer lifecycle", () => {
         res.writeHead(200, { "content-type": "application/json" });
         if (url.pathname === "/api/box/v1/boxes") {
           res.end(JSON.stringify({ boxes: [{ id: "box-1", name: machineName, state: "ready" }] }));
+        } else if (url.pathname === "/api/box/v1/boxes/box-1" && req.method === "GET") {
+          res.end(JSON.stringify({ ok: true, box: { id: "box-1", name: machineName, state: "ready" } }));
         } else if (url.pathname.endsWith("/commands")) {
           res.end(JSON.stringify({ exitCode: 0, stdout: "", stderr: "" }));
         } else {
@@ -33,7 +36,7 @@ describe("cloud computer lifecycle", () => {
     const port = (api.address() as any).port;
     vi.stubEnv("OMB_BOX_API", `http://127.0.0.1:${port}/api/box/v1`);
     vi.resetModules();
-    ({ sleepBox } = await import("./box.ts"));
+    ({ execOnBox, sleepBox } = await import("./box.ts"));
   });
 
   afterAll(async () => {
@@ -50,5 +53,22 @@ describe("cloud computer lifecycle", () => {
     expect(stopIndex).toBeGreaterThan(commandIndex);
     expect(requests[commandIndex]?.command).toContain("kill -TERM");
     expect(requests[commandIndex]?.command).toContain("pgrep -o -x");
+  });
+
+  it("runs the owner console in the same clean environment as the bot tool", async () => {
+    requests.length = 0;
+    await execOnBox({ box: { token: "box_test" } } as any, botId, `printf '%s' "$BOX_TOKEN"`);
+
+    const command = requests.find((request) => request.path.endsWith("/commands"))?.command ?? "";
+    expect(command).toContain('exec env -i HOME="$HOME"');
+    expect(command).toContain("/bin/bash -c");
+  });
+
+  it("rejects an oversized owner-console command before contacting the provider", async () => {
+    requests.length = 0;
+    await expect(
+      execOnBox({ box: { token: "box_test" } } as any, botId, "x".repeat(4001)),
+    ).rejects.toThrow("maximum 4000 characters");
+    expect(requests).toHaveLength(0);
   });
 });

--- a/server/box.ts
+++ b/server/box.ts
@@ -11,7 +11,12 @@
 //   - X11 desktop with Chrome + Ghostty; passwordless sudo; node 24.
 //   - the dedicated IP rotates across archive/resume — never persist it.
 import type { AppConfig } from "./config.ts";
-import { ensureRemoteCuaCommand, remoteComputerBootstrapCommand } from "./remote-computer.ts";
+import {
+  ensureRemoteCuaCommand,
+  isolatedRemoteCommand,
+  MAX_REMOTE_COMMAND_LENGTH,
+  remoteComputerBootstrapCommand,
+} from "./remote-computer.ts";
 
 // overridable so tests can point at a stub instead of the live provider
 const BOX_API = process.env.OMB_BOX_API || "https://ascii.dev/api/box/v1";
@@ -304,11 +309,14 @@ export async function sleepBox(cfg: AppConfig, botId: string) {
 
 /** Owner-scoped shell for the Computer panel's console. */
 export async function execOnBox(cfg: AppConfig, botId: string, command: string) {
+  if (command.length > MAX_REMOTE_COMMAND_LENGTH) {
+    throw new RangeError(`command is too long (maximum ${MAX_REMOTE_COMMAND_LENGTH} characters)`);
+  }
   const box = await findBox(cfg, botId);
   if (!box) throw new Error("no computer for this bot yet");
   const ready = await waitReady(cfg, box.id, 60_000);
   if (!ready) throw new Error("box did not wake");
-  const out = await runCommand(cfg, box.id, String(command ?? "").slice(0, 4000));
+  const out = await runCommand(cfg, box.id, isolatedRemoteCommand(command));
   return { exitCode: out.exitCode, stdout: out.stdout.slice(-4000), stderr: out.stderr.slice(-2000) };
 }
 

--- a/server/computer-proxy.test.ts
+++ b/server/computer-proxy.test.ts
@@ -163,6 +163,23 @@ describe("computer proxy (fake box)", () => {
     expect(click.description).toMatch(/return the resulting screen/i);
     const screenshot = res.result.tools.find((t: any) => t.name === "screenshot");
     expect(screenshot.inputSchema.properties.region).toBeTruthy();
+    const exec = res.result.tools.find((t: any) => t.name === "computer_exec");
+    expect(exec.inputSchema.properties.command.maxLength).toBe(4000);
+  });
+
+  it("rejects an oversized shell command instead of executing a truncated prefix", async () => {
+    const before = commands.length;
+    rpc({
+      jsonrpc: "2.0",
+      id: 77,
+      method: "tools/call",
+      params: { name: "computer_exec", arguments: { command: "x".repeat(4001) } },
+    });
+
+    const result = await waitFor(77);
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content[0].text).toContain("maximum 4000 characters");
+    expect(commands.length).toBe(before);
   });
 
   it("wait_for keeps polling on the box in one bounded command", async () => {

--- a/server/computer-proxy.ts
+++ b/server/computer-proxy.ts
@@ -38,6 +38,8 @@ import {
 import { CONTROL_REFUSAL, createControlClient } from "./control-client.ts";
 import {
   ensureRemoteCuaCommand,
+  isolatedRemoteCommand,
+  MAX_REMOTE_COMMAND_LENGTH,
   REMOTE_CUA_EXECUTABLE,
   REMOTE_CUA_SESSION,
   REMOTE_CUA_SOCKET,
@@ -126,19 +128,7 @@ async function runOnBox(command: string, timeoutMs = 60_000, allowWake = true): 
   // Old boxes may predate noEnv:true. Run every agent-issued command with an
   // explicit desktop-only environment so provider/account credentials cannot
   // leak through `computer_exec` or a child GUI process.
-  const isolatedCommand = [
-    "exec env -i",
-    'HOME="$HOME"',
-    'USER="${USER:-$(id -un)}"',
-    'LOGNAME="${LOGNAME:-${USER:-$(id -un)}}"',
-    'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
-    'DISPLAY="${DISPLAY:-:0}"',
-    'XAUTHORITY="${XAUTHORITY:-$HOME/.Xauthority}"',
-    'XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"',
-    'DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}"',
-    "/bin/bash -c",
-    shellQuote(command),
-  ].join(" ");
+  const isolatedCommand = isolatedRemoteCommand(command);
   const res = await fetch(`${BOX_API}/boxes/${boxId}/commands`, {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
@@ -633,7 +623,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
-        command: { type: "string" },
+        command: { type: "string", maxLength: MAX_REMOTE_COMMAND_LENGTH },
         observe: {
           type: "boolean",
           description: "default false — set true to also return a screenshot (e.g. after launching a GUI app)",
@@ -1010,7 +1000,10 @@ async function call(id: unknown, name: string, args: any) {
     return actAndObserve(id, actions, `ran ${actions.length} actions: ${summary}`, args, 180_000);
   }
   if (name === "computer_exec") {
-    const command = String(args.command ?? "").slice(0, 4000);
+    const command = String(args.command ?? "");
+    if (command.length > MAX_REMOTE_COMMAND_LENGTH) {
+      return text(id, `command is too long (maximum ${MAX_REMOTE_COMMAND_LENGTH} characters)`, true);
+    }
     observations.noteAction();
     const out = await runOnBox(command, 120_000);
     const note = `exit ${out.exitCode}\n${out.stdout.slice(-6000)}${out.stderr ? `\n[stderr]\n${out.stderr.slice(-2000)}` : ""}`;

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -4678,6 +4678,16 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("rejects oversized Box console commands instead of executing a truncated prefix", async () => {
+    const bot = (await api("GET", "/api/bots?messages=0")).body.bots[0];
+    const response = await api("POST", `/api/bots/${bot.id}/computer/exec`, {
+      command: "x".repeat(4001),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain("maximum 4000 characters");
+  });
+
   it("validates the non-secret VPS alias and keeps old bots on Box by default", async () => {
     const before = await api("GET", "/api/bots");
     const bot = before.body.bots[0];

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,6 +94,7 @@ import {
   customMcpServers,
 } from "./config.ts";
 import { ComputerControl } from "./computer-control.ts";
+import { MAX_REMOTE_COMMAND_LENGTH } from "./remote-computer.ts";
 import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts";
 import { describeSpawnFailure, execCli } from "./procs.ts";
 import { buildNotification, type Notification } from "./notify.ts";
@@ -8715,7 +8716,13 @@ const server = createServer(async (req, res) => {
           return json(res, 200, await box.sleepBox(cfg, botId));
         case "exec": {
           const body = await readBody(req);
-          return json(res, 200, await box.execOnBox(cfg, botId, String(body.command ?? "")));
+          const command = String(body.command ?? "");
+          if (command.length > MAX_REMOTE_COMMAND_LENGTH) {
+            return json(res, 400, {
+              error: `command is too long (maximum ${MAX_REMOTE_COMMAND_LENGTH} characters)`,
+            });
+          }
+          return json(res, 200, await box.execOnBox(cfg, botId, command));
         }
         case "screenshot":
           return json(res, 200, await box.screenshotBox(cfg, botId));

--- a/server/remote-computer.test.ts
+++ b/server/remote-computer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   ensureRemoteCuaCommand,
+  isolatedRemoteCommand,
   REMOTE_CUA_EXECUTABLE,
   REMOTE_CUA_SOCKET,
   REMOTE_CUA_VERSION,
@@ -42,5 +43,32 @@ describe("remote Cua computer setup", () => {
     expect(command).toContain("openmausbot-cdp.mjs fill");
     expect(command).not.toContain("don't expand");
     expect(command).not.toContain("$HOME");
+  });
+
+  it("encodes a bot display name before composing the tmux shell", () => {
+    const botName = "$(touch /tmp/openmaus-pwned) `id` ' \\\"";
+    const command = remoteComputerBootstrapCommand(botName);
+    const encodedBanner = Buffer.from(`  ▦ ${botName}'s computer — OpenMausBot`).toString("base64");
+
+    expect(command).toContain(encodedBanner);
+    expect(command).not.toContain("touch /tmp/openmaus-pwned");
+    expect(command).not.toContain("`id`");
+    if (process.platform !== "win32") {
+      expect(spawnSync("/bin/bash", ["-n"], { input: command }).status).toBe(0);
+    }
+  });
+
+  it("builds a clean remote shell environment without interpolating the command", () => {
+    const command = isolatedRemoteCommand(`printf '%s' "$BOX_TOKEN"`);
+    expect(command).toContain('exec env -i HOME="$HOME"');
+    expect(command).toContain("/bin/bash -c");
+    if (process.platform !== "win32") {
+      const result = spawnSync("/bin/bash", ["-c", command], {
+        encoding: "utf8",
+        env: { ...process.env, BOX_TOKEN: "must-not-leak" },
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("");
+    }
   });
 });

--- a/server/remote-computer.ts
+++ b/server/remote-computer.ts
@@ -92,6 +92,28 @@ socket.close();`;
 
 const shellQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
 
+export const MAX_REMOTE_COMMAND_LENGTH = 4_000;
+
+/** Run a user- or model-supplied command without inheriting provider or
+ * account credentials from an older box image. Keep this shared by the bot
+ * tool and the owner's Computer-panel console so the two boundaries cannot
+ * drift apart. */
+export function isolatedRemoteCommand(command: string): string {
+  return [
+    "exec env -i",
+    'HOME="$HOME"',
+    'USER="${USER:-$(id -un)}"',
+    'LOGNAME="${LOGNAME:-${USER:-$(id -un)}}"',
+    'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
+    'DISPLAY="${DISPLAY:-:0}"',
+    'XAUTHORITY="${XAUTHORITY:-$HOME/.Xauthority}"',
+    'XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"',
+    'DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}"',
+    "/bin/bash -c",
+    shellQuote(command),
+  ].join(" ");
+}
+
 /** Start the already-installed daemon after a box resume. This is cheap when
  * it is healthy and intentionally does not install anything on the hot path. */
 export function ensureRemoteCuaCommand(): string {
@@ -129,7 +151,15 @@ export function remoteComputerBootstrapCommand(botName: string): string {
     `touch /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready`,
     'rm -f "$wheel"',
   ].join("\n");
-  const safeName = botName.replace(/["'\\]/g, "");
+  // The display name is untrusted. Encode the banner before composing the
+  // nested tmux shell so substitutions/backticks can never become syntax.
+  const banner = Buffer.from(`  ▦ ${botName}'s computer — OpenMausBot`).toString("base64");
+  const tmuxSessionCommand = [
+    "echo",
+    `printf %s ${shellQuote(banner)} | base64 -d`,
+    "echo",
+    "exec bash -i",
+  ].join("; ");
   return [
     "if ! command -v xdotool >/dev/null || ! command -v convert >/dev/null || ! command -v curl >/dev/null || ! command -v python3 >/dev/null; then sudo apt-get update -qq || true; sudo apt-get install -y -qq ca-certificates curl python3 gnome-screenshot xclip wmctrl xdotool imagemagick scrot >/dev/null 2>&1 || true; fi",
     "sudo mkdir -p /opt/ogb/run",
@@ -138,7 +168,7 @@ export function remoteComputerBootstrapCommand(botName: string): string {
     'pkill -f "^/opt/ogb/venv/bin/python -m computer_server( |$)" >/dev/null 2>&1 || true',
     `[ -f /opt/ogb/cua-${REMOTE_CUA_VERSION}-ready ] || [ -f /tmp/ogb-cua-installing ] || { touch /tmp/ogb-cua-installing; nohup bash -c ${shellQuote(installer)} > /tmp/ogb-cua-install.log 2>&1 & }`,
     ensureRemoteCuaCommand(),
-    `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work 'echo; echo "  ▦ ${safeName}'"'"'s computer — OpenMausBot"; echo; exec bash -i'`,
+    `tmux has-session -t work 2>/dev/null || tmux new-session -d -s work ${shellQuote(tmuxSessionCommand)}`,
     "echo bootstrapped",
   ].join("\n");
 }


### PR DESCRIPTION
## What changed

- encode bot display names before composing the cloud bootstrap shell command
- enforce one 4,000-character command limit in both the MCP schema and runtime
- reject oversized Box console commands instead of silently truncating them
- run owner-console commands through the same `env -i` isolation boundary as bot commands
- add regression coverage for shell metacharacters, secret isolation, and oversized commands

## Why

This closes three computer-boundary findings from the 0.1.46 audit:

- bot names could reach a nested shell command and allow command substitution
- commands over 4,000 characters were silently truncated
- owner-issued Box console commands did not receive the environment isolation already used for bot commands

## How it was verified

- `pnpm exec vitest run server/remote-computer.test.ts server/computer-proxy.test.ts server/box-lifecycle.test.ts server/index.test.ts` — 174 tests passed
- `pnpm typecheck`
- changed-file Oxlint (the existing unrelated warning in `server/index.ts` remains unchanged)
- `git diff --check`
- launched the repository's isolated verification fixture, confirmed the server connected, created a disposable bot, completed a chat turn, inspected the transcript, and stopped the fixture
- the real Box request boundary is covered with fake-provider contract tests because the isolated fixture does not expose that provider route

## Screenshots (UI changes)

Not applicable — no UI changes.

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally (typecheck and all 174 focused tests pass; full suite is delegated to CI)
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commands run through the box console and computer tools now use a clean, isolated environment.
  * Commands exceeding 4,000 characters are rejected before execution instead of being truncated.
  * Improved safety when displaying names containing special characters in remote console sessions.
  * Added clearer validation errors for oversized commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->