### PR TITLE
feat(ios): add file previews and chat attachments

### DIFF
--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -19,7 +19,7 @@ import {
   MAX_COMPANION_ENDPOINTS,
   type CompanionEndpoint,
 } from "./endpoints.ts";
-import { denyReason, isCloudDesktopJoin } from "./routes.ts";
+import { denyReason, isCloudDesktopJoin, isMessageFileDownload } from "./routes.ts";
 import { createSseScrubber, isJson, scrub } from "./wire.ts";
 
 /** What the forwarding handler needs from the process around it. */
@@ -460,7 +460,11 @@ export function createProxyHandler(options: ProxyOptions) {
         const encoding = String(harness.headers["content-encoding"] ?? "")
           .trim()
           .toLowerCase();
-        if (!isJson(String(contentType ?? "")) || (encoding && encoding !== "identity")) {
+        if (
+          isMessageFileDownload(method, path)
+          || !isJson(String(contentType ?? ""))
+          || (encoding && encoding !== "identity")
+        ) {
           // images and anything else: byte-for-byte, no parsing.
           //
           // Encoded bodies come through here too. Scrubbing one would mean

--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -40,8 +40,20 @@ export const CLOUD_DESKTOP_JOIN_ROUTE = {
   path: /^\/api\/bots\/[\w-]+\/computer\/join$/,
 } as const;
 
+/** A POST whose response is file bytes. Keep this exact classifier shared
+ * with the proxy: a `.json` document must not enter the ordinary JSON
+ * scrub/re-serialise path and come back as different bytes. */
+export const MESSAGE_FILE_ROUTE = {
+  method: "POST",
+  path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/file$/,
+} as const;
+
 export function isCloudDesktopJoin(method: string, path: string): boolean {
   return method === CLOUD_DESKTOP_JOIN_ROUTE.method && CLOUD_DESKTOP_JOIN_ROUTE.path.test(path);
+}
+
+export function isMessageFileDownload(method: string, path: string): boolean {
+  return method === MESSAGE_FILE_ROUTE.method && MESSAGE_FILE_ROUTE.path.test(path);
 }
 
 /** Every request the iOS app makes, and nothing else.
@@ -96,6 +108,7 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
   // a transcript, its images, and answering an approval
   { method: "GET", path: /^\/api\/threads\/[\w-]+\/messages$/ },
   { method: "GET", path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/image$/ },
+  MESSAGE_FILE_ROUTE,
   { method: "POST", path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/reactions$/ },
   { method: "GET", path: /^\/api\/threads\/[\w-]+\/export$/ },
   { method: "POST", path: /^\/api\/threads\/[\w-]+\/respond$/ },

--- a/companion/test/proxy-response.test.ts
+++ b/companion/test/proxy-response.test.ts
@@ -40,11 +40,16 @@ const close = (server: Server | undefined): Promise<void> =>
 const device = async (
   path = "/api/bots",
   method = "GET",
+  body?: string,
 ): Promise<{ status: number; text: string; headers: Headers }> => {
-  const res = await fetch(`http://127.0.0.1:${sidecarPort}${path}`, {
-    method,
-    headers: { authorization: `Bearer ${TOKEN}` },
-  });
+  const headers = {
+    authorization: `Bearer ${TOKEN}`,
+    ...(body === undefined ? {} : { "content-type": "application/json" }),
+  };
+  const init: RequestInit = body === undefined
+    ? { method, headers }
+    : { method: "POST", headers, body };
+  const res = await fetch(`http://127.0.0.1:${sidecarPort}${path}`, init);
   return { status: res.status, text: await res.text(), headers: res.headers };
 };
 
@@ -199,5 +204,26 @@ describe("preparing a harness response for a device", () => {
     expect(response.text).toBe("image-bytes");
     expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+  });
+
+  it("passes an application/json message file through byte-for-byte", async () => {
+    const bytes = '{\n  "resumeCursors": { "this-is-file-content": true },\n  "n": 1\n}\n';
+    respond = (res) => {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-disposition": 'attachment; filename="report.json"',
+      });
+      res.end(bytes);
+    };
+
+    const response = await device(
+      "/api/threads/thread-1/messages/message-1/file",
+      "POST",
+      JSON.stringify({ path: "report.json" }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(bytes);
+    expect(response.headers.get("content-disposition")).toContain("report.json");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
 });

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -65,6 +65,7 @@ describe("what the app may do", () => {
     ["DELETE", "/api/groups/room-1/tasks/th_1"],
     ["GET", "/api/threads/th_1/messages"],
     ["GET", "/api/threads/th_1/messages/msg_2/image"],
+    ["POST", "/api/threads/th_1/messages/msg_2/file"],
     ["POST", "/api/threads/th_1/messages/msg_2/reactions"],
     ["GET", "/api/threads/th_1/export"],
     ["POST", "/api/threads/th_1/respond"],
@@ -165,6 +166,8 @@ describe("what it may not", () => {
     expect(allowed("GET", "/api/bots")).toBe(true);
     expect(allowed("DELETE", "/api/bots/bot_123")).toBe(false);
     expect(allowed("POST", "/api/threads/th_1/messages")).toBe(false);
+    expect(allowed("GET", "/api/threads/th_1/messages/msg_2/file")).toBe(false);
+    expect(allowed("POST", "/api/threads/th_1/messages/msg_2/file/extra")).toBe(false);
     expect(allowed("GET", "/api/groups/room-1")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123/profile/execution-policy")).toBe(false);

--- a/docs/ios-privacy.md
+++ b/docs/ios-privacy.md
@@ -33,17 +33,24 @@ account. A user may separately sign in on the desktop to enable the optional
 - Connector tokens stay in the desktop operating system's encrypted credential
   store. Pairing and device tokens are not stored in the hosted control-plane
   database.
-- When a user explicitly chooses OpenMausBot from another app's Share sheet,
-  the selected text, link, image, or supported document is sent to the bot or
-  room the user confirms. Images and documents are stored in the attachments
-  directory on the user's computer with generated names and owner-only file
-  permissions. Individual images are limited to 10 MiB, documents to 25 MiB,
-  and the computer refuses new uploads after 512 MiB of attachments rather than
-  silently deleting files referenced by older conversations. Temporary iPhone
-  copies are removed after a completed send or cancellation. If iOS terminates
-  the extension mid-transfer, the next Share sheet session removes the abandoned
-  copy immediately; an OpenMausMobile foreground launch removes it once it is at
-  least 60 minutes old.
+- When a user explicitly chooses OpenMausBot from another app's Share sheet, or
+  uses the attachment button in a chat, the selected text, link, image, or
+  supported document is sent to the bot or room the user confirms. Images and
+  documents are stored in the attachments directory on the user's computer with
+  generated names and owner-only file permissions. Individual images are
+  limited to 10 MiB, documents to 25 MiB, and one message to four items and
+  50 MiB total. The computer refuses new uploads after 512 MiB of attachments
+  rather than silently deleting files referenced by older conversations.
+  In-chat selections remain in memory until the message succeeds or the draft
+  is discarded. Temporary Share-extension copies are removed after a completed
+  send or cancellation. If iOS terminates the extension mid-transfer, the next
+  Share sheet session removes the abandoned copy immediately; an OpenMausMobile
+  foreground launch removes it once it is at least 60 minutes old.
+- Opening a file link sent by a bot requests that exact file from the paired
+  computer over the selected authenticated companion connection. The app keeps
+  a temporary local preview only while it is open, then removes it. Ordinary
+  web links continue to open in the system browser. The hosted control plane
+  does not store either the source file or its preview.
 - The app contains no advertising or analytics SDKs, does not track users
   across other companies' apps or websites, and does not sell personal data.
 

--- a/ios/App/AttachmentViews.swift
+++ b/ios/App/AttachmentViews.swift
@@ -1,0 +1,230 @@
+import CompanionCore
+import QuickLook
+import SwiftUI
+import UIKit
+
+enum AttachmentImportError: LocalizedError {
+    case unreadable(String)
+    case unsupported(String)
+    case tooLarge(String, Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unreadable(name):
+            return "OpenMausBot couldn't read \(name). Try exporting it to Files first."
+        case let .unsupported(name):
+            return "\(name) isn't a supported attachment. Try an image, PDF, text, Word, Excel, or PowerPoint file."
+        case let .tooLarge(name, bytes):
+            let limit = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+            return "\(name) is larger than the \(limit) remaining attachment limit."
+        }
+    }
+}
+
+struct PendingAttachmentChip: View {
+    let attachment: PendingMessageAttachment
+    let remove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            preview
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(attachment.name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+                Text(ByteCountFormatter.string(fromByteCount: Int64(attachment.data.count), countStyle: .file))
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.secondary)
+            }
+
+            Button(action: remove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(Color.secondary)
+                    .frame(width: 24, height: 24)
+                    .background(Color.secondary.opacity(0.12), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(attachment.name)")
+        }
+        .padding(.leading, 7)
+        .padding(.trailing, 6)
+        .padding(.vertical, 6)
+        .frame(maxWidth: 280, alignment: .leading)
+        .background(Color.secondary.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(Color.secondary.opacity(0.10))
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if attachment.kind == .image, let image = UIImage(data: attachment.data) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 34, height: 34)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .accessibilityHidden(true)
+        } else {
+            Image(systemName: "doc.fill")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+struct FilePreviewItem: Identifiable {
+    enum Kind { case markdown, text, quickLook }
+
+    let id = UUID()
+    let url: URL
+    let filename: String
+    let contentType: String
+    let data: Data
+
+    init?(downloaded: DownloadedFile) {
+        guard let localURL = downloaded.localURL else { return nil }
+        data = downloaded.data
+        filename = downloaded.filename
+        contentType = downloaded.contentType
+        url = localURL
+    }
+
+    var kind: Kind {
+        let mime = contentType.lowercased()
+        let suffix = url.pathExtension.lowercased()
+        if mime == "text/markdown" || suffix == "md" || suffix == "markdown" {
+            return .markdown
+        }
+        if mime.hasPrefix("text/") || mime == "application/json" {
+            return .text
+        }
+        return .quickLook
+    }
+
+    var text: String {
+        let limit = 2 * 1_024 * 1_024
+        let visible = data.prefix(limit)
+        var decoded = String(decoding: visible, as: UTF8.self)
+        if data.count > limit {
+            decoded += "\n\n— Preview truncated. Share or open the file to read the rest. —"
+        }
+        return decoded
+    }
+
+    func cleanUp() {
+        let directory = url.deletingLastPathComponent()
+        if directory.deletingLastPathComponent().lastPathComponent == "OpenMausBotFilePreviews" {
+            try? FileManager.default.removeItem(at: directory)
+        } else {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+}
+
+struct FilePreviewView: View {
+    let item: FilePreviewItem
+    let close: () -> Void
+    @State private var linkError: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch item.kind {
+                case .markdown:
+                    ScrollView {
+                        MarkdownText(source: item.text, openLink: openPreviewLink)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: 900, alignment: .leading)
+                            .frame(maxWidth: .infinity, alignment: .top)
+                            .padding(20)
+                    }
+                case .text:
+                    ScrollView([.horizontal, .vertical]) {
+                        Text(item.text)
+                            .font(.system(size: 14, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                            .padding(20)
+                    }
+                case .quickLook:
+                    QuickLookPreview(url: item.url)
+                        .ignoresSafeArea(edges: .bottom)
+                }
+            }
+            .background(Color(uiColor: .systemBackground))
+            .navigationTitle(item.filename)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done", action: close)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    ShareLink(item: item.url) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .accessibilityLabel("Share \(item.filename)")
+                }
+            }
+        }
+        .onDisappear { item.cleanUp() }
+        .alert("Couldn't open link", isPresented: Binding(
+            get: { linkError != nil },
+            set: { if !$0 { linkError = nil } }
+        )) {
+            Button("OK", role: .cancel) { linkError = nil }
+        } message: {
+            Text(linkError ?? "That link couldn't be opened.")
+        }
+    }
+
+    private func openPreviewLink(_ url: URL) -> OpenURLAction.Result {
+        guard let scheme = url.scheme?.lowercased(),
+              (scheme == "http" || scheme == "https"),
+              url.host != nil
+        else {
+            linkError = "Open links to other computer files from the original chat message."
+            return .handled
+        }
+        return .systemAction(url)
+    }
+}
+
+private struct QuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator { Coordinator(url: url) }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
+        context.coordinator.url = url
+        controller.reloadData()
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        var url: URL
+
+        init(url: URL) { self.url = url }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(
+            _ controller: QLPreviewController,
+            previewItemAt index: Int
+        ) -> QLPreviewItem {
+            url as NSURL
+        }
+    }
+}

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -6,6 +6,9 @@
 // did that and having two folds is how two clients start disagreeing.
 import SwiftUI
 import CompanionCore
+import PhotosUI
+import UniformTypeIdentifiers
+import ImageIO
 // Unconditional, because the uses below are: `Color(uiColor:)` and
 // `UIImage(data:)` are reached on every path through this file. A
 // `canImport` guard around the import alone does not make the file portable
@@ -29,6 +32,17 @@ struct ChatView: View {
     @State private var showingProfile = false
     @State private var showCommandHUD = false
     @State private var shareFile: ShareFile?
+    @State private var showingPhotoPicker = false
+    @State private var showingFileImporter = false
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @State private var attachments: [PendingMessageAttachment] = []
+    @State private var preparingAttachments = false
+    @State private var sendingMessage = false
+    @State private var attachmentError: String?
+    @State private var openingFileName: String?
+    @State private var fileOpenError: String?
+    @State private var filePreview: FilePreviewItem?
+    @State private var fileDownloadTask: Task<Void, Never>?
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
     /// The opening beat: the island grows with the bot's face in it, then
@@ -152,7 +166,8 @@ struct ChatView: View {
                                     MessageRow(
                                         chat: current,
                                         message: message,
-                                        endsRun: endsRun(at: index, in: transcript)
+                                        endsRun: endsRun(at: index, in: transcript),
+                                        openLink: openLink
                                     )
                                 case let .activityRun(items):
                                     ActivityRunChip(items: items)
@@ -304,7 +319,10 @@ struct ChatView: View {
             // bit here rather than leaving a badge on an open conversation.
             if unread { Task { await session.markRead(current) } }
         }
-        .onDisappear { dictation.stop() }
+        .onDisappear {
+            dictation.stop()
+            fileDownloadTask?.cancel()
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase != .active { dictation.stop() }
         }
@@ -343,6 +361,28 @@ struct ChatView: View {
         }
         .sheet(item: $shareFile) { file in
             ActivityShareSheet(items: [file.url])
+        }
+        .photosPicker(
+            isPresented: $showingPhotoPicker,
+            selection: $selectedPhotos,
+            maxSelectionCount: max(1, AttachmentPolicy.maximumItems - attachments.count),
+            matching: .images,
+            preferredItemEncoding: .current
+        )
+        .onChange(of: selectedPhotos) { _, items in
+            guard !items.isEmpty else { return }
+            Task { await importPhotos(items) }
+        }
+        .fileImporter(
+            isPresented: $showingFileImporter,
+            allowedContentTypes: [.content],
+            allowsMultipleSelection: true,
+            onCompletion: importFiles
+        )
+        .fullScreenCover(item: $filePreview) { preview in
+            FilePreviewView(item: preview) {
+                filePreview = nil
+            }
         }
     }
 
@@ -528,7 +568,18 @@ struct ChatView: View {
     }
 
     private var plusActions: [PlusAction] {
-        var out: [PlusAction] = []
+        let canAddAttachment = attachments.count < AttachmentPolicy.maximumItems
+            && !preparingAttachments && !sendingMessage
+        var out: [PlusAction] = [
+            PlusAction(
+                id: "photos", systemImage: "photo.on.rectangle", title: "Photo Library",
+                subtitle: "Add a photo to this message", disabled: !canAddAttachment
+            ) { showingPhotoPicker = true },
+            PlusAction(
+                id: "files", systemImage: "paperclip", title: "Choose File",
+                subtitle: "Add a document from Files", disabled: !canAddAttachment
+            ) { showingFileImporter = true },
+        ]
         if case let .bot(bot) = current {
             out.append(PlusAction(
                 id: "task", systemImage: "plus.square.on.square", title: "New task",
@@ -603,7 +654,8 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty)
+            && !preparingAttachments && !sendingMessage
     }
 
     private var hasPendingApproval: Bool {
@@ -614,13 +666,227 @@ struct ChatView: View {
         // This also cancels an in-flight permission prompt before it can
         // open the microphone after the message has already been sent.
         dictation.stop()
-        let text = (explicitText ?? draft).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        draft = ""
+        let draftAtSend = draft
+        let text = (explicitText ?? draftAtSend).trimmingCharacters(in: .whitespacesAndNewlines)
+        let outgoingAttachments = attachments
+        guard !text.isEmpty || !outgoingAttachments.isEmpty,
+              !preparingAttachments,
+              !sendingMessage
+        else { return }
+        sendingMessage = true
+        attachmentError = nil
         showCommandHUD = false
-        SoundEffects.playSent()
-        Haptics.impact(.medium)
-        Task { await session.send(text, to: current) }
+        showingPlus = false
+        Task {
+            let sent = await session.send(
+                text: text,
+                attachments: outgoingAttachments,
+                to: current
+            )
+            sendingMessage = false
+            guard sent else {
+                attachmentError = session.actionError ?? "Couldn't send this message. Try again."
+                session.actionError = nil
+                return
+            }
+            // HUD commands expand `/diff` into a longer prompt. Compare with
+            // what was actually in the field at tap time, not the expanded
+            // text, so the command clears without erasing a newer edit.
+            if draft == draftAtSend {
+                draft = ""
+            }
+            if attachments.map(\.id) == outgoingAttachments.map(\.id) {
+                attachments = []
+            }
+            SoundEffects.playSent()
+            Haptics.impact(.medium)
+        }
+    }
+
+    private func importPhotos(_ items: [PhotosPickerItem]) async {
+        guard !preparingAttachments, !sendingMessage else { return }
+        let available = AttachmentPolicy.maximumItems - attachments.count
+        guard items.count <= available else {
+            selectedPhotos = []
+            attachmentError = "Send up to \(AttachmentPolicy.maximumItems) items at a time."
+            return
+        }
+
+        preparingAttachments = true
+        attachmentError = nil
+        defer {
+            preparingAttachments = false
+            selectedPhotos = []
+        }
+
+        do {
+            var imported: [PendingMessageAttachment] = []
+            for (index, item) in items.enumerated() {
+                guard let raw = try await item.loadTransferable(type: Data.self) else {
+                    throw AttachmentImportError.unreadable("that photo")
+                }
+                let actualType = CGImageSourceCreateWithData(raw as CFData, nil)
+                    .flatMap(CGImageSourceGetType)
+                    .flatMap { UTType($0 as String) }
+                let actualMime = actualType?.preferredMIMEType
+                    .map(AttachmentPolicy.normalizedMIME)
+
+                let data: Data
+                let mime: String
+                let fileExtension: String
+                if let actualMime, AttachmentPolicy.imageMIMETypes.contains(actualMime) {
+                    data = raw
+                    mime = actualMime
+                    fileExtension = actualType?.preferredFilenameExtension ?? "jpg"
+                } else if let image = UIImage(data: raw),
+                          let jpeg = image.jpegData(compressionQuality: 0.9) {
+                    data = jpeg
+                    mime = "image/jpeg"
+                    fileExtension = "jpg"
+                } else {
+                    throw AttachmentImportError.unsupported("that photo")
+                }
+
+                let candidate = PendingMessageAttachment(
+                    id: UUID(),
+                    data: data,
+                    name: items.count == 1 ? "Photo.\(fileExtension)" : "Photo \(index + 1).\(fileExtension)",
+                    mime: mime,
+                    kind: .image
+                )
+                try AttachmentPolicy.validate(attachments + imported + [candidate])
+                imported.append(candidate)
+            }
+            attachments.append(contentsOf: imported)
+            Haptics.selection()
+        } catch {
+            attachmentError = error.localizedDescription
+        }
+    }
+
+    private func importFiles(_ result: Result<[URL], Error>) {
+        guard case let .success(urls) = result else {
+            if case let .failure(error) = result { attachmentError = error.localizedDescription }
+            return
+        }
+        guard !urls.isEmpty else { return }
+        Task { await importFiles(urls) }
+    }
+
+    private func importFiles(_ urls: [URL]) async {
+        guard !preparingAttachments, !sendingMessage else { return }
+        let available = AttachmentPolicy.maximumItems - attachments.count
+        guard urls.count <= available else {
+            attachmentError = "Send up to \(AttachmentPolicy.maximumItems) items at a time."
+            return
+        }
+
+        preparingAttachments = true
+        attachmentError = nil
+        defer { preparingAttachments = false }
+
+        do {
+            var imported: [PendingMessageAttachment] = []
+            for url in urls {
+                let usedBytes = (attachments + imported).reduce(0) { $0 + $1.data.count }
+                let remainingBytes = max(0, AttachmentPolicy.maximumTotalBytes - usedBytes)
+                let candidate = try await Task.detached(priority: .userInitiated) {
+                    try Self.readImportedFile(url, remainingBytes: remainingBytes)
+                }.value
+                try AttachmentPolicy.validate(attachments + imported + [candidate])
+                imported.append(candidate)
+            }
+            attachments.append(contentsOf: imported)
+            Haptics.selection()
+        } catch {
+            attachmentError = error.localizedDescription
+        }
+    }
+
+    nonisolated private static func readImportedFile(
+        _ url: URL,
+        remainingBytes: Int
+    ) throws -> PendingMessageAttachment {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+
+        let values = try url.resourceValues(
+            forKeys: [.contentTypeKey, .isRegularFileKey, .fileSizeKey]
+        )
+        guard values.isRegularFile != false else {
+            throw AttachmentImportError.unreadable(url.lastPathComponent)
+        }
+        let name = url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { throw AttachmentImportError.unreadable("that file") }
+        let inferred = values.contentType ?? UTType(filenameExtension: url.pathExtension)
+        let mime = AttachmentPolicy.normalizedMIME(
+            inferred?.preferredMIMEType ?? "application/octet-stream"
+        )
+        guard let kind = AttachmentPolicy.kind(forMIME: mime) else {
+            throw AttachmentImportError.unsupported(name)
+        }
+        let itemLimit = kind == .image
+            ? AttachmentPolicy.maximumImageBytes
+            : AttachmentPolicy.maximumFileBytes
+        let readLimit = min(itemLimit, remainingBytes)
+        if let fileSize = values.fileSize, fileSize > readLimit {
+            throw AttachmentImportError.tooLarge(name, readLimit)
+        }
+        // Some document providers do not report a size. Never let that turn
+        // into an unbounded read of a provider-controlled file: read one byte
+        // past the remaining allowance and reject it before it can become a
+        // large in-memory draft.
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: readLimit + 1) ?? Data()
+        guard data.count <= readLimit else {
+            throw AttachmentImportError.tooLarge(name, readLimit)
+        }
+        return PendingMessageAttachment(
+            id: UUID(), data: data, name: name, mime: mime, kind: kind
+        )
+    }
+
+    private func openLink(_ url: URL, from message: Message) -> OpenURLAction.Result {
+        guard let target = LocalMessageLink.resolve(url) else {
+            fileOpenError = "This link can't be opened securely."
+            return .handled
+        }
+        switch target {
+        case let .web(webURL):
+            return .systemAction(webURL)
+        case let .desktopFile(path):
+            openFile(path: path, from: message)
+            return .handled
+        }
+    }
+
+    private func openFile(path: String, from message: Message) {
+        fileDownloadTask?.cancel()
+        fileOpenError = nil
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        openingFileName = name.isEmpty ? "file" : name
+        let task = Task {
+            let downloaded = await session.downloadFile(
+                threadId: threadId,
+                messageId: message.id,
+                path: path
+            )
+            guard !Task.isCancelled else { return }
+            openingFileName = nil
+            guard let downloaded, downloaded.localURL != nil else {
+                fileOpenError = session.actionError ?? "Couldn't open that file. Try again."
+                session.actionError = nil
+                return
+            }
+            filePreview?.cleanUp()
+            guard let preview = FilePreviewItem(downloaded: downloaded) else {
+                fileOpenError = "The downloaded file couldn't be previewed."
+                return
+            }
+            filePreview = preview
+        }
+        fileDownloadTask = task
     }
 
     // MARK: - Composer
@@ -628,6 +894,54 @@ struct ChatView: View {
     /// A round + and a glass pill with dictation and send inside it.
     private var composer: some View {
         VStack(spacing: 6) {
+            if preparingAttachments || sendingMessage {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(preparingAttachments ? "Preparing attachments…" : "Sending…")
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .foregroundStyle(Color.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 4)
+                .accessibilityElement(children: .combine)
+            }
+
+            if let openingFileName {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Opening \(openingFileName)…")
+                        .font(.system(size: 13, weight: .medium))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(Color.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 4)
+                .accessibilityElement(children: .combine)
+            }
+
+            if let error = fileOpenError ?? attachmentError {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Color.orange)
+                    Text(error)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 4)
+                    Button("Dismiss") {
+                        fileOpenError = nil
+                        attachmentError = nil
+                    }
+                    .font(.system(size: 13, weight: .semibold))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 9)
+                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityElement(children: .combine)
+            }
+
             if let error = dictation.error {
                 Text(error)
                     .font(.system(size: 13))
@@ -658,11 +972,29 @@ struct ChatView: View {
                     }
                 }
                 .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else if draft.isEmpty && !current.busy && !hasPendingApproval && !storedChips.isEmpty {
+            } else if draft.isEmpty && attachments.isEmpty && !current.busy
+                        && !hasPendingApproval && !storedChips.isEmpty {
                 PredictiveActionChipsView(chips: storedChips, accentColor: MausPalette.color(current.color)) { chip in
                     submit(chip.prompt)
                 }
                 .transition(.opacity)
+            }
+
+            if !attachments.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(attachments) { attachment in
+                            PendingAttachmentChip(attachment: attachment) {
+                                guard !preparingAttachments, !sendingMessage else { return }
+                                attachments.removeAll { $0.id == attachment.id }
+                                attachmentError = nil
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                }
+                .scrollClipDisabled()
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
             GlassGroup(spacing: 10) {
@@ -682,6 +1014,7 @@ struct ChatView: View {
                     }
                     .buttonStyle(.plain)
                     .glassCapsule()
+                    .disabled(preparingAttachments || sendingMessage)
                     .accessibilityLabel(showingPlus ? "Close" : "More")
 
                     HStack(alignment: .bottom, spacing: 6) {
@@ -698,12 +1031,13 @@ struct ChatView: View {
                                 .frame(width: 30, height: 32)
                         }
                         .buttonStyle(.plain)
+                        .disabled(preparingAttachments || sendingMessage)
                         .accessibilityLabel("Slash commands")
                         .padding(.leading, 6)
                         .padding(.bottom, 6)
 
                         TextField(
-                            dictation.isListening ? "Listening…" : "Ask \(current.name)",
+                            sendingMessage ? "Sending…" : dictation.isListening ? "Listening…" : "Ask \(current.name)",
                             text: $draft,
                             axis: .vertical
                         )
@@ -714,7 +1048,10 @@ struct ChatView: View {
                             .submitLabel(.send)
                             // Partial transcripts rebuild from a frozen base;
                             // prevent competing edits without dimming the text.
-                            .allowsHitTesting(!dictation.isListening && !dictation.isStarting)
+                            .allowsHitTesting(
+                                !dictation.isListening && !dictation.isStarting
+                                    && !preparingAttachments && !sendingMessage
+                            )
                             .onChange(of: draft) { _, value in
                                 withAnimation(.easeInOut(duration: 0.15)) {
                                     showCommandHUD = value.hasPrefix("/")
@@ -745,6 +1082,7 @@ struct ChatView: View {
                                 .symbolEffect(.pulse, isActive: dictation.isListening)
                         }
                         .buttonStyle(.plain)
+                        .disabled(preparingAttachments || sendingMessage)
                         .padding(.bottom, 6)
                         .accessibilityLabel(dictation.isListening ? "Stop dictation" : "Start dictation")
 
@@ -781,6 +1119,7 @@ struct MessageRow: View {
     let message: Message
     /// Last bubble of a run from the same side: the one that gets the tail.
     var endsRun = true
+    let openLink: (URL, Message) -> OpenURLAction.Result
     @EnvironmentObject private var session: Session
     @State private var editingText = ""
     @State private var showingEdit = false
@@ -884,7 +1223,7 @@ struct MessageRow: View {
     private var content: some View {
         switch message.kind {
         case .text:
-            TextBubble(message: message, chat: chat, tailed: endsRun)
+            TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
         case .options:
             CardView(chat: chat, message: message)
         case .activity:
@@ -898,7 +1237,7 @@ struct MessageRow: View {
             // When there is nothing to show, show nothing — a placeholder
             // saying "unsupported" is a worse gap than the gap.
             if let text = message.text, !text.isEmpty {
-                TextBubble(message: message, chat: chat, tailed: endsRun)
+                TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
             }
         }
     }
@@ -935,6 +1274,7 @@ struct TextBubble: View {
     let message: Message
     let chat: Chat
     var tailed = true
+    let openLink: (URL, Message) -> OpenURLAction.Result
 
     private var attachedContent: AttachedMessageContent {
         AttachedMessageContent.parse(message.text ?? "")
@@ -1060,7 +1400,9 @@ struct TextBubble: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else {
-                    MarkdownText(source: message.text ?? "")
+                    MarkdownText(source: message.text ?? "") { url in
+                        openLink(url, message)
+                    }
                         .foregroundStyle(Color.primary)
                         .textSelection(.enabled)
                         .fixedSize(horizontal: false, vertical: true)

--- a/ios/App/MarkdownText.swift
+++ b/ios/App/MarkdownText.swift
@@ -19,6 +19,17 @@ struct MarkdownText: View {
     /// layout — a caret bolted on outside would put it on its own line the
     /// moment the reply ends in a list item.
     var caret: Bool = false
+    var openLink: ((URL) -> OpenURLAction.Result)?
+
+    init(
+        source: String,
+        caret: Bool = false,
+        openLink: ((URL) -> OpenURLAction.Result)? = nil
+    ) {
+        self.source = source
+        self.caret = caret
+        self.openLink = openLink
+    }
 
     var body: some View {
         let blocks = Markdown.blocks(source)
@@ -27,6 +38,9 @@ struct MarkdownText: View {
                 view(for: item.element, tail: caret && item.offset == blocks.count - 1)
             }
         }
+        .environment(\.openURL, OpenURLAction { url in
+            openLink?(url) ?? .systemAction(url)
+        })
     }
 
     @ViewBuilder

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -88,6 +88,14 @@ final class Session: ObservableObject {
     /// for the same attachment path.
     private var avatarFetches: [String: (id: UUID, task: Task<Data?, Never>)] = [:]
     private var avatarCacheGeneration = 0
+    /// Only one downloaded document preview is retained. A replacement is
+    /// written completely before the previous directory is removed, so a
+    /// failed download cannot invalidate the file currently on screen.
+    private var filePreviewDirectory: URL?
+    /// An ambiguous network failure may happen after the server accepted a
+    /// message. Reusing this id for the exact same retained draft makes Retry
+    /// idempotent instead of sending the attachment twice.
+    private var attachmentSendIDs: [AttachmentDraftKey: String] = [:]
     /// A saved connection exists, but its token could not be read yet. Keeps
     /// "the keychain is locked" from being mistaken for "not paired".
     private var restorePending = false
@@ -96,10 +104,17 @@ final class Session: ObservableObject {
     /// paired client can be rebuilt after unlock.
     private var pendingNotification: NotificationTarget?
 
+    private struct AttachmentDraftKey: Hashable {
+        let destination: MessageDestination
+        let text: String
+        let attachmentIDs: [UUID]
+    }
+
     private var registry = CompanionConnectionRegistry()
     // MARK: - Pairing
 
     init() {
+        Self.removeStaleFilePreviews()
         _ = NotificationCoordinator.shared
         NotificationCoordinator.shared.responseHandler = { [weak self] target in
             Task { @MainActor in await self?.openNotification(target) }
@@ -402,6 +417,8 @@ final class Session: ObservableObject {
         rotation = CandidateRotation(hosts: [])
         state = CompanionState()
         resetAvatarCache()
+        clearFilePreview()
+        attachmentSendIDs.removeAll()
         NotificationCoordinator.shared.setBadge(0)
         status = .unpaired
     }
@@ -432,6 +449,8 @@ final class Session: ObservableObject {
         token = nil
         state = CompanionState()
         resetAvatarCache()
+        clearFilePreview()
+        attachmentSendIDs.removeAll()
         NotificationCoordinator.shared.setBadge(0)
     }
 
@@ -764,6 +783,198 @@ final class Session: ObservableObject {
             case let .room(room): try await $0.send(text: text, toRoom: room.id)
             }
         }
+    }
+
+    /// Send a composer draft with app-owned attachments. The destination
+    /// includes the exact active thread at tap time, so neither a desktop task
+    /// switch nor an upload delay can move the message elsewhere. Callers only
+    /// clear their draft when this returns true.
+    func send(
+        text: String,
+        attachments: [PendingMessageAttachment],
+        to chat: Chat
+    ) async -> Bool {
+        guard let client else {
+            actionError = "This computer is offline."
+            return false
+        }
+        actionError = nil
+        do {
+            try AttachmentPolicy.validate(attachments)
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty || !attachments.isEmpty else {
+                actionError = "Write a message or attach a file first."
+                return false
+            }
+
+            if attachments.contains(where: { $0.kind == .image }) {
+                let capable: Set<String>
+                do {
+                    capable = try await client.imageCapableInstanceIDs()
+                } catch APIError.status(code: 404, message: _) {
+                    actionError = "Update OpenMausBot on this computer before sending images."
+                    return false
+                }
+                guard imageSupported(by: chat, capableInstances: capable) else {
+                    actionError = imageCompatibilityMessage(for: chat)
+                    return false
+                }
+            }
+
+            let destination: MessageDestination
+            switch chat {
+            case let .bot(bot):
+                destination = .bot(id: bot.id, threadId: bot.threadId)
+            case let .room(room):
+                destination = .room(id: room.id, threadId: room.threadId)
+            }
+            let draftKey = AttachmentDraftKey(
+                destination: destination,
+                text: text,
+                attachmentIDs: attachments.map(\.id)
+            )
+            if attachmentSendIDs.count >= 20, attachmentSendIDs[draftKey] == nil {
+                attachmentSendIDs.removeAll(keepingCapacity: true)
+            }
+            let sendID = attachmentSendIDs[draftKey] ?? UUID().uuidString
+            attachmentSendIDs[draftKey] = sendID
+
+            var uploaded: [SharedAttachmentReference] = []
+            uploaded.reserveCapacity(attachments.count)
+            for attachment in attachments {
+                try Task.checkCancellation()
+                let mime = AttachmentPolicy.normalizedMIME(attachment.mime)
+                switch attachment.kind {
+                case .image:
+                    let path = try await client.uploadImage(
+                        data: attachment.data,
+                        mime: mime,
+                        uploadId: attachment.id.uuidString
+                    )
+                    uploaded.append(SharedAttachmentReference(path: path, kind: .image))
+                case .file:
+                    let file = try await client.uploadFile(
+                        data: attachment.data,
+                        name: attachment.name,
+                        mime: mime,
+                        uploadId: attachment.id.uuidString
+                    )
+                    uploaded.append(SharedAttachmentReference(
+                        path: file.path,
+                        kind: .file,
+                        displayName: file.name
+                    ))
+                }
+            }
+
+            let message = SharedMessageComposer.compose(
+                instruction: text,
+                text: [],
+                urls: [],
+                attachments: uploaded
+            )
+            try await client.send(text: message, to: destination, sendId: sendID)
+            attachmentSendIDs.removeValue(forKey: draftKey)
+            actionError = nil
+            return true
+        } catch is CancellationError {
+            return false
+        } catch let error as APIError where error.isUnauthorized {
+            status = .unauthorized
+            actionError = error.localizedDescription
+            return false
+        } catch {
+            actionError = error.localizedDescription
+            return false
+        }
+    }
+
+    private func imageSupported(by chat: Chat, capableInstances: Set<String>) -> Bool {
+        switch chat {
+        case let .bot(bot):
+            return capableInstances.contains(bot.modelSelection.instanceId)
+        case let .room(room):
+            return !room.memberIds.isEmpty && room.memberIds.allSatisfy { id in
+                guard let bot = state.bot(id) else { return false }
+                return capableInstances.contains(bot.modelSelection.instanceId)
+            }
+        }
+    }
+
+    private func imageCompatibilityMessage(for chat: Chat) -> String {
+        switch chat {
+        case let .bot(bot):
+            return "\(bot.name)'s current model doesn't support images. Choose another model or remove the image."
+        case .room:
+            return "Every bot that may answer in this channel must use a model that supports images."
+        }
+    }
+
+    /// Download one desktop path through its originating transcript message,
+    /// then place it in a private temporary directory for Quick Look.
+    func downloadFile(
+        threadId: String,
+        messageId: String,
+        path: String
+    ) async -> DownloadedFile? {
+        guard let client else {
+            actionError = "This computer is offline."
+            return nil
+        }
+        actionError = nil
+        do {
+            let download = try await client.downloadFile(
+                threadId: threadId,
+                messageId: messageId,
+                path: path
+            )
+            try Task.checkCancellation()
+            let manager = FileManager.default
+            let root = manager.temporaryDirectory
+                .appendingPathComponent("OpenMausBotFilePreviews", isDirectory: true)
+            let nextDirectory = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try manager.createDirectory(
+                at: nextDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+            )
+            let fileURL = nextDirectory.appendingPathComponent(download.filename, isDirectory: false)
+            do {
+                try download.data.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+                // A synchronous write cannot be interrupted halfway through.
+                // Check immediately afterwards so a cancelled preview never
+                // leaves its completed temporary copy behind.
+                try Task.checkCancellation()
+            } catch {
+                try? manager.removeItem(at: nextDirectory)
+                throw error
+            }
+            let previous = filePreviewDirectory
+            filePreviewDirectory = nextDirectory
+            if let previous { try? manager.removeItem(at: previous) }
+            actionError = nil
+            return download.stored(at: fileURL)
+        } catch is CancellationError {
+            return nil
+        } catch let error as APIError where error.isUnauthorized {
+            status = .unauthorized
+            actionError = error.localizedDescription
+            return nil
+        } catch {
+            actionError = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func clearFilePreview() {
+        if let filePreviewDirectory { try? FileManager.default.removeItem(at: filePreviewDirectory) }
+        filePreviewDirectory = nil
+    }
+
+    private static func removeStaleFilePreviews() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenMausBotFilePreviews", isDirectory: true)
+        try? FileManager.default.removeItem(at: root)
     }
 
     func answer(chat: Chat, card: OptionCard, choice: String, rememberingPermission: Bool = true) async {

--- a/ios/AppStore/privacy-answers.md
+++ b/ios/AppStore/privacy-answers.md
@@ -17,12 +17,13 @@ production hosted service still match this repository.
   redacted operational errors, and connection/request metadata processed by
   Cloudflare. Select the closest current App Store Connect diagnostic/other-data
   categories during submission and do not mark these as tracking.
-- User Content: messages, approvals, transcripts, screen frames, and content
-  the user explicitly selects in another app's Share sheet are
-  processed transiently when the optional hosted route is used, but are not
-  retained by the developer's control plane. Confirm the current App Store
-  Connect definition of ephemeral processing when answering the collection
-  question for the submitted build.
+- User Content: messages, approvals, transcripts, screen frames, files opened
+  from a bot message, and content the user explicitly selects through the chat
+  attachment control or another app's Share sheet are processed transiently
+  when the optional hosted route is used, but are not retained by the
+  developer's control plane. Confirm the current App Store Connect definition
+  of ephemeral processing when answering the collection question for the
+  submitted build.
 - Privacy policy URL:
   `https://github.com/milind-soni/OpenMausBot/blob/main/docs/ios-privacy.md`
 
@@ -34,13 +35,14 @@ proxies the encrypted phone traffic to that user's computer. The computer
 remains the only transcript store; the control plane does not receive a
 persistent cloud copy.
 
-Share-sheet images and documents are transferred only after the user chooses a
-paired computer and bot or room, then taps **Send**. They are written to that
-computer's local OpenMausBot attachments directory; neither the extension nor
-the hosted control plane keeps a persistent copy. The extension removes its
-temporary copy after completion or cancellation; if iOS terminates it during a
-transfer, the next Share-sheet session or app foreground removes the abandoned
-copy.
+Images and documents are transferred only after the user chooses them and taps
+**Send**. They are written to that computer's local OpenMausBot attachments
+directory; neither the iOS app, Share extension, nor hosted control plane keeps
+a persistent copy. The extension removes its temporary copy after completion
+or cancellation; if iOS terminates it during a transfer, the next Share-sheet
+session or app foreground removes the abandoned copy. A file opened from a bot
+message is downloaded only from the paired computer and its temporary preview
+is removed when closed.
 
 Re-evaluate these answers and `PrivacyInfo.xcprivacy` before every upload,
 especially if analytics, push delivery, crash reporting, or content retention

--- a/ios/ShareExtension/ShareItemLoader.swift
+++ b/ios/ShareExtension/ShareItemLoader.swift
@@ -44,7 +44,7 @@ enum ShareItemLoadingError: LocalizedError {
         case .nothingSupported:
             return "There isn't any text, link, image, or supported document to send."
         case .tooManyItems:
-            return "Send up to 4 items at a time."
+            return "Send up to \(AttachmentPolicy.maximumItems) items at a time."
         case .tooMuchText:
             return "That text is too large to share. Send a shorter selection."
         case let .tooLarge(name, limit):
@@ -58,23 +58,7 @@ enum ShareItemLoadingError: LocalizedError {
 }
 
 enum ShareItemLoader {
-    static let maximumItems = 4
     private static let maximumTextCharacters = 100_000
-    private static let maximumTotalAttachmentBytes = 50 * 1_024 * 1_024
-    private static let imageMimes = Set(["image/png", "image/jpeg", "image/gif", "image/webp"])
-    private static let documentMimes = Set([
-        "text/plain", "text/markdown", "text/csv", "text/tab-separated-values",
-        "application/json", "application/pdf", "application/rtf", "text/rtf",
-        "application/msword",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "application/vnd.ms-excel",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/vnd.ms-powerpoint",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "application/vnd.oasis.opendocument.text",
-        "application/vnd.oasis.opendocument.spreadsheet",
-        "application/vnd.oasis.opendocument.presentation",
-    ])
 
     static func load(from context: NSExtensionContext) async throws -> LoadedShareItems {
         let extensionItems = context.inputItems.compactMap { $0 as? NSExtensionItem }
@@ -87,7 +71,9 @@ enum ShareItemLoader {
         guard !providers.isEmpty || !attributedTexts.isEmpty else {
             throw ShareItemLoadingError.nothingSupported
         }
-        guard providers.count <= maximumItems else { throw ShareItemLoadingError.tooManyItems }
+        guard providers.count <= AttachmentPolicy.maximumItems else {
+            throw ShareItemLoadingError.tooManyItems
+        }
         OpenMausSharedInbox.removeDirectories(olderThan: 0)
         guard let container = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: OpenMausSharedConfiguration.appGroupIdentifier
@@ -120,8 +106,11 @@ enum ShareItemLoader {
                 if let type = registeredType(in: provider, conformingTo: .image) {
                     let attachment = try await loadImage(provider, type: type, into: inbox)
                     attachmentBytes += attachment.bytes
-                    guard attachmentBytes <= maximumTotalAttachmentBytes else {
-                        throw ShareItemLoadingError.tooLarge("Those files together", 50)
+                    guard attachmentBytes <= AttachmentPolicy.maximumTotalBytes else {
+                        throw ShareItemLoadingError.tooLarge(
+                            "Those files together",
+                            AttachmentPolicy.maximumTotalBytes / (1_024 * 1_024)
+                        )
                     }
                     attachments.append(attachment)
                 } else if let representation = registeredDocumentRepresentation(in: provider) {
@@ -131,15 +120,21 @@ enum ShareItemLoader {
                         into: inbox
                     )
                     attachmentBytes += attachment.bytes
-                    guard attachmentBytes <= maximumTotalAttachmentBytes else {
-                        throw ShareItemLoadingError.tooLarge("Those files together", 50)
+                    guard attachmentBytes <= AttachmentPolicy.maximumTotalBytes else {
+                        throw ShareItemLoadingError.tooLarge(
+                            "Those files together",
+                            AttachmentPolicy.maximumTotalBytes / (1_024 * 1_024)
+                        )
                     }
                     attachments.append(attachment)
                 } else if let type = registeredType(in: provider, conformingTo: .fileURL) {
                     let attachment = try await loadFileURL(provider, type: type, into: inbox)
                     attachmentBytes += attachment.bytes
-                    guard attachmentBytes <= maximumTotalAttachmentBytes else {
-                        throw ShareItemLoadingError.tooLarge("Those files together", 50)
+                    guard attachmentBytes <= AttachmentPolicy.maximumTotalBytes else {
+                        throw ShareItemLoadingError.tooLarge(
+                            "Those files together",
+                            AttachmentPolicy.maximumTotalBytes / (1_024 * 1_024)
+                        )
                     }
                     attachments.append(attachment)
                 } else if let type = registeredType(in: provider, conformingTo: .url),
@@ -198,7 +193,7 @@ enum ShareItemLoader {
                   !type.conforms(to: .url),
                   !type.conforms(to: .plainText),
                   let mime = type.preferredMIMEType?.lowercased(),
-                  documentMimes.contains(mime)
+                  AttachmentPolicy.documentMIMETypes.contains(mime)
             else { continue }
             return DocumentRepresentation(identifier: identifier, mime: mime, type: type)
         }
@@ -210,7 +205,7 @@ enum ShareItemLoader {
         guard let suggestedName = provider.suggestedName,
               let inferred = UTType(filenameExtension: (suggestedName as NSString).pathExtension),
               let mime = inferred.preferredMIMEType?.lowercased(),
-              documentMimes.contains(mime),
+              AttachmentPolicy.documentMIMETypes.contains(mime),
               let identifier = provider.registeredTypeIdentifiers.first(where: { identifier in
                   guard let type = UTType(identifier) else { return false }
                   return type.conforms(to: .data)
@@ -265,9 +260,15 @@ enum ShareItemLoader {
         type: String,
         into inbox: URL
     ) async throws -> LocalShareAttachment {
-        let copied = try await copyFileRepresentation(provider, type: type, into: inbox, limit: 25)
+        let copied = try await copyFileRepresentation(
+            provider,
+            type: type,
+            into: inbox,
+            maximumBytes: AttachmentPolicy.maximumFileBytes
+        )
         let claimedMime = UTType(type)?.preferredMIMEType?.lowercased() ?? "application/octet-stream"
-        if imageMimes.contains(claimedMime), copied.bytes <= CompanionClient.maximumImageUploadBytes {
+        if AttachmentPolicy.imageMIMETypes.contains(claimedMime),
+           copied.bytes <= AttachmentPolicy.maximumImageBytes {
             return LocalShareAttachment(
                 id: UUID(), url: copied.url, name: copied.name,
                 mime: claimedMime, bytes: copied.bytes, kind: .image
@@ -275,9 +276,12 @@ enum ShareItemLoader {
         }
 
         guard let jpeg = downsampledJPEG(from: copied.url),
-              jpeg.count <= CompanionClient.maximumImageUploadBytes
+              jpeg.count <= AttachmentPolicy.maximumImageBytes
         else {
-            throw ShareItemLoadingError.tooLarge(copied.name, 10)
+            throw ShareItemLoadingError.tooLarge(
+                copied.name,
+                AttachmentPolicy.maximumImageBytes / (1_024 * 1_024)
+            )
         }
         let converted = inbox.appendingPathComponent("\(UUID().uuidString)-image.jpg")
         try jpeg.write(to: converted, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
@@ -298,7 +302,7 @@ enum ShareItemLoader {
             type: representation.identifier,
             suggestedType: representation.type,
             into: inbox,
-            limit: 25
+            maximumBytes: AttachmentPolicy.maximumFileBytes
         )
         return LocalShareAttachment(
             id: UUID(), url: copied.url, name: copied.name,
@@ -326,14 +330,14 @@ enum ShareItemLoader {
                     let inferred = UTType(filenameExtension: source.pathExtension)
                     let mime = inferred?.preferredMIMEType?.lowercased() ?? "application/octet-stream"
                     let name = safeName(suggestedName ?? source.lastPathComponent, type: inferred)
-                    guard documentMimes.contains(mime) else {
+                    guard AttachmentPolicy.documentMIMETypes.contains(mime) else {
                         throw ShareItemLoadingError.unsupportedDocument(name)
                     }
                     let copied = try copyRegularFile(
                         source,
                         name: name,
                         into: inbox,
-                        limit: 25
+                        maximumBytes: AttachmentPolicy.maximumFileBytes
                     )
                     continuation.resume(returning: LocalShareAttachment(
                         id: UUID(), url: copied.url, name: name,
@@ -351,7 +355,7 @@ enum ShareItemLoader {
         type: String,
         suggestedType: UTType? = nil,
         into inbox: URL,
-        limit: Int
+        maximumBytes: Int
     ) async throws -> (url: URL, name: String, bytes: Int) {
         let suggestedName = provider.suggestedName
         return try await withCheckedThrowingContinuation {
@@ -372,7 +376,12 @@ enum ShareItemLoader {
                         suggestedName ?? source.lastPathComponent,
                         type: suggestedType ?? UTType(type)
                     )
-                    let copied = try copyRegularFile(source, name: name, into: inbox, limit: limit)
+                    let copied = try copyRegularFile(
+                        source,
+                        name: name,
+                        into: inbox,
+                        maximumBytes: maximumBytes
+                    )
                     continuation.resume(returning: (copied.url, name, copied.bytes))
                 } catch {
                     continuation.resume(throwing: error)
@@ -385,7 +394,7 @@ enum ShareItemLoader {
         _ source: URL,
         name: String,
         into inbox: URL,
-        limit: Int
+        maximumBytes: Int
     ) throws -> (url: URL, bytes: Int) {
         let attributes = try FileManager.default.attributesOfItem(atPath: source.path)
         guard attributes[.type] as? FileAttributeType == .typeRegular else {
@@ -393,9 +402,8 @@ enum ShareItemLoader {
         }
         let advertisedBytes = (attributes[.size] as? NSNumber)?.intValue ?? 0
         guard advertisedBytes > 0 else { throw ShareItemLoadingError.unreadable(name) }
-        let maximumBytes = limit * 1_024 * 1_024
         guard advertisedBytes <= maximumBytes else {
-            throw ShareItemLoadingError.tooLarge(name, limit)
+            throw ShareItemLoadingError.tooLarge(name, maximumBytes / (1_024 * 1_024))
         }
         let destination = inbox.appendingPathComponent("\(UUID().uuidString)-\(name)")
         // Provider URLs stop being valid when their callbacks return.
@@ -421,7 +429,10 @@ enum ShareItemLoader {
         do {
             while let chunk = try sourceHandle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
                 guard copiedBytes + chunk.count <= maximumBytes else {
-                    throw ShareItemLoadingError.tooLarge(name, limit)
+                    throw ShareItemLoadingError.tooLarge(
+                        name,
+                        maximumBytes / (1_024 * 1_024)
+                    )
                 }
                 try destinationHandle.write(contentsOf: chunk)
                 copiedBytes += chunk.count

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -463,8 +463,9 @@ private struct InstanceCapabilityResponse: Decodable {
 }
 
 public struct CompanionClient: Sendable {
-    public static let maximumImageUploadBytes = 10 * 1_024 * 1_024
-    public static let maximumFileUploadBytes = 25 * 1_024 * 1_024
+    public static let maximumImageUploadBytes = AttachmentPolicy.maximumImageBytes
+    public static let maximumFileUploadBytes = AttachmentPolicy.maximumFileBytes
+    public static let maximumFileDownloadBytes = AttachmentPolicy.maximumFileBytes
 
     public let connection: Connection
     private let token: String?
@@ -807,6 +808,71 @@ public struct CompanionClient: Sendable {
         return data
     }
 
+    /// Fetch an app-owned file mentioned by one transcript message. The path
+    /// still names the file on the paired computer, so it is sent in an
+    /// authenticated JSON body rather than placed in the URL. The server
+    /// verifies both message provenance and its attachment roots.
+    public func downloadFile(
+        threadId: String,
+        messageId: String,
+        path rawPath: String
+    ) async throws -> DownloadedFile {
+        guard Self.validRouteID(threadId), Self.validRouteID(messageId),
+              case let .desktopFile(path) = LocalMessageLink.resolve(rawPath)
+        else { throw APIError.badURL }
+        let request = try makeRequest(
+            "POST",
+            "/api/threads/\(threadId)/messages/\(messageId)/file",
+            body: ["path": path]
+        )
+        let (data, response) = try await perform(request)
+        try Self.check(response, data)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.transport("The computer sent something this app couldn't read.")
+        }
+        if http.expectedContentLength > Self.maximumFileDownloadBytes ||
+            data.count > Self.maximumFileDownloadBytes {
+            throw APIError.transport("That file is larger than 25 MB.")
+        }
+        let disposition = http.value(forHTTPHeaderField: "Content-Disposition")
+        let filename = Self.downloadFilename(from: disposition, fallbackPath: path)
+        let rawContentType = http.value(forHTTPHeaderField: "Content-Type") ?? ""
+        let contentType = AttachmentPolicy.validMIME(rawContentType)
+            ? AttachmentPolicy.normalizedMIME(rawContentType)
+            : "application/octet-stream"
+        return DownloadedFile(data: data, filename: filename, contentType: contentType)
+    }
+
+    private static func downloadFilename(from disposition: String?, fallbackPath: String) -> String {
+        let parameters = disposition?.split(separator: ";").map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        } ?? []
+        let encoded = parameters.first(where: { $0.lowercased().hasPrefix("filename*=") })
+            .map { String($0.dropFirst("filename*=".count)) }
+        let ordinary = parameters.first(where: { $0.lowercased().hasPrefix("filename=") })
+            .map { String($0.dropFirst("filename=".count)) }
+        let decodedEncoded = encoded.flatMap { value -> String? in
+            let unquoted = value.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            let payload = unquoted.split(separator: "'", maxSplits: 2, omittingEmptySubsequences: false)
+            let encodedValue = payload.count == 3 ? String(payload[2]) : unquoted
+            return encodedValue.removingPercentEncoding
+        }
+        let candidate = decodedEncoded
+            ?? ordinary?.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            ?? fallbackPath.components(separatedBy: CharacterSet(charactersIn: "/\\"))
+                .last(where: { !$0.isEmpty })
+            ?? "file"
+        let basename = candidate.components(separatedBy: CharacterSet(charactersIn: "/\\"))
+            .last(where: { !$0.isEmpty }) ?? "file"
+        let cleaned = basename.unicodeScalars.map { scalar -> String in
+            let code = scalar.value
+            let isBidiControl = (0x202A...0x202E).contains(code) || (0x2066...0x2069).contains(code)
+            return CharacterSet.controlCharacters.contains(scalar) || isBidiControl ? " " : String(scalar)
+        }.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        let shortened = String(cleaned.prefix(180))
+        return shortened.isEmpty || shortened == "." || shortened == ".." ? "file" : shortened
+    }
+
     /// Fetch an app-owned avatar with the paired-device bearer token. Custom
     /// avatars never go through `AsyncImage`, which cannot attach that token.
     public func avatar(path: String) async throws -> Data {
@@ -870,10 +936,9 @@ public struct CompanionClient: Sendable {
         mime: String,
         uploadId: String? = nil
     ) async throws -> String {
-        let allowed = ["image/png", "image/jpeg", "image/gif", "image/webp"]
         let normalizedMime = mime.lowercased()
         guard Self.validUploadID(uploadId) else { throw APIError.badURL }
-        guard allowed.contains(normalizedMime),
+        guard AttachmentPolicy.imageMIMETypes.contains(normalizedMime),
               data.count <= Self.maximumImageUploadBytes
         else {
             throw APIError.transport("Choose a PNG, JPEG, GIF, or WebP image up to 10 MB.")

--- a/ios/Sources/CompanionCore/MessageAttachments.swift
+++ b/ios/Sources/CompanionCore/MessageAttachments.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// One attachment waiting in the mobile composer. The bytes are app-owned:
+/// picker URLs are copied before this value is created, so a later send never
+/// depends on a security-scoped URL still being alive.
+public struct PendingMessageAttachment: Identifiable, Hashable, Sendable {
+    public enum Kind: Hashable, Sendable {
+        case image
+        case file
+    }
+
+    public let id: UUID
+    public let data: Data
+    public let name: String
+    public let mime: String
+    public let kind: Kind
+
+    public init(
+        id: UUID = UUID(),
+        data: Data,
+        name: String,
+        mime: String,
+        kind: Kind
+    ) {
+        self.id = id
+        self.data = data
+        self.name = name
+        self.mime = mime
+        self.kind = kind
+    }
+
+    public var bytes: Int { data.count }
+}
+
+public enum AttachmentPolicyError: Error, LocalizedError, Equatable, Sendable {
+    case tooManyItems
+    case totalTooLarge
+    case invalidName
+    case unsupportedType(String)
+    case itemTooLarge(name: String, limitMB: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .tooManyItems:
+            return "Attach up to 4 items at a time."
+        case .totalTooLarge:
+            return "Those attachments are larger than 50 MB together."
+        case .invalidName:
+            return "That file doesn't have a valid filename."
+        case let .unsupportedType(name):
+            return "\(name) isn't a supported file. Try PDF, text, Word, Excel, or PowerPoint."
+        case let .itemTooLarge(name, limitMB):
+            return "\(name) is larger than \(limitMB) MB."
+        }
+    }
+}
+
+/// The same limits apply to the in-app composer and the Share extension.
+/// Keeping the policy in CompanionCore prevents either entry point from
+/// accepting an attachment that the authenticated upload route will reject.
+public enum AttachmentPolicy {
+    public static let maximumItems = 4
+    public static let maximumTotalBytes = 50 * 1_024 * 1_024
+    public static let maximumImageBytes = 10 * 1_024 * 1_024
+    public static let maximumFileBytes = 25 * 1_024 * 1_024
+
+    public static let imageMIMETypes: Set<String> = [
+        "image/png", "image/jpeg", "image/gif", "image/webp",
+    ]
+
+    public static let documentMIMETypes: Set<String> = [
+        "text/plain", "text/markdown", "text/csv", "text/tab-separated-values",
+        "application/json", "application/pdf", "application/rtf", "text/rtf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.presentation",
+    ]
+
+    public static func normalizedMIME(_ value: String) -> String {
+        value.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first.map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+    }
+
+    public static func kind(forMIME value: String) -> PendingMessageAttachment.Kind? {
+        let mime = normalizedMIME(value)
+        if imageMIMETypes.contains(mime) { return .image }
+        if documentMIMETypes.contains(mime) { return .file }
+        return nil
+    }
+
+    public static func validate(_ attachments: [PendingMessageAttachment]) throws {
+        guard attachments.count <= maximumItems else { throw AttachmentPolicyError.tooManyItems }
+        guard attachments.reduce(0, { $0 + $1.data.count }) <= maximumTotalBytes else {
+            throw AttachmentPolicyError.totalTooLarge
+        }
+
+        for attachment in attachments {
+            let name = attachment.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard validDisplayName(name) else { throw AttachmentPolicyError.invalidName }
+            let mime = normalizedMIME(attachment.mime)
+            switch attachment.kind {
+            case .image:
+                guard imageMIMETypes.contains(mime) else {
+                    throw AttachmentPolicyError.unsupportedType(name)
+                }
+                guard attachment.data.count <= maximumImageBytes else {
+                    throw AttachmentPolicyError.itemTooLarge(name: name, limitMB: 10)
+                }
+            case .file:
+                guard documentMIMETypes.contains(mime) else {
+                    throw AttachmentPolicyError.unsupportedType(name)
+                }
+                guard attachment.data.count <= maximumFileBytes else {
+                    throw AttachmentPolicyError.itemTooLarge(name: name, limitMB: 25)
+                }
+            }
+        }
+    }
+
+    static func validMIME(_ value: String) -> Bool {
+        let mime = normalizedMIME(value)
+        guard !mime.isEmpty, mime.utf8.count <= 127, mime.contains("/") else { return false }
+        return mime.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte)
+                || [33, 35, 36, 38, 43, 45, 46, 47, 94, 95].contains(byte)
+        }
+    }
+
+    private static func validDisplayName(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.count <= 255
+            && !value.contains("/") && !value.contains("\\")
+            && !value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+    }
+}
+
+/// What tapping a Markdown link in a message is allowed to do. Web links go
+/// to the system. Absolute desktop paths go back through the authenticated
+/// companion file route. Relative and custom-scheme links do nothing.
+public enum LocalMessageLink: Equatable, Sendable {
+    case web(URL)
+    case desktopFile(path: String)
+
+    public static func resolve(_ rawValue: String) -> LocalMessageLink? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, value.utf8.count <= 8_192,
+              !value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+        else { return nil }
+
+        if isWindowsAbsolutePath(value) || isUNCPath(value) {
+            return .desktopFile(path: value)
+        }
+        if value.hasPrefix("/") { return .desktopFile(path: value) }
+
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased()
+        else { return nil }
+        if scheme == "http" || scheme == "https" {
+            guard let url = components.url, components.host?.isEmpty == false else { return nil }
+            return .web(url)
+        }
+        if scheme == "file" {
+            guard components.query == nil, components.fragment == nil else { return nil }
+            var path = components.percentEncodedPath.removingPercentEncoding ?? components.path
+            if path.hasPrefix("/"), isWindowsAbsolutePath(String(path.dropFirst())) {
+                path.removeFirst()
+            }
+            if let host = components.host, !host.isEmpty, host.lowercased() != "localhost" {
+                path = "//\(host)\(path)"
+            }
+            guard path.hasPrefix("/") || isWindowsAbsolutePath(path) || isUNCPath(path) else {
+                return nil
+            }
+            return .desktopFile(path: path)
+        }
+        return nil
+    }
+
+    public static func resolve(_ url: URL) -> LocalMessageLink? {
+        let value = url.absoluteString
+        if let decoded = value.removingPercentEncoding,
+           isWindowsAbsolutePath(decoded) || isUNCPath(decoded) {
+            return .desktopFile(path: decoded)
+        }
+        return resolve(value)
+    }
+
+    private static func isWindowsAbsolutePath(_ value: String) -> Bool {
+        let bytes = Array(value.utf8)
+        guard bytes.count >= 3 else { return false }
+        let letter = (65...90).contains(bytes[0]) || (97...122).contains(bytes[0])
+        return letter && bytes[1] == 58 && (bytes[2] == 47 || bytes[2] == 92)
+    }
+
+    private static func isUNCPath(_ value: String) -> Bool {
+        value.hasPrefix("\\\\") || value.hasPrefix("//")
+    }
+}
+
+/// Bytes returned by the authenticated file route. `localURL` is nil on the
+/// low-level client and populated by Session after it safely writes a preview
+/// into the app's temporary directory.
+public struct DownloadedFile: Sendable {
+    public let data: Data
+    public let filename: String
+    public let contentType: String
+    public let localURL: URL?
+
+    public init(data: Data, filename: String, contentType: String, localURL: URL? = nil) {
+        self.data = data
+        self.filename = filename
+        self.contentType = contentType
+        self.localURL = localURL
+    }
+
+    public func stored(at url: URL) -> DownloadedFile {
+        DownloadedFile(data: data, filename: filename, contentType: contentType, localURL: url)
+    }
+}

--- a/ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift
+++ b/ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+final class MessageAttachmentsTests: XCTestCase {
+    func testClassifiesWebAndAbsoluteDesktopLinks() throws {
+        let web = try XCTUnwrap(LocalMessageLink.resolve("https://example.com/report.md?q=1"))
+        XCTAssertEqual(web, .web(try XCTUnwrap(URL(string: "https://example.com/report.md?q=1"))))
+        XCTAssertEqual(
+            LocalMessageLink.resolve("/Users/milind/Documents/report.md"),
+            .desktopFile(path: "/Users/milind/Documents/report.md")
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("file:///Users/milind/My%20Report.md"),
+            .desktopFile(path: "/Users/milind/My Report.md")
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve(#"C:\Users\Milind\report.md"#),
+            .desktopFile(path: #"C:\Users\Milind\report.md"#)
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve(try XCTUnwrap(URL(string: #"C:\Users\Milind\report.md"#))),
+            .desktopFile(path: #"C:\Users\Milind\report.md"#)
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("file:///C:/Users/Milind/report.md"),
+            .desktopFile(path: "C:/Users/Milind/report.md")
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve(#"\\server\share\report.md"#),
+            .desktopFile(path: #"\\server\share\report.md"#)
+        )
+    }
+
+    func testRejectsRelativeMalformedAndCustomSchemeLinks() {
+        XCTAssertNil(LocalMessageLink.resolve("notes/report.md"))
+        XCTAssertNil(LocalMessageLink.resolve("openmausbot://pair?token=secret"))
+        XCTAssertNil(LocalMessageLink.resolve("javascript:alert(1)"))
+        XCTAssertNil(LocalMessageLink.resolve("https:///missing-host.md"))
+        XCTAssertNil(LocalMessageLink.resolve("file:///tmp/report.md?replace=1"))
+        XCTAssertNil(LocalMessageLink.resolve("/tmp/bad\0name.md"))
+    }
+
+    func testAttachmentPolicyAcceptsSupportedImageAndMarkdown() throws {
+        let attachments = [
+            PendingMessageAttachment(
+                data: Data([0x89, 0x50]),
+                name: "photo.png",
+                mime: "IMAGE/PNG; charset=binary",
+                kind: .image
+            ),
+            PendingMessageAttachment(
+                data: Data("# Notes".utf8),
+                name: "notes.md",
+                mime: "text/markdown",
+                kind: .file
+            ),
+        ]
+
+        XCTAssertNoThrow(try AttachmentPolicy.validate(attachments))
+        XCTAssertEqual(AttachmentPolicy.kind(forMIME: " IMAGE/JPEG "), .image)
+        XCTAssertEqual(AttachmentPolicy.kind(forMIME: "application/pdf"), .file)
+        XCTAssertNil(AttachmentPolicy.kind(forMIME: "application/zip"))
+    }
+
+    func testAttachmentPolicyRejectsCountTypeNameAndSize() {
+        let valid = PendingMessageAttachment(
+            data: Data([1]), name: "notes.txt", mime: "text/plain", kind: .file
+        )
+        XCTAssertThrowsError(try AttachmentPolicy.validate(Array(repeating: valid, count: 5))) {
+            XCTAssertEqual($0 as? AttachmentPolicyError, .tooManyItems)
+        }
+        XCTAssertThrowsError(try AttachmentPolicy.validate([
+            PendingMessageAttachment(data: Data([1]), name: "archive.zip", mime: "application/zip", kind: .file),
+        ])) {
+            XCTAssertEqual($0 as? AttachmentPolicyError, .unsupportedType("archive.zip"))
+        }
+        XCTAssertThrowsError(try AttachmentPolicy.validate([
+            PendingMessageAttachment(data: Data([1]), name: "../notes.txt", mime: "text/plain", kind: .file),
+        ])) {
+            XCTAssertEqual($0 as? AttachmentPolicyError, .invalidName)
+        }
+        XCTAssertThrowsError(try AttachmentPolicy.validate([
+            PendingMessageAttachment(
+                data: Data(repeating: 0, count: AttachmentPolicy.maximumImageBytes + 1),
+                name: "huge.png",
+                mime: "image/png",
+                kind: .image
+            ),
+        ])) {
+            XCTAssertEqual($0 as? AttachmentPolicyError, .itemTooLarge(name: "huge.png", limitMB: 10))
+        }
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ShareClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/ShareClientTests.swift
@@ -5,6 +5,7 @@ import XCTest
 private final class ShareRequestStub: URLProtocol {
     static var responseBody = Data()
     static var statusCode = 200
+    static var responseHeaders = ["Content-Type": "application/json"]
     static var capturedRequest: URLRequest?
     static var capturedBody: Data?
 
@@ -18,7 +19,7 @@ private final class ShareRequestStub: URLProtocol {
             url: request.url!,
             statusCode: Self.statusCode,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"]
+            headerFields: Self.responseHeaders
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Self.responseBody)
@@ -52,6 +53,7 @@ final class ShareClientTests: XCTestCase {
         super.setUp()
         ShareRequestStub.responseBody = Data()
         ShareRequestStub.statusCode = 200
+        ShareRequestStub.responseHeaders = ["Content-Type": "application/json"]
         ShareRequestStub.capturedRequest = nil
         ShareRequestStub.capturedBody = nil
         let configuration = URLSessionConfiguration.ephemeral
@@ -262,5 +264,83 @@ final class ShareClientTests: XCTestCase {
         try await shortClient.send(text: "hello", toBot: "bot-1")
 
         XCTAssertEqual(ShareRequestStub.capturedRequest?.timeoutInterval, 7)
+    }
+
+    func testAuthenticatedFileDownloadPostsPathAndSanitizesResponseMetadata() async throws {
+        ShareRequestStub.responseBody = Data("# Report".utf8)
+        ShareRequestStub.responseHeaders = [
+            "Content-Type": "Text/Markdown; charset=utf-8",
+            "Content-Disposition": "attachment; filename*=UTF-8''Quarter%20Report.md",
+        ]
+
+        let file = try await client.downloadFile(
+            threadId: "thread-1",
+            messageId: "message-1",
+            path: "/Users/test/Documents/report.md"
+        )
+
+        XCTAssertEqual(ShareRequestStub.capturedRequest?.url?.path, "/api/threads/thread-1/messages/message-1/file")
+        XCTAssertEqual(ShareRequestStub.capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(ShareRequestStub.capturedRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer paired-token")
+        let body = try XCTUnwrap(ShareRequestStub.capturedBody)
+        XCTAssertEqual(
+            try JSONSerialization.jsonObject(with: body) as? [String: String],
+            ["path": "/Users/test/Documents/report.md"]
+        )
+        XCTAssertEqual(file.data, Data("# Report".utf8))
+        XCTAssertEqual(file.filename, "Quarter Report.md")
+        XCTAssertEqual(file.contentType, "text/markdown")
+        XCTAssertNil(file.localURL)
+    }
+
+    func testFileDownloadStripsPathAndControlsFromResponseFilename() async throws {
+        ShareRequestStub.responseBody = Data([1])
+        ShareRequestStub.responseHeaders = [
+            "Content-Type": "not a mime",
+            "Content-Disposition": "attachment; filename=\"../secret\u{202E}.txt\"",
+        ]
+
+        let file = try await client.downloadFile(
+            threadId: "thread-1",
+            messageId: "message-1",
+            path: "/Users/test/fallback.txt"
+        )
+
+        XCTAssertEqual(file.filename, "secret .txt")
+        XCTAssertEqual(file.contentType, "application/octet-stream")
+    }
+
+    func testFileDownloadRejectsUnsafeRequestBeforeNetworking() async {
+        do {
+            _ = try await client.downloadFile(
+                threadId: "../thread",
+                messageId: "message-1",
+                path: "relative/report.md"
+            )
+            XCTFail("expected local route rejection")
+        } catch APIError.badURL {
+            XCTAssertNil(ShareRequestStub.capturedRequest)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testFileDownloadRejectsOversizedDeclaredResponse() async {
+        ShareRequestStub.responseBody = Data([1])
+        ShareRequestStub.responseHeaders = [
+            "Content-Type": "text/plain",
+            "Content-Length": String(CompanionClient.maximumFileDownloadBytes + 1),
+        ]
+
+        do {
+            _ = try await client.downloadFile(
+                threadId: "thread-1",
+                messageId: "message-1",
+                path: "/Users/test/large.txt"
+            )
+            XCTFail("expected declared size rejection")
+        } catch {
+            XCTAssertNotNil(ShareRequestStub.capturedRequest)
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@trycua/cua-driver": "0.20.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
+    "mdast-util-from-markdown": "^2.0.3",
     "posthog-js": "^1.415.6",
     "qrcode.react": "^4.2.0",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.2.8)
+      mdast-util-from-markdown:
+        specifier: ^2.0.3
+        version: 2.0.3
       posthog-js:
         specifier: ^1.415.6
         version: 1.415.6

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -9,7 +9,7 @@ import { createServer, request, type Server } from "node:http";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -204,7 +204,50 @@ beforeAll(async () => {
         createdAt: 2,
         pinnedCwd: null,
       },
+      {
+        id: "test-linked-file-room",
+        threadId: "test-linked-file-room-thread",
+        name: "Linked file room",
+        memberIds: ["test-bot-a"],
+        defaultResponder: { kind: "member", botId: "test-bot-a" },
+        bulletin: "",
+        unread: false,
+        createdAt: 5,
+        dm: true,
+        pinnedCwd: null,
+      },
     ]),
+  );
+
+  const linkedWorkspace = join(home, ".openmausbot", "workspaces", "test-bot-a");
+  const linkedFile = join(linkedWorkspace, "phone report.md");
+  mkdirSync(linkedWorkspace, { recursive: true });
+  writeFileSync(linkedFile, "# Phone-ready report\n");
+  writeFileSync(
+    join(home, ".openmausbot", "messages-test-linked-file-room-thread.json"),
+    JSON.stringify({
+      activeLeafId: "prose-file-message",
+      messages: [
+        {
+          id: "linked-file-message",
+          at: 5,
+          parentId: null,
+          role: "bot",
+          kind: "text",
+          text: `[Open the report](<${pathToFileURL(linkedFile).href}>)`,
+          from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+        {
+          id: "prose-file-message",
+          at: 6,
+          parentId: "linked-file-message",
+          role: "bot",
+          kind: "text",
+          text: `I saved another copy at ${linkedFile}.`,
+          from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+      ],
+    }),
   );
 
   // A room transcript carrying an approval that outlived its turn: the card
@@ -5154,6 +5197,44 @@ describe("message pages", () => {
     const full = await seedRoom(1);
     const res = await fetch(`${BASE}/api/threads/${full.threadId}/messages/${full.messages[0].id}/image`);
     expect(res.status).toBe(404);
+  });
+
+  it("downloads only a file linked by the exact stored bot message", async () => {
+    const threadId = "test-linked-file-room-thread";
+    const linkedFile = join(home, ".openmausbot", "workspaces", "test-bot-a", "phone report.md");
+    const response = await fetch(
+      `${BASE}/api/threads/${threadId}/messages/linked-file-message/file`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        // Native URL handling decodes the `%20` carried by the stored href.
+        body: JSON.stringify({ path: linkedFile }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("# Phone-ready report\n");
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(response.headers.get("content-disposition")).toContain("phone%20report.md");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+
+    // Merely mentioning the exact same path in prose does not grant a file
+    // capability. It must be an actual Markdown/autolink/attachment target.
+    expect((await api(
+      "POST",
+      `/api/threads/${threadId}/messages/prose-file-message/file`,
+      { path: linkedFile },
+    )).status).toBe(403);
+    expect((await api(
+      "POST",
+      `/api/threads/${threadId}/messages/linked-file-message/file`,
+      { path: join(home, ".openmausbot", "workspaces", "test-bot-a", "other.md") },
+    )).status).toBe(403);
+    expect((await fetch(`${BASE}/api/threads/${threadId}/messages/no-such-message/file`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: linkedFile }),
+    })).status).toBe(404);
   });
 
   it("404s an image on a conversation that does not exist, without inventing one", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import * as checkpoints from "./checkpoints.ts";
 import { appendDecision, readDecisions } from "./decision-log.ts";
 import { validateBotCwd } from "./bot-cwd.ts";
 import {
+  ATTACHMENTS_DIR,
   attachmentExists,
   extensionForMime,
   FILE_MAX_BYTES,
@@ -44,6 +45,12 @@ import {
   type SavedAttachment,
   validateAttachmentUploadId,
 } from "./attachments.ts";
+import {
+  messageFileDisposition,
+  messageFileRoots,
+  messageReferencesFile,
+  openMessageFile,
+} from "./message-file.ts";
 import {
   avatarGenerationRequestSchema,
   avatarGenerationStateMatches,
@@ -167,6 +174,7 @@ import {
   listMemoryTopics,
   isMemoryTopicName,
   memorySystemPrompt,
+  workspaceDir,
 } from "./workspace.ts";
 import {
   readMemoryFile,
@@ -6045,6 +6053,75 @@ const server = createServer(async (req, res) => {
         "cache-control": "private, max-age=31536000, immutable",
       });
       return res.end(bytes);
+    }
+
+    // Download one local file only when this exact stored bot message links
+    // to it. The message supplies both the capability (the requested path
+    // must be an actual rendered Markdown link target, allowing only
+    // URL-decoding differences) and the bot identity used to derive the
+    // narrow set of roots; this is deliberately not a general path reader.
+    m = path.match(/^\/api\/threads\/([\w-]+)\/messages\/([\w-]+)\/file$/);
+    if (m && method === "POST") {
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      const threadId = m[1]!;
+      const directBot = store.botByThread(threadId);
+      const group = directBot ? undefined : store.groupByThread(threadId);
+      if (!directBot && !group) return json(res, 404, { error: "no such conversation" });
+
+      const message = store.messagesFor(threadId).find((candidate) => candidate.id === m![2]);
+      if (!message) return json(res, 404, { error: "no such message" });
+      const body = await readBody(req);
+      const href = typeof body.path === "string" ? body.path : "";
+      if (!href) return json(res, 400, { error: "path is required" });
+      if (message.role !== "bot" || message.kind !== "text" || !message.text || !messageReferencesFile(message.text, href)) {
+        return json(res, 403, { error: "that bot message does not link to this file" });
+      }
+
+      const senderId = directBot?.id ?? message.from?.botId;
+      if (!senderId || (group && !group.memberIds.includes(senderId))) {
+        return json(res, 403, { error: "the file's bot author could not be verified" });
+      }
+      let pinnedCwd: string | null | undefined;
+      let configuredCwd: string | undefined;
+      if (directBot) {
+        pinnedCwd = store.taskByThread(directBot.id, threadId)?.cwd;
+        configuredCwd = directBot.cwd;
+      } else if (group) {
+        const task = store.groupTaskByThread(group.id, threadId);
+        pinnedCwd = task ? task.pinnedCwd : group.threadId === threadId ? group.pinnedCwd : undefined;
+        configuredCwd = group.cwd;
+      }
+
+      const roots = messageFileRoots({
+        senderWorkspace: workspaceDir(senderId),
+        attachments: ATTACHMENTS_DIR,
+        pinnedCwd,
+        configuredCwd,
+      });
+
+      const file = await openMessageFile(href, roots);
+      res.writeHead(200, {
+        "content-type": file.mime,
+        "content-length": String(file.bytes),
+        "content-disposition": messageFileDisposition(file.name),
+        "cache-control": "private, no-store",
+        "cdn-cache-control": "no-store",
+        "cloudflare-cdn-cache-control": "no-store",
+        pragma: "no-cache",
+        vary: "Authorization",
+        "x-content-type-options": "nosniff",
+      });
+      if (file.bytes === 0) {
+        await file.handle.close();
+        return res.end();
+      }
+      const stream = file.handle.createReadStream({ start: 0, end: file.bytes - 1, autoClose: true });
+      stream.on("error", () => res.destroy());
+      res.on("close", () => stream.destroy());
+      stream.pipe(res);
+      return;
     }
 
     // ── image attachments ────────────────────────────────────────────────

--- a/server/message-file.test.ts
+++ b/server/message-file.test.ts
@@ -1,0 +1,160 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MESSAGE_FILE_MAX_BYTES,
+  messageFileDisposition,
+  messageFileRoots,
+  messageReferencesFile,
+  openMessageFile,
+} from "./message-file.ts";
+
+const suite = mkdtempSync(join(tmpdir(), "omb-message-file-"));
+const workspace = join(suite, "workspace");
+const outside = join(suite, "outside");
+
+beforeEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(outside, { recursive: true });
+});
+
+afterAll(() => rmSync(suite, { recursive: true, force: true }));
+
+describe("message-linked files", () => {
+  it("never widens an explicitly null pinned cwd to the configured folder", () => {
+    expect(messageFileRoots({
+      senderWorkspace: "/app/workspace",
+      attachments: "/app/attachments",
+      pinnedCwd: null,
+      configuredCwd: "/later/project",
+    })).toEqual(["/app/workspace", "/app/attachments"]);
+    expect(messageFileRoots({
+      senderWorkspace: "/app/workspace",
+      attachments: "/app/attachments",
+      pinnedCwd: undefined,
+      configuredCwd: "/current/project",
+    })[0]).toBe("/current/project");
+  });
+
+  it("matches the decoded path iOS sends to its encoded Markdown href", () => {
+    const encoded = "file:///Users/milind/Project/release%20notes.md";
+    expect(messageReferencesFile(`[Open the notes](${encoded})`, "/Users/milind/Project/release notes.md"))
+      .toBe(true);
+    expect(messageReferencesFile(
+      "I created /Users/milind/Project/release notes.md for you.",
+      "/Users/milind/Project/release notes.md",
+    ))
+      .toBe(false);
+    expect(messageReferencesFile(
+      "[Open it](C:\\Users\\Maus\\report.md)",
+      "C:\\Users\\Maus\\report.md",
+    )).toBe(true);
+    expect(messageReferencesFile(
+      "[Open it](file://server/share/phone%20report.md)",
+      "//server/share/phone report.md",
+    )).toBe(true);
+    expect(messageReferencesFile(
+      "[Open A&amp;B](docs/A&amp;B.md \"download\")",
+      "docs/A&B.md",
+    )).toBe(true);
+    expect(messageReferencesFile("<file:///Users/milind/report.md>", "/Users/milind/report.md"))
+      .toBe(true);
+  });
+
+  it("resolves only definitions used by rendered reference links", () => {
+    expect(messageReferencesFile(
+      "[Open the report][Download]\n\n[download]: /Users/milind/report.md",
+      "/Users/milind/report.md",
+    )).toBe(true);
+    expect(messageReferencesFile(
+      "[unused]: /project/.env",
+      "/project/.env",
+    )).toBe(false);
+  });
+
+  it("does not grant file paths from Markdown that is not a rendered link", () => {
+    const path = "/project/.env";
+    for (const markdown of [
+      "```markdown\n[x](/project/.env)\n```",
+      "~~~\n[x](/project/.env)\n~~~",
+      "    [x](/project/.env)",
+      "\t[x](/project/.env)",
+      "> ```\n> [x](/project/.env)\n> ```",
+      "- ```markdown\n  [x](/project/.env)\n  ```",
+      "`[x](/project/.env)`",
+      "``look at `[x](/project/.env)` here``",
+      "\\[x](/project/.env)",
+      "![x](/project/.env)",
+      "![x](</project/.env>)",
+      "![x][secret]\n\n[secret]: /project/.env",
+      "<!-- [x](/project/.env) -->",
+      "<attached-file path=\"/project/.env\" />",
+      "I saved it at /project/.env.",
+    ]) {
+      expect(messageReferencesFile(markdown, path), markdown).toBe(false);
+    }
+
+    expect(messageReferencesFile(
+      "`[sample](/project/.env)` but [open the real file](/project/.env)",
+      path,
+    )).toBe(true);
+    expect(messageReferencesFile("\\![open](/project/.env)", path)).toBe(true);
+    expect(messageReferencesFile(
+      "[not a valid destination](/project/foo\\ bar.md)",
+      "/project/foo\\ bar.md",
+    )).toBe(false);
+  });
+
+  it("opens encoded relative and file URL links through a stable handle", async () => {
+    const path = join(workspace, "release notes.md");
+    writeFileSync(path, "# unchanged bytes\n");
+
+    const relative = await openMessageFile("release%20notes.md#today", [workspace]);
+    expect(relative).toMatchObject({
+      bytes: 18,
+      name: "release notes.md",
+      mime: "text/markdown; charset=utf-8",
+    });
+    expect(await relative.handle.readFile("utf8")).toBe("# unchanged bytes\n");
+    await relative.handle.close();
+
+    const absolute = await openMessageFile(pathToFileURL(path).href, [workspace]);
+    expect(await absolute.handle.readFile("utf8")).toBe("# unchanged bytes\n");
+    await absolute.handle.close();
+  });
+
+  it("refuses traversal and a symlink that resolves outside the allowed root", async () => {
+    const secret = join(outside, "secret.md");
+    writeFileSync(secret, "not for this conversation");
+    symlinkSync(secret, join(workspace, "escape.md"));
+
+    await expect(openMessageFile("../outside/secret.md", [workspace]))
+      .rejects.toMatchObject({ status: 403 });
+    await expect(openMessageFile("escape.md", [workspace]))
+      .rejects.toMatchObject({ status: 403 });
+  });
+
+  it("accepts only regular files no larger than the phone download ceiling", async () => {
+    await expect(openMessageFile(".", [workspace]))
+      .rejects.toMatchObject({ status: 400 });
+
+    const large = join(workspace, "large.pdf");
+    writeFileSync(large, "x");
+    truncateSync(large, MESSAGE_FILE_MAX_BYTES + 1);
+    await expect(openMessageFile("large.pdf", [workspace]))
+      .rejects.toMatchObject({ status: 413 });
+  });
+
+  it("emits a safe UTF-8 attachment filename", () => {
+    const header = messageFileDisposition("résumé \"final\".md");
+    expect(header).toContain('filename="re_sume_ _final_.md"');
+    expect(header).toContain("filename*=UTF-8''r%C3%A9sum%C3%A9%20%22final%22.md");
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
+  });
+});

--- a/server/message-file.ts
+++ b/server/message-file.ts
@@ -1,0 +1,261 @@
+// A bot may link to a file it created in the workspace for one conversation.
+// Opening that link from a phone must not become a general-purpose host file
+// reader: the HTTP route supplies only roots derived from the exact bot
+// message, and this helper keeps the eventual file handle inside one of them.
+import { constants } from "node:fs";
+import { open, realpath, stat, type FileHandle } from "node:fs/promises";
+import { basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+export const MESSAGE_FILE_MAX_BYTES = 25 * 1024 * 1024;
+
+export interface OpenedMessageFile {
+  handle: FileHandle;
+  bytes: number;
+  name: string;
+  mime: string;
+}
+
+export function messageFileRoots(options: {
+  senderWorkspace: string;
+  attachments: string;
+  /** undefined = not pinned yet; null = explicitly pinned to no host root. */
+  pinnedCwd: string | null | undefined;
+  configuredCwd?: string;
+}): string[] {
+  const conversationRoot = options.pinnedCwd === undefined ? options.configuredCwd : options.pinnedCwd;
+  return [...new Set([
+    ...(typeof conversationRoot === "string" ? [conversationRoot] : []),
+    options.senderWorkspace,
+    options.attachments,
+  ])];
+}
+
+function statusError(status: number, message: string): Error & { status: number } {
+  return Object.assign(new Error(message), { status });
+}
+
+function referencedPath(href: string): string {
+  if (!href || Buffer.byteLength(href) > 8_192 || href.includes("\0")) {
+    throw statusError(400, "path must be a non-empty file link");
+  }
+  // A Windows drive prefix is a path, not a one-letter URL scheme. UNC is
+  // also already an absolute local path on Windows and must not be mistaken
+  // for a protocol-relative web URL.
+  if (/^[a-z]:[\\/]/i.test(href) || href.startsWith("\\\\") || href.startsWith("//")) {
+    return href;
+  }
+  if (/^[a-z][a-z\d+.-]*:/i.test(href)) {
+    let url: URL;
+    try {
+      url = new URL(href);
+    } catch {
+      throw statusError(400, "path must be a valid file link");
+    }
+    if (url.protocol !== "file:" || url.username || url.password || url.port || url.search || url.hash) {
+      throw statusError(400, "only local file links can be downloaded here");
+    }
+    if (url.hostname && url.hostname !== "localhost") {
+      try {
+        return `//${url.hostname}${decodeURIComponent(url.pathname)}`;
+      } catch {
+        throw statusError(400, "path must be a valid file link");
+      }
+    }
+    try {
+      return fileURLToPath(url);
+    } catch {
+      throw statusError(400, "path must be a valid file link");
+    }
+  }
+
+  // Query strings and fragments belong to the Markdown link, not the local
+  // filename. Percent-encoding is common for spaces in relative hrefs.
+  const path = href.split(/[?#]/, 1)[0]!;
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    throw statusError(400, "path must be a valid file link");
+  }
+}
+
+type MarkdownNode = {
+  type: string;
+  children?: MarkdownNode[];
+  identifier?: string;
+  url?: string;
+};
+
+function walkMarkdown(node: MarkdownNode, visit: (node: MarkdownNode) => void): void {
+  const pending = [node];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    visit(current);
+    const children = current.children ?? [];
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      pending.push(children[index]!);
+    }
+  }
+}
+
+function renderedMarkdownTargets(markdown: string): string[] {
+  const definitions = new Map<string, string>();
+  const links: string[] = [];
+  const references: string[] = [];
+
+  walkMarkdown(fromMarkdown(markdown), (node) => {
+    if (node.type === "definition" && node.identifier && node.url) {
+      if (!definitions.has(node.identifier)) definitions.set(node.identifier, node.url);
+    } else if (node.type === "link" && node.url) {
+      links.push(node.url);
+    } else if (node.type === "linkReference" && node.identifier) {
+      references.push(node.identifier);
+    }
+  });
+
+  for (const identifier of references) {
+    const target = definitions.get(identifier);
+    if (target) links.push(target);
+  }
+  return links;
+}
+
+/**
+ * Confirm that the requested path is carried by this message, tolerating the
+ * one representation change native URL APIs make for us: a file href with
+ * percent-encoded spaces arrives from iOS as a decoded filesystem path.
+ * Normalisation is applied only to rendered Markdown link targets, never to
+ * arbitrary prose in the message.
+ */
+export function messageReferencesFile(text: string, requested: string): boolean {
+  let wanted: string;
+  try {
+    wanted = resolve(referencedPath(requested));
+  } catch {
+    return false;
+  }
+
+  for (const target of renderedMarkdownTargets(text)) {
+    try {
+      if (resolve(referencedPath(target)) === wanted) return true;
+    } catch {
+      // A malformed candidate is not the link the client asked to open.
+    }
+  }
+  return false;
+}
+
+function containedBy(root: string, candidate: string): boolean {
+  const suffix = relative(root, candidate);
+  return suffix === "" || (suffix !== ".." && !suffix.startsWith(`..${sep}`) && !isAbsolute(suffix));
+}
+
+function mimeFor(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".md": return "text/markdown; charset=utf-8";
+    case ".txt": return "text/plain; charset=utf-8";
+    case ".csv": return "text/csv; charset=utf-8";
+    case ".tsv": return "text/tab-separated-values; charset=utf-8";
+    case ".json": return "application/json";
+    case ".pdf": return "application/pdf";
+    case ".rtf": return "application/rtf";
+    case ".png": return "image/png";
+    case ".jpg":
+    case ".jpeg": return "image/jpeg";
+    case ".gif": return "image/gif";
+    case ".webp": return "image/webp";
+    case ".doc": return "application/msword";
+    case ".docx": return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case ".xls": return "application/vnd.ms-excel";
+    case ".xlsx": return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    case ".ppt": return "application/vnd.ms-powerpoint";
+    case ".pptx": return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    default: return "application/octet-stream";
+  }
+}
+
+/**
+ * Open a message-linked file under one of the supplied roots. The returned
+ * handle, not the pathname, is what the caller streams. We canonicalise both
+ * before and after opening and compare the handle with the post-open path;
+ * this rejects symlink escapes and directory swaps instead of checking a
+ * path and then opening a potentially different file.
+ */
+export async function openMessageFile(href: string, roots: readonly string[]): Promise<OpenedMessageFile> {
+  const requested = referencedPath(href);
+  const canonicalRoots = (await Promise.all(roots.map(async (root) => {
+    try {
+      const canonical = await realpath(root);
+      return (await stat(canonical)).isDirectory() ? canonical : null;
+    } catch {
+      return null;
+    }
+  }))).filter((root): root is string => Boolean(root));
+
+  if (canonicalRoots.length === 0) throw statusError(404, "the linked file is unavailable");
+  const candidates = isAbsolute(requested)
+    ? [resolve(requested)]
+    : canonicalRoots.map((root) => resolve(root, requested));
+
+  let sawOutsideRoot = false;
+  for (const candidate of new Set(candidates)) {
+    let canonicalBefore: string;
+    try {
+      canonicalBefore = await realpath(candidate);
+    } catch {
+      continue;
+    }
+    const root = canonicalRoots.find((allowed) => containedBy(allowed, canonicalBefore));
+    if (!root) {
+      sawOutsideRoot = true;
+      continue;
+    }
+
+    let handle: FileHandle | undefined;
+    try {
+      const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+      handle = await open(canonicalBefore, constants.O_RDONLY | noFollow);
+      const opened = await handle.stat();
+      if (!opened.isFile()) throw statusError(400, "the link does not point to a regular file");
+      if (opened.size > MESSAGE_FILE_MAX_BYTES) {
+        throw statusError(413, `file exceeds ${MESSAGE_FILE_MAX_BYTES} bytes`);
+      }
+
+      const canonicalAfter = await realpath(candidate);
+      if (!containedBy(root, canonicalAfter)) throw statusError(403, "the linked file is outside this conversation's workspace");
+      const after = await stat(canonicalAfter);
+      if (opened.dev !== after.dev || opened.ino !== after.ino) {
+        throw statusError(409, "the linked file changed while it was being opened");
+      }
+
+      return {
+        handle,
+        bytes: opened.size,
+        name: basename(canonicalAfter),
+        mime: mimeFor(canonicalAfter),
+      };
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      if (error && typeof error === "object" && "status" in error) throw error;
+      continue;
+    }
+  }
+
+  if (sawOutsideRoot) throw statusError(403, "the linked file is outside this conversation's workspace");
+  throw statusError(404, "the linked file is unavailable");
+}
+
+/** A safe attachment header with a readable ASCII fallback and UTF-8 name. */
+export function messageFileDisposition(name: string): string {
+  const fallback = name
+    .normalize("NFKD")
+    .replace(/[^\x20-\x7e]/g, "_")
+    .replace(/["\\]/g, "_")
+    .slice(0, 180) || "download";
+  const encoded = encodeURIComponent(name).replace(/[!'()*]/g, (char) =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}


### PR DESCRIPTION
## Summary\n\n- add Photo Library and Choose File actions to the iOS chat composer, with removable previews and retry-safe sends\n- make bot-sent local file links open in a native iOS preview; Markdown and text render in-app, while other supported documents use Quick Look\n- add an authenticated, message-scoped download route that works through LAN, Tailscale, or secure HTTPS companion connections\n- share the attachment limits and validation with the existing Share extension and update the iOS privacy documentation\n\n## Security\n\n- only a file target rendered as a Markdown link in the exact stored bot message can be requested\n- the bot author and conversation are verified before deriving allowed workspace and attachment roots\n- canonical containment, no-follow handles, inode checks, regular-file checks, and a 25 MiB ceiling prevent traversal, symlink races, and unbounded downloads\n- responses are private/no-store and JSON files remain byte-for-byte intact through the companion proxy\n\n## Verification\n\n- 280 Swift tests passed\n- full OpenMausCompanion simulator build passed, including the Share extension and widget\n- 76 focused companion/server tests passed\n- message-file route integration passed\n- TypeScript typecheck, focused lint, and server build passed\n- isolated fixture doctor plus real send/wait/messages flow passed without touching live app data\n\nPhysical-device UI verification is still pending; the implementation and complete simulator target build are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iOS support for attaching photos and files to chat messages, with previews, validation, progress indicators, and retry-safe sending.
  * Added secure downloads and previews for files linked in bot messages, including sharing and temporary local storage.
  * Added support for Markdown, text, image, and document previews.
* **Bug Fixes**
  * File downloads now preserve binary content and enforce safe paths, size limits, filenames, and response handling.
* **Documentation**
  * Updated privacy documentation with attachment limits, temporary storage, and file-download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->