### PR TITLE
Bump version to 0.1.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop release version from 0.1.47 to 0.1.48.

This release includes the simplified Automations UI and five-minute scheduling from #708.

After this PR is merged, the unified release workflow will build, sign, notarize, verify, and publish macOS arm64/x64, Windows, and Ubuntu artifacts from the pinned merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.47 to 0.1.48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->