### PR TITLE
feat(plugins): manage custom MCP servers

### DIFF
--- a/docs/custom-mcp-servers.md
+++ b/docs/custom-mcp-servers.md
@@ -1,7 +1,20 @@
 # Bring your own MCP servers
 
-Give every capable engine extra tools by listing MCP servers in
-`~/.openmausbot/config.json` — the same shape Claude Code and friends use:
+Open **Plugins → MCP servers → Add server** to give your bots tools from a
+trusted local MCP server. Add the executable, put each argument on its own
+line, and add any environment variables as `KEY=value`.
+
+OpenMausBot saves a new server switched off. Use **Test** to start it briefly,
+complete the MCP handshake, and see the tools it advertises. Then turn it on.
+It becomes available to compatible bots on their next task; no app restart is
+needed.
+
+This first version supports local stdio commands. It deliberately does not
+accept remote MCP URLs or shell command strings.
+
+## Advanced: edit the file
+
+The same registry lives in `~/.openmausbot/config.json`:
 
 ```json
 {
@@ -15,9 +28,8 @@ Give every capable engine extra tools by listing MCP servers in
 }
 ```
 
-Restart the app after editing. Every bot whose engine can mount MCP servers
-(Claude, Codex, and all ACP engines — Grok, Gemini, Kimi, Droid, Cursor,
-opencode, Qwen, Hermes, and `customAcp`) gets the tools on its next turn.
+If you edit the file by hand, restart OpenMausBot. Every bot whose engine can
+mount custom MCP servers gets the enabled tools on its next task.
 
 ## Rules that keep this safe
 
@@ -32,11 +44,18 @@ opencode, Qwen, Hermes, and `customAcp`) gets the tools on its next turn.
   32 chars, starting with a letter.
 - **One bad entry never takes the fleet down.** Invalid entries are skipped
   with a logged reason; the rest still mount.
+- **Credentials are write-only in the UI.** The API returns environment names,
+  never their values. Leaving an existing value blank keeps it saved; removing
+  its line deletes it.
 - **Credentials stay off argv.** `env` values travel in the child
   environment (Codex argv carries env *names* only; Claude uses the private
   0600 mcp-config file; ACP passes them in the session payload with the
   wire log redacted). They do persist as plaintext in the 0600 config file —
   prefer tokens scoped to the one server.
+- **Testing is bounded.** The test command is stopped after the handshake (or
+  eight seconds), its output is capped, and its stderr is never sent to the UI.
+  It inherits none of OpenMausBot's workspace or provider credentials; only
+  the environment variables configured for that MCP server are added.
 - `"enabled": false` parks an entry without deleting it.
 - Stdio servers only for now — `url` transports are a planned follow-up and
   are skipped with a note.

--- a/server/config.ts
+++ b/server/config.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import { writeFileAtomic } from "./atomic.ts";
 import type { InstanceConfigMap } from "./contracts.ts";
+import { parseStoredMcpServer } from "./mcp-registry.ts";
 import { parseJson, schemaIssue, type JsonObject, type JsonValue } from "./schema.ts";
 
 const optionalText = z.string().optional();
@@ -592,6 +593,11 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   if (checkedPatch.vps !== undefined) disk.vps = normalizeVpsConfig(checkedPatch.vps);
   // scalar, not a section: the merge loop above only walks objects
   if (checkedPatch.language !== undefined) disk.language = checkedPatch.language;
