### PR TITLE
feat(remote): pair once, then use the server from any machine

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,40 +64,53 @@ jobs:
             echo "server answered on $ip — it must only bind 127.0.0.1"; exit 1
           fi
           echo "unreachable on $ip: loopback-only holds"
-      - name: Run the tenant stack (server + Caddy) and use it like a browser would
-        # deploy/docker-compose.yml is the product here: prove the login wall,
-        # the Host/Origin rules that satisfy the server's loopback gates, the
-        # unbuffered SSE stream, and the advertised webhook base — through TLS.
+      - name: Run the tenant stack (server + Caddy) and pair like a browser would
+        # deploy/docker-compose.yml is the product here: through TLS, prove that
+        # nothing but the descriptor and the UI shell is served before pairing,
+        # that a code minted inside the container turns into a Secure cookie
+        # session, that the cookie is same-origin only, that the event stream is
+        # unbuffered, and that hooks stay reachable without a session.
         run: |
           set -euo pipefail
           docker rm -f omb >/dev/null
           docker tag openmausbot:ci ghcr.io/milind-soni/openmausbot:latest
-          hash=$(docker run --rm caddy:2 caddy hash-password --plaintext 'ci-pass')
-          printf 'DOMAIN=localhost\nBASIC_AUTH_USER=ci\nBASIC_AUTH_HASH=%s\nENGINES=\n' "$(printf '%s' "$hash" | sed 's/\$/$$/g')" > deploy/.env
+          printf 'DOMAIN=localhost\nENGINES=\n' > deploy/.env
           docker compose -f deploy/docker-compose.yml up -d --no-build
           for i in $(seq 1 45); do
