### PR TITLE
fix(delegations): preserve originating group through delegate_bot

### DIFF
--- a/server/comms-visibility.test.ts
+++ b/server/comms-visibility.test.ts
@@ -43,4 +43,41 @@ describe("bot-to-bot channel context", () => {
     expect(channel.section).toBe("Agents");
     expect(channel.section).not.toBe("Bot Chats");
   });
+
+  it("reuses an originating shared group when both bots are members", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const shared = store.createGroup("Planning", [from.id, target.id], false, "Agents");
+
+    const channel = getOrCreateChannel(store, from, target, shared);
+
+    expect(channel.id).toBe(shared.id);
+    expect(channel.dm).toBeFalsy();
+  });
+
+  it("falls back to a DM when the originating group is missing a member", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const other = store.createBot({ name: "Observer", section: "Agents" });
+    const shared = store.createGroup("Planning", [from.id, other.id], false, "Agents");
+
+    const channel = getOrCreateChannel(store, from, target, shared);
+
+    expect(channel.dm).toBe(true);
+    expect(store.dmGroup(from.id, target.id)?.id).toBe(channel.id);
+  });
+
+  it("ignores a DM passed as the originating group and uses the pair DM fallback", () => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const dm = store.createGroup("Forge ⇄ Quarry", [from.id, target.id], true, "Agents");
+
+    const channel = getOrCreateChannel(store, from, target, dm);
+
+    expect(channel.id).toBe(dm.id);
+    expect(channel.dm).toBe(true);
+  });
 });

--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -14,10 +14,24 @@ export interface CommsBus {
   /** SSE broadcast (kind: "group" envelope) for a single group. */
 }
 
