### PR TITLE
fix(server): create the environment id only after the legacy data dir is migrated

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -272,14 +272,6 @@ const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
 // Behind a proxy or tunnel, the base URL senders should use (docs/self-hosting.md).
 const WEBHOOK_PUBLIC_URL = process.env.OMB_WEBHOOK_PUBLIC_URL || undefined;
 const STATIC_DIR = process.env.OMB_STATIC_DIR || null;
-// Remote clients (server/request-auth.ts, server/sessions.ts): a stable identity
-// for this server, the paired sessions, and the cookie the served UI uses.
-const ENVIRONMENT_ID = loadEnvironmentId(DATA_DIR);
-const sessions = new SessionRegistry({ file: join(DATA_DIR, "sessions.json") });
-const SESSION_COOKIE = sessionCookieName(PORT, ENVIRONMENT_ID);
-const DESKTOP_MANAGED = process.env.OMB_DESKTOP_PARENT === "1";
-// Where remote clients reach this server (a proxy's public address); pairing URLs use it.
-const PUBLIC_URL = process.env.OMB_PUBLIC_URL?.trim().replace(/\/+$/, "") || null;
 const MIME: Record<string, string> = {
   ".html": "text/html",
   ".js": "text/javascript",
@@ -292,6 +284,16 @@ const MIME: Record<string, string> = {
 };
 
 ensureDirs();
+// Only after ensureDirs(): it performs the one-time rename of the legacy data
+// dir, which must not find a freshly created ~/.openmausbot already there.
+// Remote clients (server/request-auth.ts, server/sessions.ts): a stable identity
+// for this server, the paired sessions, and the cookie the served UI uses.
+const ENVIRONMENT_ID = loadEnvironmentId(DATA_DIR);
+const sessions = new SessionRegistry({ file: join(DATA_DIR, "sessions.json") });
+const SESSION_COOKIE = sessionCookieName(PORT, ENVIRONMENT_ID);
+const DESKTOP_MANAGED = process.env.OMB_DESKTOP_PARENT === "1";
+// Where remote clients reach this server (a proxy's public address); pairing URLs use it.
+const PUBLIC_URL = process.env.OMB_PUBLIC_URL?.trim().replace(/\/+$/, "") || null;
 const cfg = loadConfig();
 const registry = new ProviderRegistry(BUILT_IN_DRIVERS);
 await registry.load(instanceConfigs(cfg));

--- a/server/legacy-migration.test.ts
+++ b/server/legacy-migration.test.ts
@@ -1,0 +1,68 @@
+// A user upgrading from the pre-rename data dir (~/.opengrokbot) must find
+// everything in ~/.openmausbot after the first boot. Anything that touches
+// the new dir before ensureDirs() runs would make that rename a no-op and
+// boot the user into an empty workspace — this test pins the order.
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const PORT = 18800 + Math.floor(Math.random() * 10_000);
+const WEBHOOK_PORT = 39000 + Math.floor(Math.random() * 10_000);
+
+let home: string;
+let child: ChildProcess;
+let stderr = "";
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "omb-legacy-test-"));
+  const legacy = join(home, ".opengrokbot");
+  mkdirSync(legacy, { recursive: true });
+  writeFileSync(join(legacy, "config.json"), JSON.stringify({ instances: {} }));
+  writeFileSync(join(legacy, "keep-me.txt"), "carried over");
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(PORT),
+      OMB_WEBHOOK_PORT: String(WEBHOOK_PORT),
+      OMB_BROWSER_CONNECTION: join(home, "browser-test-connection.json"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${PORT}/api/health`);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server did not start:\n${stderr}`);
+}, 30_000);
+
+afterAll(async () => {
+  await waitForExit(child, { signal: "SIGTERM" });
+  await removeTempDir(home);
+});
+
+describe("legacy data dir", () => {
+  it("is renamed to the new name on first boot, with its contents and a fresh environment id", () => {
+    const fresh = join(home, ".openmausbot");
+    expect(existsSync(join(home, ".opengrokbot"))).toBe(false);
+    expect(readFileSync(join(fresh, "keep-me.txt"), "utf8")).toBe("carried over");
+    expect(readFileSync(join(fresh, "environment-id"), "utf8").trim()).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});


### PR DESCRIPTION
Regression from #693, caught by the post-merge security review and confirmed in the source.

`loadEnvironmentId()` creates `~/.openmausbot` to write `environment-id`, and it ran **before** `ensureDirs()`, whose one-time rename of the legacy `~/.opengrokbot` folder only fires when the new dir does not exist yet. A user upgrading from the old folder name would boot into an empty workspace with their bots, transcripts and keys left behind in the old dir. Users already on `~/.openmausbot` are unaffected.

The identity, session registry, cookie name and public-URL setup now run right after `ensureDirs()`.

## Verified

| check | result |
|---|---|
| new `server/legacy-migration.test.ts`: boots the real server with a seeded `~/.opengrokbot` (config + a marker file) and no `~/.openmausbot`; asserts the old dir is gone, the marker is carried over, and `environment-id` exists | ✅ |
| mutation: moving the block back before `ensureDirs()` fails that test | ✅ |
| `server/remote-sessions.test.ts` still green after the move; typecheck; lint | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed first-time startup migration so existing data from the legacy storage directory is moved to the current storage location before the environment is initialized.
  * Preserved existing configuration and files during the migration.
  * Ensured a new environment identifier is generated when required after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->