### PR TITLE
Settle a screenshot only when the turn touched a changed screen

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -232,6 +232,7 @@ import {
   type BrowserConnection,
 } from "./browser-connection.ts";
 import { captureOutsideHumanControl } from "./private-screen-capture.ts";
+import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
 import { RoutineRequestService } from "./routine-requests.ts";
 import { fetchBotDirectory, matchDirectoryBots, type MatchedDirectoryBot } from "./bot-directory.ts";
 import { scoutProject, suggestTeam } from "./project-scout.ts";
@@ -2017,9 +2018,15 @@ bus.subscribe((event: RuntimeEvent) => {
         // the bot just acted ON ITS SCREEN — refresh the preview now. Only
         // computer tools can change the screen, and each capture competes
         // with the agent for the box's command endpoint, so a bot grinding
-        // through file edits must not trigger one per tool.
-        if (bot && /computer|screenshot|click|type_text|press_key|scroll|open_url|wait_for|browser_/i.test(toolName)) {
-          pokeScreenPoller(bot.id);
+        // through file edits must not trigger one per tool. The refresh is
+        // deliberately broad (a computer_exec may well have launched a
+        // window); whether the turn has EARNED a settled screenshot is the
+        // narrower question, and only the allow-list answers it.
+        if (bot) {
+          const touches = screenTouchingTool(toolName);
+          if (touches || /computer|screenshot|click|type_text|press_key|scroll|open_url|wait_for|browser_/i.test(toolName)) {
+            pokeScreenPoller(bot.id, touches);
+          }
         }
       }
       break;
@@ -2350,7 +2357,7 @@ bus.subscribe((event: RuntimeEvent) => {
           // it arrives — otherwise the user's next message ends up stranded
           // above the screenshot (the browser-mode ordering bug).
           const settleLeafId = store.activePath(event.threadId).at(-1)?.id;
-          void finalScreenFrame(bot.id).then((frame) => {
+          void finalScreenFrame(bot.id, event.threadId).then((frame) => {
             // the bot may have been deleted while the capture ran
             if (frame && store.bot(bot.id)) {
               if (group) pushMessage({ role: "bot", kind: "screen", png: frame.png, mime: frame.mime });
@@ -2739,7 +2746,8 @@ const SCREEN_MIN_GAP_MS = 3000;
 
 /** `screenIsTheWork` starts the turn already counting as screen usage: a
  * boxAgent's whole session runs ON the box, so every tool it calls acts on
- * that screen even though none of them is named like a computer tool. */
+ * that screen even though none of them is named like a computer tool. Its
+ * shell-only turns are kept honest by the settle-time hash gate instead. */
 function startScreenPoller(
   botId: string,
   capture: () => Promise<{ png: string; format: string }>,
@@ -2793,13 +2801,17 @@ function startScreenPoller(
  * instead of waiting for the next interval tick. Rate-limited inside
  * capture() — a tool-heavy turn used to fire one full REST chain per
  * completed tool, competing with the agent for the same endpoint. */
-function pokeScreenPoller(botId: string) {
+function pokeScreenPoller(botId: string, touches: boolean) {
   const entry = screenPollers.get(botId);
   if (!entry) return;
   // the same signal, read twice: a completed computer tool is both the
-  // reason to refresh the preview NOW and the proof that this turn's
-  // final frame is worth settling into the transcript
-  entry.touched = true;
+  // reason to refresh the preview NOW and — when it acted on or looked at
+  // the screen — the proof that this turn's final frame is worth settling
+  // into the transcript. A shell command or a status read earns only the
+  // refresh: under the Claude driver every tool of the computer server is
+  // named mcp__computer__*, and matching that alone used to append an
+  // untouched desktop to every curl-and-answer reply.
+  if (touches) entry.touched = true;
   void entry.capture();
 }
 
@@ -2810,20 +2822,41 @@ function stopScreenPoller(botId: string) {
   screenPollers.delete(botId);
 }
 
+/** sha256 of the frame each bot last settled into a transcript — the
+ * comparison the hash gate needs is "this turn's end state against what
+ * the reader can already see". Keyed per bot (one physical screen, however
+ * many threads it reports into); a cold entry is seeded from the thread's
+ * newest screen message so a restart does not re-picture the same idle
+ * desktop either. */
+const settledScreenHashes = new Map<string, string>();
+
+function shownScreenHash(botId: string, threadId: string): string | undefined {
+  const known = settledScreenHashes.get(botId);
+  if (known) return known;
+  const shown = store.messagesFor(threadId).findLast((m) => m.kind === "screen" && Boolean(m.png));
+  return shown?.png ? screenFrameHash(shown.png) : undefined;
+}
+
 /** Turn end: stop polling, then take ONE last fresh frame (awaiting any
  * in-flight poke first) so the settled screenshot shows the screen's actual
  * end state, not the previous action's. A turn that never touched the
  * screen settles nothing — and skips the capture, which is one less
- * command on the box's single endpoint. Either way the poller is torn down
- * here, so no per-turn state survives the turn. */
-async function finalScreenFrame(botId: string): Promise<Frame | null> {
+ * command on the box's single endpoint. A frame the reader can already see
+ * settles nothing either: the boxAgent pre-touch counts every turn as
+ * screen work, so without this its shell-only replies would all end in the
+ * same idle desktop. Either way the poller is torn down here, so no
+ * per-turn state survives the turn. */
+async function finalScreenFrame(botId: string, threadId: string): Promise<Frame | null> {
   const entry = screenPollers.get(botId);
   if (!entry) return null;
   if (entry.timer) clearInterval(entry.timer);
   screenPollers.delete(botId);
   if (!entry.touched) return null;
   await entry.capture();
-  return entry.last;
+  const frame = entry.last;
+  if (!frame || !settledFrameIsNews(shownScreenHash(botId, threadId), frame.png)) return null;
+  settledScreenHashes.set(botId, screenFrameHash(frame.png));
+  return frame;
 }
 
 // ── turn dispatch (upstream ProviderCommandReactor, miniature) ──────────

--- a/server/screen-frame-gate.test.ts
+++ b/server/screen-frame-gate.test.ts
@@ -1,0 +1,79 @@
+// The two gates between a completed turn and a screenshot in the chat. Both
+// are pure, so every spelling a driver can hand the poke site — and every
+// tool that must NOT count — is pinned down here.
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
+
+describe("screenTouchingTool", () => {
+  it("strips the Claude driver's mcp__<server>__ prefix", () => {
+    expect(screenTouchingTool("mcp__computer__click")).toBe(true);
+    expect(screenTouchingTool("mcp__computer__screenshot")).toBe(true);
+    expect(screenTouchingTool("mcp__browser__browser_navigate")).toBe(true);
+  });
+
+  it("takes Codex's bare names and pi's server_tool names", () => {
+    expect(screenTouchingTool("click")).toBe(true);
+    expect(screenTouchingTool("hotkey")).toBe(true);
+    expect(screenTouchingTool("computer_click")).toBe(true);
+    expect(screenTouchingTool("computer_zoom")).toBe(true);
+    expect(screenTouchingTool("computer_computer_batch")).toBe(true);
+    expect(screenTouchingTool("browser_browser_navigate")).toBe(true);
+    // the box's own Chrome tools live on the computer server
+    expect(screenTouchingTool("computer_browser_fill")).toBe(true);
+  });
+
+  const acting = [
+    "screenshot", "click", "type_text", "press_key", "scroll", "computer_batch", "open_url", "browser_click", "browser_fill",
+    "browser_navigate", "browser_type", "browser_press", "browser_scroll", "browser_hover", "browser_drag",
+    "browser_select_option", "browser_back", "browser_forward", "browser_screenshot",
+    "double_click", "right_click", "drag", "hotkey", "move_cursor", "launch_app", "bring_to_front", "zoom",
+  ];
+  for (const tool of acting) {
+    it(`counts: ${tool}`, () => expect(screenTouchingTool(tool)).toBe(true));
+  }
+
+  const bystanders = [
+    // the bug: every tool on the computer server is "mcp__computer__…", and
+    // a shell command there leaves the desktop exactly as it was
+    "mcp__computer__computer_exec",
+    "computer_exec",
+    "computer_computer_exec",
+    // read-only text tools
+    "computer_status", "browser_state", "browser_snapshot", "browser_read", "observation_metrics",
+    "mcp__browser__browser_snapshot", "browser_browser_read",
+    "start_session", "get_window_state", "get_desktop_state", "get_accessibility_tree",
+    "list_windows", "list_apps", "check_permissions", "get_screen_size",
+    // waits change nothing; the action before them already counted
+    "wait_for", "mcp__computer__wait_for", "wait_for_navigation", "browser_wait_for",
+    // the person's hands, not the bot's
+    "computer_request_help", "browser_request_takeover",
+    // not computer tools at all
+    "Bash", "Read", "mcp__agents__ask_bot", "mcp__composio__GMAIL_SEND_EMAIL", "screenshot_helper",
+  ];
+  for (const tool of bystanders) {
+    it(`ignores: ${tool}`, () => expect(screenTouchingTool(tool)).toBe(false));
+  }
+});
+
+describe("settledFrameIsNews", () => {
+  const frame = "iVBORw0KGgo-frame-a";
+
+  it("fails open when no frame has been shown yet", () => {
+    expect(settledFrameIsNews(undefined, frame)).toBe(true);
+  });
+
+  it("is not news when the end frame is byte-identical to the shown one", () => {
+    expect(settledFrameIsNews(screenFrameHash(frame), frame)).toBe(false);
+  });
+
+  it("is news once a single byte differs", () => {
+    expect(settledFrameIsNews(screenFrameHash(frame), "iVBORw0KGgo-frame-b")).toBe(true);
+  });
+
+  it("fingerprints with sha256 over the base64, like the observation dedupe", () => {
+    expect(screenFrameHash(frame)).toBe(createHash("sha256").update(frame).digest("hex"));
+  });
+});

--- a/server/screen-frame-gate.ts
+++ b/server/screen-frame-gate.ts
@@ -1,0 +1,84 @@
+// Which turns earn a settled screenshot in the transcript.
+//
+// The screen poller folds a turn's last frame into the chat on turn end.
+// Two questions decide whether that frame is worth the reader's attention,
+// and both are answered here, pure, so they can be pinned down in tests:
+//   1. did the tool that just completed act on (or look at) the screen — a
+//      shell command over computer_exec or a status read does not count,
+//      however the driver happens to spell the tool's name;
+//   2. is the end frame different from the one the transcript already
+//      shows — a boxAgent turn starts as screen work by definition, so this
+//      is what keeps its shell-only replies from re-picturing the same idle
+//      desktop.
+import { createHash } from "node:crypto";
+
+/** Tools that change or show the screen, by their bare MCP names. One list
+ * for every computer surface, because the poke site only has the name: the
+ * cloud box and remote computers (server/computer-proxy.ts), the built-in
+ * browser (server/drivers/browser-proxy.ts) and Cua Driver's own surface
+ * for the local Mac, Local VM and VPS (docs/computer-use-integration.md).
+ *
+ * Deliberately NOT here: computer_exec (a shell — no screenshot unless
+ * asked, and the ask is not visible at the poke site); the read-only text
+ * tools (computer_status, browser_state, browser_snapshot, browser_read,
+ * observation_metrics, start_session, get_*, list_*, check_permissions);
+ * the waits (wait_for, wait_for_navigation, browser_wait_for — they change
+ * nothing, and the action they follow already counted); and the takeover
+ * pleas (computer_request_help, browser_request_takeover — whatever changed
+ * during those was the person's doing, and captures are withheld under
+ * their lease anyway). */
+const SCREEN_TOUCHING_TOOLS = new Set([
+  // cloud box / remote computer
+  "screenshot",
+  "click",
+  "type_text",
+  "press_key",
+  "scroll",
+  "computer_batch",
+  "open_url",
+  "browser_click",
+  "browser_fill",
+  // built-in browser
+  "browser_navigate",
+  "browser_type",
+  "browser_press",
+  "browser_scroll",
+  "browser_hover",
+  "browser_drag",
+  "browser_select_option",
+  "browser_back",
+  "browser_forward",
+  "browser_screenshot",
+  // Cua Driver (local Mac, Local VM, VPS)
+  "double_click",
+  "right_click",
+  "drag",
+  "hotkey",
+  "move_cursor",
+  "launch_app",
+  "bring_to_front",
+  "zoom",
+]);
+
+/** The same tool reaches the poke site under three spellings: the Claude
+ * driver's `mcp__computer__click`, Codex's bare `click`, and pi's
+ * `computer_click` (server_tool, lowercased). A server prefix is stripped
+ * at most once, so pi's `computer_computer_exec` lands on `computer_exec`
+ * — still a shell — and never on a bare `exec`. */
+export function screenTouchingTool(toolName: string): boolean {
+  const bare = toolName.toLowerCase().replace(/^mcp__.+?__/, "");
+  return SCREEN_TOUCHING_TOOLS.has(bare) || SCREEN_TOUCHING_TOOLS.has(bare.replace(/^(?:computer|browser)_/, ""));
+}
+
+/** sha256 over the base64 frame — the same fingerprint the model-side
+ * observation dedupe uses (server/computer-observation.ts). */
+export function screenFrameHash(png: string): string {
+  return createHash("sha256").update(png).digest("hex");
+}
+
+/** A settled frame is news only when it differs from the frame the reader
+ * can already see. With nothing to compare against it fails open, like the
+ * observation dedupe does: an unshown screen beats a wrongly hidden one. */
+export function settledFrameIsNews(shownFrameHash: string | undefined, png: string): boolean {
+  return shownFrameHash === undefined || screenFrameHash(png) !== shownFrameHash;
+}


### PR DESCRIPTION
## In plain terms

Replies no longer end with a screenshot of an idle desktop. A turn earns the end-of-turn screen frame only when a tool actually acted on or looked at the screen, and only when that frame differs from the one already shown in the transcript.

## Why it happened

The settle-time frame was gated by a name regex, and under the Claude driver every tool of the computer server is named `mcp__computer__*` — so `computer_exec` (a shell command), `computer_status` or `browser_state` counted as screen work. A bot that ran `curl` on its Box and answered in text got the untouched desktop appended. The "Computer" engine (boxAgent) additionally pre-touches every turn, and nothing compared the final frame with what the reader could already see.

## Changes

- `server/screen-frame-gate.ts` (pure, tested): `screenTouchingTool(name)` strips one `mcp__<server>__` prefix and matches an explicit allow-list of screen-changing/showing tools across the cloud box, the built-in browser and Cua Driver surfaces. Excluded on purpose: `computer_exec`, the read-only text tools, the waits, and the takeover pleas (captures are withheld under a person's lease anyway). `settledFrameIsNews(shownHash, png)` compares sha256 fingerprints, failing open when nothing is known.
- `server/index.ts`: the live-preview refresh stays broad (a shell may well have opened a window); `touched` is set only by the allow-list. `finalScreenFrame` returns nothing when the frame hashes the same as the bot's last settled frame (seeded from the thread's newest screen message after a restart). The boxAgent pre-touch is kept; its shell-only turns are now caught by the hash gate.

Consumers of settled frames (chat, Computer panel, iOS last-known screen) are unchanged; frames are suppressed, never removed.

## Known limit

The hash gate compares against the frame the bot last settled (not the turn's first poller capture, which already fires post-action). It assumes an idle desktop hashes identically between turns; a desktop with a visible clock will still slip one frame past the gate on "Computer"-engine (boxAgent) turns, where every turn is pre-counted as screen work. The honest follow-up there is to stop pre-touching and instead mark `touched` from the box's own tool/browse events, so the same allow-list applies. The main cause — every `mcp__computer__*` tool counting as screen work under the Claude driver — is fixed regardless.

## Test plan

- [x] `server/screen-frame-gate.test.ts`: prefixed/bare/`computer_`-prefixed spellings, exclusions, hash news/no-news. Mutation-checked (prefix stripping and the hash compare each fail a test when removed).
- [x] `pnpm typecheck`, touched tests, oxlint clean on touched files; full `pnpm vitest run` on the branch: 277 files, 3081 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
