### PR TITLE
Harden dynamic model refresh

### DIFF
--- a/server/harness/registry.test.ts
+++ b/server/harness/registry.test.ts
@@ -3,6 +3,7 @@
 // unavailable shadow, never crash the fleet. These tests pin that.
 import { describe, expect, it } from "vitest";
 
+import type { ModelCatalog } from "../contracts.ts";
 import { makeFakeDriver } from "../testing/fake-driver.ts";
 import { ProviderRegistry } from "./registry.ts";
 
@@ -151,27 +152,30 @@ describe("ProviderRegistry", () => {
   it("refreshes a live model catalog before returning each description", async () => {
     const fake = makeFakeDriver();
     const registry = new ProviderRegistry([fake.driver]);
-    await registry.load({ a: { driver: "fake" } });
-    const instance = registry.get("a")!;
-    let refreshes = 0;
-    Object.assign(instance, {
-      refreshModels: async () => {
-        refreshes += 1;
-        instance.models.default = `dynamic-${refreshes}`;
-        instance.models.options = [
-          { id: `dynamic-${refreshes}`, label: `Dynamic ${refreshes}` },
-        ];
-      },
-    });
+    await registry.load({ a: { driver: "fake" }, b: { driver: "fake" } });
+    const refreshes = { a: 0, b: 0 };
+    for (const instanceId of ["a", "b"] as const) {
+      const instance = registry.get(instanceId)!;
+      const models: ModelCatalog = { default: "", options: [] };
+      Object.assign(instance, {
+        models,
+        refreshModels: async () => {
+          refreshes[instanceId] += 1;
+          const id = `${instanceId}-${refreshes[instanceId]}`;
+          models.default = id;
+          models.options = [{ id, label: `Dynamic ${id}` }];
+        },
+      });
+    }
 
-    expect((await registry.describe())[0].models).toEqual({
-      default: "dynamic-1",
-      options: [{ id: "dynamic-1", label: "Dynamic 1" }],
-    });
-    expect((await registry.describe())[0].models).toEqual({
-      default: "dynamic-2",
-      options: [{ id: "dynamic-2", label: "Dynamic 2" }],
-    });
+    const first = Object.fromEntries((await registry.describe()).map((row) => [row.instanceId, row.models]));
+    expect(first.a.default).toBe("a-1");
+    expect(first.b.default).toBe("b-1");
+
+    const second = Object.fromEntries((await registry.describe()).map((row) => [row.instanceId, row.models]));
+    expect(second.a.default).toBe("a-2");
+    expect(second.b.default).toBe("b-2");
+    expect(refreshes).toEqual({ a: 2, b: 2 });
   });
 
   it("disposeAll disposes every live instance and empties the registry", async () => {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -135,10 +135,14 @@ export function ModelPicker({
     if (refreshingRef.current) return;
     refreshingRef.current = true;
     setRefreshing(true);
-    void refreshInstances().finally(() => {
-      refreshingRef.current = false;
-      setRefreshing(false);
-    });
+    void refreshInstances()
+      .catch(() => {
+        // Keep the last known catalog when the app is temporarily offline.
+      })
+      .finally(() => {
+        refreshingRef.current = false;
+        setRefreshing(false);
+      });
   }, [refreshInstances]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary\n- safely absorb a future refresh rejection while preserving spinner cleanup\n- prove independent catalogs refresh for every live provider instance\n\nFollow-up to #710 after its original head auto-merged while this review hardening was being pushed.\n\n## Verification\n- pnpm exec oxlint src/components/ModelPicker.tsx server/harness/registry.test.ts\n- pnpm vitest run server/harness/registry.test.ts server/drivers/acp/opencode-go.test.ts server/drivers/openai-compat.test.ts src/lib/custom-models.test.ts\n- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model catalog refresh behavior in the model picker.
  - If a refresh fails, the picker now retains the last known model list instead of losing available models.
  - Refreshing always returns to a ready state, including after an error.
  - Improved handling of model catalogs when multiple instances refresh independently, providing more consistent descriptions and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->