### PR TITLE
fix(ios): make the keyboard send key submit

### DIFF
--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -43,6 +43,7 @@ struct ChatView: View {
     @State private var fileOpenError: String?
     @State private var filePreview: FilePreviewItem?
     @State private var fileDownloadTask: Task<Void, Never>?
+    @State private var acceptsNextHardwareLineBreak = false
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
     /// The opening beat: the island grows with the bot's face in it, then
@@ -658,6 +659,29 @@ struct ChatView: View {
             && !preparingAttachments && !sendingMessage
     }
 
+    /// A vertically growing SwiftUI TextField treats the software keyboard's
+    /// Return key as a newline even when the key is labelled “Send”. Intercept
+    /// that proposed edit before it reaches the draft. Hardware Shift-Return
+    /// opts into one real line break through `acceptsNextHardwareLineBreak`.
+    private var composerDraft: Binding<String> {
+        Binding(
+            get: { draft },
+            set: { proposed in
+                if acceptsNextHardwareLineBreak {
+                    acceptsNextHardwareLineBreak = false
+                    draft = proposed
+                } else if ComposerKeyboard.shouldSubmit(
+                    previousText: draft,
+                    proposedText: proposed
+                ) {
+                    submit()
+                } else {
+                    draft = proposed
+                }
+            }
+        )
+    }
+
     private var hasPendingApproval: Bool {
         messages.contains { $0.card?.isPending == true }
     }
@@ -1038,7 +1062,7 @@ struct ChatView: View {
 
                         TextField(
                             sendingMessage ? "Sending…" : dictation.isListening ? "Listening…" : "Ask \(current.name)",
-                            text: $draft,
+                            text: composerDraft,
                             axis: .vertical
                         )
                             .lineLimit(1...5)
@@ -1058,7 +1082,11 @@ struct ChatView: View {
                                 }
                             }
                             .onKeyPress(.return, phases: .down) { press in
-                                guard !press.modifiers.contains(.shift) else { return .ignored }
+                                if press.modifiers.contains(.shift) {
+                                    acceptsNextHardwareLineBreak = true
+                                    return .ignored
+                                }
+                                acceptsNextHardwareLineBreak = false
                                 submit()
                                 return .handled
                             }

--- a/ios/Sources/CompanionCore/ComposerKeyboard.swift
+++ b/ios/Sources/CompanionCore/ComposerKeyboard.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Identifies the edit proposed by the software keyboard's Return key in a
+/// vertically growing SwiftUI TextField. `.submitLabel(.send)` changes the
+/// key's artwork but does not make that field submit; iOS still proposes a
+/// newline. Keeping the classifier outside the view makes that behavior
+/// deterministic and testable without a simulator keyboard.
+public enum ComposerKeyboard {
+    public static func shouldSubmit(previousText: String, proposedText: String) -> Bool {
+        let changes = proposedText.difference(from: previousText)
+        var insertedLineBreaks = 0
+
+        for change in changes {
+            guard case let .insert(_, character, _) = change else { continue }
+            guard isLineBreak(character) else { return false }
+            insertedLineBreaks += 1
+        }
+        return insertedLineBreaks == 1
+    }
+
+    private static func isLineBreak(_ character: Character) -> Bool {
+        !character.unicodeScalars.isEmpty
+            && character.unicodeScalars.allSatisfy(CharacterSet.newlines.contains)
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ComposerKeyboardTests.swift
+++ b/ios/Tests/CompanionCoreTests/ComposerKeyboardTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import CompanionCore
+
+final class ComposerKeyboardTests: XCTestCase {
+    func testSoftwareReturnAtTheEndSubmits() {
+        XCTAssertTrue(ComposerKeyboard.shouldSubmit(
+            previousText: "Send this",
+            proposedText: "Send this\n"
+        ))
+    }
+
+    func testSoftwareReturnReplacingASelectionSubmitsTheOriginalDraft() {
+        XCTAssertTrue(ComposerKeyboard.shouldSubmit(
+            previousText: "Send selected words",
+            proposedText: "Send \n words"
+        ))
+    }
+
+    func testOrdinaryTypingAndDeletionDoNotSubmit() {
+        XCTAssertFalse(ComposerKeyboard.shouldSubmit(previousText: "Send", proposedText: "Send!"))
+        XCTAssertFalse(ComposerKeyboard.shouldSubmit(previousText: "Send", proposedText: "Sen"))
+    }
+
+    func testPastingMultilineTextDoesNotSubmit() {
+        XCTAssertFalse(ComposerKeyboard.shouldSubmit(
+            previousText: "First",
+            proposedText: "First\nSecond"
+        ))
+        XCTAssertFalse(ComposerKeyboard.shouldSubmit(
+            previousText: "",
+            proposedText: "First\nSecond"
+        ))
+    }
+}

--- a/server/message-file.test.ts
+++ b/server/message-file.test.ts
@@ -41,10 +41,11 @@ describe("message-linked files", () => {
     })[0]).toBe("/current/project");
   });
 
