### PR TITLE
Add a per-bot depth profile

### DIFF
--- a/server/depth-profile.test.ts
+++ b/server/depth-profile.test.ts
@@ -1,0 +1,70 @@
+// The setting is one enum and one string, so the tests are mostly about the
+// two things that would hurt: a default that is not silent, and a stored
+// value that is not one of the three still reaching a prompt.
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_DEPTH,
+  DEPTH_PROFILES,
+  depthProfileSystemPrompt,
+  isDepthProfile,
+  resolveDepthProfile,
+} from "./depth-profile.ts";
+
+describe("depth profiles", () => {
+  it("offers exactly three, defaulting to the silent one", () => {
+    expect([...DEPTH_PROFILES]).toEqual(["quick", "standard", "deep"]);
+    expect(DEFAULT_DEPTH).toBe("standard");
+    // the whole point of the default: an existing bot's prompt is unchanged
+    expect(depthProfileSystemPrompt("standard")).toBe("");
+    expect(depthProfileSystemPrompt(undefined)).toBe("");
+  });
+
+  it("falls back rather than letting an unknown value reach a prompt", () => {
+    // values arrive from bots.json on disk and from the API, so "not one of
+    // the three" has to mean standard, not a crash and not a passthrough
+    for (const bad of [null, 42, "DEEP", "verbose", "", {}, [], true]) {
+      expect(resolveDepthProfile(bad)).toBe("standard");
+      expect(depthProfileSystemPrompt(bad)).toBe("");
+    }
+    expect(isDepthProfile("deep")).toBe(true);
+    expect(isDepthProfile("Deep")).toBe(false);
+  });
+
+  it("asks quick for brevity and deep for evidence", () => {
+    const quick = depthProfileSystemPrompt("quick");
+    const deep = depthProfileSystemPrompt("deep");
+    // quick's whole job is to cap length and kill preamble
+    expect(quick).toMatch(/one-line question gets a one-line answer/i);
+    expect(quick).toMatch(/no preamble/i);
+    // and it must not smuggle in the report contract
+    expect(quick).not.toMatch(/still open/i);
+    // both are appended to a running system prompt, so each needs its own
+    // leading separator or it welds onto the previous sentence
+    expect(quick.startsWith(" ")).toBe(true);
+    expect(deep.startsWith(" ")).toBe(true);
+  });
+
+  it("tells a deep bot to keep the report in the reply", () => {
+    // the failure this exists to prevent: a bot writes the real work to a
+    // file in its workspace and leaves a summary in chat, so the person who
+    // asked never sees it
+    expect(depthProfileSystemPrompt("deep")).toMatch(/put the report in your reply/i);
+    expect(depthProfileSystemPrompt("deep")).toMatch(/verified/i);
+    expect(depthProfileSystemPrompt("deep")).toMatch(/still open/i);
+  });
+
+  it("carries nothing dynamic that would move between turns", () => {
+    // This rides the cached system prompt, so the text has to depend on the
+    // profile and nothing else. The way that breaks in practice is someone
+    // interpolating a timestamp, a bot name, or a count into the guidance —
+    // all of which show up as digits or a template hole, and none of which
+    // any of the three profiles legitimately contains.
+    for (const profile of DEPTH_PROFILES) {
+      const text = depthProfileSystemPrompt(profile);
+      expect(text).not.toMatch(/\d/);
+      expect(text).not.toContain("${");
+      expect(text).not.toContain("undefined");
+    }
+  });
+});

