### PR TITLE
Cloud desktop viewer takes the keyboard on takeover

### DIFF
--- a/electron/desktop-viewer-permissions.mjs
+++ b/electron/desktop-viewer-permissions.mjs
@@ -1,0 +1,37 @@
+// Permission policy for the in-app desktop viewer window. A VNC page needs a
+// few browser capabilities that are gated behind permission checks: keyboard
+// capture (so ⌘/Alt chords reach the guest instead of the host), pointer
+// capture, the clipboard for paste, and full screen. Denying those along with
+// everything else leaves a viewer where the mouse works but typing does not.
+//
+// Every privileged capability — camera, microphone, geolocation,
+// notifications, USB, HID, serial, MIDI, screen capture, file system — stays
+// off: this window renders a provider's remote content, not ours. The
+// allow-list also applies only to the viewer's own origin; anything the page
+// embeds cross-origin is refused outright.
+
+const DESKTOP_VIEWER_PERMISSIONS = new Set([
+  "keyboardLock",
+  "pointerLock",
+  "clipboard-read",
+  "clipboard-sanitized-write",
+  "fullscreen",
+]);
+
+// Opaque origins (data:, about:blank, javascript:) serialise as the string
+// "null"; never let two of them match each other.
+function webOrigin(value) {
+  if (Object.prototype.toString.call(value) !== "[object String]") return null;
+  try {
+    const origin = new URL(value).origin;
+    return origin === "null" ? null : origin;
+  } catch {
+    return null;
+  }
+}
+
+export function desktopViewerPermissionAllowed(permission, requestingOrigin, viewerOrigin) {
+  if (!DESKTOP_VIEWER_PERMISSIONS.has(permission)) return false;
+  const requesting = webOrigin(requestingOrigin);
+  return requesting !== null && requesting === webOrigin(viewerOrigin);
+}

--- a/electron/desktop-viewer-permissions.node-test.mjs
+++ b/electron/desktop-viewer-permissions.node-test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { desktopViewerPermissionAllowed } from "./desktop-viewer-permissions.mjs";
+
+const VIEWER = "https://desktop.example";
+const VIEWER_PAGE = "https://desktop.example/vnc.html?_token=secret";
+
+test("grants the viewer page keyboard, pointer, clipboard and fullscreen", () => {
+  for (const permission of ["keyboardLock", "pointerLock", "clipboard-read", "clipboard-sanitized-write", "fullscreen"]) {
+    assert.equal(desktopViewerPermissionAllowed(permission, VIEWER_PAGE, VIEWER), true, permission);
+  }
+});
+
+test("accepts a bare origin or a full URL on either side", () => {
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", VIEWER, VIEWER), true);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", `${VIEWER}/vnc.html#x`, `${VIEWER}/session?y=1`), true);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "http://127.0.0.1:6080/vnc.html", "http://127.0.0.1:6080"), true);
+});
+
+test("refuses input permissions to any other origin", () => {
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "https://other.example/vnc.html", VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("clipboard-read", "https://desktop.example.evil/vnc.html", VIEWER), false);
+  // Scheme and port are part of the origin.
+  assert.equal(desktopViewerPermissionAllowed("pointerLock", "http://desktop.example/vnc.html", VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("fullscreen", "https://desktop.example:8443/vnc.html", VIEWER), false);
+});
+
+test("keeps every privileged capability off even for the viewer page", () => {
+  const privileged = [
+    "media", "mediaKeySystem", "notifications", "geolocation", "usb", "hid", "serial", "midi", "midiSysex",
+    "display-capture", "fileSystem", "openExternal", "idle-detection", "speaker-selection", "window-management",
+    "storage-access", "top-level-storage-access", "deprecated-sync-clipboard-read", "unknown",
+  ];
+  for (const permission of privileged) {
+    assert.equal(desktopViewerPermissionAllowed(permission, VIEWER_PAGE, VIEWER), false, permission);
+  }
+  assert.equal(desktopViewerPermissionAllowed(undefined, VIEWER_PAGE, VIEWER), false);
+});
+
+test("fails closed on unparsable or opaque origins", () => {
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "not a url", VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "", VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", undefined, VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", null, VIEWER), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", VIEWER_PAGE, "not a url"), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", VIEWER_PAGE, undefined), false);
+  // Opaque origins all serialise as "null"; two of them must never match.
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "data:text/html,x", "about:blank"), false);
+  assert.equal(desktopViewerPermissionAllowed("keyboardLock", "javascript:alert(1)", VIEWER), false);
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -30,6 +30,7 @@ import { pollServerIdentity } from "./server-boot-probe.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
 import { defaultSaveName, withSavableFile } from "./save-file.mjs";
