### PR TITLE
Notify when a turn dies before it starts

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2565,6 +2565,64 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("leaves a failed credential-card continuation on the card without buzzing twice", async () => {
+    let botId: string | undefined;
+    let stream: Awaited<ReturnType<typeof openSse>> | undefined;
+    try {
+      expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
+      const bot = (await api("POST", "/api/bots")).body.bot;
+      botId = bot.id;
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+      stream = await openSse(`${BASE}/api/events`);
+      await stream.until((frame) => frame.kind === "hello");
+
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "stay active" })).status).toBe(202);
+      const dump = await readJsonFileWhenReady<{
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+      }>(fakeClaudeDump);
+      const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
+      const requested = await fetch(`${BASE}/api/internal/request-credential`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          fromBotId: bot.id,
+          fromThreadId: bot.threadId,
+          credentialId: "openaiImageApiKey",
+          reason: "needed for the task",
+        }),
+      });
+      expect(requested.status).toBe(201);
+      const { messageId } = (await requested.json()) as { messageId: string };
+
+      expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+      expect((await api("POST", `/api/bots/${bot.id}/secret-cards/${messageId}/dismiss`, {
+        threadId: bot.threadId,
+      })).status).toBe(200);
+
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=20")).body.bots
+          .find((candidate: { id: string }) => candidate.id === bot.id);
+        return current?.messages.find((message: { id: string }) => message.id === messageId)?.secret?.error;
+      }).toMatch(/box|cloud/i);
+      expect(stream.frames.some(
+        (frame) => frame.kind === "notify" && frame.notification?.kind === "turn-failed",
+      )).toBe(false);
+    } finally {
+      if (botId) await api("POST", `/api/bots/${botId}/interrupt`, {}).catch(() => undefined);
+      stream?.close();
+      if (botId) await api("DELETE", `/api/bots/${botId}`);
+      await api("PUT", "/api/config", { box: { token: "" } });
+      rmSync(fakeClaudeDump, { force: true });
+    }
+  });
+
   it("reports a failed routine once, not twice", async () => {
     // A routine reaches the same dispatch catch as an interactive turn and
     // then reports through onDispatchError, which raises routine-failed.

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2520,6 +2520,92 @@ describe("harness HTTP API", () => {
     expect(patched.body.error).toContain("not recognized");
   });
 
+  it("buzzes when a turn dies before it can start", async () => {
+    // A dispatch failure already leaves an error row in the thread, but the
+    // person who has to fix it is often not looking at the thread — the cause
+    // is usually a setting, so no retry can clear it on its own. A routine
+    // failure already buzzes; an interactive turn should behave the same.
+    //
+    // The cloud destination with no Box configured fails inside dispatch
+    // without touching the network, which keeps this deterministic wherever
+    // it runs in the file.
+    expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      await stream.until((frame) => frame.kind === "hello");
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "go" })).status).toBe(202);
+      const buzz = await stream.until(
+        (frame) => frame.kind === "notify" && frame.notification?.kind === "turn-failed",
+        5_000,
+      );
+      expect(buzz.notification).toMatchObject({
+        botId: bot.id,
+        threadId: bot.threadId,
+        title: `${bot.name} couldn't start`,
+      });
+      expect(String(buzz.notification.body)).toMatch(/box|cloud/i);
+
+      // the error row the chat already renders stays exactly as it was
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=20")).body.bots
+          .find((candidate: { id: string }) => candidate.id === bot.id);
+        return Boolean(current?.messages.at(-1)?.tool?.name?.startsWith("error: "));
+      }).toBe(true);
+    } finally {
+      stream.close();
+      await api("DELETE", `/api/bots/${bot.id}`);
+      // the token is write-only, so there is no prior value to restore —
+      // leave the box unconfigured rather than half-set for whatever runs next
+      await api("PUT", "/api/config", { box: { token: "" } });
+    }
+  });
+
+  it("reports a failed routine once, not twice", async () => {
+    // A routine reaches the same dispatch catch as an interactive turn and
+    // then reports through onDispatchError, which raises routine-failed.
+    // Without the interactive guard the person would be buzzed twice for one
+    // failure, so this pins the count rather than merely the presence.
+    expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+    const created = await api("POST", "/api/routines", {
+      name: "Cloud check",
+      prompt: "look at the cloud desktop",
+      target: "bot",
+      botId: bot.id,
+      runOn: "maus",
+      enabled: true,
+      schedule: { type: "daily", time: "10:00", weekdays: [1, 2, 3, 4, 5] },
+    });
+    expect(created.status).toBe(201);
+    const stream = await openSse(`${BASE}/api/events`);
+    try {
+      await stream.until((frame) => frame.kind === "hello");
+      expect((await api("POST", `/api/routines/${created.body.routine.id}/run`)).status).toBe(201);
+      await stream.until(
+        (frame) =>
+          frame.kind === "notify" &&
+          frame.notification?.kind === "routine-failed" &&
+          frame.notification?.botId === bot.id,
+        5_000,
+      );
+      const buzzes = stream.frames.filter(
+        (frame: { kind?: string; notification?: { kind?: string; botId?: string } }) =>
+          frame.kind === "notify" && frame.notification?.botId === bot.id,
+      );
+      expect(buzzes.map((frame: { notification: { kind: string } }) => frame.notification.kind)).toEqual([
+        "routine-failed",
+      ]);
+    } finally {
+      stream.close();
+      await api("DELETE", `/api/routines/${created.body.routine.id}`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+      await api("PUT", "/api/config", { box: { token: "" } });
+    }
+  });
+
   it("creates a fully configured bot in one request and greets with its final name", async () => {
     const created = await api("POST", "/api/bots", {
       name: "  Pathfinder  ",

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2529,11 +2529,14 @@ describe("harness HTTP API", () => {
     // The cloud destination with no Box configured fails inside dispatch
     // without touching the network, which keeps this deterministic wherever
     // it runs in the file.
-    expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
-    const bot = (await api("POST", "/api/bots")).body.bot;
-    expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
-    const stream = await openSse(`${BASE}/api/events`);
+    let botId: string | undefined;
+    let stream: Awaited<ReturnType<typeof openSse>> | undefined;
     try {
+      expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
+      const bot = (await api("POST", "/api/bots")).body.bot;
+      botId = bot.id;
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+      stream = await openSse(`${BASE}/api/events`);
       await stream.until((frame) => frame.kind === "hello");
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "go" })).status).toBe(202);
       const buzz = await stream.until(
@@ -2554,8 +2557,8 @@ describe("harness HTTP API", () => {
         return Boolean(current?.messages.at(-1)?.tool?.name?.startsWith("error: "));
       }).toBe(true);
     } finally {
-      stream.close();
-      await api("DELETE", `/api/bots/${bot.id}`);
+      stream?.close();
+      if (botId) await api("DELETE", `/api/bots/${botId}`);
       // the token is write-only, so there is no prior value to restore —
       // leave the box unconfigured rather than half-set for whatever runs next
       await api("PUT", "/api/config", { box: { token: "" } });
@@ -2567,21 +2570,26 @@ describe("harness HTTP API", () => {
     // then reports through onDispatchError, which raises routine-failed.
     // Without the interactive guard the person would be buzzed twice for one
     // failure, so this pins the count rather than merely the presence.
-    expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
-    const bot = (await api("POST", "/api/bots")).body.bot;
-    expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
-    const created = await api("POST", "/api/routines", {
-      name: "Cloud check",
-      prompt: "look at the cloud desktop",
-      target: "bot",
-      botId: bot.id,
-      runOn: "maus",
-      enabled: true,
-      schedule: { type: "daily", time: "10:00", weekdays: [1, 2, 3, 4, 5] },
-    });
-    expect(created.status).toBe(201);
-    const stream = await openSse(`${BASE}/api/events`);
+    let botId: string | undefined;
+    let routineId: string | undefined;
+    let stream: Awaited<ReturnType<typeof openSse>> | undefined;
     try {
+      expect((await api("PUT", "/api/config", { box: { token: "" } })).status).toBe(200);
+      const bot = (await api("POST", "/api/bots")).body.bot;
+      botId = bot.id;
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+      const created = await api("POST", "/api/routines", {
+        name: "Cloud check",
+        prompt: "look at the cloud desktop",
+        target: "bot",
+        botId: bot.id,
+        runOn: "maus",
+        enabled: true,
+        schedule: { type: "daily", time: "10:00", weekdays: [1, 2, 3, 4, 5] },
+      });
+      expect(created.status).toBe(201);
+      routineId = created.body.routine.id;
+      stream = await openSse(`${BASE}/api/events`);
       await stream.until((frame) => frame.kind === "hello");
       expect((await api("POST", `/api/routines/${created.body.routine.id}/run`)).status).toBe(201);
       await stream.until(
@@ -2599,9 +2607,9 @@ describe("harness HTTP API", () => {
         "routine-failed",
       ]);
     } finally {
-      stream.close();
-      await api("DELETE", `/api/routines/${created.body.routine.id}`);
-      await api("DELETE", `/api/bots/${bot.id}`);
+      stream?.close();
+      if (routineId) await api("DELETE", `/api/routines/${routineId}`);
+      if (botId) await api("DELETE", `/api/bots/${botId}`);
       await api("PUT", "/api/config", { box: { token: "" } });
     }
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -3473,7 +3473,7 @@ async function startTurn(
       // raises routine-failed; buzzing here too would ring twice for one
       // failure. A delegated sub-turn is reported to the bot that asked
       // for it, in its own thread, so it does not need a second channel.
-      if (opts?.automationSource === undefined && !opts?.commsDepth) {
+      if (opts?.automationSource === undefined && !opts?.commsDepth && !opts?.cardContinuation) {
         notify(
           buildNotification("turn-failed", bot, threadId, redactSecretsInText(message), { avatarUrl: bot.avatarUrl }),
         );

--- a/server/index.ts
+++ b/server/index.ts
@@ -3463,6 +3463,19 @@ async function startTurn(
         kind: "activity",
         tool: { name: `error: ${message.slice(0, 160)}`, ok: false },
       });
+      // Worth a buzz for the same reason a routine failure is, and the rule
+      // notify.ts encodes: the bot is not working, and the cause is usually
+      // a setting only a person can change — an unattended user would
+      // otherwise learn nothing until they next opened the thread.
+      //
+      // Only for a turn the person started themselves. A routine reaches
+      // this same catch and then reports through onDispatchError, which
+      // raises routine-failed; buzzing here too would ring twice for one
+      // failure. A delegated sub-turn is reported to the bot that asked
+      // for it, in its own thread, so it does not need a second channel.
+      if (opts?.automationSource === undefined && !opts?.commsDepth) {
+        notify(buildNotification("turn-failed", bot, threadId, message, { avatarUrl: bot.avatarUrl }));
+      }
       store.setActivity(bot.id, "idle");
       retryDelegationsWaitingOn(bot.id);
       opts?.onDispatchError?.(message);

--- a/server/index.ts
+++ b/server/index.ts
@@ -3474,7 +3474,9 @@ async function startTurn(
       // failure. A delegated sub-turn is reported to the bot that asked
       // for it, in its own thread, so it does not need a second channel.
       if (opts?.automationSource === undefined && !opts?.commsDepth) {
-        notify(buildNotification("turn-failed", bot, threadId, message, { avatarUrl: bot.avatarUrl }));
+        notify(
+          buildNotification("turn-failed", bot, threadId, redactSecretsInText(message), { avatarUrl: bot.avatarUrl }),
+        );
       }
       store.setActivity(bot.id, "idle");
       retryDelegationsWaitingOn(bot.id);

--- a/server/notify.test.ts
+++ b/server/notify.test.ts
@@ -18,11 +18,13 @@ describe("buildNotification", () => {
     expect(buildNotification("question", bot, "thread-1", "which branch?")?.title).toBe("Scout has a question");
     expect(buildNotification("done", bot, "thread-1", "pushed the branch")?.title).toBe("Scout finished");
     expect(buildNotification("routine-failed", bot, "thread-1", "boom")?.title).toBe("Scout's routine failed");
+    expect(buildNotification("turn-failed", bot, "thread-1", "the Local VM is not ready")?.title)
+      .toBe("Scout couldn't start");
   });
 
   it("stays silent for a bot whose notifications are off", () => {
     const quiet = { ...bot, notifications: false };
-    for (const kind of ["approval", "question", "done", "routine-failed"] as const) {
+    for (const kind of ["approval", "question", "done", "routine-failed", "turn-failed"] as const) {
       expect(buildNotification(kind, quiet, "thread-1", "anything")).toBeNull();
     }
     // absent means "not turned off" — older bot records predate the flag
@@ -35,6 +37,7 @@ describe("buildNotification", () => {
     expect(buildNotification("done", bot, "thread-1", "")).toBeNull();
     // ...but a blocked bot is worth knowing about even with a thin summary
     expect(buildNotification("approval", bot, "thread-1", "")).not.toBeNull();
+    expect(buildNotification("turn-failed", bot, "thread-1", "")).not.toBeNull();
   });
 
   it("uses the thread it was raised on, not the bot's current one", () => {

--- a/server/notify.ts
+++ b/server/notify.ts
@@ -6,11 +6,16 @@
 // a bot that *finished* is worth one if you asked for it; everything else a
 // bot does while it works is not.
 //
+// A turn that dies before it starts is the first case, not the last: the
+// bot is not working, and the fix is usually a setting only a person can
+// change, so a retry cannot clear it. A routine failure already buzzed;
+// this makes an interactive turn behave the same way.
+//
 // Delivery is a separate concern. The harness emits a frame; whoever is
 // listening decides what to do with it — desktop and paired-phone local
 // notifications today, and closed-app APNs delivery once a relay exists.
 
-export type NotifyKind = "approval" | "question" | "done" | "routine-failed" | "takeover";
+export type NotifyKind = "approval" | "question" | "done" | "routine-failed" | "turn-failed" | "takeover";
 
 export interface Notification {
   kind: NotifyKind;
@@ -64,7 +69,9 @@ export function buildNotification(
           ? `${bot.name} needs your hands`
           : kind === "routine-failed"
             ? `${bot.name}'s routine failed`
-            : `${bot.name} finished`;
+            : kind === "turn-failed"
+              ? `${bot.name} couldn't start`
+              : `${bot.name} finished`;
 
   // A "finished" with nothing to say is not worth a notification — the
   // badge in the sidebar already carries that much.


### PR DESCRIPTION
## What changed

Adds a `turn-failed` notification kind and raises it when a direct turn fails during dispatch.

## Why

`notify.ts` encodes one rule: *"a bot that is **blocked on you** is worth a buzz, and a bot that **finished** is worth one if you asked for it."*

A routine that fails to dispatch already follows it — `routine-failed` fires from the routine path. An interactive turn that fails to dispatch did not: it appended an `error:` activity row and set the bot idle. The row renders fine in chat, so this is not invisible if you are looking at the thread. The problem is that nothing tells you when you are not.

That gap matters most exactly when the bot is unattended, and the causes are mostly configuration a person has to change before any retry can work:

- an unconfigured cloud box (`Cloud box is not configured — add a Box API key or choose Local VM`)
- a Local VM that was never created (`Create the Local VM (App Settings → Local VM)`)
- an engine that cannot reach the selected computer destination

I hit the second one with a bot on `computer: "vm"` whose container had gone missing. The turn produced a single activity row and stopped. Nothing surfaced anywhere until I went looking in the thread, and `server.log` had nothing either.

The notification fires for **every** dispatch failure, including transient ones a retry would clear. That is deliberate — classifying failures into "retryable" and "needs you" is a larger judgement call, and I did not want to make it inside a bugfix. Happy to narrow it if you would rather.

## How it was verified

macOS, Node 24.20.0. `pnpm typecheck` and `pnpm test` both pass on this branch.

- `server/notify.test.ts` — extended to cover the new kind: its title, and that it stays silent when `notifications: false`.
- New API smoke test in `server/index.test.ts` — drives a real dispatch failure over the HTTP API and waits for the `notify` frame on `/api/events`. Confirmed it **fails without** the `notify(...)` call (times out after 5.5s waiting for the frame) and passes with it, so it is not a test that would pass either way.

The smoke test clears the Box token itself rather than relying on file order, because the existing `"saves config keys write-only and reports booleans"` test sets `box_good` and does not restore it.

## Note on the base

This branch is cut from my fork's `main`, which is behind upstream. The diff is the four files below and nothing else, but say the word and I will rebase onto current `main` before you merge.

## Screenshots (UI changes)

None — server-side only. Delivery is unchanged; clients already render whatever frames `notify` emits, so this needs no renderer work.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notifications when an interactive bot turn cannot start, identifying the affected bot.
  * Notifications respect bot notification preferences and can be delivered without a message body.

* **Bug Fixes**
  * Prevented turn-failed alerts for background card-continuation actions, which report errors through their own failure handling.
  * Prevented duplicate notifications for routine and delegated turn failures.

* **Tests**
  * Expanded coverage for interactive, routine, delegated, and card-continuation failure notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->