-            curl -sk -o /dev/null --max-time 2 https://localhost/api/health && break
+            curl -sk -o /dev/null --max-time 2 https://localhost/.well-known/openmausbot/environment && break
             sleep 2
             if [ "$i" = "45" ]; then docker compose -f deploy/docker-compose.yml logs; echo "caddy never answered"; exit 1; fi
           done
           code() { curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$@"; }
-          H=https://localhost
-          test "$(code $H/api/health)" = 401                                      # login wall
-          test "$(code -u ci:wrong $H/api/health)" = 401
-          # Bodies are captured before grepping: with pipefail, `curl | grep -q`
-          # can fail on SIGPIPE when grep closes the pipe early.
           body() { curl -sk --max-time 10 "$@"; }
-          grep -q openmausbot <<<"$(body -u ci:ci-pass $H/api/health)"             # Host rule satisfies the loopback gate
-          grep -qi '<html' <<<"$(body -u ci:ci-pass $H/)"                          # UI served through the proxy
-          test "$(code -u ci:ci-pass -H 'Origin: https://evil.example' $H/api/health)" = 403   # CSRF gate survives the proxy
-          test "$(code -u ci:ci-pass -H 'Origin: https://localhost' $H/api/health)" = 200      # own origin is mapped
-          grep -q error <<<"$(body -X POST $H/hooks/wh_nope)"                      # hook path reaches the receiver without login
+          H=https://localhost
+          grep -q '"environmentId"' <<<"$(body $H/.well-known/openmausbot/environment)"   # descriptor is public
+          test "$(code $H/api/health)" = 403                                      # nothing else before pairing
+          grep -q 'pair this device' <<<"$(body $H/api/health)"
+          grep -qi '<html' <<<"$(body $H/pair)"                                    # the UI shell is served so /pair can load
           test "$(code http://localhost/)" = 308                                   # HTTP redirects to HTTPS
+          pairing=$(docker compose -f deploy/docker-compose.yml exec -T omb node dist-server/pair-cli.js --label ci)
+          echo "$pairing"
+          pcode=$(grep -o 'code=[A-Z2-9-]*' <<<"$pairing" | head -1 | cut -d= -f2)
+          test -n "$pcode"
+          jar=$(mktemp)
+          paired=$(curl -sk --max-time 10 -c "$jar" -D - -X POST $H/api/auth/pair -H 'content-type: application/json' -d "{\"code\":\"$pcode\",\"cookie\":true}")
+          grep -qi 'set-cookie: omb_session_' <<<"$paired"                        # cookie session
+          grep -qi 'Secure' <<<"$paired"                                          # over TLS the cookie is Secure
+          grep -qi 'HttpOnly' <<<"$paired"
+          test "$(code -b "$jar" $H/api/health)" = 200                              # paired: the API answers
+          grep -q openmausbot <<<"$(body -b "$jar" $H/api/health)"
+          test "$(code -b "$jar" -H 'Origin: https://evil.example' -X POST -d '{}' $H/api/bots)" = 403   # cookie is same-origin only
+          test "$(code -b "$jar" -H 'Origin: https://localhost' $H/api/auth/session)" = 200
+          grep -q '"via":"cookie"' <<<"$(body -b "$jar" $H/api/auth/session)"
+          grep -q '"label":"ci"' <<<"$(body -b "$jar" $H/api/auth/sessions)"        # listed for revocation
+          grep -q error <<<"$(body -X POST $H/hooks/wh_nope)"                      # hook path reaches the receiver without a session
           # The event stream never ends, so curl's own --max-time exit (28) is expected;
           # the proof is that bytes arrived within the window (a buffering proxy sends none).
-          sse=$( (curl -sk -u ci:ci-pass -N --max-time 4 $H/api/events || true) | head -c 64 )
+          sse=$( (curl -sk -b "$jar" -N --max-time 4 $H/api/events || true) | head -c 64 )
           test -n "$sse"                                                           # SSE streams, not buffered
-          grep -q '"baseUrl":"https://localhost"' <<<"$(body -u ci:ci-pass $H/api/webhooks)"   # OMB_WEBHOOK_PUBLIC_URL is advertised
+          grep -q '"baseUrl":"https://localhost"' <<<"$(body -b "$jar" $H/api/webhooks)"   # OMB_WEBHOOK_PUBLIC_URL is advertised
+          test "$(code $H/api/health)" = 403                                      # and without the cookie it is still closed
           docker compose -f deploy/docker-compose.yml down -v
 
   publish:

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,11 +1,6 @@
-# Public hostname for automatic HTTPS (must resolve to this machine)
+# Public hostname for automatic HTTPS (must resolve to this machine).
+# Pairing links (`docker compose exec omb node dist-server/pair-cli.js`) point here.
 DOMAIN=maus.example.com
-
-# Login for the web UI. Compose treats `$` in this file as a variable, so the
-# bcrypt hash must have every `$` doubled. This prints it ready to paste:
-#   docker run --rm caddy:2 caddy hash-password --plaintext 'your-password' | sed 's/\$/$$/g'
-BASIC_AUTH_USER=maus
-BASIC_AUTH_HASH=$$2a$$14$$replace-me-with-the-escaped-hash
 
 # Engine CLIs baked into the image at build time (space-separated npm packages).
 # Sign in afterwards with:  docker compose exec omb claude   (etc.)

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,34 +1,28 @@
-# Edge for one OpenMausBot tenant: automatic HTTPS + login in front of a server
-# that only listens on loopback. The two header rules are load-bearing —
-# see docs/self-hosting.md "Putting a proxy in front" before changing them.
+# Edge for one OpenMausBot tenant: automatic HTTPS in front of a server that
+# only listens on loopback. Login is pairing (docs/self-hosting.md "Using it
+# from your computer"): a remote browser without a session sees the pair
+# page, everything else is refused by the server itself, so Caddy adds no
+# password of its own. Caddy forwards the real Host and sets
+# X-Forwarded-For / X-Forwarded-Proto, which the server uses for the
+# same-origin rule, Secure cookies and the pairing lockout.
 {$DOMAIN} {
 	encode zstd gzip
 
-	# Webhook ingress (/hooks/wh_...) is meant to be reachable by third parties
-	# — every hook carries its own secret — so it sits outside the login wall.
+	# Webhook ingress is designed to be reachable by third parties (it has its
+	# own per-hook secrets), so it sits outside any login. The path is passed
+	# through unchanged: the receiver routes on /hooks/<id>.
 	handle /hooks/* {
-		reverse_proxy 127.0.0.1:8800 {
-			header_up Host 127.0.0.1:8800
-		}
+		reverse_proxy 127.0.0.1:8800
 	}
 
 	handle {
-		# A shared password in front of everything. Optional since pairing landed
-		# (docs/self-hosting.md "Using it from your computer"): delete this block
-		# once every device has paired, or keep it as a second wall.
-		basic_auth {
-			{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
-		}
-
-		# The server accepts browser requests only from its own origin. Map
-		# THIS site's origin onto the loopback origin it expects; any other
-		# Origin passes through unchanged and is still refused — CSRF
-		# protection survives the proxy.
-		@own header Origin https://{$DOMAIN}
-		request_header @own Origin http://127.0.0.1:8799
-
+		# Optional second wall in front of pairing (a shared password):
+		#   basic_auth {
+		#     {$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+		#   }
+		# and set both variables in .env (hash with `caddy hash-password`,
+		# every `$` doubled for Compose).
 		reverse_proxy 127.0.0.1:8799 {
-			header_up Host 127.0.0.1:8799
 			# SSE: stream events as they arrive
 			flush_interval -1
 		}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -13,6 +13,9 @@
 	}
 
 	handle {
+		# A shared password in front of everything. Optional since pairing landed
+		# (docs/self-hosting.md "Using it from your computer"): delete this block
+		# once every device has paired, or keep it as a second wall.
 		basic_auth {
 			{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
 		}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       OMB_WEBHOOK_PORT: "8800"
       # what the app prints as hook URLs — Caddy passes /hooks/* straight through
       OMB_WEBHOOK_PUBLIC_URL: https://${DOMAIN}
+      # pairing links for remote clients point here (docs/self-hosting.md)
+      OMB_PUBLIC_URL: https://${DOMAIN}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot"]
       interval: 30s

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -4,7 +4,7 @@
 # 127.0.0.1 — the server never binds a public interface. Ports are therefore
 # declared on the `omb` service (the namespace owner).
 #
-#   cp .env.example .env   # set DOMAIN, BASIC_AUTH_USER, BASIC_AUTH_HASH
+#   cp .env.example .env   # set DOMAIN
 #   docker compose pull omb && docker compose up -d     # prebuilt image
 #   docker compose up -d --build                        # or build from source
 services:
@@ -43,8 +43,6 @@ services:
         condition: service_healthy
     environment:
       DOMAIN: ${DOMAIN}
-      BASIC_AUTH_USER: ${BASIC_AUTH_USER}
-      BASIC_AUTH_HASH: ${BASIC_AUTH_HASH}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -119,40 +119,47 @@ that user (`sudo -u maus claude` etc.) before starting the service.
 
 ## Using it from your computer
 
-Open an SSH tunnel and use the web UI in any browser:
+Pair once, then use the server from any browser on any machine that can
+reach it. On the server:
+
+```sh
+pnpm pair                                  # from a checkout
+docker compose exec omb node dist-server/pair-cli.js   # Docker
+```
+
+It prints a 12-character code (single use, five minutes) and, when the
+server knows its public address (`OMB_PUBLIC_URL`, set by the Docker stack),
+a link like `https://maus.example.com/pair#code=XXXX-XXXX-XXXX`. Open the
+link, or open `/pair` on the address you use and type the code. The browser
+gets a session cookie (30 days, revocable) and the app loads. Sessions are
+listed and revoked at `GET`/`DELETE /api/auth/sessions` for now; a Settings
+screen follows.
+
+What this changes about the trust model: the server still binds loopback
+and still trusts loopback as the owner. A **paired session** is the second
+way in: a bearer token or the cookie, same-origin only, with a scope (`admin`
+by default, `--client` for a device that may chat but not change settings or
+pair others). Five bad codes from one address lock that address out for ten
+minutes. The Docker stack's Caddy login (`basic_auth`) is now optional: keep
+it as a second wall, or delete that block once everyone has paired.
+
+Native clients (CLI, scripts) send the token as `Authorization: Bearer …`
+and take a 5-minute ticket from `POST /api/auth/stream-ticket` for the
+event stream, because `EventSource` cannot set headers:
+`GET /api/events?ticket=…`.
+
+`GET /.well-known/openmausbot/environment` is public and tells a client what
+it is talking to: a stable `environmentId`, the label, the version and
+capabilities. Saved connections check the id so a reused address that now
+points at a different server is refused loudly.
+
+An SSH tunnel still works, and is the right answer when the server has no
+address of its own:
 
 ```sh
 ssh -L 8799:localhost:8799 you@your-server
-# then open http://localhost:8799
+# then open http://localhost:8799 — loopback, so no pairing needed
 ```
-
-The server serves the full app UI itself — no desktop install needed on the
-client. The tunnel keeps the loopback trust model intact: to the server,
-you look local, because through the tunnel you are.
-
-Note: a plain `tailscale serve` or reverse proxy is refused — the server
-checks that requests look like loopback on purpose. A proxy can satisfy
-that check; see "Putting a proxy in front" below. Only do it behind a login.
-
-## Putting a proxy in front
-
-The server has two request gates, both aimed at browsers:
-
-1. **Host** must be loopback (`localhost`, `127.x.x.x`, `::1`). The proxy
-   must rewrite `Host` to `127.0.0.1:8799` on the way in.
-2. **Origin**, when present, must be a loopback origin. Browsers send the
-   proxy's origin (`https://your.domain`), so the proxy must map exactly
-   that one origin onto `http://127.0.0.1:8799` — and leave every other
-   Origin untouched, so cross-site requests are still refused.
-
-Plus two non-security rules: the UI streams events over SSE, so the proxy
-must not buffer responses (`flush_interval -1` in Caddy,
-`proxy_buffering off` in nginx); and the webhook receiver (port 8800,
-paths `/hooks/...`) only knows its loopback address, so set
-`OMB_WEBHOOK_PUBLIC_URL=https://your.domain` to make the app print hook
-URLs senders can reach. [`deploy/Caddyfile`](../deploy/Caddyfile) is the
-reference implementation. The proxy itself must add the login — the
-server has none — so never point it at the internet without one.
 
 ## Using it from your phone
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -33,15 +33,13 @@ Desktop-only for now (needs the Mac/Linux app):
 
 ## Docker (recommended)
 
-One tenant = one container for the server plus Caddy for HTTPS and login.
+One tenant = one container for the server plus Caddy for HTTPS.
 Requirements: Docker with Compose, a DNS name pointing at the machine, and
 ports 80/443 open.
 
 ```sh
 git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot/deploy
-cp .env.example .env
-# set DOMAIN, BASIC_AUTH_USER and BASIC_AUTH_HASH (the file says how;
-# the hash's `$` signs must be doubled, Compose interpolates them)
+cp .env.example .env            # set DOMAIN
 docker compose pull omb && docker compose up -d
 ```
 
@@ -49,17 +47,20 @@ That uses the image CI publishes on every `main` push
 (`ghcr.io/milind-soni/openmausbot`, tagged `latest`, `sha-…` and `v…`).
 To build from your checkout instead: `docker compose up -d --build`.
 
-Then sign the engine CLIs in **inside the container** — their logins live
-on the `data` volume, so they survive restarts and image upgrades:
+Then sign the engine CLIs in **inside the container** (their logins live on
+the `data` volume, so they survive restarts and image upgrades) and mint a
+pairing code for your first device:
 
 ```sh
-docker compose exec omb claude     # each CLI you listed in ENGINES
+docker compose exec omb claude                       # each CLI you listed in ENGINES
+docker compose exec omb node dist-server/pair-cli.js # prints a code and a link
 ```
 
-Open `https://<DOMAIN>` and log in with the basic-auth user. Webhook URLs
-(`https://<DOMAIN>/hooks/wh_…`) work without the login — every hook
-carries its own secret — and that is the base the app prints on new hooks,
-because the stack sets `OMB_WEBHOOK_PUBLIC_URL`.
+Open the link (`https://<DOMAIN>/pair#code=…`) in a browser and it is
+paired; see "Using it from your computer" for what a session is. Webhook
+URLs (`https://<DOMAIN>/hooks/wh_…`) work without a session, and that is the
+base the app prints on new hooks because the stack sets
+`OMB_WEBHOOK_PUBLIC_URL`.
 
 What the stack does, so you can adapt it:
 
@@ -69,16 +70,15 @@ What the stack does, so you can adapt it:
   into the image.
 - [`deploy/docker-compose.yml`](../deploy/docker-compose.yml) runs Caddy
   **in the server's network namespace**, so Caddy reaches the server on
-  `127.0.0.1` and the server never binds anything public. The loopback
-  invariant above holds unchanged.
-- [`deploy/Caddyfile`](../deploy/Caddyfile) carries the two header rules
-  from "Putting a proxy in front" below. Swap `basic_auth` for
-  `forward_auth` to an identity provider (Authentik, oauth2-proxy) when you
-  outgrow a shared password — nothing in the server needs to change.
+  `127.0.0.1` and the server never binds anything public.
+- [`deploy/Caddyfile`](../deploy/Caddyfile) terminates TLS and forwards
+  the real `Host` plus `X-Forwarded-For`/`X-Forwarded-Proto`; the server's
+  own pairing is the login. A shared-password `basic_auth` block is there,
+  commented out, if you want a second wall in front of pairing.
 
 Upgrade with `docker compose pull omb && docker compose up -d` (or
 `git pull && docker compose up -d --build`). State (chats, routines,
-engine logins) is on the `data` volume; back that up.
+engine logins, paired sessions) is on the `data` volume; back that up.
 
 ## From source
 
@@ -140,8 +140,9 @@ and still trusts loopback as the owner. A **paired session** is the second
 way in: a bearer token or the cookie, same-origin only, with a scope (`admin`
 by default, `--client` for a device that may chat but not change settings or
 pair others). Five bad codes from one address lock that address out for ten
-minutes. The Docker stack's Caddy login (`basic_auth`) is now optional: keep
-it as a second wall, or delete that block once everyone has paired.
+minutes. Over plain HTTP (a LAN address without TLS) the cookie is not
+marked `Secure` and travels in clear: use the Docker stack, Tailscale, or
+another TLS front for anything beyond a trusted private network.
 
 Native clients (CLI, scripts) send the token as `Authorization: Bearer …`
 and take a 5-minute ticket from `POST /api/auth/stream-ticket` for the
@@ -160,6 +161,26 @@ address of its own:
 ssh -L 8799:localhost:8799 you@your-server
 # then open http://localhost:8799 — loopback, so no pairing needed
 ```
+
+## Putting a proxy in front
+
+Any reverse proxy works, given three things:
+
+1. **Forward the real `Host`** and set `X-Forwarded-Proto`. Any request that
+   carries forwarded headers is treated as remote and needs a session, so a
+   proxy that rewrites `Host` to `127.0.0.1`, or forwards a stranger's
+   `Host: localhost`, gains nothing. The proxy's scheme decides whether the
+   session cookie is `Secure` and is part of the same-origin check.
+2. **Set `X-Forwarded-For` yourself** (Caddy and nginx do by default) and
+   drop any the client sent: the pairing lockout counts failures per first
+   forwarded address.
+3. **Do not buffer** the event stream (`flush_interval -1` in Caddy,
+   `proxy_buffering off` in nginx); the UI streams events over SSE.
+
+Plus one convenience: set `OMB_PUBLIC_URL=https://your.domain` so pairing
+links, and `OMB_WEBHOOK_PUBLIC_URL=https://your.domain` so hook URLs, are
+printed with the public address. [`deploy/Caddyfile`](../deploy/Caddyfile)
+is the reference implementation.
 
 ## Using it from your phone
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -859,6 +859,8 @@ async function startServerOn(port) {
     OMB_RESOURCES_PATH: process.resourcesPath,
     OMB_SKILLS_DIR: path.join(process.resourcesPath, "skills"),
     OMB_PORT: String(port),
+    // the server advertises this to remote clients so version skew is visible
+    OMB_APP_VERSION: app.getVersion(),
     OMB_USER_DATA: app.getPath("userData"),
     ...(secureCredentials.composioApiKey
       ? { COMPOSIO_API_KEY: secureCredentials.composioApiKey }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docs:build": "pnpm --filter @openmausbot/docs build",
     "docs:preview": "pnpm --filter @openmausbot/docs preview",
     "companion": "node --experimental-strip-types companion/src/index.ts",
+    "pair": "node --experimental-strip-types server/pair-cli.ts",
     "dev:server": "node --experimental-strip-types server/index.ts",
     "mcp": "node --experimental-strip-types scripts/mcp-server.ts",
     "control:omb": "node --experimental-strip-types scripts/control-omb.ts",

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -41,6 +41,8 @@ const yamlEsmPlugin = {
 // Every file run as its own process. Keep in sync with the spawn sites above.
 const ENTRY_POINTS = [
   "index.ts",
+  // `pair` for operators of a container or headless install (docs/self-hosting.md)
+  "pair-cli.ts",
   // The packaged smoke probe imports this manifest directly. Importing the
   // shared avatar contract widens TypeScript's inferred emit root to the repo,
   // so tsc may place its copy under dist-server/server/. Bundle an explicit

--- a/server/environment.test.ts
+++ b/server/environment.test.ts
@@ -18,7 +18,7 @@ describe("environment identity", () => {
     dirs.push(dir);
     const id = loadEnvironmentId(dir);
     expect(id).toMatch(/^[0-9a-f-]{36}$/);
-    expect(statSync(join(dir, "environment-id")).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") expect(statSync(join(dir, "environment-id")).mode & 0o777).toBe(0o600); // Windows has no POSIX modes
     expect(loadEnvironmentId(dir)).toBe(id);
     writeFileSync(join(dir, "environment-id"), "garbage\n");
     expect(loadEnvironmentId(dir)).not.toBe("garbage");

--- a/server/environment.test.ts
+++ b/server/environment.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { environmentDescriptor, loadEnvironmentId, serverVersion } from "./environment.ts";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  delete process.env.OMB_APP_VERSION;
+  delete process.env.OMB_ENVIRONMENT_LABEL;
+});
+
+describe("environment identity", () => {
+  it("creates the id once, owner-only, and keeps it across restarts", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-env-"));
+    dirs.push(dir);
+    const id = loadEnvironmentId(dir);
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(statSync(join(dir, "environment-id")).mode & 0o777).toBe(0o600);
+    expect(loadEnvironmentId(dir)).toBe(id);
+    writeFileSync(join(dir, "environment-id"), "garbage\n");
+    expect(loadEnvironmentId(dir)).not.toBe("garbage");
+    expect(readFileSync(join(dir, "environment-id"), "utf8").trim()).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("describes the server for clients without leaking anything secret", () => {
+    process.env.OMB_APP_VERSION = "0.1.99";
+    process.env.OMB_ENVIRONMENT_LABEL = "cab mini";
+    const d = environmentDescriptor({ environmentId: "abc", desktopManaged: true });
+    expect(d).toEqual({
+      environmentId: "abc",
+      label: "cab mini",
+      platform: process.platform,
+      version: "0.1.99",
+      capabilities: { remoteSessions: true, selfUpdate: "desktop-managed" },
+    });
+    expect(environmentDescriptor({ environmentId: "abc", desktopManaged: false }).capabilities.selfUpdate).toBe("operator");
+  });
+
+  it("falls back to the checkout's package.json version, then to unknown", () => {
+    delete process.env.OMB_APP_VERSION;
+    expect(serverVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/server/environment.ts
+++ b/server/environment.ts
@@ -1,0 +1,64 @@
+// What a client learns about this server before it authenticates: a stable
+// identity, a label, the version, and what it can do. Served without auth at
+// /.well-known/openmausbot/environment so a saved connection can check it is
+// still talking to the same server, and so version skew is visible.
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+
+import { SERVER_ROOT } from "./proxy-paths.ts";
+
+export interface EnvironmentDescriptor {
+  environmentId: string;
+  label: string;
+  platform: NodeJS.Platform;
+  version: string;
+  capabilities: {
+    /** Pairing and sessions are available (this build). */
+    remoteSessions: true;
+    /** Who can update the server: the desktop app that runs it, or the operator. */
+    selfUpdate: "desktop-managed" | "operator";
+  };
+}
+
+/** Read or create the id. Written once, never rotated by the server itself. */
+export function loadEnvironmentId(dataDir: string): string {
+  const file = join(dataDir, "environment-id");
+  if (existsSync(file)) {
+    const existing = readFileSync(file, "utf8").trim();
+    if (/^[0-9a-f-]{36}$/i.test(existing)) return existing;
+  }
+  const id = randomUUID();
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+  writeFileSync(file, id + "\n", { mode: 0o600 });
+  return id;
+}
+
+/** The desktop app passes its own version; a checkout reads package.json;
+ * an image sets OMB_APP_VERSION at build time. */
+export function serverVersion(): string {
+  const fromEnv = process.env.OMB_APP_VERSION?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const pkg: unknown = JSON.parse(readFileSync(join(SERVER_ROOT, "..", "package.json"), "utf8"));
+    const version = Reflect.get(Object(pkg), "version");
+    if (typeof version === "string" && version) return version;
+  } catch {
+    /* no package.json next to the bundle */
+  }
+  return "unknown";
+}
+
+export function environmentDescriptor(input: { environmentId: string; desktopManaged: boolean }): EnvironmentDescriptor {
+  return {
+    environmentId: input.environmentId,
+    label: process.env.OMB_ENVIRONMENT_LABEL?.trim() || hostname(),
+    platform: process.platform,
+    version: serverVersion(),
+    capabilities: {
+      remoteSessions: true,
+      selfUpdate: input.desktopManaged ? "desktop-managed" : "operator",
+    },
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,7 +4,6 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { isIP } from "node:net";
 import { extname, join } from "node:path";
 
 import { z } from "zod";
@@ -241,12 +240,31 @@ import {
 } from "./turn-dispatch-guard.ts";
 import { createGracefulShutdown } from "./graceful-shutdown.ts";
 import { describeEdition, editionStatus, loadEnterpriseLayer } from "./enterprise.ts";
+import { environmentDescriptor, loadEnvironmentId } from "./environment.ts";
+import {
+  clearSessionCookie,
+  labelFromUserAgent,
+  requestOrigin,
+  requestSource,
+  resolveRequestAuth,
+  serializeSessionCookie,
+  sessionCookieName,
+} from "./request-auth.ts";
+import { formatPairingCode, SESSION_TTL_MS, SessionRegistry, type Scope } from "./sessions.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
 // Behind a proxy or tunnel, the base URL senders should use (docs/self-hosting.md).
 const WEBHOOK_PUBLIC_URL = process.env.OMB_WEBHOOK_PUBLIC_URL || undefined;
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
+// Remote clients (server/request-auth.ts, server/sessions.ts): a stable identity
+// for this server, the paired sessions, and the cookie the served UI uses.
+const ENVIRONMENT_ID = loadEnvironmentId(DATA_DIR);
+const sessions = new SessionRegistry({ file: join(DATA_DIR, "sessions.json") });
+const SESSION_COOKIE = sessionCookieName(PORT, ENVIRONMENT_ID);
+const DESKTOP_MANAGED = process.env.OMB_DESKTOP_PARENT === "1";
+// Where remote clients reach this server (a proxy's public address); pairing URLs use it.
+const PUBLIC_URL = process.env.OMB_PUBLIC_URL?.trim().replace(/\/+$/, "") || null;
 const MIME: Record<string, string> = {
   ".html": "text/html",
   ".js": "text/javascript",
@@ -5095,6 +5113,33 @@ let providerConfigBusy = false;
 const claudeUpdatesInFlight = new Set<string>();
 
 // ── HTTP plumbing ─────────────────────────────────────────────────────
+/** The built UI, when this process serves it (OMB_STATIC_DIR: set by the
+ * desktop app and by the container image). Public by design: it is the same
+ * bundle anyone can download, holds no secrets, and a remote browser must be
+ * able to load /pair before it has a session. Returns false when there is
+ * nothing to serve so the caller can answer 404. */
+function serveStatic(res: ServerResponse, path: string): boolean {
+  if (!STATIC_DIR) return false;
+  const safe = path === "/" ? "/index.html" : path.replace(/\.\./g, "");
+  const file = join(STATIC_DIR, safe);
+  try {
+    const data = readFileSync(file);
+    res.writeHead(200, { "content-type": MIME[extname(file)] ?? "application/octet-stream" });
+    res.end(data);
+    return true;
+  } catch {
+    // SPA fallback
+    try {
+      const data = readFileSync(join(STATIC_DIR, "index.html"));
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
 function json(res: ServerResponse, status: number, body: unknown) {
   const data = JSON.stringify(body);
   res.writeHead(status, { "content-type": "application/json" });
@@ -5142,39 +5187,6 @@ function readBody(req: IncomingMessage): Promise<any> {
 // requests from any loopback connection and any web page that DNS-rebinds
 // onto it. Reject non-loopback Hosts outright (defeats rebinding) and
 // origins outside loopback (blocks remote-web CSRF).
-function isLoopbackHost(host: string | undefined): boolean {
-  if (!host) return false;
-  const value = host.trim().toLowerCase();
-  if (!value) return false;
-
-  let hostname = value;
-  if (value.startsWith("[")) {
-    const close = value.indexOf("]");
-    if (close < 0 || (value.length > close + 1 && !/^:\d+$/.test(value.slice(close + 1)))) return false;
-    hostname = value.slice(1, close);
-  } else {
-    const firstColon = value.indexOf(":");
-    const lastColon = value.lastIndexOf(":");
-    if (firstColon >= 0 && firstColon === lastColon) {
-      if (!/^\d+$/.test(value.slice(firstColon + 1))) return false;
-      hostname = value.slice(0, firstColon);
-    }
-  }
-
-  if (hostname === "localhost" || hostname === "localhost.") return true;
-  if (isIP(hostname) === 4) return hostname.startsWith("127.");
-  return hostname === "::1" || hostname === "0:0:0:0:0:0:0:1";
-}
-
-function isAllowedOrigin(origin: string | undefined | null): boolean {
-  if (!origin) return true; // non-browser clients (CLIs, curl, tests) send none
-  try {
-    const o = new URL(origin);
-    return isLoopbackHost(o.hostname) && (o.protocol === "http:" || o.protocol === "https:");
-  } catch {
-    return false;
-  }
-}
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
@@ -5183,13 +5195,95 @@ const server = createServer(async (req, res) => {
   /** scratch for route matches, shared by every `path.match` below */
   let m: RegExpMatchArray | null = null;
   try {
-    // loopback-host + loopback-origin gate before any route (DNS rebinding / CSRF)
-    if (!isLoopbackHost(req.headers.host)) {
-      return json(res, 403, { error: "forbidden: loopback host required" });
+    // ── who is asking (server/request-auth.ts) ──────────────────────────
+    // Two public routes come first: what this server is, and turning a pairing
+    // code into a session. Everything else needs the loopback owner or a
+    // paired session with the right scope.
+    if (method === "GET" && !path.startsWith("/api/") && !path.startsWith("/.well-known/") && serveStatic(res, path)) return;
+    if (method === "GET" && path === "/.well-known/openmausbot/environment") {
+      return json(res, 200, environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED }));
     }
-    const origin = req.headers.origin;
-    if (origin && !isAllowedOrigin(origin)) {
-      return json(res, 403, { error: "forbidden: cross-origin request" });
+    if (method === "POST" && path === "/api/auth/pair") {
+      const body = await readBody(req);
+      const code = typeof body?.code === "string" ? body.code : "";
+      const wantsCookie = body?.cookie === true;
+      const label = typeof body?.label === "string" && body.label.trim() ? body.label : labelFromUserAgent(req.headers["user-agent"]);
+      const result = sessions.exchange({ code, label, source: requestSource(req) });
+      if (!result.ok) {
+        console.warn(`pairing refused from ${requestSource(req)}: ${result.error}`);
+        return json(res, result.status, { error: result.error });
+      }
+      const environment = environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED });
+      if (wantsCookie) {
+        const secure = requestOrigin(req)?.startsWith("https://") === true;
+        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, result.token, { secure, maxAgeSeconds: SESSION_TTL_MS / 1000 }));
+        return json(res, 200, { session: result.session, environment });
+      }
+      return json(res, 200, { token: result.token, session: result.session, environment });
+    }
+    const gate = resolveRequestAuth(req, { sessions, cookieName: SESSION_COOKIE, streamPath: "/api/events", url });
+    if (!gate.auth) return json(res, gate.status, { error: gate.error });
+    const auth = gate.auth;
+
+    // ── sessions: who am I, tickets, pairing and revocation ─────────────
+    if (method === "GET" && path === "/api/auth/session") {
+      return json(
+        res,
+        200,
+        auth.kind === "loopback"
+          ? { kind: "loopback", scopes: auth.scopes, environmentId: ENVIRONMENT_ID }
+          : {
+              kind: "session",
+              id: auth.session.id,
+              label: auth.session.label,
+              scopes: auth.scopes,
+              expiresAt: auth.session.expiresAt,
+              via: auth.via,
+              environmentId: ENVIRONMENT_ID,
+            },
+      );
+    }
+    if (method === "POST" && path === "/api/auth/stream-ticket") {
+      if (auth.kind === "loopback") return json(res, 200, { ticket: null, reason: "loopback needs no ticket" });
+      return json(res, 200, sessions.issueStreamTicket(auth.session.id));
+    }
+    if (method === "POST" && path === "/api/auth/logout") {
+      if (auth.kind === "session") sessions.revoke(auth.session.id);
+      res.setHeader("set-cookie", clearSessionCookie(SESSION_COOKIE));
+      return json(res, 200, { ok: true });
+    }
+    if (method === "POST" && path === "/api/auth/pairing") {
+      const body = await readBody(req);
+      const requested: unknown = body?.scopes;
+      const scopes = Array.isArray(requested) ? requested.filter((v): v is Scope => v === "admin" || v === "client") : undefined;
+      const opened = sessions.openPairing({ label: typeof body?.label === "string" ? body.label : undefined, scopes });
+      const origin = requestOrigin(req);
+      const base = PUBLIC_URL ?? (auth.kind === "session" && origin ? origin : null);
+      const code = formatPairingCode(opened.code);
+      return json(res, 200, {
+        id: opened.id,
+        code,
+        expiresAt: opened.expiresAt,
+        url: base ? `${base}/pair#code=${code}` : null,
+        hint: base
+          ? null
+          : "this server has no public address to put in a link: set OMB_PUBLIC_URL, or open /pair on the address you use and type the code",
+      });
+    }
+    if (method === "GET" && path === "/api/auth/pairing") return json(res, 200, { pairings: sessions.openPairings() });
+    m = path.match(/^\/api\/auth\/pairing\/([\w-]+)$/);
+    if (m && method === "DELETE") {
+      const cancelled = sessions.cancelPairing(m[1]);
+      return json(res, cancelled ? 200 : 404, cancelled ? { ok: true } : { error: "no such pairing code" });
+    }
+    if (method === "GET" && path === "/api/auth/sessions") {
+      return json(res, 200, { sessions: sessions.list(), current: auth.kind === "session" ? auth.session.id : null });
+    }
+    m = path.match(/^\/api\/auth\/sessions\/([\w-]+)$/);
+    if (m && method === "DELETE") {
+      const revoked = sessions.revoke(m[1]);
+      if (auth.kind === "session" && auth.session.id === m[1]) res.setHeader("set-cookie", clearSessionCookie(SESSION_COOKIE));
+      return json(res, revoked ? 200 : 404, revoked ? { ok: true } : { error: "no such session" });
     }
     // ── internal peer-agent comms (localhost + shared token only) ──────
     // The agents-proxy (spawned inside a bot's agent process) calls these to
@@ -8804,27 +8898,6 @@ const server = createServer(async (req, res) => {
         }
         case "screenshot":
           return json(res, 200, await box.screenshotBox(cfg, botId));
-      }
-    }
-
-    // packaged app: the server serves the built UI too (window → :8799 for
-    // everything, no dev proxy to die). OMB_STATIC_DIR is set by Electron.
-    if (method === "GET" && !path.startsWith("/api/") && STATIC_DIR) {
-      const safe = path === "/" ? "/index.html" : path.replace(/\.\./g, "");
-      const file = join(STATIC_DIR, safe);
-      try {
-        const data = readFileSync(file);
-        res.writeHead(200, { "content-type": MIME[extname(file)] ?? "application/octet-stream" });
-        return res.end(data);
-      } catch {
-        // SPA fallback
-        try {
-          const data = readFileSync(join(STATIC_DIR, "index.html"));
-          res.writeHead(200, { "content-type": "text/html" });
-          return res.end(data);
-        } catch {
-          /* fall through to 404 */
-        }
       }
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5207,8 +5207,8 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const code = typeof body?.code === "string" ? body.code : "";
       const wantsCookie = body?.cookie === true;
-      const label = typeof body?.label === "string" && body.label.trim() ? body.label : labelFromUserAgent(req.headers["user-agent"]);
-      const result = sessions.exchange({ code, label, source: requestSource(req) });
+      const label = typeof body?.label === "string" ? body.label : "";
+      const result = sessions.exchange({ code, label, source: requestSource(req), fallbackLabel: labelFromUserAgent(req.headers["user-agent"]) });
       if (!result.ok) {
         console.warn(`pairing refused from ${requestSource(req)}: ${result.error}`);
         return json(res, result.status, { error: result.error });

--- a/server/pair-cli.ts
+++ b/server/pair-cli.ts
@@ -1,0 +1,49 @@
+// Mint a pairing code for a remote client, from the machine the server runs on.
+//
+//   pnpm pair [--label "Milind's MacBook"] [--client] [--public-url https://mini.example]
+//   docker compose exec omb node dist-server/pair-cli.js
+//
+// Talks to the server over loopback (which is trusted as the owner) and prints
+// the code, when it expires, and the link to open. Bundled as its own entry so
+// the container image, which ships no source, has it too.
+const port = Number(process.env.OMB_PORT || 8799);
+const args = process.argv.slice(2);
+let label: string | undefined;
+let publicUrl: string | undefined;
+let clientOnly = false;
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--label") label = args[++i];
+  else if (arg === "--public-url") publicUrl = args[++i];
+  else if (arg === "--client") clientOnly = true;
+  else {
+    console.error(`unknown argument ${arg}\nusage: pair [--label <name>] [--client] [--public-url <https://host>]`);
+    process.exit(2);
+  }
+}
+
+const base = `http://127.0.0.1:${port}`;
+let res: Response;
+try {
+  res = await fetch(`${base}/api/auth/pairing`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...(label ? { label } : {}), ...(clientOnly ? { scopes: ["client"] } : {}) }),
+  });
+} catch (error) {
+  console.error(`no OpenMausBot server on ${base} (${error instanceof Error ? error.message : String(error)}); is it running, or is OMB_PORT different?`);
+  process.exit(1);
+}
+const body: unknown = await res.json().catch(() => ({}));
+const record = Object(body) as Record<string, unknown>; // SAFETY: fields are read with typeof checks below
+if (!res.ok) {
+  console.error(`server refused: ${typeof record.error === "string" ? record.error : res.status}`);
+  process.exit(1);
+}
+const code = typeof record.code === "string" ? record.code : "";
+const expiresAt = typeof record.expiresAt === "number" ? new Date(record.expiresAt) : null;
+const url = publicUrl ? `${publicUrl.replace(/\/+$/, "")}/pair#code=${code}` : typeof record.url === "string" ? record.url : null;
+console.log(`pairing code:  ${code}${clientOnly ? "   (client scope: cannot change settings or pair others)" : ""}`);
+if (expiresAt) console.log(`expires:       ${expiresAt.toLocaleTimeString()} (single use)`);
+if (url) console.log(`open:          ${url}`);
+else console.log(`open:          /pair on the address you use for this server, and type the code\n               (${typeof record.hint === "string" ? record.hint : "set OMB_PUBLIC_URL for a full link"})`);

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -175,7 +175,11 @@ describe("pairing", () => {
     expect(paired.body.token).toMatch(/^omb_sess_/);
     expect(paired.body.session.label).toBe("Safari on Mac");
     expect(paired.body.environment.label).toBe("cab mini");
-    const again = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: opened.code }) });
+    // a retry from the same address (lost response) replays the same session; another address is refused
+    const replay = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: opened.code }) });
+    expect(replay.status).toBe(200);
+    expect(replay.body.token).toBe(paired.body.token);
+    const again = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.33"), body: JSON.stringify({ code: opened.code }) });
     expect(again.status).toBe(401);
 
     const bearer = remote("10.0.0.3", { authorization: `Bearer ${paired.body.token}` });

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -1,0 +1,251 @@
+// End to end over a real harness: a client that is not on this machine pairs
+// once, then uses the API, the served UI and the event stream with a bearer
+// token or the session cookie, and is refused again after revocation.
+import { spawn, type ChildProcess } from "node:child_process";
+import { request } from "node:http";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { openSse } from "./testing/sse.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const WEBHOOK_PORT = 39000 + Math.floor(Math.random() * 10_000);
+const BASE = `http://127.0.0.1:${PORT}`;
+const REMOTE_HOST = "mini.tail1234.ts.net:8799";
+const PUBLIC_URL = "https://mini.tail1234.ts.net";
+
+let home: string;
+let child: ChildProcess;
+let stderr = "";
+
+/** Every request from "elsewhere": a non-loopback Host, and a distinct
+ * forwarded source so the pairing lockout is exercised on purpose only. */
+const remote = (source: string, extra: Record<string, string> = {}) => ({ host: REMOTE_HOST, "x-forwarded-for": source, ...extra });
+
+/** Plain node:http, because fetch silently drops a custom Host header and the
+ * whole point is to arrive with one that is not loopback. */
+function call(
+  path: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<{ status: number; body: any; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { host: "127.0.0.1", port: PORT, path, method: init.method ?? "GET", headers: { "content-type": "application/json", ...init.headers } },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () => {
+          let body: any = {};
+          try {
+            body = raw ? JSON.parse(raw) : {};
+          } catch {
+            body = { raw };
+          }
+          resolve({ status: res.statusCode ?? 0, body, headers: res.headers });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (init.body) req.write(init.body);
+    req.end();
+  });
+}
+
+const header = (headers: Record<string, string | string[] | undefined>, name: string): string => {
+  const v = headers[name];
+  return Array.isArray(v) ? v.join("\n") : (v ?? "");
+};
+
+async function pairingCode(scopes?: string[]): Promise<{ code: string; url: string | null; hint: string | null }> {
+  const opened = await call("/api/auth/pairing", { method: "POST", body: JSON.stringify(scopes ? { scopes } : {}) });
+  expect(opened.status).toBe(200);
+  return opened.body;
+}
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "omb-remote-test-"));
+  const staticDir = join(home, "static");
+  mkdirSync(join(home, ".openmausbot"), { recursive: true });
+  mkdirSync(join(staticDir, "assets"), { recursive: true });
+  writeFileSync(join(staticDir, "index.html"), "<!doctype html><title>Served UI</title>");
+  writeFileSync(join(home, ".openmausbot", "config.json"), JSON.stringify({ instances: {} }));
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(PORT),
+      OMB_WEBHOOK_PORT: String(WEBHOOK_PORT),
+      OMB_STATIC_DIR: staticDir,
+      OMB_PUBLIC_URL: `${PUBLIC_URL}/`,
+      OMB_APP_VERSION: "9.9.9-test",
+      OMB_ENVIRONMENT_LABEL: "cab mini",
+      OMB_BROWSER_CONNECTION: join(home, "browser-test-connection.json"),
+      OMB_SSE_HEARTBEAT_MS: "50",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE}/api/health`);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server did not start:\n${stderr}`);
+}, 30_000);
+
+afterAll(async () => {
+  await waitForExit(child, { signal: "SIGTERM" });
+  await removeTempDir(home);
+});
+
+describe("before pairing", () => {
+  it("describes itself to anyone, but serves nothing else off-machine", async () => {
+    const descriptor = await call("/.well-known/openmausbot/environment", { headers: remote("10.0.0.1") });
+    expect(descriptor.status).toBe(200);
+    expect(descriptor.body.environmentId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(descriptor.body.label).toBe("cab mini");
+    expect(descriptor.body.version).toBe("9.9.9-test");
+    expect(descriptor.body.capabilities).toEqual({ remoteSessions: true, selfUpdate: "operator" });
+    const refused = await call("/api/bots", { headers: remote("10.0.0.1") });
+    expect(refused.status).toBe(403);
+    expect(refused.body.error).toMatch(/pair this device/);
+  });
+
+  it("serves the UI shell to a remote browser so it can reach the pair page", async () => {
+    const res = await call("/pair", { headers: remote("10.0.0.1") });
+    expect(res.status).toBe(200);
+    expect(res.body.raw).toContain("Served UI");
+  });
+
+  it("keeps the owner's loopback path untouched", async () => {
+    expect((await call("/api/bots")).status).toBe(200);
+    const me = await call("/api/auth/session");
+    expect(me.body).toMatchObject({ kind: "loopback", scopes: ["admin", "client"] });
+    const ticket = await call("/api/auth/stream-ticket", { method: "POST" });
+    expect(ticket.body.ticket).toBeNull();
+  });
+});
+
+describe("pairing", () => {
+  it("mints a code on the server with a link built from the public address", async () => {
+    const opened = await pairingCode();
+    expect(opened.code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+    expect(opened.url).toBe(`${PUBLIC_URL}/pair#code=${opened.code}`);
+    expect(opened.hint).toBeNull();
+    const listed = await call("/api/auth/pairing");
+    expect(listed.body.pairings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("refuses to mint or list codes from a client-only session", async () => {
+    const opened = await pairingCode(["client"]);
+    const paired = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.2"), body: JSON.stringify({ code: opened.code, label: "viewer" }) });
+    expect(paired.status).toBe(200);
+    const denied = await call("/api/auth/pairing", { method: "POST", headers: remote("10.0.0.2", { authorization: `Bearer ${paired.body.token}` }), body: "{}" });
+    expect(denied.status).toBe(403);
+    expect(denied.body.error).toContain("lacks the admin scope");
+    expect((await call("/api/bots", { headers: remote("10.0.0.2", { authorization: `Bearer ${paired.body.token}` }) })).status).toBe(200);
+  });
+
+  it("exchanges a code exactly once, with a bearer token for native clients", async () => {
+    const opened = await pairingCode();
+    const wrong = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: "AAAA-AAAA-AAAA" }) });
+    expect(wrong.status).toBe(401);
+    expect(wrong.body.error).toMatch(/wrong or has expired/);
+    const paired = await call("/api/auth/pair", {
+      method: "POST",
+      headers: remote("10.0.0.3", { "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) Safari/605.1" }),
+      body: JSON.stringify({ code: opened.code.toLowerCase() }),
+    });
+    expect(paired.status).toBe(200);
+    expect(paired.body.token).toMatch(/^omb_sess_/);
+    expect(paired.body.session.label).toBe("Safari on Mac");
+    expect(paired.body.environment.label).toBe("cab mini");
+    const again = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: opened.code }) });
+    expect(again.status).toBe(401);
+
+    const bearer = remote("10.0.0.3", { authorization: `Bearer ${paired.body.token}` });
+    expect((await call("/api/bots", { headers: bearer })).status).toBe(200);
+    const me = await call("/api/auth/session", { headers: bearer });
+    expect(me.body).toMatchObject({ kind: "session", via: "bearer", label: "Safari on Mac", scopes: ["admin", "client"] });
+
+    const ticket = await call("/api/auth/stream-ticket", { method: "POST", headers: bearer });
+    expect(ticket.body.ticket).toMatch(/^omb_tick_/);
+    const stream = await openSse(`${BASE}/api/events?ticket=${ticket.body.ticket}`, { host: REMOTE_HOST });
+    try {
+      const hello = await stream.until((f) => f.kind === "hello", 5_000);
+      expect(hello.kind).toBe("hello");
+    } finally {
+      stream.close();
+    }
+    const reused = await call(`/api/events?ticket=${ticket.body.ticket}`, { headers: remote("10.0.0.3") });
+    expect(reused.status).toBe(401);
+
+    const sessionsList = await call("/api/auth/sessions");
+    const mine = sessionsList.body.sessions.find((s: { id: string }) => s.id === me.body.id);
+    expect(mine.label).toBe("Safari on Mac");
+    expect(JSON.stringify(sessionsList.body)).not.toContain(paired.body.token);
+    const revoked = await call(`/api/auth/sessions/${me.body.id}`, { method: "DELETE" });
+    expect(revoked.status).toBe(200);
+    const after = await call("/api/bots", { headers: bearer });
+    expect(after.status).toBe(401);
+    expect(after.body.error).toMatch(/pair this device again/);
+  });
+
+  it("gives a browser a cookie that only works same-origin", async () => {
+    const opened = await pairingCode();
+    const res = await call("/api/auth/pair", {
+      method: "POST",
+      headers: remote("10.0.0.4", { "x-forwarded-proto": "https" }),
+      body: JSON.stringify({ code: opened.code, label: "iPad in the kitchen", cookie: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeUndefined();
+    const setCookie = header(res.headers, "set-cookie");
+    expect(setCookie).toMatch(new RegExp(`^omb_session_${PORT}_[a-f0-9]{12}=omb_sess_`));
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("Secure");
+    const cookie = setCookie.split(";")[0];
+
+    const sameOrigin = await call("/api/bots", { headers: remote("10.0.0.4", { cookie, origin: `http://${REMOTE_HOST}` }) });
+    expect(sameOrigin.status).toBe(200);
+    const noOrigin = await call("/api/auth/session", { headers: remote("10.0.0.4", { cookie }) });
+    expect(noOrigin.body).toMatchObject({ kind: "session", via: "cookie", label: "iPad in the kitchen" });
+    const csrf = await call("/api/bots", { method: "POST", headers: remote("10.0.0.4", { cookie, origin: "https://evil.example" }), body: "{}" });
+    expect(csrf.status).toBe(403);
+    expect(csrf.body.error).toBe("forbidden: cross-origin request");
+
+    const logout = await call("/api/auth/logout", { method: "POST", headers: remote("10.0.0.4", { cookie }) });
+    expect(header(logout.headers, "set-cookie")).toContain("Max-Age=0");
+    expect((await call("/api/bots", { headers: remote("10.0.0.4", { cookie }) })).status).toBe(401);
+  });
+
+  it("locks a source out after five bad codes and says how long", async () => {
+    for (let i = 0; i < 5; i++) {
+      const r = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.99"), body: JSON.stringify({ code: `BAD${i}-BADB-ADBA` }) });
+      expect(r.status).toBe(401);
+    }
+    const opened = await pairingCode();
+    const locked = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.99"), body: JSON.stringify({ code: opened.code }) });
+    expect(locked.status).toBe(429);
+    expect(locked.body.error).toMatch(/try again in \d+ min/);
+    // the code itself is untouched: another source can still use it
+    expect((await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.100"), body: JSON.stringify({ code: opened.code }) })).status).toBe(200);
+    expect(stderr).toMatch(/pairing refused from 10\.0\.0\.99/);
+  });
+});

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -1,0 +1,161 @@
+import type { IncomingMessage } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearSessionCookie,
+  isAllowedOrigin,
+  isLoopbackHost,
+  isSameOrigin,
+  parseCookies,
+  requestOrigin,
+  requiredScope,
+  resolveRequestAuth,
+  serializeSessionCookie,
+  sessionCookieName,
+} from "./request-auth.ts";
+import { SessionRegistry } from "./sessions.ts";
+
+function request(headers: Record<string, string>, method = "GET"): IncomingMessage {
+  // SAFETY: the resolver reads only headers and method; a bare object is the whole contract here
+  return { headers, method } as unknown as IncomingMessage;
+}
+
+describe("loopback rules (moved from the server entry, behaviour unchanged)", () => {
+  it("accepts localhost, 127.x and ::1 with or without a port", () => {
+    for (const host of ["localhost", "localhost:8799", "127.0.0.1", "127.9.9.9:80", "[::1]", "[::1]:8799", "LOCALHOST"]) {
+      expect(isLoopbackHost(host), host).toBe(true);
+    }
+    for (const host of ["", "example.com", "127.0.0.1:x", "[::1]x", "100.64.0.1:8799", "localhost.evil.com", "[fe80::1]"]) {
+      expect(isLoopbackHost(host), host).toBe(false);
+    }
+  });
+  it("allows absent origins and loopback origins only", () => {
+    expect(isAllowedOrigin(undefined)).toBe(true);
+    expect(isAllowedOrigin("http://127.0.0.1:8799")).toBe(true);
+    expect(isAllowedOrigin("https://localhost")).toBe(true);
+    expect(isAllowedOrigin("https://evil.example")).toBe(false);
+    expect(isAllowedOrigin("ftp://localhost")).toBe(false);
+    expect(isAllowedOrigin("not a url")).toBe(false);
+  });
+});
+
+describe("origin and cookies", () => {
+  it("derives the request origin from Host and the proxy's scheme", () => {
+    expect(requestOrigin(request({ host: "bots.example.com" }))).toBe("http://bots.example.com");
+    expect(requestOrigin(request({ host: "Bots.Example.com", "x-forwarded-proto": "https" }))).toBe("https://bots.example.com");
+    expect(requestOrigin(request({ host: "a:8799", "x-forwarded-proto": "https, http" }))).toBe("https://a:8799");
+    expect(requestOrigin(request({}))).toBeNull();
+  });
+  it("treats absent or matching Origin as same-origin, anything else as foreign", () => {
+    expect(isSameOrigin(request({ host: "a.example" }))).toBe(true);
+    expect(isSameOrigin(request({ host: "a.example", origin: "http://a.example" }))).toBe(true);
+    expect(isSameOrigin(request({ host: "a.example", "x-forwarded-proto": "https", origin: "https://a.example" }))).toBe(true);
+    expect(isSameOrigin(request({ host: "a.example", origin: "https://evil.example" }))).toBe(false);
+  });
+  it("parses cookies and names the session cookie per port and environment", () => {
+    expect(parseCookies("a=1; omb_session_8799_abc=tok; b = 2")).toEqual(new Map([["a", "1"], ["omb_session_8799_abc", "tok"], ["b", "2"]]));
+    expect(parseCookies(undefined).size).toBe(0);
+    expect(sessionCookieName(8799, "3f2a-uuid-like-id")).toBe("omb_session_8799_3f2auuidlike");
+    expect(serializeSessionCookie("c", "t", { secure: true, maxAgeSeconds: 60 })).toBe("c=t; Path=/; HttpOnly; SameSite=Lax; Max-Age=60; Secure");
+    expect(serializeSessionCookie("c", "t", { secure: false, maxAgeSeconds: 60 })).not.toContain("Secure");
+    expect(clearSessionCookie("c")).toContain("Max-Age=0");
+  });
+});
+
+describe("scopes", () => {
+  it("needs admin for pairing, session management and configuration writes; client elsewhere", () => {
+    expect(requiredScope("POST", "/api/auth/pairing")).toBe("admin");
+    expect(requiredScope("DELETE", "/api/auth/sessions/abc")).toBe("admin");
+    expect(requiredScope("PUT", "/api/config")).toBe("admin");
+    expect(requiredScope("GET", "/api/config")).toBe("client");
+    expect(requiredScope("POST", "/api/instances")).toBe("admin");
+    expect(requiredScope("GET", "/api/instances")).toBe("client");
+    expect(requiredScope("POST", "/api/bots/x/messages")).toBe("client");
+    expect(requiredScope("POST", "/api/auth/pair")).toBe("client");
+    expect(requiredScope("POST", "/api/auth/stream-ticket")).toBe("client");
+  });
+});
+
+describe("resolveRequestAuth", () => {
+  let dir: string;
+  let sessions: SessionRegistry;
+  const cookieName = "omb_session_8799_env";
+  const resolve = (headers: Record<string, string>, path = "/api/bots", method = "GET") =>
+    resolveRequestAuth(request(headers, method), { sessions, cookieName, streamPath: "/api/events", url: new URL(path, "http://x") });
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-auth-"));
+    sessions = new SessionRegistry({ file: join(dir, "sessions.json") });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function pairedToken(scopes: Array<"admin" | "client"> = ["admin", "client"]): string {
+    const { code } = sessions.openPairing({ scopes });
+    const result = sessions.exchange({ code, label: "test", source: "1.2.3.4" });
+    if (!result.ok) throw new Error(result.error);
+    return result.token;
+  }
+
+  it("keeps the loopback owner path exactly as before", () => {
+    expect(resolve({ host: "127.0.0.1:8799" }).auth).toEqual({ kind: "loopback", scopes: ["admin", "client"] });
+    expect(resolve({ host: "127.0.0.1:8799", origin: "http://localhost:8799" }).auth?.kind).toBe("loopback");
+    const foreignHost = resolve({ host: "100.64.0.9:8799" });
+    expect(foreignHost.auth).toBeNull();
+    expect(foreignHost.status).toBe(403);
+    expect(foreignHost.error).toMatch(/loopback host required.*pair this device/);
+    const foreignOrigin = resolve({ host: "127.0.0.1:8799", origin: "https://evil.example" });
+    expect(foreignOrigin.status).toBe(403);
+    expect(foreignOrigin.error).toBe("forbidden: cross-origin request");
+  });
+
+  it("admits a bearer session from any host and reports how it authenticated", () => {
+    const token = pairedToken();
+    const r = resolve({ host: "100.64.0.9:8799", authorization: `Bearer ${token}` });
+    expect(r.auth?.kind).toBe("session");
+    expect(r.auth?.kind === "session" && r.auth.via).toBe("bearer");
+  });
+
+  it("admits the cookie only same-origin, so a foreign page cannot ride it", () => {
+    const token = pairedToken();
+    const ok = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "http://bots.example.com" });
+    expect(ok.auth?.kind).toBe("session");
+    const csrf = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "https://evil.example" }, "/api/bots", "POST");
+    expect(csrf.auth).toBeNull();
+    expect(csrf.status).toBe(403);
+    expect(csrf.error).toBe("forbidden: cross-origin request");
+  });
+
+  it("accepts a stream ticket on the event stream only, once", () => {
+    const token = pairedToken();
+    const session = sessions.authenticate(token);
+    if (!session) throw new Error("no session");
+    const { ticket } = sessions.issueStreamTicket(session.id);
+    expect(resolve({ host: "bots.example.com" }, `/api/events?ticket=${ticket}`).auth?.kind).toBe("session");
+    expect(resolve({ host: "bots.example.com" }, `/api/events?ticket=${ticket}`).status).toBe(401);
+    const { ticket: other } = sessions.issueStreamTicket(session.id);
+    expect(resolve({ host: "bots.example.com" }, `/api/bots?ticket=${other}`).auth).toBeNull();
+  });
+
+  it("enforces scope: a client-only session cannot manage pairing or write config", () => {
+    const token = pairedToken(["client"]);
+    const denied = resolve({ host: "bots.example.com", authorization: `Bearer ${token}` }, "/api/auth/pairing", "POST");
+    expect(denied.status).toBe(403);
+    expect(denied.error).toContain("lacks the admin scope");
+    expect(resolve({ host: "bots.example.com", authorization: `Bearer ${token}` }, "/api/bots").auth?.kind).toBe("session");
+  });
+
+  it("explains a dead credential instead of silently falling back, except on loopback", () => {
+    const token = pairedToken();
+    const session = sessions.authenticate(token);
+    if (!session) throw new Error("no session");
+    sessions.revoke(session.id);
+    const remote = resolve({ host: "bots.example.com", authorization: `Bearer ${token}` });
+    expect(remote.status).toBe(401);
+    expect(remote.error).toMatch(/expired or was revoked; pair this device again/);
+    // the owner on the same machine keeps working even with a stale cookie
+    expect(resolve({ host: "127.0.0.1:8799", cookie: `${cookieName}=${token}` }).auth?.kind).toBe("loopback");
+  });
+});

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -8,9 +8,11 @@ import {
   clearSessionCookie,
   isAllowedOrigin,
   isLoopbackHost,
+  isProxied,
   isSameOrigin,
   parseCookies,
   requestOrigin,
+  requestSource,
   requiredScope,
   resolveRequestAuth,
   serializeSessionCookie,
@@ -65,6 +67,18 @@ describe("origin and cookies", () => {
   });
 });
 
