### PR TITLE
feat(chat): render generated images from ACP engines

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -278,6 +278,27 @@ describe("ACP turns (fake CLI)", () => {
     expect(texts).toEqual(["before one", "before two", "after"]);
   });
 
+  it("normalizes a structured ACP image block without treating it as text", async () => {
+    await create(GeminiAgentDriver, "image");
+    await instance.adapter.sendTurn({ threadId: "t-image", text: "draw it" });
+    await recorder.until((event) => event.type === "turn.completed");
+
+    const image = recorder.events.find(
+      (event) => event.type === "item.completed" && event.itemType === "assistant_image",
+    );
+    expect(image).toMatchObject({
+      type: "item.completed",
+      itemType: "assistant_image",
+      alt: "Generated image",
+    });
+    expect(image && "data" in image ? image.data : "").toMatch(/^iVBOR/);
+    expect(
+      recorder.events.some(
+        (event) => event.type === "item.completed" && event.itemType === "assistant_text",
+      ),
+    ).toBe(false);
+  });
+
   it("reads token usage from the root of the prompt result", async () => {
     process.env.FAKE_ACP_USAGE_ROOT = "1";
     await create();

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -230,6 +230,29 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
       const emit = (event: RuntimeEvent) => {
         for (const l of [...listeners]) l(event);
       };
+
+      // ACP content blocks may carry a complete raster image inline. Keep the
+      // bytes available to the normalizer, but never duplicate megabytes of
+      // base64 into the provider-native diagnostic log.
+      const nativeLogMessage = (msg: any): unknown => {
+        const content = msg?.params?.update?.content;
+        if (
+          msg?.method !== "session/update" ||
+          msg?.params?.update?.sessionUpdate !== "agent_message_chunk" ||
+          content?.type !== "image" ||
+          typeof content.data !== "string"
+        ) return msg;
+        return {
+          ...msg,
+          params: {
+            ...msg.params,
+            update: {
+              ...msg.params.update,
+              content: { ...content, data: `[image data: ${content.data.length} base64 chars]` },
+            },
+          },
+        };
+      };
       const base = (threadId: string, turnId: string) => ({
         eventId: newEventId(),
         provider: DRIVER_KIND,
@@ -463,8 +486,18 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           const u = p.update ?? {};
           switch (u.sessionUpdate) {
             case "agent_message_chunk": {
-              const delta = u.content?.text;
-              if (typeof delta === "string" && delta) {
+              const content = u.content;
+              const delta = content?.text;
+              if (content?.type === "image" && typeof content.data === "string" && content.data) {
+                flushAssistantText();
+                emit({
+                  ...base(threadId, turnId),
+                  type: "item.completed",
+                  itemType: "assistant_image",
+                  data: content.data,
+                  alt: "Generated image",
+                });
+              } else if (typeof delta === "string" && delta) {
                 state.text += delta;
                 emit({ ...base(threadId, turnId), type: "content.delta", streamKind: "assistant_text", delta });
               }
@@ -520,7 +553,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             } catch {
               continue;
             }
-            appendNative(threadId, { dir: "in", source: SOURCE, msg });
+            appendNative(threadId, { dir: "in", source: SOURCE, msg: nativeLogMessage(msg) });
             if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
               const pend = rpcPending.get(msg.id);
               if (pend) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -473,6 +473,16 @@ function generatedImageTurnKey(threadId: string, turnId?: string): string {
   return `${threadId}:${turnId ?? "active"}`;
 }
 
+function purgeGeneratedImagesForThread(threadId: string): void {
+  for (const [key, attachments] of generatedImagesByTurn) {
+    if (!key.startsWith(`${threadId}:`)) continue;
+    generatedImagesByTurn.delete(key);
+    for (const attachment of attachments) {
+      try { unlinkSync(attachment.path); } catch {}
+    }
+  }
+}
+
 function markCancelledProviderHandshake(threadId: string, ownerId: string): void {
   pendingCancelledProviderHandshakes.mark(threadId, ownerId);
 }
@@ -7365,6 +7375,9 @@ const server = createServer(async (req, res) => {
         const directThreadId = directClaim?.threadId ?? bot.threadId;
         await registry.get(bot.modelSelection.instanceId)?.adapter.interruptTurn(directThreadId).catch(() => {});
         closeOpenApprovals(directThreadId);
+        // Deletion removes the thread before a late turn.completed can fold
+        // staged provider images into a message, so dispose them here.
+        purgeGeneratedImagesForThread(directThreadId);
         stopScreenPoller(bot.id);
         activeVpsThreads.delete(bot.id);
         routines!.disableForBot(bot.id);

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -5,7 +5,7 @@
 // session/prompt, and streams session/update notifications for a scripted
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
-//   FAKE_ACP_MODE   happy (default) | empty-reply | exit-early | fail-after-text | hang | no-auth | auth-required | permission
+//   FAKE_ACP_MODE   happy (default) | image | empty-reply | exit-early | fail-after-text | hang | no-auth | auth-required | permission
 //                   | interleave (message → tool → message → tool → message)
 //                   | no-session-config (reject session/set_mode + set_model
 //                     with -32601, i.e. an agent predating those methods)
@@ -40,6 +40,7 @@ import { spawn } from "node:child_process";
 import { existsSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "happy";
+const ONE_PIXEL_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 // opencode-shaped surface: the session carries its own model catalog and the
 // model is chosen with session/set_config_option, because `opencode acp` takes
 // no -m. Off unless FAKE_ACP_MODELS is set, so every existing mode is byte-
@@ -533,7 +534,18 @@ function handle(msg: any) {
           });
         return;
       }
-      if (mode === "interleave") playInterleaveTurn();
+      if (mode === "image") {
+        out({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "image", data: ONE_PIXEL_PNG, mimeType: "image/png" },
+            },
+          },
+        });
+      } else if (mode === "interleave") playInterleaveTurn();
       else if (mode !== "empty-reply") playTurn();
       if (mode === "permission") {
         // ask the client to approve a tool, then complete once answered


### PR DESCRIPTION
## What
- normalize structured ACP image output into the assistant-image contract shipped in #684
- preserve text/image ordering and reuse the private attachment store + shared gallery
- redact inline image bytes from native diagnostics
- purge staged image files when their bot is deleted mid-turn (follow-up to the valid #684 review finding)

## Why
T3 Code has the right per-provider adapter boundary, but currently treats Codex image generation as generic activity and does not project generated images into its timeline. ACP itself already defines structured image content blocks, so this adds the missing mapping without scraping Markdown or trusting arbitrary file paths. This covers ACP-backed engines such as Gemini, OpenCode, Cursor, Grok, Kimi, and custom ACP agents whenever the engine emits that standard block.

## Verification
- `pnpm vitest run server/index.test.ts server/drivers/acp/acp.test.ts server/generated-image.test.ts` (190 passed)
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image responses from providers are now delivered as image content instead of being converted to text.
  - Image data is preserved for display while sensitive payloads are omitted from diagnostic logs.

- **Bug Fixes**
  - Generated images are now cleaned up when a conversation is deleted, preventing leftover files or late message attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->