### PR TITLE
iOS: file viewer, phone attachments, calls, send key and dictation fixes (TestFlight 8)

### DIFF
--- a/ios/App/CallView.swift
+++ b/ios/App/CallView.swift
@@ -1,0 +1,284 @@
+// Call mode — the bot on the line, on the phone.
+//
+// The same loop as the desktop's CallView, and deliberately HALF-DUPLEX for
+// the same reason: the microphone is live only while the bot is not
+// speaking. The phone's voice-chat audio mode does cancel echo, but a
+// recognizer that hears even a little of the bot's own voice sends it
+// back as a message, and the two of them talk forever. Interrupting is a
+// tap instead.
+//
+// Turn-taking is the silence endpointer in `SpeechDictation.listenForTurn`:
+// the turn ends 850 ms after the transcript last changed. Waiting is
+// narrated — every activity chip the harness phrases for a voice
+// (`tool.spoken`) is read as it lands — so an agent turn of tool calls
+// sounds like someone working rather than a dropped call.
+//
+// Approvals and questions are not answered by voice here yet; a card
+// that appears mid-call is announced, and answering it happens in the
+// chat. Saying "yes" to a permission is the kind of thing that should not
+// be inferred from a sentence that happened to contain the word.
+import AVFoundation
+import Combine
+import SwiftUI
+import CompanionCore
+
+/// Sequential playback of utterances fetched from the computer.
+@MainActor
+final class CallSpeaker: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published private(set) var isSpeaking = false
+    private var player: AVAudioPlayer?
+    private var finished: CheckedContinuation<Void, Never>?
+    private var generation = 0
+
+    /// Speak every utterance in order. Returns false when stopped early.
+    func speak(_ utterances: [Data]) async -> Bool {
+        generation += 1
+        let mine = generation
+        isSpeaking = true
+        defer { if generation == mine { isSpeaking = false } }
+        for data in utterances {
+            guard generation == mine else { return false }
+            guard let next = try? AVAudioPlayer(data: data) else { continue }
+            next.delegate = self
+            player = next
+            guard next.prepareToPlay(), next.play() else { continue }
+            await withCheckedContinuation { continuation in finished = continuation }
+            guard generation == mine else { return false }
+        }
+        return generation == mine
+    }
+
+    func stop() {
+        generation += 1
+        player?.stop()
+        player = nil
+        isSpeaking = false
+        finished?.resume()
+        finished = nil
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.finished?.resume()
+            self.finished = nil
+        }
+    }
+}
+
+struct CallView: View {
+    let bot: Bot
+    @EnvironmentObject private var session: Session
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var microphone = SpeechDictation()
+    @StateObject private var speaker = CallSpeaker()
+    @State private var phase: Phase = .listening
+    @State private var note: String?
+    /// Everything already on screen when the call starts has been read or
+    /// ignored — a call must not open by reciting the backlog.
+    @State private var spokenIds: Set<String> = []
+    @State private var announcedRequests: Set<String> = []
+    @State private var started = false
+    @State private var sayGeneration = 0
+
+    private static let endpointGap: TimeInterval = 0.85
+
+    enum Phase { case listening, sending, working, speaking }
+
+    private var current: Bot { session.state.bot(bot.id) ?? bot }
+    private var messages: [Message] { session.state.visibleTranscript(forThread: current.threadId) }
+    private var pendingCard: Message? {
+        messages.last { $0.card?.isPending == true }
+    }
+
+    var body: some View {
+        ZStack {
+            MausPalette.color(current.color).opacity(0.18).ignoresSafeArea()
+            VStack(spacing: 24) {
+                Spacer()
+                BotAvatarView(bot: current, size: 160)
+                    .scaleEffect(phase == .speaking ? 1.06 : 1)
+                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: phase == .speaking)
+                Text(current.name)
+                    .font(.system(size: 28, weight: .semibold))
+                Text(phaseText)
+                    .font(.system(size: 17))
+                    .foregroundStyle(Color.secondary)
+                    .contentTransition(.opacity)
+                if !microphone.transcript.isEmpty, phase == .listening {
+                    Text(microphone.transcript)
+                        .font(.system(size: 17))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 28)
+                        .lineLimit(4)
+                }
+                if let note {
+                    Text(note)
+                        .font(.system(size: 14))
+                        .foregroundStyle(.orange)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 28)
+                }
+                Spacer()
+                HStack(spacing: 40) {
+                    Button {
+                        interrupt()
+                    } label: {
+                        Label("Interrupt", systemImage: "hand.raised.fill")
+                            .labelStyle(.iconOnly)
+                            .font(.system(size: 24, weight: .semibold))
+                            .frame(width: 68, height: 68)
+                            .background(Circle().fill(Color.secondary.opacity(0.18)))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(phase != .speaking)
+                    .opacity(phase == .speaking ? 1 : 0.35)
+                    .accessibilityLabel("Interrupt and speak")
+
+                    Button {
+                        hangUp()
+                    } label: {
+                        Image(systemName: "phone.down.fill")
+                            .font(.system(size: 26, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 68, height: 68)
+                            .background(Circle().fill(Color.red))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("End call")
+                }
+                .padding(.bottom, 36)
+            }
+        }
+        .onAppear { startIfNeeded() }
+        .onDisappear { microphone.stop(); speaker.stop() }
+        .onChange(of: messages) { _, _ in react() }
+        .onChange(of: current.busy) { _, _ in react() }
+        .onChange(of: microphone.error) { _, error in
+            if let error { note = error }
+        }
+    }
+
+    private var phaseText: String {
+        switch phase {
+        case .listening: return "Listening…"
+        case .sending: return "Sending…"
+        case .working: return "\(current.name) is working…"
+        case .speaking: return "Speaking"
+        }
+    }
+
+    // MARK: - The loop
+
+    private func startIfNeeded() {
+        guard !started else { return }
+        started = true
+        spokenIds = Set(messages.map(\.id))
+        if current.busy == true { move(.working) } else { listen() }
+    }
+
+    private func move(_ next: Phase) {
+        withAnimation(.easeInOut(duration: 0.2)) { phase = next }
+    }
+
+    private func listen() {
+        move(.listening)
+        note = nil
+        microphone.listenForTurn(endpointAfter: Self.endpointGap) { heard in
+            turnEnded(heard)
+        }
+    }
+
+    private func turnEnded(_ heard: String) {
+        let said = heard.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !said.isEmpty else { listen(); return }
+        move(.sending)
+        Task { await session.send(said, to: .bot(current)) }
+    }
+
+    /// Speak with the microphone closed, then return whether this call is
+    /// still the one that asked (an interrupt or hang-up bumps the
+    /// generation).
+    private func say(_ text: String) async -> Bool {
+        sayGeneration += 1
+        let mine = sayGeneration
+        move(.speaking)
+        microphone.stop()
+        do {
+            let prepared = try await session.prepareSpeech(text, voiceId: current.voice)
+            guard prepared.ready else {
+                note = "Set up a voice in Settings → Voice to hear \(current.name)."
+                return sayGeneration == mine
+            }
+            var clips: [Data] = []
+            for utterance in prepared.utterances {
+                guard sayGeneration == mine else { return false }
+                clips.append(try await session.speak(utterance, voiceId: current.voice))
+            }
+            guard sayGeneration == mine else { return false }
+            let finished = await speaker.speak(clips)
+            return finished && sayGeneration == mine
+        } catch {
+            note = error.localizedDescription
+            return sayGeneration == mine
+        }
+    }
+
+    private func sayThenListen(_ text: String) {
+        Task {
+            let stillMine = await say(text)
+            if stillMine, phase == .speaking { listen() }
+        }
+    }
+
+    private func react() {
+        guard started else { return }
+        let fresh = messages.filter { !spokenIds.contains($0.id) }
+        for message in fresh { spokenIds.insert(message.id) }
+
+        if let card = pendingCard, let requestId = card.card?.requestId,
+           !announcedRequests.contains(requestId), phase != .speaking {
+            announcedRequests.insert(requestId)
+            let what = card.card?.tool == nil ? "has a question" : "is asking for permission"
+            sayThenListen("\(current.name) \(what). Open the chat to answer it.")
+            return
+        }
+
+        let reply = fresh.last { $0.role == .bot && $0.kind == .text && !($0.text ?? "").trimmingCharacters(in: .whitespaces).isEmpty }
+        let chip = fresh.last { $0.kind == .activity && $0.tool?.spoken != nil }
+        if let text = reply?.text {
+            sayThenListen(text)
+            return
+        }
+        if let spoken = chip?.tool?.spoken, phase == .working {
+            Task {
+                let stillMine = await say(spoken)
+                if stillMine, phase == .speaking { move(.working) }
+            }
+            return
+        }
+
+        if current.busy == true {
+            if phase == .listening || phase == .sending {
+                microphone.stop()
+                move(.working)
+            }
+        } else if phase == .working || phase == .sending, !speaker.isSpeaking {
+            listen()
+        }
+    }
+
+    private func interrupt() {
+        guard phase == .speaking else { return }
+        sayGeneration += 1
+        speaker.stop()
+        listen()
+    }
+
+    private func hangUp() {
+        sayGeneration += 1
+        microphone.stop()
+        speaker.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        dismiss()
+    }
+}

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -954,6 +954,8 @@ struct TextBubble: View {
     let message: Message
     let chat: Chat
     var tailed = true
+    /// A linked file being opened, and the viewer's presentation in one value.
+    @State private var viewingFile: FileViewRequest?
 
     private var attachedContent: AttachedMessageContent {
         AttachedMessageContent.parse(message.text ?? "")
@@ -1083,6 +1085,17 @@ struct TextBubble: View {
                         .foregroundStyle(Color.primary)
                         .textSelection(.enabled)
                         .fixedSize(horizontal: false, vertical: true)
+                        // A link to a file the bot wrote opens in the viewer;
+                        // the system's own action would refuse a bare path
+                        // and has nothing behind a file:// URL, which is why
+                        // tapping one used to do nothing. Web links still go
+                        // to the system.
+                        .environment(\.openURL, OpenURLAction { url in
+                            guard let path = LocalFileLink.path(for: url) else { return .systemAction }
+                            viewingFile = FileViewRequest(path: path)
+                            return .handled
+                        })
+                        .sheet(item: $viewingFile) { FileViewerSheet(path: $0.path) }
                 }
             }
             .padding(.horizontal, customCard ? 0 : 15)

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -32,6 +32,14 @@ struct ChatView: View {
     /// typed-Return detector lets that one through instead of sending.
     @State private var allowsNewline = false
     @State private var shareFile: ShareFile?
+    /// Files and folders picked for the next message, copied into our own
+    /// inbox and uploaded when it is sent.
+    @State private var pendingAttachments: [PendingAttachment] = []
+    @State private var showingFilePicker = false
+    @State private var showingFolderPicker = false
+    /// A line above the composer: upload progress, or why the last send
+    /// did not happen. Cleared on the next successful send.
+    @State private var composerNotice: ComposerNotice?
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
     /// The opening beat: the island grows with the bot's face in it, then
@@ -285,6 +293,27 @@ struct ChatView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
         .overlay(alignment: .bottom) { plusSheet }
+        // Two pickers rather than one with both types: with `.folder` in
+        // the list a folder shows an Open button instead of being entered,
+        // which is not what someone browsing for a file expects.
+        .fileImporter(
+            isPresented: $showingFilePicker,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            attach {
+                try AttachmentIntake.takeFiles(try result.get())
+            }
+        }
+        .fileImporter(
+            isPresented: $showingFolderPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            attach {
+                try result.get().map { try AttachmentIntake.takeFolder($0) }
+            }
+        }
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $showingComputer) {
@@ -321,6 +350,12 @@ struct ChatView: View {
             if shown { dictation.stop() }
         }
         .onChange(of: showingPlus) { _, shown in
+            if shown { dictation.stop() }
+        }
+        .onChange(of: showingFilePicker) { _, shown in
+            if shown { dictation.stop() }
+        }
+        .onChange(of: showingFolderPicker) { _, shown in
             if shown { dictation.stop() }
         }
         .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)) { note in
@@ -558,6 +593,14 @@ struct ChatView: View {
             ) { showingTasks = true })
         }
         out.append(PlusAction(
+            id: "attach-files", systemImage: "doc.badge.plus", title: "Attach files",
+            subtitle: "Documents and photos from this phone"
+        ) { showingFilePicker = true })
+        out.append(PlusAction(
+            id: "attach-folder", systemImage: "folder.badge.plus", title: "Attach a folder",
+            subtitle: "Everything inside it, for \(current.name) to read"
+        ) { showingFolderPicker = true })
+        out.append(PlusAction(
             id: "share", systemImage: "doc.plaintext", title: "Share transcript",
             subtitle: "This chat as Markdown"
         ) {
@@ -606,7 +649,23 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty
+    }
+
+    /// Run a picker's result through intake. A refused pick says why above
+    /// the composer; what was accepted before it stays attached.
+    private func attach(_ take: () throws -> [PendingAttachment]) {
+        do {
+            pendingAttachments.append(contentsOf: try take())
+            if case .error = composerNotice { composerNotice = nil }
+        } catch {
+            composerNotice = .error(error.localizedDescription)
+        }
+    }
+
+    private func remove(_ attachment: PendingAttachment) {
+        pendingAttachments.removeAll { $0.id == attachment.id }
+        AttachmentIntake.discard(attachment)
     }
 
     private var hasPendingApproval: Bool {
@@ -618,12 +677,37 @@ struct ChatView: View {
         // open the microphone after the message has already been sent.
         dictation.stop()
         let text = (explicitText ?? draft).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        let attachments = pendingAttachments
+        guard !text.isEmpty || !attachments.isEmpty else { return }
         draft = ""
+        pendingAttachments = []
         showCommandHUD = false
         SoundEffects.playSent()
         Haptics.impact(.medium)
-        Task { await session.send(text, to: current) }
+        guard !attachments.isEmpty else {
+            composerNotice = nil
+            Task { await session.send(text, to: current) }
+            return
+        }
+        // Uploads first, then one message carrying the same tags the
+        // desktop composer writes. If an upload fails the draft and its
+        // chips come back, so a dropped Wi-Fi hop costs a retry, not a
+        // retype.
+        Task {
+            do {
+                let references = try await session.upload(attachments) { composerNotice = .progress($0) }
+                let message = SharedMessageComposer.compose(
+                    instruction: text, text: [], urls: [], attachments: references
+                )
+                composerNotice = nil
+                await session.send(message, to: current)
+                attachments.forEach(AttachmentIntake.discard)
+            } catch {
+                composerNotice = .error(error.localizedDescription)
+                pendingAttachments = attachments + pendingAttachments
+                if draft.isEmpty { draft = text }
+            }
+        }
     }
 
     // MARK: - Composer
@@ -637,6 +721,20 @@ struct ChatView: View {
                     .foregroundStyle(.orange)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 4)
+            }
+
+            if let notice = composerNotice {
+                Text(notice.text)
+                    .font(.system(size: 13))
+                    .foregroundStyle(notice.isError ? Color.orange : Color.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 4)
+                    .transition(.opacity)
+            }
+
+            if !pendingAttachments.isEmpty {
+                PendingAttachmentChips(items: pendingAttachments, onRemove: remove)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
             if showCommandHUD {
@@ -792,6 +890,24 @@ struct ChatView: View {
         .padding(.bottom, 8)
         .frame(maxWidth: CompanionLayout.chatWidth)
         .frame(maxWidth: .infinity)
+    }
+}
+
+/// The line above the composer while attachments go up, or after a send
+/// that could not happen.
+enum ComposerNotice: Equatable {
+    case progress(String)
+    case error(String)
+
+    var text: String {
+        switch self {
+        case let .progress(text), let .error(text): return text
+        }
+    }
+
+    var isError: Bool {
+        if case .error = self { return true }
+        return false
     }
 }
 

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -28,6 +28,7 @@ struct ChatView: View {
     @State private var showingComputer = false
     @State private var showingPlus = false
     @State private var showingProfile = false
+    @State private var showingCall = false
     @State private var showCommandHUD = false
     /// Set by a hardware shift-Return just before the newline lands, so the
     /// typed-Return detector lets that one through instead of sending.
@@ -365,6 +366,12 @@ struct ChatView: View {
         .onChange(of: showingProfile) { _, shown in
             if shown { dictation.stop() }
         }
+        .onChange(of: showingCall) { _, shown in
+            if shown { dictation.stop() }
+        }
+        .fullScreenCover(isPresented: $showingCall) {
+            if case let .bot(bot) = current { CallView(bot: bot) }
+        }
         .onChange(of: showingPlus) { _, shown in
             if shown { dictation.stop() }
         }
@@ -434,6 +441,10 @@ struct ChatView: View {
             Spacer(minLength: 4)
 
             if case .bot = current {
+                GlassButton(systemImage: "phone.fill", size: 44, weight: .medium) {
+                    showingCall = true
+                }
+                .accessibilityLabel("Call \(current.name)")
                 GlassButton(systemImage: "display", size: 44, weight: .medium) {
                     showingComputer = true
                 }

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -6,6 +6,7 @@
 // did that and having two folds is how two clients start disagreeing.
 import SwiftUI
 import CompanionCore
+import PhotosUI
 // Unconditional, because the uses below are: `Color(uiColor:)` and
 // `UIImage(data:)` are reached on every path through this file. A
 // `canImport` guard around the import alone does not make the file portable
@@ -37,6 +38,10 @@ struct ChatView: View {
     @State private var pendingAttachments: [PendingAttachment] = []
     @State private var showingFilePicker = false
     @State private var showingFolderPicker = false
+    @State private var showingPhotoPicker = false
+    /// The photo library's selection; drained into `pendingAttachments`
+    /// as each item's bytes arrive, then cleared for the next pick.
+    @State private var pickedPhotos: [PhotosPickerItem] = []
     /// A line above the composer: upload progress, or why the last send
     /// did not happen. Cleared on the next successful send.
     @State private var composerNotice: ComposerNotice?
@@ -314,6 +319,17 @@ struct ChatView: View {
                 try result.get().map { try AttachmentIntake.takeFolder($0) }
             }
         }
+        .photosPicker(
+            isPresented: $showingPhotoPicker,
+            selection: $pickedPhotos,
+            maxSelectionCount: 10,
+            matching: .images
+        )
+        .onChange(of: pickedPhotos) { _, items in
+            guard !items.isEmpty else { return }
+            pickedPhotos = []
+            Task { await attachPhotos(items) }
+        }
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $showingComputer) {
@@ -356,6 +372,9 @@ struct ChatView: View {
             if shown { dictation.stop() }
         }
         .onChange(of: showingFolderPicker) { _, shown in
+            if shown { dictation.stop() }
+        }
+        .onChange(of: showingPhotoPicker) { _, shown in
             if shown { dictation.stop() }
         }
         .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)) { note in
@@ -593,6 +612,10 @@ struct ChatView: View {
             ) { showingTasks = true })
         }
         out.append(PlusAction(
+            id: "attach-photos", systemImage: "photo.badge.plus", title: "Add photos",
+            subtitle: "Screenshots and pictures from your library"
+        ) { showingPhotoPicker = true })
+        out.append(PlusAction(
             id: "attach-files", systemImage: "doc.badge.plus", title: "Attach files",
             subtitle: "Documents and photos from this phone"
         ) { showingFilePicker = true })
@@ -660,6 +683,28 @@ struct ChatView: View {
             if case .error = composerNotice { composerNotice = nil }
         } catch {
             composerNotice = .error(error.localizedDescription)
+        }
+    }
+
+    /// Photos arrive one at a time as the library hands over their bytes.
+    /// Each lands as its own chip; one that cannot be read says so and
+    /// does not stop the rest.
+    private func attachPhotos(_ items: [PhotosPickerItem]) async {
+        let start = pendingAttachments.filter { $0.kind == .image }.count
+        for (offset, item) in items.enumerated() {
+            let ordinal = start + offset + 1
+            do {
+                guard let data = try await item.loadTransferable(type: Data.self) else {
+                    throw AttachmentIntake.IntakeError.unreadable("Photo \(ordinal)")
+                }
+                let attachment = try await Task.detached(priority: .userInitiated) {
+                    try AttachmentIntake.takeImage(data, ordinal: ordinal)
+                }.value
+                pendingAttachments.append(attachment)
+                if case .error = composerNotice { composerNotice = nil }
+            } catch {
+                composerNotice = .error(error.localizedDescription)
+            }
         }
     }
 

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -28,6 +28,9 @@ struct ChatView: View {
     @State private var showingPlus = false
     @State private var showingProfile = false
     @State private var showCommandHUD = false
+    /// Set by a hardware shift-Return just before the newline lands, so the
+    /// typed-Return detector lets that one through instead of sending.
+    @State private var allowsNewline = false
     @State private var shareFile: ShareFile?
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
@@ -715,13 +718,29 @@ struct ChatView: View {
                             // Partial transcripts rebuild from a frozen base;
                             // prevent competing edits without dimming the text.
                             .allowsHitTesting(!dictation.isListening && !dictation.isStarting)
-                            .onChange(of: draft) { _, value in
+                            .onChange(of: draft) { old, value in
+                                // The software keyboard's Return on a vertical
+                                // TextField inserts "\n" and never fires
+                                // onSubmit, so the blue send key added a line.
+                                // Recognise that exact edit and send instead.
+                                // Dictation rebuilds the draft wholesale and
+                                // is left alone.
+                                if !allowsNewline, !dictation.isListening,
+                                   let stripped = ComposerReturn.textWithoutTypedReturn(old: old, new: value) {
+                                    draft = stripped
+                                    submit(stripped)
+                                    return
+                                }
+                                allowsNewline = false
                                 withAnimation(.easeInOut(duration: 0.15)) {
                                     showCommandHUD = value.hasPrefix("/")
                                 }
                             }
                             .onKeyPress(.return, phases: .down) { press in
-                                guard !press.modifiers.contains(.shift) else { return .ignored }
+                                guard !press.modifiers.contains(.shift) else {
+                                    allowsNewline = true
+                                    return .ignored
+                                }
                                 submit()
                                 return .handled
                             }

--- a/ios/App/ComposerAttachments.swift
+++ b/ios/App/ComposerAttachments.swift
@@ -1,0 +1,235 @@
+// What is attached to the next message, and how it got there.
+//
+// The desktop attaches a file or a folder by path, because the bot runs on
+// that same disk. Everything on the phone has to travel: a picked file is
+// copied out of its security-scoped URL into our own temp inbox the moment
+// it is chosen (the picker's URL is only good for that moment), a folder is
+// copied file by file with its structure kept, and the copies are uploaded
+// when the message is sent. The chips above the composer are these copies.
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PendingAttachment: Identifiable, Hashable {
+    enum Kind: Hashable {
+        case image
+        case file
+        case folder
+    }
+
+    let id: UUID
+    let kind: Kind
+    let name: String
+    /// The copy in our inbox: a file, or the root of a rebuilt folder.
+    let url: URL
+    let bytes: Int
+    let mime: String
+    /// Regular files inside a folder; 1 for a file.
+    let fileCount: Int
+
+    var subtitle: String {
+        switch kind {
+        case .folder:
+            return "\(fileCount) file\(fileCount == 1 ? "" : "s") · \(AttachmentIntake.formatSize(bytes))"
+        case .image, .file:
+            return AttachmentIntake.formatSize(bytes)
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .image: return "photo"
+        case .file: return "doc"
+        case .folder: return "folder"
+        }
+    }
+}
+
+enum AttachmentIntake {
+    /// The server's ceilings, checked here so a too-big pick is refused
+    /// before a single byte is copied rather than after the upload fails.
+    static let fileLimitBytes = 25 * 1_024 * 1_024
+    static let folderLimitBytes = 200 * 1_024 * 1_024
+    static let folderFileLimit = 500
+    /// The desktop's image types; anything else is an ordinary file.
+    private static let imageMimes: Set<String> = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+
+    enum IntakeError: LocalizedError {
+        case unreadable(String)
+        case empty(String)
+        case tooLarge(String, Int)
+        case tooManyFiles(String, Int)
+        case nothingInside(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unreadable(name): return "\(name) couldn't be read."
+            case let .empty(name): return "\(name) is empty."
+            case let .tooLarge(name, mb): return "\(name) is larger than \(mb) MB."
+            case let .tooManyFiles(name, limit): return "\(name) has more than \(limit) files."
+            case let .nothingInside(name): return "\(name) has no files to attach."
+            }
+        }
+    }
+
+    /// Files from the document picker. Each is copied now, while the
+    /// picker's grant on it is still valid.
+    static func takeFiles(_ sources: [URL]) throws -> [PendingAttachment] {
+        try sources.map { source in
+            let accessed = source.startAccessingSecurityScopedResource()
+            defer { if accessed { source.stopAccessingSecurityScopedResource() } }
+            let name = source.lastPathComponent
+            let attributes = try FileManager.default.attributesOfItem(atPath: source.path)
+            guard attributes[.type] as? FileAttributeType == .typeRegular else {
+                throw IntakeError.unreadable(name)
+            }
+            let bytes = (attributes[.size] as? NSNumber)?.intValue ?? 0
+            guard bytes > 0 else { throw IntakeError.empty(name) }
+            guard bytes <= fileLimitBytes else { throw IntakeError.tooLarge(name, fileLimitBytes / 1_048_576) }
+            let id = UUID()
+            let destination = try inbox(for: id).appendingPathComponent(name)
+            try FileManager.default.copyItem(at: source, to: destination)
+            let mime = mimeFor(source)
+            return PendingAttachment(
+                id: id, kind: imageMimes.contains(mime) ? .image : .file, name: name,
+                url: destination, bytes: bytes, mime: mime, fileCount: 1
+            )
+        }
+    }
+
+    /// A folder from the document picker, copied with its structure. Hidden
+    /// files and packages' insides are skipped; an empty file is skipped
+    /// too, since the server refuses one and it says nothing anyway.
+    static func takeFolder(_ source: URL) throws -> PendingAttachment {
+        let accessed = source.startAccessingSecurityScopedResource()
+        defer { if accessed { source.stopAccessingSecurityScopedResource() } }
+        let name = source.lastPathComponent
+        let id = UUID()
+        let root = try inbox(for: id).appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let keys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey, .isDirectoryKey]
+        guard let walker = FileManager.default.enumerator(
+            at: source, includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { throw IntakeError.unreadable(name) }
+
+        var count = 0
+        var bytes = 0
+        let base = source.standardizedFileURL.path
+        for case let file as URL in walker {
+            let values = try file.resourceValues(forKeys: Set(keys))
+            guard values.isRegularFile == true else { continue }
+            let size = values.fileSize ?? 0
+            guard size > 0 else { continue }
+            guard size <= fileLimitBytes else {
+                throw IntakeError.tooLarge(file.lastPathComponent, fileLimitBytes / 1_048_576)
+            }
+            count += 1
+            bytes += size
+            guard count <= folderFileLimit else { throw IntakeError.tooManyFiles(name, folderFileLimit) }
+            guard bytes <= folderLimitBytes else { throw IntakeError.tooLarge(name, folderLimitBytes / 1_048_576) }
+            let full = file.standardizedFileURL.path
+            guard full.hasPrefix(base + "/") else { continue }
+            let relative = String(full.dropFirst(base.count + 1))
+            let destination = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(at: file, to: destination)
+        }
+        guard count > 0 else {
+            discard(root.deletingLastPathComponent())
+            throw IntakeError.nothingInside(name)
+        }
+        return PendingAttachment(
+            id: id, kind: .folder, name: name, url: root, bytes: bytes,
+            mime: "inode/directory", fileCount: count
+        )
+    }
+
+    /// Every regular file under a rebuilt folder, as (relative path, url).
+    static func files(in folder: PendingAttachment) -> [(relativePath: String, url: URL)] {
+        guard folder.kind == .folder,
+              let walker = FileManager.default.enumerator(
+                at: folder.url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]
+              )
+        else { return [] }
+        let base = folder.url.standardizedFileURL.path
+        var out: [(String, URL)] = []
+        for case let file as URL in walker {
+            guard (try? file.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true else { continue }
+            let full = file.standardizedFileURL.path
+            guard full.hasPrefix(base + "/") else { continue }
+            out.append((String(full.dropFirst(base.count + 1)), file))
+        }
+        return out.sorted { $0.0 < $1.0 }
+    }
+
+    static func discard(_ attachment: PendingAttachment) {
+        discard(attachment.url.deletingLastPathComponent())
+    }
+
+    private static func discard(_ inbox: URL) {
+        try? FileManager.default.removeItem(at: inbox)
+    }
+
+    private static func inbox(for id: UUID) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-\(id.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func mimeFor(_ url: URL) -> String {
+        UTType(filenameExtension: url.pathExtension)?.preferredMIMEType?.lowercased() ?? "application/octet-stream"
+    }
+
+    static func formatSize(_ bytes: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}
+
+/// The chips above the composer: one per pending attachment, each with a
+/// way off.
+struct PendingAttachmentChips: View {
+    let items: [PendingAttachment]
+    let onRemove: (PendingAttachment) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(items) { item in
+                    HStack(spacing: 6) {
+                        Image(systemName: item.systemImage)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Color.secondary)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(item.name)
+                                .font(.system(size: 13, weight: .medium))
+                                .lineLimit(1)
+                            Text(item.subtitle)
+                                .font(.system(size: 11))
+                                .foregroundStyle(Color.secondary)
+                        }
+                        .frame(maxWidth: 160, alignment: .leading)
+                        Button {
+                            onRemove(item)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Remove \(item.name)")
+                    }
+                    .padding(.leading, 10)
+                    .padding(.trailing, 6)
+                    .padding(.vertical, 6)
+                    .background(Color.secondary.opacity(0.12), in: Capsule())
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(item.kind == .folder ? "Folder" : "File"): \(item.name), \(item.subtitle)")
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+}

--- a/ios/App/ComposerAttachments.swift
+++ b/ios/App/ComposerAttachments.swift
@@ -7,6 +7,7 @@
 // copied file by file with its structure kept, and the copies are uploaded
 // when the message is sent. The chips above the composer are these copies.
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 
 struct PendingAttachment: Identifiable, Hashable {
@@ -94,6 +95,68 @@ enum AttachmentIntake {
                 url: destination, bytes: bytes, mime: mime, fileCount: 1
             )
         }
+    }
+
+    /// The server's ceiling for an image, and the four formats it accepts.
+    static let imageLimitBytes = 10 * 1_024 * 1_024
+
+    /// A picture from the photo library: a screenshot, a camera shot, a
+    /// saved image. What arrives is whatever the library holds, and a
+    /// camera shot is usually HEIC, which the Mac side does not take — so
+    /// anything that is not one of its four formats is re-encoded as JPEG,
+    /// and anything over the ceiling is scaled down until it fits. A
+    /// screenshot is PNG and small, and passes through untouched.
+    static func takeImage(_ data: Data, ordinal: Int) throws -> PendingAttachment {
+        let sniffed = sniffImageMime(data)
+        var bytes = data
+        var mime = sniffed ?? ""
+        if sniffed == nil || data.count > imageLimitBytes {
+            guard let image = UIImage(data: data) else { throw IntakeError.unreadable("Photo \(ordinal)") }
+            bytes = try jpegWithinLimit(image, ordinal: ordinal)
+            mime = "image/jpeg"
+        }
+        let ext = ["image/png": "png", "image/jpeg": "jpg", "image/gif": "gif", "image/webp": "webp"][mime] ?? "jpg"
+        let name = "Photo \(ordinal).\(ext)"
+        let id = UUID()
+        let destination = try inbox(for: id).appendingPathComponent(name)
+        try bytes.write(to: destination, options: .atomic)
+        return PendingAttachment(
+            id: id, kind: .image, name: name, url: destination,
+            bytes: bytes.count, mime: mime, fileCount: 1
+        )
+    }
+
+    private static func jpegWithinLimit(_ image: UIImage, ordinal: Int) throws -> Data {
+        var current = image
+        for _ in 0..<6 {
+            if let jpeg = current.jpegData(compressionQuality: 0.85), jpeg.count <= imageLimitBytes {
+                return jpeg
+            }
+            // halve the pixel count each time; six halvings takes a 100 MP
+            // shot under 2 MP, which is always under the ceiling
+            let scale = 1 / 2.0.squareRoot()
+            let size = CGSize(width: current.size.width * scale, height: current.size.height * scale)
+            let renderer = UIGraphicsImageRenderer(size: size, format: {
+                let format = UIGraphicsImageRendererFormat.default()
+                format.scale = 1
+                return format
+            }())
+            current = renderer.image { _ in current.draw(in: CGRect(origin: .zero, size: size)) }
+        }
+        throw IntakeError.tooLarge("Photo \(ordinal)", imageLimitBytes / 1_048_576)
+    }
+
+    /// The format by its first bytes, for the four the server accepts.
+    /// The library's own type claim is not consulted: an edited screenshot
+    /// can carry a type that no longer matches its bytes.
+    private static func sniffImageMime(_ data: Data) -> String? {
+        guard data.count >= 12 else { return nil }
+        let head = [UInt8](data.prefix(12))
+        if head.starts(with: [0x89, 0x50, 0x4E, 0x47]) { return "image/png" }
+        if head.starts(with: [0xFF, 0xD8, 0xFF]) { return "image/jpeg" }
+        if head.starts(with: [0x47, 0x49, 0x46, 0x38]) { return "image/gif" }
+        if head.starts(with: [0x52, 0x49, 0x46, 0x46]), Array(head[8..<12]) == [0x57, 0x45, 0x42, 0x50] { return "image/webp" }
+        return nil
     }
 
     /// A folder from the document picker, copied with its structure. Hidden

--- a/ios/App/FileViewerSheet.swift
+++ b/ios/App/FileViewerSheet.swift
@@ -1,0 +1,133 @@
+// A file the bot linked, opened on the phone.
+//
+// The desktop turns a linked file into a "save a copy" button because the
+// file is already on that disk. Here the bytes come from the Mac over the
+// pairing connection, and what the person wanted was to read the thing: a
+// markdown report renders as a reply would, text and code show as text,
+// and everything else goes to QuickLook, which knows PDFs, images and
+// Office documents. The share button is the "save a copy" half — it offers
+// Save to Files along with everything else the share sheet does.
+import QuickLook
+import SwiftUI
+import CompanionCore
+
+struct FileViewRequest: Identifiable {
+    let id = UUID()
+    let path: String
+}
+
+struct FileViewerSheet: View {
+    let path: String
+    @EnvironmentObject private var session: Session
+    @Environment(\.dismiss) private var dismiss
+    @State private var phase: Phase = .loading
+
+    private enum Phase {
+        case loading
+        case failed(String)
+        case loaded(FetchedFile, URL)
+    }
+
+    private var title: String { URL(fileURLWithPath: path).lastPathComponent }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .loading:
+                    ProgressView("Fetching from your computer…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case let .failed(reason):
+                    ContentUnavailableView(
+                        "Couldn't open this file",
+                        systemImage: "doc.questionmark",
+                        description: Text(reason)
+                    )
+                case let .loaded(file, url):
+                    content(file, url)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                if case let .loaded(_, url) = phase {
+                    ToolbarItem(placement: .primaryAction) {
+                        ShareLink(item: url) { Image(systemName: "square.and.arrow.up") }
+                            .accessibilityLabel("Share or save this file")
+                    }
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder
+    private func content(_ file: FetchedFile, _ url: URL) -> some View {
+        let mime = file.mime.split(separator: ";").first.map {
+            $0.trimmingCharacters(in: .whitespaces).lowercased()
+        } ?? ""
+        if mime == "text/markdown", let text = String(data: file.data, encoding: .utf8) {
+            ScrollView {
+                MarkdownText(source: text)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+        } else if mime.hasPrefix("text/") || mime == "application/json",
+                  let text = String(data: file.data, encoding: .utf8) {
+            ScrollView([.vertical, .horizontal]) {
+                Text(text)
+                    .font(.system(size: 13, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+        } else {
+            QuickLookPreview(url: url)
+                .ignoresSafeArea(edges: .bottom)
+        }
+    }
+
+    private func load() async {
+        do {
+            let file = try await session.fetchFile(path: path)
+            // QuickLook and the share sheet both want a file URL, and the
+            // name matters: it is what Save to Files offers.
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("viewed-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let name = file.name.isEmpty ? title : file.name
+            let url = directory.appendingPathComponent(name)
+            try file.data.write(to: url, options: .atomic)
+            phase = .loaded(file, url)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}
+
+struct QuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(url: url) }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let url: URL
+        init(url: URL) { self.url = url }
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            url as NSURL
+        }
+    }
+}

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1240,13 +1240,6 @@ final class Session: ObservableObject {
         return try await client.fetchFile(path: path)
     }
 
-    /// A bot-created file for the viewer sheet. Throws so the sheet can say
-    /// why rather than sit blank.
-    func fetchFile(path: String) async throws -> FetchedFile {
-        guard let client else { throw APIError.transport("This computer is offline.") }
-        return try await client.fetchFile(path: path)
-    }
-
     /// Upload what the composer attached and hand back the references the
     /// message will carry — the same tags the share extension and the
     /// desktop write, so a bot sees no difference in where it came from.

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1090,6 +1090,32 @@ final class Session: ObservableObject {
         catch { actionError = error.localizedDescription; return nil }
     }
 
+    /// A reply as utterances the computer can voice, or nil when it has no
+    /// voice set up (so the call can say so rather than fall silent).
+    func prepareSpeech(_ text: String, voiceId: String?) async throws -> PreparedSpeech {
+        guard let client else { throw APIError.transport("This computer is offline.") }
+        return try await client.prepareSpeech(text: text, voiceId: voiceId)
+    }
+
+    func speak(_ text: String, voiceId: String?) async throws -> Data {
+        guard let client else { throw APIError.transport("This computer is offline.") }
+        return try await client.speak(text: text, voiceId: voiceId)
+    }
+
+    /// Save the ElevenLabs key on the computer. Returns the server's
+    /// reason when it rejects the key, nil on success.
+    func updateVoiceKey(_ key: String) async -> String? {
+        guard let client else { return "This computer is offline." }
+        do { try await client.updateVoiceKey(key); return nil }
+        catch { return error.localizedDescription }
+    }
+
+    func updateVoiceProvider(_ provider: String) async -> String? {
+        guard let client else { return "This computer is offline." }
+        do { try await client.updateVoiceProvider(provider); return nil }
+        catch { return error.localizedDescription }
+    }
+
     func configStatus() async -> ConfigStatus? {
         guard let client else { return nil }
         return try? await client.config()

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1233,6 +1233,80 @@ final class Session: ObservableObject {
         }
     }
 
+    /// A bot-created file for the viewer sheet. Throws so the sheet can say
+    /// why rather than sit blank.
+    func fetchFile(path: String) async throws -> FetchedFile {
+        guard let client else { throw APIError.transport("This computer is offline.") }
+        return try await client.fetchFile(path: path)
+    }
+
+    /// A bot-created file for the viewer sheet. Throws so the sheet can say
+    /// why rather than sit blank.
+    func fetchFile(path: String) async throws -> FetchedFile {
+        guard let client else { throw APIError.transport("This computer is offline.") }
+        return try await client.fetchFile(path: path)
+    }
+
+    /// Upload what the composer attached and hand back the references the
+    /// message will carry — the same tags the share extension and the
+    /// desktop write, so a bot sees no difference in where it came from.
+    /// A folder goes up file by file and comes back as one reference to
+    /// the rebuilt folder. Each attachment's own id is its uploadId, so a
+    /// retry after a dropped connection replaces rather than duplicates.
+    func upload(
+        _ attachments: [PendingAttachment],
+        progress: @MainActor (String) -> Void
+    ) async throws -> [SharedAttachmentReference] {
+        guard let client else { throw APIError.transport("This computer is offline.") }
+        var references: [SharedAttachmentReference] = []
+        for attachment in attachments {
+            switch attachment.kind {
+            case .image:
+                progress("Uploading \(attachment.name)…")
+                let data = try await Self.read(attachment.url)
+                let path = try await client.uploadImage(
+                    data: data, mime: attachment.mime, uploadId: attachment.id.uuidString
+                )
+                references.append(SharedAttachmentReference(path: path, kind: .image))
+            case .file:
+                progress("Uploading \(attachment.name)…")
+                let data = try await Self.read(attachment.url)
+                let uploaded = try await client.uploadFile(
+                    data: data, name: attachment.name, mime: attachment.mime,
+                    uploadId: attachment.id.uuidString
+                )
+                references.append(SharedAttachmentReference(
+                    path: uploaded.path, kind: .file, displayName: uploaded.name
+                ))
+            case .folder:
+                let files = AttachmentIntake.files(in: attachment)
+                var folderPath: String?
+                for (index, file) in files.enumerated() {
+                    progress("Uploading \(attachment.name) (\(index + 1) of \(files.count))…")
+                    let data = try await Self.read(file.url)
+                    let uploaded = try await client.uploadFolderFile(
+                        data: data, uploadId: attachment.id.uuidString,
+                        folder: attachment.name, relativePath: file.relativePath
+                    )
+                    folderPath = uploaded.folderPath
+                }
+                guard let folderPath else {
+                    throw APIError.transport("\(attachment.name) has no files to attach.")
+                }
+                references.append(SharedAttachmentReference(
+                    path: folderPath, kind: .file, displayName: attachment.name
+                ))
+            }
+        }
+        return references
+    }
+
+    private static func read(_ url: URL) async throws -> Data {
+        try await Task.detached(priority: .userInitiated) {
+            try Data(contentsOf: url, options: .mappedIfSafe)
+        }.value
+    }
+
     // MARK: - Connected apps
 
     func loadConnectorCatalog() async -> ConnectorCatalog? {

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -124,6 +124,16 @@ struct SettingsView: View {
                             SettingsIcon(symbol: "link", color: .blue)
                         }
                     }
+
+                    NavigationLink {
+                        VoiceSettingsView()
+                    } label: {
+                        Label {
+                            Text("Voice")
+                        } icon: {
+                            SettingsIcon(symbol: "phone.fill", color: .green)
+                        }
+                    }
                 }
             }
         }

--- a/ios/App/SpeechDictation.swift
+++ b/ios/App/SpeechDictation.swift
@@ -55,6 +55,22 @@ final class SpeechDictation: ObservableObject {
     private var generation = 0
     private var startTask: Task<Void, Never>?
 
+    /// Call mode. Composer dictation runs until the person taps stop; a
+    /// call has to notice when they have finished a sentence. The same
+    /// silence endpointer as the desktop helper: the turn ends `endpointGap`
+    /// after the transcript last *changed* — the recognizer keeps
+    /// re-emitting an unchanged partial, and only a change counts. An
+    /// empty turn never ends: a call may be quiet for as long as the
+    /// person needs before they begin.
+    private var endpointGap: TimeInterval?
+    private var onTurnEnded: ((String) -> Void)?
+    private var lastTranscriptChange = Date()
+    private var endpointTimer: Timer?
+    /// `.playAndRecord` with voice-chat processing for a call (the phone's
+    /// echo cancellation, and playback stays routed); plain `.record` for
+    /// the composer.
+    private var forCall = false
+
     func toggle(capturing base: String) {
         if isListening || isStarting {
             stop()
@@ -69,6 +85,27 @@ final class SpeechDictation: ObservableObject {
         self.base = base.trimmingCharacters(in: .whitespacesAndNewlines)
         transcript = ""
         accumulator = DictationAccumulator()
+        forCall = false
+        endpointGap = nil
+        onTurnEnded = nil
+        isStarting = true
+        generation += 1
+        let gen = generation
+        startTask = Task { await actuallyStart(generation: gen) }
+    }
+
+    /// One turn of a call: listen until `gap` of silence follows speech,
+    /// then stop and hand the transcript to `onTurn`. Stopping any other
+    /// way (hang up, interruption) ends the turn without a callback.
+    func listenForTurn(endpointAfter gap: TimeInterval, onTurn: @escaping (String) -> Void) {
+        guard !isListening, !isStarting else { return }
+        error = nil
+        base = ""
+        transcript = ""
+        accumulator = DictationAccumulator()
+        forCall = true
+        endpointGap = gap
+        onTurnEnded = onTurn
         isStarting = true
         generation += 1
         let gen = generation
@@ -82,7 +119,17 @@ final class SpeechDictation: ObservableObject {
         isStarting = false
         stopping = true
         isListening = false
+        onTurnEnded = nil
         teardown()
+    }
+
+    private func endTurn() {
+        guard let onTurnEnded, isListening else { return }
+        let heard = transcript
+        // stop() clears the callback; take it first
+        self.onTurnEnded = nil
+        stop()
+        onTurnEnded(heard)
     }
 
     // MARK: - Authorization
@@ -142,10 +189,17 @@ final class SpeechDictation: ObservableObject {
         self.recognizer = recognizer
 
         let session = AVAudioSession.sharedInstance()
-        // `.record` rather than `.playAndRecord`: this is composer
-        // dictation, not a call, and holding the playback route would
-        // duck whatever else is on the phone for no reason.
-        try session.setCategory(.record, mode: .measurement)
+        if forCall {
+            try session.setCategory(
+                .playAndRecord, mode: .voiceChat,
+                options: [.defaultToSpeaker, .allowBluetooth]
+            )
+        } else {
+            // `.record` rather than `.playAndRecord`: this is composer
+            // dictation, not a call, and holding the playback route would
+            // duck whatever else is on the phone for no reason.
+            try session.setCategory(.record, mode: .measurement)
+        }
         try session.setActive(true, options: .notifyOthersOnDeactivation)
 
         let engine = AVAudioEngine()
@@ -185,6 +239,17 @@ final class SpeechDictation: ObservableObject {
 
         stopping = false
         isListening = true
+        lastTranscriptChange = Date()
+        if let gap = endpointGap {
+            let timer = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self, self.isListening, !self.transcript.isEmpty else { return }
+                    if Date().timeIntervalSince(self.lastTranscriptChange) >= gap { self.endTurn() }
+                }
+            }
+            RunLoop.main.add(timer, forMode: .common)
+            endpointTimer = timer
+        }
 
         recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, recognitionError in
             Task { @MainActor in
@@ -210,15 +275,20 @@ final class SpeechDictation: ObservableObject {
         if let result {
             // On-device recognition starts a fresh result after a pause,
             // dropping what came before it. The accumulator keeps it.
-            transcript = accumulator.accept(
+            let next = accumulator.accept(
                 text: result.bestTranscription.formattedString,
                 start: result.bestTranscription.segments.first?.timestamp
             )
+            if next != transcript {
+                transcript = next
+                lastTranscriptChange = Date()
+            }
             // Composer dictation does not wait for isFinal — the last
             // partial is what you send. If the recognizer finalizes on
-            // its own (rare without endAudio), just stop listening.
+            // its own (rare without endAudio), just stop listening; on a
+            // call that is the turn ending.
             if result.isFinal {
-                stop()
+                if onTurnEnded != nil { endTurn() } else { stop() }
                 return
             }
         }
@@ -237,6 +307,8 @@ final class SpeechDictation: ObservableObject {
     }
 
     private func teardown() {
+        endpointTimer?.invalidate()
+        endpointTimer = nil
         // Drop the tap before ending the request: a buffer that arrives
         // after endAudio() can fail the task instead of being ignored.
         if let engine = audioEngine {

--- a/ios/App/SpeechDictation.swift
+++ b/ios/App/SpeechDictation.swift
@@ -41,6 +41,9 @@ final class SpeechDictation: ObservableObject {
     /// substitute the live draft.
     private(set) var base = ""
 
+    /// Joins the recognizer's restarts back into one transcript; see
+    /// `DictationAccumulator` for why the raw result is not enough.
+    private var accumulator = DictationAccumulator()
     private var recognizer: SFSpeechRecognizer?
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
@@ -65,6 +68,7 @@ final class SpeechDictation: ObservableObject {
         error = nil
         self.base = base.trimmingCharacters(in: .whitespacesAndNewlines)
         transcript = ""
+        accumulator = DictationAccumulator()
         isStarting = true
         generation += 1
         let gen = generation
@@ -204,7 +208,12 @@ final class SpeechDictation: ObservableObject {
         // new draft or stopping the new capture.
         guard gen == generation, !stopping, isListening else { return }
         if let result {
-            transcript = result.bestTranscription.formattedString
+            // On-device recognition starts a fresh result after a pause,
+            // dropping what came before it. The accumulator keeps it.
+            transcript = accumulator.accept(
+                text: result.bestTranscription.formattedString,
+                start: result.bestTranscription.segments.first?.timestamp
+            )
             // Composer dictation does not wait for isFinal — the last
             // partial is what you send. If the recognizer finalizes on
             // its own (rare without endAudio), just stop listening.

--- a/ios/App/VoiceSettingsView.swift
+++ b/ios/App/VoiceSettingsView.swift
@@ -1,0 +1,127 @@
+// Voice: the key that lets a bot talk, set from the phone.
+//
+// The desktop has this under App Settings → Voice. The credential lives on
+// the computer, in the same config the desktop writes, so entering it here
+// is the same as entering it there: one PUT, the server checks the key
+// against ElevenLabs before saving, and the key never comes back in any
+// response. What the phone shows afterwards is only whether one is on file.
+import SwiftUI
+import CompanionCore
+
+struct VoiceSettingsView: View {
+    @EnvironmentObject private var session: Session
+    @State private var status: ConfigStatus?
+    @State private var key = ""
+    @State private var saving = false
+    @State private var message: String?
+    @State private var messageIsError = false
+
+    private var configured: Bool { status?.isTTSConfigured == true }
+    private var provider: String { status?.tts?.provider ?? "elevenlabs" }
+
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Text("Status")
+                    Spacer()
+                    if let status {
+                        Text(status.isTTSConfigured ? "Ready" : "Not set up")
+                            .foregroundStyle(status.isTTSConfigured ? Color.green : Color.secondary)
+                    } else {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                if provider == "system" {
+                    Text("This computer is using its built-in voices. Switch to ElevenLabs to use a key from here.")
+                        .font(.footnote)
+                        .foregroundStyle(Color.secondary)
+                    Button("Use ElevenLabs") { Task { await switchProvider("elevenlabs") } }
+                        .disabled(saving)
+                }
+            } header: {
+                Text("Calls and spoken replies")
+            } footer: {
+                Text("Calls use the voice set up on your computer. Each bot's voice is chosen on its profile.")
+            }
+
+            if provider != "system" {
+                Section {
+                    SecureField("ElevenLabs API key", text: $key)
+                        .textContentType(.password)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        HStack {
+                            Text(configured ? "Replace key" : "Save key")
+                            if saving { Spacer(); ProgressView().controlSize(.small) }
+                        }
+                    }
+                    .disabled(saving || key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    if configured {
+                        Button("Remove key", role: .destructive) { Task { await remove() } }
+                            .disabled(saving)
+                    }
+                } header: {
+                    Text("ElevenLabs")
+                } footer: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        if let message {
+                            Text(message).foregroundStyle(messageIsError ? Color.orange : Color.green)
+                        }
+                        Text("The key is checked and stored on your computer, never on this phone. Get one at elevenlabs.io → Settings → API Keys.")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Voice")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await refresh() }
+    }
+
+    private func refresh() async {
+        status = await session.configStatus()
+    }
+
+    private func save() async {
+        saving = true
+        defer { saving = false }
+        message = nil
+        if let error = await session.updateVoiceKey(key) {
+            message = error
+            messageIsError = true
+            return
+        }
+        key = ""
+        message = "Key saved. Calls are ready."
+        messageIsError = false
+        await refresh()
+    }
+
+    private func remove() async {
+        saving = true
+        defer { saving = false }
+        message = nil
+        if let error = await session.updateVoiceKey("") {
+            message = error
+            messageIsError = true
+            return
+        }
+        message = "Key removed."
+        messageIsError = false
+        await refresh()
+    }
+
+    private func switchProvider(_ provider: String) async {
+        saving = true
+        defer { saving = false }
+        if let error = await session.updateVoiceProvider(provider) {
+            message = error
+            messageIsError = true
+            return
+        }
+        await refresh()
+    }
+}

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -455,6 +455,21 @@ public struct FetchedFile: Sendable {
     }
 }
 
+private struct FolderFileUploadResponse: Decodable {
+    let path: String
+    let folderPath: String
+}
+
+public struct UploadedFolderFile: Hashable, Sendable {
+    public let path: String
+    public let folderPath: String
+
+    public init(path: String, folderPath: String) {
+        self.path = path
+        self.folderPath = folderPath
+    }
+}
+
 public struct UploadedFile: Hashable, Sendable {
     public let path: String
     public let name: String
@@ -976,6 +991,43 @@ public struct CompanionClient: Sendable {
             throw APIError.transport("The uploaded file could not be used.")
         }
         return UploadedFile(path: saved.path, name: returnedName)
+    }
+
+    /// One file of a folder picked on the phone. The server rebuilds the
+    /// folder under its attachments directory and answers with both this
+    /// file's path and the folder's, which is what the message will carry.
+    public func uploadFolderFile(
+        data: Data,
+        uploadId: String,
+        folder: String,
+        relativePath: String
+    ) async throws -> UploadedFolderFile {
+        let folderName = folder.trimmingCharacters(in: .whitespacesAndNewlines)
+        let segments = relativePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard Self.validUploadID(uploadId),
+              Self.validUploadedName(folderName),
+              !segments.isEmpty, segments.count <= 32,
+              segments.allSatisfy({ Self.validUploadedName($0) && $0 != "." && $0 != ".." }),
+              !data.isEmpty, data.count <= Self.maximumFileUploadBytes
+        else {
+            throw APIError.transport("Folders can hold files up to 25 MB each, with ordinary names.")
+        }
+        var request = try makeRequest(
+            "POST",
+            "/api/folders/files",
+            query: [
+                URLQueryItem(name: "uploadId", value: uploadId),
+                URLQueryItem(name: "folder", value: folderName),
+                URLQueryItem(name: "path", value: segments.joined(separator: "/")),
+            ]
+        )
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        let saved = try await send(request, as: FolderFileUploadResponse.self)
+        guard Self.validUploadedPath(saved.path), Self.validUploadedPath(saved.folderPath) else {
+            throw APIError.transport("The uploaded folder could not be used.")
+        }
+        return UploadedFolderFile(path: saved.path, folderPath: saved.folderPath)
     }
 
     private static func validUploadMime(_ mime: String) -> Bool {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -443,6 +443,11 @@ private struct FileUploadResponse: Decodable {
 }
 
 /// A bot-created file fetched from the Mac for viewing on the phone.
+public struct PreparedSpeech: Decodable, Sendable {
+    public var ready: Bool
+    public var utterances: [String]
+}
+
 public struct FetchedFile: Sendable {
     public let data: Data
     public let name: String
@@ -1069,13 +1074,45 @@ public struct CompanionClient: Sendable {
     }
 
     public func previewVoice(text: String, voiceId: String) async throws -> Data {
-        let request = try makeRequest(
-            "POST", "/api/tts/speak",
-            body: ["text": String(text.prefix(500)), "voiceId": voiceId]
-        )
+        try await speak(text: text, voiceId: voiceId)
+    }
+
+    /// One utterance, synthesized on the paired computer. The server caps
+    /// this at 500 characters; `prepareSpeech` splits a reply into pieces
+    /// that fit.
+    public func speak(text: String, voiceId: String?) async throws -> Data {
+        var body: [String: Any] = ["text": String(text.prefix(500))]
+        if let voiceId, !voiceId.isEmpty { body["voiceId"] = voiceId }
+        let request = try makeRequest("POST", "/api/tts/speak", body: body)
         let (data, response) = try await perform(request)
         try Self.check(response, data)
         return data
+    }
+
+    /// Split a reply into utterances the way the desktop does — on the
+    /// server, next to the transform that shapes replies — and learn
+    /// whether the computer can voice them at all.
+    public func prepareSpeech(text: String, voiceId: String?) async throws -> PreparedSpeech {
+        var body: [String: Any] = ["text": text]
+        if let voiceId, !voiceId.isEmpty { body["voiceId"] = voiceId }
+        return try await send(try makeRequest("POST", "/api/tts/prepare", body: body), as: PreparedSpeech.self)
+    }
+
+    /// Store (or, with an empty string, remove) the workspace's ElevenLabs
+    /// key. The server checks a non-empty key against the provider before
+    /// saving it and answers 400 with the reason if it is rejected; the
+    /// key itself never comes back in any response.
+    public func updateVoiceKey(_ key: String) async throws {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.utf8.count <= 512, !trimmed.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) else {
+            throw APIError.transport("That doesn't look like an API key.")
+        }
+        try await send(try makeRequest("PUT", "/api/config", body: ["tts": ["key": trimmed]]))
+    }
+
+    /// Pick the voice engine: "elevenlabs" or "system".
+    public func updateVoiceProvider(_ provider: String) async throws {
+        try await send(try makeRequest("PUT", "/api/config", body: ["tts": ["provider": provider]]))
     }
 
     public func createRoutine(_ input: RoutineInput) async throws -> Routine {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -442,6 +442,19 @@ private struct FileUploadResponse: Decodable {
     let bytes: Int
 }
 
+/// A bot-created file fetched from the Mac for viewing on the phone.
+public struct FetchedFile: Sendable {
+    public let data: Data
+    public let name: String
+    public let mime: String
+
+    public init(data: Data, name: String, mime: String) {
+        self.data = data
+        self.name = name
+        self.mime = mime
+    }
+}
+
 public struct UploadedFile: Hashable, Sendable {
     public let path: String
     public let name: String
@@ -750,18 +763,49 @@ public struct CompanionClient: Sendable {
         try Self.check(response, data)
         let http = response as? HTTPURLResponse
         let fallback = "transcript.\(format == "json" ? "json" : "md")"
-        let disposition = http?.value(forHTTPHeaderField: "Content-Disposition") ?? ""
-        let filenamePart = disposition
-            .split(separator: ";")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .first { $0.lowercased().hasPrefix("filename=") }
-        let filename = filenamePart.map {
-            String($0.dropFirst("filename=".count)).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-        } ?? fallback
+        let filename = Self.filename(fromDisposition: http?.value(forHTTPHeaderField: "Content-Disposition"))
+            ?? fallback
         return TranscriptExport(
             data: data,
             filename: filename,
             contentType: http?.value(forHTTPHeaderField: "Content-Type") ?? "application/octet-stream"
+        )
+    }
+
+    /// The name a Content-Disposition header carries, preferring the RFC 5987
+    /// `filename*` form (exact, UTF-8) over the ASCII-only quoted one.
+    static func filename(fromDisposition disposition: String?) -> String? {
+        let parts = (disposition ?? "")
+            .split(separator: ";")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        if let starred = parts.first(where: { $0.lowercased().hasPrefix("filename*=") }) {
+            let value = String(starred.dropFirst("filename*=".count))
+            // UTF-8''encoded — the charset and an empty language, then the bytes
+            if let quote = value.range(of: "''"),
+               let decoded = String(value[quote.upperBound...]).removingPercentEncoding,
+               !decoded.isEmpty {
+                return decoded
+            }
+        }
+        guard let plain = parts.first(where: { $0.lowercased().hasPrefix("filename=") }) else { return nil }
+        let name = String(plain.dropFirst("filename=".count)).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        return name.isEmpty ? nil : name
+    }
+
+    /// A file a reply linked, read off the Mac. The path is whatever the
+    /// link carried; the server decides whether it is one it will serve.
+    public func fetchFile(path: String) async throws -> FetchedFile {
+        guard !path.isEmpty, path.utf8.count <= 4_096, !path.contains("\0") else { throw APIError.badURL }
+        let request = try makeRequest("GET", "/api/files", query: [URLQueryItem(name: "path", value: path)])
+        let (data, response) = try await perform(request)
+        try Self.check(response, data)
+        let http = response as? HTTPURLResponse
+        let name = Self.filename(fromDisposition: http?.value(forHTTPHeaderField: "Content-Disposition"))
+            ?? URL(fileURLWithPath: path).lastPathComponent
+        return FetchedFile(
+            data: data,
+            name: name,
+            mime: http?.value(forHTTPHeaderField: "Content-Type") ?? "application/octet-stream"
         )
     }
 

--- a/ios/Sources/CompanionCore/ComposerReturn.swift
+++ b/ios/Sources/CompanionCore/ComposerReturn.swift
@@ -1,0 +1,33 @@
+// The Return key on a multi-line composer.
+//
+// A `TextField` with `axis: .vertical` treats the software keyboard's Return
+// as "insert a newline" and never calls `onSubmit`, even with
+// `.submitLabel(.send)` painting the key as a blue send arrow. `onKeyPress`
+// only sees hardware keyboards. So the phone showed a send key that added a
+// line instead — the bug this exists to close.
+//
+// The only signal the view gets is the text changing. This recognises the
+// one edit a tapped Return makes — a single "\n" inserted somewhere — so the
+// view can strip it and send. Anything else (a paste of several lines, a
+// dictation rebuild, a deletion) is left alone.
+import Foundation
+
+public enum ComposerReturn {
+    /// The text with the typed newline removed, or nil when the change from
+    /// `old` to `new` was not exactly one inserted "\n".
+    public static func textWithoutTypedReturn(old: String, new: String) -> String? {
+        let before = Array(old)
+        let after = Array(new)
+        guard after.count == before.count + 1 else { return nil }
+        // Return inserts at the cursor, which is usually but not always the
+        // end: find the first divergence, check it is the newline, and that
+        // the remainder lines up.
+        var index = 0
+        while index < before.count, before[index] == after[index] { index += 1 }
+        guard after[index] == "\n" else { return nil }
+        guard Array(after[(index + 1)...]) == Array(before[index...]) else { return nil }
+        var stripped = after
+        stripped.remove(at: index)
+        return String(stripped)
+    }
+}

--- a/ios/Sources/CompanionCore/DictationAccumulator.swift
+++ b/ios/Sources/CompanionCore/DictationAccumulator.swift
@@ -1,0 +1,49 @@
+// Stitching a recognizer's restarts back into one transcript.
+//
+// `SFSpeechRecognizer` does not promise that each partial result extends
+// the last. On-device recognition in particular treats a pause as the end
+// of an utterance and starts the next result from nothing — so with the
+// composer showing `bestTranscription.formattedString` verbatim, a pause
+// mid-sentence made the first half vanish and the second half take its
+// place. That is the bug this closes.
+//
+// The signal that the recognizer started over is in the segments: every
+// segment carries a timestamp from the start of the audio, and a fresh
+// utterance begins later than the one before it. A revision of the current
+// utterance keeps its start. So: same start, replace; later start, commit
+// what was there and begin a new piece.
+import Foundation
+
+public struct DictationAccumulator: Sendable {
+    /// A revision of the current utterance may nudge its start by a few
+    /// milliseconds; only a clear jump forward is a new utterance.
+    public static let restartTolerance: TimeInterval = 0.5
+
+    private var committed: [String] = []
+    private var current = ""
+    private var currentStart: TimeInterval?
+
+    public init() {}
+
+    /// Everything heard so far, committed utterances then the live one.
+    public var transcript: String {
+        (committed + [current]).filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
+    /// Feed one result. `start` is the timestamp of its first segment, nil
+    /// when the result has no segments, in which case the text is treated
+    /// as a revision of the current utterance.
+    @discardableResult
+    public mutating func accept(text: String, start: TimeInterval?) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let start, let previous = currentStart, start > previous + Self.restartTolerance {
+            if !current.isEmpty { committed.append(current) }
+            current = ""
+            currentStart = start
+        } else if currentStart == nil {
+            currentStart = start
+        }
+        current = trimmed
+        return transcript
+    }
+}

--- a/ios/Sources/CompanionCore/LocalFileLink.swift
+++ b/ios/Sources/CompanionCore/LocalFileLink.swift
@@ -1,0 +1,31 @@
+// Links in a reply that point at a file on the Mac.
+//
+// Bots hand over documents they wrote as `[report.md](/Users/…/report.md)`
+// or as a `file://` URL. The desktop recognises both and offers to save a
+// copy; SwiftUI hands them to `UIApplication.open`, which refuses a URL with
+// no scheme and has nothing behind a `file://` one, so the tap did nothing.
+// This is the desktop's `localFilePath` check, so the two clients agree on
+// which links are files and which are the web.
+import Foundation
+
+public enum LocalFileLink {
+    /// The path to ask the server for, or nil when the link is an ordinary
+    /// web link the system should open.
+    public static func path(for url: URL) -> String? {
+        let scheme = url.scheme?.lowercased() ?? ""
+        switch scheme {
+        case "":
+            // "/Users/…" parses with no scheme; `path` percent-decodes.
+            let path = url.path
+            return path.hasPrefix("/") ? path : nil
+        case "file":
+            // Handed over whole: the server's URL parser also knows about
+            // the "/C:/…" shape a Windows file URL takes.
+            return url.absoluteString
+        default:
+            // "C:\…" parses as scheme "c". A one-letter scheme is a drive.
+            if scheme.count == 1, scheme.first!.isLetter { return url.absoluteString }
+            return nil
+        }
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ComposerReturnTests.swift
+++ b/ios/Tests/CompanionCoreTests/ComposerReturnTests.swift
@@ -1,0 +1,48 @@
+// The typed-Return detector behind the composer's send key.
+//
+// Every case is a real edit the composer receives: the send key at the end
+// of a draft, in the middle of one, on an empty field, and the edits that
+// must not be mistaken for it.
+import XCTest
+@testable import CompanionCore
+
+final class ComposerReturnTests: XCTestCase {
+    func testReturnAtEndOfDraftIsStripped() {
+        XCTAssertEqual(ComposerReturn.textWithoutTypedReturn(old: "hello", new: "hello\n"), "hello")
+    }
+
+    func testReturnInTheMiddleIsStripped() {
+        XCTAssertEqual(ComposerReturn.textWithoutTypedReturn(old: "ab", new: "a\nb"), "ab")
+    }
+
+    func testReturnOnEmptyDraftYieldsEmpty() {
+        XCTAssertEqual(ComposerReturn.textWithoutTypedReturn(old: "", new: "\n"), "")
+    }
+
+    func testReturnAfterExistingNewlineIsStripped() {
+        // a draft that already holds a hardware shift-return newline
+        XCTAssertEqual(ComposerReturn.textWithoutTypedReturn(old: "a\nb", new: "a\nb\n"), "a\nb")
+    }
+
+    func testTypingAnyOtherCharacterIsNotAReturn() {
+        XCTAssertNil(ComposerReturn.textWithoutTypedReturn(old: "hell", new: "hello"))
+    }
+
+    func testDeletionIsNotAReturn() {
+        XCTAssertNil(ComposerReturn.textWithoutTypedReturn(old: "hello\n", new: "hello"))
+    }
+
+    func testMultiLinePasteIsNotAReturn() {
+        XCTAssertNil(ComposerReturn.textWithoutTypedReturn(old: "", new: "one\ntwo"))
+        XCTAssertNil(ComposerReturn.textWithoutTypedReturn(old: "x", new: "x\n\n"))
+    }
+
+    func testReplacementOfSameLengthPlusOneIsNotAReturn() {
+        // "ab" -> "c\nd": one longer, contains a newline, but not an insertion
+        XCTAssertNil(ComposerReturn.textWithoutTypedReturn(old: "ab", new: "c\nd"))
+    }
+
+    func testEmojiAndCombiningCharactersCountAsSingleCharacters() {
+        XCTAssertEqual(ComposerReturn.textWithoutTypedReturn(old: "👍🏽é", new: "👍🏽é\n"), "👍🏽é")
+    }
+}

--- a/ios/Tests/CompanionCoreTests/DictationAccumulatorTests.swift
+++ b/ios/Tests/CompanionCoreTests/DictationAccumulatorTests.swift
@@ -1,0 +1,46 @@
+// How partial results become one transcript across recognizer restarts.
+import XCTest
+@testable import CompanionCore
+
+final class DictationAccumulatorTests: XCTestCase {
+    func testPartialsOfOneUtteranceReplaceEachOther() {
+        var acc = DictationAccumulator()
+        XCTAssertEqual(acc.accept(text: "send the", start: 0.4), "send the")
+        XCTAssertEqual(acc.accept(text: "send the report", start: 0.4), "send the report")
+        XCTAssertEqual(acc.accept(text: "Send the report.", start: 0.42), "Send the report.")
+    }
+
+    func testRestartAfterAPauseKeepsTheFirstUtterance() {
+        var acc = DictationAccumulator()
+        acc.accept(text: "Send the report", start: 0.4)
+        acc.accept(text: "Send the report to Sam.", start: 0.4)
+        // the recognizer starts over: a later first segment, new text
+        XCTAssertEqual(acc.accept(text: "and", start: 4.1), "Send the report to Sam. and")
+        XCTAssertEqual(acc.accept(text: "and copy Lee", start: 4.1), "Send the report to Sam. and copy Lee")
+        XCTAssertEqual(acc.accept(text: "then", start: 9.0), "Send the report to Sam. and copy Lee then")
+    }
+
+    func testSmallDriftInStartIsARevisionNotARestart() {
+        var acc = DictationAccumulator()
+        acc.accept(text: "hello there", start: 1.0)
+        XCTAssertEqual(acc.accept(text: "hello their friend", start: 1.3), "hello their friend")
+    }
+
+    func testMissingTimestampsAreARevision() {
+        var acc = DictationAccumulator()
+        acc.accept(text: "one", start: nil)
+        XCTAssertEqual(acc.accept(text: "one two", start: nil), "one two")
+        acc.accept(text: "one two three", start: 2.0)
+        XCTAssertEqual(acc.transcript, "one two three")
+    }
+
+    func testEmptyPiecesAreDropped() {
+        var acc = DictationAccumulator()
+        acc.accept(text: "", start: 0.1)
+        XCTAssertEqual(acc.transcript, "")
+        acc.accept(text: "first", start: 0.1)
+        acc.accept(text: "", start: 5.0)
+        XCTAssertEqual(acc.transcript, "first")
+        XCTAssertEqual(acc.accept(text: "second", start: 5.0), "first second")
+    }
+}

--- a/ios/Tests/CompanionCoreTests/LocalFileLinkTests.swift
+++ b/ios/Tests/CompanionCoreTests/LocalFileLinkTests.swift
@@ -1,0 +1,39 @@
+// Which tapped links are files on the Mac and which are the web.
+import XCTest
+@testable import CompanionCore
+
+final class LocalFileLinkTests: XCTestCase {
+    private func url(_ string: String) -> URL { URL(string: string)! }
+
+    func testAbsolutePathIsAFile() {
+        XCTAssertEqual(LocalFileLink.path(for: url("/Users/omkar/.openmausbot/report.md")),
+                       "/Users/omkar/.openmausbot/report.md")
+    }
+
+    func testPercentEncodedPathIsDecoded() {
+        XCTAssertEqual(LocalFileLink.path(for: url("/Users/omkar/My%20Report.md")),
+                       "/Users/omkar/My Report.md")
+    }
+
+    func testFileURLIsHandedOverWhole() {
+        XCTAssertEqual(LocalFileLink.path(for: url("file:///Users/omkar/report.md")),
+                       "file:///Users/omkar/report.md")
+        XCTAssertEqual(LocalFileLink.path(for: url("FILE:///Users/omkar/report.md")),
+                       "FILE:///Users/omkar/report.md")
+    }
+
+    func testWindowsDriveIsAFile() {
+        XCTAssertEqual(LocalFileLink.path(for: url("C:/Users/omkar/report.md")), "C:/Users/omkar/report.md")
+    }
+
+    func testWebLinksAreNotFiles() {
+        XCTAssertNil(LocalFileLink.path(for: url("https://example.com/report.md")))
+        XCTAssertNil(LocalFileLink.path(for: url("http://example.com")))
+        XCTAssertNil(LocalFileLink.path(for: url("mailto:someone@example.com")))
+    }
+
+    func testRelativePathIsNotAFile() {
+        XCTAssertNil(LocalFileLink.path(for: url("docs/report.md")))
+        XCTAssertNil(LocalFileLink.path(for: url("report.md")))
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -35,7 +35,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "6"
+        CURRENT_PROJECT_VERSION: "8"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1,2"
         # The catalog lives in App/, which is already a source path.
@@ -137,7 +137,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app.share
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "6"
+        CURRENT_PROJECT_VERSION: "8"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1,2"
         APPLICATION_EXTENSION_API_ONLY: YES
@@ -191,7 +191,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app.widgets
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "6"
+        CURRENT_PROJECT_VERSION: "8"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1,2"
         SKIP_INSTALL: true

--- a/server/file-view.test.ts
+++ b/server/file-view.test.ts
@@ -1,0 +1,98 @@
+// file-view.ts: the containment that keeps a linked path inside the data
+// directory, the mime table, and the errors a bad link produces.
+import { mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DATA_DIR } from "./config.ts";
+import { contentDispositionFor, mimeForViewableFile, resolveViewableFile, viewableFileRoots } from "./file-view.ts";
+
+// The vitest setup gives this file a throwaway home, and DATA_DIR is the
+// .openmausbot directory inside it. The home itself is "outside".
+const DATA = DATA_DIR;
+const ROOT = dirname(DATA_DIR);
+
+const inside = join(DATA, "documents", "report.md");
+const outside = join(ROOT, "elsewhere.md");
+
+beforeAll(() => {
+  mkdirSync(join(DATA, "documents"), { recursive: true });
+  writeFileSync(inside, "# Report\n\nhello\n");
+  writeFileSync(outside, "not yours\n");
+  symlinkSync(outside, join(DATA, "documents", "escape.md"));
+});
+
+afterAll(() => rmSync(DATA, { recursive: true, force: true }));
+
+const status = (fn: () => unknown): number => {
+  try {
+    fn();
+  } catch (error) {
+    return (error as { status: number }).status;
+  }
+  throw new Error("expected a status error");
+};
+
+describe("resolveViewableFile", () => {
+  it("serves a regular file under the data directory", () => {
+    const file = resolveViewableFile(inside);
+    expect(file.path).toBe(realpathSync(inside));
+    expect(file.name).toBe("report.md");
+    expect(file.mime).toBe("text/markdown; charset=utf-8");
+    expect(file.bytes).toBe(16);
+  });
+
+  it("accepts the file:// form bots also emit", () => {
+    expect(resolveViewableFile(pathToFileURL(inside).href).name).toBe("report.md");
+  });
+
+  it("includes the data directory in its roots", () => {
+    expect(viewableFileRoots()).toContain(realpathSync(DATA));
+  });
+
+  it("refuses a path outside the data directory", () => {
+    expect(status(() => resolveViewableFile(outside))).toBe(403);
+  });
+
+  it("refuses a symlink that escapes the data directory", () => {
+    expect(status(() => resolveViewableFile(join(DATA, "documents", "escape.md")))).toBe(403);
+  });
+
+  it("refuses traversal that lands outside", () => {
+    expect(status(() => resolveViewableFile(join(DATA, "documents", "..", "..", "elsewhere.md")))).toBe(403);
+  });
+
+  it("refuses a directory", () => {
+    expect(status(() => resolveViewableFile(join(DATA, "documents")))).toBe(400);
+  });
+
+  it("refuses relative, empty, and malformed paths", () => {
+    expect(status(() => resolveViewableFile("documents/report.md"))).toBe(400);
+    expect(status(() => resolveViewableFile(""))).toBe(400);
+    expect(status(() => resolveViewableFile(undefined))).toBe(400);
+    expect(status(() => resolveViewableFile("file://not a url\0"))).toBe(400);
+  });
+
+  it("reports a missing file as 404", () => {
+    expect(status(() => resolveViewableFile(join(DATA, "documents", "gone.md")))).toBe(404);
+  });
+});
+
+describe("mimeForViewableFile", () => {
+  it("serves markdown and code as text, markup as text, unknown as a download", () => {
+    expect(mimeForViewableFile("/x/a.md")).toBe("text/markdown; charset=utf-8");
+    expect(mimeForViewableFile("/x/a.swift")).toBe("text/plain; charset=utf-8");
+    expect(mimeForViewableFile("/x/a.html")).toBe("text/plain; charset=utf-8");
+    expect(mimeForViewableFile("/x/a.svg")).toBe("text/plain; charset=utf-8");
+    expect(mimeForViewableFile("/x/a.pdf")).toBe("application/pdf");
+    expect(mimeForViewableFile("/x/a.bin")).toBe("application/octet-stream");
+  });
+});
+
+describe("contentDispositionFor", () => {
+  it("keeps the quoted name ASCII and the starred name exact", () => {
+    expect(contentDispositionFor('ré"port.md')).toBe(
+      `inline; filename="r__port.md"; filename*=UTF-8''r%C3%A9%22port.md`,
+    );
+  });
+});

--- a/server/file-view.ts
+++ b/server/file-view.ts
@@ -1,0 +1,123 @@
+// Serving a bot-created file to a client that has no disk to read.
+//
+// When a reply links a document it wrote, the desktop app reads that path
+// straight off the local disk (electron/save-file.mjs). The phone sees the
+// same link and has nothing behind it, so it asks the server for the bytes
+// instead. The containment rule is the same one the desktop applies: the
+// canonical path must sit under the data directory, and it must be a regular
+// file. Paths arrive from model-rendered markdown, so they are untrusted.
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, extname, isAbsolute, join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DATA_DIR } from "./config.ts";
+
+export const VIEW_FILE_MAX_BYTES = 25 * 1024 * 1024;
+
+export interface ViewableFile {
+  path: string;
+  name: string;
+  mime: string;
+  bytes: number;
+}
+
+function statusError(status: number, message: string): Error & { status: number } {
+  return Object.assign(new Error(message), { status });
+}
+
+/** Extensions served as something other than plain text. HTML and SVG are
+ * deliberately absent: a bot-written page is shown as its source, never
+ * rendered as markup by whatever fetched it. */
+const KNOWN_TYPES: Readonly<Record<string, string>> = {
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".tsv": "text/tab-separated-values",
+  ".json": "application/json",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+};
+
+/** Source and config files a bot commonly writes; shown as text. Anything
+ * not listed here or above is an opaque download. */
+const TEXT_EXTENSIONS = new Set([
+  ".log", ".yaml", ".yml", ".toml", ".ini", ".env", ".xml", ".html", ".htm", ".svg", ".css",
+  ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".rb", ".go", ".rs", ".swift", ".kt",
+  ".java", ".c", ".h", ".cpp", ".hpp", ".cs", ".sh", ".zsh", ".bash", ".sql", ".diff", ".patch",
+]);
+
+export function mimeForViewableFile(path: string): string {
+  const extension = extname(path).toLowerCase();
+  const known = KNOWN_TYPES[extension];
+  if (known) return known.startsWith("text/") || known === "application/json" ? `${known}; charset=utf-8` : known;
+  if (TEXT_EXTENSIONS.has(extension)) return "text/plain; charset=utf-8";
+  return "application/octet-stream";
+}
+
+/** Where bot-created files may be read from: the data directory, and the
+ * default one, which differ only when OMB_DATA_DIR points elsewhere. */
+export function viewableFileRoots(): string[] {
+  const roots = new Set<string>();
+  for (const candidate of [DATA_DIR, join(homedir(), ".openmausbot")]) {
+    try {
+      roots.add(realpathSync(candidate));
+    } catch {
+      // A root that does not exist cannot contain anything.
+    }
+  }
+  return [...roots];
+}
+
+function normalizeRequestedPath(rawPath: unknown): string {
+  if (typeof rawPath !== "string" || !rawPath.trim()) throw statusError(400, "path is required");
+  const trimmed = rawPath.trim();
+  if (trimmed.includes("\0")) throw statusError(400, "That file path is invalid");
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      return fileURLToPath(trimmed);
+    } catch {
+      throw statusError(400, "That file path is invalid");
+    }
+  }
+  if (!isAbsolute(trimmed)) throw statusError(400, "That file path is invalid");
+  return trimmed;
+}
+
+/** Resolve a linked path to a file this server is willing to serve, or
+ * throw an error carrying the HTTP status that explains why not. */
+export function resolveViewableFile(rawPath: unknown, roots: string[] = viewableFileRoots()): ViewableFile {
+  const requested = normalizeRequestedPath(rawPath);
+  let path: string;
+  try {
+    path = realpathSync(requested);
+  } catch {
+    throw statusError(404, "That file no longer exists");
+  }
+  const contained = roots.some((root) => path === root || path.startsWith(root + sep));
+  if (!contained) throw statusError(403, "Only files created by your bots can be viewed");
+  const stats = statSync(path);
+  if (!stats.isFile()) throw statusError(400, "That path is not a file");
+  if (stats.size > VIEW_FILE_MAX_BYTES) {
+    throw statusError(413, `That file is larger than ${VIEW_FILE_MAX_BYTES} bytes`);
+  }
+  return { path, name: basename(path), mime: mimeForViewableFile(path), bytes: stats.size };
+}
+
+export function readViewableFile(file: ViewableFile): Buffer {
+  return readFileSync(file.path);
+}
+
+/** A Content-Disposition value that survives header encoding: ASCII-only in
+ * the quoted form, the real name in the RFC 5987 form. */
+export function contentDispositionFor(name: string): string {
+  const ascii = name.replace(/["\\]/g, "_").replace(/[^\x20-\x7e]/g, "_");
+  return `inline; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(name)}`;
+}

--- a/server/folder-upload.test.ts
+++ b/server/folder-upload.test.ts
@@ -1,0 +1,120 @@
+// folder-upload.ts: rebuilding a phone's folder under the attachments
+// directory — the name rules that keep every file inside it, the caps, and
+// what a retry does.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { ATTACHMENTS_DIR, FILE_MAX_BYTES } from "./attachments.ts";
+import {
+  FOLDERS_DIR,
+  folderPath,
+  folderUsage,
+  sanitizeFolderName,
+  sanitizeRelativePath,
+  saveFolderFile,
+} from "./folder-upload.ts";
+
+async function* bytesOf(...parts: string[]): AsyncIterable<Uint8Array> {
+  for (const part of parts) yield Buffer.from(part);
+}
+
+const status = async (promise: Promise<unknown>): Promise<number> => {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as { status: number }).status;
+  }
+  throw new Error("expected a status error");
+};
+
+describe("name rules", () => {
+  it("keeps ordinary names and replaces reserved characters", () => {
+    expect(sanitizeFolderName("Project Notes")).toBe("Project Notes");
+    expect(sanitizeFolderName('a<b>:"c|d?e*f')).toBe("a_b___c_d_e_f");
+    expect(sanitizeFolderName("trailing. ")).toBe("trailing");
+  });
+
+  it("refuses separators, traversal and empties", () => {
+    for (const bad of ["", "  ", ".", "..", "a/b", "a\\b", "a%2Fb", "a%00b", "\t"]) {
+      expect(() => sanitizeFolderName(bad), bad).toThrow();
+    }
+    expect(() => sanitizeFolderName(undefined)).toThrow();
+  });
+
+  it("splits a relative path into safe segments", () => {
+    expect(sanitizeRelativePath("src/lib/util.ts")).toEqual(["src", "lib", "util.ts"]);
+    expect(() => sanitizeRelativePath("src/../secret")).toThrow();
+    expect(() => sanitizeRelativePath("/etc/passwd")).toThrow();
+    expect(() => sanitizeRelativePath("a//b")).toThrow();
+    expect(() => sanitizeRelativePath("")).toThrow();
+    expect(() => sanitizeRelativePath(Array.from({ length: 40 }, () => "d").join("/"))).toThrow();
+  });
+});
+
+describe("saveFolderFile", () => {
+  it("rebuilds the folder under attachments/folders/<uploadId>/<name>", async () => {
+    const uploadId = randomUUID();
+    const saved = await saveFolderFile(bytesOf("hello ", "world"), {
+      uploadId,
+      folder: "Notes",
+      relativePath: "week 1/monday.md",
+    });
+    const root = folderPath(uploadId, "Notes");
+    expect(root).toBe(join(FOLDERS_DIR, uploadId, "Notes"));
+    expect(root.startsWith(ATTACHMENTS_DIR)).toBe(true);
+    expect(saved).toEqual({ path: join(root, "week 1", "monday.md"), folderPath: root, bytes: 11 });
+    expect(readFileSync(saved.path, "utf8")).toBe("hello world");
+    expect(readdirSync(join(root, "week 1")).filter((name) => name.includes("partial"))).toEqual([]);
+    expect(folderUsage(root)).toEqual({ files: 1, bytes: 11 });
+  });
+
+  it("replaces the same file on retry and keeps siblings", async () => {
+    const uploadId = randomUUID();
+    const options = { uploadId, folder: "Notes", relativePath: "a.txt" };
+    await saveFolderFile(bytesOf("first"), options);
+    await saveFolderFile(bytesOf("b"), { ...options, relativePath: "b.txt" });
+    const again = await saveFolderFile(bytesOf("second"), options);
+    expect(readFileSync(again.path, "utf8")).toBe("second");
+    expect(folderUsage(again.folderPath)).toEqual({ files: 2, bytes: 7 });
+  });
+
+  it("requires a uploadId and refuses bad names", async () => {
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId: undefined, folder: "N", relativePath: "a" }))).toBe(400);
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId: "nope", folder: "N", relativePath: "a" }))).toBe(400);
+    const uploadId = randomUUID();
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId, folder: "../N", relativePath: "a" }))).toBe(400);
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId, folder: "N", relativePath: "../a" }))).toBe(400);
+    expect(existsSync(join(FOLDERS_DIR, uploadId))).toBe(false);
+  });
+
+  it("refuses an empty file and leaves nothing behind", async () => {
+    const uploadId = randomUUID();
+    expect(await status(saveFolderFile(bytesOf(), { uploadId, folder: "N", relativePath: "empty.txt" }))).toBe(400);
+    const root = folderPath(uploadId, "N");
+    expect(readdirSync(root)).toEqual([]);
+  });
+
+  it("caps one file, the folder's file count, and the folder's bytes", async () => {
+    const uploadId = randomUUID();
+    const big = { uploadId, folder: "N", relativePath: "big.bin", expectedBytes: FILE_MAX_BYTES + 1 };
+    expect(await status(saveFolderFile(bytesOf("x"), big))).toBe(413);
+
+    const limits = { maxFiles: 2, maxBytes: 10 };
+    await saveFolderFile(bytesOf("aaaa"), { uploadId, folder: "N", relativePath: "1" }, limits);
+    await saveFolderFile(bytesOf("bbbb"), { uploadId, folder: "N", relativePath: "2" }, limits);
+    expect(await status(saveFolderFile(bytesOf("c"), { uploadId, folder: "N", relativePath: "3" }, limits))).toBe(413);
+    // replacing an existing file is not a new file, but the bytes still count
+    await saveFolderFile(bytesOf("aa"), { uploadId, folder: "N", relativePath: "1" }, limits);
+    expect(await status(saveFolderFile(bytesOf("bbbbbbbbb"), { uploadId, folder: "N", relativePath: "2" }, limits))).toBe(413);
+    expect(readFileSync(join(folderPath(uploadId, "N"), "2"), "utf8")).toBe("bbbb");
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId, folder: "N", relativePath: "1", expectedBytes: 20 }, limits))).toBe(413);
+  });
+
+  it("refuses to write over a directory", async () => {
+    const uploadId = randomUUID();
+    await saveFolderFile(bytesOf("x"), { uploadId, folder: "N", relativePath: "dir/file" });
+    expect(await status(saveFolderFile(bytesOf("x"), { uploadId, folder: "N", relativePath: "dir" }))).toBe(409);
+    expect(statSync(join(folderPath(uploadId, "N"), "dir")).isDirectory()).toBe(true);
+  });
+});

--- a/server/folder-upload.ts
+++ b/server/folder-upload.ts
@@ -1,0 +1,177 @@
+// A folder uploaded from the phone, one file at a time.
+//
+// On the desktop a folder is attached by path: the bot can already read it.
+// The phone's folders live on the phone, so it sends each file with its
+// relative path, and the folder is rebuilt here under the attachments
+// directory. The message then carries the rebuilt folder's path in the
+// same <attached-file> tag a desktop folder gets, so bots see no difference.
+//
+// Every name arrives from the phone and is treated as untrusted: separators
+// and traversal are refused rather than cleaned, reserved characters are
+// replaced, and one folder is bounded in files, bytes, and depth.
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
+import { open } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { ATTACHMENTS_DIR, FILE_MAX_BYTES, validateAttachmentUploadId } from "./attachments.ts";
+
+export const FOLDERS_DIR = join(ATTACHMENTS_DIR, "folders");
+export const FOLDER_MAX_FILES = 500;
+export const FOLDER_MAX_BYTES = 200 * 1024 * 1024;
+export const FOLDER_MAX_DEPTH = 32;
+
+export interface FolderLimits {
+  maxFiles: number;
+  maxBytes: number;
+}
+
+export interface SavedFolderFile {
+  path: string;
+  folderPath: string;
+  bytes: number;
+}
+
+const PARTIAL_NAME = /^\.openmaus-upload-[0-9a-f-]+\.partial$/i;
+
+function statusError(status: number, message: string): Error & { status: number } {
+  return Object.assign(new Error(message), { status });
+}
+
+/** One path segment: no separators, no traversal, no control or reserved
+ * characters, and something visible left once those are gone. */
+export function sanitizeSegment(value: unknown, what: string): string {
+  if (typeof value !== "string") throw statusError(400, `${what} is required`);
+  const normalized = value.normalize("NFKC").trim();
+  if (!normalized) throw statusError(400, `${what} is required`);
+  if (normalized === "." || normalized === "..") throw statusError(400, `${what} must not be a traversal`);
+  if (/[\\/]/.test(normalized) || /%(?:00|2f|5c)/i.test(normalized)) {
+    throw statusError(400, `${what} must not contain a path separator`);
+  }
+  const safe = Array.from(normalized, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127 || "<>:\"|?*".includes(character) ? "_" : character;
+  }).join("").replace(/[.\s]+$/, "");
+  if (!safe || Buffer.byteLength(safe) > 255) throw statusError(400, `${what} must be a valid name`);
+  return safe;
+}
+
+export function sanitizeFolderName(value: unknown): string {
+  return sanitizeSegment(value, "folder");
+}
+
+/** The relative path of one file inside the folder, as safe segments. */
+export function sanitizeRelativePath(value: unknown): string[] {
+  if (typeof value !== "string" || !value.trim()) throw statusError(400, "path is required");
+  const segments = value.split("/");
+  if (segments.length > FOLDER_MAX_DEPTH) throw statusError(400, `path is nested deeper than ${FOLDER_MAX_DEPTH}`);
+  return segments.map((segment) => sanitizeSegment(segment, "path"));
+}
+
+export function folderPath(uploadId: string, folderName: string): string {
+  return join(FOLDERS_DIR, uploadId, folderName);
+}
+
+/** Files and bytes already in a folder, ignoring in-flight partials. */
+export function folderUsage(root: string): { files: number; bytes: number } {
+  let files = 0;
+  let bytes = 0;
+  const walk = (directory: string) => {
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (entry.isFile() && !PARTIAL_NAME.test(entry.name)) {
+        files += 1;
+        try {
+          bytes += statSync(path).size;
+        } catch {
+          // removed underneath the scan
+        }
+      }
+    }
+  };
+  walk(root);
+  return { files, bytes };
+}
+
+/** Stream one file of a folder into place. A retry of the same file
+ * replaces it; a failed or empty upload leaves nothing behind. */
+export async function saveFolderFile(
+  chunks: AsyncIterable<Uint8Array>,
+  options: { uploadId: string | undefined; folder: unknown; relativePath: unknown; expectedBytes?: number },
+  limits: FolderLimits = { maxFiles: FOLDER_MAX_FILES, maxBytes: FOLDER_MAX_BYTES },
+): Promise<SavedFolderFile> {
+  const uploadId = validateAttachmentUploadId(options.uploadId);
+  if (!uploadId) throw statusError(400, "uploadId is required");
+  const folderName = sanitizeFolderName(options.folder);
+  const segments = sanitizeRelativePath(options.relativePath);
+  const expectedBytes = options.expectedBytes;
+  if (expectedBytes !== undefined && (!Number.isSafeInteger(expectedBytes) || expectedBytes < 0)) {
+    throw statusError(400, "content-length must be a non-negative integer");
+  }
+  if (expectedBytes !== undefined && expectedBytes > FILE_MAX_BYTES) {
+    throw statusError(413, `file exceeds ${FILE_MAX_BYTES} bytes`);
+  }
+
+  const root = folderPath(uploadId, folderName);
+  const target = join(root, ...segments);
+  const replacing = existsSync(target);
+  if (replacing && !statSync(target).isFile()) {
+    throw statusError(409, "path names a directory in this folder");
+  }
+  const usage = folderUsage(root);
+  const existingBytes = replacing ? statSync(target).size : 0;
+  if (!replacing && usage.files >= limits.maxFiles) {
+    throw statusError(413, `folder exceeds ${limits.maxFiles} files`);
+  }
+  const otherBytes = usage.bytes - existingBytes;
+  if (otherBytes + (expectedBytes ?? 0) > limits.maxBytes) {
+    throw statusError(413, `folder exceeds ${limits.maxBytes} bytes`);
+  }
+
+  mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+  const partialPath = join(dirname(target), `.openmaus-upload-${randomUUID()}.partial`);
+  let file: Awaited<ReturnType<typeof open>> | undefined;
+  let bytes = 0;
+  let closed = false;
+  try {
+    file = await open(partialPath, "wx", 0o600);
+    for await (const value of chunks) {
+      const chunk = Buffer.isBuffer(value)
+        ? value
+        : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+      if (chunk.byteLength === 0) continue;
+      if (bytes + chunk.byteLength > FILE_MAX_BYTES) {
+        throw statusError(413, `file exceeds ${FILE_MAX_BYTES} bytes`);
+      }
+      if (otherBytes + bytes + chunk.byteLength > limits.maxBytes) {
+        throw statusError(413, `folder exceeds ${limits.maxBytes} bytes`);
+      }
+      let offset = 0;
+      while (offset < chunk.byteLength) {
+        const result = await file.write(chunk, offset, chunk.byteLength - offset, null);
+        if (result.bytesWritten === 0) throw new Error("file write made no progress");
+        offset += result.bytesWritten;
+      }
+      bytes += chunk.byteLength;
+    }
+    if (bytes === 0) throw statusError(400, "empty file");
+    await file.close();
+    closed = true;
+    renameSync(partialPath, target);
+    return { path: target, folderPath: root, bytes };
+  } catch (error) {
+    if (file && !closed) await file.close().catch(() => undefined);
+    try {
+      unlinkSync(partialPath);
+    } catch {
+      // never written, or already moved into place
+    }
+    throw error;
+  }
+}

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1525,6 +1525,46 @@ describe("harness HTTP API", () => {
     expect(malformedId.status).toBe(400);
   });
 
+  it("rebuilds a phone's folder file by file under the attachments directory", async () => {
+    const uploadId = "6f1d2c3b-4a5e-4f60-8a1b-2c3d4e5f6a7b";
+    const put = (path: string, body: string) =>
+      fetch(`${BASE}/api/folders/files?uploadId=${uploadId}&folder=${encodeURIComponent("Trip Notes")}&path=${encodeURIComponent(path)}`, {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body,
+      });
+
+    const first = await put("day 1/plan.md", "# Day 1\n");
+    expect(first.status).toBe(201);
+    const saved = await first.json() as { path: string; folderPath: string; bytes: number };
+    expect(saved.folderPath).toBe(join(home, ".openmausbot", "attachments", "folders", uploadId, "Trip Notes"));
+    expect(saved.path).toBe(join(saved.folderPath, "day 1", "plan.md"));
+    expect(saved.bytes).toBe(8);
+    expect(readFileSync(saved.path, "utf8")).toBe("# Day 1\n");
+
+    const second = await put("budget.csv", "item,cost\n");
+    expect(second.status).toBe(201);
+    expect((await second.json() as { folderPath: string }).folderPath).toBe(saved.folderPath);
+
+    // the rebuilt folder is something the viewer route will serve from
+    const viewed = await fetch(`${BASE}/api/files?path=${encodeURIComponent(saved.path)}`);
+    expect(viewed.status).toBe(200);
+
+    expect((await put("../escape.md", "x")).status).toBe(400);
+    expect((await put("", "x")).status).toBe(400);
+    expect((await put("empty.txt", "")).status).toBe(400);
+    const noId = await fetch(`${BASE}/api/folders/files?folder=N&path=a.txt`, { method: "POST", body: "x" });
+    expect(noId.status).toBe(400);
+    const badFolder = await fetch(`${BASE}/api/folders/files?uploadId=${uploadId}&folder=..&path=a.txt`, { method: "POST", body: "x" });
+    expect(badFolder.status).toBe(400);
+    const tooBig = await fetch(`${BASE}/api/folders/files?uploadId=${uploadId}&folder=N&path=big.bin`, {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: Buffer.alloc(FILE_MAX_BYTES + 1),
+    });
+    expect(tooBig.status).toBe(413);
+  });
+
   it("serves a bot-created file to the phone, and only from inside the data directory", async () => {
     const documents = join(home, ".openmausbot", "documents");
     mkdirSync(documents, { recursive: true });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1525,6 +1525,39 @@ describe("harness HTTP API", () => {
     expect(malformedId.status).toBe(400);
   });
 
+  it("serves a bot-created file to the phone, and only from inside the data directory", async () => {
+    const documents = join(home, ".openmausbot", "documents");
+    mkdirSync(documents, { recursive: true });
+    const report = join(documents, "weekly report.md");
+    writeFileSync(report, "# Weekly\n\n- done\n");
+    const elsewhere = join(home, "private.md");
+    writeFileSync(elsewhere, "not for bots\n");
+
+    const viewed = await fetch(`${BASE}/api/files?path=${encodeURIComponent(report)}`);
+    expect(viewed.status).toBe(200);
+    expect(viewed.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(viewed.headers.get("content-disposition")).toContain('filename="weekly report.md"');
+    expect(viewed.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await viewed.text()).toBe("# Weekly\n\n- done\n");
+
+    // the file:// form bots also emit
+    const asUrl = await fetch(`${BASE}/api/files?path=${encodeURIComponent(`file://${report}`)}`);
+    expect(asUrl.status).toBe(200);
+
+    const outside = await fetch(`${BASE}/api/files?path=${encodeURIComponent(elsewhere)}`);
+    expect(outside.status).toBe(403);
+    const traversal = await fetch(`${BASE}/api/files?path=${encodeURIComponent(join(documents, "..", "..", "private.md"))}`);
+    expect(traversal.status).toBe(403);
+    const missing = await fetch(`${BASE}/api/files?path=${encodeURIComponent(join(documents, "gone.md"))}`);
+    expect(missing.status).toBe(404);
+    const directory = await fetch(`${BASE}/api/files?path=${encodeURIComponent(documents)}`);
+    expect(directory.status).toBe(400);
+    const relative = await fetch(`${BASE}/api/files?path=documents%2Fweekly%20report.md`);
+    expect(relative.status).toBe(400);
+    const unnamed = await fetch(`${BASE}/api/files`);
+    expect(unnamed.status).toBe(400);
+  });
+
   it("streams shared documents safely into the local attachments directory", async () => {
     const contents = Buffer.from("name,score\nAda,10\n");
     const saved = await fetch(`${BASE}/api/files?name=${encodeURIComponent("scores.exe")}`, {

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ import {
 import * as checkpoints from "./checkpoints.ts";
 import { appendDecision, readDecisions } from "./decision-log.ts";
 import { validateBotCwd } from "./bot-cwd.ts";
+import { contentDispositionFor, readViewableFile, resolveViewableFile } from "./file-view.ts";
 import {
   attachmentExists,
   extensionForMime,
@@ -6033,6 +6034,24 @@ const server = createServer(async (req, res) => {
     // partial uploads on error. Its optional UUID uploadId is stable across
     // route retries, while the aggregate store quota rejects rather than
     // silently deleting files that old prompts may still reference.
+    // ── viewing a bot-created file ───────────────────────────────────────
+    // A reply that links a document it wrote: the desktop reads that path
+    // off its own disk, the phone asks here. Containment is the desktop's
+    // (electron/save-file.mjs): a regular file whose canonical path sits
+    // under the data directory, never a symlink out of it.
+    if (method === "GET" && path === "/api/files") {
+      const file = resolveViewableFile(url.searchParams.get("path"));
+      const bytes = readViewableFile(file);
+      res.writeHead(200, {
+        "content-type": file.mime,
+        "content-length": String(bytes.byteLength),
+        "content-disposition": contentDispositionFor(file.name),
+        "cache-control": "no-store",
+        "x-content-type-options": "nosniff",
+      });
+      return res.end(bytes);
+    }
+
     if (method === "POST" && path === "/api/files") {
       let uploadId: string | undefined;
       try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import * as checkpoints from "./checkpoints.ts";
 import { appendDecision, readDecisions } from "./decision-log.ts";
 import { validateBotCwd } from "./bot-cwd.ts";
 import { contentDispositionFor, readViewableFile, resolveViewableFile } from "./file-view.ts";
+import { saveFolderFile } from "./folder-upload.ts";
 import {
   attachmentExists,
   extensionForMime,
@@ -6034,6 +6035,39 @@ const server = createServer(async (req, res) => {
     // partial uploads on error. Its optional UUID uploadId is stable across
     // route retries, while the aggregate store quota rejects rather than
     // silently deleting files that old prompts may still reference.
+    // ── a folder from the phone ──────────────────────────────────────────
+    // The desktop attaches a folder by path. The phone's folders are on the
+    // phone, so it sends each file with its relative path and the folder is
+    // rebuilt under attachments/folders/<uploadId>/<name>; the message then
+    // carries that folder's path in an ordinary <attached-file> tag.
+    if (method === "POST" && path === "/api/folders/files") {
+      const rawLength = Array.isArray(req.headers["content-length"])
+        ? req.headers["content-length"][0]
+        : req.headers["content-length"];
+      const declaredLength = rawLength === undefined ? undefined : Number(rawLength);
+      if (declaredLength !== undefined && (!Number.isSafeInteger(declaredLength) || declaredLength < 0)) {
+        req.resume();
+        return json(res, 400, { error: "content-length must be a non-negative integer" });
+      }
+      if (declaredLength !== undefined && declaredLength > FILE_MAX_BYTES) {
+        req.resume();
+        return json(res, 413, { error: `file exceeds ${FILE_MAX_BYTES} bytes` });
+      }
+      try {
+        const chunks = req.iterator({ destroyOnReturn: false }) as AsyncIterable<Buffer>;
+        const saved = await saveFolderFile(chunks, {
+          uploadId: url.searchParams.get("uploadId") ?? undefined,
+          folder: url.searchParams.get("folder"),
+          relativePath: url.searchParams.get("path"),
+          expectedBytes: declaredLength,
+        });
+        return json(res, 201, saved);
+      } catch (error) {
+        req.resume();
+        throw error;
+      }
+    }
+
     // ── viewing a bot-created file ───────────────────────────────────────
     // A reply that links a document it wrote: the desktop reads that path
     // off its own disk, the phone asks here. Containment is the desktop's


### PR DESCRIPTION
## Summary

Two user-reported iOS bugs and the mobile features testers asked for, shipped as TestFlight build 8.

**Fixes**
- **Keyboard send key inserted a newline.** A vertical-axis `TextField` never fires `onSubmit` on the software keyboard, so the blue send arrow added a line. `ComposerReturn` recognises the one edit a tapped Return makes and sends instead; hardware shift-Return still inserts a newline.
- **File links in bot replies did nothing.** Bots link documents as absolute paths or `file://` URLs; the desktop reads them off its own disk, the phone handed them to `UIApplication.open`, which refused. New `GET /api/files?path=` serves a bot-created file with the desktop's containment rule (canonical path under the data directory, regular file only, no symlink out), and bot bubbles route those links to a viewer sheet (markdown rendered, text as text, everything else via QuickLook, share sheet for Save to Files).
- **Dictation restarted mid-sentence.** On-device `SFSpeechRecognizer` starts a fresh result after a pause. `DictationAccumulator` uses segment timestamps to tell a restart from a revision and stitches the pieces together.

**Features**
- **Attach from the phone.** `+` menu gains Add photos, Attach files, and Attach a folder. Picks are copied into the app's inbox, shown as chips, and uploaded on send. Folders go file by file to new `POST /api/folders/files`, which rebuilds them under `attachments/folders/<uploadId>/<name>` with phone-supplied names treated as untrusted (separators/traversal refused, reserved characters replaced, 500 files / 200 MB / 25 MB-per-file caps). Messages carry the same `<attached-file>` / `<attached-image>` tags the desktop composer writes. Camera HEIC is re-encoded to JPEG; images over 10 MB are scaled down.
- **Calls.** A phone button in a bot's chat opens the desktop's half-duplex call loop: listen until 850 ms of silence, send, narrate spoken activity chips while the bot works, read the reply through the computer's voice (`/api/tts/prepare` + `/api/tts/speak`), listen again. Approvals and questions are announced, not answered by voice.
- **Settings → Voice.** Enter or remove the ElevenLabs key from the phone via the same `PUT /api/config` the desktop uses; the server verifies it before storing and it never reaches the phone.

## Test plan

- [x] `swift test` — 279 pass
- [x] `vitest` file-view, folder-upload, attachments, and full `index.test.ts` route suites — 183 pass; `tsc -p tsconfig.server.json` clean
- [x] Simulator and device builds
- [x] Device: send key, file viewer, file/folder/photo attach exercised on an iPhone 16 Pro against a 0.1.46 desktop packaged from this branch
- [x] Uploaded as TestFlight 1.0.0 (8), IN_BETA_TESTING on Public Beta
- [ ] Call flow and key save from the phone — compiled and installed, needs a tester with a microphone and an ElevenLabs key

Requires desktop 0.1.46+ for file viewing and folder attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added half-duplex voice calls with turn-based speaking, transcripts, interruptions, and call status updates.
  * Added voice provider settings, including system voice and ElevenLabs configuration.
  * Added photo, file, and folder attachments with upload progress and error recovery.
  * Added support for viewing and sharing bot-created files on iOS.
  * Added a call button for bot conversations.
* **Improvements**
  * Pressing Return now sends a message; Shift-Return continues to insert a new line.
  * Improved speech dictation across pauses and recognizer restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->