+  // Custom MCP mutations go through their own dedicated local API, but
+  // saveConfig remains the single atomic persistence boundary.
+  if (checkedPatch.mcpServers !== undefined) {
+    disk.mcpServers = jsonObjectSchema.parse(checkedPatch.mcpServers);
+  }
   // the whole list is the unit of change: an add or a delete arrives as the
   // new list, never as a per-item merge
   if (checkedPatch.browserProfiles !== undefined) {
@@ -801,30 +807,6 @@ export interface CustomMcpServer {
   env: Record<string, string>;
 }
 
-const customMcpEntrySchema = z
-  .object({
-    command: z.string().min(1),
-    args: z.array(z.string()).optional(),
-    env: z.record(z.string(), z.string()).optional(),
-    enabled: z.boolean().optional(),
-  })
-  .strict();
-
-const CUSTOM_MCP_NAME = /^[a-z][a-z0-9_-]{0,31}$/;
-/** Server keys the harness mounts itself — a custom entry must never
- * shadow or clobber one of these across any driver's namespace. */
-const RESERVED_MCP_NAMES = new Set([
-  "ogb",
-  "computer",
-  "agents",
-  "composio",
-  "browser",
-  "phone",
-  "dweb",
-  "openmausbot_connectors",
-  "openmausbot_phone",
-]);
-
 const reportedMcpSkips = new Set<string>();
 function skipMcpEntry(name: string, why: string): void {
   const key = `${name}: ${why}`;
@@ -837,28 +819,20 @@ function skipMcpEntry(name: string, why: string): void {
 export function customMcpServers(cfg: AppConfig): Record<string, CustomMcpServer> {
   const out: Record<string, CustomMcpServer> = {};
   for (const [name, raw] of Object.entries(cfg.mcpServers ?? {})) {
-    if (!CUSTOM_MCP_NAME.test(name)) {
-      skipMcpEntry(name, "server names are lowercase letters, digits, _ or - (max 32 chars), starting with a letter");
-      continue;
-    }
-    if (RESERVED_MCP_NAMES.has(name)) {
-      skipMcpEntry(name, "that name is reserved for a built-in server — pick another");
-      continue;
-    }
     if (raw && typeof raw === "object" && "url" in raw) {
       skipMcpEntry(name, 'only stdio servers ("command") are supported so far — HTTP transports are a planned follow-up');
       continue;
     }
-    const parsed = customMcpEntrySchema.safeParse(raw);
-    if (!parsed.success) {
-      skipMcpEntry(name, `invalid entry (${parsed.error.issues[0]?.message ?? "schema mismatch"}) — expected { "command": "npx", "args": [...], "env": { ... } }`);
+    const parsed = parseStoredMcpServer(name, raw);
+    if (!parsed.ok) {
+      skipMcpEntry(name, `${parsed.error} Expected { "command": "npx", "args": [...], "env": { ... } }`);
       continue;
     }
-    if (parsed.data.enabled === false) continue;
+    if (!parsed.server.enabled) continue;
     out[name] = {
-      command: parsed.data.command,
-      args: parsed.data.args ?? [],
-      env: parsed.data.env ?? {},
+      command: parsed.server.command,
+      args: parsed.server.args,
+      env: parsed.server.env,
     };
   }
   return out;

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -22,6 +22,7 @@ import { FILE_MAX_BYTES, IMAGE_MAX_BYTES } from "./attachments.ts";
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
 const FAKE_CLAUDE_CLI = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+const FAKE_MCP_SERVER = join(SERVER_DIR, "testing", "fake-mcp-server.ts");
 const PORT = 18800 + Math.floor(Math.random() * 10_000);
 const BASE = `http://127.0.0.1:${PORT}`;
 const WEBHOOK_PORT = 39000 + Math.floor(Math.random() * 10_000);
@@ -2681,6 +2682,52 @@ describe("harness HTTP API", () => {
 
     const nothing = await api("PUT", "/api/config", {});
     expect(nothing.status).toBe(400);
+  });
+
+  it("manages and probes custom MCP servers without returning secret values", async () => {
+    const secret = "mcp-secret-that-must-never-render";
+    const created = await api("POST", "/api/mcp/servers", {
+      name: "fixture",
+      command: process.execPath,
+      args: ["--experimental-strip-types", FAKE_MCP_SERVER],
+      env: { FIXTURE_TOKEN: secret, REMOVE_ME: "old" },
+    });
+    expect(created.status).toBe(201);
+    expect(created.body.servers).toEqual([expect.objectContaining({
+      name: "fixture",
+      enabled: false,
+      envKeys: ["FIXTURE_TOKEN", "REMOVE_ME"],
+    })]);
+    expect(JSON.stringify(created.body)).not.toContain(secret);
+
+    const tested = await api("POST", "/api/mcp/servers/fixture/test");
+    expect(tested).toEqual({
+      status: 200,
+      body: { ok: true, tools: [{ name: "read_notes", description: "Read saved notes" }] },
+    });
+
+    const updated = await api("PUT", "/api/mcp/servers/fixture", {
+      command: process.execPath,
+      args: ["--experimental-strip-types", FAKE_MCP_SERVER],
+      env: { FIXTURE_TOKEN: true, NEXT: "fresh" },
+      enabled: false,
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.body.servers[0].envKeys).toEqual(["FIXTURE_TOKEN", "NEXT"]);
+    expect(JSON.stringify(updated.body)).not.toContain(secret);
+
+    const enabled = await api("PATCH", "/api/mcp/servers/fixture", { enabled: true });
+    expect(enabled.body.servers[0].enabled).toBe(true);
+    const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
+    expect(disk.mcpServers.fixture.env).toEqual({ FIXTURE_TOKEN: secret, NEXT: "fresh" });
+
+    const reserved = await api("POST", "/api/mcp/servers", { name: "computer", command: "evil" });
+    expect(reserved.status).toBe(400);
+
+    const removed = await api("DELETE", "/api/mcp/servers/fixture");
+    expect(removed).toEqual({ status: 200, body: { servers: [] } });
+    const after = await api("GET", "/api/mcp/servers");
+    expect(after).toEqual({ status: 200, body: { servers: [] } });
   });
 
   it("round-trips the UI language and clears it back to system", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -115,6 +115,13 @@ import {
 import { RETRY_MAX_ATTEMPTS } from "./drivers/retry.ts";
 import { decodeGeneratedImage } from "./generated-image.ts";
 import {
+  MAX_MCP_SERVERS,
+  listMcpServers,
+  parseMcpServerMutation,
+  parseStoredMcpServer,
+} from "./mcp-registry.ts";
+import { probeMcpServer } from "./mcp-probe.ts";
+import {
   GROUP_GOAL_MAX_TURNS,
   groupGoalAssignmentKey,
   groupGoalCompletionTurnId,
@@ -5073,6 +5080,19 @@ function configStatus() {
   };
 }
 
+function mcpServerResponse() {
+  return { servers: listMcpServers(cfg.mcpServers) };
+}
+
+function persistMcpServers(next: Record<string, unknown>): void {
+  saveConfig({ mcpServers: next });
+  // Do not reload the provider fleet: integrations are assembled from cfg at
+  // the next turn boundary. Updating this property directly also correctly
+  // clears the final entry; Object.assign(loadConfig()) would leave it stale
+  // when an empty section is omitted by an older config file.
+  cfg.mcpServers = next;
+}
+
 /** Rebuild the provider fleet after a config change so new keys take
  * effect without a server restart (kills any in-flight turns). */
 async function reloadProviders() {
@@ -5116,6 +5136,7 @@ async function reloadProviders() {
 // and reload sequence single-flight so two settings requests cannot drop one
 // another's changes or dispose a fleet while another reload is creating it.
 let providerConfigBusy = false;
+let mcpConfigBusy = false;
 // One updater per executable: multiple Claude instances can point at the same
 // install, and running two self-updates against it would race its files.
 const claudeUpdatesInFlight = new Set<string>();
@@ -8431,6 +8452,87 @@ const server = createServer(async (req, res) => {
         return json(res, 200, { instances: await registry.describe() });
       } finally {
         providerConfigBusy = false;
+      }
+    }
+
+    // ── custom MCP servers (stdio, local, secrets write-only) ──
+    if (method === "GET" && path === "/api/mcp/servers") {
+      return json(res, 200, mcpServerResponse());
+    }
+
+    const mcpTest = /^\/api\/mcp\/servers\/([a-z][a-z0-9_-]{0,31})\/test$/.exec(path);
+    if (method === "POST" && mcpTest) {
+      const raw = cfg.mcpServers?.[mcpTest[1]];
+      if (raw === undefined) return json(res, 404, { error: "MCP server not found." });
+      const parsed = parseStoredMcpServer(mcpTest[1], raw);
+      if (!parsed.ok) return json(res, 400, { error: parsed.error });
+      return json(res, 200, await probeMcpServer(parsed.server));
+    }
+
+    if (method === "POST" && path === "/api/mcp/servers") {
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      if (mcpConfigBusy) return json(res, 409, { error: "MCP servers are already being updated." });
+      mcpConfigBusy = true;
+      try {
+        const body = await readBody(req);
+        const name = typeof body?.name === "string" ? body.name : "";
+        const current = cfg.mcpServers ?? {};
+        if (Object.hasOwn(current, name)) return json(res, 409, { error: "An MCP server with that name already exists." });
+        if (Object.keys(current).length >= MAX_MCP_SERVERS) {
+          return json(res, 400, { error: `You can add at most ${MAX_MCP_SERVERS} MCP servers.` });
+        }
+        const parsed = parseMcpServerMutation(name, {
+          command: body?.command,
+          args: body?.args,
+          env: body?.env,
+          enabled: body?.enabled,
+        });
+        if (!parsed.ok) return json(res, 400, { error: parsed.error });
+        persistMcpServers({ ...current, [name]: parsed.server });
+        return json(res, 201, mcpServerResponse());
+      } finally {
+        mcpConfigBusy = false;
+      }
+    }
+
+    const mcpServerRoute = /^\/api\/mcp\/servers\/([a-z][a-z0-9_-]{0,31})$/.exec(path);
+    if (mcpServerRoute && ["PUT", "PATCH", "DELETE"].includes(method)) {
+      if (method !== "DELETE" && !String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      if (mcpConfigBusy) return json(res, 409, { error: "MCP servers are already being updated." });
+      mcpConfigBusy = true;
+      try {
+        const name = mcpServerRoute[1];
+        const current = cfg.mcpServers ?? {};
+        if (!Object.hasOwn(current, name)) return json(res, 404, { error: "MCP server not found." });
+        if (method === "DELETE") {
+          const next = { ...current };
+          delete next[name];
+          persistMcpServers(next);
+          return json(res, 200, mcpServerResponse());
+        }
+
+        const existing = parseStoredMcpServer(name, current[name]);
+        if (!existing.ok) return json(res, 400, { error: existing.error });
+        const body = await readBody(req);
+        if (method === "PATCH") {
+          if (!body || typeof body !== "object" || Array.isArray(body)
+            || Object.keys(body).length !== 1 || typeof body.enabled !== "boolean") {
+            return json(res, 400, { error: "Only an enabled boolean can be changed here." });
+          }
+          persistMcpServers({ ...current, [name]: { ...existing.server, enabled: body.enabled } });
+          return json(res, 200, mcpServerResponse());
+        }
+
+        const parsed = parseMcpServerMutation(name, body, existing.server);
+        if (!parsed.ok) return json(res, 400, { error: parsed.error });
+        persistMcpServers({ ...current, [name]: parsed.server });
+        return json(res, 200, mcpServerResponse());
+      } finally {
+        mcpConfigBusy = false;
       }
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5137,6 +5137,8 @@ async function reloadProviders() {
 // another's changes or dispose a fleet while another reload is creating it.
 let providerConfigBusy = false;
 let mcpConfigBusy = false;
+const MAX_CONCURRENT_MCP_PROBES = 2;
+let mcpProbesInFlight = 0;
 // One updater per executable: multiple Claude instances can point at the same
 // install, and running two self-updates against it would race its files.
 const claudeUpdatesInFlight = new Set<string>();
@@ -8466,7 +8468,21 @@ const server = createServer(async (req, res) => {
       if (raw === undefined) return json(res, 404, { error: "MCP server not found." });
       const parsed = parseStoredMcpServer(mcpTest[1], raw);
       if (!parsed.ok) return json(res, 400, { error: parsed.error });
-      return json(res, 200, await probeMcpServer(parsed.server));
+      if (mcpProbesInFlight >= MAX_CONCURRENT_MCP_PROBES) {
+        return json(res, 429, { error: "Two MCP connection tests are already running." });
+      }
+      const controller = new AbortController();
+      const disconnect = () => {
+        if (!res.writableEnded) controller.abort();
+      };
+      res.once("close", disconnect);
+      mcpProbesInFlight += 1;
+      try {
+        return json(res, 200, await probeMcpServer(parsed.server, undefined, controller.signal));
+      } finally {
+        res.off("close", disconnect);
+        mcpProbesInFlight -= 1;
+      }
     }
 
     if (method === "POST" && path === "/api/mcp/servers") {

--- a/server/mcp-probe.test.ts
+++ b/server/mcp-probe.test.ts
@@ -1,0 +1,56 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { probeMcpServer } from "./mcp-probe.ts";
+
+const fakeServer = fileURLToPath(new URL("./testing/fake-mcp-server.ts", import.meta.url));
+
+describe("custom MCP probe", () => {
+  it("performs an MCP handshake and returns the bounded public tool list", async () => {
+    await expect(probeMcpServer({
+      command: process.execPath,
+      args: ["--experimental-strip-types", fakeServer],
+      env: {},
+      enabled: false,
+    }, 2_000)).resolves.toEqual({
+      ok: true,
+      tools: [{ name: "read_notes", description: "Read saved notes" }],
+    });
+  });
+
+  it("times out a server that never completes initialization", async () => {
+    await expect(probeMcpServer({
+      command: process.execPath,
+      args: ["--experimental-strip-types", fakeServer],
+      env: { FAKE_MCP_MODE: "silent" },
+      enabled: false,
+    }, 100)).resolves.toEqual({ ok: false, error: "The server did not answer in time." });
+  });
+
+  it("does not expose native spawn details", async () => {
+    const result = await probeMcpServer({
+      command: "/definitely/missing/openmaus-mcp",
+      args: [],
+      env: { SECRET_TOKEN: "never-render-this" },
+      enabled: false,
+    }, 100);
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("SECRET_TOKEN");
+    expect(JSON.stringify(result)).not.toContain("never-render-this");
+    expect(JSON.stringify(result)).not.toContain("/definitely/missing");
+  });
+
+  it("redacts a configured value even if a server echoes it in tool metadata", async () => {
+    const result = await probeMcpServer({
+      command: process.execPath,
+      args: ["--experimental-strip-types", fakeServer],
+      env: { FAKE_MCP_DESCRIPTION: "token=very-secret-value" },
+      enabled: false,
+    }, 2_000);
+    expect(result).toEqual({
+      ok: true,
+      tools: [{ name: "read_notes", description: "[redacted]" }],
+    });
+    expect(JSON.stringify(result)).not.toContain("very-secret-value");
+  });
+});

--- a/server/mcp-probe.test.ts
+++ b/server/mcp-probe.test.ts
@@ -27,6 +27,18 @@ describe("custom MCP probe", () => {
     }, 100)).resolves.toEqual({ ok: false, error: "The server did not answer in time." });
   });
 
+  it("stops a probe when its caller disconnects", async () => {
+    const controller = new AbortController();
+    const pending = probeMcpServer({
+      command: process.execPath,
+      args: ["--experimental-strip-types", fakeServer],
+      env: { FAKE_MCP_MODE: "silent" },
+      enabled: false,
+    }, 2_000, controller.signal);
+    controller.abort();
+    await expect(pending).resolves.toEqual({ ok: false, error: "Connection test was cancelled." });
+  });
+
   it("does not expose native spawn details", async () => {
     const result = await probeMcpServer({
       command: "/definitely/missing/openmaus-mcp",

--- a/server/mcp-probe.ts
+++ b/server/mcp-probe.ts
@@ -1,0 +1,148 @@
+import { augmentedPath } from "./env-path.ts";
+import {
+  PROVIDER_CREDENTIAL_ENV,
+  stripWorkspaceCredentialEnv,
+} from "./config.ts";
+import { createLineSplitter } from "./mcp-bridge.ts";
+import type { StoredMcpServer } from "./mcp-registry.ts";
+import { killCliTree, spawnCli } from "./procs.ts";
+
+export interface McpProbeTool {
+  name: string;
+  description?: string;
+}
+
+export type McpProbeResult =
+  | { ok: true; tools: McpProbeTool[] }
+  | { ok: false; error: string };
+
+const MAX_STDOUT_BYTES = 1_048_576;
+const MAX_TOOLS = 100;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+function probeEnvironment(server: StoredMcpServer): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmentedPath() };
+  stripWorkspaceCredentialEnv(env);
+  for (const key of PROVIDER_CREDENTIAL_ENV) delete env[key];
+  Object.assign(env, server.env);
+  return env;
+}
+
+function publicProbeError(kind: "spawn" | "timeout" | "protocol" | "closed"): string {
+  if (kind === "spawn") return "Could not start this command. Check that it is installed and executable.";
+  if (kind === "timeout") return "The server did not answer in time.";
+  if (kind === "closed") return "The server stopped before the MCP handshake finished.";
+  return "The command did not return a valid MCP tools list.";
+}
+
+function redactConfiguredValues(value: string, env: Record<string, string>): string {
+  let redacted = value;
+  for (const secret of Object.values(env)) {
+    if (secret) redacted = redacted.split(secret).join("[redacted]");
+  }
+  return redacted;
+}
+
+/** Start one stdio server long enough to prove the MCP handshake and list its
+ * tools. It is always reaped, never inherits OpenMaus credentials, and never
+ * returns child stderr or environment values to the renderer. */
+export function probeMcpServer(
+  server: StoredMcpServer,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<McpProbeResult> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawnCli>;
+    try {
+      child = spawnCli(server.command, server.args, {
+        cwd: process.cwd(),
+        env: probeEnvironment(server),
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch {
+      resolve({ ok: false, error: publicProbeError("spawn") });
+      return;
+    }
+
+    let settled = false;
+    let stdoutBytes = 0;
+    let initialized = false;
+    const finish = (result: McpProbeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      killCliTree(child);
+      resolve(result);
+    };
+    const write = (frame: unknown) => {
+      try {
+        child.stdin.write(`${JSON.stringify(frame)}\n`);
+      } catch {
+        finish({ ok: false, error: publicProbeError("closed") });
+      }
+    };
+    const splitter = createLineSplitter((line) => {
+      if (settled || !line.trim()) return;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (!frame || typeof frame !== "object") return;
+      const value = frame as Record<string, unknown>;
+      if (value.id === 1 && value.result && !initialized) {
+        initialized = true;
+        write({ jsonrpc: "2.0", method: "notifications/initialized" });
+        write({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+        return;
+      }
+      if (value.id !== 2) return;
+      const result = value.result as { tools?: unknown } | undefined;
+      if (!Array.isArray(result?.tools)) {
+        finish({ ok: false, error: publicProbeError("protocol") });
+        return;
+      }
+      const tools: McpProbeTool[] = [];
+      for (const raw of result.tools.slice(0, MAX_TOOLS)) {
+        if (!raw || typeof raw !== "object") continue;
+        const candidate = raw as Record<string, unknown>;
+        if (typeof candidate.name !== "string" || !candidate.name.trim()) continue;
+        tools.push({
+          name: redactConfiguredValues(candidate.name, server.env).slice(0, 200),
+          ...(typeof candidate.description === "string"
+            ? { description: redactConfiguredValues(candidate.description, server.env).slice(0, 500) }
+            : {}),
+        });
+      }
+      finish({ ok: true, tools });
+    });
+
+    const timer = setTimeout(() => {
+      finish({ ok: false, error: publicProbeError("timeout") });
+    }, timeoutMs);
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.byteLength;
+      if (stdoutBytes > MAX_STDOUT_BYTES) {
+        finish({ ok: false, error: publicProbeError("protocol") });
+        return;
+      }
+      splitter.push(chunk);
+    });
+    // Drain without retaining it. Child stderr often contains secrets or
+    // arbitrary native logs and is not part of the MCP protocol.
+    child.stderr.resume();
+    child.once("error", () => finish({ ok: false, error: publicProbeError("spawn") }));
+    child.once("close", () => finish({ ok: false, error: publicProbeError("closed") }));
+
+    write({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "OpenMausBot", version: "probe" },
+      },
+    });
+  });
+}

--- a/server/mcp-probe.ts
+++ b/server/mcp-probe.ts
@@ -28,10 +28,11 @@ function probeEnvironment(server: StoredMcpServer): NodeJS.ProcessEnv {
   return env;
 }
 
-function publicProbeError(kind: "spawn" | "timeout" | "protocol" | "closed"): string {
+function publicProbeError(kind: "spawn" | "timeout" | "protocol" | "closed" | "cancelled"): string {
   if (kind === "spawn") return "Could not start this command. Check that it is installed and executable.";
   if (kind === "timeout") return "The server did not answer in time.";
   if (kind === "closed") return "The server stopped before the MCP handshake finished.";
+  if (kind === "cancelled") return "Connection test was cancelled.";
   return "The command did not return a valid MCP tools list.";
 }
 
@@ -49,8 +50,14 @@ function redactConfiguredValues(value: string, env: Record<string, string>): str
 export function probeMcpServer(
   server: StoredMcpServer,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  signal?: AbortSignal,
 ): Promise<McpProbeResult> {
   return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve({ ok: false, error: publicProbeError("cancelled") });
+      return;
+    }
+
     let child: ReturnType<typeof spawnCli>;
     try {
       child = spawnCli(server.command, server.args, {
@@ -66,10 +73,13 @@ export function probeMcpServer(
     let settled = false;
     let stdoutBytes = 0;
     let initialized = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => finish({ ok: false, error: publicProbeError("cancelled") });
     const finish = (result: McpProbeResult) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       killCliTree(child);
       resolve(result);
     };
@@ -117,9 +127,10 @@ export function probeMcpServer(
       finish({ ok: true, tools });
     });
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       finish({ ok: false, error: publicProbeError("timeout") });
     }, timeoutMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
     child.stdout.on("data", (chunk: Buffer) => {
       stdoutBytes += chunk.byteLength;
       if (stdoutBytes > MAX_STDOUT_BYTES) {
@@ -133,6 +144,11 @@ export function probeMcpServer(
     child.stderr.resume();
     child.once("error", () => finish({ ok: false, error: publicProbeError("spawn") }));
     child.once("close", () => finish({ ok: false, error: publicProbeError("closed") }));
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
 
     write({
       jsonrpc: "2.0",

--- a/server/mcp-registry.test.ts
+++ b/server/mcp-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  listMcpServers,
+  mcpServerNameError,
+  parseMcpServerMutation,
+  parseStoredMcpServer,
+} from "./mcp-registry.ts";
+
+describe("custom MCP registry", () => {
+  it("parses stdio servers and keeps newly added commands disabled", () => {
+    expect(parseMcpServerMutation("notes", { command: "npx", args: ["-y", "notes-mcp"] })).toEqual({
+      ok: true,
+      server: { command: "npx", args: ["-y", "notes-mcp"], env: {}, enabled: false },
+    });
+    expect(parseStoredMcpServer("notes", { command: "npx" })).toEqual({
+      ok: true,
+      server: { command: "npx", args: [], env: {}, enabled: true },
+    });
+  });
+
+  it("refuses unsafe and reserved routing names", () => {
+    expect(mcpServerNameError("Bad.Name")).toMatch(/lowercase/);
+    expect(mcpServerNameError("computer")).toMatch(/reserved/);
+    expect(mcpServerNameError("safe-notes")).toBeNull();
+  });
+
+  it("never puts environment values in renderer listings", () => {
+    const listings = listMcpServers({
+      github: { command: "github-mcp", env: { GITHUB_TOKEN: "ghp_real", MODE: "read-only" } },
+    });
+    expect(listings).toEqual([{
+      name: "github",
+      command: "github-mcp",
+      args: [],
+      envKeys: ["GITHUB_TOKEN", "MODE"],
+      enabled: true,
+    }]);
+    expect(JSON.stringify(listings)).not.toContain("ghp_real");
+    expect(JSON.stringify(listings)).not.toContain("read-only");
+  });
+
+  it("preserves write-only values only when a matching value is stored", () => {
+    const existing = { command: "old", args: [], env: { TOKEN: "secret", DROP: "gone" }, enabled: true };
+    expect(parseMcpServerMutation("notes", {
+      command: "new",
+      env: { TOKEN: true, NEXT: "fresh" },
+      enabled: true,
+    }, existing)).toEqual({
+      ok: true,
+      server: { command: "new", args: [], env: { TOKEN: "secret", NEXT: "fresh" }, enabled: true },
+    });
+    expect(parseMcpServerMutation("notes", { command: "new", env: { MISSING: true } }, existing)).toEqual({
+      ok: false,
+      error: "No saved value exists for MISSING.",
+    });
+  });
+
+});

--- a/server/mcp-registry.ts
+++ b/server/mcp-registry.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+
+export interface StoredMcpServer {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  enabled: boolean;
+}
+
+export interface McpServerListing {
+  name: string;
+  command: string;
+  args: string[];
+  envKeys: string[];
+  enabled: boolean;
+}
+
+export const MAX_MCP_SERVERS = 20;
+const MAX_ARGS = 64;
+const MAX_ENV = 64;
+const MCP_NAME = /^[a-z][a-z0-9_-]{0,31}$/;
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const RESERVED_MCP_NAMES = new Set([
+  "ogb",
+  "computer",
+  "agents",
+  "composio",
+  "browser",
+  "phone",
+  "dweb",
+  "openmausbot_connectors",
+  "openmausbot_phone",
+]);
+
+const storedEntrySchema = z.object({
+  command: z.string().trim().min(1).max(1_024),
+  args: z.array(z.string().max(4_096)).max(MAX_ARGS).optional(),
+  env: z.record(z.string(), z.string().max(16_384)).optional(),
+  enabled: z.boolean().optional(),
+}).strict();
+
+const mutationEntrySchema = storedEntrySchema.extend({
+  env: z.record(z.string(), z.union([z.string().max(16_384), z.literal(true)])).optional(),
+});
+
+export function mcpServerNameError(name: string): string | null {
+  if (!MCP_NAME.test(name)) {
+    return "Use 1–32 lowercase letters, numbers, underscores, or hyphens, starting with a letter.";
+  }
+  if (RESERVED_MCP_NAMES.has(name)) return "That name is reserved by OpenMausBot.";
+  return null;
+}
+
+export function parseStoredMcpServer(
+  name: string,
+  raw: unknown,
+): { ok: true; server: StoredMcpServer } | { ok: false; error: string } {
+  const nameError = mcpServerNameError(name);
+  if (nameError) return { ok: false, error: nameError };
+  const parsed = storedEntrySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid MCP server." };
+  }
+  const env = parsed.data.env ?? {};
+  const invalidEnv = Object.keys(env).find((key) => !ENV_NAME.test(key));
+  if (invalidEnv) return { ok: false, error: `Environment variable “${invalidEnv}” is not valid.` };
+  if (Object.keys(env).length > MAX_ENV) {
+    return { ok: false, error: `Use at most ${MAX_ENV} environment variables.` };
+  }
+  return {
+    ok: true,
+    server: {
+      command: parsed.data.command,
+      args: parsed.data.args ?? [],
+      env,
+      enabled: parsed.data.enabled !== false,
+    },
+  };
+}
+
+/** Parse a renderer mutation. `true` is a write-only placeholder meaning
+ * “keep this already stored value”; it is never accepted for a new key. */
+export function parseMcpServerMutation(
+  name: string,
+  raw: unknown,
+  existing?: StoredMcpServer,
+): { ok: true; server: StoredMcpServer } | { ok: false; error: string } {
+  const nameError = mcpServerNameError(name);
+  if (nameError) return { ok: false, error: nameError };
+  const parsed = mutationEntrySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid MCP server." };
+  }
+  const incomingEnv = parsed.data.env ?? {};
+  const invalidEnv = Object.keys(incomingEnv).find((key) => !ENV_NAME.test(key));
+  if (invalidEnv) return { ok: false, error: `Environment variable “${invalidEnv}” is not valid.` };
+  if (Object.keys(incomingEnv).length > MAX_ENV) {
+    return { ok: false, error: `Use at most ${MAX_ENV} environment variables.` };
+  }
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(incomingEnv)) {
+    if (value === true) {
+      const saved = existing?.env[key];
+      if (saved === undefined) return { ok: false, error: `No saved value exists for ${key}.` };
+      env[key] = saved;
+    } else {
+      env[key] = value;
+    }
+  }
+  return {
+    ok: true,
+    server: {
+      command: parsed.data.command,
+      args: parsed.data.args ?? [],
+      env,
+      // A newly added command is inert until the person has tested and
+      // explicitly enabled it. Existing file-authored entries keep today's
+      // enabled-by-default behavior through parseStoredMcpServer.
+      enabled: existing ? (parsed.data.enabled ?? existing.enabled) : false,
+    },
+  };
+}
+
+export function listMcpServers(raw: Record<string, unknown> | undefined): McpServerListing[] {
+  return Object.entries(raw ?? {}).flatMap(([name, value]) => {
+    const parsed = parseStoredMcpServer(name, value);
+    if (!parsed.ok) return [];
+    return [{
+      name,
+      command: parsed.server.command,
+      args: parsed.server.args,
+      envKeys: Object.keys(parsed.server.env).sort(),
+      enabled: parsed.server.enabled,
+    }];
+  });
+}

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -87,6 +87,9 @@ describe("scopes", () => {
     expect(requiredScope("GET", "/api/config")).toBe("client");
     expect(requiredScope("POST", "/api/instances")).toBe("admin");
     expect(requiredScope("GET", "/api/instances")).toBe("client");
+    expect(requiredScope("POST", "/api/mcp/servers")).toBe("admin");
+    expect(requiredScope("POST", "/api/mcp/servers/github/test")).toBe("admin");
+    expect(requiredScope("GET", "/api/mcp/servers")).toBe("client");
     expect(requiredScope("POST", "/api/bots/x/messages")).toBe("client");
     expect(requiredScope("POST", "/api/auth/pair")).toBe("client");
     expect(requiredScope("POST", "/api/auth/stream-ticket")).toBe("client");
@@ -173,6 +176,13 @@ describe("resolveRequestAuth", () => {
     const denied = resolve({ host: "bots.example.com", authorization: `Bearer ${token}` }, "/api/auth/pairing", "POST");
     expect(denied.status).toBe(403);
     expect(denied.error).toContain("lacks the admin scope");
+    const mcpDenied = resolve(
+      { host: "bots.example.com", authorization: `Bearer ${token}` },
+      "/api/mcp/servers/github/test",
+      "POST",
+    );
+    expect(mcpDenied.status).toBe(403);
+    expect(mcpDenied.error).toContain("lacks the admin scope");
     expect(resolve({ host: "bots.example.com", authorization: `Bearer ${token}` }, "/api/bots").auth?.kind).toBe("session");
   });
 

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -160,7 +160,7 @@ const ADMIN_ROUTES: ReadonlyArray<{ methods: readonly string[] | null; path: Reg
   { methods: null, path: /^\/api\/auth\/pairing(\/|$)/ },
   { methods: null, path: /^\/api\/auth\/sessions(\/|$)/ },
   { methods: ["PUT", "PATCH", "DELETE"], path: /^\/api\/config$/ },
-  { methods: ["POST", "PUT", "PATCH", "DELETE"], path: /^\/api\/(instances|engines|mcp-servers|custom-engines)(\/|$)/ },
+  { methods: ["POST", "PUT", "PATCH", "DELETE"], path: /^\/api\/(instances|engines|mcp-servers|mcp\/servers|custom-engines)(\/|$)/ },
 ];
 
 export function requiredScope(method: string, path: string): Scope {

--- a/server/testing/fake-mcp-server.ts
+++ b/server/testing/fake-mcp-server.ts
@@ -1,0 +1,31 @@
+import { createInterface } from "node:readline";
+
+const mode = process.env.FAKE_MCP_MODE ?? "healthy";
+if (mode === "silent") setInterval(() => {}, 60_000);
+else {
+  const lines = createInterface({ input: process.stdin });
+  lines.on("line", (line) => {
+    const frame = JSON.parse(line) as { id?: number; method?: string };
+    if (frame.method === "initialize") {
+      process.stdout.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: frame.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "fake-mcp", version: "1" },
+        },
+      })}\n`);
+    }
+    if (frame.method === "tools/list") {
+      process.stdout.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: frame.id,
+        result: { tools: [{
+          name: "read_notes",
+          description: process.env.FAKE_MCP_DESCRIPTION ?? "Read saved notes",
+        }] },
+      })}\n`);
+    }
+  });
+}

--- a/src/components/McpServersPanel.test.ts
+++ b/src/components/McpServersPanel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMcpArguments, parseMcpEnvironment } from "./McpServersPanel";
+
+describe("MCP server form", () => {
+  it("uses one explicit argument per line", () => {
+    expect(parseMcpArguments("-y\n  @scope/server  \n\n--read-only")).toEqual([
+      "-y",
+      "@scope/server",
+      "--read-only",
+    ]);
+  });
+
+  it("preserves write-only saved values without putting them back in the form", () => {
+    expect(parseMcpEnvironment("TOKEN=\nMODE=read-only", ["TOKEN"])).toEqual({
+      ok: true,
+      env: { TOKEN: true, MODE: "read-only" },
+    });
+  });
+
+  it("rejects malformed and duplicate environment names", () => {
+    expect(parseMcpEnvironment("NOT A KEY=value")).toEqual({
+      ok: false,
+      error: "“NOT A KEY” is not a valid environment variable.",
+    });
+    expect(parseMcpEnvironment("TOKEN=one\nTOKEN=two")).toEqual({
+      ok: false,
+      error: "“TOKEN” is listed more than once.",
+    });
+  });
+});

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -214,7 +214,7 @@ export function McpServersPanel() {
             <button
               type="button"
               onClick={() => void load()}
-              disabled={busy === "load"}
+              disabled={busy !== null}
               className="rounded-lg p-2 text-ink-secondary transition-colors hover:bg-raised hover:text-ink disabled:opacity-40"
               aria-label="Refresh MCP servers"
             >
@@ -222,13 +222,14 @@ export function McpServersPanel() {
             </button>
             <button
               type="button"
+              disabled={busy !== null}
               onClick={() => {
                 setEditing("new");
                 setDraft(EMPTY_DRAFT);
                 setError(null);
                 setNotice(null);
               }}
-              className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-medium text-white"
+              className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-medium text-white disabled:opacity-40"
             >
               <Plus size={14} /> Add server
             </button>
@@ -294,7 +295,7 @@ export function McpServersPanel() {
               <button type="button" onClick={closeEditor} className="rounded-lg px-3 py-2 text-[12.5px] text-ink-secondary hover:bg-raised">Cancel</button>
               <button
                 type="button"
-                disabled={busy === "save"}
+                disabled={busy !== null}
                 onClick={() => void save()}
                 className="flex items-center gap-1.5 rounded-lg bg-accent px-3.5 py-2 text-[12.5px] font-medium text-white disabled:opacity-50"
               >

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  CirclePower,
+  FlaskConical,
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  ServerCog,
+  Trash2,
+} from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import { api } from "@/state/store";
+
+export interface McpServerListing {
+  name: string;
+  command: string;
+  args: string[];
+  envKeys: string[];
+  enabled: boolean;
+}
+
+interface McpDraft {
+  name: string;
+  command: string;
+  args: string;
+  env: string;
+}
+
+interface ProbeResult {
+  ok: boolean;
+  tools?: Array<{ name: string; description?: string }>;
+  error?: string;
+}
+
+const EMPTY_DRAFT: McpDraft = { name: "", command: "", args: "", env: "" };
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function parseMcpArguments(value: string): string[] {
+  return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+export function parseMcpEnvironment(
+  value: string,
+  savedKeys: readonly string[] = [],
+): { ok: true; env: Record<string, string | true> } | { ok: false; error: string } {
+  const saved = new Set(savedKeys);
+  const env: Record<string, string | true> = {};
+  for (const original of value.split(/\r?\n/)) {
+    const line = original.trim();
+    if (!line) continue;
+    const equals = line.indexOf("=");
+    if (equals <= 0) return { ok: false, error: `Use KEY=value for “${line}”.` };
+    const key = line.slice(0, equals).trim();
+    const secret = line.slice(equals + 1);
+    if (!ENV_NAME.test(key)) return { ok: false, error: `“${key}” is not a valid environment variable.` };
+    if (Object.hasOwn(env, key)) return { ok: false, error: `“${key}” is listed more than once.` };
+    env[key] = secret === "" && saved.has(key) ? true : secret;
+  }
+  return { ok: true, env };
+}
+
+function draftFor(server: McpServerListing): McpDraft {
+  return {
+    name: server.name,
+    command: server.command,
+    args: server.args.join("\n"),
+    // Values are intentionally never returned by the server. A blank value
+    // beside an existing key is a write-only “keep saved value” placeholder.
+    env: server.envKeys.map((key) => `${key}=`).join("\n"),
+  };
+}
+
+export function McpServersPanel() {
+  const [servers, setServers] = useState<McpServerListing[] | null>(null);
+  const [editing, setEditing] = useState<string | "new" | null>(null);
+  const [draft, setDraft] = useState<McpDraft>(EMPTY_DRAFT);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [probe, setProbe] = useState<Record<string, ProbeResult>>({});
+
+  const load = useCallback(() => {
+    setBusy("load");
+    setError(null);
+    return api("/api/mcp/servers")
+      .then((result) => setServers(result.servers ?? []))
+      .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
+      .finally(() => setBusy(null));
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const closeEditor = () => {
+    setEditing(null);
+    setDraft(EMPTY_DRAFT);
+  };
+
+  const save = async () => {
+    const name = draft.name.trim();
+    const command = draft.command.trim();
+    if (!name || !command) {
+      setError("Add a server name and executable command.");
+      return;
+    }
+    const existing = editing === "new" ? undefined : servers?.find((server) => server.name === editing);
+    const parsedEnv = parseMcpEnvironment(draft.env, existing?.envKeys);
+    if (!parsedEnv.ok) {
+      setError(parsedEnv.error);
+      return;
+    }
+    setBusy("save");
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await api(
+        editing === "new" ? "/api/mcp/servers" : `/api/mcp/servers/${encodeURIComponent(name)}`,
+        {
+          method: editing === "new" ? "POST" : "PUT",
+          body: JSON.stringify({
+            ...(editing === "new" ? { name } : {}),
+            command,
+            args: parseMcpArguments(draft.args),
+            env: parsedEnv.env,
+            ...(existing ? { enabled: existing.enabled } : {}),
+          }),
+        },
+      );
+      setServers(result.servers ?? []);
+      setNotice(editing === "new"
+        ? `${name} was saved off. Test it, then turn it on when you are ready.`
+        : `${name} was updated.`);
+      closeEditor();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggle = async (server: McpServerListing) => {
+    setBusy(`toggle:${server.name}`);
+    setError(null);
+    try {
+      const result = await api(`/api/mcp/servers/${server.name}`, {
+        method: "PATCH",
+        body: JSON.stringify({ enabled: !server.enabled }),
+      });
+      setServers(result.servers ?? []);
+      setNotice(`${server.name} is now ${server.enabled ? "off" : "on"}. New tasks will use this change.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const test = async (server: McpServerListing) => {
+    setBusy(`test:${server.name}`);
+    setError(null);
+    setProbe((current) => {
+      const next = { ...current };
+      delete next[server.name];
+      return next;
+    });
+    try {
+      const result: ProbeResult = await api(`/api/mcp/servers/${server.name}/test`, { method: "POST" });
+      setProbe((current) => ({ ...current, [server.name]: result }));
+    } catch (cause) {
+      setProbe((current) => ({
+        ...current,
+        [server.name]: { ok: false, error: cause instanceof Error ? cause.message : String(cause) },
+      }));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const remove = async (server: McpServerListing) => {
+    if (!window.confirm(`Remove the “${server.name}” MCP server?`)) return;
+    setBusy(`delete:${server.name}`);
+    setError(null);
+    try {
+      const result = await api(`/api/mcp/servers/${server.name}`, { method: "DELETE" });
+      setServers(result.servers ?? []);
+      setProbe((current) => {
+        const next = { ...current };
+        delete next[server.name];
+        return next;
+      });
+      if (editing === server.name) closeEditor();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-7 pt-5 sm:px-8">
+      <div className="mx-auto max-w-[840px]">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="text-[15px] font-semibold text-ink">Your MCP servers</h3>
+            <p className="mt-1 max-w-[610px] text-[12.5px] leading-relaxed text-ink-secondary">
+              Add a local stdio MCP command once and every compatible bot can use its tools. Tool calls still follow your normal approval settings.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={busy === "load"}
+              className="rounded-lg p-2 text-ink-secondary transition-colors hover:bg-raised hover:text-ink disabled:opacity-40"
+              aria-label="Refresh MCP servers"
+            >
+              <RefreshCw size={16} className={cn(busy === "load" && "animate-spin")} />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditing("new");
+                setDraft(EMPTY_DRAFT);
+                setError(null);
+                setNotice(null);
+              }}
+              className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-medium text-white"
+            >
+              <Plus size={14} /> Add server
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl border border-hairline/50 bg-raised/35 px-4 py-3 text-[12px] leading-relaxed text-ink-secondary">
+          MCP commands run on this computer with the environment variables you provide. Only add software you trust. New servers stay off until you enable them.
+        </div>
+
+        {error && <div role="alert" className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12px] text-danger">{error}</div>}
+        {notice && <div role="status" className="mt-3 rounded-lg bg-success/10 px-3 py-2 text-[12px] text-success">{notice}</div>}
+
+        {editing && (
+          <div className="mt-4 rounded-2xl border border-hairline/60 bg-card p-4 sm:p-5">
+            <div className="text-[14px] font-medium text-ink">{editing === "new" ? "Add MCP server" : `Edit ${editing}`}</div>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="text-[12px] font-medium text-ink-secondary">Server name</span>
+                <input
+                  autoFocus={editing === "new"}
+                  disabled={editing !== "new"}
+                  value={draft.name}
+                  maxLength={32}
+                  onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value.toLowerCase() }))}
+                  placeholder="github"
+                  className="mt-1.5 w-full rounded-lg border border-hairline/60 bg-raised px-3 py-2.5 text-[13px] text-ink outline-none focus:border-accent disabled:opacity-60"
+                />
+              </label>
+              <label className="block">
+                <span className="text-[12px] font-medium text-ink-secondary">Executable command</span>
+                <input
+                  autoFocus={editing !== "new"}
+                  value={draft.command}
+                  onChange={(event) => setDraft((current) => ({ ...current, command: event.target.value }))}
+                  placeholder="npx"
+                  className="mt-1.5 w-full rounded-lg border border-hairline/60 bg-raised px-3 py-2.5 text-[13px] text-ink outline-none focus:border-accent"
+                />
+              </label>
+              <label className="block">
+                <span className="text-[12px] font-medium text-ink-secondary">Arguments · one per line</span>
+                <textarea
+                  value={draft.args}
+                  onChange={(event) => setDraft((current) => ({ ...current, args: event.target.value }))}
+                  placeholder={"-y\n@modelcontextprotocol/server-github"}
+                  rows={5}
+                  className="mt-1.5 w-full resize-y rounded-lg border border-hairline/60 bg-raised px-3 py-2.5 font-mono text-[12px] text-ink outline-none focus:border-accent"
+                />
+              </label>
+              <label className="block">
+                <span className="text-[12px] font-medium text-ink-secondary">Environment · KEY=value per line</span>
+                <textarea
+                  value={draft.env}
+                  onChange={(event) => setDraft((current) => ({ ...current, env: event.target.value }))}
+                  placeholder="GITHUB_TOKEN=…"
+                  rows={5}
+                  className="mt-1.5 w-full resize-y rounded-lg border border-hairline/60 bg-raised px-3 py-2.5 font-mono text-[12px] text-ink outline-none focus:border-accent"
+                />
+                {editing !== "new" && <span className="mt-1.5 block text-[11px] text-ink-secondary">Leave an existing value blank to keep it saved. Remove the line to delete it.</span>}
+              </label>
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <button type="button" onClick={closeEditor} className="rounded-lg px-3 py-2 text-[12.5px] text-ink-secondary hover:bg-raised">Cancel</button>
+              <button
+                type="button"
+                disabled={busy === "save"}
+                onClick={() => void save()}
+                className="flex items-center gap-1.5 rounded-lg bg-accent px-3.5 py-2 text-[12.5px] font-medium text-white disabled:opacity-50"
+              >
+                {busy === "save" && <Loader2 size={13} className="animate-spin" />} Save
+              </button>
+            </div>
+          </div>
+        )}
+
+        {servers === null ? (
+          <div className="flex items-center justify-center gap-2 py-24 text-[13px] text-ink-secondary"><Loader2 size={14} className="animate-spin" /> Loading MCP servers…</div>
+        ) : servers.length === 0 && !editing ? (
+          <div className="mt-5 flex min-h-64 flex-col items-center justify-center rounded-2xl border border-dashed border-hairline/60 text-center">
+            <div className="flex size-11 items-center justify-center rounded-xl bg-raised text-ink-secondary"><ServerCog size={21} /></div>
+            <div className="mt-3 text-[14px] font-medium text-ink">No custom MCP servers yet</div>
+            <div className="mt-1 max-w-sm text-[12.5px] text-ink-secondary">Add a trusted stdio MCP server to give your bots more tools.</div>
+          </div>
+        ) : (
+          <div className="mt-5 space-y-3">
+            {servers.map((server) => {
+              const result = probe[server.name];
+              return (
+                <div key={server.name} className="rounded-2xl border border-hairline/50 bg-card px-4 py-4 sm:px-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                    <div className={cn("flex size-10 shrink-0 items-center justify-center rounded-xl", server.enabled ? "bg-success/10 text-success" : "bg-raised text-ink-secondary")}>
+                      <ServerCog size={19} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-[14px] font-medium text-ink">{server.name}</span>
+                        <span className={cn("rounded-full px-2 py-0.5 text-[10.5px]", server.enabled ? "bg-success/10 text-success" : "bg-raised text-ink-secondary")}>{server.enabled ? "On" : "Off"}</span>
+                      </div>
+                      <div className="mt-1 truncate font-mono text-[11.5px] text-ink-secondary">{[server.command, ...server.args].join(" ")}</div>
+                      {server.envKeys.length > 0 && <div className="mt-1 truncate text-[11px] text-ink-secondary">Secrets saved: {server.envKeys.join(", ")}</div>}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button type="button" disabled={busy !== null} onClick={() => void test(server)} className="flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40">
+                        {busy === `test:${server.name}` ? <Loader2 size={14} className="animate-spin" /> : <FlaskConical size={14} />} Test
+                      </button>
+                      <button type="button" disabled={busy !== null} onClick={() => void toggle(server)} className="flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-[12px] text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40" aria-label={`Turn ${server.name} ${server.enabled ? "off" : "on"}`}>
+                        {busy === `toggle:${server.name}` ? <Loader2 size={14} className="animate-spin" /> : <CirclePower size={14} />} {server.enabled ? "Turn off" : "Turn on"}
+                      </button>
+                      <button type="button" disabled={busy !== null} onClick={() => { setEditing(server.name); setDraft(draftFor(server)); setError(null); setNotice(null); }} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-40" aria-label={`Edit ${server.name}`}><Pencil size={14} /></button>
+                      <button type="button" disabled={busy !== null} onClick={() => void remove(server)} className="rounded-lg p-2 text-ink-secondary hover:bg-danger/10 hover:text-danger disabled:opacity-40" aria-label={`Remove ${server.name}`}><Trash2 size={14} /></button>
+                    </div>
+                  </div>
+                  {result && (
+                    <div role="status" className={cn("mt-3 rounded-lg px-3 py-2 text-[12px]", result.ok ? "bg-success/10 text-success" : "bg-danger/10 text-danger")}>
+                      {result.ok ? (
+                        <span className="flex items-start gap-2"><CheckCircle2 size={14} className="mt-px shrink-0" /> Connected{result.tools?.length ? ` · ${result.tools.length} tool${result.tools.length === 1 ? "" : "s"}: ${result.tools.map((tool) => tool.name).join(", ")}` : " · no tools advertised"}</span>
+                      ) : result.error}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   CheckCircle2,
   CirclePower,
@@ -81,14 +81,22 @@ export function McpServersPanel() {
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [probe, setProbe] = useState<Record<string, ProbeResult>>({});
+  const loadGeneration = useRef(0);
 
   const load = useCallback(() => {
+    const generation = ++loadGeneration.current;
     setBusy("load");
     setError(null);
     return api("/api/mcp/servers")
-      .then((result) => setServers(result.servers ?? []))
-      .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
-      .finally(() => setBusy(null));
+      .then((result) => {
+        if (generation === loadGeneration.current) setServers(result.servers ?? []);
+      })
+      .catch((cause) => {
+        if (generation === loadGeneration.current) setError(cause instanceof Error ? cause.message : String(cause));
+      })
+      .finally(() => {
+        if (generation === loadGeneration.current) setBusy(null);
+      });
   }, []);
 
   useEffect(() => {
@@ -114,6 +122,7 @@ export function McpServersPanel() {
       return;
     }
     setBusy("save");
+    loadGeneration.current += 1;
     setError(null);
     setNotice(null);
     try {
@@ -144,6 +153,7 @@ export function McpServersPanel() {
 
   const toggle = async (server: McpServerListing) => {
     setBusy(`toggle:${server.name}`);
+    loadGeneration.current += 1;
     setError(null);
     try {
       const result = await api(`/api/mcp/servers/${server.name}`, {
@@ -161,6 +171,7 @@ export function McpServersPanel() {
 
   const test = async (server: McpServerListing) => {
     setBusy(`test:${server.name}`);
+    loadGeneration.current += 1;
     setError(null);
     setProbe((current) => {
       const next = { ...current };
@@ -183,6 +194,7 @@ export function McpServersPanel() {
   const remove = async (server: McpServerListing) => {
     if (!window.confirm(`Remove the “${server.name}” MCP server?`)) return;
     setBusy(`delete:${server.name}`);
+    loadGeneration.current += 1;
     setError(null);
     try {
       const result = await api(`/api/mcp/servers/${server.name}`, { method: "DELETE" });

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -7,6 +7,7 @@ import { Check, Loader2, RefreshCw, Search, TriangleAlert, X } from "lucide-reac
 import { api, useStore } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { readCachedInventory, writeCachedInventory } from "@/lib/connected-apps-cache";
+import { McpServersPanel } from "./McpServersPanel";
 
 interface ToolkitCard {
   slug: string;
@@ -193,6 +194,7 @@ function ServiceIcon({ card }: { card: ToolkitCard }) {
 export function PluginsPanel() {
   const { dispatch } = useStore();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [surface, setSurface] = useState<"apps" | "mcp">("apps");
   const [cards, setCards] = useState<ToolkitCard[] | null>(null);
   const [source, setSource] = useState<"api" | "curated">("curated");
   const [configured, setConfigured] = useState(true);
@@ -476,27 +478,29 @@ export function PluginsPanel() {
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="connected-apps-title"
+        aria-labelledby="plugins-title"
         tabIndex={-1}
         className="animate-pop-in flex h-[min(780px,calc(100dvh-2rem))] w-full max-w-[1040px] flex-col overflow-hidden rounded-[24px] border border-hairline/50 bg-panel shadow-2xl shadow-black/50"
       >
         <header className="flex items-start justify-between gap-4 px-6 pb-3 pt-6 sm:px-8 sm:pt-7">
           <div>
-            <h2 id="connected-apps-title" className="text-[22px] font-semibold tracking-[-0.01em] text-ink">Connected apps</h2>
-            <p className="mt-1 text-[13px] text-ink-secondary">Connect the apps your bots can use.</p>
+            <h2 id="plugins-title" className="text-[22px] font-semibold tracking-[-0.01em] text-ink">Plugins</h2>
+            <p className="mt-1 text-[13px] text-ink-secondary">Connect apps and your own MCP tools.</p>
           </div>
           <div className="flex items-center gap-1">
-            <button
-              onClick={() => void loadConnectionInventory(true)}
-              disabled={refreshing}
-              className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
-              title="Refresh connection status"
-            >
-              <RefreshCw size={17} className={cn(refreshing && "animate-spin")} />
-            </button>
+            {surface === "apps" && (
+              <button
+                onClick={() => void loadConnectionInventory(true)}
+                disabled={refreshing}
+                className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+                title="Refresh connection status"
+              >
+                <RefreshCw size={17} className={cn(refreshing && "animate-spin")} />
+              </button>
+            )}
             <button
               onClick={close}
-              aria-label="Close connected apps"
+              aria-label="Close plugins"
               className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"
             >
               <X size={21} />
@@ -504,6 +508,28 @@ export function PluginsPanel() {
           </div>
         </header>
 
+        <div className="border-b border-hairline/40 px-6 sm:px-8">
+          <div className="flex gap-6" role="tablist" aria-label="Plugin type">
+            {(["apps", "mcp"] as const).map((item) => (
+              <button
+                key={item}
+                type="button"
+                role="tab"
+                aria-selected={surface === item}
+                onClick={() => setSurface(item)}
+                className={cn(
+                  "border-b-2 px-0.5 pb-3 pt-1 text-[13.5px] font-medium transition-colors",
+                  surface === item ? "border-accent text-ink" : "border-transparent text-ink-secondary hover:text-ink",
+                )}
+              >
+                {item === "apps" ? "Connected apps" : "MCP servers"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {surface === "apps" ? (
+          <>
         {stale && (
           // Say which of the two things is true. Silence here is what makes a
           // remembered list indistinguishable from a confirmed one.
@@ -741,6 +767,10 @@ export function PluginsPanel() {
             </div>
           )}
         </div>
+          </>
+        ) : (
+          <McpServersPanel />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- add a first-class **MCP servers** tab beside Connected apps in Plugins
- manage trusted local stdio servers: add, edit, test, enable/disable, and remove
- keep new servers off until explicitly enabled, while preserving existing config-file behavior
- apply enabled servers globally to every engine that already supports custom MCP on its next task

## Safety and scope

- v1 is deliberately stdio-only: no remote URL transport, shell parsing, or per-bot grant model
- environment values are write-only; the API returns names only and preserves existing values through placeholders
- the bounded connection test strips OpenMaus/provider credentials, caps output/tool counts, kills the full process tree, suppresses stderr, and redacts configured values echoed in tool metadata
- custom tools retain the existing provider approval behavior and cannot shadow built-in MCP server names

This rebuilds the useful registry/probe ideas from #61 and the UI direction from #397 on current `main`, without their stale per-bot/routing risks.

## Verification

- `pnpm exec vitest run server/mcp-registry.test.ts server/mcp-probe.test.ts src/components/McpServersPanel.test.ts server/config.test.ts server/index.test.ts` — 220 passed
- `pnpm typecheck`
- `pnpm lint` — clean for this change; existing warnings only
- `pnpm build`
- `pnpm test:electron` — 80 passed
- isolated `control:omb doctor` confirmed the exact fixture server identity

The all-files concurrent Vitest run passed 2,888 tests but starved six existing long-running sidebar/team-import cases at their 20s timeout; `server/index.test.ts` passed in isolation before and after rebasing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP server management under **Plugins → MCP servers**.
  - Add, edit, enable, test, and delete local MCP servers.
  - Newly added servers are saved disabled and become available to the next task without restarting the app.
  - Server tests display available tools with bounded, sanitized results.
  - Credentials remain protected; only credential names—not secret values—are shown.

- **Documentation**
  - Updated setup guidance for UI-based configuration, local stdio-only support, testing behavior, and credential safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->