-/** Find or create the bot⇄bot channel for the pair. The channel keeps
- * the pair's full exchange, lives in the sidebar like any room, and the
- * user can open it to chip in. */
-export function getOrCreateChannel(store: Store, from: BotRecord, target: BotRecord): GroupRecord {
+/** Find or create the channel for a peer exchange. When an originating
+ * group is supplied and both bots are members, the exchange is mirrored
+ * back into that group. Otherwise the pair's DM is used (creating it if
+ * necessary) so 1:1-bot-thread delegations keep their historical fallback. */
+export function getOrCreateChannel(
+  store: Store,
+  from: BotRecord,
+  target: BotRecord,
+  originatingGroup?: GroupRecord,
+): GroupRecord {
+  if (
+    originatingGroup &&
+    !originatingGroup.dm &&
+    originatingGroup.memberIds.includes(from.id) &&
+    originatingGroup.memberIds.includes(target.id)
+  ) {
+    return originatingGroup;
+  }
   const existing = store.dmGroup(from.id, target.id);
   if (existing) {
     if (sectionKey(existing.section) !== sectionKey(from.section)) {

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -30,7 +30,7 @@ import {
   _pendingCount,
 } from "./delegations.ts";
 import { peerAllowKey, resolvePeerComms } from "./peer-approval.ts";
-import { Store, type BotRecord } from "./store.ts";
+import { Store, type BotRecord, type GroupRecord } from "./store.ts";
 
 const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
 
@@ -743,6 +743,79 @@ describe("busy retries and receipts", () => {
     discardDelegations(commsBus, from.threadId);
     expect(_pendingCount(from.threadId)).toBe(0);
     expect(findDelegationReceipt(queued.id!)).toMatchObject({ status: "dropped" });
+  });
+});
+
+describe("originating group routing", () => {
+  let store: Store;
+  let from: BotRecord;
+  let target: BotRecord;
+  let group: GroupRecord;
+  let commsBus: CommsBus;
+  let approvalBus: { store: Store; broadcast: (payload: unknown) => void };
+
+  beforeEach(() => {
+    rmSync(DATA_DIR, { recursive: true, force: true });
+    _resetPending();
+    store = new Store(selection);
+    from = store.createBot();
+    target = store.createBot();
+    store.patchBot(target.id, { name: "Helper" });
+    group = store.createGroup("Planning", [from.id, target.id], false, "Agents");
+    const buses = setupBuses(store);
+    commsBus = buses.commsBus;
+    approvalBus = buses.approvalBus;
+  });
+  afterEach(() => _resetPending());
+
+  it("routes a group-thread delegation through the shared channel, not a pair DM", async () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "plan the sprint", depth: 0 }, 1, group.threadId);
+    const runTargetCalls: { channel: GroupRecord | undefined }[] = [];
+    drainDelegations(commsBus, approvalBus, group.threadId, (...args: unknown[]) => {
+      runTargetCalls.push({ channel: args[4] as GroupRecord | undefined });
+    });
+
+    await waitFor(() => runTargetCalls.length === 1);
+    expect(runTargetCalls[0]!.channel?.id).toBe(group.id);
+    expect(runTargetCalls[0]!.channel?.dm).toBeFalsy();
+    expect(store.dmGroup(from.id, target.id)).toBeUndefined();
+    expect(store.messagesFor(group.threadId).some((m) => m.kind === "text" && m.text?.includes("plan the sprint"))).toBe(true);
+    expect(store.messagesFor(group.threadId).some((m) => m.kind === "activity" && m.tool?.name === "Messaged @Helper")).toBe(true);
+  });
+
+  it("still uses a pair DM when the source is the bot's 1:1 thread", async () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "do this", depth: 0 }, 1, from.threadId);
+    const runTargetCalls: { channel: GroupRecord | undefined }[] = [];
+    drainDelegations(commsBus, approvalBus, from.threadId, (...args: unknown[]) => {
+      runTargetCalls.push({ channel: args[4] as GroupRecord | undefined });
+    });
+
+    await waitFor(() => runTargetCalls.length === 1);
+    expect(runTargetCalls[0]!.channel?.dm).toBe(true);
+    expect(runTargetCalls[0]!.channel?.memberIds).toEqual(expect.arrayContaining([from.id, target.id]));
+  });
+
+  it("does not create a pair DM when a valid shared channel exists", async () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "in the room", depth: 0 }, 1, group.threadId);
+    const before = store.groups.filter((g) => g.dm).length;
+    drainDelegations(commsBus, approvalBus, group.threadId, () => {});
+    await waitFor(() => _pendingCount(group.threadId) === 0);
+    const after = store.groups.filter((g) => g.dm).length;
+    expect(after).toBe(before);
+  });
+
+  it("survives persistence: a loaded delegation keeps its originating group", async () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "left over", depth: 0 }, 1, group.threadId);
+    _resetPending();
+    _loadPending();
+    expect(pendingThreads()).toEqual([group.threadId]);
+
+    const runTargetCalls: { channel: GroupRecord | undefined }[] = [];
+    drainDelegations(commsBus, approvalBus, group.threadId, (...args: unknown[]) => {
+      runTargetCalls.push({ channel: args[4] as GroupRecord | undefined });
+    });
+    await waitFor(() => runTargetCalls.length === 1 && _pendingCount(group.threadId) === 0);
+    expect(runTargetCalls[0]!.channel?.id).toBe(group.id);
   });
 });
 

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -154,7 +154,7 @@ describe("queueDelegation", () => {
     }, 1);
     const ownSnapshot = pendingDelegationSnapshot().filter((item) => item.sourceThreadId === from.threadId);
     expect(ownSnapshot).toEqual([
-      { sourceThreadId: from.threadId, toBotId: target.id, reason: "followup" },
+      { sourceThreadId: from.threadId, sourceBotId: from.id, toBotId: target.id, reason: "followup" },
     ]);
     expect(JSON.stringify(ownSnapshot)).not.toContain("private customer task details");
   });
@@ -842,6 +842,34 @@ describe("originating group routing", () => {
       .messagesFor(group.threadId)
       .find((m) => m.kind === "activity" && m.tool?.name?.startsWith("Delegated to @"));
     expect(chip?.from?.botId).toBe(from.id);
+  });
+
+  it("preserves each source bot's identity for two bots delegating to the same target", async () => {
+    const other = store.createBot();
+    store.patchBot(other.id, { name: "Other" });
+    store.patchGroup(group.id, { memberIds: [from.id, target.id, other.id] });
+
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "from A", depth: 0 }, 1, group.threadId);
+    queueDelegation(commsBus, other, { toBotId: target.id, message: "from B", depth: 0 }, 1, group.threadId);
+
+    const snapshot = pendingDelegationSnapshot().filter((item) => item.sourceThreadId === group.threadId);
+    expect(snapshot.map((item) => item.sourceBotId).sort()).toEqual([from.id, other.id].sort());
+
+    const calls: Array<{ sourceBotId: string; sourceThreadId: string; channel?: GroupRecord }> = [];
+    drainDelegations(commsBus, approvalBus, group.threadId, (...args: unknown[]) => {
+      calls.push({
+        sourceBotId: args[6] as string,
+        sourceThreadId: args[3] as string,
+        channel: args[4] as GroupRecord | undefined,
+      });
+    });
+    await waitFor(() => calls.length === 2);
+
+    const sourceBotIds = calls.map((c) => c.sourceBotId).sort();
+    expect(sourceBotIds).toEqual([from.id, other.id].sort());
+    expect(calls.every((c) => c.sourceThreadId === group.threadId)).toBe(true);
+    expect(calls.every((c) => c.channel?.id === group.id && !c.channel?.dm)).toBe(true);
+    expect(store.dmGroup(from.id, target.id)).toBeUndefined();
   });
 });
 

