### PR TITLE
feat(ios): add discoverable bot model settings

### DIFF
--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -91,6 +91,9 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
   // Paired-safe profile subset. The harness route itself rejects fields
   // outside identity, avatar, notifications, and voice preferences.
   { method: "PATCH", path: /^\/api\/bots\/[\w-]+\/profile$/ },
+  // Full model selection, but no other bot settings. The harness validates
+  // the live catalog and refuses changes while the bot is working.
+  { method: "PATCH", path: /^\/api\/bots\/[\w-]+\/model$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/avatar\/generate$/ },
   // Full cloud desktop access. The route is narrow and the proxy applies a
   // second, per-device capability check before it reaches the harness.

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -55,6 +55,7 @@ describe("what the app may do", () => {
     ["PATCH", "/api/bots/bot_123/tasks/th_1"],
     ["DELETE", "/api/bots/bot_123/tasks/th_1"],
     ["PATCH", "/api/bots/bot_123/profile"],
+    ["PATCH", "/api/bots/bot_123/model"],
     ["POST", "/api/bots/bot_123/avatar/generate"],
     ["POST", "/api/bots/bot_123/computer/join"],
     ["POST", "/api/groups/room-1/messages"],
@@ -170,6 +171,9 @@ describe("what it may not", () => {
     expect(allowed("POST", "/api/threads/th_1/messages/msg_2/file/extra")).toBe(false);
     expect(allowed("GET", "/api/groups/room-1")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123")).toBe(false);
+    expect(allowed("GET", "/api/bots/bot_123/model")).toBe(false);
+    expect(allowed("POST", "/api/bots/bot_123/model")).toBe(false);
+    expect(allowed("PATCH", "/api/bots/bot_123/model/extra")).toBe(false);
     expect(allowed("PATCH", "/api/bots/bot_123/profile/execution-policy")).toBe(false);
     expect(allowed("GET", "/api/sidebar-sections")).toBe(false);
     expect(allowed("PATCH", "/api/sidebar-sections")).toBe(false);

--- a/ios/App/AgentProfileView.swift
+++ b/ios/App/AgentProfileView.swift
@@ -3,9 +3,9 @@ import CompanionCore
 import PhotosUI
 import SwiftUI
 
-/// The paired-safe subset of an agent profile. Shared provider keys remain on
-/// the computer; the phone sees only configured/not-configured status and the
-/// renderer-neutral voice/avatar operations.
+/// The paired-safe subset of bot settings. Shared provider keys remain on the
+/// computer; the phone sees only the model catalog, configured/not-configured
+/// status, and renderer-neutral profile operations.
 struct AgentProfileView: View {
     let bot: Bot
 
@@ -22,6 +22,12 @@ struct AgentProfileView: View {
     @State private var prompt = ""
     @State private var voices: [Voice] = []
     @State private var config: ConfigStatus?
+    @State private var instances: [Instance] = []
+    @State private var modelsLoaded = false
+    @State private var selectedInstanceID: String
+    @State private var selectedModelID: String
+    @State private var selectedEffort: String?
+    @State private var savedModel: ModelSelection
     @State private var busy = false
     @State private var player: AVAudioPlayer?
     @State private var baseline: ProfileFormSnapshot
@@ -35,6 +41,10 @@ struct AgentProfileView: View {
         _crop = State(initialValue: bot.avatarCrop ?? .mascot)
         _voice = State(initialValue: bot.voice ?? "")
         _speakReplies = State(initialValue: bot.speakReplies == true)
+        _selectedInstanceID = State(initialValue: bot.modelSelection.instanceId)
+        _selectedModelID = State(initialValue: bot.modelSelection.model)
+        _selectedEffort = State(initialValue: bot.modelSelection.effort)
+        _savedModel = State(initialValue: bot.modelSelection)
         _baseline = State(initialValue: ProfileFormSnapshot(bot: bot))
     }
 
@@ -43,6 +53,56 @@ struct AgentProfileView: View {
     private var voiceConfigured: Bool { config?.isTTSConfigured == true }
     private var hasWorkspaceDefaultVoice: Bool { config?.hasWorkspaceDefaultVoice == true }
     private var selectedVoiceCanSpeak: Bool { config?.canSpeak(agentVoice: voice) == true }
+    private var selectedInstance: Instance? {
+        instances.first { $0.instanceId == selectedInstanceID }
+    }
+    private var availableInstances: [Instance] { instances.filter(\.snapshot.isAvailable) }
+    private var instanceChoices: [Instance] {
+        guard let currentInstance = instances.first(where: { $0.instanceId == savedModel.instanceId }),
+              !currentInstance.snapshot.isAvailable
+        else { return availableInstances }
+        return [currentInstance] + availableInstances
+    }
+    private var selectedModelChoices: [ModelChoice] {
+        guard let instance = selectedInstance else {
+            return selectedModelID.isEmpty ? [] : [ModelChoice(id: selectedModelID, label: selectedModelID)]
+        }
+        var seen = Set<String>()
+        var choices: [ModelChoice] = []
+        let defaultOption = instance.models.options.first { $0.id == instance.models.default }
+        if !instance.models.default.isEmpty {
+            seen.insert(instance.models.default)
+            choices.append(ModelChoice(
+                id: instance.models.default,
+                label: defaultOption?.label ?? instance.models.default
+            ))
+        }
+        for option in instance.models.options where seen.insert(option.id).inserted {
+            choices.append(ModelChoice(id: option.id, label: option.label))
+        }
+        if !selectedModelID.isEmpty, seen.insert(selectedModelID).inserted {
+            choices.append(ModelChoice(id: selectedModelID, label: selectedModelID))
+        }
+        return choices
+    }
+    private var effortLevels: [String] {
+        var seen = Set<String>()
+        return (selectedInstance?.capabilities?.effortLevels ?? []).filter {
+            !$0.isEmpty && seen.insert($0).inserted
+        }
+    }
+    private var modelDraft: ModelSelection {
+        ModelSelection(instanceId: selectedInstanceID, model: selectedModelID, effort: selectedEffort)
+    }
+    private var canApplyModel: Bool {
+        guard modelsLoaded, current.busy != true,
+              let selectedInstance, selectedInstance.snapshot.isAvailable
+        else { return false }
+        let modelIsOffered = selectedModelID == selectedInstance.models.default
+            || selectedInstance.models.options.contains { $0.id == selectedModelID }
+        let effortIsOffered = selectedEffort.map(effortLevels.contains) ?? true
+        return modelIsOffered && effortIsOffered && modelDraft != savedModel
+    }
     /// Which engine's words to use. An unloaded status is ElevenLabs for the
     /// same reason a missing `provider` is: that is the server's own fallback,
     /// and the copy that shipped.
@@ -51,6 +111,70 @@ struct AgentProfileView: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    if !modelsLoaded {
+                        HStack {
+                            Text("Loading models")
+                            Spacer()
+                            ProgressView()
+                        }
+                    } else if instanceChoices.isEmpty {
+                        Label("No model providers are available", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Picker("Provider", selection: $selectedInstanceID) {
+                            if !instances.contains(where: { $0.instanceId == selectedInstanceID }) {
+                                Text("Current provider (unavailable)")
+                                    .tag(selectedInstanceID)
+                                    .disabled(true)
+                            }
+                            ForEach(instanceChoices) { instance in
+                                Text(instanceLabel(instance))
+                                    .tag(instance.instanceId)
+                                    .disabled(!instance.snapshot.isAvailable)
+                            }
+                        }
+                        .onChange(of: selectedInstanceID) { _, instanceID in
+                            selectDefaults(for: instanceID)
+                        }
+
+                        Picker("Model", selection: $selectedModelID) {
+                            ForEach(selectedModelChoices) { option in
+                                Text(option.label).tag(option.id)
+                            }
+                        }
+                        .disabled(selectedInstance?.snapshot.isAvailable != true)
+
+                        if !effortLevels.isEmpty {
+                            Picker("Reasoning effort", selection: $selectedEffort) {
+                                Text("Default").tag(String?.none)
+                                ForEach(effortLevels, id: \.self) { level in
+                                    Text(effortLabel(level)).tag(Optional(level))
+                                }
+                            }
+                        }
+
+                        if current.busy == true {
+                            Label("Stop this bot before changing its model.", systemImage: "hourglass")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        } else if selectedInstance?.snapshot.isAvailable != true {
+                            Label("Choose an available provider to change this bot's model.", systemImage: "info.circle")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Button("Apply model", systemImage: "checkmark") {
+                            Task { await saveModel() }
+                        }
+                        .disabled(busy || !canApplyModel)
+                    }
+                } header: {
+                    Text("Model")
+                } footer: {
+                    Text("Provider accounts and API keys stay on your computer. Default sends no reasoning level and lets the provider decide.")
+                }
+
                 Section {
                     HStack {
                         Spacer()
@@ -171,11 +295,11 @@ struct AgentProfileView: View {
                 }
 
                 Section {
-                    Button("Save profile") { Task { await save() } }
+                    Button("Save profile changes") { Task { await save() } }
                         .disabled(busy || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .navigationTitle("Agent profile")
+            .navigationTitle("Bot settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
@@ -184,9 +308,12 @@ struct AgentProfileView: View {
             .task {
                 async let status = session.configStatus()
                 async let options = session.voiceOptions()
-                let loadedConfig = await status
+                async let catalog = session.modelInstances()
+                let (loadedConfig, loadedVoices, loadedInstances) = await (status, options, catalog)
                 config = loadedConfig
-                voices = await options
+                voices = loadedVoices
+                instances = loadedInstances
+                modelsLoaded = true
                 if let loadedConfig, !loadedConfig.canSpeak(agentVoice: voice) {
                     speakReplies = false
                 }
@@ -222,6 +349,43 @@ struct AgentProfileView: View {
             synchronizeForm(with: updated)
         }
         busy = false
+    }
+
+    private func saveModel() async {
+        guard canApplyModel else { return }
+        busy = true
+        defer { busy = false }
+        if let updated = await session.updateModel(modelDraft, for: current) {
+            selectedInstanceID = updated.modelSelection.instanceId
+            selectedModelID = updated.modelSelection.model
+            selectedEffort = updated.modelSelection.effort
+            savedModel = updated.modelSelection
+        }
+    }
+
+    private func selectDefaults(for instanceID: String) {
+        guard let instance = instances.first(where: { $0.instanceId == instanceID }) else { return }
+        if instanceID == savedModel.instanceId {
+            selectedModelID = savedModel.model
+            let supported = instance.capabilities?.effortLevels ?? []
+            selectedEffort = savedModel.effort.flatMap { supported.contains($0) ? $0 : nil }
+        } else {
+            selectedModelID = instance.models.default
+            selectedEffort = nil
+        }
+    }
+
+    private func instanceLabel(_ instance: Instance) -> String {
+        let base = instance.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = base.flatMap { $0.isEmpty ? nil : $0 } ?? instance.instanceId
+        return instance.snapshot.isAvailable ? name : "\(name) (Unavailable)"
+    }
+
+    private func effortLabel(_ effort: String) -> String {
+        switch effort.lowercased() {
+        case "xhigh": "X-High"
+        default: effort.capitalized
+        }
     }
 
     private func clearImage() async {
@@ -349,6 +513,11 @@ struct AgentProfileView: View {
         speakReplies = bot.speakReplies == true
         baseline = ProfileFormSnapshot(bot: bot)
     }
+}
+
+private struct ModelChoice: Identifiable {
+    let id: String
+    let label: String
 }
 
 private struct ProfileFormSnapshot {

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -466,8 +466,8 @@ struct ChatView: View {
                 .buttonStyle(.plain)
                 .allowsHitTesting(!islandVisible)
                 .accessibilityHidden(islandVisible)
-                .accessibilityLabel("Open \(current.name) profile")
-                .accessibilityHint("Edits this agent's identity, avatar, notifications, and voice")
+                .accessibilityLabel("Open \(current.name) settings")
+                .accessibilityHint("Changes this bot's model, profile, notifications, and voice")
             } else {
                 Color.clear.frame(width: 60, height: 60)
             }
@@ -486,7 +486,7 @@ struct ChatView: View {
                             .foregroundStyle(Color.secondary)
                             .lineLimit(1)
                     }
-                    Image(systemName: current.isBot ? "person.crop.circle" : "ellipsis")
+                    Image(systemName: current.isBot ? "gearshape" : "ellipsis")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundStyle(Color.secondary)
                 }
@@ -497,7 +497,7 @@ struct ChatView: View {
             }
             .buttonStyle(.plain)
             .glassCapsule()
-            .accessibilityLabel(current.isBot ? "Open \(current.name) profile" : "Open \(current.name) chat options")
+            .accessibilityLabel(current.isBot ? "Open \(current.name) settings" : "Open \(current.name) chat options")
         }
         .padding(.top, -4)
     }
@@ -590,6 +590,10 @@ struct ChatView: View {
                 id: "tasks", systemImage: "square.stack", title: "Tasks",
                 subtitle: "Switch, rename or remove one"
             ) { showingTasks = true })
+            out.append(PlusAction(
+                id: "settings", systemImage: "gearshape", title: "Bot settings",
+                subtitle: "Model, profile, voice and notifications"
+            ) { showingProfile = true })
             out.append(PlusAction(
                 id: "computer", systemImage: "display", title: "Watch computer",
                 subtitle: "Live view of what \(bot.name) is doing"

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1217,6 +1217,31 @@ final class Session: ObservableObject {
 
     // MARK: - Agent profile
 
+    /// The model catalog lives on the paired computer because availability
+    /// depends on which engines are installed and signed in there.
+    func modelInstances() async -> [Instance] {
+        guard let client else { return [] }
+        do {
+            return try await client.instances()
+        } catch {
+            if !Task.isCancelled { actionError = error.localizedDescription }
+            return []
+        }
+    }
+
+    func updateModel(_ selection: ModelSelection, for bot: Bot) async -> Bot? {
+        guard let client else { return nil }
+        do {
+            let updated = try await client.updateModel(botId: bot.id, selection: selection)
+            guard !Task.isCancelled else { return nil }
+            state.apply(.bot(updated))
+            return updated
+        } catch {
+            if !Task.isCancelled { actionError = error.localizedDescription }
+            return nil
+        }
+    }
+
     func updateProfile(_ patch: BotProfilePatch, for bot: Bot) async -> Bot? {
         guard let client else { return nil }
         do {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -929,6 +929,17 @@ public struct CompanionClient: Sendable {
         ).bot
     }
 
+    /// Change only the engine, model and optional reasoning effort. This uses
+    /// the companion's narrow model route rather than the desktop's general
+    /// bot PATCH, which also owns execution policy and computer settings.
+    public func updateModel(botId: String, selection: ModelSelection) async throws -> Bot {
+        guard Self.validRouteID(botId) else { throw APIError.badURL }
+        return try await send(
+            try makeRequest("PATCH", "/api/bots/\(botId)/model", encodedBody: selection),
+            as: BotResponse.self
+        ).bot
+    }
+
     /// Upload raw image bytes and return the path the agent can open on its
     /// Mac. This is also the primitive used by avatar upload and sharing.
     public func uploadImage(

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -186,6 +186,15 @@ public struct Message: Codable, Hashable, Identifiable, Sendable {
 public struct ModelSelection: Codable, Hashable, Sendable {
     public var instanceId: String
     public var model: String
+    /// Optional reasoning effort passed through to engines that support it.
+    /// Older computers omit this field, which means the engine default.
+    public var effort: String?
+
+    public init(instanceId: String, model: String, effort: String? = nil) {
+        self.instanceId = instanceId
+        self.model = model
+        self.effort = effort
+    }
 }
 
 public struct BotTask: Codable, Hashable, Sendable {
@@ -480,12 +489,24 @@ public struct ModelCatalog: Codable, Hashable, Sendable {
     public var options: [ModelOption]
 }
 
+/// The small, phone-safe part of an engine's capabilities needed by bot
+/// settings. Missing capabilities or effort levels mean the engine does not
+/// offer a reasoning control.
+public struct InstanceCapabilities: Codable, Hashable, Sendable {
+    public var effortLevels: [String]?
+
+    public init(effortLevels: [String]? = nil) {
+        self.effortLevels = effortLevels
+    }
+}
+
 public struct Instance: Codable, Hashable, Identifiable, Sendable {
     public var instanceId: String
     public var driverKind: String
     public var displayName: String?
     public var snapshot: ProviderSnapshot
     public var models: ModelCatalog
+    public var capabilities: InstanceCapabilities? = nil
 
     public var id: String { instanceId }
 }

--- a/ios/Tests/CompanionCoreTests/BotModelClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/BotModelClientTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class BotModelRequestStub: URLProtocol {
+    static var responseBody = Data()
+    static var capturedRequest: URLRequest?
+    static var capturedBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequest = request
+        Self.capturedBody = Self.readBody(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+final class BotModelClientTests: XCTestCase {
+    private var session: URLSession!
+    private var client: CompanionClient!
+
+    override func setUp() {
+        super.setUp()
+        BotModelRequestStub.capturedRequest = nil
+        BotModelRequestStub.capturedBody = nil
+        BotModelRequestStub.responseBody = Self.botResponse(effort: "high")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BotModelRequestStub.self]
+        session = URLSession(configuration: configuration)
+        client = CompanionClient(
+            connection: Connection(name: "Mac", host: "127.0.0.1", port: 8810),
+            token: "paired-token",
+            session: session
+        )
+    }
+
+    override func tearDown() {
+        session.invalidateAndCancel()
+        session = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testUpdatesModelAndReasoningThroughTheNarrowRoute() async throws {
+        let updated = try await client.updateModel(
+            botId: "bot-1",
+            selection: ModelSelection(instanceId: "codex", model: "gpt-5", effort: "high")
+        )
+
+        let request = try XCTUnwrap(BotModelRequestStub.capturedRequest)
+        XCTAssertEqual(request.httpMethod, "PATCH")
+        XCTAssertEqual(request.url?.path, "/api/bots/bot-1/model")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer paired-token")
+        let data = try XCTUnwrap(BotModelRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: String])
+        XCTAssertEqual(body, ["instanceId": "codex", "model": "gpt-5", "effort": "high"])
+        XCTAssertEqual(updated.modelSelection.effort, "high")
+    }
+
+    func testEngineDefaultOmitsEffortRatherThanSendingNull() async throws {
+        BotModelRequestStub.responseBody = Self.botResponse(effort: nil)
+
+        let updated = try await client.updateModel(
+            botId: "bot-1",
+            selection: ModelSelection(instanceId: "codex", model: "gpt-5")
+        )
+
+        let data = try XCTUnwrap(BotModelRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: String])
+        XCTAssertEqual(body, ["instanceId": "codex", "model": "gpt-5"])
+        XCTAssertNil(updated.modelSelection.effort)
+    }
+
+    func testRejectsUnsafeBotIDsBeforeNetworking() async throws {
+        do {
+            _ = try await client.updateModel(
+                botId: "../another-bot",
+                selection: ModelSelection(instanceId: "codex", model: "gpt-5")
+            )
+            XCTFail("expected unsafe route rejection")
+        } catch APIError.badURL {
+            XCTAssertNil(BotModelRequestStub.capturedRequest)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testDecodesOptionalEffortAndInstanceEffortLevels() throws {
+        let data = Data(#"""
+        {"instances":[{
+          "instanceId":"codex","driverKind":"codexAgent","displayName":"Codex",
+          "snapshot":{"state":"available"},
+          "models":{"default":"gpt-5","options":[{"id":"gpt-5","label":"GPT-5"}]},
+          "capabilities":{"effortLevels":["low","medium","high"]}
+        }]}
+        """#.utf8)
+
+        let instance = try XCTUnwrap(JSONDecoder().decode(InstanceList.self, from: data).instances.first)
+        XCTAssertEqual(instance.capabilities?.effortLevels, ["low", "medium", "high"])
+
+        let old = try JSONDecoder().decode(
+            ModelSelection.self,
+            from: Data(#"{"instanceId":"claude","model":"sonnet"}"#.utf8)
+        )
+        XCTAssertNil(old.effort)
+    }
+
+    private static func botResponse(effort: String?) -> Data {
+        let effortField = effort.map { ",\"effort\":\"\($0)\"" } ?? ""
+        return Data("""
+        {"bot":{
+          "id":"bot-1","threadId":"thread-1","name":"Scout","title":"Researcher",
+          "description":"Finds evidence.","notifications":true,"color":"blue","unread":false,
+          "modelSelection":{"instanceId":"codex","model":"gpt-5"\(effortField)},"createdAt":1
+        }}
+        """.utf8)
+    }
+}

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1741,6 +1741,144 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("updates a paired bot's model, persists it, broadcasts it, and clears effort", async () => {
+    const instances = (await api("GET", "/api/instances")).body.instances;
+    const claude = instances.find((instance: { instanceId: string }) => instance.instanceId === "claude");
+    expect(claude).toMatchObject({
+      snapshot: { state: "available" },
+      capabilities: { effortLevels: expect.arrayContaining(["high"]) },
+    });
+    const selection = { instanceId: claude.instanceId, model: claude.models.default };
+    const bot = (await api("POST", "/api/bots", {
+      modelSelection: selection,
+      requireAvailableModel: true,
+    })).body.bot;
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      await stream.until((frame) => frame.kind === "hello");
+      const saved = await api("PATCH", `/api/bots/${bot.id}/model`, {
+        ...selection,
+        effort: "high",
+      });
+      expect(saved.status).toBe(200);
+      expect(saved.body.bot.modelSelection).toEqual({ ...selection, effort: "high" });
+      expect(saved.body.bot).not.toHaveProperty("resumeCursors");
+
+      const setFrame = await stream.until(
+        (frame) => frame.kind === "bot" &&
+          frame.bot?.id === bot.id &&
+          frame.bot?.modelSelection?.effort === "high",
+      );
+      expect(setFrame.bot.modelSelection).toEqual({ ...selection, effort: "high" });
+      const afterSet = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(afterSet.modelSelection).toEqual({ ...selection, effort: "high" });
+
+      // Omitting effort is the complete "use the engine default" selection,
+      // rather than a partial patch that accidentally preserves the old one.
+      const cleared = await api("PATCH", `/api/bots/${bot.id}/model`, selection);
+      expect(cleared.status).toBe(200);
+      expect(cleared.body.bot.modelSelection).toEqual(selection);
+      const clearFrame = await stream.until(
+        (frame) => frame.kind === "bot" &&
+          frame.bot?.id === bot.id &&
+          frame.bot?.modelSelection?.model === selection.model &&
+          frame.bot?.modelSelection?.effort === undefined,
+      );
+      expect(clearFrame.bot.modelSelection).toEqual(selection);
+      const afterClear = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(afterClear.modelSelection).toEqual(selection);
+    } finally {
+      stream.close();
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("keeps paired model writes inside the live catalog and exact request shape", async () => {
+    const instances = (await api("GET", "/api/instances")).body.instances;
+    const claude = instances.find((instance: { instanceId: string }) => instance.instanceId === "claude");
+    const selection = { instanceId: claude.instanceId, model: claude.models.default };
+    const bot = (await api("POST", "/api/bots", {
+      modelSelection: selection,
+      requireAvailableModel: true,
+    })).body.bot;
+    try {
+      const cases: Array<{ body: unknown; error: RegExp }> = [
+        { body: { instanceId: "missing", model: "anything" }, error: /instance .* unavailable/i },
+        { body: { ...selection, model: `${selection.model}-not-offered` }, error: /not offered/i },
+        { body: { ...selection, effort: "turbo" }, error: /not recognized/i },
+        { body: { ...selection, effort: "none" }, error: /not offered/i },
+        { body: { instanceId: selection.instanceId }, error: /modelSelection\.model/i },
+        { body: { ...selection, autoApprove: true }, error: /unsupported model field: autoApprove/i },
+      ];
+      for (const testCase of cases) {
+        const rejected = await api("PATCH", `/api/bots/${bot.id}/model`, testCase.body);
+        expect(rejected.status).toBe(400);
+        expect(rejected.body.error).toMatch(testCase.error);
+      }
+
+      for (const raw of ["null", "[]"]) {
+        const rejected = await fetch(`${BASE}/api/bots/${bot.id}/model`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: raw,
+        });
+        expect(rejected.status).toBe(400);
+      }
+      expect((await api("PATCH", "/api/bots/no-such-bot/model", selection)).status).toBe(404);
+
+      const after = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(after.modelSelection).toEqual(selection);
+      expect(after.autoApprove).toBeUndefined();
+    } finally {
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
+  it("refuses paired model changes while the bot is working", async () => {
+    const instances = (await api("GET", "/api/instances")).body.instances;
+    const claude = instances.find((instance: { instanceId: string }) => instance.instanceId === "claude");
+    const selection = { instanceId: claude.instanceId, model: claude.models.default };
+    const bot = (await api("POST", "/api/bots", {
+      modelSelection: selection,
+      requireAvailableModel: true,
+    })).body.bot;
+    try {
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "keep running" })).status).toBe(202);
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+          (candidate: { id: string }) => candidate.id === bot.id,
+        );
+        return current?.busy;
+      }).toBe(true);
+
+      const blocked = await api("PATCH", `/api/bots/${bot.id}/model`, {
+        ...selection,
+        effort: "high",
+      });
+      expect(blocked.status).toBe(409);
+      expect(blocked.body.error).toMatch(/working.*stop it before changing models/i);
+      const unchanged = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      );
+      expect(unchanged.modelSelection).toEqual(selection);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`, {});
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots.find(
+          (candidate: { id: string }) => candidate.id === bot.id,
+        );
+        return current?.busy;
+      }, { timeout: 5_000 }).toBe(false);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("exports every visible bot and imports the team without creating a room", async () => {
     const first = (await api("POST", "/api/bots")).body.bot;
     const second = (await api("POST", "/api/bots")).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -7240,6 +7240,29 @@ const server = createServer(async (req, res) => {
       broadcast({ kind: "bot", bot: visible });
       return json(res, 200, { bot: visible });
     }
+    m = path.match(/^\/api\/bots\/([\w-]+)\/model$/);
+    if (m && method === "PATCH") {
+      const body = await readBody(req);
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const unsupported = Object.keys(body).find(
+          (key) => key !== "instanceId" && key !== "model" && key !== "effort",
+        );
+        if (unsupported) return json(res, 400, { error: `unsupported model field: ${unsupported}` });
+      }
+      const existing = store.bot(m[1]);
+      if (!existing) return json(res, 404, { error: "no such bot" });
+      const checked = checkedModelSelection(
+        body,
+        { selection: existing.modelSelection, busy: Boolean(existing.busy) },
+        true,
+      );
+      if (!checked.ok) return json(res, checked.status, { error: checked.error });
+      // patchBot persists first and emits the canonical bot change, which the
+      // store listener above turns into the slim wire-format SSE broadcast.
+      const bot = store.patchBot(existing.id, { modelSelection: checked.selection });
+      if (!bot) return json(res, 404, { error: "no such bot" });
+      return json(res, 200, { bot: wireBot(bot) });
+    }
     m = path.match(/^\/api\/bots\/([\w-]+)\/read$/);
     if (m && method === "POST") {
       const bot = store.patchBot(m[1], { unread: false });


### PR DESCRIPTION
## What changed

- makes Bot settings explicit from the chat header and composer menu
- adds provider, model, and reasoning-effort controls to the iOS settings sheet
- keeps unavailable providers visible only when needed to explain the current selection
- adds an exact paired-safe model endpoint; provider credentials and broader execution settings stay on the computer
- refuses model changes while a bot is working and validates every choice against the live model catalog

## Verification

- iOS simulator app build succeeded (including app, widgets, and Share extension)
- Swift: 284 tests passed
- server + companion: 206 tests passed
- TypeScript typecheck passed
- companion production build passed
- isolated verification fixture launched, reported a healthy available engine, then shut down cleanly
- settings sheet visually checked on an iPhone 17 simulator

The control fixture currently has no model-mutation command, so the save workflow is covered by the full HTTP route integration tests plus the Swift request/decoding tests; the simulator check validates the rendered screen and app compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bot model settings for selecting a provider, model, and reasoning effort.
  - Added “Bot settings” access from the chat interface.
  - Added support for reasoning-effort levels where available.
  - Model changes are validated against available options and blocked while a bot is working.
  - Model updates now synchronize across the app and paired devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->