+import { desktopViewerPermissionAllowed } from "./desktop-viewer-permissions.mjs";
 import {
   ensureManagedComposioCredentials,
   managedComposioAccess,
@@ -1101,13 +1102,29 @@ function openDesktopViewer(owner, rawUrl, rawTitle, contextId) {
   desktopViewerWindow = viewer;
   const viewerOrigin = url.origin;
 
-  // VNC needs rendering, keyboard/mouse input and WebSockets — never host
-  // camera, microphone, geolocation, notifications, USB, or other privileged
-  // browser capabilities in this remote-content window.
-  viewer.webContents.session.setPermissionCheckHandler(() => false);
-  viewer.webContents.session.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+  // VNC needs rendering, keyboard/mouse input and WebSockets, plus the few
+  // permission-gated input capabilities a viewer page asks for: keyboard and
+  // pointer capture, the clipboard for paste, full screen. Those go to the
+  // viewer's own origin only — never camera, microphone, geolocation,
+  // notifications, USB, or any other privileged browser capability in this
+  // remote-content window (see desktop-viewer-permissions.mjs).
+  viewer.webContents.session.setPermissionCheckHandler((_webContents, permission, requestingOrigin) =>
+    desktopViewerPermissionAllowed(permission, requestingOrigin, viewerOrigin),
+  );
+  viewer.webContents.session.setPermissionRequestHandler((webContents, permission, callback, details) =>
+    callback(desktopViewerPermissionAllowed(permission, details?.requestingUrl || webContents.getURL(), viewerOrigin)),
+  );
 
-  viewer.on("ready-to-show", () => viewer.show());
+  // A child window floats above the app but does not take the keyboard until
+  // it is focused: clicks land in the VNC canvas either way, keystrokes only
+  // reach the key window. Left unfocused, typing "into the VM" lands in the
+  // composer and ⌘1–9 switch bots while the mouse appears to work.
+  viewer.once("ready-to-show", () => {
+    if (viewer.isDestroyed()) return;
+    viewer.show();
+    viewer.focus();
+    viewer.webContents.focus();
+  });
   viewer.on("closed", () => {
     if (desktopViewerWindow !== viewer) return;
     desktopViewerWindow = null;


### PR DESCRIPTION
## In plain terms

Taking over a cloud (Box) computer opened the desktop viewer window but never gave it the keyboard, and denied the viewer page every browser permission, including the ones a VNC page uses to capture keys and paste. Mouse clicks landed in the VM; keystrokes did not. The viewer is now focused when it appears, and its page may use keyboard capture, pointer capture, clipboard and full screen on its own origin only. Everything privileged (camera, mic, geolocation, notifications, USB, HID, serial, MIDI, screen capture, file system) stays off.

## Why this shape

OpenMausBot forwards no input itself for a Box takeover: `openDesktopViewer` shows the provider's VNC page in a child `BrowserWindow`. A child window floats above the app but does not take the keyboard until focused, so typing "into the VM" went to the composer (and ⌘1–9 switched bots) while the mouse appeared to work. The old blanket `setPermissionCheckHandler(() => false)` was meant for camera/mic/etc., but also refused `keyboardLock`, `pointerLock`, `clipboard-read`, `clipboard-sanitized-write` and `fullscreen`.

The policy lives in a pure module (`electron/desktop-viewer-permissions.mjs`) so it is testable without Electron: allow-list of the five input permissions, origin compared via `new URL(x).origin`, opaque or unparsable origins fail closed.

## Not verified against a live Box

There is no Box in CI and the app is not launched on the dev Mac. Manual check:

1. Open a Box takeover and type. Letters appearing in the VM = fixed.
2. If not, open the same join URL in Chrome. Typing works there → still an Electron-window issue; next step is embedding the viewer as a `WebContentsView` like the Local VM workspace.
3. Typing fails in Chrome too → the guest's keymap (`setxkbmap -print`, `xdotool type hello` via `computer_exec`), i.e. provider side.

## Test plan

- [x] `electron/desktop-viewer-permissions.node-test.mjs` (5 tests): grants the viewer page the five input permissions; accepts bare origin or full URL on either side; refuses them to any other origin (scheme/port included); keeps 19 privileged permissions off even for the viewer page; fails closed on unparsable/opaque origins. Mutation-checked (removing the origin comparison fails 2 tests; removing the opaque-origin guard fails 1).
- [x] `pnpm typecheck`, `pnpm test:electron` (90/90), `pnpm check:electron`, oxlint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Desktop viewer now supports keyboard and pointer locking, clipboard access, and fullscreen mode when requested by its own origin.
  - Viewer windows automatically receive focus when ready.

- **Bug Fixes**
  - Permission handling now restricts access to approved capabilities and continues blocking sensitive features such as camera, microphone, location, device access, and screen capture.
  - Invalid or mismatched origins are denied by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->