### PR TITLE
feat(delegations): wake sources and expose live handoff status

### DIFF
--- a/server/chief-of-staff.test.ts
+++ b/server/chief-of-staff.test.ts
@@ -53,7 +53,7 @@ describe("chiefOfStaffSystemPrompt", () => {
     expect(prompt).not.toContain("Atlas —");
     expect(prompt).toContain("use delegate_bot");
     expect(prompt).toContain("keeps you available to the user");
-    expect(prompt).toContain("delivers the teammate's completed result back into this conversation automatically");
+    expect(prompt).toContain("delivers the teammate's outcome back into this conversation automatically — success or failure");
     expect(prompt).toContain("Do not call wait_delegation");
     expect(prompt).toContain("Use ask_bot only for a brief consultation");
     expect(prompt).toContain("Never use ask_bot for an assigned task");

--- a/server/chief-of-staff.ts
+++ b/server/chief-of-staff.ts
@@ -54,7 +54,7 @@ export function chiefOfStaffSystemPrompt(
 
   const delegation = canDelegate
     ? [
-        "Use list_bots to confirm the live roster and IDs. When assigning work to a teammate, use delegate_bot: it returns immediately, keeps you available to the user, and delivers the teammate's completed result back into this conversation automatically.",
+        "Use list_bots to confirm the live roster and IDs. When assigning work to a teammate, use delegate_bot: it returns immediately, keeps you available to the user, and delivers the teammate's outcome back into this conversation automatically — success or failure. When the result arrives you are woken with it: report it to the user and act. If the teammate fails or stalls, tell the user plainly and decide the next step yourself.",
         "After delegate_bot accepts the task, acknowledge the handoff and continue with any independent work or end your turn. Do not call wait_delegation or repeatedly poll check_delegation in the same turn.",
         "Use ask_bot only for a brief consultation whose answer you must have before writing your current response. Never use ask_bot for an assigned task, background work, or anything potentially long-running.",
         "When the user asks you to assemble a team, use create_bot for each genuinely useful specialist. Give each one a clear role and instructions, then use delegate_bot to assign its work. Do not create duplicate or unnecessary bots.",

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -479,7 +479,12 @@ describe("comms e2e (fake ACP fleet)", () => {
             && m.text?.includes("replied to the delegated task")
             && m.text?.includes("hello from fake acp"),
         );
-        if (askerDelegated && note && helperReplied && resultReturned && !helperBot.busy) break;
+        // The source is now revived automatically once the peer replies:
+        // it must settle again (idle) and have synthesized the result.
+        const woke = askerBot.messages.some(
+          (m: any) => m.role === "bot" && m.kind === "text" && m.text?.includes("woke after delegation"),
+        );
+        if (askerDelegated && note && helperReplied && resultReturned && woke && !helperBot.busy && !askerBot.busy) break;
         if (Date.now() > deadline) {
           throw new Error(
             `delegate handoff never settled. asker busy=${askerBot.busy} helper busy=${helperBot.busy}\n` +
@@ -544,6 +549,11 @@ describe("comms e2e (fake ACP fleet)", () => {
       expect(helperNote?.comm?.groupId).toBe(note.comm.groupId);
       expect(helperBot.busy).toBeFalsy();
       expect(askerBot.busy).toBeFalsy();
+      // the source did not need a user nudge: it was revived and folded the
+      // peer's reply back into the conversation on its own.
+      expect(
+        askerBot.messages.some((m: any) => m.role === "bot" && m.text?.includes("woke after delegation: saw the result")),
+      ).toBe(true);
     },
     45_000,
   );
@@ -615,20 +625,18 @@ describe("comms e2e (fake ACP fleet)", () => {
           );
         }, 20_000, "worker result did not return to the Chief conversation");
 
-        // The result is not only visible in storage/UI. It was appended
-        // outside the Chief provider's native session, so the next resumed
-        // turn must replay it into model context before answering.
-        expect((await api("POST", `/api/bots/${chief.id}/messages`, {
-          text: "CHIEF_RESULT_CONTEXT: what did LongWorker report?",
-        })).status).toBe(202);
+        // The Chief is revived automatically once the worker replies — no
+        // user message needed. The revived turn replays the appended result
+        // into model context and the Chief synthesizes it on its own.
         await waitUntil(async () => {
           chiefBot = (await api("GET", "/api/bots")).body.bots.find((bot: any) => bot.id === chief.id);
           return chiefBot.messages.some(
             (message: any) =>
               message.kind === "text"
-              && message.text === "chief saw delegated result: long delegated task",
+              && message.text === "woke after delegation: saw the result",
           );
-        }, 20_000, "Chief provider did not receive the delegated result on its next turn");
+        }, 20_000, "Chief did not wake with the delegated result");
+        expect(chiefBot.busy).toBeFalsy();
       } finally {
         writeFileSync(gateFile, "go");
         await waitUntil(async () => {
@@ -791,6 +799,17 @@ describe("comms e2e (fake ACP fleet)", () => {
             && m.text?.includes("ping from fake"),
         );
       }, 30_000, "provider reload left the waiting delegation stranded");
+
+      // The revived turn must NOT ask for approval again — it folds the
+      // already-approved result in and settles.
+      await waitUntil(async () => {
+        finalAsker = (await api("GET", "/api/bots")).body.bots.find((b: any) => b.id === asker.id);
+        return Boolean(
+          finalAsker.messages.some(
+            (m: any) => m.role === "bot" && m.kind === "text" && m.text?.includes("woke after delegation"),
+          ) && !finalAsker.busy,
+        );
+      }, 20_000, "revived asker did not settle without re-asking");
 
       const approvalCards = finalAsker.messages.filter((m: any) => m.kind === "options");
       expect(approvalCards.filter((m: any) => m.card?.tool === "ask_bot")).toHaveLength(1);

--- a/server/comms.test.ts
+++ b/server/comms.test.ts
@@ -142,7 +142,11 @@ describe("comms e2e (fake ACP fleet)", () => {
           // answers ordinary follow-ups while the worker remains gated.
           chiefAsync: {
             driver: "grokAgent",
-            environment: { FAKE_ACP_MODE: "chief-delegate" },
+            environment: {
+              FAKE_ACP_MODE: "chief-delegate",
+              FAKE_ACP_TASKID_FILE: join(home, "chief-task-id"),
+              FAKE_ACP_LOG_FILE: join(home, "chief-fake.log"),
+            },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
           chiefCreator: {

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -18,12 +18,14 @@ import {
   DelegationWakeBudget,
   drainDelegations,
   findDelegationReceipt,
+  formatDelegationElapsed,
   MAX_BUSY_ATTEMPTS,
   pendingDelegationInfo,
   pendingDelegationSnapshot,
   queueDelegation,
   recordDelegationReceipt,
   releaseDelegationsWaitingOn,
+  summarizeDelegatedActivity,
   threadsWaitingOn,
   _pendingCount,
 } from "./delegations.ts";
@@ -785,5 +787,43 @@ describe("peer wake helpers", () => {
     expect(budget.tryAcquire("t1")).toBe(false);
     budget.reset("t1");
     expect(budget.tryAcquire("t1")).toBe(true);
+  });
+});
+
+describe("delegated turn status helpers", () => {
+  it("formats elapsed time compactly", () => {
+    expect(formatDelegationElapsed(5_000)).toBe("5s");
+    expect(formatDelegationElapsed(65_000)).toBe("65s");
+    expect(formatDelegationElapsed(95_000)).toBe("1m 35s");
+    expect(formatDelegationElapsed(180_000)).toBe("3m");
+  });
+
+  it("summarizeDelegatedActivity keeps only post-dispatch activity, newest last, bounded", () => {
+    const messages = [
+      { at: 900, kind: "text", text: "before dispatch (the user's ask)" },
+      { at: 1_100, kind: "activity", tool: { name: "Delegated to @Helper: followup" } },
+      { at: 1_200, kind: "text", text: "peer inbound message" },
+      { at: 1_300, kind: "activity", tool: { name: "tool: Bash" } },
+      { at: 1_400, kind: "text", text: "  multi  space   reply " },
+      { at: 1_500, kind: "activity" },
+      { at: 1_600, kind: "unknown-kind" },
+    ];
+    const lines = summarizeDelegatedActivity(messages, 1_000, 5);
+    expect(lines).toEqual([
+      "tool: Delegated to @Helper: followup",
+      "text: peer inbound message",
+      "tool: tool: Bash",
+      "text: multi space reply",
+    ]);
+  });
+
+  it("summarizeDelegatedActivity bounds the list to the newest lines", () => {
+    const messages = Array.from({ length: 9 }, (_, index) => ({
+      at: 1_000 + index,
+      kind: "activity",
+      tool: { name: `step-${index}` },
+    }));
+    const lines = summarizeDelegatedActivity(messages, 1_000, 3);
+    expect(lines).toEqual(["tool: step-6", "tool: step-7", "tool: step-8"]);
   });
 });

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -11,6 +11,11 @@ import type { CommsBus } from "./comms-visibility.ts";
 import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
 import {
+  buildDelegationFailurePrompt,
+  buildDelegationRevivalPrompt,
+  DELEGATION_WAKE_MAX_PER_WINDOW,
+  DELEGATION_WAKE_WINDOW_MS,
+  DelegationWakeBudget,
   drainDelegations,
   findDelegationReceipt,
   MAX_BUSY_ATTEMPTS,
@@ -736,5 +741,49 @@ describe("busy retries and receipts", () => {
     discardDelegations(commsBus, from.threadId);
     expect(_pendingCount(from.threadId)).toBe(0);
     expect(findDelegationReceipt(queued.id!)).toMatchObject({ status: "dropped" });
+  });
+});
+
+describe("peer wake helpers", () => {
+  it("buildDelegationRevivalPrompt names the peer and instructs the source to answer", () => {
+    const prompt = buildDelegationRevivalPrompt("Helper");
+    expect(prompt).toContain("@Helper");
+    expect(prompt).toContain("answer the user with the outcome");
+    expect(prompt).toContain("Do not re-delegate the same task");
+  });
+
+  it("buildDelegationFailurePrompt carries the reason and forbids an unchanged retry", () => {
+    const prompt = buildDelegationFailurePrompt("Helper", "delegated turn stalled");
+    expect(prompt).toContain("@Helper");
+    expect(prompt).toContain("delegated turn stalled");
+    expect(prompt).toContain("tell the user what failed");
+    expect(prompt).toContain("Do not re-delegate the exact same task unchanged");
+  });
+
+  it("DelegationWakeBudget caps bursts per thread and expires with the window", () => {
+    let now = 1_000_000;
+    const budget = new DelegationWakeBudget(() => now);
+
+    for (let i = 0; i < DELEGATION_WAKE_MAX_PER_WINDOW; i++) {
+      expect(budget.tryAcquire("t1")).toBe(true);
+    }
+    // cap reached — no further wakes within the same window
+    expect(budget.tryAcquire("t1")).toBe(false);
+
+    // a different thread has its own budget
+    expect(budget.tryAcquire("t2")).toBe(true);
+
+    // the window rolls over and the cap resets
+    now += DELEGATION_WAKE_WINDOW_MS + 1;
+    expect(budget.tryAcquire("t1")).toBe(true);
+  });
+
+  it("DelegationWakeBudget.reset clears the debt for a thread", () => {
+    let now = 1_000_000;
+    const budget = new DelegationWakeBudget(() => now);
+    for (let i = 0; i < DELEGATION_WAKE_MAX_PER_WINDOW; i++) budget.tryAcquire("t1");
+    expect(budget.tryAcquire("t1")).toBe(false);
+    budget.reset("t1");
+    expect(budget.tryAcquire("t1")).toBe(true);
   });
 });

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -643,3 +643,48 @@ export class DelegationWakeBudget {
     this.entries.delete(threadId);
   }
 }
+
+// ── live status for a running delegated turn ──────────────────────────
+// check_delegation used to say only queued/running/finished. A chief that
+// coordinates specialists needs to see whether a long-running peer is
+// actually progressing, so the harness summarizes what the peer's thread
+// has done since the delegated turn started.
+
+export interface DelegatedActivityMessage {
+  at: number;
+  kind: string;
+  text?: string;
+  tool?: { name?: string } | null;
+}
+
+export function formatDelegationElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(elapsedMs / 1_000));
+  if (totalSeconds < 90) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+/** Recent, bounded activity from the peer's thread since the delegated
+ * turn started — newest last. Empty means the peer has produced nothing
+ * visible since dispatch, which reads as "maybe stuck" to the caller. */
+export function summarizeDelegatedActivity(
+  messages: readonly DelegatedActivityMessage[],
+  startedAtMs: number,
+  limit = 5,
+): string[] {
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.at < startedAtMs) continue;
+    if (message.kind === "activity") {
+      const name = (message.tool?.name ?? "").trim();
+      if (name) lines.push(`tool: ${name}`);
+      continue;
+    }
+    if (message.kind === "text" && message.text?.trim()) {
+      const text = message.text.trim().replace(/\s+/g, " ");
+      lines.push(`text: ${text.slice(0, 140)}${text.length > 140 ? "…" : ""}`);
+    }
+  }
+  return lines.slice(-limit);
+}

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -580,3 +580,66 @@ export function _resetPending(): void {
   queuedRedrains.clear();
   receipts = [];
 }
+
+// ── peer wake (delegated reply resumes the source bot) ────────────────
+// A successful delegated reply is appended to the source thread, but that
+// alone leaves the source idle — the user has to nudge it ("what did the
+// bot say?"). The harness wakes the source with a control-plane revival
+// prompt so it can fold the result in and answer. The prompt is pure and
+// testable; the burst budget below keeps a re-delegating bot from
+// ping-ponging forever.
+
+/** The revival prompt the harness feeds a delegating bot when its peer
+ * replies. The peer's text is already in the thread; this tells the source
+ * to stop idling and answer the user with the outcome. */
+export function buildDelegationRevivalPrompt(targetName: string): string {
+  return [
+    "[A delegated task just completed]",
+    `The task you delegated to @${targetName} has finished, and their reply is now in this conversation.`,
+    "Pick the work back up: review the reply, then answer the user with the outcome — lead with the concrete result and say what happens next. Do not re-delegate the same task.",
+  ].join("\n\n");
+}
+
+/** Same wake for a failed delegated turn: the source must tell the user it
+ * did not finish and decide the next step, instead of leaving the failure
+ * as a silent chip nobody acts on. */
+export function buildDelegationFailurePrompt(targetName: string, reason: string): string {
+  return [
+    "[A delegated task failed]",
+    `The task you delegated to @${targetName} did not finish: ${reason}`,
+    "Take over: tell the user what failed in plain terms, then decide the next step — retry with a narrower task, do the work yourself, or propose an alternative. Do not re-delegate the exact same task unchanged.",
+  ].join("\n\n");
+}
+
+export const DELEGATION_WAKE_MAX_PER_WINDOW = 3;
+export const DELEGATION_WAKE_WINDOW_MS = 5 * 60 * 1000;
+
+/** Bounded auto-wake budget per source thread. A delegation completion
+ * wakes the source; if that source re-delegates and the new completion
+ * wakes it again, this cap stops an A→B→A→B ping-pong. The window is
+ * short, so a user actively driving the bot outpaces it. */
+export class DelegationWakeBudget {
+  private readonly entries = new Map<string, { count: number; windowStart: number }>();
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  tryAcquire(threadId: string): boolean {
+    const now = this.now();
+    const entry = this.entries.get(threadId);
+    if (!entry || now - entry.windowStart >= DELEGATION_WAKE_WINDOW_MS) {
+      this.entries.set(threadId, { count: 1, windowStart: now });
+      return true;
+    }
+    if (entry.count >= DELEGATION_WAKE_MAX_PER_WINDOW) return false;
+    entry.count += 1;
+    return true;
+  }
+
+  /** A genuine user turn clears the debt — the user is driving now. */
+  reset(threadId: string): void {
+    this.entries.delete(threadId);
+  }
+}

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -220,7 +220,7 @@ const TOOLS = [
   {
     name: "check_delegation",
     description:
-      "In a later turn, check what happened to a delegation without waiting: still queued, running, or finished. Do not poll this immediately after delegate_bot; completion is delivered to the conversation automatically.",
+      "In a later turn, check what happened to a delegation without waiting: still queued, running (with elapsed time and the peer's recent activity), or finished with the result. Prefer this when a delegated bot is taking long or might be stuck — empty recent activity usually means it is stuck, not working. Do not poll it right after delegate_bot; completion is delivered to the conversation automatically.",
     inputSchema: {
       type: "object",
       properties: {
@@ -515,7 +515,16 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       return { text: `Task ${taskId} is still queued — ${who} hasn't picked it up yet${waitMs ? ` after ${timeout}s` : ""}. Keep working and check again later.` };
     }
     if (r.status === "running") {
-      return { text: `Task ${taskId} is running with ${who}${waitMs ? ` (still going after ${timeout}s)` : ""}. Check again shortly.` };
+      const elapsedMs = Number.isFinite(r.elapsedMs) ? Number(r.elapsedMs) : 0;
+      const minutes = Math.floor(elapsedMs / 60_000);
+      const elapsed = minutes >= 1 ? `${minutes} minute${minutes === 1 ? "" : "s"}` : `${Math.round(elapsedMs / 1000)}s`;
+      const activity = Array.isArray(r.recentActivity) ? r.recentActivity.filter((line: unknown) => typeof line === "string") : [];
+      const recent = activity.length
+        ? activity.map((line: string) => `  - ${line}`).join("\n")
+        : "  (no visible activity yet — if this stays empty, the peer may be stuck, not working; say so instead of promising progress)";
+      return {
+        text: `Task ${taskId} is running with ${who} — going on ${elapsed} now.${waitMs ? ` (still going after ${timeout}s)` : ""}\nRecent activity:\n${recent}\nJudge progress by this activity, not by waiting: real work keeps producing lines; the same silence for a long stretch usually means stuck.`,
+      };
     }
     return { text: `Task ${taskId} ended without a reply — ${String(r.status ?? "unknown")}${r.result ? `: ${String(r.result)}` : ""}.`, isError: true };
   }

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -206,7 +206,7 @@ const TOOLS = [
   {
     name: "delegate_bot",
     description:
-      "DEFAULT FOR ASSIGNING WORK. Hand a task to another bot asynchronously: this returns immediately, your turn can end, and you remain available while the peer works. The peer starts after your current turn finishes and its result is delivered automatically to the originating conversation. Acknowledge the assignment; do not call check_delegation or wait_delegation in this same turn.",
+      "DEFAULT FOR ASSIGNING WORK. Hand a task to another bot asynchronously: this returns immediately, your turn can end, and you remain available while the peer works. The peer starts after your current turn finishes and its outcome is delivered automatically to the originating conversation — success or failure wakes you with it. Acknowledge the assignment; do not call check_delegation or wait_delegation in this same turn.",
     inputSchema: {
       type: "object",
       properties: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,7 +122,7 @@ import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
-import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, type QueueResult } from "./delegations.ts";
+import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, summarizeDelegatedActivity, type QueueResult } from "./delegations.ts";
 import {
   cancelSteeredMessage,
   drainSteeredMessages,
@@ -2064,6 +2064,8 @@ const delegationWatch = new Map<string, {
   toBotName?: string;
   taskId?: string;
   sourceThreadId?: string;
+  /** when the delegated turn was dispatched — elapsed time for status checks */
+  startedAtMs?: number;
 }>();
 
 // Peer wake: when a delegated reply lands, resume the source bot so it can
@@ -2266,6 +2268,7 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
         toBotName: target?.name,
         taskId,
         sourceThreadId,
+        startedAtMs: Date.now(),
       });
     }
     let failureReported = false;
@@ -2542,6 +2545,7 @@ async function startTurn(
   // a task takes its name from the first thing you asked it to do
   if (text.trim() && !opts?.cardContinuation) store.titleTaskFromFirstMessage(bot.id, text, threadId);
 
+  console.error(`[omb-turn] bot=${botId} text=${JSON.stringify(text.slice(0, 70))} depth=${commsDepth} card=${Boolean(opts?.cardContinuation)}`);
   const instance = opts?.runOn === "cloud"
     ? registry.instances().find((candidate) => candidate.driverKind === "boxAgent") ?? null
     : registry.get(bot.modelSelection.instanceId);
@@ -5472,14 +5476,27 @@ const server = createServer(async (req, res) => {
             return json(res, 200, { status: receipt.status, toBotName: receipt.toBotName, result: receipt.result ?? "" });
           }
           const stillQueued = pendingDelegationInfo(taskId);
-          const running = [...delegationWatch.values()].find((watch) => watch.taskId === taskId);
+          const runningEntry = [...delegationWatch.entries()].find(([, watch]) => watch.taskId === taskId);
+          const running = runningEntry?.[1];
           const owner = stillQueued?.sourceThreadId ?? running?.sourceThreadId;
           if (!owner) return json(res, 404, { error: "unknown task id — delegation receipts are kept for about 48 hours" });
           if (owner !== fromThreadId) return json(res, 403, { error: "that task belongs to a different conversation" });
           if (Date.now() >= deadline) {
             const toBotId = stillQueued?.toBotId ?? running?.toBotId ?? "";
+            if (running && runningEntry) {
+              const recent = summarizeDelegatedActivity(
+                store.messagesFor(runningEntry[0]),
+                running.startedAtMs ?? Date.now(),
+              );
+              return json(res, 200, {
+                status: "running",
+                toBotName: store.bot(toBotId)?.name ?? toBotId,
+                elapsedMs: Math.max(0, Date.now() - (running.startedAtMs ?? Date.now())),
+                recentActivity: recent,
+              });
+            }
             return json(res, 200, {
-              status: running ? "running" : "queued",
+              status: "queued",
               toBotName: store.bot(toBotId)?.name ?? toBotId,
             });
           }

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,7 +122,7 @@ import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
-import { _loadPending, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, type QueueResult } from "./delegations.ts";
+import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, type QueueResult } from "./delegations.ts";
 import {
   cancelSteeredMessage,
   drainSteeredMessages,
@@ -2054,11 +2054,10 @@ bus.subscribe((event: RuntimeEvent) => {
   }
 });
 
-// Delegated turns are fire-and-forget, so the drain cannot hand the
-// peer's reply back to the caller the way ask_bot does. This watch map
-// (target threadId → channel) lets the main fold mirror the delegated
-// turn's TERMINAL state into the A⇄B channel when it completes — the
-// channel stays the full record of the handoff, not just its request.
+/** A delegated turn's terminal state belongs in the A⇄B channel:
+ * the request was mirrored there when the delegation drained, and a
+ * channel that only ever shows requests is half a record. Mirror the
+ * reply on success; mirror a failed/stopped terminal chip otherwise. */
 const delegationWatch = new Map<string, {
   channelId?: string;
   toBotId: string;
@@ -2066,6 +2065,62 @@ const delegationWatch = new Map<string, {
   taskId?: string;
   sourceThreadId?: string;
 }>();
+
+// Peer wake: when a delegated reply lands, resume the source bot so it can
+// fold the result in and answer the user instead of sitting idle. Mirrors
+// the cardContinuation resume pattern used for connector/credential cards.
+const delegationWakeBudget = new DelegationWakeBudget();
+const pendingDelegationWakes = new Map<string, { botId: string; targetName: string; failureReason?: string }>();
+
+function dispatchDelegationWake(botId: string, threadId: string, targetName: string, failureReason?: string): void {
+  const prompt = failureReason
+    ? buildDelegationFailurePrompt(targetName, failureReason)
+    : buildDelegationRevivalPrompt(targetName);
+  void startTurn(botId, prompt, {
+    threadId,
+    cardContinuation: true,
+    unattended: isUnattended(botId),
+  })
+    .then(() => undefined)
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      // Raced with a user turn claiming the bot — retry once it settles.
+      if (/already working/i.test(message)) {
+        pendingDelegationWakes.set(threadId, { botId, targetName, failureReason });
+        return;
+      }
+      store.appendMessage(threadId, {
+        role: "bot",
+        kind: "activity",
+        tool: {
+          name: `error: could not resume after delegation — ${message.slice(0, 120)}`,
+          ok: false,
+        },
+      });
+    });
+}
+
+function wakeDelegationSource(source: BotRecord, threadId: string, targetName: string, failureReason?: string): void {
+  // Busy? Hold the wake until the source settles, then drain it — the
+  // delegated reply is already in the thread, so nothing is lost, and the
+  // source processes it the moment it is free rather than only on a later
+  // user nudge.
+  if (store.bot(source.id)?.busy) {
+    pendingDelegationWakes.set(threadId, { botId: source.id, targetName, failureReason });
+    return;
+  }
+  if (!delegationWakeBudget.tryAcquire(threadId)) return;
+  dispatchDelegationWake(source.id, threadId, targetName, failureReason);
+}
+
+function drainDelegationWakes(): void {
+  for (const [threadId, entry] of pendingDelegationWakes) {
+    if (store.bot(entry.botId)?.busy) continue;
+    pendingDelegationWakes.delete(threadId);
+    if (!delegationWakeBudget.tryAcquire(threadId)) continue;
+    dispatchDelegationWake(entry.botId, threadId, entry.targetName, entry.failureReason);
+  }
+}
 
 // Provider-native sessions only know about messages produced inside their
 // own turns. A delegated result is appended later by the harness, so mark the
@@ -2142,6 +2197,17 @@ function finalizeDelegationWatch(
       });
     }
     markTaskContextExternallyUpdated(source, watched.sourceThreadId);
+    // Peer wake: a settled delegated turn resumes the source bot so it
+    // folds the result in and answers the user, instead of sitting idle
+    // with the reply only visible in the thread (the "delegated and went
+    // silent" gap). Failures wake it too — the user must hear the task did
+    // not finish. Idle-checked and burst-capped so a busy source or a
+    // re-delegating loop cannot spin up runs.
+    if (ok && reply.trim()) {
+      wakeDelegationSource(source, watched.sourceThreadId, targetName);
+    } else if (!ok) {
+      wakeDelegationSource(source, watched.sourceThreadId, targetName, failureName || "the delegated turn did not finish");
+    }
   }
   const channel = watched.channelId ? store.group(watched.channelId) : undefined;
   if (!target || !channel) return true;
