### PR TITLE
Rooms show who they are waiting on

### DIFF
--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -42,7 +42,7 @@ import { useFocusMessage } from "@/lib/focus-message";
 import { shortPath } from "@/lib/short-path";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 import { useComposerDockPad } from "@/lib/composer-dock";
-import { showWorkingDots } from "@/lib/turn-tail";
+import { awaitedMemberId, showWorkingDots } from "@/lib/turn-tail";
 import { liveActivityLabel } from "@/lib/live-activity";
 import { splitTranscriptAttachments } from "@/lib/composer-attachments";
 import {
@@ -883,9 +883,13 @@ export function GroupView({ group }: { group: Group }) {
   const lastGroupMessage = group.messages.at(-1);
   const toolInFlight = lastGroupMessage?.kind === "activity" && lastGroupMessage.tool?.ok === undefined;
   const activityLabel = liveActivityLabel(lastGroupMessage);
-  const waiting = Boolean(
-    speaker && showWorkingDots(true, group.messages.at(-1), speaker.id),
+  // A member busy elsewhere takes its turn when free; until then the room
+  // works with no speaker, and the presence row names who it is waiting on.
+  const awaited = members.find(
+    (b) => b.id === awaitedMemberId(group.working, group.busyBotId, lastGroupMessage),
   );
+  const waiting =
+    Boolean(speaker && showWorkingDots(true, group.messages.at(-1), speaker.id)) || awaited !== undefined;
   const wasWaiting = useRef(false);
   const [popping, setPopping] = useState<{ id: string; text: string; botId?: string } | null>(null);
   useEffect(() => {
@@ -914,7 +918,8 @@ export function GroupView({ group }: { group: Group }) {
   ]);
   const presenceVisible = waiting || popping !== null;
   const poppingMessage = popping ? group.messages.find((message) => message.id === popping.id) : undefined;
-  const presenceSpeaker = speaker ?? members.find((member) => member.id === popping?.botId) ?? members[0];
+  const presenceSpeaker =
+    speaker ?? awaited ?? members.find((member) => member.id === popping?.botId) ?? members[0];
 
   // Windowed transcript, mirroring ChatView: only a tail of the room mounts;
   // the anchored boundary re-tails on a render-phase reset when the room (or
@@ -1263,7 +1268,7 @@ export function GroupView({ group }: { group: Group }) {
               avatar={
                 <MausAvatar
                   color={presenceSpeaker?.color ?? "green"}
-                  state={toolInFlight ? "working" : "thinking"}
+                  state={toolInFlight && !awaited ? "working" : "thinking"}
                   size={36}
                   forward={false}
                   lookAround={1}

--- a/src/lib/turn-tail.test.ts
+++ b/src/lib/turn-tail.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { Message } from "@/state/store";
-import { showWorkingDots } from "./turn-tail";
+import { awaitedMemberId, showWorkingDots } from "./turn-tail";
 
 const msg = (m: Partial<Message>): Message => ({ id: "m1", role: "bot", kind: "text", at: 1, ...m });
 
@@ -30,5 +30,32 @@ describe("showWorkingDots", () => {
     expect(showWorkingDots(true, fromA, "b")).toBe(true);
     // no attribution (older data) — fail toward showing the indicator
     expect(showWorkingDots(true, msg({}), "a")).toBe(true);
+  });
+});
+
+describe("awaitedMemberId", () => {
+  const waitChip = msg({
+    kind: "activity",
+    from: { botId: "b", name: "B", color: "blue" },
+    tool: { name: "B is finishing another conversation — will reply here when free", spoken: "B is finishing another conversation" },
+  });
+
+  it("names the member whose wait chip is the newest thing in a working room with no speaker", () => {
+    expect(awaitedMemberId(true, null, waitChip)).toBe("b");
+    expect(awaitedMemberId(true, undefined, waitChip)).toBe("b");
+  });
+
+  it("stands down once someone has the floor or the room stops working", () => {
+    expect(awaitedMemberId(true, "a", waitChip)).toBeUndefined();
+    expect(awaitedMemberId(false, null, waitChip)).toBeUndefined();
+    expect(awaitedMemberId(undefined, null, waitChip)).toBeUndefined();
+  });
+
+  it("ignores a settled chip and any other tail", () => {
+    expect(awaitedMemberId(true, null, { ...waitChip, tool: { ...waitChip.tool!, ok: true } })).toBeUndefined();
+    expect(awaitedMemberId(true, null, { ...waitChip, tool: { ...waitChip.tool!, ok: false } })).toBeUndefined();
+    expect(awaitedMemberId(true, null, msg({ from: { botId: "b", name: "B", color: "blue" } }))).toBeUndefined();
+    expect(awaitedMemberId(true, null, msg({ kind: "goal.run" }))).toBeUndefined();
+    expect(awaitedMemberId(true, null, undefined)).toBeUndefined();
   });
 });

--- a/src/lib/turn-tail.ts
+++ b/src/lib/turn-tail.ts
@@ -25,3 +25,21 @@ export function showWorkingDots(
   if (!settledReply) return true;
   return speakerBotId !== undefined && lastMessage.from?.botId !== speakerBotId;
 }
+
+/** rooms: the member the room is waiting on before anyone has the floor.
+ *
+ * A responder busy in another conversation takes its turn when it frees.
+ * Until then the room is working with no speaker, and the newest message is
+ * that member's neutral wait chip — an activity with no verdict yet. Naming
+ * them keeps the presence row honest; otherwise the room sits silent for as
+ * long as the wait lasts. A settled chip (promise kept, or the cap's verdict)
+ * or any other tail means nobody is being waited on. */
+export function awaitedMemberId(
+  working: boolean | undefined,
+  speakerBotId: string | null | undefined,
+  lastMessage: Message | undefined,
+): string | undefined {
+  if (!working || speakerBotId) return undefined;
+  if (lastMessage?.kind !== "activity" || !lastMessage.tool || lastMessage.tool.ok !== undefined) return undefined;
+  return lastMessage.from?.botId;
+}


### PR DESCRIPTION
## In plain terms

Follow-up to #704. When a room waits for a member who is busy in another conversation, the room now shows that member's mascot with "B is finishing another conversation" and the working dots, instead of sitting silent until they reply.

## Why

#704 made rooms wait rather than skip, and records the wait as a neutral activity chip. Rooms hide neutral chips by default (only failures, errors, or "show tool calls" render them), and the presence row keys off `busyBotId`, which stays unset until the member actually owns the provider process — by design, since that field drives 409 ownership and approval routing. So with default settings the wait was invisible.

## Changes

- `awaitedMemberId()` in `src/lib/turn-tail.ts`: the room is working, nobody has the floor, and the newest message is a member's unsettled activity chip → that member is being awaited. A settled chip (promise kept, or the cap's verdict), a speaker, or an idle room → nobody.
- `GroupView`: the presence row falls back to the awaited member with the chip's own spoken label; mascot state stays "thinking" (it isn't working here yet). Stands down the instant the chip settles or someone takes the floor.

## Test plan

- [x] Unit tests for `awaitedMemberId` (working/no speaker/wait chip → member; speaker or idle → none; settled chip or other tails → none). Mutation-checked: removing the speaker guard or the `ok` check each fails a test.
- [x] Typecheck clean; zero oxlint findings on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room presence indicators when a member is busy working elsewhere.
  - The presence row now identifies the member associated with an unresolved activity and displays them as waiting.
  - Speaker attribution now prioritizes the member awaiting completion.
  - The working avatar state is shown only when a tool is actively running and no member is awaiting a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->