### PR TITLE
Bump version to 0.1.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the desktop release version from 0.1.48 to 0.1.49
- prepare the unified macOS, Windows, and Ubuntu release workflow

## Verification

- `pnpm typecheck`
- isolated fixture: `control:omb doctor`
- isolated fixture: `control:omb models`

Fixture evidence: `/var/folders/91/pdc4mdh53xs59x0r4z7_0qzc0000gn/T/openmausbot-verification-evidence/server-1788364422663-93420.log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.48 to 0.1.49.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->