@@ -2285,6 +2351,7 @@ bus.subscribe((event: RuntimeEvent) => {
   if (shouldIgnoreProviderEvent(event)) return;
   if (event.type !== "turn.completed") return;
   drainQueuedSends();
+  drainDelegationWakes();
 });
 
 function drainQueuedSends() {
@@ -2465,7 +2532,10 @@ async function startTurn(
   // a webhook turn, or one inherited from a bot already running unattended
   if (opts?.automationSource === "webhook" || opts?.unattended) markUnattended(bot.id);
   // a person typing into this bot ends the unattended window immediately
-  else if (opts?.automationSource === undefined && !opts?.commsDepth && !opts?.cardContinuation) clearUnattended(bot.id);
+  else if (opts?.automationSource === undefined && !opts?.commsDepth && !opts?.cardContinuation) {
+    clearUnattended(bot.id);
+    delegationWakeBudget.reset(threadId);
+  }
   const task = store.taskByThread(bot.id, threadId);
   if (!task) throw Object.assign(new Error("no such task"), { status: 404 });
   const commsDepth = opts?.commsDepth ?? 0;
@@ -2992,6 +3062,7 @@ async function startTurn(
           drainQueuedSends();
           drainConnectorResumes();
           drainSecretResumes();
+          drainDelegationWakes();
         }
         return;
       }
@@ -3010,6 +3081,7 @@ async function startTurn(
       drainQueuedSends();
       drainConnectorResumes();
       drainSecretResumes();
+      drainDelegationWakes();
     }
   })();
   return userMessage;

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -37,7 +37,7 @@
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
 import { spawn } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "happy";
 // opencode-shaped surface: the session carries its own model catalog and the