-  it("matches the decoded path iOS sends to its encoded Markdown href", () => {
-    const encoded = "file:///Users/milind/Project/release%20notes.md";
-    expect(messageReferencesFile(`[Open the notes](${encoded})`, "/Users/milind/Project/release notes.md"))
-      .toBe(true);
+  it("matches Unix, Windows, and UNC links independently of the server OS", () => {
+    expect(messageReferencesFile(
+      "[Open the notes](file:///Users/milind/Project/release%20notes.md)",
+      "/Users/milind/Project/release notes.md",
+    )).toBe(true);
     expect(messageReferencesFile(
       "I created /Users/milind/Project/release notes.md for you.",
       "/Users/milind/Project/release notes.md",
@@ -55,8 +56,12 @@ describe("message-linked files", () => {
       "C:\\Users\\Maus\\report.md",
     )).toBe(true);
     expect(messageReferencesFile(
+      "[Open it](file:///C:/Users/Maus/release%20notes.md)",
+      "C:\\Users\\Maus\\release notes.md",
+    )).toBe(true);
+    expect(messageReferencesFile(
       "[Open it](file://server/share/phone%20report.md)",
-      "//server/share/phone report.md",
+      "\\\\server\\share\\phone report.md",
     )).toBe(true);
     expect(messageReferencesFile(
       "[Open A&amp;B](docs/A&amp;B.md \"download\")",
@@ -64,6 +69,17 @@ describe("message-linked files", () => {
     )).toBe(true);
     expect(messageReferencesFile("<file:///Users/milind/report.md>", "/Users/milind/report.md"))
       .toBe(true);
+
+    // Equivalent separators and dot segments are normalised within a path
+    // flavour, but distinct path flavours and casing remain distinct.
+    expect(messageReferencesFile(
+      "[Open it](C:/Users/Maus/drafts/../report.md)",
+      "C:\\Users\\Maus\\report.md",
+    )).toBe(true);
+    expect(messageReferencesFile("[Open it](/C:/Users/Maus/report.md)", "C:/Users/Maus/report.md"))
+      .toBe(false);
+    expect(messageReferencesFile("[Open it](C:/Users/Maus/report.md)", "c:/users/maus/report.md"))
+      .toBe(false);
   });
 
   it("resolves only definitions used by rendered reference links", () => {

--- a/server/message-file.ts
+++ b/server/message-file.ts
@@ -4,7 +4,7 @@
 // message, and this helper keeps the eventual file handle inside one of them.
 import { constants } from "node:fs";
 import { open, realpath, stat, type FileHandle } from "node:fs/promises";
-import { basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { basename, extname, isAbsolute, posix, relative, resolve, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { fromMarkdown } from "mdast-util-from-markdown";
@@ -37,7 +37,7 @@ function statusError(status: number, message: string): Error & { status: number 
   return Object.assign(new Error(message), { status });
 }
 
-function referencedPath(href: string): string {
+function referencedPath(href: string, portableFileURL = false): string {
   if (!href || Buffer.byteLength(href) > 8_192 || href.includes("\0")) {
     throw statusError(400, "path must be a non-empty file link");
   }
@@ -64,8 +64,19 @@ function referencedPath(href: string): string {
         throw statusError(400, "path must be a valid file link");
       }
     }
+    if (!portableFileURL) {
+      try {
+        return fileURLToPath(url);
+      } catch {
+        throw statusError(400, "path must be a valid file link");
+      }
+    }
     try {
-      return fileURLToPath(url);
+      const decoded = decodeURIComponent(url.pathname);
+      // WHATWG file URLs always spell drive paths as /C:/..., even when the
+      // URL is parsed on macOS or Linux. Strip only that drive sentinel; an
+      // ordinary /Users/... URL must remain a POSIX path on every host.
+      return /^\/[a-z]:[\\/]/i.test(decoded) ? decoded.slice(1) : decoded;
     } catch {
       throw statusError(400, "path must be a valid file link");
     }
@@ -79,6 +90,23 @@ function referencedPath(href: string): string {
   } catch {
     throw statusError(400, "path must be a valid file link");
   }
+}
+
+/**
+ * A lexical path identity used only for matching a requested file against a
+ * rendered Markdown link. Native `resolve` and `fileURLToPath` follow the
+ * runner OS, which makes a Unix link compare differently on Windows CI and a
+ * Windows link compare differently on macOS. Keeping the path flavour in the
+ * identity also prevents a POSIX path such as `/C:/notes.md` from being
+ * mistaken for the Windows path `C:\\notes.md`.
+ */
+function referencedPathIdentity(href: string): string {
+  const path = referencedPath(href, true);
+  if (/^[a-z]:[\\/]/i.test(path) || path.startsWith("\\\\") || path.startsWith("//")) {
+    return `windows:${win32.resolve(path)}`;
+  }
+  if (path.startsWith("/")) return `posix:${posix.resolve(path)}`;
+  return `relative:${posix.normalize(path)}`;
 }
 
 type MarkdownNode = {
@@ -132,14 +160,14 @@ function renderedMarkdownTargets(markdown: string): string[] {
 export function messageReferencesFile(text: string, requested: string): boolean {
   let wanted: string;
   try {
-    wanted = resolve(referencedPath(requested));
+    wanted = referencedPathIdentity(requested);
   } catch {
     return false;
   }
 
   for (const target of renderedMarkdownTargets(text)) {
     try {
-      if (resolve(referencedPath(target)) === wanted) return true;
+      if (referencedPathIdentity(target) === wanted) return true;
     } catch {
       // A malformed candidate is not the link the client asked to open.
     }


### PR DESCRIPTION
## Summary\n\n- make the blue Send key on the iOS software keyboard actually submit the current message\n- keep hardware Shift-Return as the explicit multiline shortcut\n- preserve pasted multiline text instead of mistaking it for a submission\n- fix the cross-platform file-link comparison caught by Windows CI after #695 merged\n\n## Why\n\nA vertically growing SwiftUI TextField still proposes a newline when the software keyboard key is labelled Send, so the existing onSubmit callback never ran on iPhone. The composer now recognizes that exact keyboard edit before it changes the draft.\n\nThe message-file matcher also used the CI runner's native path semantics. It now compares Unix, Windows drive, UNC, and file URL paths consistently without widening one path flavour into another.\n\n## Verification\n\n- 284 Swift tests passed\n- complete OpenMausCompanion simulator build passed\n- message-file tests passed 8/8\n- real message-file route integration passed\n- TypeScript typecheck, focused lint, and diff checks passed\n\nPhysical iPhone verification is pending because iPhone Mirroring is not currently connected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shift-Return now inserts a line break in the message composer, while Return continues to submit messages when appropriate.
  - File links are now matched consistently across Unix, Windows, and UNC path formats.

- **Bug Fixes**
  - Improved handling of pasted multiline text, selected text replacement, and path separator differences when matching file references.

- **Tests**
  - Added coverage for composer keyboard behavior and cross-platform file link matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->