--- a/server/depth-profile.ts
+++ b/server/depth-profile.ts
@@ -1,0 +1,59 @@
+// How much work an answer is supposed to show.
+//
+// A bot's persona says who it is; the section context says what the team is
+// doing; neither says what a finished answer looks like. Without that, the
+// shape of a reply is whatever the underlying CLI happens to default to —
+// and the coding CLIs default to terse, which is wrong for a bot whose job
+// is analysis.
+//
+// Three profiles, because two is not enough (a short answer and a report are
+// different things, but so is "normal") and four is a menu nobody reads.
+//
+// `standard` deliberately emits NOTHING. Every bot that predates this
+// setting resolves to it, so turning this on changes no existing behaviour
+// until someone opts a bot into quick or deep. That also keeps the emitted
+// text byte-stable per bot, which matters because this rides the cached
+// system prompt: a value that varied per turn would break the provider's
+// prefix cache on every message.
+export const DEPTH_PROFILES = ["quick", "standard", "deep"] as const;
+
+export type DepthProfile = (typeof DEPTH_PROFILES)[number];
+
+export const DEFAULT_DEPTH: DepthProfile = "standard";
+
+export function isDepthProfile(value: unknown): value is DepthProfile {
+  return typeof value === "string" && (DEPTH_PROFILES as readonly string[]).includes(value);
+}
+
+/** Stored values come from JSON on disk and from the API, so anything that
+ * is not one of the three falls back rather than reaching a prompt. */
+export function resolveDepthProfile(stored: unknown): DepthProfile {
+  return isDepthProfile(stored) ? stored : DEFAULT_DEPTH;
+}
+
+const QUICK = [
+  " Answer at the length the question deserves: a one-line question gets a one-line answer.",
+  "Lead with the answer itself — no preamble, no restating the question, no summary of what you are about to do.",
+  "Skip headings and tables unless the answer is genuinely a list or a comparison.",
+].join(" ");
+
+const DEEP = [
+  " This bot's job is analysis, so a finished piece of work is a report, not a verdict.",
+  "Lead with what you found, not with how you worked.",
+  "Say what you actually examined — name the sources and, where it matters, when you looked.",
+  "Keep what you verified separate from what you inferred, and say which is which.",
+  "Name what you could not check and why. An honest gap is worth more than a plausible-looking number:" +
+    " never present an estimate as a measurement, and never fill a hole with something you did not observe.",
+  "Close with what is still open — the questions your work raised and did not settle.",
+  "Use headings and tables where they earn their place; this chat renders Markdown.",
+  "Put the report in your reply. Writing it to a file and leaving a summary here hides the work" +
+    " from the person who asked for it — save a file as well only when they asked for one.",
+].join(" ");
+
+/** The layer itself. Empty for `standard`, so the default costs no tokens. */
+export function depthProfileSystemPrompt(stored: unknown): string {
+  const profile = resolveDepthProfile(stored);
+  if (profile === "quick") return QUICK;
+  if (profile === "deep") return DEEP;
+  return "";
+}

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -4147,6 +4147,38 @@ describe("harness HTTP API", () => {
     }
   });
 