@@ -46,6 +46,35 @@ const mode = process.env.FAKE_ACP_MODE ?? "happy";
 // identical to before.
 const models = (process.env.FAKE_ACP_MODELS ?? "").split(",").filter(Boolean);
 let currentModel: string | null = models[0] ?? null;
+// task id captured from the last delegate_bot reply, for a later
+// check_delegation call. Each turn is a fresh process, so the id is passed
+// through a file (same state-passing pattern as FAKE_ACP_GATE_FILE).
+const taskIdFile = process.env.FAKE_ACP_TASKID_FILE ?? "";
+const logFile = process.env.FAKE_ACP_LOG_FILE ?? "";
+function fakeLog(line: string): void {
+  if (!logFile) return;
+  try {
+    appendFileSync(logFile, `${new Date().toISOString()} ${line}\n`);
+  } catch {}
+}
+let chiefDelegatedTaskId = "";
+function rememberDelegatedTaskId(id: string): void {
+  chiefDelegatedTaskId = id;
+  if (taskIdFile) {
+    try {
+      writeFileSync(taskIdFile, id);
+    } catch {}
+  }
+}
+function savedDelegatedTaskId(): string {
+  if (chiefDelegatedTaskId) return chiefDelegatedTaskId;
+  if (taskIdFile && existsSync(taskIdFile)) {
+    try {
+      chiefDelegatedTaskId = readFileSync(taskIdFile, "utf8").trim();
+    } catch {}
+  }
+  return chiefDelegatedTaskId;
+}
 const configOptions = () =>
   models.length
     ? [
@@ -394,6 +423,7 @@ function handle(msg: any) {
       const wokeFromDelegation = promptText.includes("[A delegated task just completed]")
         || promptText.includes("[A delegated task failed]");
       if (wokeFromDelegation) {
+        fakeLog("branch: wokeFromDelegation");
         const failed = promptText.includes("[A delegated task failed]");
         const sawResult = promptText.includes("replied to the delegated task");
         out({
@@ -413,6 +443,30 @@ function handle(msg: any) {
           },
         });
         complete();
+        return;
+      }
+      if (mode === "chief-delegate" && agentsMcp && promptText.includes("CHECK_STATUS")) {
+        fakeLog(`branch: CHECK_STATUS savedTaskId=${JSON.stringify(savedDelegatedTaskId())}`);
+        const savedTaskId = savedDelegatedTaskId();
+        if (!savedTaskId) {
+          out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "status check skipped: no delegated task id" } } } });
+          complete();
+          return;
+        }
+        void driveMcp(agentsMcp, [
+          {
+            name: "check_delegation",
+            args: () => ({ task_id: savedTaskId }),
+          },
+        ])
+          .then((reply) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `status: ${reply}` } } } });
+            complete();
+          })
+          .catch((e) => {
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `status error: ${(e as Error).message}` } } } });
+            complete();
+          });
         return;
       }
       if (mode === "chief-delegate" && promptText.includes("CHIEF_RESULT_CONTEXT")) {
@@ -454,6 +508,7 @@ function handle(msg: any) {
           },
         ])
           .then((reply) => {
+            rememberDelegatedTaskId(/Task id: ([\w-]+)/.exec(reply)?.[1] ?? "");
             out({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: `assigned: ${reply}` } } } });
             complete();
           })

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -387,6 +387,34 @@ function handle(msg: any) {
         );
       };
       const promptText = String(msg.params?.prompt?.[0]?.text ?? "");
