### PR TITLE
feat(chat): render generated images and composer queue

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -110,6 +110,11 @@ export type RuntimeEvent = RuntimeEventBase &
     | { type: "item.updated"; itemType: "tool" | "reasoning"; tokens?: number | null }
     | { type: "item.completed"; itemType: "tool"; ok: boolean }
     | { type: "item.completed"; itemType: "assistant_text"; text: string }
+    /** Provider-generated raster bytes. This event is folded into the
+     * private attachment store and is never forwarded to renderer SSE: a
+     * multi-megabyte base64 result belongs in one durable message URL, not
+     * duplicated through every connected window. */
+    | { type: "item.completed"; itemType: "assistant_image"; data: string; alt?: string }
     | { type: "content.delta"; streamKind: "assistant_text" | "reasoning_text"; delta: string }
     | {
         type: "request.opened";

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -129,6 +129,28 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(threadStart.params).toMatchObject({ model: "gpt-5.6-sol", modelProvider: "openai" });
   });
 
+  it("normalizes native image generation bytes without exposing the provider path", async () => {
+    process.env.FAKE_CODEX_MODE = "image";
+    await create();
+    await instance.adapter.sendTurn({
+      threadId: "t-image",
+      text: "make an image",
+      model: "gpt-5.6-sol",
+    });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const image = recorder.events.find(
+      (event) => event.type === "item.completed" && event.itemType === "assistant_image",
+    );
+    expect(image).toMatchObject({
+      itemType: "assistant_image",
+      itemId: "img1",
+      alt: "a tiny green mouse",
+    });
+    expect(image && "data" in image ? image.data : "").toMatch(/^iVBOR/);
+    expect(JSON.stringify(image)).not.toContain("provider-owned-path");
+  });
+
   it("keeps the full command when a Windows interpreter prefix is long", async () => {
     await create({ mode: "windows-command" });
     await instance.adapter.sendTurn({ threadId: "t-windows-command", text: "read notes" });

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -396,6 +396,22 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
                 state.sawStreamDelta = false;
                 emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: item.text });
               }