+  it("stores a bot's depth profile and refuses anything outside the three", async () => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    try {
+      // absent by default, so an existing bot's prompt is untouched
+      expect(bot.depth).toBeUndefined();
+
+      const deep = await api("PATCH", `/api/bots/${bot.id}`, { depth: "deep" });
+      expect(deep.status).toBe(200);
+      expect(deep.body.bot.depth).toBe("deep");
+
+      // it survives a reload of the public view, not just the write response
+      const listed = (await api("GET", "/api/bots?messages=0")).body.bots
+        .find((candidate: { id: string }) => candidate.id === bot.id);
+      expect(listed.depth).toBe("deep");
+
+      for (const bad of ["DEEP", "verbose", "", 3, null]) {
+        const refused = await api("PATCH", `/api/bots/${bot.id}`, { depth: bad });
+        expect(refused.status).toBe(400);
+        expect(refused.body.error).toMatch(/quick, standard, or deep/);
+      }
+      // a refused write leaves the stored value alone
+      const after = (await api("GET", "/api/bots?messages=0")).body.bots
+        .find((candidate: { id: string }) => candidate.id === bot.id);
+      expect(after.depth).toBe("deep");
+
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { depth: "standard" })).body.bot.depth)
+        .toBe("standard");
+    } finally {
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("creates a fully configured bot in one request and greets with its final name", async () => {
     const created = await api("POST", "/api/bots", {
       name: "  Pathfinder  ",
@@ -5041,6 +5073,43 @@ describe("harness HTTP API", () => {
     expect(disk.rooms).toEqual({ turnTimeoutMinutes: 20 });
 
     await api("PUT", "/api/config", { rooms: { turnTimeoutMinutes: 5 } });
+  });
+
+  it("puts the depth contract into the system prompt a real engine receives", async () => {
+    // The unit tests prove the string; this proves the wiring. A setting that
+    // never reaches the provider is worse than no setting, because the UI
+    // would claim it is on.
+    const bot = (await api("POST", "/api/bots", {})).body.bot;
+    try {
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+
+      // standard is the default and is deliberately silent
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "hello" })).status).toBe(202);
+      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
+      expect(JSON.parse(readFileSync(fakeClaudeDump, "utf8")).systemPrompt ?? "")
+        .not.toMatch(/put the report in your reply/i);
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots
+          .find((candidate: { id: string }) => candidate.id === bot.id);
+        return Boolean(current?.busy);
+      }, { timeout: 5_000 }).toBe(false);
+
+      // deep carries the contract through to the engine
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { depth: "deep" })).status).toBe(200);
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "hello again" })).status).toBe(202);
+      await expect.poll(() => existsSync(fakeClaudeDump), { timeout: 5_000 }).toBe(true);
+      const system = JSON.parse(readFileSync(fakeClaudeDump, "utf8")).systemPrompt ?? "";
+      expect(system).toMatch(/put the report in your reply/i);
+      expect(system).toMatch(/keep what you verified separate/i);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
   });
 
   it("mounts the verification skill into a real turn when its trigger appears", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -80,6 +80,7 @@ import {
 } from "./cloud-backend.ts";
 import * as composio from "./composio.ts";
 import { chiefOfStaffSystemPrompt } from "./chief-of-staff.ts";
+import { depthProfileSystemPrompt, isDepthProfile } from "./depth-profile.ts";
 import { peerAllowed, peerName, peerRosterSystemPrompt, reachablePeers, roomPeerRosterSystemPrompt, roomRosterLine } from "./peer-roster.ts";
 import { openMausStatusSystemPrompt } from "./openmaus-status-capsule.ts";
 import {
@@ -1158,6 +1159,7 @@ function previewSystemPrompt(bot: BotRecord) {
     { id: "browser", label: "Browser", text: caps?.browserMcp && builtInBrowserEnabled(cfg) && bot.browser !== false && bot.computer !== "off" ? BUILT_IN_BROWSER_SYSTEM_PROMPT : "" },
     { id: "coordination", label: "Team", text: agentsMounted && coordination ? ` ${coordination}` : "" },
     { id: "credential", label: "Credentials", text: agentsMounted ? CREDENTIAL_PROMPT : "" },
+    { id: "depth", label: "Answer depth", text: depthProfileSystemPrompt(bot.depth) },
     { id: "routine", label: "Routines", text: agentsMounted ? ROUTINE_PROMPT : "" },
     { id: "profile", label: "Profile changes", text: agentsMounted ? PROFILE_PROMPT : "" },
     { id: "section-context", label: "Section context", text: sectionContextSystemPrompt(bot.section) },
@@ -4401,6 +4403,7 @@ async function startTurn(
         { id: "routine", label: "Routines", text: routinePrompt },
         { id: "profile", label: "Profile changes", text: profilePrompt },
         { id: "learn", label: "Skill authoring", text: learnPrompt },
+        { id: "depth", label: "Answer depth", text: depthProfileSystemPrompt(bot.depth) },
         { id: "section-context", label: "Section context", text: sectionContextSystemPrompt(bot.section) },
         { id: "memory", label: "Memory", text: privateWorkspace ? memorySystemPrompt(bot.id) : "" },
         { id: "skills", label: "Skills index", text: privateWorkspace ? skillsSystemPrompt(bot.id) : "" },
@@ -5439,6 +5442,7 @@ async function runGroupMemberTurn(
   const roomSystem = buildSystemPrompt(system, store.bot(bot.id)?.soul ?? bot.soul ?? "", [
     { id: "browser", label: "Browser", text: integrations.browser ? BUILT_IN_BROWSER_SYSTEM_PROMPT : "" },
     { id: "recall", label: "Recall", text: integrations.agents ? SESSION_SEARCH_SYSTEM_PROMPT : "" },
+    { id: "depth", label: "Answer depth", text: depthProfileSystemPrompt(bot.depth) },
     { id: "section-context", label: "Section context", text: sectionContextSystemPrompt(bot.section) },
     // the room path has always put a newline before memory and trimmed
     // the block's leading space; keep that so existing prompts are
@@ -10262,6 +10266,12 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         ) {
           patch.browserProfile = requestedProfile;
         } else return json(res, 400, { error: "browserProfile must name an existing browser profile" });
+      }
+      if (body.depth !== undefined) {
+        if (!isDepthProfile(body.depth)) {
+          return json(res, 400, { error: "depth must be quick, standard, or deep" });
+        }
+        patch.depth = body.depth;
       }
       if (body.cloudBackend !== undefined && !["box", "vps"].includes(String(body.cloudBackend))) {
         return json(res, 400, { error: "cloudBackend must be box or vps" });

--- a/server/store.ts
+++ b/server/store.ts
@@ -12,6 +12,7 @@ import type { BotProfilePatch } from "./bot-profile.ts";
 import { peerAllowKey, type PeerAction } from "./peer-approval-key.ts";
 import { DATA_DIR, loadBrowserProfileIdAliases } from "./config.ts";
 import * as mdb from "./message-db.ts";
+import type { DepthProfile } from "./depth-profile.ts";
 import { workspaceDir } from "./workspace.ts";
 import { newId, type CloudBackend, type ModelSelection, type ThreadId } from "./contracts.ts";
 import { pickBotName } from "./names.ts";
@@ -494,6 +495,9 @@ export interface BotRecord {
   computer?: "cloud" | "vm" | "local" | "browser" | "off";
   /** Which cloud computer backs `computer: "cloud"`; absent means Box. */
   cloudBackend?: CloudBackend;
+  /** How much work an answer shows. Absent = "standard", which emits no
+   * guidance at all, so bots created before this setting are unchanged. */
+  depth?: DepthProfile;
   /** Auto mode may prepare/start this bot's managed VPS container. Off by
    * default because starting remote infrastructure is an external action. */
   autoStartVps?: boolean;

--- a/src/components/bot-settings/ModelSection.tsx
+++ b/src/components/bot-settings/ModelSection.tsx
@@ -67,6 +67,35 @@ export function ModelSection({
           </div>
         </div>
       )}
+
+      <div className="rounded-xl bg-card p-4">
+        <div className="text-[15px] font-medium text-ink">Answer depth</div>
+        {/* Same shape as Effort above, and for the same reason: the default
+            sends nothing at all, so a bot that predates this setting reads
+            exactly as it always did. Unlike Effort it needs no engine
+            capability — it is prompt text, so every engine honours it. */}
+        <div className="mt-0.5 text-[13px] text-ink-secondary">
+          How much work a reply shows{bot.depth && bot.depth !== "standard" ? "" : " (Standard: nothing is added)"}
+        </div>
+        <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
+          {(["quick", "standard", "deep"] as const).map((level, i) => (
+            <button
+              key={level}
+              aria-pressed={(bot.depth ?? "standard") === level}
+              onClick={() => patch({ depth: level })}
+              className={cn(
+                "flex-1 py-1.5 text-[13px] capitalize",
+                i > 0 && "border-l border-hairline/40",
+                (bot.depth ?? "standard") === level
+                  ? "bg-control text-ink"
+                  : "text-ink-secondary hover:bg-control/60 hover:text-ink",
+              )}
+            >
+              {level === "deep" ? "Deep report" : level}
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/bot-settings/useBotSettingsDerived.ts
+++ b/src/components/bot-settings/useBotSettingsDerived.ts
@@ -29,6 +29,7 @@ export type BotPatch = Partial<
     | "autoApprove"
     | "approvalMode"
     | "autoReview"
+    | "depth"
     | "speakReplies"
     | "voice"
     | "chiefOfStaff"

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -14,6 +14,7 @@ import {
   type ReactNode,
 } from "react";
 import type { CloudBackend, EffortLevel } from "../../server/contracts.ts";
+import type { DepthProfile } from "../../server/depth-profile.ts";
 import type { MausColor, MausMotion } from "@/lib/mascot";
 import type { BotAvatarCrop } from "../../shared/bot-avatar";
 import { approvalModeFor, type ApprovalMode } from "../../shared/approval-mode";
@@ -271,6 +272,8 @@ export interface Bot {
   computer?: "cloud" | "vm" | "local" | "browser" | "off";
   /** Which cloud computer backs `computer: "cloud"`; absent means Box. */
   cloudBackend?: CloudBackend;
+  /** How much work an answer shows. Absent = "standard", which adds nothing. */
+  depth?: DepthProfile;
   /** Allow Auto to prepare/start the managed VPS container. Off by default. */
   autoStartVps?: boolean;
   /** where new tasks run their shell tools; absent = the private bot workspace */


### PR DESCRIPTION
Implements #718. Opening it as code because the shape is easier to argue about when you can read it — happy to reshape or drop it if you'd rather answer the design questions there first.

## What changed

A per-bot `depth` setting with three values, injected as a layer of the system prompt alongside persona and roster.

- `quick` — answer at the length the question deserves, lead with the answer, no preamble
- `standard` — **the default, and emits nothing at all**
- `deep` — states what a report contains: what was examined, what was found, what is verified as against inferred, what could not be checked, and what is still open

New file `server/depth-profile.ts`, one field on `BotRecord`, one enum check on `PATCH /api/bots/:id`, one call at the prompt assembly site.

## Why

A bot's persona says who it is and the section context says what the team is doing. Neither says what a finished answer looks like, so the shape of a reply is whatever the underlying CLI defaults to — and the coding CLIs default to terse, which is wrong for a bot whose job is analysis.

The evidence that this works is in #718: I have a bot whose `description` field happens to contain an output contract I typed by hand, and it returns structured, sourced reports from plain questions. This makes that a setting instead of something each user has to reinvent in a free-text field.

One clause in `deep` comes from watching that same bot: it wrote 4.8KB to chat and saved a fuller 7.3KB write-up to a file in its workspace, so the person who asked never saw most of the work. Hence *"Put the report in your reply … save a file as well only when they asked for one."*

## Two deliberate choices

**`standard` emits an empty string.** Every bot that predates the setting resolves to it, so this changes no existing behaviour until someone opts a bot in. It also costs no tokens for bots that do not use it.

**The text is fixed per profile.** It rides the cached system prompt, so a value that varied per turn would break the provider's prefix cache on every message. `depth-profile.test.ts` pins that.

## How it was verified

macOS, Node 24.20.0. `pnpm typecheck` clean, `pnpm lint` clean on the new files.

Five unit tests in `server/depth-profile.test.ts` cover the enum, the silent default, and that an unknown stored value falls back rather than reaching a prompt.

The test I would actually look at is the end-to-end one in `server/index.test.ts`: it runs a real turn through the fake Claude CLI, reads the system prompt the engine received, and asserts the contract is present on `deep` and absent on `standard`. A setting that never reaches the provider is worse than no setting, because the UI would claim it is on.

`pnpm test` — 3104 pass. One pre-existing failure, `server/control-omb.test.ts > launches, drives a real fake-engine turn`, which fails identically on a clean `origin/main` on my machine with none of this applied. I believe it is environment-dependent (it expects `availableEngines` to equal exactly `["claude"]`; I also have `grok` configured).

## Screenshots (UI changes)

None — there is no UI in this PR. The setting is API-only on purpose, so the prompt wording can be settled before a control is designed around it. If you want the dropdown in the same PR, say so and I will add it with before/after shots.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally (one pre-existing failure, noted above)
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable answer-depth profiles: Quick, Standard, and Deep.
  * Added an Answer depth setting for each bot, with validation and persistence.
  * Deep responses provide additional guidance to verify reports and identify unresolved items.
  * Existing bots default to Standard behavior without additional instructions.

* **Tests**
  * Added coverage for profile selection, persistence, validation, and prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->