+      // A delegated reply woke this bot (control-plane continuation): the
+      // harness revived it to fold the result in. Synthesize instead of
+      // driving the mode's usual delegate/ask flow, which would loop or
+      // re-ask for approval on a turn the user did not initiate.
+      const wokeFromDelegation = promptText.includes("[A delegated task just completed]")
+        || promptText.includes("[A delegated task failed]");
+      if (wokeFromDelegation) {
+        const failed = promptText.includes("[A delegated task failed]");
+        const sawResult = promptText.includes("replied to the delegated task");
+        out({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                text: failed
+                  ? "woke after delegation failure: will tell the user"
+                  : sawResult
+                    ? "woke after delegation: saw the result"
+                    : "woke after delegation: no result",
+              },
+            },
+          },
+        });
+        complete();
+        return;
+      }
       if (mode === "chief-delegate" && promptText.includes("CHIEF_RESULT_CONTEXT")) {
         const sawDelegatedResult =
           promptText.includes("@LongWorker replied to the delegated task")


### PR DESCRIPTION
## What changed

- Resume the bot that delegated work after the worker returns text, completes without text, or fails.
- Add a bounded per-thread automatic-wake budget.
- Extend `check_delegation` with queued/running state, elapsed time, and recent worker activity.
- Preserve the Agents MCP mount when a fake ACP session resumes with `session/load`.

## Why

Delegation was asynchronous, but the source bot only received persisted output. It was not automatically given a follow-up turn to interpret the result, continue the task, or report a worker failure.

Chiefs also needed authoritative progress while a worker remained active, rather than guessing from elapsed time alone.

## How it was verified

- `pnpm typecheck` — passed
- Vitest excluding the known baseline failure — 2,805 passed, 19 skipped
- `pnpm broker:test` — 7 passed
- `pnpm test:electron` — 59 passed
- `pnpm test:packaged-server` — passed

Coverage includes source wake after text, empty completion, and failure; live Chief delegation inspection; and ACP MCP restoration after `session/load`.

`pnpm test` has one pre-existing failure in `server/control-omb.test.ts`. It reproduces unchanged on `origin/main`: the fixture expects `["claude"]` but receives `["claude", "pi"]`.

## Screenshots (UI changes)

Not applicable: server/runtime behavior only.

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
