### PR TITLE
Refresh dynamic model catalogs from the picker

### DIFF
--- a/server/harness/registry.test.ts
+++ b/server/harness/registry.test.ts
@@ -148,6 +148,32 @@ describe("ProviderRegistry", () => {
     expect((await registry.describe())[0].capabilities.approvalReview).toBe(true);
   });
 
+  it("refreshes a live model catalog before returning each description", async () => {
+    const fake = makeFakeDriver();
+    const registry = new ProviderRegistry([fake.driver]);
+    await registry.load({ a: { driver: "fake" } });
+    const instance = registry.get("a")!;
+    let refreshes = 0;
+    Object.assign(instance, {
+      refreshModels: async () => {
+        refreshes += 1;
+        instance.models.default = `dynamic-${refreshes}`;
+        instance.models.options = [
+          { id: `dynamic-${refreshes}`, label: `Dynamic ${refreshes}` },
+        ];
+      },
+    });
+
+    expect((await registry.describe())[0].models).toEqual({
+      default: "dynamic-1",
+      options: [{ id: "dynamic-1", label: "Dynamic 1" }],
+    });
+    expect((await registry.describe())[0].models).toEqual({
+      default: "dynamic-2",
+      options: [{ id: "dynamic-2", label: "Dynamic 2" }],
+    });
+  });
+
   it("disposeAll disposes every live instance and empties the registry", async () => {
     const fake = makeFakeDriver();
     const registry = new ProviderRegistry([fake.driver]);

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,8 +1,8 @@
 // Compact model picker: providers live on a Cloud/Local rail. Ready engines
 // show a short suggested list with search and an explicit all-models view;
 // engines that need setup show one focused action instead of a disabled wall.
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown, ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Check, ChevronDown, ChevronLeft, ChevronRight, Loader2, RefreshCw, Search } from "lucide-react";
 import { useStore, type Bot, type InstanceInfo, type ModelSelection } from "@/state/store";
 import { filterCustomModels, partitionCustomModels, suggestedModels } from "@/lib/custom-models";
 import { isCustomOnly, splitEngineRail } from "@/lib/engine-rail";
@@ -122,16 +122,28 @@ export function ModelPicker({
   const [pane, setPane] = useState<"main" | "custom">("main");
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const refreshingRef = useRef(false);
 
   const selection = bot.modelSelection;
   const active = state.instances.find((instance) => instance.instanceId === selection.instanceId);
   const railInstance =
     state.instances.find((instance) => instance.instanceId === (railId ?? selection.instanceId)) ?? state.instances[0];
 
+  const refreshModels = useCallback(() => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    void refreshInstances().finally(() => {
+      refreshingRef.current = false;
+      setRefreshing(false);
+    });
+  }, [refreshInstances]);
+
   useEffect(() => {
-    if (open) void refreshInstances();
-  }, [open, refreshInstances]);
+    if (open) refreshModels();
+  }, [open, refreshModels]);
 
   useEffect(() => {
     if (!open) return;
@@ -333,14 +345,35 @@ export function ModelPicker({
                 <div className="shrink-0 px-4 pb-2 pt-3.5">
                   <div className="flex items-center justify-between gap-3">
                     <div className="truncate text-[14px] font-semibold text-ink">{railInstance.displayName}</div>
-                    <span
-                      className={cn(
-                        "shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-medium",
-                        blocked ? "bg-warning/10 text-warning" : "bg-success/10 text-success",
-                      )}
-                    >
-                      {pane === "custom" && !blocked ? "Local models" : engineStatus(railInstance)}
-                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        data-model-refresh
+                        disabled={refreshing}
+                        onClick={refreshModels}
+                        aria-label={
+                          refreshing
+                            ? `Refreshing ${railInstance.displayName} models`
+                            : `Refresh ${railInstance.displayName} models`
+                        }
+                        title="Refresh models"
+                        className="flex size-6 items-center justify-center rounded-md text-ink-secondary hover:bg-control hover:text-ink disabled:cursor-wait disabled:opacity-70"
+                      >
+                        {refreshing ? (
+                          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+                        ) : (
+                          <RefreshCw size={12} aria-hidden="true" />
+                        )}
+                      </button>
+                      <span
+                        className={cn(
+                          "shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-medium",
+                          blocked ? "bg-warning/10 text-warning" : "bg-success/10 text-success",
+                        )}
+                      >
+                        {pane === "custom" && !blocked ? "Local models" : engineStatus(railInstance)}
+                      </span>
+                    </div>
                   </div>
                   <div className="mt-0.5 text-[11.5px] text-ink-secondary">
                     {pane === "custom"


### PR DESCRIPTION
## Summary\n- keep refreshing provider model catalogs whenever the model picker opens\n- add a T3-style guarded refresh button and loading spinner inside the picker\n- prove each instance catalog is refreshed before the API returns it\n\n## Verification\n- pnpm exec oxlint src/components/ModelPicker.tsx server/harness/registry.test.ts\n- pnpm vitest run server/harness/registry.test.ts server/drivers/acp/opencode-go.test.ts server/drivers/openai-compat.test.ts src/lib/custom-models.test.ts\n- pnpm typecheck\n- pnpm build\n- isolated fixture: doctor + models against explicit temporary URL\n\nThe local in-app browser blocked the loopback fixture, so no browser screenshot assertion was available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual refresh button to the model picker, allowing users to reload available model instances.
  * The refresh button shows progress and is temporarily disabled while models are being refreshed.

* **Bug Fixes**
  * Model information now refreshes before being displayed, ensuring updated defaults and options appear in subsequent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->