+            } else if (item.type === "imageGeneration" && item.status !== "failed") {
+              // Current Codex app-server (the same schema consumed by T3
+              // Code) returns the generated raster as base64 `result` and
+              // may also expose a local `savedPath`. Use bytes, never the
+              // provider-owned path: the harness will validate and copy
+              // them into its private attachment store.
+              if (typeof item.result === "string" && item.result.trim()) {
+                emit({
+                  ...base(threadId, turnId),
+                  type: "item.completed",
+                  itemType: "assistant_image",
+                  itemId: item.id,
+                  data: item.result,
+                  alt: typeof item.revisedPrompt === "string" ? item.revisedPrompt : undefined,
+                });
+              }
             } else if (["commandExecution", "fileChange", "mcpToolCall", "webSearch"].includes(item.type)) {
               emit({
                 ...base(threadId, turnId),
@@ -473,7 +489,20 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           } catch {
             continue;
           }
-          appendNative(threadId, { dir: "in", source: "codex.app-server", msg });
+          const loggedMessage = msg.method === "item/completed" && msg.params?.item?.type === "imageGeneration"
+            ? {
+                ...msg,
+                params: {
+                  ...msg.params,
+                  item: {
+                    ...msg.params.item,
+                    result: `[generated image omitted · ${String(msg.params.item.result ?? "").length} base64 chars]`,
+                    savedPath: undefined,
+                  },
+                },
+              }
+            : msg;
+          appendNative(threadId, { dir: "in", source: "codex.app-server", msg: loggedMessage });
           if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
             const pend = rpcPending.get(msg.id);
             if (pend) {

--- a/server/generated-image.test.ts
+++ b/server/generated-image.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { decodeGeneratedImage } from "./generated-image.ts";
+
+const ONE_PIXEL_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+describe("decodeGeneratedImage", () => {
+  it("accepts Codex raw base64 and sniffs the actual raster type", () => {
+    const image = decodeGeneratedImage(ONE_PIXEL_PNG);
+    expect(image.mime).toBe("image/png");
+    expect(image.bytes.subarray(1, 4).toString("ascii")).toBe("PNG");
+  });
+
+  it("accepts a raster data URL without trusting its claimed type", () => {
+    expect(decodeGeneratedImage(`data:image/jpeg;base64,${ONE_PIXEL_PNG}`).mime).toBe("image/png");
+  });
+
+  it("rejects non-image and malformed provider output", () => {
+    expect(() => decodeGeneratedImage(Buffer.from("not an image").toString("base64"))).toThrow(/supported raster/);
+    expect(() => decodeGeneratedImage("%%%" )).toThrow(/invalid/);
+  });
+});

--- a/server/generated-image.ts
+++ b/server/generated-image.ts
@@ -1,0 +1,47 @@
+import { IMAGE_MAX_BYTES } from "./attachments.ts";
+
+export interface DecodedGeneratedImage {
+  bytes: Buffer;
+  mime: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+}
+
+const MAX_BASE64_CHARS = Math.ceil(IMAGE_MAX_BYTES / 3) * 4 + 8;
+
+function sniffRaster(bytes: Buffer): DecodedGeneratedImage["mime"] | null {
+  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))) {
+    return "image/png";
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  const head = bytes.subarray(0, 6).toString("ascii");
+  if (head === "GIF87a" || head === "GIF89a") return "image/gif";
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/** Decode an untrusted provider image without trusting its claimed MIME.
+ * Codex normally sends raw base64, but accepting a raster data URL makes the
+ * boundary resilient to app-server shape changes without widening formats. */
+export function decodeGeneratedImage(input: string): DecodedGeneratedImage {
+  const trimmed = input.trim();
+  const comma = trimmed.startsWith("data:") ? trimmed.indexOf(",") : -1;
+  const encoded = comma >= 0 ? trimmed.slice(comma + 1) : trimmed;
+  if (!encoded || encoded.length > MAX_BASE64_CHARS || !/^[A-Za-z0-9+/\s]*={0,2}$/.test(encoded)) {
+    throw new Error("generated image payload is invalid or too large");
+  }
+  const compact = encoded.replace(/\s/g, "");
+  const bytes = Buffer.from(compact, "base64");
+  if (bytes.length === 0 || bytes.length > IMAGE_MAX_BYTES) {
+    throw new Error(`generated image exceeds ${IMAGE_MAX_BYTES} bytes`);
+  }
+  const mime = sniffRaster(bytes);
+  if (!mime) throw new Error("generated image is not a supported raster format");
+  return { bytes, mime };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,6 +107,7 @@ import {
   newId,
 } from "./contracts.ts";
 import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
+import { decodeGeneratedImage } from "./generated-image.ts";
 import {
   GROUP_GOAL_MAX_TURNS,
   groupGoalAssignmentKey,
@@ -463,6 +464,14 @@ const directTurnDispatchClaims = new Map<string, DirectTurnDispatchClaim>();
 const directTurnGenerationByBot = new Map<string, string>();
 const retiredProviderTurns = new RetiredTurnRegistry();
 const pendingCancelledProviderHandshakes = new PendingTurnCancellations();
+const generatedImagesByTurn = new Map<
+  string,
+  Array<NonNullable<Message["attachments"]>[number]>
+>();
+
+function generatedImageTurnKey(threadId: string, turnId?: string): string {
+  return `${threadId}:${turnId ?? "active"}`;
+}
 
 function markCancelledProviderHandshake(threadId: string, ownerId: string): void {
   pendingCancelledProviderHandshakes.mark(threadId, ownerId);
@@ -474,6 +483,16 @@ function clearCancelledProviderHandshake(threadId: string, ownerId: string): voi
 
 function retireProviderTurn(turnId: string): void {
   retiredProviderTurns.retire(turnId);
+  // A stopped/replaced turn is never folded again. Delete only image files
+  // that were staged for that exact provider turn so unattached output does
+  // not accumulate invisibly on disk.
+  for (const [key, attachments] of generatedImagesByTurn) {
+    if (!key.endsWith(`:${turnId}`)) continue;
+    generatedImagesByTurn.delete(key);
+    for (const attachment of attachments) {
+      try { unlinkSync(attachment.path); } catch {}
+    }
+  }
 }
 
 function shouldIgnoreProviderEvent(event: RuntimeEvent): boolean {
@@ -1655,6 +1674,13 @@ bus.subscribe((event: RuntimeEvent) => {
     if (goalCoordinatorTurn && !goalCoordinatorTurn.discard) goalCoordinatorTurn.assistantItems.push(event.text);
     return;
   }
+  // Goal coordinators speak a private control envelope. Their incidental
+  // artifacts are private too; never leak one into the public room.
+  if (
+    event.type === "item.completed" &&
+    event.itemType === "assistant_image" &&
+    (goalCoordinatorTurn || ambiguousCoordinatorText)
+  ) return;
   if (
     event.type === "content.delta" &&
     event.streamKind === "assistant_text" &&
@@ -1676,8 +1702,11 @@ bus.subscribe((event: RuntimeEvent) => {
     };
     broadcast({ kind: "runtime", event: publicAssistantEvent });
   }
-  broadcast({ kind: "runtime", event });
-  const routineRun = routines?.handleRuntimeEvent(event) ?? null;
+  const privateImageEvent = event.type === "item.completed" && event.itemType === "assistant_image";
+  // The durable message patch below is the public frame. Sending raw base64
+  // through runtime SSE would multiply large bytes across every app window.
+  if (!privateImageEvent) broadcast({ kind: "runtime", event });
+  const routineRun = privateImageEvent ? null : (routines?.handleRuntimeEvent(event) ?? null);
   const bot = store.botByThread(event.threadId);
   const group = bot ? undefined : store.groupByThread(event.threadId);
   if (!bot && !group) return;
@@ -1706,6 +1735,24 @@ bus.subscribe((event: RuntimeEvent) => {
         // kept so "finished" can say what it finished with, rather than
         // just that something ended
         lastReply.set(event.threadId, text);
+      } else if (event.itemType === "assistant_image") {
+        try {
+          const decoded = decodeGeneratedImage(event.data);
+          const saved = saveImage(decoded.bytes, decoded.mime);
+          const key = generatedImageTurnKey(event.threadId, event.turnId);
+          const current = generatedImagesByTurn.get(key) ?? [];
+          current.push({ kind: "image", path: saved.path, mime: saved.mime });
+          generatedImagesByTurn.set(key, current);
+        } catch (error) {
+          pushMessage({
+            role: "bot",
+            kind: "activity",
+            tool: {
+              name: `generated image could not be attached — ${error instanceof Error ? error.message : "invalid image"}`.slice(0, 160),
+              ok: false,
+            },
+          });
+        }
       } else if (event.itemType === "tool" && event.itemId) {
         const itemKey = `${event.threadId}:${event.itemId}`;
         const messageId = toolMessageByItem.get(itemKey);
@@ -1978,6 +2025,32 @@ bus.subscribe((event: RuntimeEvent) => {
       turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
+      const generatedKey = generatedImageTurnKey(event.threadId, event.turnId);
+      const generated = generatedImagesByTurn.get(generatedKey) ?? [];
+      generatedImagesByTurn.delete(generatedKey);
+      if (generated.length) {
+        const response = [...store.messagesFor(event.threadId)].reverse().find(
+          (message) =>
+            message.role === "bot" &&
+            message.kind === "text" &&
+            message.turnId === completedTurnId,
+        );
+        if (response) {
+          store.patchMessage(event.threadId, response.id, {
+            attachments: [...(response.attachments ?? []), ...generated],
+          });
+        } else {
+          // Some image turns have no textual epilogue. Keep the image as the
+          // terminal assistant response instead of inventing model words.
+          pushMessage({
+            role: "bot",
+            kind: "text",
+            text: "",
+            attachments: generated,
+            turnId: completedTurnId,
+          });
+        }
+      }
       if (completedTurnId) store.markTerminalAssistantMessage(event.threadId, completedTurnId);
       const reply = lastReply.get(event.threadId) ?? "";
       lastReply.delete(event.threadId);

--- a/server/store.ts
+++ b/server/store.ts
@@ -97,6 +97,10 @@ export interface Message {
   role: "bot" | "user";
   kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run" | "goal.run";
   text?: string;
+  /** Durable provider output stored by the harness. Paths always point into
+   * OpenMausBot's private attachment directory; renderers receive only the
+   * existing allowlisted /api/attachments URL. */
+  attachments?: Array<{ kind: "image"; path: string; mime: string }>;
   card?: OptionCardData;
   connector?: ConnectorCardData;
   secret?: SecretRequestCardData;

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -5,7 +5,7 @@
 // real app-server, it never exits on its own — the driver kills it.
 //
 //   FAKE_CODEX_MODE   happy (default) | approval | resume | stream | windows-command |
-//                     mcp-elicitation | logged-in-stdout | logged-out | unauthorized
+//                     mcp-elicitation | image | logged-in-stdout | logged-out | unauthorized
 //   FAKE_CODEX_DUMP   path to write {argv, env, calls, decision} as JSON
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
@@ -50,6 +50,18 @@ const finishTurn = () => {
     // token deltas, then the whole message — the driver must not double-emit
     notify("item/agentMessage/delta", { itemId: "m1", delta: "done from " });
     notify("item/agentMessage/delta", { itemId: "m1", delta: "fake codex" });
+  }
+  if (mode === "image") {
+    notify("item/completed", {
+      item: {
+        id: "img1",
+        type: "imageGeneration",
+        status: "completed",
+        result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        revisedPrompt: "a tiny green mouse",
+        savedPath: "/tmp/provider-owned-path-must-not-be-read.png",
+      },
+    });
   }
   notify("item/completed", { item: { id: "m1", type: "agentMessage", text: "done from fake codex" } });
   notify("thread/tokenUsage/updated", { tokenUsage: { total: { inputTokens: 7, cachedInputTokens: 4, outputTokens: 3 } } });

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -7,7 +7,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Bug,
-  Clock,
   Copy,
   Crown,
   Folder,
@@ -452,16 +451,22 @@ function Bubble({
               )}
             </>
           ) : (
-            <MessageBoundary fallbackText={text}>
-              <ChatMarkdown text={text} />
+            <MessageBoundary fallbackText={text || "Generated image"}>
+              {message.attachments?.length ? (
+                <AttachedImageGallery
+                  paths={message.attachments.map((attachment) => attachment.path)}
+                  className={text ? "justify-start" : "mb-0 justify-start"}
+                />
+              ) : null}
+              {text ? <ChatMarkdown text={text} /> : null}
             </MessageBoundary>
           )}
         </div>
         {!user && (
           <>
             <div className="flex flex-col gap-0.5 self-end pb-0.5">
-              <CopyButton text={text} />
-              {message.kind === "text" && (
+              {text && <CopyButton text={text} />}
+              {message.kind === "text" && text && (
                 <SpeakButton text={text} botId={bot.id} messageId={message.id} voiceId={bot.voice} />
               )}
               {isLastBotText && !bot.busy && onRegenerate && (
@@ -945,6 +950,7 @@ export function ChatView({ bot }: { bot: Bot }) {
     return () => clearTimeout(timer);
   }, [lastMessage?.id, lastMessage?.role, lastMessage?.kind, lastMessage?.text]);
   const presenceVisible = waiting || popping !== null;
+  const poppingMessage = popping ? messages.find((message) => message.id === popping.id) : undefined;
   // Wall-clock anchor for the working row's elapsed readout — set when the
   // turn starts, cleared when it settles, reset on bot switch.
   const [busySince, setBusySince] = useState<number | null>(null);
@@ -1289,39 +1295,18 @@ export function ChatView({ bot }: { bot: Bot }) {
           >
             {popping ? (
               <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed text-ink">
-                <MessageBoundary fallbackText={popping.text}>
-                  <ChatMarkdown text={popping.text} />
+                <MessageBoundary fallbackText={popping.text || "Generated image"}>
+                  {poppingMessage?.attachments?.length ? (
+                    <AttachedImageGallery
+                      paths={poppingMessage.attachments.map((attachment) => attachment.path)}
+                      className={popping.text ? "justify-start" : "mb-0 justify-start"}
+                    />
+                  ) : null}
+                  {popping.text ? <ChatMarkdown text={popping.text} /> : null}
                 </MessageBoundary>
               </div>
             ) : null}
           </TurnPresence>
-          {/* Ghost tail: 1:1 sends made mid-turn wait in the server's steer
-              queue and stay off the transcript until drain (they must never
-              become the active leaf). These rows are that queue made visible,
-              in send order, each with its own cancel. */}
-          {bot.busy &&
-            (state.pendingQueued[bot.threadId] ?? []).map((entry) => (
-              <div key={entry.queueId} className="flex flex-col items-end">
-                <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl border border-dashed border-hairline/70 bg-panel/60 px-4 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap text-ink-secondary">
-                  {entry.text}
-                </div>
-                <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
-                  <Clock size={11} aria-hidden="true" />
-                  <span>Queued — wait, or inject now</span>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      dispatch({ type: "cancelQueued", botId: bot.id, queueId: entry.queueId })
-                    }
-                    aria-label="Cancel queued message"
-                    title="Cancel queued message"
-                    className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
-                  >
-                    <X size={11} strokeWidth={2.5} />
-                  </button>
-                </div>
-              </div>
-            ))}
         </div>
       </div>
 

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -35,6 +35,7 @@ import { PendingApprovalActions, PendingApprovalPanel, pendingApprovals } from "
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { ReplyQuote } from "./ReplyQuote";
 import { ComposerInjectNow, composerCanInjectNow } from "./ComposerInjectNow";
+import { QueuedComposerMessages } from "./ComposerQueuedMessages";
 
 /** The active @mention query at the caret: the text between an `@` that
  * starts a word and the caret. null = no mention being typed. */
@@ -337,6 +338,7 @@ export function Composer({
   // 1:1 chats. Keeping a channel follow-up in this component used to lose its
   // auto-send intent whenever navigation unmounted the composer.
   const pendingCount = (state.pendingQueued[threadId] ?? []).length;
+  const queuedMessages = state.pendingQueued[threadId] ?? [];
   const canInject = composerCanInjectNow(busy, locked, pendingCount);
   const interruptTurn = () => {
     if (group) dispatch({ type: "interruptGroup", groupId: group.id });
@@ -589,6 +591,13 @@ export function Composer({
             />
           </div>
         )}
+        <QueuedComposerMessages
+          items={queuedMessages}
+          onCancel={(queueId) => {
+            if (group) dispatch({ type: "cancelGroupQueued", groupId: group.id, threadId, queueId });
+            else if (bot) dispatch({ type: "cancelQueued", botId: bot.id, queueId });
+          }}
+        />
         <ComposerAttachments
           items={attachments}
           onAdd={addAttachments}
@@ -760,7 +769,7 @@ export function Composer({
           <div className="flex items-center gap-1">
           {/* Inject is stop-then-steer made visible. The square stop would
               drain the same queue, so it yields while a send is waiting.
-              Cancelling the ghost/chip brings Stop back. */}
+              Cancelling the queued composer card brings Stop back. */}
           {canInject && <ComposerInjectNow onInject={interruptTurn} />}
           {busy && !locked && !canInject && (
           <button

--- a/src/components/ComposerQueuedMessages.test.ts
+++ b/src/components/ComposerQueuedMessages.test.ts
@@ -1,0 +1,18 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { QueuedComposerMessages } from "./ComposerQueuedMessages";
+
+describe("QueuedComposerMessages", () => {
+  it("keeps pending sends visibly attached to the composer", () => {
+    const html = renderToStaticMarkup(createElement(QueuedComposerMessages, {
+      items: [{ queueId: "q1", text: "follow up after this" }],
+      onCancel: vi.fn(),
+    }));
+
+    expect(html).toContain('aria-label="Queued messages"');
+    expect(html).toContain("follow up after this");
+    expect(html).toContain("Queued for the next turn");
+    expect(html).toContain('aria-label="Cancel queued message"');
+  });
+});

--- a/src/components/ComposerQueuedMessages.tsx
+++ b/src/components/ComposerQueuedMessages.tsx
@@ -1,0 +1,35 @@
+import { Clock, X } from "lucide-react";
+
+export function QueuedComposerMessages({
+  items,
+  onCancel,
+}: {
+  items: Array<{ queueId: string; text: string }>;
+  onCancel: (queueId: string) => void;
+}) {
+  if (!items.length) return null;
+  return (
+    <div className="mb-2 flex flex-col items-end gap-1.5 px-1" aria-label="Queued messages">
+      {items.map((item) => (
+        <div key={item.queueId} className="flex max-w-[min(42rem,86%)] flex-col items-end">
+          <div className="rounded-2xl rounded-br-md border border-dashed border-hairline/70 bg-panel/80 px-4 py-2.5 text-[14px] leading-relaxed whitespace-pre-wrap text-ink-secondary shadow-sm">
+            {item.text}
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-[11px] text-ink-secondary/75">
+            <Clock size={11} aria-hidden="true" />
+            <span>Queued for the next turn</span>
+            <button
+              type="button"
+              onClick={() => onCancel(item.queueId)}
+              aria-label="Cancel queued message"
+              title="Cancel queued message"
+              className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
+            >
+              <X size={11} strokeWidth={2.5} />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -3,7 +3,7 @@
 // does not become a wall of competing motion. Plain messages go to the room's
 // default responder; @mentions override that routing.
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Check, ChevronDown, Clock, Folder, FolderOpen, Loader2, MessageSquareReply, Pin, PinOff, Plus, Search, X } from "lucide-react";
+import { ArrowDown, Check, ChevronDown, Folder, FolderOpen, Loader2, MessageSquareReply, Pin, PinOff, Plus, Search, X } from "lucide-react";
 import {
   api,
   useStore,
@@ -219,7 +219,7 @@ const Transcript = memo(function Transcript({
             m.tool.ok === false || m.tool.name.startsWith("error:") || showToolCalls ? (
               <RoomToolChip message={m} />
             ) : null
-          ) : m.kind === "text" && m.text ? (
+          ) : m.kind === "text" && (m.text || m.attachments?.length) ? (
             <div className={cn("group flex w-full flex-col", user ? "items-end" : "items-start")}>
               <div className={cn("flex w-full items-end gap-1.5", user ? "justify-end" : "justify-start")}>
                 {user && (
@@ -271,7 +271,17 @@ const Transcript = memo(function Transcript({
                       )}
                       {attachments?.display ?? m.text}
                     </>
-                  ) : <ChatMarkdown text={m.text} />}
+                  ) : (
+                    <>
+                      {m.attachments?.length ? (
+                        <AttachedImageGallery
+                          paths={m.attachments.map((attachment) => attachment.path)}
+                          className={m.text ? "justify-start" : "mb-0 justify-start"}
+                        />
+                      ) : null}
+                      {m.text ? <ChatMarkdown text={m.text} /> : null}
+                    </>
+                  )}
                 </div>
                 {!user && (
                   <>
@@ -903,6 +913,7 @@ export function GroupView({ group }: { group: Group }) {
     lastGroupMessage?.from?.botId,
   ]);
   const presenceVisible = waiting || popping !== null;
+  const poppingMessage = popping ? group.messages.find((message) => message.id === popping.id) : undefined;
   const presenceSpeaker = speaker ?? members.find((member) => member.id === popping?.botId) ?? members[0];
 
   // Windowed transcript, mirroring ChatView: only a tail of the room mounts;
@@ -1265,38 +1276,17 @@ export function GroupView({ group }: { group: Group }) {
             >
               {popping ? (
                 <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed text-ink">
-                  <ChatMarkdown text={popping.text} />
+                  {poppingMessage?.attachments?.length ? (
+                    <AttachedImageGallery
+                      paths={poppingMessage.attachments.map((attachment) => attachment.path)}
+                      className={popping.text ? "justify-start" : "mb-0 justify-start"}
+                    />
+                  ) : null}
+                  {popping.text ? <ChatMarkdown text={popping.text} /> : null}
                 </div>
               ) : null}
             </TurnPresence>
           )}
-          {(state.pendingQueued[group.threadId] ?? []).map((entry) => (
-            <div key={entry.queueId} className="flex flex-col items-end">
-              <div className="w-fit max-w-[min(42rem,78%)] whitespace-pre-wrap rounded-2xl border border-dashed border-hairline/70 bg-panel/60 px-4 py-2.5 text-[15px] leading-relaxed text-ink-secondary">
-                {entry.text}
-              </div>
-              <div className="mt-1 flex items-center gap-1 pr-1 text-[11px] text-ink-secondary/70">
-                <Clock size={11} aria-hidden="true" />
-                <span>{group.working ? "Queued — wait, or inject now" : "Queued — sending now"}</span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    dispatch({
-                      type: "cancelGroupQueued",
-                      groupId: group.id,
-                      threadId: group.threadId,
-                      queueId: entry.queueId,
-                    })
-                  }
-                  aria-label="Cancel queued message"
-                  title="Cancel queued message"
-                  className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink"
-                >
-                  <X size={11} strokeWidth={2.5} />
-                </button>
-              </div>
-            </div>
-          ))}
         </div>
         )}
       </div>

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -84,6 +84,7 @@ export function summarizeRuntime(e: RuntimeEvent): { summary: string; tone: Insp
       return { summary: `${e.itemType} updated${typeof e.tokens === "number" ? ` · ${e.tokens} tok` : ""}`, tone: "plain" };
     case "item.completed":
       if (e.itemType === "assistant_text") return { summary: `assistant: ${clip(oneLine(e.text))}`, tone: "plain" };
+      if (e.itemType === "assistant_image") return { summary: "assistant image generated", tone: "plain" };
       return { summary: `tool ${e.ok ? "ok" : "failed"}`, tone: e.ok ? "plain" : "error" };
     case "content.delta":
       return { summary: `${e.streamKind}: ${clip(oneLine(e.delta))}`, tone: "plain" };

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -499,6 +499,24 @@ describe("pending queued chip", () => {
     expect(landed.pendingQueued).toEqual({});
   });
 
+  it("starts mascot work motion when the queued line is released into the transcript", () => {
+    const withBot = reducer(initialState, { type: "botPatched", bot });
+    const landed = reducer(withBot, {
+      type: "messageAdded",
+      threadId: "t1",
+      message: {
+        id: "landed",
+        at: 2,
+        role: "user",
+        kind: "text",
+        text: "now run this",
+        queueId: "q-landed",
+      },
+    });
+
+    expect(landed.mascotMotion).toMatchObject({ botId: "b1", kind: "working" });
+  });
+
   it("keeps a Shift+Enter multiline message as one entry", () => {
     const withBot = reducer(initialState, { type: "botPatched", bot });
     const queued = reducer(withBot, {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -87,6 +87,8 @@ export interface Message {
   role: "bot" | "user";
   kind: "text" | "options" | "activity" | "screen" | "connector" | "secret" | "routine.run" | "goal.run";
   text?: string;
+  /** Provider-generated files attached to this assistant response. */
+  attachments?: Array<{ kind: "image"; path: string; mime: string }>;
   card?: OptionCardData;
   connector?: ConnectorCardData;
   secret?: SecretRequestCardData;
@@ -982,7 +984,9 @@ export function reducer(state: AppState, action: Action): AppState {
         return { ...b, messages, activeLeafId: adoptsLeaf ? action.message.id : b.activeLeafId };
       });
       const motion =
-        action.message.kind === "options"
+        action.message.role === "user" && action.message.kind === "text" && Boolean(action.message.queueId)
+          ? "working"
+          : action.message.kind === "options"
           ? "thinking"
           : action.message.kind === "activity"
             ? action.message.tool?.ok === false


### PR DESCRIPTION
## What changed

- handle Codex app-server `imageGeneration` results and persist validated raster bytes through the private attachment store
- attach generated images to the terminal assistant response, including image-only turns and channel replies
- omit raw image bytes and provider paths from renderer SSE and native diagnostics
- move waiting sends from the transcript tail to a queued-message stack above the composer
- restore normal working/mascot motion when a queued line is released into the transcript

The Codex item shape follows the current generated app-server schema used by T3 Code; OpenMausBot consumes `result` bytes rather than trusting `savedPath`.

## Verification

- `pnpm test` — 2,876 passed / 20 skipped; broker, Electron, and packaged-server checks passed
- `pnpm build`
- `pnpm typecheck`
- 117 focused tests after rebasing onto current `main`
- documented isolated fixture: doctor → new-bot → send → wait (`settled`) → messages; fixture stopped and temp data removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying provider-generated images alongside assistant messages.
  * Images without accompanying text now appear with a “Generated image” label.
  * Added a visible queue for pending composer messages, including cancellation controls.
  * Queued messages now provide clearer working-state feedback.

* **Bug Fixes**
  * Improved handling and validation of generated image data.
  * Prevented sensitive provider image details from appearing in runtime logs or broadcasts.
  * Corrected queued-message state updates when messages enter the transcript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->