### PR TITLE
Rooms wait for a busy member instead of skipping them

### DIFF
--- a/docs/plans/2026-09-02-bot-concurrency.md
+++ b/docs/plans/2026-09-02-bot-concurrency.md
@@ -36,6 +36,21 @@ Status: decision record (Sep 2, 2026). Scopes the "parallel runtime" part of
    driver conformance and off by default. The UI must never promise parallel work for a serialized
    driver or resource.
 
+## Prerequisites before any opt-in parallelism (from the codebase audit)
+
+- `unattendedBots` is keyed per bot on the stated assumption of one turn at a time. Under two live
+  turns an attended chat turn would clear a concurrently running webhook turn's unattended mark and
+  hand it auto-approve. Rekey it per thread first — a privilege fix, not a UX one.
+- `MEMORY.md` writes go through the atomic temp→rename helper (#703); a per-bot single-writer path
+  is required before two turns of one bot may both "remember".
+- The 409 text "already working" is string-matched as control flow in three retry paths (delegation
+  wake, connector resume, secret resume). Introduce a typed error code before changing any gate.
+- Stop routing (`activeGroupTurnForBot`) is a first-match scan; it must resolve by (bot, thread).
+- Drivers need no work: Claude, Codex and every ACP driver already isolate turns by thread.
+
+Open product question: a turn parked on a human's approval card (`waiting-on-you`) counts as busy.
+Under a per-bot lane count it would consume a slot; the UI must say so or "1 of 2 busy" reads as a bug.
+
 Sources: docs.x.ai/grok-bot (bots, chat-and-collaboration, computer-and-apps, faq, overview,
 skills-routines-and-automations, teams-and-enterprises), x.ai/bot/guides/how-i-run-multiple-teams-of-grok-bots,
 brianlovin.com (first impressions), flaviocopes.com/grok-bot (Matt Palmer), cursor.com/docs/grok-bot.

--- a/docs/plans/2026-09-02-bot-concurrency.md
+++ b/docs/plans/2026-09-02-bot-concurrency.md
@@ -1,0 +1,44 @@
+# Bot concurrency: fan-out membership, serialized turns, queued wakes
+
+Status: decision record (Sep 2, 2026). Scopes the "parallel runtime" part of
+`2026-08-22-channels-plan.md` against how Grok Bot actually behaves.
+
+## What Grok Bot does (verified against docs.x.ai/grok-bot and hands-on reports)
+
+- **Membership fans out.** One bot can sit in many group chats; xAI's own guide reuses the same
+  Coder/Researcher/Writer across project channels. Bots are personas, not copies.
+- **Execution is serialized per bot.** A bot has one conversation and one *current turn*. A user DM
+  "takes priority over background work and can redirect the current turn"; "Stop now" ends it.
+  Bot-to-bot messages are asynchronous *wakes* ("the receiving Bot wakes, handles the request, and
+  can reply later"). In a group, "the host wakes each member in turn". There is no queue UI and no
+  second lane: messaging a busy bot redirects it.
+- **Parallelism comes from more bots.** Every parallel claim in the docs is plural ("several Bots
+  can work at the same time… each gets its own screen"), never one bot doing two things. One
+  computer-use task per screen at a time; one shared computer per user (not a security boundary).
+- **Routines are wakes on the owning bot's lane** (they run in that bot's conversation context —
+  xAI staff recommend a dedicated routine bot so schedules don't queue behind a long chat turn).
+- Memory is per bot, files per user; no concurrent-write semantics are published — the product
+  pushes conflicts to "a single owner at each stage".
+
+## Decision for OpenMausBot
+
+1. **Default stays serial per bot; membership fans out; a busy bot is *woken later*, never
+   skipped.** Ordinary room turns join the same bounded wait that goals use (`waitForGroupGoalBot`
+   → a shared member wait): a responder busy elsewhere takes its turn when it frees, with a visible
+   "finishing another conversation" note; past the wait cap the round moves on with a chip that says
+   so. Stop on the room releases the wait. This closes the "busy member → skipped/failed" fragility
+   for chat rooms the way #702 closed it for goals.
+2. **A user's DM outranks background work** (Grok Bot's rule): the steer queue already holds it for
+   the next settle; Stop remains the redirect.
+3. **Parallel turns for one bot are an explicit opt-in, not the default** — the channels plan's
+   turn-lease design (`maxConcurrentTurnsPerBot > 1`, exclusive leases on the bot's computer and any
+   shared working folder, single-writer memory) stays the follow-up (PR 3/4 of that plan), gated on
+   driver conformance and off by default. The UI must never promise parallel work for a serialized
+   driver or resource.
+
+Sources: docs.x.ai/grok-bot (bots, chat-and-collaboration, computer-and-apps, faq, overview,
+skills-routines-and-automations, teams-and-enterprises), x.ai/bot/guides/how-i-run-multiple-teams-of-grok-bots,
+brianlovin.com (first impressions), flaviocopes.com/grok-bot (Matt Palmer), cursor.com/docs/grok-bot.
+Comparison: Buzz (one prompt in flight per channel, agents × channels sessions), OpenClaw (per-session
+lane, `maxConcurrent` across sessions, steer/followup/collect/interrupt), Hermes kanban
+(`max_in_progress_per_profile`), Claude Code agent teams (one teammate = one process, one task).

--- a/server/group-goal-run.e2e.test.ts
+++ b/server/group-goal-run.e2e.test.ts
@@ -426,7 +426,7 @@ describe("goal-driven channel runs", () => {
     }
   });
 
-  it("stops a waiting goal without interrupting unrelated direct work, while chat still skips busy bots", async () => {
+  it("stops a waiting goal without interrupting unrelated direct work, and chat waits for busy bots the same way", async () => {
     const lead = (await api("POST", "/api/bots", {
       name: "Occupied lead",
       modelSelection: { instanceId: "directHang", model: "claude-sonnet-5" },
@@ -437,6 +437,15 @@ describe("goal-driven channel runs", () => {
       memberIds: [lead.id],
       setup: { bulletin: "", defaultResponder: { kind: "member", botId: lead.id } },
     })).body.group;
+    const chips = (messages: Array<{ kind: string; role?: string; tool?: { name?: string; ok?: boolean } }>) => ({
+      waiting: messages.some((message) =>
+        message.kind === "activity" &&
+        /finishing another conversation — will reply here when free/i.test(message.tool?.name ?? "") &&
+        message.tool?.ok === undefined
+      ),
+      skipped: messages.some((message) => /skipped this round/i.test(message.tool?.name ?? "")),
+      replies: messages.filter((message) => message.kind === "text" && message.role === "bot").length,
+    });
 
     try {
       expect((await api("POST", `/api/bots/${lead.id}/messages`, { text: "Keep this direct task running" })).status)
@@ -446,17 +455,27 @@ describe("goal-driven channel runs", () => {
         return state.bots.find((bot: { id: string }) => bot.id === lead.id)?.busy;
       }).toBe(true);
 
+      // ordinary chat: the round parks on the busy lead — visibly working,
+      // nobody named as speaker, one neutral note, and no skip
       expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "Ordinary room chat" })).status).toBe(202);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=30")).body;
+        const current = state.groups.find((group: { id: string }) => group.id === room.id);
+        return { working: current?.working, busyBotId: current?.busyBotId, ...chips(current?.messages ?? []) };
+      }).toEqual({ working: true, busyBotId: null, waiting: true, skipped: false, replies: 0 });
+
+      // Stop releases the parked chat round quietly: no reply, no skip chip,
+      // and the lead's unrelated direct turn is untouched
+      expect((await api("POST", `/api/groups/${room.id}/interrupt`, { threadId: room.threadId })).status).toBe(200);
       await expect.poll(async () => {
         const state = (await api("GET", "/api/bots?messages=30")).body;
         const current = state.groups.find((group: { id: string }) => group.id === room.id);
         return {
           working: current?.working,
-          skipped: current?.messages.some((message: { tool?: { name?: string } }) =>
-            /busy in another conversation.+skipped this round/i.test(message.tool?.name ?? "")
-          ),
+          directBusy: state.bots.find((bot: { id: string }) => bot.id === lead.id)?.busy,
+          ...chips(current?.messages ?? []),
         };
-      }).toEqual({ working: false, skipped: true });
+      }).toEqual({ working: false, directBusy: true, waiting: true, skipped: false, replies: 0 });
 
       expect((await api("POST", `/api/groups/${room.id}/messages`, {
         text: "Wait and run this as a goal",

--- a/server/group-goal-wait-cap.e2e.test.ts
+++ b/server/group-goal-wait-cap.e2e.test.ts
@@ -9,12 +9,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { freePortBlock } from "./testing/ports.ts";
 
-// A goal waits for a busy teammate, but not forever, and it survives one
+// A room waits for a busy teammate, but not forever, and a goal survives one
 // transient provider failure. This server runs with a short wait cap so the
 // cap fires in seconds: a worker that never frees up comes back to the lead
 // as a reassign note, a lead that never frees up ends the run as blocked —
-// never as a provider failure — and a lead whose provider dies is retried
-// once before the run gives up.
+// never as a provider failure — a lead whose provider dies is retried once
+// before the run gives up, and an ordinary chat round gives up on a member
+// that stays busy with a chip that says so, then moves on to the next one.
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
@@ -224,6 +225,51 @@ describe("goal wait cap and transient retry", () => {
     const activity = current?.messages.filter((message: { kind: string }) => message.kind === "activity") ?? [];
     const failures = activity.filter((message: { tool?: { name?: string } }) => /error:/i.test(message.tool?.name ?? ""));
     expect(failures.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("chat: a responder that stays busy past the cap is skipped with the bounded truth, and the next responder still runs", async () => {
+    const stuck = await createBot("Stuck", "hang");
+    const helper = await createBot("Chat helper", "helper");
+    const room = (await api("POST", "/api/groups", {
+      name: "Wait cap chat",
+      memberIds: [stuck.id, helper.id],
+      setup: { bulletin: "", defaultResponder: { kind: "everyone" } },
+    })).body.group;
+
+    await holdBusy(stuck.id, "Never finish this chat");
+    expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "Quick check-in" })).status).toBe(202);
+
+    await expect.poll(async () => {
+      const { room: current } = await roomState(room.id);
+      const messages: Array<{ kind: string; role?: string; from?: { botId?: string }; tool?: { name?: string; ok?: boolean } }> =
+        current?.messages ?? [];
+      const chip = messages.find((message) =>
+        message.kind === "activity" && message.from?.botId === stuck.id && /skipped this round/i.test(message.tool?.name ?? "")
+      );
+      return {
+        working: current?.working,
+        chip: chip?.tool?.name,
+        chipOk: chip?.tool?.ok,
+        // the neutral promise is rewritten, not joined by a second chip
+        waitChips: messages.filter((message) =>
+          message.kind === "activity" && message.from?.botId === stuck.id && /another conversation/i.test(message.tool?.name ?? "")
+        ).length,
+        stuckSpoke: messages.some((message) => message.kind === "text" && message.role === "bot" && message.from?.botId === stuck.id),
+        helperSpoke: messages.some((message) => message.kind === "text" && message.role === "bot" && message.from?.botId === helper.id),
+      };
+    }, { timeout: 20_000 }).toEqual({
+      working: false,
+      chip: "Stuck stayed busy in another conversation for 1 minute — skipped this round",
+      chipOk: false,
+      waitChips: 1,
+      stuckSpoke: false,
+      helperSpoke: true,
+    });
+
+    // the stuck direct turn was never touched by the room's wait
+    const state = (await api("GET", "/api/bots?messages=0")).body;
+    expect(state.bots.find((bot: { id: string }) => bot.id === stuck.id)?.busy).toBe(true);
+    expect((await api("POST", `/api/bots/${stuck.id}/interrupt`)).status).toBe(200);
   });
 
   it.todo("parks on a busy worker and leaves the room usable for chat while it waits (park-and-release)");

--- a/server/index.ts
+++ b/server/index.ts
@@ -1219,6 +1219,70 @@ async function waitForGroupMemberBot(
   });
 }
 
+/** Ordinary chat rounds share the goal wait, with the room's own notes: one
+ * neutral chip when the wait begins (the transcript's promise that the member
+ * replies here when free), rewritten in place if the cap runs out so the
+ * promise never outlives the truth. `ok` stays undefined while waiting on
+ * purpose — this is neither a failure nor a finished step, and the live label
+ * reads `spoken` while the chip is the newest thing in the room. Stop leaves
+ * nothing extra behind: the round simply ends. */
+async function waitForChatRoomMember(
+  operation: GroupTurnOperation,
+  threadId: string,
+  bot: BotRecord,
+): Promise<"run" | "skip" | "stop"> {
+  const waitTool = {
+    name: `${bot.name} is finishing another conversation — will reply here when free`,
+    spoken: `${bot.name} is finishing another conversation`,
+  };
+  let waitChip: Message | undefined;
+  const availability = await waitForGroupMemberBot(bot, operation, () => {
+    waitChip = store.appendMessage(threadId, {
+      role: "bot",
+      kind: "activity",
+      from: { botId: bot.id, name: bot.name, color: bot.color },
+      tool: waitTool,
+    });
+  });
+  switch (availability) {
+    case "ready":
+      // The promise is kept the moment the turn starts; settle the chip so
+      // the live label stops narrating a wait that is over.
+      if (waitChip) store.patchMessage(threadId, waitChip.id, { tool: { ...waitTool, ok: true } });
+      // Membership means the bot is part of the room operation NOW, so its
+      // own Stop button reaches this turn rather than an idle 1:1 thread.
+      operation.botIds.add(bot.id);
+      return "run";
+    case "cancelled":
+      return "stop";
+    case "unavailable":
+      store.appendMessage(threadId, {
+        role: "bot",
+        kind: "activity",
+        from: { botId: bot.id, name: bot.name, color: bot.color },
+        tool: { name: `${bot.name} is no longer available — skipped this round`, ok: false },
+      });
+      return "skip";
+    case "timed_out": {
+      const minutes = Math.max(1, Math.round(GROUP_GOAL_WAIT_MAX_MS / 60_000));
+      const name =
+        `${bot.name} stayed busy in another conversation for ${minutes} minute${minutes === 1 ? "" : "s"} — skipped this round`;
+      // The cap only fires after a wait began, so the chip exists; append
+      // rather than lose the verdict if that ever stops being true.
+      if (waitChip) store.patchMessage(threadId, waitChip.id, { tool: { name, ok: false } });
+      else {
+        store.appendMessage(threadId, {
+          role: "bot",
+          kind: "activity",
+          from: { botId: bot.id, name: bot.name, color: bot.color },
+          tool: { name, ok: false },
+        });
+      }
+      return "skip";
+    }
+  }
+}
+
 function cancelGroupTurnOperations(groupId: string, threadId: string) {
   for (const operation of groupTurnOperations.get(groupId) ?? []) {
     if (operation.threadId !== threadId) continue;
@@ -3836,6 +3900,9 @@ async function runGroupMemberTurn(
   onProviderHandshakeSettled?: () => void,
   skillAuthoringClaim: { claimed: boolean } = { claimed: false },
   orchestration?: GroupTurnOrchestration,
+  // chat rounds only: lets a chained @mention wait for a busy teammate the
+  // way the responder loop does (goal runs never follow mentions)
+  operation?: GroupTurnOperation,
 ): Promise<boolean> {
   if (isCancelled?.()) return false;
   const group = store.group(groupId);
@@ -3861,7 +3928,10 @@ async function runGroupMemberTurn(
   // One turn per bot at a time, across BOTH engines. Without this a bot
   // could run its 1:1 turn and a room turn concurrently — two provider
   // processes, interleaved token spend, and an interrupt that only ever
-  // reached one of them.
+  // reached one of them. Callers wait for a busy member before getting here
+  // (waitForChatRoomMember / the goal wait), so this is the last-line guard
+  // for the narrow window in which a 1:1 re-claims the bot between that wait
+  // settling and this turn starting.
   if (bot.busy) {
     if (orchestration) {
       orchestration.result.outcome = "busy";
@@ -4278,6 +4348,17 @@ async function runGroupMemberTurn(
     for (const next of roomResponders(replyText, members, { kind: "mentions" })) {
       if (isCancelled?.()) return false;
       if (spoken.has(next.id)) continue;
+      if (operation) {
+        // a summoned teammate busy elsewhere is woken later, exactly like a
+        // direct responder; one skipped by the cap must not be retried as a
+        // direct responder of the same round
+        const verdict = await waitForChatRoomMember(operation, threadId, next);
+        if (verdict === "stop") return false;
+        if (verdict === "skip") {
+          spoken.add(next.id);
+          continue;
+        }
+      }
       if (!(await runGroupMemberTurn(
         groupId,
         threadId,
@@ -4290,6 +4371,8 @@ async function runGroupMemberTurn(
         onProviderHandshakeStarted,
         onProviderHandshakeSettled,
         skillAuthoringClaim,
+        undefined,
+        operation,
       ))) {
         return false;
       }
@@ -4761,6 +4844,16 @@ function startGroupTurn(
       for (const responder of responders) {
         if (operation.cancelled) break;
         if (spoken.has(responder.id)) continue;
+        // A responder busy in another conversation takes its turn when it
+        // frees (the host wakes each member in turn) — never skipped, only
+        // bounded. Stop ends the round; a member the cap gave up on, or one
+        // that vanished meanwhile, is passed over for this round only.
+        const verdict = await waitForChatRoomMember(operation, threadId, responder);
+        if (verdict === "stop") break;
+        if (verdict === "skip") {
+          spoken.add(responder.id);
+          continue;
+        }
         if (!(await runGroupMemberTurn(
           groupId,
           threadId,
@@ -4773,6 +4866,8 @@ function startGroupTurn(
           () => groupProviderHandshakeStarted(operation),
           () => groupProviderHandshakeSettled(operation),
           skillAuthoringClaim,
+          undefined,
+          operation,
         ))) break;
       }
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1156,35 +1156,39 @@ function updateGroupGoalRunProgress(operation: GroupTurnOperation, detail: strin
   });
 }
 
-type GroupGoalBotAvailability = "ready" | "busy" | "unavailable" | "cancelled" | "timed_out";
+type GroupMemberBotAvailability = "ready" | "busy" | "unavailable" | "cancelled" | "timed_out";
+type GroupMemberBotWaitResult = Exclude<GroupMemberBotAvailability, "busy">;
 
-function groupGoalBotAvailability(botId: string, operation: GroupTurnOperation): GroupGoalBotAvailability {
+function groupMemberBotAvailability(botId: string, operation: GroupTurnOperation): GroupMemberBotAvailability {
   if (operation.cancelled || operation.cancellation.signal.aborted) return "cancelled";
   const bot = store.bot(botId);
   if (!bot || bot.hidden) return "unavailable";
   return bot.busy ? "busy" : "ready";
 }
 
-/** Goal runs are patient with work already in progress. Store changes are
- * the wake-up signal, so waiting consumes neither a model turn nor a polling
- * loop. The operation's abort signal lets the room Stop button release the
- * listener immediately without touching the unrelated turn that owns bot.busy. */
-async function waitForGroupGoalBot(
+/** A room is patient with a member's work already in progress: a busy bot
+ * is woken later, never dropped. Goal runs and ordinary chat rounds share
+ * this wait; only the note they leave differs (`onWaiting` fires once, when
+ * the wait actually begins). Store changes are the wake-up signal, so waiting
+ * consumes neither a model turn nor a polling loop. The operation's abort
+ * signal lets the room Stop button release the listener immediately without
+ * touching the unrelated turn that owns bot.busy. While it waits, the bot is
+ * not part of this operation: its own Stop button must keep reaching the
+ * conversation it is actually in. */
+async function waitForGroupMemberBot(
   bot: BotRecord,
   operation: GroupTurnOperation,
-): Promise<Exclude<GroupGoalBotAvailability, "busy">> {
+  onWaiting: (detail: string) => void,
+): Promise<GroupMemberBotWaitResult> {
   operation.botIds.delete(bot.id);
-  const initial = groupGoalBotAvailability(bot.id, operation);
+  const initial = groupMemberBotAvailability(bot.id, operation);
   if (initial !== "busy") return initial;
-  updateGroupGoalRunProgress(
-    operation,
-    `${bot.name} is finishing another conversation. This goal will continue when they are available.`,
-  );
+  onWaiting(`${bot.name} is finishing another conversation.`);
 
   return await new Promise((resolve) => {
     let settled = false;
     let unsubscribe = () => {};
-    const finish = (availability: Exclude<GroupGoalBotAvailability, "busy">) => {
+    const finish = (availability: GroupMemberBotWaitResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(waitCap);
@@ -1192,11 +1196,11 @@ async function waitForGroupGoalBot(
       operation.cancellation.signal.removeEventListener("abort", onAbort);
       resolve(availability);
     };
-    // unref'd: a parked goal must never keep the process alive on its own
+    // unref'd: a parked room must never keep the process alive on its own
     const waitCap = setTimeout(() => finish("timed_out"), GROUP_GOAL_WAIT_MAX_MS);
     waitCap.unref?.();
     const check = () => {
-      const availability = groupGoalBotAvailability(bot.id, operation);
+      const availability = groupMemberBotAvailability(bot.id, operation);
       if (availability !== "busy") finish(availability);
     };
     const onAbort = () => finish("cancelled");
@@ -1557,10 +1561,11 @@ const TURN_STALL_MS = Math.max(60_000, Number(process.env.OMB_TURN_STALL_MS) || 
 /** How long ask_bot waits synchronously before the ask is converted into a
  * delegation claim ticket (the peer's turn keeps running either way). */
 const ASK_BOT_TIMEOUT_MS = Math.max(5_000, Number(process.env.OMB_ASK_BOT_TIMEOUT_MS) || 4 * 60_000);
-// A goal waits for a busy teammate instead of failing, but never forever: a
-// bot parked on a permission card in another chat is "busy" until a human
-// returns. Past this cap the lead is told the teammate could not free up and
-// reassigns — the wait ends as data, not as a dead goal. Tests shrink it.
+// A room waits for a busy teammate instead of dropping them, but never
+// forever: a bot parked on a permission card in another chat is "busy" until
+// a human returns. Past this cap a goal's lead is told the teammate could not
+// free up and reassigns, and a chat round moves on with a chip that says so —
+// the wait ends as data, not as a dead room. Tests shrink it.
 const GROUP_GOAL_WAIT_MAX_MS = Math.max(1_000, Number(process.env.OMB_GOAL_WAIT_MAX_MS) || 30 * 60_000);
 // Reassigning around a busy teammate is bounded too: after this many
 // exhausted waits in one run the team is blocked on availability, not stuck.
@@ -4308,7 +4313,9 @@ async function runGroupGoalStep(args: {
   }
   let retriedTransient = false;
   for (;;) {
-    const availability = await waitForGroupGoalBot(args.bot, args.operation);
+    const availability = await waitForGroupMemberBot(args.bot, args.operation, (detail) => {
+      updateGroupGoalRunProgress(args.operation, `${detail} This goal will continue when they are available.`);
+    });
     if (availability === "cancelled") return { ran: false, replyText: "", outcome: "cancelled" };
     if (availability === "unavailable") {
       return { ran: false, replyText: "", outcome: "unavailable", stopReason: `${args.bot.name} is no longer available` };

--- a/server/room-chat-wait.e2e.test.ts
+++ b/server/room-chat-wait.e2e.test.ts
@@ -1,0 +1,317 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { freePortBlock } from "./testing/ports.ts";
+
+// An ordinary room round never skips a member who is busy in another
+// conversation: the round parks on them with one neutral note and they take
+// their turn when they free — whether they were a direct responder, a
+// teammate summoned by a chained @mention, or the peer in a bot⇄bot channel
+// the user chipped into. The member's own 1:1 turn is never touched by the
+// wait. The bounded end of the wait (the cap) lives in the short-cap server
+// of group-goal-wait-cap.e2e.test.ts.
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+
+const WAIT_CHIP = (name: string) => `${name} is finishing another conversation — will reply here when free`;
+
+let child: ChildProcess;
+let home = "";
+let base = "";
+let stderr = "";
+let penDump = "";
+
+type StateMessage = {
+  id: string;
+  kind: string;
+  role?: string;
+  text?: string;
+  from?: { botId?: string; name?: string };
+  tool?: { name?: string; ok?: boolean; spoken?: string };
+};
+
+const api = async (
+  method: string,
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: any }> => {
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers: { ...(body ? { "content-type": "application/json" } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: response.status, body: await response.json() };
+};
+
+const fixture = (displayName: string, environment: Record<string, string>) => ({
+  driver: "claudeAgent",
+  displayName,
+  environment,
+  config: { cli: FAKE_CLAUDE },
+});
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "omb-room-chat-wait-"));
+  const data = join(home, ".openmausbot");
+  const staticDir = join(home, "static");
+  mkdirSync(data, { recursive: true });
+  mkdirSync(join(staticDir, "assets"), { recursive: true });
+  writeFileSync(join(staticDir, "index.html"), "<!doctype html><title>Room chat wait test</title>");
+  writeFileSync(join(staticDir, "assets", "smoke.css"), "body{}");
+  penDump = join(home, "pen-dump.json");
+  writeFileSync(join(data, "config.json"), JSON.stringify({
+    instances: {
+      // `slow` leaves a gap before the closing reply, which is how a bot is
+      // held busy in a 1:1 long enough for a room round to park on it; the
+      // closing reply echoes the prompt, so a room reply carries the room's
+      // own @mentions back out
+      patient: fixture("Patient fixture", { FAKE_CLAUDE_MODE: "slow" }),
+      quick: fixture("Quick fixture", { FAKE_CLAUDE_MODE: "happy" }),
+      summoner: fixture("Summoning fixture", {
+        FAKE_CLAUDE_MODE: "happy",
+        FAKE_CLAUDE_REPLIES: JSON.stringify(["Let me pull in @Bee for this."]),
+        FAKE_CLAUDE_REPLY_STATE: join(home, "summoner-replies.txt"),
+      }),
+      // the dump is the only place a test can read the per-boot comms
+      // token from, and ask_bot is the only way a bot⇄bot channel is born
+      pen: fixture("Dumping fixture", { FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: penDump }),
+    },
+  }));
+  const port = await freePortBlock([0, 1]);
+  base = `http://127.0.0.1:${port}`;
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(port),
+      OMB_WEBHOOK_PORT: String(port + 1),
+      OMB_STATIC_DIR: staticDir,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr!.on("data", (chunk) => (stderr += chunk));
+
+  const deadline = Date.now() + 20_000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}: ${stderr}`);
+    try {
+      if ((await fetch(`${base}/api/health`)).status === 200) break;
+    } catch {
+      // Still starting.
+    }
+    if (Date.now() >= deadline) throw new Error(`server never became healthy: ${stderr}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}, 30_000);
+
+afterAll(async () => {
+  if (child) await waitForExit(child, { signal: "SIGTERM" });
+  if (home) await removeTempDir(home);
+});
+
+const createBot = async (name: string, instanceId: string) =>
+  (await api("POST", "/api/bots", {
+    name,
+    modelSelection: { instanceId, model: "claude-sonnet-5" },
+    requireAvailableModel: true,
+  })).body.bot;
+
+const snapshot = async (groupId: string) => {
+  const state = (await api("GET", "/api/bots?messages=40")).body;
+  const room = state.groups.find((group: { id: string }) => group.id === groupId);
+  const messages: StateMessage[] = room?.messages ?? [];
+  return { state, room, messages };
+};
+
+const botBusy = async (botId: string) => {
+  const state = (await api("GET", "/api/bots?messages=0")).body;
+  return state.bots.find((bot: { id: string }) => bot.id === botId)?.busy;
+};
+
+const holdBusy = async (botId: string, text: string) => {
+  expect((await api("POST", `/api/bots/${botId}/messages`, { text })).status).toBe(202);
+  await expect.poll(() => botBusy(botId)).toBe(true);
+};
+
+const roundSummary = (messages: StateMessage[], waitedBotId: string) => {
+  const waitChip = messages.find((message) =>
+    message.kind === "activity" && message.from?.botId === waitedBotId && /another conversation/i.test(message.tool?.name ?? "")
+  );
+  return {
+    waitChip: waitChip?.tool?.name,
+    waitChipOk: waitChip?.tool?.ok,
+    waitChips: messages.filter((message) =>
+      message.kind === "activity" && message.from?.botId === waitedBotId && /another conversation/i.test(message.tool?.name ?? "")
+    ).length,
+    skipped: messages.some((message) => /skipped this round/i.test(message.tool?.name ?? "")),
+    // who spoke, in order; the slow fixture splits one turn into two text
+    // items, so consecutive repeats collapse to the speaker
+    speakers: messages
+      .filter((message) => message.kind === "text" && message.role === "bot")
+      .map((message) => message.from?.name)
+      .filter((name, index, names) => index === 0 || name !== names[index - 1]),
+  };
+};
+
+const directReply = async (botId: string, needle: string) => {
+  const state = (await api("GET", "/api/bots?messages=20")).body;
+  const messages: StateMessage[] = state.bots.find((bot: { id: string }) => bot.id === botId)?.messages ?? [];
+  return messages.some((message) => message.kind === "text" && message.role === "bot" && (message.text ?? "").includes(needle));
+};
+
+const cleanup = async (roomId: string | undefined, botIds: string[]) => {
+  if (roomId) await api("POST", `/api/groups/${roomId}/interrupt`, {}).catch(() => undefined);
+  for (const botId of botIds) await api("POST", `/api/bots/${botId}/interrupt`, {}).catch(() => undefined);
+  if (roomId) await api("DELETE", `/api/groups/${roomId}`).catch(() => undefined);
+  for (const botId of botIds) await api("DELETE", `/api/bots/${botId}`).catch(() => undefined);
+};
+
+describe("chat rooms wait for a member busy elsewhere", () => {
+  it("parks on a responder busy in a 1:1, then lets them reply once that turn settles, in order", async () => {
+    const busy = await createBot("Busy", "patient");
+    const quick = await createBot("Quick", "quick");
+    const room = (await api("POST", "/api/groups", {
+      name: "Wait chat",
+      memberIds: [busy.id, quick.id],
+      setup: { bulletin: "", defaultResponder: { kind: "everyone" } },
+    })).body.group;
+
+    try {
+      await holdBusy(busy.id, "Finish this first");
+      expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "Hello team" })).status).toBe(202);
+
+      await expect.poll(async () => {
+        const { room: current, messages } = await snapshot(room.id);
+        return { working: current?.working, ...roundSummary(messages, busy.id) };
+      }, { timeout: 15_000 }).toEqual({
+        working: false,
+        waitChip: WAIT_CHIP("Busy"),
+        // settled, not failed: the promise was kept
+        waitChipOk: true,
+        waitChips: 1,
+        skipped: false,
+        // the round kept its order — the waited-on member still went first
+        speakers: ["Busy", "Quick"],
+      });
+
+      // the 1:1 turn the room waited on was left alone to finish on its own
+      expect(await directReply(busy.id, "Finish this first")).toBe(true);
+      expect(await botBusy(busy.id)).toBe(false);
+    } finally {
+      await cleanup(room?.id, [busy.id, quick.id]);
+    }
+  });
+
+  it("waits for a teammate summoned by a chained @mention who is busy elsewhere", async () => {
+    const ace = await createBot("Ace", "summoner");
+    const bee = await createBot("Bee", "patient");
+    const room = (await api("POST", "/api/groups", {
+      name: "Chained chat",
+      memberIds: [ace.id, bee.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: ace.id } },
+    })).body.group;
+
+    try {
+      await holdBusy(bee.id, "Bee, finish this first");
+      // only Ace is addressed; Bee arrives through Ace's reply
+      expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "@Ace please bring Bee in" })).status).toBe(202);
+
+      await expect.poll(async () => {
+        const { room: current, messages } = await snapshot(room.id);
+        return { working: current?.working, ...roundSummary(messages, bee.id) };
+      }, { timeout: 15_000 }).toEqual({
+        working: false,
+        waitChip: WAIT_CHIP("Bee"),
+        waitChipOk: true,
+        waitChips: 1,
+        skipped: false,
+        speakers: ["Ace", "Bee"],
+      });
+
+      expect(await directReply(bee.id, "Bee, finish this first")).toBe(true);
+    } finally {
+      await cleanup(room?.id, [ace.id, bee.id]);
+    }
+  });
+
+  it("waits for the peer of a bot⇄bot channel when the user chips in while that peer is busy", async () => {
+    const pen = await createBot("Pen", "pen");
+    const ink = await createBot("Ink", "patient");
+    let channelId: string | undefined;
+
+    try {
+      // one direct turn hands the fake CLI its MCP config, which carries the
+      // comms token every internal endpoint is sealed behind
+      expect((await api("POST", `/api/bots/${pen.id}/messages`, { text: "Warm up" })).status).toBe(202);
+      const readToken = (): string | undefined => {
+        try {
+          const dump = JSON.parse(readFileSync(penDump, "utf8"));
+          const value: unknown = dump?.mcpConfig?.mcpServers?.agents?.env?.OMB_COMMS_TOKEN;
+          return typeof value === "string" && value ? value : undefined;
+        } catch {
+          // not written yet, or mid-write
+          return undefined;
+        }
+      };
+      await expect.poll(readToken, { timeout: 10_000 }).toBeTruthy();
+      const token = readToken() ?? "";
+      expect(token).toBeTruthy();
+      await expect.poll(() => botBusy(pen.id)).toBe(false);
+
+      // ask_bot is what births the channel; the peer answers at once here
+      const asked = await api(
+        "POST",
+        "/api/internal/ask-bot",
+        { fromBotId: pen.id, toBotId: ink.id, message: "Ink, quick question" },
+        { authorization: `Bearer ${token}` },
+      );
+      expect(asked.status).toBe(200);
+      expect(asked.body.botName).toBe("Ink");
+      const channel = (await api("GET", "/api/bots?messages=0")).body.groups.find((group: {
+        dm?: boolean;
+        memberIds: string[];
+      }) => group.dm === true && group.memberIds.includes(pen.id) && group.memberIds.includes(ink.id));
+      expect(channel).toBeTruthy();
+      channelId = channel.id;
+      await expect.poll(() => botBusy(ink.id)).toBe(false);
+
+      await holdBusy(ink.id, "Ink, finish this first");
+      expect((await api("POST", `/api/groups/${channel.id}/messages`, { text: "@Ink one more thing" })).status).toBe(202);
+
+      await expect.poll(async () => {
+        const { room: current, messages } = await snapshot(channel.id);
+        const { speakers: _speakers, ...summary } = roundSummary(messages, ink.id);
+        // Ink's earlier answer to Pen is already in the channel; the chip-in
+        // must have produced a fresh Ink reply AFTER the wait note
+        const waitAt = messages.findIndex((message) => message.tool?.name === WAIT_CHIP("Ink"));
+        const inkRepliedAfterWait = waitAt !== -1 && messages.slice(waitAt + 1).some((message) =>
+          message.kind === "text" && message.role === "bot" && message.from?.botId === ink.id
+        );
+        return { working: current?.working, ...summary, inkRepliedAfterWait };
+      }, { timeout: 15_000 }).toEqual({
+        working: false,
+        waitChip: WAIT_CHIP("Ink"),
+        waitChipOk: true,
+        waitChips: 1,
+        skipped: false,
+        inkRepliedAfterWait: true,
+      });
+
+      expect(await directReply(ink.id, "Ink, finish this first")).toBe(true);
+    } finally {
+      await cleanup(channelId, [pen.id, ink.id]);
+    }
+  });
+});


### PR DESCRIPTION
## In plain terms

A bot that's busy in another conversation is no longer *skipped* when a room needs it — it takes its turn when it frees up, the way Grok Bot "wakes each member in turn". The room shows "X is finishing another conversation — will reply here when free"; the reply lands when they're done; Stop ends the round; and if they stay busy past the wait cap the chip becomes the honest "stayed busy for N minutes — skipped this round".

## Why this shape

Research on how Grok Bot actually works (recorded in `docs/plans/2026-09-02-bot-concurrency.md`): one bot can be a member of many teams, but it executes **one turn at a time** — a DM redirects the current turn, bot-to-bot messages are async wakes, the group host wakes members in turn, one computer-use task per screen. Parallelism comes from more bots. OMB already matched that at default; what didn't match was dropping a busy member with "skipped this round". Goals stopped doing that in #702; ordinary chat rounds and chained @mentions now share the same bounded wait.

True parallel turns for one bot (the channels plan's turn-lease design) stays an explicit opt-in follow-up, off by default; the doc lists the prerequisites the codebase audit surfaced (per-thread unattended marks, single-writer memory — the atomic write landed in #703 — a typed error code for the "already working" gate, Stop by (bot, thread)) and the open product question that a bot parked on an approval card would consume a lane.

## Changes

- `waitForGroupMemberBot` extracted from the goal wait (same store-change wake, race-closed subscribe, Stop-abort release, wall-clock cap) — goals unchanged.
- `waitForChatRoomMember`: chat responders and chained @mention hops wait; one neutral chip per wait, patched to settled when the turn starts, rewritten in place on cap; `unavailable` → skipped for this round; Stop → the round ends quietly. Membership is added to the operation only when the turn actually runs, so the bot's own Stop reaches this turn and never an idle 1:1.
- dm (bot⇄bot) channels wait the same way.

## Test plan

- [x] New `server/room-chat-wait.e2e.test.ts`: responder busy in a 1:1 → neutral chip, no skip, replies after its 1:1 settles with that 1:1 untouched; chained "@A ask @B" with B busy; Stop while waiting → no reply, no skip chip, B's 1:1 continues; dm peer busy → waits then replies. Short-cap server: hang → "stayed busy … skipped this round" and the next responder still runs (mutation-checked).
- [x] Existing "chat still skips busy bots" scenario re-titled/re-asserted to the new contract.
- [x] Typecheck clean; zero new oxlint findings; goal e2e files green; full suite run on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group conversations now wait for busy responders instead of immediately skipping them.
  - Chained mentions and bot-to-bot channel conversations preserve speaker order while waiting for participants to become available.
  - Waiting, unavailable, and timed-out states are now shown through activity updates.
  - Waits remain bounded, allowing the conversation to continue when a responder stays busy too long.
  - Direct conversations remain uninterrupted while a group conversation waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->