### PR TITLE
Simplify automations and add five-minute scheduling

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
@@ -28,9 +28,9 @@ object RoutineRules {
     /** `String(prompt.trimming….prefix(20_000))`. */
     const val PROMPT_LIMIT: Int = 20_000
 
-    /** `Stepper(value: $duration, in: 15...240, step: 15)`. */
-    val DURATION_RANGE: IntRange = 15..240
-    const val DURATION_STEP: Int = 15
+    /** `Stepper(value: $duration, in: 5...240, step: 5)`. */
+    val DURATION_RANGE: IntRange = 5..240
+    const val DURATION_STEP: Int = 5
     const val DEFAULT_DURATION: Int = 30
 
     /** `.prefix(50)` on the sorted receipts. */

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
@@ -320,14 +320,14 @@ class RoutineRulesTest {
             runOn = RoutineRunLocation.CLOUD,
             enabled = false,
             schedule = RoutineSchedule.daily("09:00", listOf(1)),
-            durationMinutes = 45,
+            durationMinutes = 5,
         )
 
         assertEquals(80, input.name.length)
         assertEquals(20_000, input.prompt.length)
         assertEquals("cloud", input.runOn)
         assertEquals(false, input.enabled)
-        assertEquals(45, input.durationMinutes)
+        assertEquals(5, input.durationMinutes)
     }
 
     @Test
@@ -719,11 +719,15 @@ class RoutineRulesTest {
     }
 
     @Test