--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -817,6 +817,32 @@ describe("originating group routing", () => {
     await waitFor(() => runTargetCalls.length === 1 && _pendingCount(group.threadId) === 0);
     expect(runTargetCalls[0]!.channel?.id).toBe(group.id);
   });
+
+  it("drains each shared-group item under the bot that queued it", async () => {
+    const other = store.createBot();
+    store.patchBot(other.id, { name: "Other" });
+    store.patchGroup(group.id, { memberIds: [from.id, target.id, other.id] });
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "from A", depth: 0 }, 1, group.threadId);
+    queueDelegation(commsBus, other, { toBotId: target.id, message: "from B", depth: 0 }, 1, group.threadId);
+
+    const seen: { message: string }[] = [];
+    drainDelegations(commsBus, approvalBus, group.threadId, (_to, message) => {
+      seen.push({ message });
+    });
+    await waitFor(() => seen.length === 2);
+
+    expect(seen[0]!.message).toContain(`[Delegated by @${from.name},`);
+    expect(seen[1]!.message).toContain("[Delegated by @Other,");
+    expect(store.dmGroup(from.id, target.id)).toBeUndefined();
+  });
+
+  it("tags the queue activity with the source bot in a shared group", () => {
+    queueDelegation(commsBus, from, { toBotId: target.id, message: "plan", depth: 0 }, 1, group.threadId);
+    const chip = store
+      .messagesFor(group.threadId)
+      .find((m) => m.kind === "activity" && m.tool?.name?.startsWith("Delegated to @"));
+    expect(chip?.from?.botId).toBe(from.id);
+  });
 });
 
 describe("peer wake helpers", () => {

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -246,12 +246,14 @@ export function pendingThreads(): string[] {
  * the UI only needs to know who handed work to whom and the optional label. */
 export function pendingDelegationSnapshot(): Array<{
   sourceThreadId: string;
+  sourceBotId: string;
   toBotId: string;
   reason?: string;
 }> {
   return [...pendingDelegations.entries()].flatMap(([sourceThreadId, items]) =>
     items.map((item) => ({
       sourceThreadId,
+      sourceBotId: item.sourceBotId,
       toBotId: item.toBotId,
       ...(item.reason ? { reason: item.reason } : {}),
     })),
@@ -326,6 +328,7 @@ export function drainDelegations(
     sourceThreadId: string,
     channel: GroupRecord | undefined,
     taskId: string,
+    sourceBotId: string,
   ) => void | Promise<void>,
 ): void {
   if (drainingThreads.has(threadId)) {
@@ -449,6 +452,7 @@ async function processOne(
     sourceThreadId: string,
     channel: GroupRecord | undefined,
     taskId: string,
+    sourceBotId: string,
   ) => void | Promise<void>,
 ): Promise<"settled" | "requeued"> {
   let sender = from;
@@ -579,7 +583,7 @@ async function processOne(
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id);
+  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id, item.sourceBotId);
   return "settled";
 }
 

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -19,7 +19,7 @@ import { getOrCreateChannel, mirrorExchange, type CommsBus } from "./comms-visib
 import { DATA_DIR } from "./config.ts";
 import { newId } from "./contracts.ts";
 import { requestPeerApproval, type ApprovalBus } from "./peer-approval.ts";
-import { sectionKey, type BotRecord, type GroupRecord } from "./store.ts";
+import { sectionKey, type BotRecord, type GroupRecord, type Store } from "./store.ts";
 
 export interface DelegationItem {
   toBotId: string;
@@ -34,12 +34,18 @@ export interface DelegationItem {
    * (= 1) for a user turn — so the peer has no agents integration, and
    * recursive delegation is structurally impossible. */
   depth: number;
+  /** When the delegation is initiated from a shared channel, mirror the
+   * exchange back into that channel instead of creating a pair DM. */
+  originatingGroupId?: string;
 }
 
 interface PendingDelegationItem extends DelegationItem {
   /** Stable acknowledgement key for crash-safe removal from the queue —
    * and the task id the delegating bot uses with check/wait_delegation. */
   id: string;
+  /** The bot that queued this handoff. Stored explicitly because a shared
+   * channel's thread is not owned by any single bot. */
+  sourceBotId: string;
   /** Busy-target retries so far. The item stays queued (not canceled) while
    * the target is busy, and is retried when any of the target's turns
    * settles — up to MAX_BUSY_ATTEMPTS. */
@@ -184,6 +190,7 @@ export function _loadPending(): void {
         ) return [];
         const loaded: PendingDelegationItem = {
           id: typeof item.id === "string" && item.id ? item.id : newId(),
+          sourceBotId: typeof item.sourceBotId === "string" && item.sourceBotId ? item.sourceBotId : newId(),
           toBotId: item.toBotId,
           message: item.message,
           ...(typeof item.reason === "string" ? { reason: item.reason } : {}),
@@ -192,6 +199,9 @@ export function _loadPending(): void {
         };
         if (item.approvalAlreadyGranted === true) loaded.approvalAlreadyGranted = true;
         if (item.waitingOnBusy === true) loaded.waitingOnBusy = true;
+        if (typeof item.originatingGroupId === "string" && item.originatingGroupId) {
+          loaded.originatingGroupId = item.originatingGroupId;
+        }
         return [loaded];
       });
       if (items.length) pendingDelegations.set(threadId, items);
@@ -270,8 +280,20 @@ export function queueDelegation(
   // making the caller wait. Without a cap, one turn can queue unboundedly
   // and fan out into as many real turns on the next settle.
   if (list.length >= MAX_QUEUED_PER_THREAD) return { result: "too_many" };
+  // If the source thread is a shared group that contains both bots, keep it
+  // as the authoritative channel instead of routing into a pair DM later.
+  const originatingGroup = item.originatingGroupId
+    ? bus.store.group(item.originatingGroupId)
+    : (sourceThreadId ? bus.store.groupByThread(sourceThreadId) : undefined);
+  const groupId =
+    originatingGroup &&
+    !originatingGroup.dm &&
+    originatingGroup.memberIds.includes(from.id) &&
+    originatingGroup.memberIds.includes(target.id)
+      ? originatingGroup.id
+      : undefined;
   const id = newId();
-  list.push({ ...item, id, attempts: 0 });
+  list.push({ ...item, id, sourceBotId: from.id, attempts: 0, ...(groupId ? { originatingGroupId: groupId } : {}) });
   pendingDelegations.set(sourceThreadId, list);
   savePending();
   const label = `Delegated to @${target.name}${item.reason ? `: ${item.reason}` : ""}`;
@@ -308,7 +330,11 @@ export function drainDelegations(
   }
   const list = pendingDelegations.get(threadId);
   if (!list?.length) return;
-  const from = bus.store.botByThread(threadId);
+  // A shared channel's thread is not owned by any single bot, so the queued
+  // item itself carries the source bot identity.
+  const from =
+    bus.store.botByThread(threadId) ??
+    bus.store.bot(list[0]!.sourceBotId);
   if (!from) {
     pendingDelegations.delete(threadId);
     savePending();
@@ -388,7 +414,7 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
       result: "the delegating turn did not finish",
     });
   }
-  const from = bus.store.botByThread(threadId);
+  const from = bus.store.botByThread(threadId) ?? bus.store.bot(list[0]!.sourceBotId);
   if (!from) return;
   bus.store.appendMessage(threadId, {
     role: "bot",
@@ -496,7 +522,7 @@ async function processOne(
     // and mirror a "Messaged @X" chip for an exchange that never happens.
     const current = bus.store.bot(item.toBotId);
     const currentSender = bus.store.bot(from.id);
-    if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return "settled";
+    if (!current || !currentSender || !sourceThreadBelongsToBot(bus.store, currentSender.id, sourceThreadId)) return "settled";
     if (dropIfSectionsChanged(bus, currentSender, current, sourceThreadId, item)) {
       return "settled";
     }
@@ -531,12 +557,35 @@ async function processOne(
     sender = currentSender;
     target = current;
   }
-  const channel = getOrCreateChannel(bus.store, sender, target);
+  // Use the originating group as the channel when both bots are still
+  // members; otherwise the exchange falls back to the pair DM.
+  const originatingGroup =
+    (item.originatingGroupId && bus.store.group(item.originatingGroupId)) ??
+    (sourceThreadId ? bus.store.groupByThread(sourceThreadId) : undefined);
+  const channel = getOrCreateChannel(
+    bus.store,
+    sender,
+    target,
+    originatingGroup &&
+      !originatingGroup.dm &&
+      originatingGroup.memberIds.includes(sender.id) &&
+      originatingGroup.memberIds.includes(target.id)
+      ? originatingGroup
+      : undefined,
+  );
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
   await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id);
   return "settled";
+}
+
+/** The source thread may be a bot's own task or a shared group where the
+ * bot is a member. This is the same check the API gate uses for group turns. */
+function sourceThreadBelongsToBot(store: Store, botId: string, threadId: string): boolean {
+  if (store.taskByThread(botId, threadId)) return true;
+  const group = store.groupByThread(threadId);
+  return Boolean(group && group.memberIds.includes(botId));
 }
 
 /** Section membership is an execution boundary, not just sidebar styling.

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -297,10 +297,14 @@ export function queueDelegation(
   pendingDelegations.set(sourceThreadId, list);
   savePending();
   const label = `Delegated to @${target.name}${item.reason ? `: ${item.reason}` : ""}`;
+  const sourceGroup = sourceThreadId ? bus.store.groupByThread(sourceThreadId) : undefined;
   bus.store.appendMessage(sourceThreadId, {
     role: "bot",
     kind: "activity",
     tool: { name: label },
+    ...(sourceGroup && !sourceGroup.dm
+      ? { from: { botId: from.id, name: from.name, color: from.color } }
+      : {}),
   });
   return { result: "ok", id };
 }
@@ -330,20 +334,27 @@ export function drainDelegations(
   }
   const list = pendingDelegations.get(threadId);
   if (!list?.length) return;
-  // A shared channel's thread is not owned by any single bot, so the queued
-  // item itself carries the source bot identity.
-  const from =
-    bus.store.botByThread(threadId) ??
-    bus.store.bot(list[0]!.sourceBotId);
-  if (!from) {
-    pendingDelegations.delete(threadId);
-    savePending();
-    return;
-  }
   const snapshot = [...list];
   drainingThreads.add(threadId);
   void (async () => {
     for (const item of snapshot) {
+      // A shared channel's thread is not owned by any single bot, so each
+      // queued item carries its own source bot identity.
+      const from =
+        bus.store.botByThread(threadId) ??
+        bus.store.bot(item.sourceBotId);
+      if (!from) {
+        recordDelegationReceipt({
+          id: item.id,
+          sourceThreadId: threadId,
+          toBotId: item.toBotId,
+          toBotName: bus.store.bot(item.toBotId)?.name ?? item.toBotId,
+          status: "dropped",
+          result: "the delegating bot no longer exists",
+        });
+        acknowledgeDelegation(threadId, item.id);
+        continue;
+      }
       let outcome: "settled" | "requeued" = "settled";
       try {
         outcome = await processOne(bus, approvalBus, from, threadId, item, runTarget);
@@ -414,7 +425,9 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
       result: "the delegating turn did not finish",
     });
   }
-  const from = bus.store.botByThread(threadId) ?? bus.store.bot(list[0]!.sourceBotId);
+  const from =
+    bus.store.botByThread(threadId) ??
+    bus.store.bot(list.find((item) => bus.store.bot(item.sourceBotId))?.sourceBotId ?? list[0]!.sourceBotId);
   if (!from) return;
   bus.store.appendMessage(threadId, {
     role: "bot",
@@ -560,19 +573,9 @@ async function processOne(
   // Use the originating group as the channel when both bots are still
   // members; otherwise the exchange falls back to the pair DM.
   const originatingGroup =
-    (item.originatingGroupId && bus.store.group(item.originatingGroupId)) ??
+    (item.originatingGroupId ? bus.store.group(item.originatingGroupId) : undefined) ??
     (sourceThreadId ? bus.store.groupByThread(sourceThreadId) : undefined);
-  const channel = getOrCreateChannel(
-    bus.store,
-    sender,
-    target,
-    originatingGroup &&
-      !originatingGroup.dm &&
-      originatingGroup.memberIds.includes(sender.id) &&
-      originatingGroup.memberIds.includes(target.id)
-      ? originatingGroup
-      : undefined,
-  );
+  const channel = getOrCreateChannel(bus.store, sender, target, originatingGroup);
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -190,7 +190,7 @@ export function _loadPending(): void {
         ) return [];
         const loaded: PendingDelegationItem = {
           id: typeof item.id === "string" && item.id ? item.id : newId(),
-          sourceBotId: typeof item.sourceBotId === "string" && item.sourceBotId ? item.sourceBotId : newId(),
+          sourceBotId: typeof item.sourceBotId === "string" && item.sourceBotId ? item.sourceBotId : "",
           toBotId: item.toBotId,
           message: item.message,
           ...(typeof item.reason === "string" ? { reason: item.reason } : {}),
@@ -583,7 +583,7 @@ async function processOne(
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
   const reasonLine = item.reason ? `\n\n[Reason: ${item.reason}]` : "";
   const prefixed = `[Delegated by @${sender.name}, another bot in this OpenMausBot workspace. Do the work and reply directly.]\n\n${item.message}${reasonLine}`;
-  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id, item.sourceBotId);
+  await runTarget(item.toBotId, prefixed, item.depth + 1, sourceThreadId, channel, item.id, sender.id);
   return "settled";
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -2413,6 +2413,7 @@ const delegationWatch = new Map<string, {
   toBotName?: string;
   taskId?: string;
   sourceThreadId?: string;
+  sourceBotId?: string;
   /** when the delegated turn was dispatched — elapsed time for status checks */
   startedAtMs?: number;
 }>();
@@ -2525,7 +2526,9 @@ function finalizeDelegationWatch(
   }
   const target = store.bot(watched.toBotId);
   const targetName = target?.name ?? watched.toBotName ?? watched.toBotId;
-  const source = watched.sourceThreadId ? store.botByThread(watched.sourceThreadId) : undefined;
+  const source = watched.sourceBotId
+    ? store.bot(watched.sourceBotId)
+    : (watched.sourceThreadId ? store.botByThread(watched.sourceThreadId) : undefined);
   if (source && watched.sourceThreadId) {
     if (ok && reply.trim()) {
       const sourceReply: Omit<Message, "id" | "at"> = {
@@ -2603,7 +2606,7 @@ bus.subscribe((event: RuntimeEvent) => {
 /** How a drained delegation becomes a real turn on the target. Shared by
  * the settle-time drain and the boot-time drain of what a previous process
  * left queued. */
-const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text, commsDepth, sourceThreadId, channel, taskId) => {
+const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text, commsDepth, sourceThreadId, channel, taskId, sourceBotId) => {
     // startTurn REJECTS on an ordinary condition — busy target, deleted bot,
     // unavailable provider. Unhandled, that rejection is fatal to the
     // harness (Node's default), which in the packaged app kills the server
@@ -2617,6 +2620,7 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
         toBotName: target?.name,
         taskId,
         sourceThreadId,
+        sourceBotId,
         startedAtMs: Date.now(),
       });
     }
@@ -6265,6 +6269,7 @@ const server = createServer(async (req, res) => {
             toBotName: currentTarget.name,
             taskId,
             sourceThreadId: fromThreadId,
+            sourceBotId: currentFrom.id,
           });
           store.appendMessage(fromThreadId, {
             role: "bot",
@@ -6587,14 +6592,14 @@ const server = createServer(async (req, res) => {
         }))
         .sort((a, b) => b.lastAt - a.lastAt);
       const queued = pendingDelegationSnapshot().flatMap((item) => {
-        const source = store.botByThread(item.sourceThreadId);
-        if (!source || !visible.has(source.id) || !visible.has(item.toBotId)) return [];
-        return [{ sourceBotId: source.id, targetBotId: item.toBotId, reason: item.reason }];
+        if (!visible.has(item.sourceBotId) || !visible.has(item.toBotId)) return [];
+        return [{ sourceBotId: item.sourceBotId, targetBotId: item.toBotId, reason: item.reason }];
       });
       const running = [...delegationWatch.entries()].flatMap(([threadId, watch]) => {
         if (!visible.has(watch.toBotId)) return [];
         const channel = watch.channelId ? store.group(watch.channelId) : undefined;
-        const sourceBotId = channel?.memberIds.find((botId) => botId !== watch.toBotId);
+        const sourceBotId = watch.sourceBotId ??
+          channel?.memberIds.find((botId) => botId !== watch.toBotId);
         if (!sourceBotId || !visible.has(sourceBotId)) return [];
         return [{ sourceBotId, targetBotId: watch.toBotId, threadId, groupId: channel?.id }];
       });

--- a/server/index.ts
+++ b/server/index.ts
@@ -2529,45 +2529,99 @@ function finalizeDelegationWatch(
   const source = watched.sourceBotId
     ? store.bot(watched.sourceBotId)
     : (watched.sourceThreadId ? store.botByThread(watched.sourceThreadId) : undefined);
+
+  let channel: GroupRecord | undefined = watched.channelId ? store.group(watched.channelId) : undefined;
+  let terminalThreadId: string | undefined = watched.sourceThreadId;
+
   if (source && watched.sourceThreadId) {
-    if (ok && reply.trim()) {
-      const sourceReply: Omit<Message, "id" | "at"> = {
-        role: "bot",
-        kind: "text",
-        text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
-      };
-      if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
-      store.appendMessage(watched.sourceThreadId, sourceReply);
+    const sourceGroup = store.groupByThread(watched.sourceThreadId);
+    if (sourceGroup) {
+      // Shared-channel (or DM) source: revalidate membership, since a roster
+      // change while the target ran must not force a result into a group
+      // that no longer contains both bots.
+      const sourceStillMember = sourceGroup.memberIds.includes(source.id);
+      const targetStillMember = target ? sourceGroup.memberIds.includes(target.id) : false;
+      if (!sourceStillMember || !targetStillMember) {
+        if (target) {
+          channel = getOrCreateChannel(store, source, target);
+          terminalThreadId = channel.threadId;
+        } else {
+          // Target is gone: the source may still see the original group, but
+          // there is no peer to share a DM with. Keep the group for source.
+          terminalThreadId = sourceStillMember ? watched.sourceThreadId : undefined;
+          channel = undefined;
+        }
+      }
+      if (terminalThreadId) {
+        if (ok && reply.trim()) {
+          const sourceReply: Omit<Message, "id" | "at"> = {
+            role: "bot",
+            kind: "text",
+            text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
+          };
+          if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
+          store.appendMessage(terminalThreadId, sourceReply);
+        } else {
+          store.appendMessage(terminalThreadId, {
+            role: "bot",
+            kind: "activity",
+            tool: {
+              name: ok
+                ? `Delegation to @${targetName} completed without a text reply`
+                : `Delegation to @${targetName} failed — ${failureName}`,
+              ok,
+            },
+          });
+        }
+        if (channel && terminalThreadId === channel.threadId && !channel.dm) {
+          store.patchGroup(channel.id, { unread: true });
+        }
+      }
+      // Group/DM sources do not have a single direct task to mark or wake.
+      // The delegated result is already in the shared transcript; a group
+      // continuation is the responsibility of the room's own turn engine.
     } else {
-      store.appendMessage(watched.sourceThreadId, {
-        role: "bot",
-        kind: "activity",
-        tool: {
-          name: ok
-            ? `Delegation to @${targetName} completed without a text reply`
-            : `Delegation to @${targetName} failed — ${failureName}`,
-          ok,
-        },
-      });
-    }
-    markTaskContextExternallyUpdated(source, watched.sourceThreadId);
-    // Peer wake: a settled delegated turn resumes the source bot so it
-    // folds the result in and answers the user, instead of sitting idle
-    // with the reply only visible in the thread (the "delegated and went
-    // silent" gap). Failures wake it too — the user must hear the task did
-    // not finish. Idle-checked and burst-capped so a busy source or a
-    // re-delegating loop cannot spin up runs.
-    if (ok && reply.trim()) {
-      wakeDelegationSource(source, watched.sourceThreadId, targetName);
-    } else if (!ok) {
-      wakeDelegationSource(source, watched.sourceThreadId, targetName, failureName || "the delegated turn did not finish");
+      // 1:1 source: the source thread is the delegating bot's own task.
+      if (ok && reply.trim()) {
+        const sourceReply: Omit<Message, "id" | "at"> = {
+          role: "bot",
+          kind: "text",
+          text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
+        };
+        if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
+        store.appendMessage(watched.sourceThreadId, sourceReply);
+      } else {
+        store.appendMessage(watched.sourceThreadId, {
+          role: "bot",
+          kind: "activity",
+          tool: {
+            name: ok
+              ? `Delegation to @${targetName} completed without a text reply`
+              : `Delegation to @${targetName} failed — ${failureName}`,
+            ok,
+          },
+        });
+      }
+      markTaskContextExternallyUpdated(source, watched.sourceThreadId);
+      // Peer wake: a settled delegated turn resumes the source bot so it
+      // folds the result in and answers the user, instead of sitting idle
+      // with the reply only visible in the thread (the "delegated and went
+      // silent" gap). Failures wake it too — the user must hear the task did
+      // not finish. Idle-checked and burst-capped so a busy source or a
+      // re-delegating loop cannot spin up runs.
+      if (ok && reply.trim()) {
+        wakeDelegationSource(source, watched.sourceThreadId, targetName);
+      } else if (!ok) {
+        wakeDelegationSource(source, watched.sourceThreadId, targetName, failureName || "the delegated turn did not finish");
+      }
     }
   }
-  const channel = watched.channelId ? store.group(watched.channelId) : undefined;
-  if (!target || !channel) return true;
-  if (ok && reply.trim()) mirrorReply(commsBus, target, reply, channel);
-  else if (ok) mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
-  else mirrorActivity(commsBus, target, channel, failureName, false);
+
+  if (target && channel) {
+    if (ok && reply.trim()) mirrorReply(commsBus, target, reply, channel);
+    else if (ok) mirrorActivity(commsBus, target, channel, "Delegated turn completed", true);
+    else mirrorActivity(commsBus, target, channel, failureName, false);
+  }
   return true;
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -6295,7 +6295,7 @@ const server = createServer(async (req, res) => {
         const fromBotId = String(url.searchParams.get("fromBotId") ?? "");
         const fromThreadId = String(url.searchParams.get("fromThreadId") ?? "");
         const from = store.bot(fromBotId);
-        if (!from || !store.taskByThread(from.id, fromThreadId)) return json(res, 403, { error: "unknown sender" });
+        if (!from || !connectorThread(from.id, fromThreadId)) return json(res, 403, { error: "unknown sender" });
         const waitMs = Math.min(Math.max(Number(url.searchParams.get("wait_ms")) || 0, 0), 240_000);
         const deadline = Date.now() + waitMs;
         // Bounded long-poll: the delegating bot parks ONE cheap HTTP request
@@ -6352,7 +6352,7 @@ const server = createServer(async (req, res) => {
           return json(res, 403, { error: "that bot belongs to a different section" });
         }
         const fromThreadId = String(body.fromThreadId ?? from.threadId);
-        if (!store.taskByThread(from.id, fromThreadId)) {
+        if (!connectorThread(from.id, fromThreadId)) {
           return json(res, 403, { error: "source thread does not belong to sender" });
         }
         const queued = queueDelegation(

--- a/server/index.ts
+++ b/server/index.ts
@@ -2649,7 +2649,7 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
     };
     return startTurn(toBotId, text, {
       commsDepth,
-      unattended: isUnattended(store.botByThread(sourceThreadId)?.id),
+      unattended: isUnattended(sourceBotId),
       // startTurn schedules provider/integration setup after marking the bot
       // busy. Those asynchronous setup failures do not emit turn.completed,
       // so clear the watch and report them through this callback too.


### PR DESCRIPTION
## What changed
- `server/comms-visibility.ts`: `getOrCreateChannel` now accepts an optional originating `GroupRecord`; when both bots are members, the peer exchange is mirrored into that shared group instead of an auto-created pair DM.
- `server/delegations.ts`: `DelegationItem` carries `originatingGroupId`; the value is captured at queue time, persisted in `delegations.json`, and restored by `_loadPending`. `processOne` uses it to choose the channel, falling back to the pair DM when the group is gone or a member left.
- `server/delegations.ts`: `PendingDelegationItem` now stores `sourceBotId`, so `drainDelegations` and `discardDelegations` can resolve the delegating bot for a shared-channel source thread.
- `server/index.ts`: the `/api/internal/delegate-bot` endpoint and the delegation long-poll gate accept a group thread that the sender is a member of, using the existing `connectorThread` helper.

## Why
`delegate_bot` was always routing into a `Bot A <-> Bot B` DM via `getOrCreateChannel(bus.store, sender, target)` and losing the originating shared channel. The user in the shared channel could not see or audit the delegated request, reply, or failure.

## How it was verified
- `PATH=/home/ubuntu/.n/bin:$PATH pnpm typecheck` — green.
- `PATH=/home/ubuntu/.n/bin:$PATH pnpm exec vitest run server/delegations.test.ts server/comms-visibility.test.ts` — 47/47 passing, including new tests for shared-channel routing, 1:1 fallback, no DM creation, and persistence.
- `PATH=/home/ubuntu/.n/bin:$PATH pnpm exec vitest run server/comms.test.ts` — 25/25 passing (full fake-engine e2e suite).

Fixes milind-soni/OpenMausBot#683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegations initiated in shared group conversations remain routed through those groups when both bots are members.
  * Delegation activity now identifies the bot that initiated each handoff, including delegations from shared group conversations.
  * Delegations from direct conversations continue using dedicated bot-to-bot conversations.

* **Bug Fixes**
  * Improved delegation status and handoff tracking for shared group conversations.
  * Added fallback routing when a shared group is unavailable, missing a bot, or provided as a direct conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->