+describe("request source for the lockout", () => {
+  const withPeer = (peer: string, headers: Record<string, string>) =>
+    // SAFETY: only headers and the socket peer are read
+    ({ headers, method: "POST", socket: { remoteAddress: peer } }) as unknown as IncomingMessage;
+  it("takes the forwarded address only from a proxy on this machine", () => {
+    expect(requestSource(withPeer("127.0.0.1", { "x-forwarded-for": "203.0.113.9, 10.0.0.1" }))).toBe("203.0.113.9");
+    expect(requestSource(withPeer("::ffff:127.0.0.1", { "x-forwarded-for": "203.0.113.9" }))).toBe("203.0.113.9");
+    expect(requestSource(withPeer("127.0.0.1", {}))).toBe("127.0.0.1");
+    expect(requestSource(withPeer("100.64.0.7", { "x-forwarded-for": "1.1.1.1" }))).toBe("100.64.0.7");
+  });
+});
+
 describe("scopes", () => {
   it("needs admin for pairing, session management and configuration writes; client elsewhere", () => {
     expect(requiredScope("POST", "/api/auth/pairing")).toBe("admin");
@@ -109,6 +123,21 @@ describe("resolveRequestAuth", () => {
     const foreignOrigin = resolve({ host: "127.0.0.1:8799", origin: "https://evil.example" });
     expect(foreignOrigin.status).toBe(403);
     expect(foreignOrigin.error).toBe("forbidden: cross-origin request");
+  });
+
+  it("never grants loopback trust to a request that came through a proxy, whatever Host it carries", () => {
+    expect(isProxied(request({ host: "localhost", "x-forwarded-for": "203.0.113.9" }))).toBe(true);
+    expect(isProxied(request({ host: "localhost", "x-forwarded-proto": "https" }))).toBe(true);
+    expect(isProxied(request({ host: "localhost" }))).toBe(false);
+    const viaProxy = resolve({ host: "localhost", "x-forwarded-for": "203.0.113.9" });
+    expect(viaProxy.auth).toBeNull();
+    expect(viaProxy.status).toBe(403);
+    expect(viaProxy.error).toMatch(/came through a proxy.*pair this device/);
+    const rewritten = resolve({ host: "127.0.0.1:8799", "x-forwarded-proto": "https", "x-forwarded-for": "203.0.113.9" });
+    expect(rewritten.auth).toBeNull();
+    // a paired session through the same proxy is fine
+    const token = pairedToken();
+    expect(resolve({ host: "localhost", "x-forwarded-for": "203.0.113.9", authorization: `Bearer ${token}` }).auth?.kind).toBe("session");
   });
 
   it("admits a bearer session from any host and reports how it authenticated", () => {

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -73,6 +73,15 @@ export function requestOrigin(req: IncomingMessage): string | null {
   return `${proto}://${host.toLowerCase()}`;
 }
 
+/** A proxy on the way in sets forwarded headers; a client on this machine
+ * does not. Loopback trust is for the latter only: a proxy that hands the
+ * server a loopback Host (or forwards `Host: localhost` from a stranger)
+ * must not turn a remote client into the owner. */
+export function isProxied(req: IncomingMessage): boolean {
+  const h = req.headers;
+  return Boolean(h["x-forwarded-for"] || h["x-forwarded-proto"] || h["x-forwarded-host"] || h["forwarded"]);
+}
+
 /** Origin absent (non-browser) or equal to this request's own origin. */
 export function isSameOrigin(req: IncomingMessage): boolean {
   const origin = headerValue(req.headers.origin);
@@ -81,11 +90,16 @@ export function isSameOrigin(req: IncomingMessage): boolean {
   return own !== null && origin.trim().toLowerCase() === own;
 }
 
-/** Who to count a pairing attempt against: the first forwarded hop when a
- * proxy says so, else the socket peer. Lockout keys on this. */
+/** Who to count a pairing attempt against. The server binds loopback, so a
+ * remote client always arrives through a proxy or tunnel on this machine;
+ * that proxy's X-Forwarded-For (Caddy overwrites any the client sent) names
+ * the real source. A connection whose peer is not loopback (a future bind to
+ * an interface) is the source itself, and its forwarded header is ignored. */
 export function requestSource(req: IncomingMessage): string {
-  const forwarded = headerValue(req.headers["x-forwarded-for"])?.split(",")[0]?.trim();
-  return forwarded || req.socket?.remoteAddress || "unknown";
+  const peer = req.socket?.remoteAddress || "unknown";
+  const viaLocalProxy = peer === "127.0.0.1" || peer === "::1" || peer === "::ffff:127.0.0.1";
+  const forwarded = viaLocalProxy ? headerValue(req.headers["x-forwarded-for"])?.split(",")[0]?.trim() : undefined;
+  return forwarded || peer;
 }
 
 /** "Safari on iPhone" beats "Unnamed device" in the sessions list. */
@@ -198,11 +212,15 @@ export function resolveRequestAuth(req: IncomingMessage, options: ResolveOptions
     return { auth: { kind: "session", session, via, scopes: session.scopes }, status: 401, error: "" };
   }
 
-  const loopback = isLoopbackHost(headerValue(req.headers.host)) && isAllowedOrigin(headerValue(req.headers.origin));
+  const proxied = isProxied(req);
+  const loopback = !proxied && isLoopbackHost(headerValue(req.headers.host)) && isAllowedOrigin(headerValue(req.headers.origin));
   if (loopback) return { auth: { kind: "loopback", scopes: LOOPBACK_SCOPES }, status: 401, error: "" };
 
   if (via) {
     return deny(401, "unauthorized: this session has expired or was revoked; pair this device again");
+  }
+  if (proxied) {
+    return deny(403, "forbidden: this request came through a proxy (pair this device to use the server remotely)");
   }
   if (!isLoopbackHost(headerValue(req.headers.host))) {
     return deny(403, "forbidden: loopback host required (pair this device to use the server remotely)");

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -1,0 +1,211 @@
+// Who is asking, and are they allowed to?
+//
+// Two ways in. A **loopback** request (Host and Origin both loopback) is the
+// desktop app on the same machine and has always been trusted as the owner;
+// that stays. A **session** request carries a credential minted by pairing
+// (server/sessions.ts): a bearer token, the session cookie the served web UI
+// uses, or, for the event stream only, a short-lived ticket. With a session
+// the loopback rule is replaced by a same-origin rule, so a browser on
+// another site still cannot ride the cookie (CSRF), and by a scope check.
+import type { IncomingMessage } from "node:http";
+import { isIP } from "node:net";
+
+import type { Scope, SessionRecord, SessionRegistry } from "./sessions.ts";
+
+export type RequestAuth =
+  | { kind: "loopback"; scopes: readonly Scope[] }
+  | { kind: "session"; session: SessionRecord; via: "bearer" | "cookie" | "ticket"; scopes: readonly Scope[] };
+
+export interface RequestAuthResult {
+  auth: RequestAuth | null;
+  /** HTTP status and the reason to send when auth is null. */
+  status: 401 | 403;
+  error: string;
+}
+
+const LOOPBACK_SCOPES: readonly Scope[] = ["admin", "client"];
+
+export function isLoopbackHost(host: string | undefined): boolean {
+  if (!host) return false;
+  const value = host.trim().toLowerCase();
+  if (!value) return false;
+
+  let hostname = value;
+  if (value.startsWith("[")) {
+    const close = value.indexOf("]");
+    if (close < 0 || (value.length > close + 1 && !/^:\d+$/.test(value.slice(close + 1)))) return false;
+    hostname = value.slice(1, close);
+  } else {
+    const firstColon = value.indexOf(":");
+    const lastColon = value.lastIndexOf(":");
+    if (firstColon >= 0 && firstColon === lastColon) {
+      if (!/^\d+$/.test(value.slice(firstColon + 1))) return false;
+      hostname = value.slice(0, firstColon);
+    }
+  }
+
+  if (hostname === "localhost" || hostname === "localhost.") return true;
+  if (isIP(hostname) === 4) return hostname.startsWith("127.");
+  return hostname === "::1" || hostname === "0:0:0:0:0:0:0:1";
+}
+
+export function isAllowedOrigin(origin: string | undefined | null): boolean {
+  if (!origin) return true; // non-browser clients (CLIs, curl, tests) send none
+  try {
+    const o = new URL(origin);
+    return isLoopbackHost(o.hostname) && (o.protocol === "http:" || o.protocol === "https:");
+  } catch {
+    return false;
+  }
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/** The origin a browser would send for this request: the proxy's scheme
+ * when one says so (x-forwarded-proto), else plain http, plus the Host. */
+export function requestOrigin(req: IncomingMessage): string | null {
+  const host = headerValue(req.headers.host)?.trim();
+  if (!host) return null;
+  const forwarded = headerValue(req.headers["x-forwarded-proto"])?.split(",")[0]?.trim().toLowerCase();
+  const proto = forwarded === "https" || forwarded === "http" ? forwarded : "http";
+  return `${proto}://${host.toLowerCase()}`;
+}
+
+/** Origin absent (non-browser) or equal to this request's own origin. */
+export function isSameOrigin(req: IncomingMessage): boolean {
+  const origin = headerValue(req.headers.origin);
+  if (!origin) return true;
+  const own = requestOrigin(req);
+  return own !== null && origin.trim().toLowerCase() === own;
+}
+
+/** Who to count a pairing attempt against: the first forwarded hop when a
+ * proxy says so, else the socket peer. Lockout keys on this. */
+export function requestSource(req: IncomingMessage): string {
+  const forwarded = headerValue(req.headers["x-forwarded-for"])?.split(",")[0]?.trim();
+  return forwarded || req.socket?.remoteAddress || "unknown";
+}
+
+/** "Safari on iPhone" beats "Unnamed device" in the sessions list. */
+export function labelFromUserAgent(userAgent: string | undefined): string {
+  const ua = userAgent ?? "";
+  if (!ua) return "Unnamed device";
+  const browser = /Edg\//.test(ua) ? "Edge" : /OPR\//.test(ua) ? "Opera" : /Chrome\//.test(ua) ? "Chrome" : /Firefox\//.test(ua) ? "Firefox" : /Safari\//.test(ua) ? "Safari" : /curl\//.test(ua) ? "curl" : "Client";
+  const os = /iPhone/.test(ua) ? "iPhone" : /iPad/.test(ua) ? "iPad" : /Android/.test(ua) ? "Android" : /Mac OS X/.test(ua) ? "Mac" : /Windows/.test(ua) ? "Windows" : /Linux/.test(ua) ? "Linux" : "";
+  return os ? `${browser} on ${os}` : browser;
+}
+
+export function parseCookies(header: string | undefined): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!header) return out;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (!name) continue;
+    out.set(name, part.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+export function bearerToken(header: string | string[] | undefined): string | undefined {
+  const value = headerValue(header);
+  if (!value) return undefined;
+  const m = /^Bearer\s+(\S+)$/i.exec(value.trim());
+  return m?.[1];
+}
+
+/** Cookies are scoped by host, not port: two servers on one machine would
+ * otherwise clobber each other's session. The environment id keeps a
+ * reinstalled server from reading a cookie signed by its predecessor. */
+export function sessionCookieName(port: number, environmentId: string): string {
+  return `omb_session_${port}_${environmentId.replace(/[^a-z0-9]/gi, "").slice(0, 12)}`;
+}
+
+export function serializeSessionCookie(
+  name: string,
+  token: string,
+  options: { secure: boolean; maxAgeSeconds: number },
+): string {
+  const parts = [`${name}=${token}`, "Path=/", "HttpOnly", "SameSite=Lax", `Max-Age=${options.maxAgeSeconds}`];
+  if (options.secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+export function clearSessionCookie(name: string): string {
+  return `${name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+}
+
+/** Route → scope. Anything not listed needs `client`, which every session has;
+ * the listed routes change who can get in or what the server runs, so they
+ * need `admin`. Loopback holds both. Keep this table next to the routes it
+ * names when adding one. */
+const ADMIN_ROUTES: ReadonlyArray<{ methods: readonly string[] | null; path: RegExp }> = [
+  { methods: null, path: /^\/api\/auth\/pairing(\/|$)/ },
+  { methods: null, path: /^\/api\/auth\/sessions(\/|$)/ },
+  { methods: ["PUT", "PATCH", "DELETE"], path: /^\/api\/config$/ },
+  { methods: ["POST", "PUT", "PATCH", "DELETE"], path: /^\/api\/(instances|engines|mcp-servers|custom-engines)(\/|$)/ },
+];
+
+export function requiredScope(method: string, path: string): Scope {
+  const upper = method.toUpperCase();
+  for (const rule of ADMIN_ROUTES) {
+    if (rule.path.test(path) && (rule.methods === null || rule.methods.includes(upper))) return "admin";
+  }
+  return "client";
+}
+
+export interface ResolveOptions {
+  sessions: SessionRegistry;
+  cookieName: string;
+  /** Path that may authenticate with a stream ticket in its query string. */
+  streamPath: string;
+  url: URL;
+}
+
+/** Decide how this request is authenticated. Never throws. */
+export function resolveRequestAuth(req: IncomingMessage, options: ResolveOptions): RequestAuthResult {
+  const method = req.method ?? "GET";
+  const path = options.url.pathname;
+  const deny = (status: 401 | 403, error: string): RequestAuthResult => ({ auth: null, status, error });
+
+  // A presented session credential wins over the loopback rule so the served
+  // web UI behaves the same on 127.0.0.1 and on a public domain.
+  const bearer = bearerToken(req.headers.authorization);
+  const cookie = parseCookies(headerValue(req.headers.cookie)).get(options.cookieName);
+  const ticket = path === options.streamPath ? options.url.searchParams.get("ticket") : null;
+  let session: SessionRecord | null = null;
+  let via: "bearer" | "cookie" | "ticket" | null = null;
+  if (bearer?.startsWith("omb_sess_")) {
+    session = options.sessions.authenticate(bearer);
+    via = "bearer";
+  } else if (ticket) {
+    session = options.sessions.redeemStreamTicket(ticket);
+    via = "ticket";
+  } else if (cookie) {
+    session = options.sessions.authenticate(cookie);
+    via = "cookie";
+  }
+
+  if (session && via) {
+    if (via === "cookie" && !isSameOrigin(req)) return deny(403, "forbidden: cross-origin request");
+    const needed = requiredScope(method, path);
+    if (!session.scopes.includes(needed)) {
+      return deny(403, `forbidden: this session lacks the ${needed} scope`);
+    }
+    return { auth: { kind: "session", session, via, scopes: session.scopes }, status: 401, error: "" };
+  }
+
+  const loopback = isLoopbackHost(headerValue(req.headers.host)) && isAllowedOrigin(headerValue(req.headers.origin));
+  if (loopback) return { auth: { kind: "loopback", scopes: LOOPBACK_SCOPES }, status: 401, error: "" };
+
+  if (via) {
+    return deny(401, "unauthorized: this session has expired or was revoked; pair this device again");
+  }
+  if (!isLoopbackHost(headerValue(req.headers.host))) {
+    return deny(403, "forbidden: loopback host required (pair this device to use the server remotely)");
+  }
+  return deny(403, "forbidden: cross-origin request");
+}

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  EXCHANGE_REPLAY_MS,
   formatPairingCode,
   generatePairingCode,
+  GLOBAL_LOCKOUT,
   LOCKOUT,
   normalizePairingCode,
   PAIRING_CODE_ALPHABET,
@@ -51,7 +53,9 @@ describe("pairing codes", () => {
     const first = registry.exchange({ code: formatPairingCode(code).toLowerCase(), label: "", source: "a" });
     expect(first.ok).toBe(true);
     if (first.ok) expect(first.session.label).toBe("phone");
-    const again = registry.exchange({ code, label: "x", source: "a" });
+    // the same source retrying gets the same answer (lost-response replay); anyone else is refused
+    expect(registry.exchange({ code, label: "x", source: "a" })).toEqual(first);
+    const again = registry.exchange({ code, label: "x", source: "someone-else" });
     expect(again.ok).toBe(false);
     if (!again.ok) expect(again.error).toMatch(/wrong or has expired/);
     const { code: stale } = registry.openPairing();
@@ -78,6 +82,45 @@ describe("pairing codes", () => {
     expect(registry.exchange({ code: fresh, label: "", source: "attacker" }).ok).toBe(true);
   });
 
+  it("answers a lost-response retry with the same session for a minute, from the same source only", () => {
+    const { code } = registry.openPairing();
+    const first = registry.exchange({ code, label: "phone", source: "a" });
+    const retry = registry.exchange({ code, label: "phone", source: "a" });
+    expect(retry).toEqual(first);
+    expect(registry.list()).toHaveLength(1);
+    const stranger = registry.exchange({ code, label: "x", source: "b" });
+    expect(stranger.ok).toBe(false);
+    clock += EXCHANGE_REPLAY_MS + 1;
+    expect(registry.exchange({ code, label: "phone", source: "a" }).ok).toBe(false);
+  });
+
+  it("caps failures across all sources so rotating the forwarded address does not help", () => {
+    for (let i = 0; i < GLOBAL_LOCKOUT.failures; i++) {
+      expect(registry.exchange({ code: "AAAAAAAAAAAA", label: "", source: `rotating-${i}` }).ok).toBe(false);
+    }
+    const { code } = registry.openPairing();
+    const blocked = registry.exchange({ code, label: "", source: "fresh-address" });
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) expect(blocked.error).toMatch(/across all clients/);
+    clock += GLOBAL_LOCKOUT.lockMs + 1;
+    expect(registry.exchange({ code, label: "", source: "fresh-address" }).ok).toBe(true);
+  });
+
+  it("names the device from the client, else the code's label, else the user agent", () => {
+    const a = registry.openPairing({ label: "Milind's MacBook" });
+    const named = registry.exchange({ code: a.code, label: "", source: "s1", fallbackLabel: "Safari on Mac" });
+    if (!named.ok) throw new Error(named.error);
+    expect(named.session.label).toBe("Milind's MacBook");
+    const b = registry.openPairing();
+    const ua = registry.exchange({ code: b.code, label: "  ", source: "s2", fallbackLabel: "Safari on Mac" });
+    if (!ua.ok) throw new Error(ua.error);
+    expect(ua.session.label).toBe("Safari on Mac");
+    const c = registry.openPairing({ label: "ignored" });
+    const explicit = registry.exchange({ code: c.code, label: "Kitchen iPad", source: "s3", fallbackLabel: "Safari on iPad" });
+    if (!explicit.ok) throw new Error(explicit.error);
+    expect(explicit.session.label).toBe("Kitchen iPad");
+  });
+
   it("carries scopes from the code into the session, deduplicated", () => {
     const { code } = registry.openPairing({ scopes: ["client", "client"] });
     const result = registry.exchange({ code, label: "viewer", source: "s" });
@@ -93,7 +136,7 @@ describe("sessions", () => {
     const onDisk = readFileSync(file(), "utf8");
     expect(onDisk).not.toContain(token);
     expect(onDisk).toContain(session.id);
-    expect(statSync(file()).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") expect(statSync(file()).mode & 0o777).toBe(0o600); // Windows has no POSIX modes
     const reloaded = new SessionRegistry({ file: file(), now: () => clock });
     expect(reloaded.authenticate(token)?.id).toBe(session.id);
     expect(reloaded.authenticate("omb_sess_nope")).toBeNull();

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  formatPairingCode,
+  generatePairingCode,
+  LOCKOUT,
+  normalizePairingCode,
+  PAIRING_CODE_ALPHABET,
+  PAIRING_CODE_TTL_MS,
+  SESSION_TTL_MS,
+  SessionRegistry,
+  STREAM_TICKET_TTL_MS,
+} from "./sessions.ts";
+
+let dir: string;
+let clock: number;
+let registry: SessionRegistry;
+const file = () => join(dir, "sessions.json");
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "omb-sessions-"));
+  clock = 1_700_000_000_000;
+  registry = new SessionRegistry({ file: file(), now: () => clock });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function pair(label = "MacBook", source = "10.0.0.2") {
+  const { code } = registry.openPairing();
+  const result = registry.exchange({ code, label, source });
+  if (!result.ok) throw new Error(result.error);
+  return result;
+}
+
+describe("pairing codes", () => {
+  it("are 12 unambiguous symbols and survive human retyping", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generatePairingCode();
+      expect(code).toHaveLength(12);
+      for (const ch of code) expect(PAIRING_CODE_ALPHABET).toContain(ch);
+    }
+    expect(formatPairingCode("ABCDEFGHJKLM")).toBe("ABCD-EFGH-JKLM");
+    expect(normalizePairingCode(" abcd-efgh jklm ")).toBe("ABCDEFGHJKLM");
+    expect(normalizePairingCode("0O1I")).toBe("OOII");
+  });
+
+  it("exchange once, then never again, and expire after five minutes", () => {
+    const { code } = registry.openPairing({ label: "phone" });
+    const first = registry.exchange({ code: formatPairingCode(code).toLowerCase(), label: "", source: "a" });
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.session.label).toBe("phone");
+    const again = registry.exchange({ code, label: "x", source: "a" });
+    expect(again.ok).toBe(false);
+    if (!again.ok) expect(again.error).toMatch(/wrong or has expired/);
+    const { code: stale } = registry.openPairing();
+    clock += PAIRING_CODE_TTL_MS + 1;
+    expect(registry.exchange({ code: stale, label: "x", source: "b" }).ok).toBe(false);
+    expect(registry.openPairings()).toEqual([]);
+  });
+
+  it("locks a source out after repeated failures, and forgets on success", () => {
+    for (let i = 0; i < LOCKOUT.failures; i++) {
+      expect(registry.exchange({ code: "AAAAAAAAAAAA", label: "", source: "attacker" }).ok).toBe(false);
+    }
+    const { code } = registry.openPairing();
+    const locked = registry.exchange({ code, label: "", source: "attacker" });
+    expect(locked.ok).toBe(false);
+    if (!locked.ok) {
+      expect(locked.status).toBe(429);
+      expect(locked.error).toMatch(/try again in 10 min/);
+    }
+    // a different source is unaffected, and the code is still unused
+    expect(registry.exchange({ code, label: "", source: "friend" }).ok).toBe(true);
+    clock += LOCKOUT.lockMs + 1;
+    const { code: fresh } = registry.openPairing();
+    expect(registry.exchange({ code: fresh, label: "", source: "attacker" }).ok).toBe(true);
+  });
+
+  it("carries scopes from the code into the session, deduplicated", () => {
+    const { code } = registry.openPairing({ scopes: ["client", "client"] });
+    const result = registry.exchange({ code, label: "viewer", source: "s" });
+    if (!result.ok) throw new Error(result.error);
+    expect(result.session.scopes).toEqual(["client"]);
+    expect(pair().session.scopes).toEqual(["admin", "client"]);
+  });
+});
+
+describe("sessions", () => {
+  it("stores only a hash, owner-only, and reloads from disk", () => {
+    const { token, session } = pair();
+    const onDisk = readFileSync(file(), "utf8");
+    expect(onDisk).not.toContain(token);
+    expect(onDisk).toContain(session.id);
+    expect(statSync(file()).mode & 0o777).toBe(0o600);
+    const reloaded = new SessionRegistry({ file: file(), now: () => clock });
+    expect(reloaded.authenticate(token)?.id).toBe(session.id);
+    expect(reloaded.authenticate("omb_sess_nope")).toBeNull();
+  });
+
+  it("expires after 30 days and can be revoked", () => {
+    const { token, session } = pair();
+    clock += SESSION_TTL_MS - 1;
+    expect(registry.authenticate(token)?.id).toBe(session.id);
+    clock += 2;
+    expect(registry.authenticate(token)).toBeNull();
+    const other = pair("iPad");
+    expect(registry.list().map((s) => s.label)).toEqual(["iPad"]);
+    expect(registry.revoke(other.session.id)).toBe(true);
+    expect(registry.revoke(other.session.id)).toBe(false);
+    expect(registry.authenticate(other.token)).toBeNull();
+  });
+
+  it("updates last-seen at most once a minute so reads stay cheap", () => {
+    const { token } = pair();
+    const before = statSync(file()).mtimeMs;
+    clock += 1_000;
+    registry.authenticate(token);
+    expect(registry.list()[0]?.lastSeenAt).toBe(clock - 1_000);
+    clock += 60_000;
+    registry.authenticate(token);
+    expect(registry.list()[0]?.lastSeenAt).toBe(clock);
+    expect(statSync(file()).mtimeMs).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe("stream tickets", () => {
+  it("are single use, short-lived, and die with their session", () => {
+    const { session } = pair();
+    const { ticket } = registry.issueStreamTicket(session.id);
+    expect(registry.redeemStreamTicket(ticket)?.id).toBe(session.id);
+    expect(registry.redeemStreamTicket(ticket)).toBeNull();
+    const { ticket: late } = registry.issueStreamTicket(session.id);
+    clock += STREAM_TICKET_TTL_MS + 1;
+    expect(registry.redeemStreamTicket(late)).toBeNull();
+    const { ticket: orphan } = registry.issueStreamTicket(session.id);
+    registry.revoke(session.id);
+    expect(registry.redeemStreamTicket(orphan)).toBeNull();
+  });
+});

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -22,6 +22,12 @@ export const PAIRING_CODE_TTL_MS = 5 * 60_000;
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
 export const STREAM_TICKET_TTL_MS = 5 * 60_000;
 export const LOCKOUT = { failures: 5, windowMs: 60_000, lockMs: 10 * 60_000 } as const;
+/** Every source together: a client rotating its forwarded address still
+ * cannot try more than this many codes a minute. */
+export const GLOBAL_LOCKOUT = { failures: 30, windowMs: 60_000, lockMs: 60_000 } as const;
+/** A consumed code presented again by the same source within this window
+ * gets the same answer, so a lost response does not strand the device. */
+export const EXCHANGE_REPLAY_MS = 60_000;
 const LAST_SEEN_WRITE_INTERVAL_MS = 60_000;
 
 const scopeSchema = z.enum(["admin", "client"]);
@@ -123,6 +129,8 @@ export class SessionRegistry {
   private pairings: PairingCode[] = [];
   private tickets = new Map<string, { sessionId: string; expiresAt: number }>();
   private failures = new Map<string, { count: number; windowStart: number; lockedUntil: number }>();
+  private globalFailures = { count: 0, windowStart: 0, lockedUntil: 0 };
+  private replays: Array<{ codeHash: string; source: string; result: ExchangeResult; expiresAt: number }> = [];
   private lastSeenWrites = new Map<string, number>();
   private readonly now: () => number;
   private readonly options: { file: string; now?: () => number };
@@ -160,6 +168,7 @@ export class SessionRegistry {
   private prune(): void {
     const now = this.now();
     this.pairings = this.pairings.filter((p) => p.expiresAt > now);
+    this.replays = this.replays.filter((r) => r.expiresAt > now);
     for (const [hash, ticket] of this.tickets) if (ticket.expiresAt <= now) this.tickets.delete(hash);
     const live = this.sessions.filter((s) => s.expiresAt > now);
     if (live.length !== this.sessions.length) {
@@ -208,6 +217,17 @@ export class SessionRegistry {
 
   private recordFailure(source: string): void {
     const now = this.now();
+    const g = this.globalFailures;
+    if (now - g.windowStart > GLOBAL_LOCKOUT.windowMs) {
+      g.count = 0;
+      g.windowStart = now;
+    }
+    g.count += 1;
+    if (g.count >= GLOBAL_LOCKOUT.failures) {
+      g.lockedUntil = now + GLOBAL_LOCKOUT.lockMs;
+      g.count = 0;
+      g.windowStart = now;
+    }
     const entry = this.failures.get(source) ?? { count: 0, windowStart: now, lockedUntil: 0 };
     if (now - entry.windowStart > LOCKOUT.windowMs) {
       entry.count = 0;
@@ -224,14 +244,23 @@ export class SessionRegistry {
 
   /** Turn a pairing code into a session. `source` identifies the caller for
    * the lockout (an IP); `label` names the device in the sessions list. */
-  exchange(input: { code: string; label: string; source: string }): ExchangeResult {
+  /** `label` is what the client asked to be called; the code's own label
+   * (set by whoever minted it) comes next; `fallbackLabel` (derived from the
+   * user agent) last. */
+  exchange(input: { code: string; label: string; source: string; fallbackLabel?: string }): ExchangeResult {
     this.prune();
+    const now = this.now();
+    const presented = sha256(normalizePairingCode(input.code));
+    const replay = this.replays.find((r) => r.source === input.source && sameDigest(r.codeHash, presented));
+    if (replay) return replay.result;
     const lock = this.lockState(input.source);
     if (lock.locked) {
       const minutes = Math.ceil(lock.retryAfterMs / 60_000);
       return { ok: false, status: 429, error: `too many failed pairing attempts; try again in ${minutes} min` };
     }
-    const presented = sha256(normalizePairingCode(input.code));
+    if (this.globalFailures.lockedUntil > now) {
+      return { ok: false, status: 429, error: "too many failed pairing attempts across all clients; try again in a minute" };
+    }
     const index = this.pairings.findIndex((p) => sameDigest(p.codeHash, presented));
     if (index < 0) {
       this.recordFailure(input.source);
@@ -239,12 +268,11 @@ export class SessionRegistry {
     }
     const [pairing] = this.pairings.splice(index, 1); // single use
     this.failures.delete(input.source);
-    const now = this.now();
     const token = `omb_sess_${randomBytes(32).toString("base64url")}`;
     const record: SessionRecord = {
       id: randomUUID(),
       tokenHash: sha256(token),
-      label: (input.label || pairing.label || "Unnamed device").trim().slice(0, 80),
+      label: (input.label.trim() || pairing.label || input.fallbackLabel?.trim() || "Unnamed device").slice(0, 80),
       scopes: [...pairing.scopes],
       createdAt: now,
       lastSeenAt: now,
@@ -253,7 +281,9 @@ export class SessionRegistry {
     this.sessions.push(record);
     this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting
     this.persist();
-    return { ok: true, token, session: publicSession(record) };
+    const result: ExchangeResult = { ok: true, token, session: publicSession(record) };
+    this.replays.push({ codeHash: presented, source: input.source, result, expiresAt: now + EXCHANGE_REPLAY_MS });
+    return result;
   }
 
   // ── sessions ───────────────────────────────────────────────────────────

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1,0 +1,311 @@
+// Pairing codes, sessions and stream tickets for clients that are not on
+// this machine. The shape the iOS companion already proved (short-lived
+// pairing → durable per-device credential, hashed at rest), generalized.
+//
+// A pairing code is 12 characters from a 32-symbol alphabet with no 0/O/1/I
+// (60 bits), single use, five minutes. Exchanging it yields an opaque
+// session token (`omb_sess_…`, 256 bits) that lives 30 days; only its sha256
+// is stored. A stream ticket is a 5-minute single-use credential for the SSE
+// endpoint, because EventSource cannot set headers. Failed exchanges are
+// counted per source: five in a minute lock that source out for ten.
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { z } from "zod";
+
+export type Scope = "admin" | "client";
+export const SCOPES: readonly Scope[] = ["admin", "client"];
+
+export const PAIRING_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+export const PAIRING_CODE_LENGTH = 12;
+export const PAIRING_CODE_TTL_MS = 5 * 60_000;
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
+export const STREAM_TICKET_TTL_MS = 5 * 60_000;
+export const LOCKOUT = { failures: 5, windowMs: 60_000, lockMs: 10 * 60_000 } as const;
+const LAST_SEEN_WRITE_INTERVAL_MS = 60_000;
+
+const scopeSchema = z.enum(["admin", "client"]);
+
+const sessionSchema = z.object({
+  id: z.string().min(1),
+  tokenHash: z.string().length(64),
+  label: z.string().max(80),
+  scopes: z.array(scopeSchema).min(1),
+  createdAt: z.number(),
+  lastSeenAt: z.number(),
+  expiresAt: z.number(),
+});
+
+const fileSchema = z.object({ version: z.literal(1), sessions: z.array(sessionSchema) });
+
+export type SessionRecord = z.infer<typeof sessionSchema>;
+
+/** What the UI may see: never the hash. */
+export interface PublicSession {
+  id: string;
+  label: string;
+  scopes: Scope[];
+  createdAt: number;
+  lastSeenAt: number;
+  expiresAt: number;
+}
+
+export interface PairingCode {
+  id: string;
+  codeHash: string;
+  scopes: Scope[];
+  label: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface PublicPairing {
+  id: string;
+  label: string;
+  scopes: Scope[];
+  createdAt: number;
+  expiresAt: number;
+}
+
+export type ExchangeResult =
+  | { ok: true; token: string; session: PublicSession }
+  | { ok: false; status: 401 | 429; error: string };
+
+const sha256 = (value: string) => createHash("sha256").update(value).digest("hex");
+
+function sameDigest(a: string, b: string): boolean {
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/** 12 symbols, rejection-sampled so every symbol is equally likely. */
+export function generatePairingCode(): string {
+  const limit = Math.floor(256 / PAIRING_CODE_ALPHABET.length) * PAIRING_CODE_ALPHABET.length;
+  let code = "";
+  while (code.length < PAIRING_CODE_LENGTH) {
+    for (const byte of randomBytes(PAIRING_CODE_LENGTH)) {
+      if (byte >= limit) continue;
+      code += PAIRING_CODE_ALPHABET[byte % PAIRING_CODE_ALPHABET.length];
+      if (code.length === PAIRING_CODE_LENGTH) break;
+    }
+  }
+  return code;
+}
+
+/** Accept what a human typed: dashes, spaces, lowercase, lookalikes. */
+export function normalizePairingCode(input: string): string {
+  return input
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .replace(/0/g, "O")
+    .replace(/1/g, "I");
+}
+
+/** XXXX-XXXX-XXXX, easier to read out loud. */
+export function formatPairingCode(code: string): string {
+  return code.match(/.{1,4}/g)?.join("-") ?? code;
+}
+
+function publicSession(record: SessionRecord): PublicSession {
+  return {
+    id: record.id,
+    label: record.label,
+    scopes: [...record.scopes],
+    createdAt: record.createdAt,
+    lastSeenAt: record.lastSeenAt,
+    expiresAt: record.expiresAt,
+  };
+}
+
+export class SessionRegistry {
+  private sessions: SessionRecord[] = [];
+  private pairings: PairingCode[] = [];
+  private tickets = new Map<string, { sessionId: string; expiresAt: number }>();
+  private failures = new Map<string, { count: number; windowStart: number; lockedUntil: number }>();
+  private lastSeenWrites = new Map<string, number>();
+  private readonly now: () => number;
+  private readonly options: { file: string; now?: () => number };
+
+  // No parameter properties: the server runs this file under Node's
+  // strip-only TypeScript mode, which only erases types.
+  constructor(options: { file: string; now?: () => number }) {
+    this.options = options;
+    this.now = options.now ?? Date.now;
+    this.load();
+  }
+
+  private load(): void {
+    if (!existsSync(this.options.file)) return;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(this.options.file, "utf8"));
+    } catch {
+      return; // unreadable: start empty rather than refuse to boot; pairing again is cheap
+    }
+    const parsed = fileSchema.safeParse(raw);
+    if (parsed.success) this.sessions = parsed.data.sessions;
+  }
+
+  /** Atomic write, owner-only, directory owner-only. */
+  private persist(): void {
+    const dir = dirname(this.options.file);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const tmp = `${this.options.file}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify({ version: 1, sessions: this.sessions }, null, 2) + "\n", { mode: 0o600 });
+    chmodSync(tmp, 0o600);
+    renameSync(tmp, this.options.file);
+  }
+
+  private prune(): void {
+    const now = this.now();
+    this.pairings = this.pairings.filter((p) => p.expiresAt > now);
+    for (const [hash, ticket] of this.tickets) if (ticket.expiresAt <= now) this.tickets.delete(hash);
+    const live = this.sessions.filter((s) => s.expiresAt > now);
+    if (live.length !== this.sessions.length) {
+      this.sessions = live;
+      this.persist();
+    }
+  }
+
+  // ── pairing ────────────────────────────────────────────────────────────
+
+  openPairing(input: { scopes?: Scope[]; label?: string; ttlMs?: number } = {}): { id: string; code: string; expiresAt: number } {
+    this.prune();
+    const now = this.now();
+    const code = generatePairingCode();
+    const scopes = input.scopes?.length ? [...new Set(input.scopes)] : [...SCOPES];
+    const pairing: PairingCode = {
+      id: randomUUID(),
+      codeHash: sha256(code),
+      scopes,
+      label: (input.label ?? "").trim().slice(0, 80),
+      createdAt: now,
+      expiresAt: now + (input.ttlMs ?? PAIRING_CODE_TTL_MS),
+    };
+    this.pairings.push(pairing);
+    return { id: pairing.id, code, expiresAt: pairing.expiresAt };
+  }
+
+  openPairings(): PublicPairing[] {
+    this.prune();
+    return this.pairings.map((p) => ({ id: p.id, label: p.label, scopes: [...p.scopes], createdAt: p.createdAt, expiresAt: p.expiresAt }));
+  }
+
+  cancelPairing(id: string): boolean {
+    const before = this.pairings.length;
+    this.pairings = this.pairings.filter((p) => p.id !== id);
+    return this.pairings.length !== before;
+  }
+
+  private lockState(source: string): { locked: boolean; retryAfterMs: number } {
+    const entry = this.failures.get(source);
+    if (!entry) return { locked: false, retryAfterMs: 0 };
+    const now = this.now();
+    if (entry.lockedUntil > now) return { locked: true, retryAfterMs: entry.lockedUntil - now };
+    return { locked: false, retryAfterMs: 0 };
+  }
+
+  private recordFailure(source: string): void {
+    const now = this.now();
+    const entry = this.failures.get(source) ?? { count: 0, windowStart: now, lockedUntil: 0 };
+    if (now - entry.windowStart > LOCKOUT.windowMs) {
+      entry.count = 0;
+      entry.windowStart = now;
+    }
+    entry.count += 1;
+    if (entry.count >= LOCKOUT.failures) {
+      entry.lockedUntil = now + LOCKOUT.lockMs;
+      entry.count = 0;
+      entry.windowStart = now;
+    }
+    this.failures.set(source, entry);
+  }
+
+  /** Turn a pairing code into a session. `source` identifies the caller for
+   * the lockout (an IP); `label` names the device in the sessions list. */
+  exchange(input: { code: string; label: string; source: string }): ExchangeResult {
+    this.prune();
+    const lock = this.lockState(input.source);
+    if (lock.locked) {
+      const minutes = Math.ceil(lock.retryAfterMs / 60_000);
+      return { ok: false, status: 429, error: `too many failed pairing attempts; try again in ${minutes} min` };
+    }
+    const presented = sha256(normalizePairingCode(input.code));
+    const index = this.pairings.findIndex((p) => sameDigest(p.codeHash, presented));
+    if (index < 0) {
+      this.recordFailure(input.source);
+      return { ok: false, status: 401, error: "pairing code is wrong or has expired; create a new one on the server" };
+    }
+    const [pairing] = this.pairings.splice(index, 1); // single use
+    this.failures.delete(input.source);
+    const now = this.now();
+    const token = `omb_sess_${randomBytes(32).toString("base64url")}`;
+    const record: SessionRecord = {
+      id: randomUUID(),
+      tokenHash: sha256(token),
+      label: (input.label || pairing.label || "Unnamed device").trim().slice(0, 80),
+      scopes: [...pairing.scopes],
+      createdAt: now,
+      lastSeenAt: now,
+      expiresAt: now + SESSION_TTL_MS,
+    };
+    this.sessions.push(record);
+    this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting
+    this.persist();
+    return { ok: true, token, session: publicSession(record) };
+  }
+
+  // ── sessions ───────────────────────────────────────────────────────────
+
+  authenticate(token: string | undefined): SessionRecord | null {
+    if (!token) return null;
+    const hash = sha256(token);
+    const now = this.now();
+    const record = this.sessions.find((s) => sameDigest(s.tokenHash, hash));
+    if (!record || record.expiresAt <= now) return null;
+    const lastWrite = this.lastSeenWrites.get(record.id) ?? 0;
+    if (now - lastWrite >= LAST_SEEN_WRITE_INTERVAL_MS) {
+      record.lastSeenAt = now;
+      this.lastSeenWrites.set(record.id, now);
+      this.persist();
+    }
+    return record;
+  }
+
+  list(): PublicSession[] {
+    this.prune();
+    return this.sessions.map(publicSession);
+  }
+
+  revoke(id: string): boolean {
+    const before = this.sessions.length;
+    this.sessions = this.sessions.filter((s) => s.id !== id);
+    for (const [hash, ticket] of this.tickets) if (ticket.sessionId === id) this.tickets.delete(hash);
+    if (this.sessions.length === before) return false;
+    this.persist();
+    return true;
+  }
+
+  // ── stream tickets ─────────────────────────────────────────────────────
+
+  issueStreamTicket(sessionId: string): { ticket: string; expiresAt: number } {
+    this.prune();
+    const ticket = `omb_tick_${randomBytes(24).toString("base64url")}`;
+    const expiresAt = this.now() + STREAM_TICKET_TTL_MS;
+    this.tickets.set(sha256(ticket), { sessionId, expiresAt });
+    return { ticket, expiresAt };
+  }
+
+  /** Single use: a reconnecting client asks for a fresh ticket first. */
+  redeemStreamTicket(ticket: string): SessionRecord | null {
+    this.prune();
+    const hash = sha256(ticket);
+    const entry = this.tickets.get(hash);
+    if (!entry) return null;
+    this.tickets.delete(hash);
+    const now = this.now();
+    const record = this.sessions.find((s) => s.id === entry.sessionId);
+    return record && record.expiresAt > now ? record : null;
+  }
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,80 @@
+// The served web UI's view of its own authentication. On the owner's machine
+// the server trusts loopback and none of this is visible; on a remote host
+// the browser must hold a session cookie from pairing (see /pair).
+
+export interface EnvironmentDescriptor {
+  environmentId: string;
+  label: string;
+  platform: string;
+  version: string;
+  capabilities: { remoteSessions: true; selfUpdate: "desktop-managed" | "operator" };
+}
+
+export type SessionState =
+  | { kind: "loopback" }
+  | { kind: "session"; id: string; label: string; scopes: string[]; expiresAt: number }
+  | { kind: "unauthenticated"; error: string }
+  | { kind: "unreachable"; error: string };
+
+/** Ask the server who we are. A 401/403 means "go pair"; a network failure
+ * is reported separately so the pair page can say the server is down. */
+export async function readSessionState(fetchImpl: typeof fetch = fetch): Promise<SessionState> {
+  let res: Response;
+  try {
+    res = await fetchImpl("/api/auth/session", { credentials: "same-origin" });
+  } catch (error) {
+    return { kind: "unreachable", error: error instanceof Error ? error.message : String(error) };
+  }
+  const body: unknown = await res.json().catch(() => ({}));
+  const record = Object(body) as Record<string, unknown>; // SAFETY: read with typeof checks below; never trusted as a shape
+  if (res.status === 401 || res.status === 403) {
+    return { kind: "unauthenticated", error: typeof record.error === "string" ? record.error : `${res.status}` };
+  }
+  if (!res.ok) return { kind: "unreachable", error: `${res.status} ${res.statusText}` };
+  if (record.kind === "session" && typeof record.id === "string") {
+    return {
+      kind: "session",
+      id: record.id,
+      label: typeof record.label === "string" ? record.label : "",
+      scopes: Array.isArray(record.scopes) ? record.scopes.filter((s): s is string => typeof s === "string") : [],
+      expiresAt: typeof record.expiresAt === "number" ? record.expiresAt : 0,
+    };
+  }
+  return { kind: "loopback" };
+}
+
+/** Pull `#code=…` off the URL and out of history, the way a pairing link is meant to be consumed. */
+export function takePairingCodeFromLocation(): string | null {
+  const m = /[#&]code=([^&]+)/.exec(location.hash);
+  if (!m) return null;
+  history.replaceState(null, "", location.pathname + location.search);
+  return decodeURIComponent(m[1]);
+}
+
+/** A default device name, so the sessions list reads "Safari on iPhone" not "Unnamed device". */
+export function defaultDeviceLabel(userAgent: string = navigator.userAgent): string {
+  const browser = /Edg\//.test(userAgent) ? "Edge" : /OPR\//.test(userAgent) ? "Opera" : /Chrome\//.test(userAgent) ? "Chrome" : /Firefox\//.test(userAgent) ? "Firefox" : /Safari\//.test(userAgent) ? "Safari" : "Browser";
+  const os = /iPhone/.test(userAgent) ? "iPhone" : /iPad/.test(userAgent) ? "iPad" : /Android/.test(userAgent) ? "Android" : /Mac OS X/.test(userAgent) ? "Mac" : /Windows/.test(userAgent) ? "Windows" : /Linux/.test(userAgent) ? "Linux" : "";
+  return os ? `${browser} on ${os}` : browser;
+}
+
+export async function pairWithCode(
+  input: { code: string; label: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let res: Response;
+  try {
+    res = await fetchImpl("/api/auth/pair", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: input.code, label: input.label, cookie: true }),
+    });
+  } catch (error) {
+    return { ok: false, error: `could not reach the server (${error instanceof Error ? error.message : String(error)})` };
+  }
+  const body: unknown = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true };
+  const error = Reflect.get(Object(body), "error");
+  return { ok: false, error: typeof error === "string" ? error : `${res.status} ${res.statusText}` };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,26 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { readSessionState, takePairingCodeFromLocation } from "./lib/session";
 import { applySkin, readSkin } from "./lib/skins";
+import { PairPage } from "./pair/PairPage";
 import "./styles.css";
 
 // Before the first paint, not inside a component: stamping the skin during
 // render would show one frame of the default palette first.
 applySkin(readSkin());
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+/** A pairing link lands on /pair. A remote browser without a session lands
+ * there too, because every API call would otherwise fail with "pair this
+ * device"; on the owner's own machine the server trusts loopback and this
+ * check is a single fast request. */
+async function chooseRoot(): Promise<React.ReactNode> {
+  if (location.pathname === "/pair") return <PairPage initialCode={takePairingCodeFromLocation()} />;
+  const session = await readSessionState();
+  if (session.kind === "unauthenticated") return <PairPage initialCode={null} reason={session.error} />;
+  return <App />;
+}
+
+void chooseRoot().then((root) => {
+  createRoot(document.getElementById("root")!).render(<StrictMode>{root}</StrictMode>);
+});

--- a/src/pair/PairPage.tsx
+++ b/src/pair/PairPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+
+import { defaultDeviceLabel, pairWithCode, readSessionState, type EnvironmentDescriptor, type SessionState } from "../lib/session";
+
+/** The page a pairing link opens: /pair#code=XXXX-XXXX-XXXX. Also what the
+ * app shows instead of itself when a remote browser has no session yet. */
+export function PairPage({ initialCode, reason }: { initialCode: string | null; reason?: string }) {
+  const [code, setCode] = useState(initialCode ?? "");
+  const [label, setLabel] = useState(defaultDeviceLabel());
+  const [environment, setEnvironment] = useState<EnvironmentDescriptor | null>(null);
+  const [session, setSession] = useState<SessionState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetch("/.well-known/openmausbot/environment")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: EnvironmentDescriptor | null) => setEnvironment(d))
+      .catch(() => setEnvironment(null));
+    void readSessionState().then(setSession);
+  }, []);
+
+  const connected = session?.kind === "loopback" || session?.kind === "session";
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    const result = await pairWithCode({ code, label });
+    setBusy(false);
+    if (result.ok) {
+      location.replace("/");
+      return;
+    }
+    setError(result.error);
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-app px-6 text-ink">
+      <form onSubmit={submit} className="w-full max-w-[420px]">
+        <h1 className="text-[20px] font-semibold">Connect to {environment?.label ?? "this OpenMausBot"}</h1>
+        <p className="mt-1.5 text-[13.5px] leading-relaxed text-ink-secondary">
+          {environment ? `Version ${environment.version} on ${environment.platform}. ` : ""}
+          Enter the pairing code shown on the server. Codes work once and expire after five minutes.
+        </p>
+        {reason && !connected ? <p className="mt-3 text-[13px] text-ink-secondary">{reason}</p> : null}
+        {connected ? (
+          <p className="mt-4 text-[13.5px]">
+            This browser is already connected.{" "}
+            <a href="/" className="text-accent underline">
+              Open the app
+            </a>
+          </p>
+        ) : (
+          <>
+            <label className="mt-5 block text-[12px] font-medium text-ink-secondary" htmlFor="pair-code">
+              Pairing code
+            </label>
+            <input
+              id="pair-code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="XXXX-XXXX-XXXX"
+              autoComplete="one-time-code"
+              autoCapitalize="characters"
+              spellCheck={false}
+              className="mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-[15px] tracking-[0.12em] text-ink outline-none focus:border-accent-border"
+            />
+            <label className="mt-4 block text-[12px] font-medium text-ink-secondary" htmlFor="pair-label">
+              This device
+            </label>
+            <input
+              id="pair-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={80}
+              className="mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-[14px] text-ink outline-none focus:border-accent-border"
+            />
+            {error ? <p className="mt-3 text-[13px] text-danger">{error}</p> : null}
+            <button
+              type="submit"
+              disabled={busy || code.replace(/[^a-z0-9]/gi, "").length < 12}
+              className="mt-5 w-full rounded-md bg-accent px-4 py-2 text-[14px] font-medium text-accent-ink disabled:opacity-50"
+            >
+              {busy ? "Connecting…" : "Connect"}
+            </button>
+          </>
+        )}
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
First code PR of Remote Workspace (plan: #680, issue #672). The ask from the community, verbatim: run the server on a Mac mini or VPS, use it from other Macs, Windows, the browser and the phone, without SSH tunnels. This PR is the server half plus the browser client: **pair once, then use the server from any machine.**

## What changes, and what does not

The server still binds `127.0.0.1` and still trusts loopback as the owner; the desktop app on the same machine is untouched (the existing 142-test API suite passes as-is). What is new is a second way in:

- **Pairing.** On the server, `pnpm pair` (or `node dist-server/pair-cli.js` in the container) prints a 12-character code from a 32-symbol alphabet with no 0/O/1/I, single use, five minutes, and, when `OMB_PUBLIC_URL` is set, a link `https://host/pair#code=…` (code in the hash, never the query).
- **Sessions.** Exchanging the code gives a 30-day per-device session: an `omb_sess_…` bearer for native clients, or an `HttpOnly` `SameSite=Lax` cookie for browsers, named per port plus environment so two servers on one host never clobber each other. Only the sha256 is stored, in an owner-only file. Sessions are listed and revoked over the API (Settings screen follows).
- **Stream tickets.** `EventSource` cannot set headers, so `POST /api/auth/stream-ticket` mints a 5-minute single-use ticket for `/api/events?ticket=`. Cookies work for the served UI without it.
- **Scopes.** `admin` (pairing, session management, configuration writes) and `client` (everything else). Loopback holds both; a code can be minted `--client` for a device that may chat but not change settings or pair others.
- **CSRF.** A cookie is honoured only when the request's `Origin` is absent or equals the request's own origin; a foreign page cannot ride it.
- **Lockout.** Five failed exchanges from one address (first forwarded hop behind a proxy) lock that address for ten minutes, logged with the source.
- **Identity.** A persisted `environmentId` and a public descriptor at `/.well-known/openmausbot/environment` (id, label, platform, version, capabilities) so saved connections can verify what they talk to and version skew is visible. Electron now passes `OMB_APP_VERSION`.
- **The gate itself** moved out of the 8.7k-line `server/index.ts` into `server/request-auth.ts` with tests; static assets are served before it so a remote browser can load `/pair` (the bundle is public code, it holds no secrets).
- **`/pair` page** in the renderer: code prefilled from the link, device name defaulted from the user agent; a remote browser with no session lands there instead of a wall of 403s. The Discord "send button doesn't work on LAN" report was exactly that wall.

## Verified

| check | result |
|---|---|
| unit: request gate (loopback unchanged, bearer/cookie/ticket, same-origin, scopes), session registry (single use, expiry, lockout, hashing, 0600), descriptor | ✅ 23/23 |
| end-to-end over a real harness with non-loopback `Host` (node:http, since fetch drops it): descriptor public, API refused before pairing, UI shell served, mint → pair → bearer → session → ticket → SSE hello → revoke → 401; cookie flow with `Secure`, CSRF refusal, logout; client scope refused admin; lockout 429 | ✅ 8/8 |
| existing `server/index.test.ts` on the refactored gate | ✅ 142/142 |
| mutations: static behind gate, cookie never Secure, cookie ignores Origin, no admin scope, code reusable, no lockout | ✅ each breaks a test |
| headless Chrome with `--host-resolver-rules` as a remote host: `/pair#code=` renders "Connect to cab mini" with the form; `/` without a session renders the pair page with the reason; loopback `/` renders the app | ✅ |
| `pnpm pair` output, `build:server` (new `pair-cli` entry), packaged-server smoke, typecheck, lint, vite build | ✅ |

## Follow-ups (each its own PR)

1. Desktop **Environments**: saved servers, "add via pairing link", switch by loading the remote server's served UI with the cookie in the Electron session.
2. **Live desktop over remote**: serve the Electron screen frames through the server so the Mac-mini-as-server topology shows the computer view on other machines.
3. Settings screen for sessions and pairing (the API is there); version-skew banner from the descriptor.
4. Tailscale helper and the managed tunnel for the desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added device pairing for remote browsers and clients using expiring, single-use codes.
  - Added session management with scoped access, logout, revocation, bearer authentication, and stream access.
  - Added a pairing page with device labeling, connection status, and error handling.
  - Added command-line pairing for Docker and headless installations.
  - Added server environment details, including label, platform, version, and capabilities.
  - Added protection against repeated pairing failures and safe retry handling.
  - Enabled webhook access without requiring an authenticated session.
- **Documentation**
  - Expanded self-hosting guidance for pairing, sessions, authentication, lockouts, and SSH tunneling.
- **Changes**
  - Replaced the default proxy login flow with pairing-based access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->