-    fun `the duration stepper walks 15 to 240 in quarter hours`() {
-        assertEquals(15, RoutineRules.steppedDuration(15, -15))
-        assertEquals(30, RoutineRules.steppedDuration(15, 15))
-        assertEquals(240, RoutineRules.steppedDuration(240, 15))
-        assertEquals(225, RoutineRules.steppedDuration(240, -15))
+    fun `the duration stepper walks 5 to 240 in five minute steps`() {
+        assertEquals(5, RoutineRules.DURATION_RANGE.first)
+        assertEquals(240, RoutineRules.DURATION_RANGE.last)
+        assertEquals(5, RoutineRules.DURATION_STEP)
+        assertEquals(30, RoutineRules.DEFAULT_DURATION)
+        assertEquals(5, RoutineRules.steppedDuration(5, -5))
+        assertEquals(10, RoutineRules.steppedDuration(5, 5))
+        assertEquals(240, RoutineRules.steppedDuration(240, 5))
+        assertEquals(235, RoutineRules.steppedDuration(240, -5))
     }
 
     @Test

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
@@ -55,7 +55,7 @@ class RoutineClientTest {
                 prompt = exactPrompt,
                 botId = "bot-1",
                 schedule = RoutineSchedule.once(2_000_000.0),
-                durationMinutes = 15,
+                durationMinutes = 5,
             ),
         )
         client.updateRoutine(
@@ -96,7 +96,7 @@ class RoutineClientTest {
         assertEquals(exactName, create.getValue("name").jsonPrimitive.content)
         assertEquals(exactPrompt, create.getValue("prompt").jsonPrimitive.content)
         assertEquals("maus", create.getValue("runOn").jsonPrimitive.content)
-        assertEquals(15, create.getValue("durationMinutes").jsonPrimitive.content.toInt())
+        assertEquals(5, create.getValue("durationMinutes").jsonPrimitive.content.toInt())
         assertEquals(
             mapOf("type" to "once", "at" to "2000000.0"),
             create.getValue("schedule").jsonObject.mapValues { it.value.jsonPrimitive.content },

--- a/ios/App/TasksRoutinesView.swift
+++ b/ios/App/TasksRoutinesView.swift
@@ -235,7 +235,7 @@ private struct RoutineEditorView: View {
                         ForEach(session.state.bots.filter { $0.hidden != true }) { bot in Text(bot.name).tag(bot.id) }
                     }
                     TextField("What should the agent do?", text: $prompt, axis: .vertical).lineLimit(4...10)
-                    Stepper("Allow up to \(duration) minutes", value: $duration, in: 15...240, step: 15)
+                    Stepper("Allow up to \(duration) minutes", value: $duration, in: 5...240, step: 5)
                 }
 
                 Section {

--- a/server/bot-package.test.ts
+++ b/server/bot-package.test.ts
@@ -76,6 +76,32 @@ describe("bot packages", () => {
     });
   });
 
+  it("accepts five-minute routine windows and rejects shorter ones", () => {
+    const routine = {
+      key: "morning-brief",
+      name: "Morning brief",
+      agent: "lead",
+      prompt: "Summarize the overnight queue.",
+      runOn: "maus",
+      schedule: { type: "daily", time: "09:00", weekdays: [1] },
+      durationMinutes: 5,
+      enabledAfterInstall: false,
+    };
+    const document = {
+      ...validPackage,
+      package: { ...validPackage.package, routines: [routine] },
+    };
+
+    expect(parseBotPackage(document).package.routines?.[0]?.durationMinutes).toBe(5);
+    expect(() => parseBotPackage({
+      ...document,
+      package: {
+        ...document.package,
+        routines: [{ ...routine, durationMinutes: 4 }],
+      },
+    })).toThrow(/expected number to be >=5/);
+  });
+
   it("rejects dangling agent, room, playbook, chief, and routine references", () => {
     expect(() => parseBotPackage({
       ...validPackage,

--- a/server/bot-package.ts
+++ b/server/bot-package.ts
@@ -100,7 +100,7 @@ const packageSchema = z.object({
           weekdays: z.array(z.number().int().min(0).max(6)).min(1).max(7),
         }),
       ]),
-      durationMinutes: z.number().int().min(15).max(240),
+      durationMinutes: z.number().int().min(5).max(240),
       enabledAfterInstall: z.literal(false),
     })).max(50).optional(),
     playbooks: z.array(z.object({

--- a/server/calendar-calls.test.ts
+++ b/server/calendar-calls.test.ts
@@ -47,7 +47,7 @@ describe("CalendarCallManager", () => {
   it("persists calls and returns defensive copies", () => {
     const file = tempFile();
     const calls = manager(file);
-    const created = calls.create(input());
+    const created = calls.create(input({ durationMinutes: 5 }));
     created.botIds.push("chief");
     created.attachments[0]!.name = "changed";
 
@@ -59,7 +59,7 @@ describe("CalendarCallManager", () => {
     expect(manager(file).list()[0]).toMatchObject({
       id: created.id,
       description: "Review the launch plan",
-      durationMinutes: 45,
+      durationMinutes: 5,
       attachments: [{ path: "/safe/local/Launch brief.pdf", kind: "file" }],
     });
   });
@@ -143,7 +143,9 @@ describe("CalendarCallManager", () => {
     const calls = manager();
     expect(() => calls.create(input({ botIds: [] }))).toThrow(/at least one bot/i);
     expect(() => calls.create(input({ botIds: ["missing"] }))).toThrow(/no longer exist/i);
-    expect(() => calls.create(input({ durationMinutes: 10 }))).toThrow(/15 and 240/);
+    expect(() => calls.create(input({ durationMinutes: 4 }))).toThrow(
+      "Call duration must be between 5 and 240 minutes",
+    );
     expect(() => calls.create(input({
       schedule: { type: "daily", time: "25:00", weekdays: [1] },
     }))).toThrow(/valid call schedule/i);

--- a/server/calendar-calls.ts
+++ b/server/calendar-calls.ts
@@ -83,7 +83,7 @@ const callSchema = z.object({
   description: z.string(),
   botIds: z.array(z.string().min(1)).min(1).max(MAX_BOTS),
   schedule: scheduleSchema,
-  durationMinutes: z.number().int().min(15).max(240),
+  durationMinutes: z.number().int().min(5).max(240),
   attachments: z.array(attachmentSchema).max(MAX_ATTACHMENTS),
   roomId: z.string().min(1).optional(),
   nextRunAt: z.number().finite().nonnegative().nullable().optional(),
@@ -157,8 +157,8 @@ function cleanInput(
   if (botIds.some((botId) => !botExists(botId))) throw new Error("One or more bots no longer exist");
 
   const duration = input.durationMinutes ?? 30;
-  if (!Number.isInteger(duration) || duration < 15 || duration > 240) {
-    throw new Error("Call duration must be between 15 and 240 minutes");
+  if (!Number.isInteger(duration) || duration < 5 || duration > 240) {
+    throw new Error("Call duration must be between 5 and 240 minutes");
   }
 
   return {

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -260,6 +260,7 @@ describe("agents-proxy MCP surface", () => {
       "saturday",
       "sunday",
     ]);
+    expect(create.inputSchema.properties.duration_minutes).toMatchObject({ minimum: 5, maximum: 240 });
     expect(create.description).toContain("does NOT enable");
   });
 

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -177,7 +177,7 @@ const ROUTINE_FIELDS_SCHEMA = {
   },
   duration_minutes: {
     type: "integer",
-    minimum: 15,
+    minimum: 5,
     maximum: 240,
     description: "Maximum run duration in minutes. Defaults to 30.",
   },

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3260,10 +3260,13 @@ describe("harness HTTP API", () => {
       });
       expect(edited.status).toBe(200);
       expect(edited.body.call.schedule).toEqual({ type: "daily", time: "11:15", weekdays: [1, 2, 3, 4, 5] });
-      const invalidPatch = await api("PATCH", `/api/calendar-calls/${callId}`, { durationMinutes: 5 });
+      const fiveMinutePatch = await api("PATCH", `/api/calendar-calls/${callId}`, { durationMinutes: 5 });
+      expect(fiveMinutePatch.status).toBe(200);
+      expect(fiveMinutePatch.body.call.durationMinutes).toBe(5);
+      const invalidPatch = await api("PATCH", `/api/calendar-calls/${callId}`, { durationMinutes: 4 });
       expect(invalidPatch.status).toBe(400);
       expect((await api("GET", "/api/calendar-calls")).body.calls).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: callId, name: "Weekly bot sync" })]),
+        expect.arrayContaining([expect.objectContaining({ id: callId, name: "Weekly bot sync", durationMinutes: 5 })]),
       );
 
       expect((await api("DELETE", `/api/calendar-calls/${callId}`)).status).toBe(200);

--- a/server/routine-requests.test.ts
+++ b/server/routine-requests.test.ts
@@ -228,9 +228,9 @@ describe("RoutineRequestService", () => {
       service.propose({
         botId: "bot-a",
         threadId: "thread-a",
-        proposal: createProposal({ durationMinutes: 5 }),
+        proposal: createProposal({ durationMinutes: 4 }),
       }),
-    ).rejects.toThrow(/15 to 240/);
+    ).rejects.toThrow("durationMinutes must be a whole number from 5 to 240");
     await expect(
       service.propose({
         botId: "bot-a",
@@ -419,7 +419,11 @@ describe("RoutineRequestService", () => {
 
   it("creates only after confirmation, pins ownership, and is durable-idempotent", async () => {
     const { service, routines, store, clock } = harness();
-    const proposal = await service.propose({ botId: "bot-a", threadId: "thread-a", proposal: createProposal() });
+    const proposal = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: createProposal({ durationMinutes: 5 }),
+    });
 
     // Model a crash after routines.json was atomically written but before the
     // transcript card was settled.
@@ -432,7 +436,7 @@ describe("RoutineRequestService", () => {
       runOn: "maus",
       enabled: true,
       schedule: { type: "daily", time: "09:00", weekdays: [1, 3] },
-      durationMinutes: 30,
+      durationMinutes: 5,
     }, {
       requestId: proposal.requestId,
       messageId: message.id,
@@ -458,6 +462,7 @@ describe("RoutineRequestService", () => {
       botId: "bot-a",
       name: "Morning brief",
       enabled: true,
+      durationMinutes: 5,
       sourceThreadId: "thread-a",
     }]);
     expect(routines.routineRequestReceipt(proposal.requestId)).toBeNull();

--- a/server/routine-requests.ts
+++ b/server/routine-requests.ts
@@ -102,7 +102,7 @@ const storedDefinitionSchema = z.object({
   instructions: z.string().trim().min(1).max(20_000),
   schedule: storedScheduleSchema,
   runOn: z.enum(["maus", "cloud"]),
-  durationMinutes: z.number().int().min(15).max(240),
+  durationMinutes: z.number().int().min(5).max(240),
 }).strict();
 const storedChangesSchema = storedDefinitionSchema.partial().refine(
   (changes) => Object.values(changes).some((value) => value !== undefined),
@@ -264,8 +264,8 @@ function runOn(value: RoutineRequestRunOn | undefined): RoutineRequestRunOn {
 
 function duration(value: number | undefined): number {
   const normalized = value ?? 30;
-  if (!Number.isInteger(normalized) || normalized < 15 || normalized > 240) {
-    throw new RoutineRequestError("durationMinutes must be a whole number from 15 to 240");
+  if (!Number.isInteger(normalized) || normalized < 5 || normalized > 240) {
+    throw new RoutineRequestError("durationMinutes must be a whole number from 5 to 240");
   }
   return normalized;
 }

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -116,6 +116,22 @@ describe("nextOccurrence", () => {
 });
 
 describe("RoutineManager", () => {
+  it("accepts five-minute windows and preserves the manager's clamping semantics", () => {
+    const h = harness();
+    const create = (name: string, durationMinutes?: number) => h.manager.create({
+      name,
+      prompt: "Check the queue",
+      botId: "maus-1",
+      schedule: { type: "daily", time: "09:00", weekdays: [1] },
+      durationMinutes,
+    });
+
+    expect(create("Minimum", 5).durationMinutes).toBe(5);
+    expect(create("Below minimum", 4).durationMinutes).toBe(5);
+    expect(create("Default").durationMinutes).toBe(30);
+    expect(create("Above maximum", 241).durationMinutes).toBe(240);
+  });
+
   it("stores routine data with owner-only permissions", () => {
     const h = harness();
     h.manager.create({

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -380,7 +380,7 @@ function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | 
     runOn,
     enabled: input.enabled !== false,
     schedule: cleanSchedule(input.schedule),
-    durationMinutes: Math.min(240, Math.max(15, Math.round(Number(input.durationMinutes) || 30))),
+    durationMinutes: Math.min(240, Math.max(5, Math.round(Number(input.durationMinutes) || 30))),
     attachments,
   };
 }

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -53,6 +53,7 @@ import { MAUS_COLORS, type MausState } from "@/lib/mascot";
 import {
   addDays,
   atLocalTime,
+  CALENDAR_SLOT_MINUTES,
   calendarRangeLabel,
   formatGmtOffset,
   fromLocalDateAndTime,
@@ -82,6 +83,7 @@ const HOUR_HEIGHT = 64;
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
 const WEEKDAYS = [1, 2, 3, 4, 5];
+const EVENT_DURATION_OPTIONS = Array.from({ length: 240 / CALENDAR_SLOT_MINUTES }, (_, index) => (index + 1) * CALENDAR_SLOT_MINUTES);
 const BOT_DRAG_TYPE = "application/x-openmaus-bot";
 const EVENT_DRAG_TYPE = "application/x-openmaus-calendar-event";
 
@@ -151,6 +153,12 @@ function niceTime(at: number): string {
 
 function niceDate(at: number): string {
   return new Date(at).toLocaleDateString([], { weekday: "long", month: "long", day: "numeric" });
+}
+
+function durationLabel(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  if (minutes % 60 === 0) return `${minutes / 60} hr`;
+  return `${Math.floor(minutes / 60)} hr ${minutes % 60} min`;
 }
 
 function scheduleLabel(schedule: RoutineSchedule | CalendarCall["schedule"]): string {
@@ -353,6 +361,9 @@ function EventEditor({
   const at = fromLocalDateAndTime(date, startTime);
   const endAt = at + durationMinutes * 60_000;
   const selectedBots = botIds.flatMap((id) => bots.find((bot) => bot.id === id) ?? []);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   const selectRoutineTarget = (target: RoutineTarget) => {
     setRoutineTarget(target);
@@ -401,7 +412,7 @@ function EventEditor({
           name,
           prompt: description,
           target: routineTarget,
-          botId: botIds[0] ?? "",
+          botId: lockedBotId ?? botIds[0] ?? "",
           groupId: routineTarget === "room-goal" ? groupId : null,
           runOn: routineTarget === "room-goal" ? "maus" : runOn,
           enabled: existingRoutine ? undefined : true,
@@ -440,6 +451,7 @@ function EventEditor({
   const valid = Boolean(
     name.trim()
     && (kind === "call" || description.trim())
+    && (!lockedBotId || botIds[0] === lockedBotId)
     && (kind === "call"
       ? botIds.length > 0
       : routineTarget === "room-goal"
@@ -448,9 +460,43 @@ function EventEditor({
   );
   const canSwitchKind = !existingRoutine && !existingCall && !lockedBotId;
 
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusable = () => Array.from(dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )).filter((element) => !element.hasAttribute("hidden"));
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const controls = focusable();
+      if (!controls.length) return event.preventDefault();
+      const first = controls[0]!;
+      const last = controls[controls.length - 1]!;
+      if (event.shiftKey && (document.activeElement === first || !dialog.contains(document.activeElement))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener("keydown", onKey);
+    return () => {
+      dialog.removeEventListener("keydown", onKey);
+      previousFocus?.focus();
+    };
+  }, []);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 p-3 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
-      <div role="dialog" aria-modal="true" aria-label={existingRoutine || existingCall ? "Edit calendar event" : "Create calendar event"} className="max-h-[94vh] w-full max-w-[760px] overflow-y-auto rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-label={existingRoutine || existingCall ? "Edit calendar event" : "Create calendar event"} tabIndex={-1} className="max-h-[94vh] w-full max-w-[760px] overflow-y-auto rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
         <div className="sticky top-0 z-20 flex items-center justify-between border-b border-hairline/40 bg-panel/95 px-5 py-3.5 backdrop-blur">
           <div className="text-[15px] font-semibold text-ink">{existingRoutine || existingCall ? "Edit event" : "New event"}</div>
           <button onClick={onClose} className="rounded-full p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Close"><X size={18} /></button>
@@ -498,11 +544,11 @@ function EventEditor({
             <div className="min-w-0 flex-1 space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
-                <input type="time" step={900} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
+                <input type="time" step={CALENDAR_SLOT_MINUTES * 60} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
                 <span className="text-[12px] text-ink-secondary">to</span>
                 <span className="rounded-lg border border-hairline/40 bg-inset/60 px-3 py-2 text-[13px] text-ink">{niceTime(endAt)}</span>
                 <select value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
-                  {[15, 30, 45, 60, 90, 120, 180, 240].map((minutes) => <option key={minutes} value={minutes}>{minutes < 60 ? `${minutes} min` : `${minutes / 60} hr`}</option>)}
+                  {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
                 </select>
               </div>
               <div className="flex flex-wrap items-center gap-2">
@@ -652,6 +698,7 @@ function QuickComposer({
   const [error, setError] = useState("");
   const dialogRef = useRef<HTMLDivElement>(null);
   const [dialogPosition, setDialogPosition] = useState<{ left: number; top: number } | null>(null);
+  const durationMinutes = seed.durationMinutes;
 
   useLayoutEffect(() => {
     if (!seed.anchor) {
@@ -691,7 +738,7 @@ function QuickComposer({
             runOn: "maus",
             enabled: true,
             schedule: { type: "once", at: seed.at },
-            durationMinutes: seed.durationMinutes,
+            durationMinutes,
             attachments: [],
           } satisfies RoutineInput),
         });
@@ -704,7 +751,7 @@ function QuickComposer({
             description,
             botIds,
             schedule: { type: "once", at: seed.at },
-            durationMinutes: seed.durationMinutes,
+            durationMinutes,
           } satisfies CalendarCallInput),
         });
         onSavedCall(response.call);
@@ -732,7 +779,7 @@ function QuickComposer({
         </div>
         <div className="flex items-start gap-3 text-[12.5px] text-ink">
           <Clock3 size={16} className="mt-0.5 shrink-0 text-ink-secondary" />
-          <div><div>{niceDate(seed.at)}</div><div className="mt-0.5 text-ink-secondary">{niceTime(seed.at)} – {niceTime(seed.at + seed.durationMinutes * 60_000)}</div></div>
+          <div><div>{niceDate(seed.at)}</div><div className="mt-0.5 text-ink-secondary">{niceTime(seed.at)} – {niceTime(seed.at + durationMinutes * 60_000)}</div></div>
         </div>
         <div className="flex items-start gap-3">
           <UserRoundPlus size={16} className="mt-2.5 shrink-0 text-ink-secondary" />
@@ -757,7 +804,7 @@ function QuickComposer({
         {error && <div className="rounded-lg bg-danger/10 px-3 py-2 text-[11.5px] text-danger">{error}</div>}
       </div>
       <div className="flex items-center justify-end gap-2 border-t border-hairline/40 px-4 py-3">
-        <button onClick={() => onMore({ ...seed, kind, botIds, name, description })} className="rounded-lg px-3 py-2 text-[12px] font-medium text-accent hover:bg-accent/10">More options</button>
+        <button onClick={() => onMore({ ...seed, kind, botIds, name, description, durationMinutes })} className="rounded-lg px-3 py-2 text-[12px] font-medium text-accent hover:bg-accent/10">More options</button>
         <button onClick={save} disabled={!valid || working} className="flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-[12px] font-semibold text-white hover:brightness-110 disabled:opacity-40">{working && <Loader2 size={13} className="animate-spin" />}Save</button>
       </div>
     </div>
@@ -807,7 +854,7 @@ function CalendarEventCard({
     const startDuration = previewDuration;
     let next = startDuration;
     const move = (pointer: PointerEvent) => {
-      next = Math.max(15, Math.min(240, Math.round((startDuration + ((pointer.clientY - startY) / HOUR_HEIGHT) * 60) / 15) * 15));
+      next = Math.max(CALENDAR_SLOT_MINUTES, Math.min(240, Math.round((startDuration + ((pointer.clientY - startY) / HOUR_HEIGHT) * 60) / CALENDAR_SLOT_MINUTES) * CALENDAR_SLOT_MINUTES));
       setPreviewDuration(next);
     };
     const up = () => {
@@ -904,14 +951,14 @@ function CalendarGrid({
     setSelection({ day, start, end });
     const move = (pointer: PointerEvent) => {
       const current = slotAt(day, pointer.clientY, rect.top, HOUR_HEIGHT);
-      end = Math.max(start + 15 * 60_000, current + 15 * 60_000);
+      end = Math.max(start + CALENDAR_SLOT_MINUTES * 60_000, current + CALENDAR_SLOT_MINUTES * 60_000);
       setSelection({ day, start, end });
     };
     const up = (pointer: PointerEvent) => {
       document.removeEventListener("pointermove", move);
       document.removeEventListener("pointerup", up);
       setSelection(null);
-      onCreate({ kind: "routine", at: start, durationMinutes: Math.max(15, Math.round((end - start) / 60_000)), botIds: [], anchor: { x: pointer.clientX, y: pointer.clientY } });
+      onCreate({ kind: "routine", at: start, durationMinutes: Math.max(CALENDAR_SLOT_MINUTES, Math.round((end - start) / 60_000)), botIds: [], anchor: { x: pointer.clientX, y: pointer.clientY } });
     };
     document.addEventListener("pointermove", move);
     document.addEventListener("pointerup", up, { once: true });
@@ -1194,6 +1241,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const backButtonRef = useRef<HTMLButtonElement>(null);
+  const newMenuRef = useRef<HTMLDetailsElement>(null);
   const [section, setSection] = useState<"calendar" | "webhooks">("calendar");
   const [viewDays, setViewDays] = useState<1 | 3 | 7>(7);
   const [anchor, setAnchor] = useState(() => startOfDay(Date.now()));
@@ -1203,6 +1251,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
   const [editor, setEditor] = useState<EventSeed | null>(null);
   const [selected, setSelected] = useState<CalendarEventItem | null>(null);
   const [pausedOpen, setPausedOpen] = useState(false);
+  const [webhookCreateRequest, setWebhookCreateRequest] = useState(0);
   const [error, setError] = useState("");
   const visibleBots = state.bots.filter((bot) => !bot.hidden);
   const rangeStart = viewDays === 7 ? startOfWeek(anchor) : startOfDay(anchor);
@@ -1218,6 +1267,14 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
   }, []);
   useEffect(() => { void loadCalls(); }, [loadCalls]);
   useEffect(() => { backButtonRef.current?.focus({ preventScroll: true }); }, []);
+  useEffect(() => {
+    const closeNewMenu = (event: PointerEvent) => {
+      const menu = newMenuRef.current;
+      if (menu?.open && !menu.contains(event.target as Node)) menu.removeAttribute("open");
+    };
+    document.addEventListener("pointerdown", closeNewMenu);
+    return () => document.removeEventListener("pointerdown", closeNewMenu);
+  }, []);
 
   const items = useMemo<CalendarEventItem[]>(() => {
     const routineItems = projectedRoutineItems(state.routines, state.routineRuns, rangeStart, rangeEnd).map((item) => ({ ...item, kind: "routine" as const }));
@@ -1252,6 +1309,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
     setAnchor((current) => startOfDay(current));
   };
   const goToday = useCallback(() => setAnchor(startOfDay(Date.now())), []);
+  const handleWebhookCreateHandled = useCallback(() => setWebhookCreateRequest(0), []);
   const openCreate = useCallback((seed?: Partial<EventSeed>) => {
     setSelected(null);
     setQuick({ kind: "routine", at: nextHour(), durationMinutes: 30, botIds: [], ...seed });
@@ -1261,7 +1319,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
     const onKey = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       if (target?.matches("input, textarea, select, [contenteditable=true]")) return;
-      if (event.key === "Escape") { setQuick(null); setEditor(null); setSelected(null); return; }
+      if (event.key === "Escape") { newMenuRef.current?.removeAttribute("open"); setQuick(null); setEditor(null); setSelected(null); return; }
       if (section !== "calendar" || event.metaKey || event.ctrlKey || event.altKey) return;
       if (event.key.toLowerCase() === "c") { event.preventDefault(); openCreate(); }
       if (event.key.toLowerCase() === "t") goToday();
@@ -1326,33 +1384,53 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
           >
             <ArrowLeft size={18} />
           </button>
-          <div className="mr-3 flex items-center gap-2"><CalendarDays size={21} className="text-accent" /><h1 className="text-[18px] font-semibold tracking-tight text-ink">Calendar</h1></div>
-          <div className="flex items-center rounded-lg border border-hairline/50 bg-panel p-0.5" style={windowNoDragStyle}>
+          <div className="mr-2 flex items-center gap-2"><CalendarDays size={21} className="text-accent" /><h1 className="text-[18px] font-semibold tracking-tight text-ink">Automations</h1></div>
+          <div className="flex items-center rounded-lg border border-hairline/50 bg-panel p-0.5" style={windowNoDragStyle} aria-label="Automation type">
+            <button type="button" aria-pressed={section === "calendar"} onClick={() => setSection("calendar")} className={cn("rounded-md px-3 py-1.5 text-[11.5px] font-medium", section === "calendar" ? "bg-raised text-ink shadow-sm" : "text-ink-secondary hover:text-ink")}>Schedule</button>
+            <button type="button" aria-pressed={section === "webhooks"} onClick={() => setSection("webhooks")} className={cn("flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11.5px] font-medium", section === "webhooks" ? "bg-raised text-ink shadow-sm" : "text-ink-secondary hover:text-ink")}><Webhook size={12} />Webhooks{state.webhooks.length > 0 && <span className="rounded-full bg-accent/15 px-1.5 text-[9px] text-accent">{state.webhooks.length}</span>}</button>
+          </div>
+          <details ref={newMenuRef} className="group relative ml-auto" style={windowNoDragStyle}>
+            <summary aria-label="Create an automation" className="flex cursor-pointer list-none items-center gap-1.5 rounded-lg bg-accent px-3.5 py-2 text-[12px] font-semibold text-white hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60">
+              <Plus size={15} aria-hidden="true" />New
+            </summary>
+            <div role="group" aria-label="New automation" className="absolute right-0 top-full z-40 mt-1.5 w-[280px] rounded-xl border border-hairline/60 bg-card p-1.5 shadow-2xl">
+              <button type="button" aria-label="Create a scheduled task" onClick={() => { newMenuRef.current?.removeAttribute("open"); setSection("calendar"); openCreate({ kind: "routine" }); }} className="flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-raised">
+                <Clock3 size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+                <span><span className="block text-[12.5px] font-medium text-ink">Scheduled task</span><span className="mt-0.5 block text-[10.5px] leading-relaxed text-ink-secondary">Ask a bot to do something later.</span></span>
+              </button>
+              <button type="button" aria-label="Create a scheduled call" onClick={() => { newMenuRef.current?.removeAttribute("open"); setSection("calendar"); openCreate({ kind: "call" }); }} className="flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-raised">
+                <Video size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+                <span><span className="block text-[12.5px] font-medium text-ink">Scheduled call</span><span className="mt-0.5 block text-[10.5px] leading-relaxed text-ink-secondary">Bring bots together at a set time.</span></span>
+              </button>
+              <button type="button" aria-label="Create a webhook" disabled={visibleBots.length === 0} onClick={() => { newMenuRef.current?.removeAttribute("open"); setSection("webhooks"); setWebhookCreateRequest((request) => request + 1); }} className="flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-raised disabled:cursor-not-allowed disabled:opacity-40">
+                <Webhook size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+                <span><span className="block text-[12.5px] font-medium text-ink">Webhook</span><span className="mt-0.5 block text-[10.5px] leading-relaxed text-ink-secondary">Start a task when another app sends an event.</span></span>
+              </button>
+            </div>
+          </details>
+        </div>
+        {section === "calendar" && <div className="mt-2 flex flex-wrap items-center gap-2" style={windowNoDragStyle}>
+          <div className="flex items-center rounded-lg border border-hairline/50 bg-panel p-0.5">
             <button onClick={() => setAnchor((current) => addDays(current, -viewDays))} className="rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Previous dates"><ChevronLeft size={16} /></button>
             <button onClick={goToday} className="rounded-md px-3 py-1.5 text-[12px] font-medium text-ink hover:bg-raised">Today</button>
             <button onClick={() => setAnchor((current) => addDays(current, viewDays))} className="rounded-md p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Next dates"><ChevronRight size={16} /></button>
           </div>
           <div className="min-w-[220px] px-2 text-[15px] font-medium text-ink">{calendarRangeLabel(rangeStart, viewDays)}</div>
-          <div className="ml-auto flex items-center gap-2" style={windowNoDragStyle}>
+          <div className="ml-auto flex items-center gap-2">
             {running > 0 && <span className="hidden items-center gap-1.5 rounded-full bg-accent/10 px-2.5 py-1.5 text-[10.5px] text-accent sm:flex"><Loader2 size={11} className="animate-spin" />{running} active</span>}
             {unseenFailures > 0 && <span className="hidden items-center gap-1.5 rounded-full bg-danger/10 px-2.5 py-1.5 text-[10.5px] text-danger sm:flex"><CircleAlert size={11} />{unseenFailures}</span>}
             {paused.length > 0 && <button onClick={() => setPausedOpen(true)} className="hidden items-center gap-1.5 rounded-full border border-hairline/50 px-2.5 py-1.5 text-[10.5px] text-ink-secondary hover:bg-raised sm:flex"><Pause size={11} />{paused.length}</button>}
-            <select value={botFilter} onChange={(event) => setBotFilter(event.target.value)} className="hidden rounded-lg border border-hairline/50 bg-panel px-2.5 py-2 text-[11.5px] text-ink outline-none focus:border-accent sm:block"><option value="all">All bots</option>{visibleBots.map((bot) => <option key={bot.id} value={bot.id}>{bot.name}</option>)}</select>
-            <select value={viewDays} onChange={(event) => setView(Number(event.target.value) as 1 | 3 | 7)} className="rounded-lg border border-hairline/50 bg-panel px-2.5 py-2 text-[11.5px] text-ink outline-none focus:border-accent"><option value={1}>Day</option><option value={3}>3 days</option><option value={7}>Week</option></select>
+            <select aria-label="Filter schedule by bot" value={botFilter} onChange={(event) => setBotFilter(event.target.value)} className="hidden rounded-lg border border-hairline/50 bg-panel px-2.5 py-2 text-[11.5px] text-ink outline-none focus:border-accent sm:block"><option value="all">All bots</option>{visibleBots.map((bot) => <option key={bot.id} value={bot.id}>{bot.name}</option>)}</select>
+            <select aria-label="Schedule range" value={viewDays} onChange={(event) => setView(Number(event.target.value) as 1 | 3 | 7)} className="rounded-lg border border-hairline/50 bg-panel px-2.5 py-2 text-[11.5px] text-ink outline-none focus:border-accent"><option value={1}>Day</option><option value={3}>3 days</option><option value={7}>Week</option></select>
           </div>
-        </div>
-        <div className="mt-2 flex items-center gap-1" style={windowNoDragStyle}>
-          <button onClick={() => setSection("calendar")} className={cn("rounded-lg px-3 py-1.5 text-[11.5px] font-medium", section === "calendar" ? "bg-accent/12 text-accent" : "text-ink-secondary hover:bg-raised hover:text-ink")}>Routines &amp; calls</button>
-          <button onClick={() => setSection("webhooks")} className={cn("flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11.5px] font-medium", section === "webhooks" ? "bg-accent/12 text-accent" : "text-ink-secondary hover:bg-raised hover:text-ink")}><Webhook size={12} />Webhooks{state.webhooks.length > 0 && <span className="rounded-full bg-accent/15 px-1.5 text-[9px]">{state.webhooks.length}</span>}</button>
-          {error && <button onClick={() => setError("")} className="ml-auto flex items-center gap-1.5 rounded-lg bg-danger/10 px-2.5 py-1.5 text-[10.5px] text-danger"><CircleAlert size={11} />{error}<X size={11} /></button>}
-        </div>
+          {error && <button onClick={() => setError("")} className="flex items-center gap-1.5 rounded-lg bg-danger/10 px-2.5 py-1.5 text-[10.5px] text-danger"><CircleAlert size={11} />{error}<X size={11} /></button>}
+        </div>}
       </header>
 
-      {section === "webhooks" ? <WebhooksPanel bots={visibleBots} /> : (
+      {section === "webhooks" ? <WebhooksPanel bots={visibleBots} createRequest={webhookCreateRequest} onCreateHandled={handleWebhookCreateHandled} /> : (
         <div className="flex min-h-0 flex-1">
-          <div className="hidden shrink-0 lg:block"><CalendarSidebar bots={visibleBots} anchor={anchor} onSelectDate={(at) => setAnchor(startOfDay(at))} onCreate={() => openCreate()} /></div>
+          <div className="hidden shrink-0 lg:block"><CalendarSidebar bots={visibleBots} anchor={anchor} onSelectDate={(at) => setAnchor(startOfDay(at))} /></div>
           <CalendarGrid anchor={rangeStart} days={viewDays} items={items} bots={state.bots} groups={state.groups} onOpen={(item) => { setSelected(item); if (item.kind === "routine" && item.run && ["failed", "missed"].includes(item.run.status) && !item.run.seenAt) dispatch({ type: "markRoutineRunSeen", runId: item.run.id }); }} onCreate={openCreate} onMove={(item, at) => void moveEvent(item, at)} onResize={(item, duration) => void resizeEvent(item, duration)} />
-          <button onClick={() => openCreate()} disabled={!visibleBots.length} className="fixed bottom-5 right-5 z-30 flex size-12 items-center justify-center rounded-2xl bg-accent text-white shadow-xl shadow-black/30 hover:brightness-110 disabled:opacity-40 lg:hidden" aria-label="Create event"><Plus size={20} /></button>
         </div>
       )}
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, ChevronDown, ChevronLeft, Crown, FolderOpen, Trash2, X } from "lucide-react";
+import { BookOpen, CalendarClock, ChevronDown, ChevronLeft, Crown, FolderOpen, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api, useStore, type Bot } from "@/state/store";
 import { stateForBot } from "@/lib/mascot";
@@ -16,6 +16,7 @@ import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import { VoiceSettings } from "./VoiceSettings";
 import { BOT_PROFILE_LIMITS } from "../../shared/bot-profile";
 import { Switch } from "./SettingsPrimitives";
+import { RoutineEditor } from "./RoutinesPage";
 
 function Field({
   label,
@@ -540,6 +541,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
   const providerSupportsLocal = instanceSupportsLocalComputer(state.instances, bot);
   const localSelectable = localComputerSelectable({ capabilities, providerSupportsLocal });
   const [localAutoWarning, setLocalAutoWarning] = useState<"auto" | "local" | null>(null);
+  const [creatingRoutine, setCreatingRoutine] = useState(false);
+  useEffect(() => setCreatingRoutine(false), [bot.id]);
   const localDisabledReason = localComputerDisabledReason({ capabilities, providerSupportsLocal });
   const patch = (
     p: Partial<
@@ -590,6 +593,8 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
       candidate.chiefOfStaff &&
       (candidate.section?.trim() || "") === (bot.section?.trim() || ""),
   );
+  const botRoutines = state.routines.filter((routine) => routine.botId === bot.id);
+  const activeBotRoutines = botRoutines.filter((routine) => routine.enabled).length;
 
   return (
     <>
@@ -650,6 +655,33 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
               onChange={(e) => patch({ description: e.target.value })}
             />
           </Field>
+
+          <div className="rounded-xl bg-card p-4">
+            <div className="flex items-center gap-2">
+              <CalendarClock size={16} className="text-accent" />
+              <div className="min-w-0 flex-1 text-[15px] font-medium text-ink">Scheduled tasks</div>
+              <span className="shrink-0 text-[11.5px] tabular-nums text-ink-secondary">
+                {activeBotRoutines} active · {botRoutines.length} total
+              </span>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() => setCreatingRoutine(true)}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:brightness-110"
+              >
+                <Plus size={14} />
+                New schedule
+              </button>
+              <button
+                type="button"
+                onClick={() => dispatch({ type: "showRoutines" })}
+                className="rounded-lg bg-control px-3 py-2 text-[13px] text-ink hover:bg-raised-hover"
+              >
+                Manage
+              </button>
+            </div>
+          </div>
 
           <div className={cn(
             "rounded-xl border p-4",
@@ -964,6 +996,14 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         </div>
       </div>
     </aside>
+    {creatingRoutine && (
+      <RoutineEditor
+        key={bot.id}
+        bots={[bot]}
+        lockedBotId={bot.id}
+        onClose={() => setCreatingRoutine(false)}
+      />
+    )}
     <LocalComputerAutoWarning
       open={localAutoWarning !== null}
       onCancel={() => setLocalAutoWarning(null)}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1696,8 +1696,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           )}
           <button
             onClick={() => dispatch({ type: "showRoutines" })}
-            aria-label={density === "icons" ? "Calendar" : undefined}
-            title={density === "icons" ? "Calendar" : undefined}
+            aria-label={density === "icons" ? "Automations" : undefined}
+            title={density === "icons" ? "Automations" : undefined}
             className={cn(
               "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
               density === "icons" ? "justify-center px-2" : "gap-3 px-3",
@@ -1705,7 +1705,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             )}
           >
             <CalendarDays size={20} className={state.activeView === "routines" ? "text-accent" : "text-ink-secondary"} />
-            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Calendar</span>
+            <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Automations</span>
             {state.routineRuns.some((run) => ["failed", "missed"].includes(run.status) && !run.seenAt) && (
               <span className="size-2 rounded-full bg-danger" />
             )}
@@ -1750,7 +1750,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                 : []),
               {
                 key: "routines",
-                label: "Tasks & routines",
+                label: "Automations",
                 icon: <CalendarDays size={18} />,
                 active: state.activeView === "routines",
                 // folded away, this dot would otherwise vanish with the row

--- a/src/components/SidebarMoreMenu.tsx
+++ b/src/components/SidebarMoreMenu.tsx
@@ -1,6 +1,6 @@
 // The sidebar's utility rows, folded behind one chevron.
 //
-// Team map, Teach a skill, Tasks & routines and Connected apps are places you
+// Team map, Teach a skill, Automations and Connected apps are places you
 // visit occasionally; they were costing four permanent rows at the bottom of a
 // list whose whole job is showing bots. They now live behind a slim bar that
 // sits directly above the profile row and opens on hover — the pull-up handle

--- a/src/components/WebhooksPanel.tsx
+++ b/src/components/WebhooksPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   ChevronDown,
@@ -88,8 +88,47 @@ function WebhookEditor({ webhook, bots, onClose, onCredential }: { webhook?: Web
   const [eventTypes, setEventTypes] = useState((webhook?.eventTypes ?? []).join(", "));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   const cloudInstance = state.instances.find((instance) => instance.driverKind === "boxAgent");
   const cloudReady = Boolean(state.config?.box.configured && cloudInstance?.snapshot.state === "available");
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusable = () => Array.from(dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )).filter((element) => !element.hasAttribute("hidden"));
+    (dialog.querySelector<HTMLElement>("[data-initial-focus]") ?? focusable()[0] ?? dialog).focus();
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const controls = focusable();
+      if (!controls.length) return event.preventDefault();
+      const first = controls[0]!;
+      const last = controls[controls.length - 1]!;
+      if (event.shiftKey && (document.activeElement === first || !dialog.contains(document.activeElement))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener("keydown", onKey);
+    return () => {
+      dialog.removeEventListener("keydown", onKey);
+      if (previousFocus?.getClientRects().length) previousFocus.focus();
+      else document.querySelector<HTMLElement>('summary[aria-label="Create an automation"]')?.focus();
+    };
+  }, []);
 
   const save = async () => {
     const bot = bots.find((candidate) => candidate.id === botId);
@@ -110,10 +149,10 @@ function WebhookEditor({ webhook, bots, onClose, onCredential }: { webhook?: Web
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-5 backdrop-blur-sm" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
-      <div className="flex max-h-[90vh] w-full max-w-[590px] flex-col overflow-hidden rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
-        <div className="flex items-start justify-between border-b border-hairline/40 px-5 py-4"><div><div className="text-[17px] font-semibold text-ink">{webhook ? "Edit webhook" : "New local webhook"}</div><div className="mt-1 text-[12px] text-ink-secondary">Each request starts a new task in the MAUS chat.</div></div><button onClick={onClose} className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button></div>
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-label={webhook ? "Edit webhook" : "New webhook"} tabIndex={-1} className="flex max-h-[90vh] w-full max-w-[590px] flex-col overflow-hidden rounded-2xl border border-hairline/60 bg-panel shadow-2xl">
+        <div className="flex items-start justify-between border-b border-hairline/40 px-5 py-4"><div><div className="text-[17px] font-semibold text-ink">{webhook ? "Edit webhook" : "New webhook"}</div><div className="mt-1 text-[12px] text-ink-secondary">Each request starts a new task in the MAUS chat.</div></div><button onClick={onClose} aria-label="Close webhook editor" className="rounded-lg p-2 text-ink-secondary hover:bg-raised hover:text-ink"><X size={18} /></button></div>
         <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5">
-          <div><div className="mb-2 text-[12px] font-medium text-ink-secondary">Who receives the tasks?</div><div className="grid grid-cols-2 gap-2 sm:grid-cols-3">{bots.map((bot) => <button key={bot.id} type="button" onClick={() => setBotId(bot.id)} className={cn("flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left", botId === bot.id ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60")}><BotAvatar bot={bot} state={botId === bot.id ? "happy" : "idle"} size={38} animated={false} /><span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">{bot.name}</span></button>)}</div></div>
+          <div><div className="mb-2 text-[12px] font-medium text-ink-secondary">Who receives the tasks?</div><div className="grid grid-cols-2 gap-2 sm:grid-cols-3">{bots.map((bot) => <button key={bot.id} type="button" data-initial-focus={botId === bot.id ? "" : undefined} onClick={() => setBotId(bot.id)} className={cn("flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left", botId === bot.id ? "border-accent/70 bg-accent/10" : "border-hairline/50 bg-inset hover:bg-raised/60")}><BotAvatar bot={bot} state={botId === bot.id ? "happy" : "idle"} size={38} animated={false} /><span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">{bot.name}</span></button>)}</div></div>
           <div className="rounded-xl border border-accent/20 bg-accent/5 px-3.5 py-3 text-[11.5px] leading-relaxed text-ink-secondary">Send the task in the request: <code className="text-ink">{`{"task":"Check the failed build"}`}</code>. The MAUS keeps its model, tools, permissions, and computer setup.</div>
           <details className="group rounded-xl border border-hairline/45 bg-inset/45 px-4 py-3" open={Boolean(webhook)}>
             <summary className="cursor-pointer text-[12.5px] font-medium text-ink">Advanced options</summary>
@@ -126,7 +165,7 @@ function WebhookEditor({ webhook, bots, onClose, onCredential }: { webhook?: Web
           </details>
           {error && <div className="rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[12px] text-danger">{error}</div>}
         </div>
-        <div className="flex justify-end gap-2 border-t border-hairline/40 px-5 py-4"><button onClick={onClose} className="rounded-xl px-4 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink">Cancel</button><button disabled={saving || !botId} onClick={() => void save()} className="flex items-center gap-2 rounded-xl bg-accent px-4 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40">{saving && <Loader2 size={14} className="animate-spin" />}{webhook ? "Save changes" : "Create local webhook"}</button></div>
+        <div className="flex justify-end gap-2 border-t border-hairline/40 px-5 py-4"><button onClick={onClose} className="rounded-xl px-4 py-2 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink">Cancel</button><button disabled={saving || !botId} onClick={() => void save()} className="flex items-center gap-2 rounded-xl bg-accent px-4 py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40">{saving && <Loader2 size={14} className="animate-spin" />}{webhook ? "Save changes" : "Create webhook"}</button></div>
       </div>
     </div>
   );
@@ -136,7 +175,15 @@ interface ActivityItem { id: string; at: number; outcome: WebhookAttempt["outcom
 
 /** A destination-first webhook view: choose a MAUS endpoint on the left, then
  * either copy its setup command or inspect its deliveries on the right. */
-export function WebhooksPanel({ bots }: { bots: Bot[] }) {
+export function WebhooksPanel({
+  bots,
+  createRequest,
+  onCreateHandled,
+}: {
+  bots: Bot[];
+  createRequest: number;
+  onCreateHandled: () => void;
+}) {
   const { state, dispatch } = useStore();
   const [editor, setEditor] = useState<WebhookTrigger | "new" | null>(null);
   const [credentials, setCredentials] = useState<Record<string, WebhookCredential>>(() =>
@@ -153,6 +200,13 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
     if (!state.webhooks.length) setSelectedId(null);
     else if (!selectedId || !state.webhooks.some((webhook) => webhook.id === selectedId)) setSelectedId(state.webhooks[0]!.id);
   }, [selectedId, state.webhooks]);
+
+  useEffect(() => {
+    if (createRequest > 0) {
+      setEditor("new");
+      onCreateHandled();
+    }
+  }, [createRequest, onCreateHandled]);
 
   const selected = state.webhooks.find((webhook) => webhook.id === selectedId) ?? null;
   const selectedBot = selected ? bots.find((bot) => bot.id === selected.botId) : undefined;
@@ -235,35 +289,17 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
   const command = credential ? terminalCommand(credential) : "";
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto border-t border-hairline/40 p-4 md:p-6">
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
       <div className="mx-auto max-w-[1120px] space-y-4">
-        <header className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <div className="flex items-center gap-2">
-              <h2 className="text-[17px] font-semibold text-ink">Webhooks</h2>
-              <span className="rounded-md bg-accent/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-accent">Local beta</span>
-            </div>
-            <p className="mt-1 text-[12px] text-ink-secondary">Send a task to a MAUS when another tool reports an event.</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <div className={cn("hidden items-center gap-1.5 text-[10.5px] sm:flex", ingress?.available ? "text-success" : "text-danger")}>
-              <span className={cn("size-1.5 rounded-full", ingress?.available ? "bg-success" : "bg-danger")} />
-              {ingress?.available ? "Receiver running" : ingress?.error ?? "Receiver unavailable"}
-            </div>
-            <button onClick={() => setEditor("new")} disabled={bots.length === 0} className="flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2 text-[12.5px] font-medium text-white hover:brightness-110 disabled:opacity-40">
-              <Plus size={15} />New webhook
-            </button>
-          </div>
-        </header>
-
         {error && <div className="rounded-xl border border-danger/30 bg-danger/10 px-3.5 py-3 text-[12px] text-danger">{error}</div>}
+        {ingress && !ingress.available && <div className="flex items-center gap-2 rounded-xl border border-danger/25 bg-danger/10 px-3.5 py-3 text-[12px] text-danger"><span className="size-1.5 shrink-0 rounded-full bg-danger" />Webhook receiver unavailable{ingress.error ? `: ${ingress.error}` : "."}</div>}
 
         {state.webhooks.length === 0 ? (
           <div className="border-t border-hairline/40 px-6 py-16 text-center">
             <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-2xl bg-accent/10 text-accent"><Send size={23} /></div>
             <h3 className="text-[16px] font-semibold text-ink">Create your first webhook</h3>
             <p className="mx-auto mt-2 max-w-[420px] text-[12.5px] leading-relaxed text-ink-secondary">Choose a MAUS, copy one command, and every request becomes a new task in its chat.</p>
-            <button onClick={() => setEditor("new")} disabled={bots.length === 0} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />Create local webhook</button>
+            <button onClick={() => setEditor("new")} disabled={bots.length === 0} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-40"><Plus size={15} />Create webhook</button>
             {bots.length === 0 && <p className="mt-3 text-[12px] text-warning">Create a MAUS first, then come back here.</p>}
           </div>
         ) : selected && (
@@ -326,7 +362,7 @@ export function WebhooksPanel({ bots }: { bots: Bot[] }) {
                         <button disabled={Boolean(working) || !ingress?.available} onClick={() => void createAndCopyCommand(selected)} className="mt-3 flex items-center gap-2 rounded-xl bg-accent px-3.5 py-2.5 text-[12px] font-medium text-white hover:brightness-110 disabled:opacity-40">{working === `${selected.id}:command` ? <Loader2 size={14} className="animate-spin" /> : <RotateCw size={14} />}Generate new private URL</button>
                       </div>
                     )}
-                    <div className="mt-3 flex items-start gap-2 text-[10.5px] leading-relaxed text-ink-secondary"><Laptop size={12} className="mt-0.5 shrink-0" /><span>Local only for now. Keep OpenMausBot open while sending the request.</span></div>
+                    <div className="mt-3 flex items-start gap-2 text-[10.5px] leading-relaxed text-ink-secondary"><Laptop size={12} className="mt-0.5 shrink-0" /><span>Keep OpenMausBot open so it can receive requests.</span></div>
 
                     {selected.verificationSample && !selected.enabled && <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-y border-success/20 bg-success/5 px-3.5 py-3"><div><div className="flex items-center gap-2 text-[11.5px] font-medium text-success"><Check size={13} />Request received</div><p className="mt-1 max-w-[520px] truncate font-mono text-[10px] text-ink-secondary">{selected.verificationSample.preview || "Empty payload"}</p></div><button disabled={Boolean(working)} onClick={() => void invoke(selected, "toggle")} className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-[11px] font-medium text-white hover:brightness-110"><Play size={12} />Turn on</button></div>}
 

--- a/src/components/routines/CalendarSidebar.tsx
+++ b/src/components/routines/CalendarSidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type DragEvent } from "react";
-import { GripVertical, Plus, Search, UsersRound } from "lucide-react";
+import { GripVertical, Search, UsersRound } from "lucide-react";
 import { BotAvatar } from "@/components/Avatar";
 import type { Bot } from "@/state/store";
 import { MiniMonth } from "./MiniMonth";
@@ -10,10 +10,9 @@ export interface CalendarSidebarProps {
   bots: Bot[];
   anchor: number;
   onSelectDate: (at: number) => void;
-  onCreate: () => void;
 }
 
-export function CalendarSidebar({ bots, anchor, onSelectDate, onCreate }: CalendarSidebarProps) {
+export function CalendarSidebar({ bots, anchor, onSelectDate }: CalendarSidebarProps) {
   const [query, setQuery] = useState("");
   const filteredBots = useMemo(() => {
     const normalized = query.trim().toLocaleLowerCase();
@@ -31,20 +30,9 @@ export function CalendarSidebar({ bots, anchor, onSelectDate, onCreate }: Calend
 
   return (
     <aside
-      aria-label="Calendar sidebar"
+      aria-label="Schedule sidebar"
       className="flex h-full w-[320px] shrink-0 flex-col overflow-hidden border-r border-hairline/40 bg-panel"
     >
-      <div className="px-4 pb-2 pt-4">
-        <button
-          type="button"
-          onClick={onCreate}
-          className="group flex h-11 w-full items-center justify-center gap-2 rounded-full bg-accent px-5 text-[13px] font-semibold text-white shadow-lg shadow-accent/15 transition hover:-translate-y-px hover:brightness-110 hover:shadow-xl hover:shadow-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-panel active:translate-y-0"
-        >
-          <Plus size={17} strokeWidth={2.5} aria-hidden="true" />
-          Create
-        </button>
-      </div>
-
       <MiniMonth anchor={anchor} onSelect={onSelectDate} />
 
       <div className="mx-4 border-t border-hairline/40" />
@@ -84,8 +72,8 @@ export function CalendarSidebar({ bots, anchor, onSelectDate, onCreate }: Calend
               onDragStart={(event) => beginBotDrag(event, bot)}
               role="listitem"
               className="group flex cursor-grab items-center gap-2 rounded-xl px-2 py-2 transition-colors hover:bg-raised/80 active:cursor-grabbing"
-              aria-label={`Drag ${bot.name} onto the calendar`}
-              title={`Drag ${bot.name} onto a time slot`}
+              aria-label={`Drag ${bot.name} onto the schedule`}
+              title={`Drag ${bot.name} onto the schedule`}
             >
               <GripVertical
                 size={13}

--- a/src/lib/routine-calendar.test.ts
+++ b/src/lib/routine-calendar.test.ts
@@ -14,13 +14,13 @@ import {
 } from "./routine-calendar";
 
 describe("routine calendar geometry", () => {
-  it("snaps pointer positions to 15 minute slots", () => {
-    expect(snapMinutes(7)).toBe(0);
-    expect(snapMinutes(8)).toBe(15);
-    expect(snapMinutes(24 * 60)).toBe(23 * 60 + 45);
+  it("snaps pointer positions to 5 minute slots", () => {
+    expect(snapMinutes(2)).toBe(0);
+    expect(snapMinutes(3)).toBe(5);
+    expect(snapMinutes(24 * 60)).toBe(23 * 60 + 55);
     const day = new Date(2026, 7, 31).getTime();
-    expect(new Date(slotAt(day, 100 + 9.25 * 64, 100, 64)).getHours()).toBe(9);
-    expect(new Date(slotAt(day, 100 + 9.25 * 64, 100, 64)).getMinutes()).toBe(15);
+    expect(new Date(slotAt(day, 100 + 9.1 * 64, 100, 64)).getHours()).toBe(9);
+    expect(new Date(slotAt(day, 100 + 9.1 * 64, 100, 64)).getMinutes()).toBe(5);
   });
 
   it("starts weeks on Monday", () => {
@@ -62,6 +62,17 @@ describe("routine calendar geometry", () => {
 
     expect(layouts.get("one")).toEqual({ column: 0, columns: 1 });
     expect(layouts.get("two")).toEqual({ column: 0, columns: 1 });
+  });
+
+  it("packs adjacent five minute events around their minimum visual height", () => {
+    const at = new Date(2026, 7, 31, 9).getTime();
+    const layouts = packCalendarCollisions([
+      { id: "one", at, durationMinutes: 5 },
+      { id: "two", at: at + 5 * 60_000, durationMinutes: 5 },
+    ]);
+
+    expect(layouts.get("one")).toEqual({ column: 0, columns: 2 });
+    expect(layouts.get("two")).toEqual({ column: 1, columns: 2 });
   });
 
   it("formats whole-hour and fractional GMT offsets", () => {

--- a/src/lib/routine-calendar.ts
+++ b/src/lib/routine-calendar.ts
@@ -1,6 +1,6 @@
 import type { Routine, RoutineRun, RoutineSchedule } from "./routines";
 
-export const CALENDAR_SLOT_MINUTES = 15;
+export const CALENDAR_SLOT_MINUTES = 5;
 
 export type RoutineCalendarItem = {
   id: string;
@@ -72,9 +72,13 @@ export function snapMinutes(minutes: number, increment = CALENDAR_SLOT_MINUTES):
 export function packCalendarCollisions(
   items: readonly CalendarCollisionItem[],
 ): Map<string, CalendarCollisionLayout> {
+  // Short events keep a 16px hit target in the renderer. Pack against that
+  // same visual footprint so adjacent five-minute cards never cover each other.
+  const visualEnd = (item: CalendarCollisionItem) =>
+    item.at + Math.max(15, item.durationMinutes) * 60_000;
   const sorted = [...items].sort((left, right) =>
     left.at - right.at
-    || left.at + left.durationMinutes * 60_000 - (right.at + right.durationMinutes * 60_000)
+    || visualEnd(left) - visualEnd(right)
     || left.id.localeCompare(right.id),
   );
   const result = new Map<string, CalendarCollisionLayout>();
@@ -86,7 +90,7 @@ export function packCalendarCollisions(
       const item = sorted[cursor]!;
       if (cluster.length > 0 && item.at >= clusterEnd) break;
       cluster.push(item);
-      clusterEnd = Math.max(clusterEnd, item.at + Math.max(1, item.durationMinutes) * 60_000);
+      clusterEnd = Math.max(clusterEnd, visualEnd(item));
       cursor += 1;
     }
 
@@ -94,7 +98,7 @@ export function packCalendarCollisions(
     const assignments = cluster.map((item) => {
       const available = columnEnds.findIndex((end) => end <= item.at);
       const column = available === -1 ? columnEnds.length : available;
-      columnEnds[column] = item.at + Math.max(1, item.durationMinutes) * 60_000;
+      columnEnds[column] = visualEnd(item);
       return { id: item.id, column };
     });
     const columns = Math.max(1, columnEnds.length);


### PR DESCRIPTION
## Summary

- replace the split Calendar / Tasks and routines entry points with one clean Automations screen
- make Schedule and Webhooks sibling views with a single New menu
- hide calendar-only controls while viewing webhooks
- add a Scheduled tasks card to bot settings for quick create and management
- support 5-minute start, duration, resize, and drag precision across desktop, server, iOS, Android, and agent tools
- keep existing routine and webhook storage, APIs, and credentials unchanged
- improve modal keyboard behavior and prevent adjacent short events from overlapping

## Verification

- production desktop build
- TypeScript typecheck and focused lint
- 264 focused server and calendar tests
- 288 Swift tests plus iOS simulator app build
- focused Android routine tests
- isolated OpenMausBot fixture and visual renderer pass
- visually verified adjacent 5-minute events, Webhook dialog focus/Escape, and New-menu dismissal

No database migration or new dependency is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule durations can now be set from 5 to 240 minutes in 5-minute increments across supported platforms.
  * Added an Automations area with streamlined creation options for scheduled tasks, calls, and webhooks.
  * Added scheduled task controls and creation access from Settings.
  * Improved webhook editor keyboard navigation, focus handling, and accessibility.

* **Improvements**
  * Calendar scheduling now uses five-minute time slots.
  * Updated navigation labels and terminology to “Automations” and “Schedule.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->