### PR TITLE
feat(desktop): Server menu — pair with a remote server and switch to it

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -135,6 +135,15 @@ gets a session cookie (30 days, revocable) and the app loads. Sessions are
 listed and revoked at `GET`/`DELETE /api/auth/sessions` for now; a Settings
 screen follows.
 
+From the **desktop app**, use the Server menu: "Add Server from Copied
+Pairing Link…" reads the link you copied from the server, asks once, and
+opens that server's own UI in the app; the app stays signed in to it across
+restarts, and the menu switches between Local and any saved server (on
+Windows and Linux press Alt to show the menu bar). While a remote server is
+shown, this computer's screen, microphone, files and local control are not
+offered to it. "Forget" signs the app out of that server; revoke the
+session on the server too if the device is gone.
+
 What this changes about the trust model: the server still binds loopback
 and still trusts loopback as the owner. A **paired session** is the second
 way in: a bearer token or the cookie, same-origin only, with a scope (`admin`

--- a/electron/capabilities.cjs
+++ b/electron/capabilities.cjs
@@ -81,6 +81,9 @@ function desktopCapabilities({
   packaged = false,
   localConnection = null,
   homeDir = require("node:os").homedir(),
+  // The page asking is a remote server's UI: this computer's screen, voice
+  // and local control are not on offer, whatever the host could do.
+  remote = false,
 } = {}) {
   const hostPlatform = normalizedPlatform(platform);
   const isMac = hostPlatform === "darwin";
@@ -141,7 +144,15 @@ function desktopCapabilities({
       (hostPlatform === "darwin" ? "cua-driver-unavailable" : "unsupported-platform");
   }
 
+  if (remote) {
+    const unavailable = { reasonCode: "remote-server" };
+    Object.assign(screenPreview, { available: false, interaction: "none" }, unavailable);
+    Object.assign(dictation, { available: false, engine: "none", onDevice: false }, unavailable);
+    Object.assign(localComputer, { available: false, support: "unsupported", enabled: false, status: "unavailable" }, unavailable);
+  }
+
   return {
+    remote: Boolean(remote),
     host: {
       platform: hostPlatform,
       label:

--- a/electron/capabilities.node-test.mjs
+++ b/electron/capabilities.node-test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { desktopCapabilities } = require("./capabilities.cjs");
+
+test("a remote server's page is told this computer offers no screen, voice or local control", () => {
+  const local = desktopCapabilities({ platform: "darwin", env: {}, packaged: true, localConnection: { status: "ready", enabled: true } });
+  const remote = desktopCapabilities({ platform: "darwin", env: {}, packaged: true, localConnection: { status: "ready", enabled: true }, remote: true });
+  assert.equal(local.remote, false);
+  assert.equal(local.screenPreview.available, true);
+  assert.equal(remote.remote, true);
+  assert.deepEqual(remote.screenPreview, { available: false, interaction: "none", reasonCode: "remote-server" });
+  assert.equal(remote.dictation.available, false);
+  assert.equal(remote.dictation.reasonCode, "remote-server");
+  assert.equal(remote.localComputer.available, false);
+  assert.equal(remote.localComputer.enabled, false);
+  assert.equal(remote.localComputer.reasonCode, "remote-server");
+  assert.equal(remote.host.platform, "darwin");
+});

--- a/electron/environments.cjs
+++ b/electron/environments.cjs
@@ -1,0 +1,131 @@
+// Saved servers ("environments") for the desktop app, pure and testable.
+//
+// Local is the server this app spawns; a remote environment is a server the
+// user paired with. The app switches by loading that server's own UI, so an
+// environment is just {id, name, origin}. The session credential is the
+// HttpOnly cookie the /pair page set for that origin, held by Chromium's
+// cookie jar, never by this file.
+const LOCAL_ID = "local";
+const MAX_NAME = 60;
+
+/** `https://host[:port]` — a bare origin, no path, no credentials. */
+function normalizeOrigin(input) {
+  if (typeof input !== "string") return null;
+  let url;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  if (url.username || url.password) return null;
+  return url.origin;
+}
+
+/** Turn what the server printed — `https://host/pair#code=XXXX-XXXX-XXXX`,
+ * or just an origin — into where to go. The code stays in the hash, so the
+ * page consumes it and it never reaches a server log. */
+function parsePairingLink(input) {
+  const origin = normalizeOrigin(input);
+  if (!origin) return null;
+  let url;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    return null;
+  }
+  // A code travels in the hash only: a query string reaches server logs.
+  if (url.searchParams.has("code")) return null;
+  const code = /(?:^|[#&])code=([^&]+)/.exec(url.hash)?.[1] ?? null;
+  const isPairPage = url.pathname === "/pair" || url.pathname === "/pair/";
+  if (code && !isPairPage) return null; // a code belongs on /pair; anything else is not a pairing link
+  return { origin, code: code ? decodeURIComponent(code) : null, url: code ? `${origin}/pair#code=${code}` : origin };
+}
+
+function cleanName(value, fallback) {
+  const name = typeof value === "string" ? value.trim().replace(/\s+/g, " ").slice(0, MAX_NAME) : "";
+  return name || fallback;
+}
+
+function nameFromOrigin(origin) {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}
+
+/** Parse the persisted file. Unknown or damaged content yields the empty
+ * state rather than an error: losing a saved list costs a re-pair, not the app. */
+function parseEnvironments(raw) {
+  let value;
+  try {
+    value = typeof raw === "string" ? JSON.parse(raw) : raw;
+  } catch {
+    return { environments: [], activeId: LOCAL_ID };
+  }
+  const list = Array.isArray(value?.environments) ? value.environments : [];
+  const seen = new Set();
+  const environments = [];
+  for (const entry of list) {
+    const origin = normalizeOrigin(entry?.origin);
+    const id = typeof entry?.id === "string" && /^[\w-]{1,64}$/.test(entry.id) ? entry.id : null;
+    if (!origin || !id || id === LOCAL_ID || seen.has(id) || seen.has(origin)) continue;
+    seen.add(id);
+    seen.add(origin);
+    environments.push({ id, name: cleanName(entry?.name, nameFromOrigin(origin)), origin });
+  }
+  const activeId = typeof value?.activeId === "string" && environments.some((e) => e.id === value.activeId) ? value.activeId : LOCAL_ID;
+  return { environments, activeId };
+}
+
+function serializeEnvironments(state) {
+  return JSON.stringify({ version: 1, environments: state.environments, activeId: state.activeId }, null, 2) + "\n";
+}
+
+/** Add or update by origin (re-pairing the same server keeps one entry). */
+function withEnvironment(state, input, makeId) {
+  const origin = normalizeOrigin(input?.origin);
+  if (!origin) return state;
+  const existing = state.environments.find((e) => e.origin === origin);
+  if (existing) {
+    const name = cleanName(input?.name, existing.name);
+    const environments = state.environments.map((e) => (e === existing ? { ...e, name } : e));
+    return { ...state, environments };
+  }
+  const id = makeId();
+  const environments = [...state.environments, { id, name: cleanName(input?.name, nameFromOrigin(origin)), origin }];
+  return { ...state, environments };
+}
+
+function withoutEnvironment(state, id) {
+  const environments = state.environments.filter((e) => e.id !== id);
+  return { environments, activeId: state.activeId === id ? LOCAL_ID : state.activeId };
+}
+
+function withActive(state, id) {
+  if (id !== LOCAL_ID && !state.environments.some((e) => e.id === id)) return state;
+  return { ...state, activeId: id };
+}
+
+function activeEnvironment(state) {
+  return state.environments.find((e) => e.id === state.activeId) ?? null;
+}
+
+/** Origins the main window may navigate to: Local plus every saved server. */
+function allowedOrigins(state, localOrigin) {
+  return new Set([localOrigin, ...state.environments.map((e) => e.origin)]);
+}
+
+module.exports = {
+  LOCAL_ID,
+  activeEnvironment,
+  allowedOrigins,
+  normalizeOrigin,
+  parseEnvironments,
+  parsePairingLink,
+  serializeEnvironments,
+  withActive,
+  withEnvironment,
+  withoutEnvironment,
+};

--- a/electron/environments.node-test.mjs
+++ b/electron/environments.node-test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const env = require("./environments.cjs");
+
+test("origins are bare http(s) origins, nothing else", () => {
+  assert.equal(env.normalizeOrigin("https://mini.tail1234.ts.net/pair#code=x"), "https://mini.tail1234.ts.net");
+  assert.equal(env.normalizeOrigin("http://192.168.1.20:8799"), "http://192.168.1.20:8799");
+  assert.equal(env.normalizeOrigin("HTTPS://Mini.Example:443/"), "https://mini.example");
+  for (const bad of ["ftp://x", "mini.example", "https://user:pw@host", "", 42, null]) assert.equal(env.normalizeOrigin(bad), null, String(bad));
+});
+
+test("a pairing link keeps its code in the hash; a code anywhere else is refused", () => {
+  assert.deepEqual(env.parsePairingLink("https://mini.example/pair#code=ABCD-EFGH-JKLM"), {
+    origin: "https://mini.example",
+    code: "ABCD-EFGH-JKLM",
+    url: "https://mini.example/pair#code=ABCD-EFGH-JKLM",
+  });
+  assert.deepEqual(env.parsePairingLink("  https://mini.example  "), { origin: "https://mini.example", code: null, url: "https://mini.example" });
+  assert.equal(env.parsePairingLink("https://mini.example/?code=ABCD"), null);
+  assert.equal(env.parsePairingLink("not a link"), null);
+});
+
+test("persisted state parses defensively and never resurrects Local as a remote", () => {
+  const parsed = env.parseEnvironments(
+    JSON.stringify({
+      environments: [
+        { id: "a1", name: "  Cab   mini ", origin: "https://mini.example/" },
+        { id: "local", name: "sneaky", origin: "https://evil.example" },
+        { id: "dup", name: "again", origin: "https://mini.example" },
+        { id: "b2", origin: "http://10.0.0.5:8799" },
+        { id: "bad id!", origin: "https://x.example" },
+        { id: "c3", origin: "ftp://nope" },
+      ],
+      activeId: "b2",
+    }),
+  );
+  assert.deepEqual(parsed, {
+    environments: [
+      { id: "a1", name: "Cab mini", origin: "https://mini.example" },
+      { id: "b2", name: "10.0.0.5:8799", origin: "http://10.0.0.5:8799" },
+    ],
+    activeId: "b2",
+  });
+  assert.deepEqual(env.parseEnvironments("{not json"), { environments: [], activeId: "local" });
+  assert.deepEqual(env.parseEnvironments({ environments: [], activeId: "ghost" }), { environments: [], activeId: "local" });
+  assert.deepEqual(env.parseEnvironments(env.serializeEnvironments(parsed)), parsed);
+});
+
+test("adding the same server twice updates the name instead of duplicating; forgetting the active one falls back to Local", () => {
+  let ids = 0;
+  const makeId = () => `id${++ids}`;
+  let state = { environments: [], activeId: "local" };
+  state = env.withEnvironment(state, { origin: "https://mini.example/pair#code=X", name: "" }, makeId);
+  state = env.withEnvironment(state, { origin: "https://mini.example", name: "Cab mini" }, makeId);
+  state = env.withEnvironment(state, { origin: "nonsense" }, makeId);
+  assert.deepEqual(state.environments, [{ id: "id1", name: "Cab mini", origin: "https://mini.example" }]);
+  state = env.withActive(state, "id1");
+  assert.equal(env.activeEnvironment(state)?.origin, "https://mini.example");
+  assert.equal(env.withActive(state, "nope"), state);
+  assert.deepEqual([...env.allowedOrigins(state, "http://127.0.0.1:8799")], ["http://127.0.0.1:8799", "https://mini.example"]);
+  state = env.withoutEnvironment(state, "id1");
+  assert.deepEqual(state, { environments: [], activeId: "local" });
+  assert.equal(env.activeEnvironment(state), null);
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -54,6 +54,8 @@ import {
   resolveCompanionControlPlaneURL,
 } from "./companion-account-service.mjs";
 import capabilitiesModule from "./capabilities.cjs";
+import environmentsModule from "./environments.cjs";
+import { buildApplicationMenu } from "./menu.mjs";
 
 const { desktopCapabilities, nativeDesktopActions } = capabilitiesModule;
 const nativeActions = nativeDesktopActions(process.platform);
@@ -1286,9 +1288,9 @@ function browserSurfaceForEvent(event) {
   return browserSurface;
 }
 
-ipcMain.handle("browser:available", () => Boolean(browserSurface && browserHost?.url));
-ipcMain.handle("browser:state", (event, botId) => browserSurfaceForEvent(event).state(botId));
-ipcMain.handle("browser:layout", (event, botId, bounds, profile, mode, layoutOwner) =>
+ipcMain.handle("browser:available", localOnly("browser:available", () => Boolean(browserSurface && browserHost?.url)));
+ipcMain.handle("browser:state", localOnly("browser:state", (event, botId) => browserSurfaceForEvent(event).state(botId)));
+ipcMain.handle("browser:layout", localOnly("browser:layout", (event, botId, bounds, profile, mode, layoutOwner) =>
   browserSurfaceForEvent(event).layout(
     botId,
     bounds ?? null,
@@ -1298,27 +1300,27 @@ ipcMain.handle("browser:layout", (event, botId, bounds, profile, mode, layoutOwn
       ? layoutOwner
       : undefined,
   ),
-);
+));
 const browserProfileFromRenderer = (profile) =>
   Object.prototype.toString.call(profile) === "[object String]" ? profile : undefined;
 
-ipcMain.handle("browser:forward", async (event, botId, profile) => {
+ipcMain.handle("browser:forward", localOnly("browser:forward", async (event, botId, profile) => {
   const result = await browserSurfaceForEvent(event).forward(botId, browserProfileFromRenderer(profile), { source: "user" });
   return { url: result.url, title: result.title };
-});
-ipcMain.handle("browser:reload", async (event, botId, profile) => {
+}));
+ipcMain.handle("browser:reload", localOnly("browser:reload", async (event, botId, profile) => {
   const result = await browserSurfaceForEvent(event).reload(botId, browserProfileFromRenderer(profile), { source: "user" });
   return { url: result.url, title: result.title };
-});
-ipcMain.handle("browser:navigate", async (event, botId, url, profile) => {
+}));
+ipcMain.handle("browser:navigate", localOnly("browser:navigate", async (event, botId, url, profile) => {
   const result = await browserSurfaceForEvent(event).navigate(botId, url, browserProfileFromRenderer(profile), { source: "user" });
   return { url: result.url, title: result.title };
-});
-ipcMain.handle("browser:back", async (event, botId, profile) => {
+}));
+ipcMain.handle("browser:back", localOnly("browser:back", async (event, botId, profile) => {
   const result = await browserSurfaceForEvent(event).back(botId, browserProfileFromRenderer(profile), { source: "user" });
   return { url: result.url, title: result.title };
-});
-ipcMain.handle("browser:set-human-control", (event, botId, held, profile) => {
+}));
+ipcMain.handle("browser:set-human-control", localOnly("browser:set-human-control", (event, botId, held, profile) => {
   const owner = mainWindow;
   if (!owner || owner.isDestroyed() || event.sender !== owner.webContents) {
     throw new Error("The browser is available only to the main app window");
@@ -1338,13 +1340,13 @@ ipcMain.handle("browser:set-human-control", (event, botId, held, profile) => {
   if (held === true) browserControlHolds.add(id);
   else browserControlHolds.delete(id);
   return applied;
-});
-ipcMain.handle("browser:close", (event, botId) => browserSurfaceForEvent(event).close(botId));
+}));
+ipcMain.handle("browser:close", localOnly("browser:close", (event, botId) => browserSurfaceForEvent(event).close(botId)));
 // Deleting a profile: every bot's view on it goes, then its cookies, storage
 // and cache. The partition directory itself is left for Chromium to reuse
 // (removing it while the session object lives is the EBUSY trap every
 // Electron app with profiles has hit); nothing identifying remains in it.
-ipcMain.handle("browser:forget-profile", async (event, partitionId) => {
+ipcMain.handle("browser:forget-profile", localOnly("browser:forget-profile", async (event, partitionId) => {
   const surface = browserSurfaceForEvent(event);
   const id = String(partitionId ?? "");
   if (!/^[A-Za-z0-9_-]{1,40}$/.test(id) || id === "guest") throw new Error("That browser partition id is invalid");
@@ -1352,7 +1354,7 @@ ipcMain.handle("browser:forget-profile", async (event, partitionId) => {
   browserHost?.revokeCapabilitiesForProfile(id);
   await clearBrowserPartition(browserProfilePartition(id));
   return { dropped };
-});
+}));
 
 ipcMain.on("screen:preview-intent", (event) => {
   event.returnValue = displayMediaGuard.begin(event.senderFrame);
@@ -1364,6 +1366,143 @@ ipcMain.on("desktop:unread-count", (event, value) => {
   unreadCount = normalizeUnreadCount(value);
   applyUnreadBadge(sender);
 });
+
+// ── environments: this computer's server, or a paired remote one ──────
+// The app switches by loading the chosen server's own UI (electron/menu.mjs).
+// Only {id, name, origin} is stored here; the session credential is the
+// HttpOnly cookie /pair set for that origin, kept by Chromium's cookie jar.
+const { LOCAL_ID, activeEnvironment, allowedOrigins, parseEnvironments, parsePairingLink, serializeEnvironments, withActive, withEnvironment, withoutEnvironment } = environmentsModule;
+let environmentsState = { environments: [], activeId: LOCAL_ID };
+
+function environmentsFile() {
+  return path.join(app.getPath("userData"), "environments.json");
+}
+
+function readEnvironments() {
+  try {
+    return parseEnvironments(fs.readFileSync(environmentsFile(), "utf8"));
+  } catch {
+    return { environments: [], activeId: LOCAL_ID };
+  }
+}
+
+function writeEnvironments(state) {
+  const file = environmentsFile();
+  const temporary = `${file}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(temporary, serializeEnvironments(state), { mode: 0o600 });
+    fs.renameSync(temporary, file);
+  } catch (error) {
+    try {
+      fs.rmSync(temporary, { force: true });
+    } catch {}
+    slog(`environments save failed: ${error?.message ?? error}`);
+  }
+}
+
+/** Where the main window should be: the active remote server, else Local. */
+function activeOrigin() {
+  return activeEnvironment(environmentsState)?.origin ?? rendererOrigin();
+}
+
+function senderIsLocal(event) {
+  const url = event?.senderFrame?.url ?? event?.sender?.getURL?.() ?? "";
+  try {
+    return new URL(url).origin === rendererOrigin();
+  } catch {
+    return false;
+  }
+}
+
+/** IPC that controls this computer, its files, its logins or its updater is
+ * answered only for the local server's UI. A remote server's page gets a
+ * reduced bridge (preload.cjs) in the first place; this is the second wall. */
+function localOnly(channel, handler) {
+  return (event, ...args) => {
+    if (!senderIsLocal(event)) throw new Error(`${channel} is only available while using the local server`);
+    return handler(event, ...args);
+  };
+}
+
+function refreshApplicationMenu() {
+  Menu.setApplicationMenu(
+    buildApplicationMenu({
+      environments: environmentsState.environments,
+      activeId: environmentsState.activeId,
+      onSwitch: (id) => switchEnvironment(id),
+      onAddFromClipboard: () => void addServerFromClipboard(),
+      onForget: (id) => void forgetEnvironment(id),
+    }),
+  );
+}
+
+function persistEnvironments(next) {
+  environmentsState = next;
+  writeEnvironments(environmentsState);
+  refreshApplicationMenu();
+}
+
+function navigateMainWindow(url) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  void mainWindow.loadURL(url);
+}
+
+function switchEnvironment(id) {
+  persistEnvironments(withActive(environmentsState, id));
+  navigateMainWindow(activeOrigin());
+}
+
+async function addServerFromClipboard() {
+  const link = parsePairingLink(clipboard.readText());
+  if (!link) {
+    await dialog.showMessageBox({
+      type: "info",
+      message: "Copy a pairing link first",
+      detail:
+        "On the server run `pnpm pair` (or `node dist-server/pair-cli.js` in Docker), copy the printed https://…/pair#code=… link, then choose this item again.",
+    });
+    return;
+  }
+  const host = new URL(link.origin).host;
+  const { response } = await dialog.showMessageBox({
+    type: "question",
+    buttons: ["Connect", "Cancel"],
+    defaultId: 0,
+    cancelId: 1,
+    message: `Connect to ${host}?`,
+    detail: link.code
+      ? "The pairing code in the link is used once, then this app stays signed in to that server."
+      : "The link has no pairing code; the server will ask for one.",
+  });
+  if (response !== 0) return;
+  let next = withEnvironment(environmentsState, { origin: link.origin, name: host }, () => randomUUID());
+  const added = next.environments.find((e) => e.origin === link.origin);
+  next = withActive(next, added.id);
+  persistEnvironments(next);
+  navigateMainWindow(link.url);
+}
+
+async function forgetEnvironment(id) {
+  const env = environmentsState.environments.find((e) => e.id === id);
+  if (!env) return;
+  const { response } = await dialog.showMessageBox({
+    type: "warning",
+    buttons: ["Forget", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+    message: `Forget “${env.name}”?`,
+    detail: "This app signs out of that server. The server keeps its own session list; revoke it there too if the device is gone.",
+  });
+  if (response !== 0) return;
+  persistEnvironments(withoutEnvironment(environmentsState, id));
+  try {
+    await session.defaultSession.clearStorageData({ origin: env.origin, storages: ["cookies", "localstorage", "indexdb", "serviceworkers", "cachestorage"] });
+  } catch (error) {
+    slog(`forget server: storage clear failed: ${error?.message ?? error}`);
+  }
+  navigateMainWindow(activeOrigin());
+}
 
 function createWindow() {
   const waitsForSkinSync = process.platform === "win32";
@@ -1386,6 +1525,8 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       preload: path.join(__dirname, "preload.cjs"),
+      // The preload exposes the full bridge only to this origin (see preload.cjs).
+      additionalArguments: [`--omb-local-origin=${rendererOrigin()}`],
     },
   });
   mainWindow = win;
@@ -1410,8 +1551,38 @@ function createWindow() {
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (/^https?:\/\//i.test(url)) shell.openExternal(url);
     return { action: "deny" };
+  });
+  // The window shows Local or a saved server, nothing else: a page cannot
+  // walk the preload-bearing window to a stranger's origin.
+  const guardNavigation = (event, url) => {
+    let origin = null;
+    try {
+      origin = new URL(url).origin;
+    } catch {}
+    if (origin && allowedOrigins(environmentsState, rendererOrigin()).has(origin)) return;
+    event.preventDefault();
+    slog(`blocked navigation to ${url}`);
+  };
+  win.webContents.on("will-navigate", guardNavigation);
+  win.webContents.on("will-redirect", guardNavigation);
+  win.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame || errorCode === -3) return; // -3: aborted by a newer navigation
+    const remote = activeEnvironment(environmentsState);
+    if (!remote) return;
+    let origin = null;
+    try {
+      origin = new URL(validatedURL).origin;
+    } catch {}
+    if (origin !== remote.origin) return;
+    slog(`remote server unreachable (${errorDescription}); back to Local`);
+    void dialog.showMessageBox({
+      type: "warning",
+      message: `${remote.name} is not reachable`,
+      detail: `${errorDescription}. Showing the local server instead; choose it again from the Server menu when it is back.`,
+    });
+    switchEnvironment(LOCAL_ID);
   });
   win.webContents.on("did-finish-load", () => deliverPackageInstall(win));
 
@@ -1554,7 +1725,10 @@ function createWindow() {
     });
   }
 
-  if (app.isPackaged) {
+  const remote = activeEnvironment(environmentsState);
+  if (remote) {
+    win.loadURL(remote.origin);
+  } else if (app.isPackaged) {
     win.loadURL(serverReady ? `http://127.0.0.1:${SERVER_PORT}` : buildErrorPage({ allPortsOccupied: serverStartConflictOnly }));
   } else {
     win.loadURL(DEV_URL);
@@ -1564,14 +1738,14 @@ function createWindow() {
 
 // Local-control screen preview — served from the main process so the Screen
 // Recording permission prompt attributes to the app, never the server
-ipcMain.handle("screen:frame", async () => {
+ipcMain.handle("screen:frame", localOnly("screen:frame", async () => {
   if (process.platform !== "darwin") return null;
   const sources = await desktopCapturer.getSources({
     types: ["screen"],
     thumbnailSize: { width: 1280, height: 800 },
   });
   return sources[0]?.thumbnail.toDataURL() ?? null;
-});
+}));
 
 // Onboarding permission checks. Status reads are free; the mic request
 // pops the real TCC prompt attributed to the app.
@@ -1590,11 +1764,11 @@ ipcMain.handle("screen:frame", async () => {
 // Copy the engine command, then open a blank terminal. Renderer-controlled
 // text must never become a process argument: the user reviews and pastes it.
 // Returns false when the renderer should show the clipboard fallback.
-ipcMain.handle("engine:open-terminal", async (_event, command) => {
+ipcMain.handle("engine:open-terminal", localOnly("engine:open-terminal", async (_event, command) => {
   if (typeof command !== "string" || !command.trim()) return false;
   clipboard.writeText(command);
   return openBlankTerminal();
-});
+}));
 
 // OAuth/connect links are returned asynchronously, after Chromium's direct
 // click gesture has ended. Opening them through window.open can therefore be
@@ -1602,7 +1776,7 @@ ipcMain.handle("engine:open-terminal", async (_event, command) => {
 // renderer sandboxed and let the main process open only ordinary web links.
 // A bot's working folder: the native picker, so the path is real and the
 // user never types one. Returns null when they cancel.
-ipcMain.handle("desktop:pick-folder", async (event, current) => {
+ipcMain.handle("desktop:pick-folder", localOnly("desktop:pick-folder", async (event, current) => {
   const win = BrowserWindow.fromWebContents(event.sender) ?? undefined;
   const result = await dialog.showOpenDialog(win, {
     title: "Choose a working folder",
@@ -1610,12 +1784,12 @@ ipcMain.handle("desktop:pick-folder", async (event, current) => {
     ...(typeof current === "string" && current ? { defaultPath: current } : {}),
   });
   return result.canceled ? null : (result.filePaths[0] ?? null);
-});
+}));
 
 // One-click bug-report bundle. Secrets are never read; the report is
 // redacted again on the way out (diagnostics.mjs). null means the user
 // cancelled the save dialog.
-ipcMain.handle("desktop:export-diagnostics", async (event) => {
+ipcMain.handle("desktop:export-diagnostics", localOnly("desktop:export-diagnostics", async (event) => {
   const owner = BrowserWindow.fromWebContents(event.sender) ?? undefined;
   const report = await gatherDiagnostics();
   const result = await dialog.showSaveDialog(owner, {
@@ -1637,7 +1811,7 @@ ipcMain.handle("desktop:export-diagnostics", async (event) => {
     }
   }
   return result.filePath;
-});
+}));
 
 // Bots hand users files as markdown links to paths inside the OpenMausBot
 // home (workspaces, attachments). As plain anchors those resolved against the
@@ -1648,7 +1822,7 @@ ipcMain.handle("desktop:export-diagnostics", async (event) => {
 // where, which a silent copy into ~/Downloads does not. The path is
 // renderer-controlled, so it must resolve inside ~/.openmausbot and be a
 // regular file — never a symlink escape or directory.
-ipcMain.handle("desktop:save-file", async (event, rawPath) => {
+ipcMain.handle("desktop:save-file", localOnly("desktop:save-file", async (event, rawPath) => {
   return withSavableFile(rawPath, { home: os.homedir() }, async ({ defaultName, copyTo }) => {
     const parent = BrowserWindow.fromWebContents(event.sender);
     const defaultPath = await defaultSaveName(app.getPath("downloads"), defaultName);
@@ -1665,7 +1839,7 @@ ipcMain.handle("desktop:save-file", async (event, rawPath) => {
     shell.showItemInFolder(choice.filePath);
     return choice.filePath;
   });
-});
+}));
 
 // The renderer owns the skin. Native Windows/Linux chrome is intentionally
 // outside that surface; acknowledge the renderer handshake without creating
@@ -1693,47 +1867,47 @@ ipcMain.handle("desktop:open-external", async (_event, rawUrl) => {
 // The Box VNC viewer must be a top-level page for its token exchange. A
 // sandboxed modal BrowserWindow satisfies that requirement while keeping the
 // live desktop inside OpenMausBot instead of sending the person to a browser.
-ipcMain.handle("desktop-viewer:open", (event, rawUrl, title, contextId) => {
+ipcMain.handle("desktop-viewer:open", localOnly("desktop-viewer:open", (event, rawUrl, title, contextId) => {
   const owner = BrowserWindow.fromWebContents(event.sender);
   return openDesktopViewer(owner, rawUrl, title, contextId);
-});
+}));
 
 // Two Local VM desktops share the existing app BrowserWindow. The renderer
 // supplies only layout and intent; URL validation, sandboxing, session
 // isolation and the one-interactive-pane invariant stay in the main process.
-ipcMain.handle("desktop-workspace:open", (event, input) =>
+ipcMain.handle("desktop-workspace:open", localOnly("desktop-workspace:open", (event, input) =>
   desktopWorkspaceForEvent(event, true).open(input),
-);
-ipcMain.handle("desktop-workspace:layout", (event, items) => {
+));
+ipcMain.handle("desktop-workspace:layout", localOnly("desktop-workspace:layout", (event, items) => {
   const manager = desktopWorkspaceForEvent(event);
   if (!manager) return false;
   return manager.layout(items);
-});
-ipcMain.handle("desktop-workspace:set-interactive", (event, contextId) => {
+}));
+ipcMain.handle("desktop-workspace:set-interactive", localOnly("desktop-workspace:set-interactive", (event, contextId) => {
   const manager = desktopWorkspaceForEvent(event);
   if (!manager) return contextId == null;
   return manager.setInteractive(contextId);
-});
-ipcMain.handle("desktop-workspace:close", (event, contextId) => {
+}));
+ipcMain.handle("desktop-workspace:close", localOnly("desktop-workspace:close", (event, contextId) => {
   const manager = desktopWorkspaceForEvent(event);
   if (!manager) return true;
   return manager.close(contextId);
-});
+}));
 
 // Close only when the caller owns the current viewer — otherwise one bot's
 // "Hand control back" would close (and release) another bot's viewer.
-ipcMain.handle("desktop-viewer:close", (_event, contextId) => {
+ipcMain.handle("desktop-viewer:close", localOnly("desktop-viewer:close", (_event, contextId) => {
   const scoped = Object.prototype.toString.call(contextId) === "[object String]" ? contextId : null;
   if (scoped !== desktopViewerContextId) return false;
   if (desktopViewerWindow && !desktopViewerWindow.isDestroyed()) desktopViewerWindow.close();
   return true;
-});
+}));
 
 // Lets a (re)mounted panel seed viewer-open state instead of defaulting to false.
-ipcMain.handle("desktop-viewer:state-now", () => ({
+ipcMain.handle("desktop-viewer:state-now", localOnly("desktop-viewer:state-now", () => ({
   open: Boolean(desktopViewerWindow && !desktopViewerWindow.isDestroyed()),
   contextId: desktopViewerContextId,
-}));
+})));
 
 ipcMain.handle("perm:status", () => ({
   mic:
@@ -1741,18 +1915,18 @@ ipcMain.handle("perm:status", () => ({
       ? systemPreferences.getMediaAccessStatus?.("microphone") ?? "unknown"
       : "unsupported",
 }));
-ipcMain.handle("perm:request-mic", async () => {
+ipcMain.handle("perm:request-mic", localOnly("perm:request-mic", async () => {
   if (!nativeActions.appleMediaPermissions) return false;
   try {
     return await systemPreferences.askForMediaAccess("microphone");
   } catch {
     return false;
   }
-});
+}));
 
 // macOS never re-prompts a denied permission — the only path is System
 // Settings; deep-link straight to the right privacy pane.
-ipcMain.handle("perm:open-settings", (_event, pane) => {
+ipcMain.handle("perm:open-settings", localOnly("perm:open-settings", (_event, pane) => {
   if (!nativeActions.applePrivacySettings) return false;
   const panes = {
     mic: "Privacy_Microphone",
@@ -1764,9 +1938,9 @@ ipcMain.handle("perm:open-settings", (_event, pane) => {
   // would otherwise resolve up the prototype chain to a truthy object
   const anchor = Object.hasOwn(panes, pane) ? panes[pane] : "Privacy";
   return shell.openExternal(`x-apple.systempreferences:com.apple.preference.security?${anchor}`);
-});
+}));
 
-ipcMain.handle("speech:start", (event, options) => {
+ipcMain.handle("speech:start", localOnly("speech:start", (event, options) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!win) return;
   if (!nativeActions.appleSpeech) {
@@ -1774,59 +1948,75 @@ ipcMain.handle("speech:start", (event, options) => {
     return;
   }
   startSpeech(win, options);
-});
-ipcMain.handle("speech:stop", () => {
+}));
+ipcMain.handle("speech:stop", localOnly("speech:stop", () => {
   if (nativeActions.appleSpeech) stopSpeech();
-});
-ipcMain.handle("speech:finish", () => {
+}));
+ipcMain.handle("speech:finish", localOnly("speech:finish", () => {
   if (nativeActions.appleSpeech) finishSpeech();
-});
+}));
 
-ipcMain.handle("skill-recorder:permissions", () => recorderPermissionStatus());
-ipcMain.handle("skill-recorder:start", (event) => {
+ipcMain.handle("skill-recorder:permissions", localOnly("skill-recorder:permissions", () => recorderPermissionStatus()));
+ipcMain.handle("skill-recorder:start", localOnly("skill-recorder:start", (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!win) throw new Error("The recorder window is unavailable");
   return startRecorder(win);
-});
-ipcMain.handle("skill-recorder:stop", () => stopRecorder());
-ipcMain.handle("skill-recorder:save", (_event, payload) => saveSkillRecording(payload));
+}));
+ipcMain.handle("skill-recorder:stop", localOnly("skill-recorder:stop", () => stopRecorder()));
+ipcMain.handle("skill-recorder:save", localOnly("skill-recorder:save", (_event, payload) => saveSkillRecording(payload)));
 
 // ── companion sidecar ──────────────────────────────────────────────────
 // The renderer gets these five and nothing else: it can turn the companion
 // on and off, look at it, open or cancel a pairing window, and remove a
 // device. It cannot reach the sidecar's control port itself.
-ipcMain.handle("companion:state", () => desktopCompanionState());
-ipcMain.handle("companion:start", () => startDesktopCompanion());
-ipcMain.handle("companion:stop", () => stopDesktopCompanion());
-ipcMain.handle("companion:keep-awake", async (_event, enabled) => {
+ipcMain.handle("companion:state", localOnly("companion:state", () => desktopCompanionState()));
+ipcMain.handle("companion:start", localOnly("companion:start", () => startDesktopCompanion()));
+ipcMain.handle("companion:stop", localOnly("companion:stop", () => stopDesktopCompanion()));
+ipcMain.handle("companion:keep-awake", localOnly("companion:keep-awake", async (_event, enabled) => {
   rememberCompanionKeepAwake(Boolean(enabled));
   return desktopCompanionState();
-});
-ipcMain.handle("companion:refresh-tailscale", () => refreshDesktopCompanionTailscale());
-ipcMain.handle("companion:pairing", (_event, open, expectedToken) =>
+}));
+ipcMain.handle("companion:refresh-tailscale", localOnly("companion:refresh-tailscale", () => refreshDesktopCompanionTailscale()));
+ipcMain.handle("companion:pairing", localOnly("companion:pairing", (_event, open, expectedToken) =>
   companionPairing(Boolean(open), expectedToken).then(decorateDesktopCompanionState),
-);
-ipcMain.handle("companion:cloud-desktop", (_event, deviceId, allowed) =>
+));
+ipcMain.handle("companion:cloud-desktop", localOnly("companion:cloud-desktop", (_event, deviceId, allowed) =>
   companionCloudDesktopAccess(deviceId, Boolean(allowed)).then(() => desktopCompanionState()),
-);
-ipcMain.handle("companion:revoke", (_event, deviceId) =>
+));
+ipcMain.handle("companion:revoke", localOnly("companion:revoke", (_event, deviceId) =>
   companionRevoke(deviceId).then(() => desktopCompanionState()),
-);
+));
 
 // Auth and connector credentials never cross this boundary. Every handler
 // returns the same deliberately tiny, secret-free public account state.
-ipcMain.handle("companion-account:state", () => ensureCompanionAccountService().state());
-ipcMain.handle("companion-account:request-code", (_event, email) =>
+ipcMain.handle("companion-account:state", localOnly("companion-account:state", () => ensureCompanionAccountService().state()));
+ipcMain.handle("companion-account:request-code", localOnly("companion-account:request-code", (_event, email) =>
   ensureCompanionAccountService().requestCode(email),
-);
-ipcMain.handle("companion-account:verify-code", (_event, email, code) =>
+));
+ipcMain.handle("companion-account:verify-code", localOnly("companion-account:verify-code", (_event, email, code) =>
   ensureCompanionAccountService().verifyCode(email, code),
-);
-ipcMain.handle("companion-account:retry", () => ensureCompanionAccountService().retry());
-ipcMain.handle("companion-account:sign-out", () => ensureCompanionAccountService().signOut());
+));
+ipcMain.handle("companion-account:retry", localOnly("companion-account:retry", () => ensureCompanionAccountService().retry()));
+ipcMain.handle("companion-account:sign-out", localOnly("companion-account:sign-out", () => ensureCompanionAccountService().signOut()));
 
-ipcMain.handle("desktop:capabilities", async () =>
+ipcMain.handle("environments:state", (event) => ({
+  localOrigin: rendererOrigin(),
+  remote: !senderIsLocal(event),
+  activeId: environmentsState.activeId,
+  environments: environmentsState.environments,
+}));
+ipcMain.handle("environments:switch", localOnly("environments:switch", (_event, id) => switchEnvironment(typeof id === "string" ? id : LOCAL_ID)));
+ipcMain.handle("environments:add-from-link", localOnly("environments:add-from-link", async (_event, link) => {
+  const parsed = parsePairingLink(typeof link === "string" ? link : "");
+  if (!parsed) throw new Error("that is not a pairing link (expected https://host/pair#code=…)");
+  clipboard.writeText(parsed.url);
+  await addServerFromClipboard();
+}));
+ipcMain.handle("environments:forget", localOnly("environments:forget", (_event, id) => forgetEnvironment(typeof id === "string" ? id : "")));
+
+ipcMain.handle("desktop:capabilities", async (event) =>
   desktopCapabilities({
+    remote: !senderIsLocal(event),
     platform: process.platform,
     env: process.env,
     packaged: app.isPackaged,
@@ -1834,11 +2024,11 @@ ipcMain.handle("desktop:capabilities", async () =>
   }),
 );
 
-ipcMain.handle("assemblyai:status", () => ({
+ipcMain.handle("assemblyai:status", localOnly("assemblyai:status", () => ({
   configured: Boolean(assemblyAICredential(secureCredentials)),
-}));
+})));
 
-ipcMain.handle("assemblyai:set-key", async (_event, value) => {
+ipcMain.handle("assemblyai:set-key", localOnly("assemblyai:set-key", async (_event, value) => {
   if (typeof value !== "string") throw new Error("Unsupported credential");
   if (!(await safeStorage.isAsyncEncryptionAvailable())) {
     throw new Error("The operating-system credential store is unavailable");
@@ -1850,11 +2040,11 @@ ipcMain.handle("assemblyai:set-key", async (_event, value) => {
     return credentials;
   });
   return { configured: Boolean(secret) };
-});
+}));
 
-ipcMain.handle("assemblyai:streaming-token", () =>
+ipcMain.handle("assemblyai:streaming-token", localOnly("assemblyai:streaming-token", () =>
   mintAssemblyAIStreamingToken(assemblyAICredential(secureCredentials)),
-);
+));
 
 const CREDENTIAL_PATCH = {
   composioApiKey: (value) => ({ composio: { apiKey: value } }),
@@ -1865,7 +2055,7 @@ const CREDENTIAL_PATCH = {
   openaiImageApiKey: (value) => ({ imageGen: { key: value } }),
 };
 
-ipcMain.handle("credential:set", async (_event, name, value) => {
+ipcMain.handle("credential:set", localOnly("credential:set", async (_event, name, value) => {
   const patchFor = CREDENTIAL_PATCH[name];
   if (!patchFor || typeof value !== "string") {
     throw new Error("Unsupported credential");
@@ -1901,7 +2091,7 @@ ipcMain.handle("credential:set", async (_event, name, value) => {
     },
     applyToHarness,
   );
-});
+}));
 
 async function broadcastDesktopCapabilities() {
   const capabilities = desktopCapabilities({
@@ -2020,6 +2210,7 @@ app.whenReady().then(async () => {
   if (serverReady && companionEnabledAtRest()) {
     void startDesktopCompanion({ waitForHosted: false, remember: false });
   }
+  environmentsState = readEnvironments();
   const win = createWindow();
   // Reconcile incomplete setup and resume interrupted sign-out only after the
   // local app is usable. This background network work never gates LAN pairing
@@ -2050,6 +2241,7 @@ app.whenReady().then(async () => {
   // in-app auto-update (packaged only) — checks GitHub releases, downloads on
   // the user's click, installs on "Restart to update"
   startUpdater(win);
+  refreshApplicationMenu();
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });

--- a/electron/menu.mjs
+++ b/electron/menu.mjs
@@ -1,0 +1,46 @@
+// The application menu. Today it exists for one reason: the Server submenu,
+// where the user switches between the local server and paired remote ones.
+// Everything else is Electron's standard roles so macOS keeps Edit/Window
+// and Windows/Linux get the same items under a visible bar.
+import { Menu, app } from "electron";
+
+/**
+ * @param {object} input
+ * @param {{ id: string, name: string, origin: string }[]} input.environments
+ * @param {string} input.activeId  "local" or an environment id
+ * @param {(id: string) => void} input.onSwitch
+ * @param {() => void} input.onAddFromClipboard
+ * @param {(id: string) => void} input.onForget
+ */
+export function buildApplicationMenu({ environments, activeId, onSwitch, onAddFromClipboard, onForget }) {
+  const isMac = process.platform === "darwin";
+  const active = environments.find((e) => e.id === activeId) ?? null;
+  const server = {
+    label: "Server",
+    submenu: [
+      { label: "Local (this computer)", type: "radio", checked: !active, click: () => onSwitch("local") },
+      ...environments.map((e) => ({
+        label: `${e.name} — ${new URL(e.origin).host}`,
+        type: "radio",
+        checked: e.id === activeId,
+        click: () => onSwitch(e.id),
+      })),
+      { type: "separator" },
+      { label: "Add Server from Copied Pairing Link…", click: () => onAddFromClipboard() },
+      {
+        label: active ? `Forget “${active.name}”` : "Forget Server",
+        enabled: Boolean(active),
+        click: () => active && onForget(active.id),
+      },
+    ],
+  };
+  const template = [
+    ...(isMac ? [{ label: app.name, submenu: [{ role: "about" }, { type: "separator" }, { role: "hide" }, { role: "hideOthers" }, { role: "unhide" }, { type: "separator" }, { role: "quit" }] }] : []),
+    { role: "fileMenu" },
+    { role: "editMenu" },
+    server,
+    { role: "viewMenu" },
+    { role: "windowMenu" },
+  ];
+  return Menu.buildFromTemplate(template);
+}

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,7 +15,15 @@ ipcRenderer.on("package:install", (_event, url) => {
   for (const listener of packageInstallListeners) listener(url);
 });
 
-contextBridge.exposeInMainWorld("ogb", {
+// The bridge is built once, then exposed in full only to the local server's
+// UI. A remote server's page (Server menu) gets the safe subset: nothing that
+// captures this screen, touches this computer's files or logins, or runs
+// helpers here. Main enforces the same rule on the sensitive channels.
+const localOrigin = process.argv.find((arg) => arg.startsWith("--omb-local-origin="))?.slice("--omb-local-origin=".length) ?? null;
+const isLocalPage = !localOrigin || location.origin === localOrigin;
+const REMOTE_SAFE = new Set(["platform", "getCapabilities", "onCapabilitiesChanged", "applySkin", "setUnreadCount", "openExternal", "getPathForFile", "permStatus", "environments"]);
+
+const bridge = {
   /** Host platform ("darwin" | "win32" | "linux") — for platform-aware UI. */
   platform: process.platform,
   getCapabilities: () => ipcRenderer.invoke("desktop:capabilities"),
@@ -221,4 +229,19 @@ contextBridge.exposeInMainWorld("ogb", {
       return () => ipcRenderer.removeListener("update:state", handler);
     },
   },
-});
+
+  /** Saved servers and the active one (Server menu). Switching, adding and
+   * forgetting are local-only: a remote page may read the list but not change
+   * where this window goes. */
+  environments: {
+    state: () => ipcRenderer.invoke("environments:state"),
+    switch: (id) => ipcRenderer.invoke("environments:switch", id),
+    addFromLink: (link) => ipcRenderer.invoke("environments:add-from-link", link),
+    forget: (id) => ipcRenderer.invoke("environments:forget", id),
+  },
+};
+
+contextBridge.exposeInMainWorld(
+  "ogb",
+  isLocalPage ? bridge : Object.fromEntries(Object.entries(bridge).filter(([key]) => REMOTE_SAFE.has(key))),
+);

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -127,6 +127,19 @@ type SkillRecordingPayload = {
   interface Window {
     ogb?: {
       platform: NodeJS.Platform;
+      /** Saved servers and the active one (desktop Server menu). Present on
+       * the local server's UI; a remote server's page sees a reduced bridge. */
+      environments?: {
+        state: () => Promise<{
+          localOrigin: string;
+          remote: boolean;
+          activeId: string;
+          environments: Array<{ id: string; name: string; origin: string }>;
+        }>;
+        switch: (id: string) => Promise<void>;
+        addFromLink: (link: string) => Promise<void>;
+        forget: (id: string) => Promise<void>;
+      };
       getCapabilities(): Promise<DesktopCapabilities>;
       onCapabilitiesChanged(cb: (capabilities: DesktopCapabilities) => void): () => void;
       companionAccount?: {


### PR DESCRIPTION
**Stacked on #693** (base is `feat/remote-sessions`; retarget to `main` once that merges). This is the desktop half of Remote Workspace: the app you already run on your Mac (or Windows, or Linux) can pair with a server elsewhere and switch to it.

## What the user does

On the server: `pnpm pair` (or `node dist-server/pair-cli.js` in Docker) prints `https://host/pair#code=…`. Copy it. In the app: **Server → Add Server from Copied Pairing Link…** → confirm → the server's own UI opens in the window, paired. The Server menu lists Local and every saved server; **Forget** signs the app out of one (and revokes nothing on the server, which is said in the dialog). On Windows and Linux the menu bar shows on Alt until a Settings section lands.

## How it holds together

- **Switching = loading that server's origin.** The served UI is the client, so version skew is the server's bundle plus the descriptor from #693; nothing is compiled into this app about remote servers except the list.
- **The credential is the `/pair` cookie**, kept by Chromium's persistent default session, so the app stays signed in across restarts with no token stored by the app. `environments.json` holds only `{id, name, origin}`, written like `window-state.json` (tmp + rename, 0600).
- **Two walls between a remote page and this computer.** The preload exposes only a safe subset of `window.ogb` to any page that is not the local server's (no screen capture, files, logins, helpers, updater); main answers those 48 IPC channels only for the local origin. `desktop:capabilities` reports `remote: true` with screen preview, dictation and local control unavailable (`reasonCode: "remote-server"`), so a remote UI hides those panels instead of showing buttons that fail.
- **Navigation is pinned** to Local plus the saved origins (a page cannot walk the preload-bearing window elsewhere); a remote server that stops answering falls the window back to Local with a message; `window.open` only ever opens http(s) links externally.
- **A pairing link is accepted only with its code in the hash**, never a query string (server logs).

## Verified

| check | result |
|---|---|
| `electron/environments.node-test.mjs` (origin rules, link parsing, defensive parse, add/forget/switch), `capabilities.node-test.mjs` (remote mode) | ✅ 85 Electron node tests green |
| `pnpm check:electron` (syntax via the Electron binary), renderer `tsc -b` with the typed bridge | ✅ |
| real launch on macOS: menu and guards installed, window loaded, capabilities `remote:false`, health OK (CI's packaged Linux smoke runs the same `OMB_SMOKE_TEST` path) | ✅ |

## Follow-ups

- Settings → Servers section in the renderer (the `ogb.environments` bridge is typed and ready), so Windows and Linux users do not need Alt.
- Version-skew banner from the descriptor; live desktop over remote (the "bot computer GUI" ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connect the desktop app to remote servers using copied pairing links.
  - Switch between Local and saved servers from the Server menu.
  - Stay signed in to saved servers across app restarts.
  - Forget saved servers to sign out and revoke access.
- **Security**
  - Remote servers cannot access the computer’s screen, microphone, files, or local controls.
  - Navigation and desktop capabilities are restricted while connected remotely.
- **Documentation**
  - Added guidance for connecting to and managing remote servers from the desktop app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->